### PR TITLE
Fix encoding issues in javadoc

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/OpMultiply.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/OpMultiply.java
@@ -25,7 +25,7 @@ import org.springframework.expression.spel.ExpressionState;
  * Implements the multiply operator. Conversions and promotions:
  * http://java.sun.com/docs/books/jls/third_edition/html/conversions.html Section 5.6.2:
  *
- * <p>If any of the operands is of a reference type, unboxing conversion (¤5.1.8) is performed. Then:<br>
+ * <p>If any of the operands is of a reference type, unboxing conversion (§5.1.8) is performed. Then:<br>
  * If either operand is of type double, the other is converted to double.<br>
  * Otherwise, if either operand is of type float, the other is converted to float.<br>
  * Otherwise, if either operand is of type long, the other is converted to long.<br>

--- a/spring-test/src/main/java/org/springframework/test/context/support/DelegatingSmartContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DelegatingSmartContextLoader.java
@@ -34,7 +34,7 @@ import org.springframework.util.ObjectUtils;
  * {@code DelegatingSmartContextLoader} is an implementation of the {@link SmartContextLoader}
  * SPI that delegates to a set of <em>candidate</em> SmartContextLoaders (i.e.,
  * {@link GenericXmlContextLoader} and {@link AnnotationConfigContextLoader}) to
- * determine which context loader is appropriate for a given test class’s configuration.
+ * determine which context loader is appropriate for a given test class's configuration.
  * Each candidate is given a chance to {@link #processContextConfiguration process} the
  * {@link ContextConfigurationAttributes} for each class in the test class hierarchy that
  * is annotated with {@link ContextConfiguration @ContextConfiguration}, and the candidate


### PR DESCRIPTION
Before this change javadoc in two classes had non-UTF-8 encoded
characters. This caused building Spring API to fail in Java 1.7.

Commit fixes this by replacing wrongly encoded characters with their
UTF-8 equivalents.

Issue: SPR-9097

I have signed and agree to the terms in the SpringSource Individual Contributor License Agreement.
