### PR TITLE
Improved named parameter parsing of single quotes

### DIFF
--- a/org.springframework.jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
+++ b/org.springframework.jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
@@ -85,12 +85,18 @@ public abstract class NamedParameterUtils {
 		int escapes = 0;
 		int i = 0;
 		while (i < statement.length) {
-			int skipToPosition = skipCommentsAndQuotes(statement, i);
-			if (i != skipToPosition) {
-				if (skipToPosition >= statement.length) {
+			int skipToPosition = i;
+			while (i < statement.length) {
+				skipToPosition = skipCommentsAndQuotes(statement, i);
+				if (i == skipToPosition) {
 					break;
 				}
-				i = skipToPosition;
+				else {
+					i = skipToPosition;
+				}
+			}
+			if (i >= statement.length) {
+				break;
 			}
 			char c = statement[i];
 			if (c == ':' || c == '&') {

--- a/org.springframework.jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterUtilsTests.java
+++ b/org.springframework.jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterUtilsTests.java
@@ -268,4 +268,29 @@ public class NamedParameterUtilsTests {
 		assertEquals(expectedSql, newSql);
 	}
 
+	/*
+	 * SPR-8280
+	 */
+	@Test
+	public void parseSqlStatementWithQuotedSingleQuote() {
+		String sql = "SELECT ':foo'':doo', :xxx FROM DUAL";
+		ParsedSql psql = NamedParameterUtils.parseSqlStatement(sql);
+		assertEquals(1, psql.getTotalParameterCount());
+		assertEquals("xxx", psql.getParameterNames().get(0));
+	}
+
+	@Test
+	public void parseSqlStatementWithQuotesAndCommentBefore() {
+		String sql = "SELECT /*:doo*/':foo', :xxx FROM DUAL";
+		ParsedSql psql = NamedParameterUtils.parseSqlStatement(sql);
+		assertEquals(1, psql.getTotalParameterCount());
+		assertEquals("xxx", psql.getParameterNames().get(0));
+	}
+	@Test
+	public void parseSqlStatementWithQuotesAndCommentAfter() {
+		String sql2 = "SELECT ':foo'/*:doo*/, :xxx FROM DUAL";
+		ParsedSql psql2 = NamedParameterUtils.parseSqlStatement(sql2);
+		assertEquals(1, psql2.getTotalParameterCount());
+		assertEquals("xxx", psql2.getParameterNames().get(0));
+	}
 }


### PR DESCRIPTION
SPR-8280 Improving named parameter parsing where statement has escaped single quotes or comments are immediately before or after quoted literals
