### PR TITLE
Escape names of databound form tags

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/HtmlUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlUtils.java
@@ -63,6 +63,17 @@ public abstract class HtmlUtils {
 		StringBuilder escaped = new StringBuilder(input.length() * 2);
 		for (int i = 0; i < input.length(); i++) {
 			char character = input.charAt(i);
+			// avoid escaping escaped
+			if (character == HtmlCharacterEntityReferences.REFERENCE_START) {
+				int referenceEndIndex = input.indexOf(HtmlCharacterEntityReferences.REFERENCE_END, i);
+				if (referenceEndIndex != -1) {
+					String potentialEntityReference = input.substring(i+1, referenceEndIndex);
+					if (characterEntityReferences.convertToCharacter(potentialEntityReference) != HtmlCharacterEntityReferences.CHAR_NULL) {
+						escaped.append(character);
+						continue;
+					}
+				}
+			}
 			String reference = characterEntityReferences.convertToReference(character);
 			if (reference != null) {
 				escaped.append(reference);

--- a/spring-web/src/test/java/org/springframework/web/util/HtmlUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/HtmlUtilsTests.java
@@ -37,6 +37,14 @@ public class HtmlUtilsTests {
 		escaped = HtmlUtils.htmlEscapeHex(unescaped);
 		assertEquals("&#x22;This is a quote&#x27;", escaped);
 	}
+	
+	@Test
+	public void testHtmlEscapeEscaped() {
+		String unescaped = "\"This is a quote'";
+		String escaped = HtmlUtils.htmlEscape(unescaped);
+		escaped = HtmlUtils.htmlEscape(escaped);
+		assertEquals("&quot;This is a quote&#39;", escaped);
+	}
 
 	@Test
 	public void testHtmlUnescape() {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractDataBoundFormElementTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractDataBoundFormElementTag.java
@@ -161,7 +161,7 @@ public abstract class AbstractDataBoundFormElementTag extends AbstractFormTag im
 	 * @return the value for the HTML '<code>name</code>' attribute
 	 */
 	protected String getName() throws JspException {
-		return getPropertyPath();
+		return getDisplayString(getPropertyPath());
 	}
 
 	/**


### PR DESCRIPTION
Before this change, names of databound form tags
were not being escaped. This caused issues since
bound path and thus tag names could contain
special characters that have to be escaped to be
valid html. Names are now being always escaped.

For escaping strings a method from utility class
HtmlUtils is used. It had a bug too - when escaping
already escaped string it would wrongly escape
start character (&) of entities (e.g. &lt; would
get escaped to &amp;lt;). Fix for this bug is
also included in this commit.

Issue: SPR-5386

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
