### PR TITLE
set systemId on InputSource before parsing configuration

### DIFF
--- a/org.springframework.beans/src/main/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReader.java
+++ b/org.springframework.beans/src/main/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReader.java
@@ -18,6 +18,7 @@ package org.springframework.beans.factory.xml;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
@@ -325,9 +326,20 @@ public class XmlBeanDefinitionReader extends AbstractBeanDefinitionReader {
 					"Detected cyclic loading of " + encodedResource + " - check your import definitions!");
 		}
 		try {
-			InputStream inputStream = encodedResource.getResource().getInputStream();
+      Resource r = encodedResource.getResource();
+			InputStream inputStream = r.getInputStream();
 			try {
 				InputSource inputSource = new InputSource(inputStream);
+        // Try to set the systemId of the input source.
+        // This will make the baseURL property of dom nodes available.
+        try {
+          URL resourceUrl = r.getURL();
+          if (resourceUrl != null) {
+            inputSource.setSystemId(resourceUrl.toExternalForm());
+          }
+        } catch (IOException e) {
+          // ignore
+        }
 				if (encodedResource.getEncoding() != null) {
 					inputSource.setEncoding(encodedResource.getEncoding());
 				}

--- a/org.springframework.beans/src/main/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReader.java
+++ b/org.springframework.beans/src/main/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReader.java
@@ -18,7 +18,7 @@ package org.springframework.beans.factory.xml;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
@@ -333,9 +333,9 @@ public class XmlBeanDefinitionReader extends AbstractBeanDefinitionReader {
         // Try to set the systemId of the input source.
         // This will make the baseURL property of dom nodes available.
         try {
-          URL resourceUrl = r.getURL();
-          if (resourceUrl != null) {
-            inputSource.setSystemId(resourceUrl.toExternalForm());
+          URI resourceUri = r.getURI();
+          if (resourceUri != null) {
+            inputSource.setSystemId(resourceUri.toString());
           }
         } catch (IOException e) {
           // ignore

--- a/org.springframework.beans/src/test/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReaderTests.java
+++ b/org.springframework.beans/src/test/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReaderTests.java
@@ -22,6 +22,8 @@ import junit.framework.TestCase;
 import org.xml.sax.InputSource;
 
 import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
@@ -29,6 +31,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 
+import org.w3c.dom.Element;
 import test.beans.TestBean;
 
 /**
@@ -153,5 +156,25 @@ public class XmlBeanDefinitionReaderTests extends TestCase {
 		TestBean bean = (TestBean) factory.getBean("testBean");
 		assertNotNull(bean);
 	}
+  
+  public void testBaseURI() throws Exception {
+		SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();;
+		Resource resource = new ClassPathResource("testBaseUri.xml", getClass());
+    XmlBeanDefinitionReader definitionReader = new XmlBeanDefinitionReader(registry);
+    definitionReader.loadBeanDefinitions(resource);
+    BeanDefinition bd = registry.getBeanDefinition("test");
+    String value = (String)bd.getConstructorArgumentValues().getArgumentValue(0, String.class).getValue();
+    assertEquals(value, resource.getURI().toString());
+  }
+  
+  public static class TestBaseUriNamespaceHandler extends NamespaceHandlerSupport {
+    public void init() {
+      registerBeanDefinitionParser("test", new AbstractSingleBeanDefinitionParser() {
+        protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+          builder.addConstructorArgValue(element.getBaseURI());
+        }
+      });            
+    }
+  }
 
 }

--- a/org.springframework.beans/src/test/resources/META-INF/spring.handlers
+++ b/org.springframework.beans/src/test/resources/META-INF/spring.handlers
@@ -1,1 +1,2 @@
 http\://www.foo.com/schema/component=com.foo.ComponentNamespaceHandler
+testBaseUri=org.springframework.beans.factory.xml.XmlBeanDefinitionReaderTests$TestBaseUriNamespaceHandler

--- a/org.springframework.beans/src/test/resources/META-INF/spring.schemas
+++ b/org.springframework.beans/src/test/resources/META-INF/spring.schemas
@@ -1,1 +1,2 @@
 http\://www.foo.com/schema/component/component.xsd=com/foo/component.xsd
+http\://www.foo.com/testBaseUri.xsd=org/springframework/beans/factory/xml/testBaseUri.xsd

--- a/org.springframework.beans/src/test/resources/org/springframework/beans/factory/xml/testBaseUri.xml
+++ b/org.springframework.beans/src/test/resources/org/springframework/beans/factory/xml/testBaseUri.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:test="testBaseUri"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				testBaseUri http://www.foo.com/testBaseUri.xsd">
+
+	<test:test id="test"/>
+
+</beans>

--- a/org.springframework.beans/src/test/resources/org/springframework/beans/factory/xml/testBaseUri.xsd
+++ b/org.springframework.beans/src/test/resources/org/springframework/beans/factory/xml/testBaseUri.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<xsd:schema
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+         targetNamespace="testBaseUri"
+         elementFormDefault="qualified"
+         attributeFormDefault="unqualified">
+
+   <xsd:element name="test">
+      <xsd:complexType>
+         <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:complexType>
+   </xsd:element>
+
+</xsd:schema>


### PR DESCRIPTION
When the systemId is set then the baseURI property of the created w3c nodes is available. This would help to resolve relative resources (for example in custom NamespaceHandlers).
