### PR TITLE
Fix circular placeholder prevention

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/PropertyPlaceholderHelper.java
+++ b/spring-core/src/main/java/org/springframework/util/PropertyPlaceholderHelper.java
@@ -135,9 +135,10 @@ public class PropertyPlaceholderHelper {
 			int endIndex = findPlaceholderEndIndex(buf, startIndex);
 			if (endIndex != -1) {
 				String placeholder = buf.substring(startIndex + this.placeholderPrefix.length(), endIndex);
-				if (!visitedPlaceholders.add(placeholder)) {
+				String originalPlaceholder = placeholder;
+				if (!visitedPlaceholders.add(originalPlaceholder)) {
 					throw new IllegalArgumentException(
-							"Circular placeholder reference '" + placeholder + "' in property definitions");
+							"Circular placeholder reference '" + originalPlaceholder + "' in property definitions");
 				}
 				// Recursive invocation, parsing placeholders contained in the placeholder key.
 				placeholder = parseStringValue(placeholder, placeholderResolver, visitedPlaceholders);
@@ -173,7 +174,7 @@ public class PropertyPlaceholderHelper {
 					throw new IllegalArgumentException("Could not resolve placeholder '" + placeholder + "'");
 				}
 
-				visitedPlaceholders.remove(placeholder);
+				visitedPlaceholders.remove(originalPlaceholder);
 			}
 			else {
 				startIndex = -1;

--- a/spring-core/src/test/java/org/springframework/util/PropertyPlaceholderHelperTests.java
+++ b/spring-core/src/test/java/org/springframework/util/PropertyPlaceholderHelperTests.java
@@ -65,6 +65,16 @@ public class PropertyPlaceholderHelperTests {
 		props.setProperty("inner", "ar");
 
 		assertEquals("foo=bar", this.helper.replacePlaceholders(text, props));
+		
+		// SPR-5369
+		text = "${top}";
+		props = new Properties();
+		props.setProperty("top", "${child}+${child}");
+		props.setProperty("child", "${${differentiator}.grandchild}");
+		props.setProperty("differentiator", "first");
+		props.setProperty("first.grandchild", "actualValue");
+
+		assertEquals("actualValue+actualValue", this.helper.replacePlaceholders(text, props));
 	}
 
 	@Test


### PR DESCRIPTION
Set of resolved placeholder references is used for circular placeholder
prevention. For complex property definitions this mechanism would put
property values with unresolved inner placeholder references in the
set, but would try to remove property values with placeholders
resolved, leaving set in invalid state and mechanism broken.

This fix makes sure value that is put in set is same one that is
removed from it, and by this avoid false positives in reporting
circular placeholder.

Issue: SPR-5369

I have signed and agree to the terms in the SpringSource Individual Contributor License Agreement.
