### PR TITLE
Re: SPR-8941: Lifecycle processing ignores phases for circularly dependent SmartLifecycle beans

### DIFF
--- a/org.springframework.context/src/test/java/org/springframework/context/support/DefaultLifecycleProcessorTests.java
+++ b/org.springframework.context/src/test/java/org/springframework/context/support/DefaultLifecycleProcessorTests.java
@@ -358,6 +358,15 @@ public class DefaultLifecycleProcessorTests {
 
 	@Test
 	public void dependencyStartedFirstEvenIfItsPhaseIsHigher() throws Exception {
+		impactOfDependencyAndPhaseOnStartupOrder(true);
+	}
+
+	@Test
+	public void dependencyStartedLastIfItsPhaseIsHigher() throws Exception {
+		impactOfDependencyAndPhaseOnStartupOrder(false);
+	}
+
+	private void impactOfDependencyAndPhaseOnStartupOrder(final boolean ignorePhaseOfDependencies) {
 		CopyOnWriteArrayList<Lifecycle> startedBeans = new CopyOnWriteArrayList<Lifecycle>();
 		TestSmartLifecycleBean beanMin = TestSmartLifecycleBean.forStartupTests(Integer.MIN_VALUE, startedBeans);
 		TestSmartLifecycleBean bean2 = TestSmartLifecycleBean.forStartupTests(2, startedBeans);
@@ -369,6 +378,11 @@ public class DefaultLifecycleProcessorTests {
 		context.getBeanFactory().registerSingleton("bean99", bean99);
 		context.getBeanFactory().registerSingleton("beanMax", beanMax);
 		context.getBeanFactory().registerDependentBean("bean99", "bean2");
+
+		final BeanDefinition beanDefinition = new RootBeanDefinition(DefaultLifecycleProcessor.class);
+		beanDefinition.getPropertyValues().addPropertyValue("ignorePhaseOfDependencies", ignorePhaseOfDependencies);
+		context.registerBeanDefinition("lifecycleProcessor", beanDefinition);
+
 		context.refresh();
 		assertTrue(beanMin.isRunning());
 		assertTrue(bean2.isRunning());
@@ -376,16 +390,25 @@ public class DefaultLifecycleProcessorTests {
 		assertTrue(beanMax.isRunning());
 		assertEquals(4, startedBeans.size());
 		assertEquals(Integer.MIN_VALUE, getPhase(startedBeans.get(0)));
-		assertEquals(99, getPhase(startedBeans.get(1)));
-		assertEquals(bean99, startedBeans.get(1));
-		assertEquals(2, getPhase(startedBeans.get(2)));
-		assertEquals(bean2, startedBeans.get(2));
+		assertEquals(ignorePhaseOfDependencies ? 99 : 2, getPhase(startedBeans.get(1)));
+		assertEquals(ignorePhaseOfDependencies ? bean99 : bean2, startedBeans.get(1));
+		assertEquals(ignorePhaseOfDependencies ? 2 : 99, getPhase(startedBeans.get(2)));
+		assertEquals(ignorePhaseOfDependencies ? bean2 : bean99, startedBeans.get(2));
 		assertEquals(Integer.MAX_VALUE, getPhase(startedBeans.get(3)));
 		context.stop();
 	}
 
 	@Test
 	public void dependentShutdownFirstEvenIfItsPhaseIsLower() throws Exception {
+		impactOfDependencyAndPhaseOnShutdownOrder(true);
+	}
+
+	@Test
+	public void dependentShutdownLastIfItsPhaseIsLower() throws Exception {
+		impactOfDependencyAndPhaseOnShutdownOrder(false);
+	}
+
+	private void impactOfDependencyAndPhaseOnShutdownOrder(final boolean ignorePhaseOfDependencies) {
 		CopyOnWriteArrayList<Lifecycle> stoppedBeans = new CopyOnWriteArrayList<Lifecycle>();
 		TestSmartLifecycleBean beanMin = TestSmartLifecycleBean.forShutdownTests(Integer.MIN_VALUE, 100, stoppedBeans);
 		TestSmartLifecycleBean bean1 = TestSmartLifecycleBean.forShutdownTests(1, 200, stoppedBeans);
@@ -401,7 +424,12 @@ public class DefaultLifecycleProcessorTests {
 		context.getBeanFactory().registerSingleton("bean99", bean99);
 		context.getBeanFactory().registerSingleton("beanMax", beanMax);
 		context.getBeanFactory().registerDependentBean("bean99", "bean2");
+
+		final BeanDefinition beanDefinition = new RootBeanDefinition(DefaultLifecycleProcessor.class);
+		beanDefinition.getPropertyValues().addPropertyValue("ignorePhaseOfDependencies", ignorePhaseOfDependencies);
+		context.registerBeanDefinition("lifecycleProcessor", beanDefinition);
 		context.refresh();
+
 		assertTrue(beanMin.isRunning());
 		assertTrue(bean1.isRunning());
 		assertTrue(bean2.isRunning());
@@ -417,12 +445,21 @@ public class DefaultLifecycleProcessorTests {
 		assertFalse(beanMax.isRunning());
 		assertEquals(6, stoppedBeans.size());
 		assertEquals(Integer.MAX_VALUE, getPhase(stoppedBeans.get(0)));
-		assertEquals(2, getPhase(stoppedBeans.get(1)));
-		assertEquals(bean2, stoppedBeans.get(1));
-		assertEquals(99, getPhase(stoppedBeans.get(2)));
-		assertEquals(bean99, stoppedBeans.get(2));
-		assertEquals(7, getPhase(stoppedBeans.get(3)));
-		assertEquals(1, getPhase(stoppedBeans.get(4)));
+		if (ignorePhaseOfDependencies) {
+			assertEquals(2, getPhase(stoppedBeans.get(1)));
+			assertEquals(bean2, stoppedBeans.get(1));
+			assertEquals(99, getPhase(stoppedBeans.get(2)));
+			assertEquals(bean99, stoppedBeans.get(2));
+			assertEquals(7, getPhase(stoppedBeans.get(3)));
+			assertEquals(1, getPhase(stoppedBeans.get(4)));
+		} else {
+			assertEquals(99, getPhase(stoppedBeans.get(1)));
+			assertEquals(bean99, stoppedBeans.get(1));
+			assertEquals(7, getPhase(stoppedBeans.get(2)));
+			assertEquals(bean7, stoppedBeans.get(2));
+			assertEquals(2, getPhase(stoppedBeans.get(3)));
+			assertEquals(1, getPhase(stoppedBeans.get(4)));
+		}
 		assertEquals(Integer.MIN_VALUE, getPhase(stoppedBeans.get(5)));
 	}
 


### PR DESCRIPTION
First stab at a fix this issue. For discussion see http://jira.springsource.org/browse/SPR-8941.
