### PR TITLE
Predict specific object type in EhCacheFactoryBean

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/ehcache/EhCacheFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/cache/ehcache/EhCacheFactoryBean.java
@@ -399,7 +399,24 @@ public class EhCacheFactoryBean implements FactoryBean<Ehcache>, BeanNameAware, 
 	}
 
 	public Class<? extends Ehcache> getObjectType() {
-		return (this.cache != null ? this.cache.getClass() : Ehcache.class);
+		if (this.cache != null) {
+			return this.cache.getClass();
+		}
+		
+		if (this.cacheEntryFactory != null) {
+			if (this.cacheEntryFactory instanceof UpdatingCacheEntryFactory) {
+				return UpdatingSelfPopulatingCache.class;
+			}
+			else {
+				return SelfPopulatingCache.class;
+			}
+		}
+		
+		if (this.blocking) {
+			return BlockingCache.class;
+		}
+		
+		return Cache.class;
 	}
 
 	public boolean isSingleton() {

--- a/spring-context/src/test/java/org/springframework/cache/ehcache/EhCacheSupportTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/ehcache/EhCacheSupportTests.java
@@ -82,7 +82,7 @@ public class EhCacheSupportTests extends TestCase {
 		EhCacheManagerFactoryBean cacheManagerFb = null;
 		try {
 			EhCacheFactoryBean cacheFb = new EhCacheFactoryBean();
-			assertEquals(Ehcache.class, cacheFb.getObjectType());
+			assertTrue(Ehcache.class.isAssignableFrom(cacheFb.getObjectType()));
 			assertTrue("Singleton property", cacheFb.isSingleton());
 			if (useCacheManagerFb) {
 				cacheManagerFb = new EhCacheManagerFactoryBean();


### PR DESCRIPTION
Prior to this change, before bean gets created by EhCacheFactoryBean,
its getObjectType would return only Ehcache interface. This caused
unwanted wiring issues like one described in related JIRA issue.
This fix makes use of EhCacheFactoryBean configuration to determine
object type even before it's created, so that container is provided
with as specific as possible object type when resolving dependencies.
Nevertheless, users are advised to code to Ehcache interface.

Issue: SPR-7843

I have signed and agree to the terms of SpringSource Individual Contributor License Agreement.
