### PR TITLE
Small memory fixes

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -247,20 +247,28 @@ public class InitDestroyAnnotationBeanPostProcessor
 		public LifecycleMetadata(Class<?> targetClass, Collection<LifecycleElement> initMethods,
 				Collection<LifecycleElement> destroyMethods) {
 
-			this.initMethods = Collections.synchronizedSet(new LinkedHashSet<LifecycleElement>());
-			for (LifecycleElement element : initMethods) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Found init method on class [" + targetClass.getName() + "]: " + element);
+			if (!initMethods.isEmpty()) {
+				this.initMethods = Collections.synchronizedSet(new LinkedHashSet<LifecycleElement>(initMethods.size()));
+				for (LifecycleElement element : initMethods) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Found init method on class [" + targetClass.getName() + "]: " + element);
+					}
+					this.initMethods.add(element);
 				}
-				this.initMethods.add(element);
+			} else {
+				this.initMethods = Collections.emptySet();
 			}
 
-			this.destroyMethods = Collections.synchronizedSet(new LinkedHashSet<LifecycleElement>());
-			for (LifecycleElement element : destroyMethods) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Found destroy method on class [" + targetClass.getName() + "]: " + element);
+			if (!destroyMethods.isEmpty()) {
+				this.destroyMethods = Collections.synchronizedSet(new LinkedHashSet<LifecycleElement>(destroyMethods.size()));
+				for (LifecycleElement element : destroyMethods) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Found destroy method on class [" + targetClass.getName() + "]: " + element);
+					}
+					this.destroyMethods.add(element);
 				}
-				this.destroyMethods.add(element);
+			} else {
+				this.destroyMethods = Collections.emptySet();
 			}
 		}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,12 +54,17 @@ public class InjectionMetadata {
 
 
 	public InjectionMetadata(Class targetClass, Collection<InjectedElement> elements) {
-		this.injectedElements = Collections.synchronizedSet(new LinkedHashSet<InjectedElement>());
-		for (InjectedElement element : elements) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Found injected element on class [" + targetClass.getName() + "]: " + element);
+		if (!elements.isEmpty()) {
+			this.injectedElements = Collections.synchronizedSet(new LinkedHashSet<InjectedElement>(elements.size()));
+			for (InjectedElement element : elements) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Found injected element on class [" + targetClass.getName() + "]: " + element);
+				}
+				this.injectedElements.add(element);
 			}
-			this.injectedElements.add(element);
+			
+		} else {
+			this.injectedElements = Collections.emptySet();
 		}
 	}
 


### PR DESCRIPTION
We analysed the memory usage of our application and found a lot of empty LinkedHashSet/Collections.synchronizedSet in the following three cases:
- org.springframework.beans.factory.annotation.InjectionMetadata.injectedElements
- org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.LifecycleMetadata.initMethods
- org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.LifecycleMetadata.destroyMethods

This fix should address this issue by:
1. Creating a LinkedHashSet of the "right" size, eg. the default capacity is 16 but we know the exact capacity that we need in advance
2. If the argument is empty then we use Collections.emptySet() which is a constant so no additional memory is used. Since it's immutable we also save ourselves the Collections.synchronizedSet wrapper.

Should I additionally open an issue?
