### PR TITLE
Spring core JMS pom.xml

### DIFF
--- a/org.springframework.jms/pom.xml
+++ b/org.springframework.jms/pom.xml
@@ -20,11 +20,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.resource</groupId>
-      <artifactId>connector-api</artifactId>
-      <version>1.5</version>
-      <optional>true</optional>
-    </dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
+      <version>2.0.0</version>
+    </dependency> 
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jta_1.1_spec</artifactId>


### PR DESCRIPTION
hiya,

javax.resource:connnector-api:1.5:jar doesnt seem to exist, and the geronimo dependency is available. So this merge request uses the geronimo equivalent instead.
