### PR TITLE
Validation

### DIFF
--- a/spring-context/src/main/java/org/springframework/stereotype/Validator.java
+++ b/spring-context/src/main/java/org/springframework/stereotype/Validator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2007 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.stereotype;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that an annotated class is a "Validator".
+ * <p/>
+ * <p>This annotation serves as a specialization of {@link Component @Component},
+ * allowing for implementation classes to be autodetected through classpath scanning.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface Validator {
+
+	/**
+	 * The value may indicate a suggestion for a logical component name,
+	 * to be turned into a Spring bean in case of an autodetected component.
+	 *
+	 * @return the suggested component name, if any
+	 */
+	String value() default "";
+
+	Class<?> validates();
+}

--- a/spring-context/src/main/java/org/springframework/validation/annotation/AnnotationMethodValidator.java
+++ b/spring-context/src/main/java/org/springframework/validation/annotation/AnnotationMethodValidator.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.validation.annotation;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.stereotype.Validator;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.validation.Errors;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AnnotationMethodValidator implements org.springframework.validation.Validator,
+		ApplicationContextAware, InitializingBean {
+	private final Map<Class<?>, List<Object>> mappedValidators = new HashMap<Class<?>, List<Object>>();
+	private ApplicationContext applicationContext;
+
+	public AnnotationMethodValidator() {
+	}
+
+	public void afterPropertiesSet() throws Exception {
+		Map<String, Object> beanByName = applicationContext.getBeansWithAnnotation(Validator.class);
+
+		detectValidatedTypes(beanByName.values());
+	}
+
+	private void detectValidatedTypes(Collection<Object> beans) {
+		for (final Object validatorBean : beans) {
+			Validator annotation = AnnotationUtils.findAnnotation(validatorBean.getClass(), Validator.class);
+			Class<?> validatedType = annotation.validates();
+			addMappedValidator(validatedType, validatorBean);
+		}
+	}
+
+	private void addMappedValidator(Class<?> validatedType, Object validatorBean) {
+		if (mappedValidators.get(validatedType) == null) {
+			mappedValidators.put(validatedType, new ArrayList<Object>());
+		}
+		mappedValidators.get(validatedType).add(validatorBean);
+	}
+
+	public boolean supports(Class<?> cls) {
+		return mappedValidators.containsKey(cls);
+	}
+
+	public void validate(final Object target, final Errors errors) {
+		final Class<?> targetType = target.getClass();
+		List<Object> validators = mappedValidators.get(targetType);
+		if (validators != null) {
+			for (final Object validator : validators) {
+				ReflectionUtils.doWithMethods(validator.getClass(), new ReflectionUtils.MethodCallback() {
+					public void doWith(Method method) {
+						Validate validate = AnnotationUtils.findAnnotation(method, Validate.class);
+						if (validate != null) {
+							invokeValidateMethod(method, validator, target, errors);
+						}
+					}
+				});
+			}
+		}
+	}
+
+	private void invokeValidateMethod(Method method, Object validator, Object target, Errors errors) {
+		ReflectionUtils.makeAccessible(method);
+		try {
+			Object[] params = resolveValidatorParameters(method, validator, target, errors);
+			method.invoke(validator, params);
+		} catch (IllegalAccessException e) {
+			ReflectionUtils.rethrowRuntimeException(e);
+		} catch (InvocationTargetException e) {
+			ReflectionUtils.rethrowRuntimeException(e.getTargetException());
+		}
+	}
+
+	private Object[] resolveValidatorParameters(Method method, Object validator, Object target, Errors errors) {
+		Class<?>[] parameterTypes = method.getParameterTypes();
+		Object[] args = new Object[parameterTypes.length];
+
+		boolean foundErrorsArg = false;
+
+		for (int i = 0; i < parameterTypes.length; i++) {
+			Class<?> parameterType = parameterTypes[i];
+			if (target.getClass().equals(parameterType)) {
+				args[i] = target;
+			} else if (Errors.class.isAssignableFrom(parameterType)) {
+				args[i] = errors;
+				foundErrorsArg = true;
+			} else {
+				throw new IllegalArgumentException(buildInvalidMethodMessage(method, validator) +
+						"Expected method parameter types are " +
+						"[" + target.getClass().getName() + "] and " +
+						"[" + Errors.class.getName() + "]");
+			}
+		}
+
+		if (!foundErrorsArg) {
+			throw new IllegalArgumentException(buildInvalidMethodMessage(method, validator) +
+					"A parameter of type [" + Errors.class.getName() + "] is required.");
+		}
+
+		return args;
+	}
+
+	private String buildInvalidMethodMessage(Method method, Object object) {
+		String methodName = object.getClass().getName() + "." + method.getName();
+		return "Validation method [" + methodName + "] has an invalid signature. ";
+	}
+
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+}

