### PR TITLE
SPR-9073 Added "ant resolve" to the top level

### DIFF
--- a/spring-build/multi-bundle/common.xml
+++ b/spring-build/multi-bundle/common.xml
@@ -48,6 +48,11 @@
 		<delete quiet="true" dir="${integration.repo.dir}"/>
 	</target>
 
+	<target name="resolve" 
+			description="Retrieves all external dependencies.">
+		<all-bundles target="resolve"/>
+	</target>
+
 	<target name="clean-ivy" depends="ivy.init"
 			description="Removes the ivy cache directory.">
 		<fail message="The 'ivy.cache.dir' property must be set on this project.">


### PR DESCRIPTION
With this change, you can call "ant **resolve**" in "build-springframework" directory.
This will download all dependencies into "ivy-cache/repository".

Background:
"ant **test**" requires the unit tests to be fully passing in order to download all dependency jar files.
So, for the first time IDE setting, when test fails, it causes compilation errors in IDE due to the lack of jar files.
https://jira.springsource.org/browse/SPR-9073

Thanks,
