### PR TITLE
[SPR-8347] use .equals() in place of == when comparing objects

### DIFF
--- a/org.springframework.beans/src/main/java/org/springframework/beans/ExtendedBeanInfo.java
+++ b/org.springframework.beans/src/main/java/org/springframework/beans/ExtendedBeanInfo.java
@@ -170,8 +170,8 @@ class ExtendedBeanInfo implements BeanInfo {
 						continue ALL_METHODS;
 					}
 				}
-				if (method == pd.getReadMethod()
-						|| (pd instanceof IndexedPropertyDescriptor && method == ((IndexedPropertyDescriptor) pd).getIndexedReadMethod())) {
+				if (method.equals(pd.getReadMethod())
+						|| (pd instanceof IndexedPropertyDescriptor && method.equals((IndexedPropertyDescriptor) pd).getIndexedReadMethod()))) {
 					// yes -> copy it, including corresponding setter method (if any -- may be null)
 					if (pd instanceof IndexedPropertyDescriptor) {
 						this.addOrUpdatePropertyDescriptor(pd, pd.getName(), pd.getReadMethod(), pd.getWriteMethod(), ((IndexedPropertyDescriptor)pd).getIndexedReadMethod(), ((IndexedPropertyDescriptor)pd).getIndexedWriteMethod());


### PR DESCRIPTION
isues on mac OS x and RHEL 6 method that was compared was not the same with == but was equal with .equals
propertyDescriptors were removed.