--- a/spring-context/src/main/java/org/springframework/validation/annotation/Validate.java
+++ b/spring-context/src/main/java/org/springframework/validation/annotation/Validate.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2002-2007 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.validation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Validate {
+}

--- a/spring-context/src/test/java/org/springframework/validation/annotation/AnnotationMethodValidatorTest.java
+++ b/spring-context/src/test/java/org/springframework/validation/annotation/AnnotationMethodValidatorTest.java
@@ -1,0 +1,186 @@
+package org.springframework.validation.annotation;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.stereotype.Validator;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ObjectError;
+
+import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings({"ThrowableResultOfMethodCallIgnored"})
+public class AnnotationMethodValidatorTest {
+	private StaticApplicationContext context;
+
+	private AnnotationMethodValidator validator;
+
+	@Before
+	public void setUp() throws Exception {
+		context = new StaticApplicationContext();
+
+		validator = new AnnotationMethodValidator();
+	}
+
+	@Test
+	public void testSupportsWithNoRegisteredValidators() throws Exception {
+		initializeValidator();
+
+		assertFalse(validator.supports(String.class));
+		assertFalse(validator.supports(Object.class));
+		assertFalse(validator.supports(Integer.class));
+	}
+
+	@Test
+	public void testSupportsWithRegisteredValidator() throws Exception {
+		initializeValidatorWithRegistration();
+
+		assertTrue(validator.supports(String.class));
+		assertTrue(validator.supports(Object.class));
+		assertFalse(validator.supports(Integer.class));
+	}
+
+	@Test
+	public void testValidateWithUnvalidatedTarget() throws Exception {
+		initializeValidatorWithRegistration();
+
+		Integer target = 1;
+		BindException errors = invokeValidatorWithTarget(target);
+
+		assertEquals(0, errors.getErrorCount());
+	}
+
+	@Test
+	public void testValidateWithObjectTarget() throws Exception {
+		initializeValidatorWithRegistration();
+
+		Object target = new Object();
+		BindException errors = invokeValidatorWithTarget(target);
+
+		assertEquals(1, errors.getErrorCount());
+		assertErrorsContainsCodes(errors, "objectError");
+	}
+
+	@Test
+	public void testValidateWithStringTarget() throws Exception {
+		initializeValidatorWithRegistration();
+
+		String target = "test";
+		BindException errors = invokeValidatorWithTarget(target);
+
+		assertEquals(3, errors.getErrorCount());
+		assertErrorsContainsCodes(errors, "stringError1", "stringError2", "stringError3");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testValidateWithInvalidParameterType() throws Exception {
+		context.registerSingleton("badValidator", DummyInvalidParameterTypeValidator.class);
+		initializeValidatorWithRegistration();
+
+		String target = "test";
+		invokeValidatorWithTarget(target);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testValidateWithMissingErrorsParameter() throws Exception {
+		context.registerSingleton("badValidator", DummyMissingErrorsParameterValidator.class);
+		initializeValidatorWithRegistration();
+
+		String target = "test";
+		invokeValidatorWithTarget(target);
+	}
+
+	@Test(expected = UndeclaredThrowableException.class)
+	public void testValidateWithRuntimeException() throws Exception {
+		context.registerSingleton("badValidator", DummyExceptionThrowingValidator.class);
+		initializeValidatorWithRegistration();
+
+		String target = "test";
+		invokeValidatorWithTarget(target);
+	}
+
+	private BindException invokeValidatorWithTarget(Object target) {
+		BindException errors = new BindException(target, "target");
+		validator.validate(target, errors);
+		return errors;
+	}
+
+	private void initializeValidatorWithRegistration() throws Exception {
+		context.registerSingleton("objectValidator", DummyObjectValidator.class);
+		context.registerSingleton("stringValidator1", DummyStringValidator1.class);
+		context.registerSingleton("stringValidator2", DummyStringValidator2.class);
+		initializeValidator();
+	}
+
+	private void initializeValidator() throws Exception {
+		validator.setApplicationContext(context);
+		validator.afterPropertiesSet();
+	}
+
+	private void assertErrorsContainsCodes(Errors errors, String... codes) {
+		List<ObjectError> allErrors = errors.getAllErrors();
+		for (int i = 0; i < allErrors.size(); i++) {
+			assertEquals(codes[i], allErrors.get(i).getCode());
+		}
+	}
+}
+
+@Validator(validates = Object.class)
+class DummyObjectValidator {
+	@Validate
+	public void validateObject(Object obj, Errors errors) {
+		errors.reject("objectError");
+	}
+}
+
+@Validator(validates = String.class)
+class DummyStringValidator1 {
+	@Validate
+	private void validateString1(Errors errors) {
+		errors.reject("stringError1");
+	}
+}
+
+@Validator(validates = String.class)
+class DummyStringValidator2 {
+	@Validate
+	private void validateString2(String str, Errors errors) {
+		errors.reject("stringError2");
+	}
+
+	@Validate
+	private void validateString3(Errors errors, String str) {
+		errors.reject("stringError3");
+	}
+}
+
+@Validator(validates = String.class)
+class DummyInvalidParameterTypeValidator {
+	@Validate
+	private void invalidParameterType(Errors errors, Integer number) {
+	}
+}
+
+@Validator(validates = String.class)
+class DummyMissingErrorsParameterValidator {
+	@Validate
+	private void missingErrorsParameter(String str) {
+	}
+}
+
+@Validator(validates = String.class)
+class DummyExceptionThrowingValidator {
+	@Validate
+	private void throwException(String str, Errors errors) throws IOException {
+		throw new IOException("forced error");
+	}
+}
+


### PR DESCRIPTION
This pull request is in response to this Jira issue: https://jira.springsource.org/browse/SPR-4774. It enables the kind of Validator class shown in the example in the last comment on the issue. 

This code works great in a modified version of the PetClinic app I am using to test, by setting this AnnotationMethodValidator as the one system-level validator (i.e. by returning an object of this type from the getValidator() method of a config class that extends WebMvcConfigurerAdapter).

If an approach to validation like this one makes sense, then the next question is how to register this validation mechanism with the framework. In my opinion, registering both a LocalValidatorFactoryBean and an AnnotationMethodValidator by default would cover most validation needs in an application, reduce the need to configure custom validators in ConfigurableWebBindingInitializers or @InitBinder methods, and bring validation more in line with other parts of the framework that leverage component scanning and flexible method signatures to make it easier for developers to extend the framework. 

Unfortunately, the concept of a single validator class goes pretty deep into the framework (through the Java Config extension points to the DataBinder). It seems like it would be much more flexible for an app to be able to register multiple validators, similar to just about every other extension point (formatters, message converters, argument resolvers, handler exception resolvers, view resolvers, resource handlers, etc...). I have started to make all the changes to support registering a set of validators and defaulting, but I would like to get guidance and advice that this is the right approach before continuing. 
