### PR TITLE
Add support for creating test contexts with parent context

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/annotation/DirtiesContext.java
+++ b/spring-test/src/main/java/org/springframework/test/annotation/DirtiesContext.java
@@ -90,4 +90,11 @@ public @interface DirtiesContext {
 	 */
 	ClassMode classMode() default ClassMode.AFTER_CLASS;
 
+	/**
+	 * Close parent {@link org.springframework.context.ApplicationContext} as well as child contexts
+	 * which have same parent context.
+	 *
+	 * @since 3.2
+	 */
+	boolean parent() default false;
 }

--- a/spring-test/src/main/java/org/springframework/test/context/ContextCacheKey.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextCacheKey.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.io.Serializable;
+
+/**
+ * Key object to the {@link ContextCache}.
+ *
+ * Consists of two {@link MergedContextConfiguration}. one for current, and another for parent context.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.2
+ */
+class ContextCacheKey implements Serializable {
+
+	private static final long serialVersionUID = 2230287909396051971L;
+
+	private MergedContextConfiguration mergedContextConfiguration;
+
+	private MergedContextConfiguration parentMergedContextConfiguration;
+
+	ContextCacheKey(MergedContextConfiguration mergedContextConfiguration,
+			MergedContextConfiguration parentMergedContextConfiguration) {
+		this.mergedContextConfiguration = mergedContextConfiguration;
+		this.parentMergedContextConfiguration = parentMergedContextConfiguration;
+	}
+
+	public MergedContextConfiguration getMergedContextConfiguration() {
+		return mergedContextConfiguration;
+	}
+
+	public void setMergedContextConfiguration(MergedContextConfiguration mergedContextConfiguration) {
+		this.mergedContextConfiguration = mergedContextConfiguration;
+	}
+
+	public MergedContextConfiguration getParentMergedContextConfiguration() {
+		return parentMergedContextConfiguration;
+	}
+
+	public void setParentMergedContextConfiguration(MergedContextConfiguration parentMergedContextConfiguration) {
+		this.parentMergedContextConfiguration = parentMergedContextConfiguration;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ContextCacheKey key = (ContextCacheKey) o;
+
+		if (mergedContextConfiguration != null ? !mergedContextConfiguration.equals(key.mergedContextConfiguration) :
+				key.mergedContextConfiguration != null) {
+			return false;
+		}
+		if (parentMergedContextConfiguration != null ?
+				!parentMergedContextConfiguration.equals(key.parentMergedContextConfiguration) :
+				key.parentMergedContextConfiguration != null) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = mergedContextConfiguration != null ? mergedContextConfiguration.hashCode() : 0;
+		result = 31 * result +
+				(parentMergedContextConfiguration != null ? parentMergedContextConfiguration.hashCode() : 0);
+		return result;
+	}
+}

--- a/spring-test/src/main/java/org/springframework/test/context/ContextConfigurationAttributes.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextConfigurationAttributes.java
@@ -25,7 +25,7 @@ import org.springframework.util.ObjectUtils;
 /**
  * <code>ContextConfigurationAttributes</code> encapsulates the context 
  * configuration attributes declared on a test class via
- * {@link ContextConfiguration @ContextConfiguration}.
+ * {@link ContextConfiguration @ContextConfiguration} and {@link ParentContextConfiguration @ParentContextConfiguration}.
  * 
  * @author Sam Brannen
  * @since 3.1
@@ -55,11 +55,8 @@ public class ContextConfigurationAttributes {
 	 * 
 	 * @throws IllegalStateException if both the locations and value attributes have been declared
 	 */
-	private static String[] resolveLocations(Class<?> declaringClass, ContextConfiguration contextConfiguration) {
+	private static String[] resolveLocations(Class<?> declaringClass, String[] locations, String[] valueLocations) {
 		Assert.notNull(declaringClass, "declaringClass must not be null");
-
-		String[] locations = contextConfiguration.locations();
-		String[] valueLocations = contextConfiguration.value();
 
 		if (!ObjectUtils.isEmpty(valueLocations) && !ObjectUtils.isEmpty(locations)) {
 			String msg = String.format("Test class [%s] has been configured with @ContextConfiguration's 'value' %s "
@@ -84,8 +81,20 @@ public class ContextConfigurationAttributes {
 	 * @param contextConfiguration the annotation from which to retrieve the attributes 
 	 */
 	public ContextConfigurationAttributes(Class<?> declaringClass, ContextConfiguration contextConfiguration) {
-		this(declaringClass, resolveLocations(declaringClass, contextConfiguration), contextConfiguration.classes(),
-			contextConfiguration.inheritLocations(), contextConfiguration.loader());
+		this(declaringClass, resolveLocations(declaringClass, contextConfiguration.locations(), contextConfiguration.value())
+				, contextConfiguration.classes(), contextConfiguration.inheritLocations(), contextConfiguration.loader());
+	}
+
+	/**
+	 * Construct a new {@link ContextConfigurationAttributes} instance for the
+	 * supplied {@link ParentContextConfiguration @ParentContextConfiguration} annotation and
+	 * the {@link Class test class} that declared it.
+	 * @param declaringClass the test class that declared {@code @ParentContextConfiguration}
+	 * @param parentContextConfiguration the annotation from which to retrieve the attributes
+	 */
+	public ContextConfigurationAttributes(Class<?> declaringClass, ParentContextConfiguration parentContextConfiguration) {
+		this(declaringClass, resolveLocations(declaringClass, parentContextConfiguration.locations(), parentContextConfiguration.value())
+				, parentContextConfiguration.classes(), parentContextConfiguration.inheritLocations(), parentContextConfiguration.loader());
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/ContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextLoader.java
@@ -28,10 +28,10 @@ import org.springframework.context.ApplicationContext;
  *
  * <p>Clients of a ContextLoader should call
  * {@link #processLocations(Class,String...) processLocations()} prior to
- * calling {@link #loadContext(String...) loadContext()} in case the
+ * calling {@link #loadContext(ApplicationContext, String...) loadContext()} in case the
  * ContextLoader provides custom support for modifying or generating locations.
  * The results of {@link #processLocations(Class,String...) processLocations()}
- * should then be supplied to {@link #loadContext(String...) loadContext()}.
+ * should then be supplied to {@link #loadContext(ApplicationContext, String...) loadContext()}.
  *
  * <p>Concrete implementations must provide a <code>public</code> no-args
  * constructor.
@@ -80,10 +80,11 @@ public interface ContextLoader {
 	 * early, all context instances will be automatically closed on JVM
 	 * shutdown. This allows for freeing external resources held by beans within
 	 * the context, e.g. temporary files.
+	 * @param parentContext parent context. null if it doesn't have a parent.
 	 * @param locations the resource locations to use to load the application context
 	 * @return a new application context
 	 * @throws Exception if context loading failed
 	 */
-	ApplicationContext loadContext(String... locations) throws Exception;
+	ApplicationContext loadContext(ApplicationContext parentContext, String... locations) throws Exception;
 
 }

--- a/spring-test/src/main/java/org/springframework/test/context/MergedContextConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/MergedContextConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -28,8 +29,8 @@ import org.springframework.util.StringUtils;
 /**
  * {@code MergedContextConfiguration} encapsulates the <em>merged</em>
  * context configuration declared on a test class and all of its superclasses
- * via {@link ContextConfiguration @ContextConfiguration} and
- * {@link ActiveProfiles @ActiveProfiles}.
+ * via {@link ContextConfiguration @ContextConfiguration}, {@link ParentContextConfiguration @ParentContextConfiguration} 
+ * and {@link ActiveProfiles @ActiveProfiles}.
  * 
  * <p>Merged resource locations, configuration classes, and active profiles
  * represent all declared values in the test class hierarchy taking into
@@ -42,7 +43,7 @@ import org.springframework.util.StringUtils;
  * to load an {@link org.springframework.context.ApplicationContext ApplicationContext}.
  * 
  * <p>{@code MergedContextConfiguration} is also used by the {@link TestContext}
- * as the context cache key for caching an
+ * as the element of the context cache key({@link ContextCacheKey}) for caching an
  * {@link org.springframework.context.ApplicationContext ApplicationContext}
  * that was loaded using properties of this {@code MergedContextConfiguration}.
  * 
@@ -51,7 +52,7 @@ import org.springframework.util.StringUtils;
  * @see ContextConfiguration
  * @see ActiveProfiles
  * @see ContextConfigurationAttributes
- * @see SmartContextLoader#loadContext(MergedContextConfiguration)
+ * @see SmartContextLoader#loadContext(ApplicationContext, MergedContextConfiguration)
  */
 public class MergedContextConfiguration implements Serializable {
 

--- a/spring-test/src/main/java/org/springframework/test/context/ParentContextConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ParentContextConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.ApplicationContext;
+
+/**
+ * {@code ParentContextConfiguration} defines class-level metadata that is used to determine how to load and configure a
+ * <em>parent</em> {@link org.springframework.context.ApplicationContext ApplicationContext} for test classes.
+ *
+ * Test classes which have same {@link ParentContextConfiguration} configuration will share the same {@link
+ * ApplicationContext} as a parent.
+ *
+ * @author Tadaya Tsuyukubo
+ * @see ContextConfiguration
+ * @since 3.2
+ */
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ParentContextConfiguration {
+
+	/**
+	 * {@link org.springframework.test.context.ContextConfiguration#value()} for the parent {@link ApplicationContext}.
+	 *
+	 * @see org.springframework.test.context.ContextConfiguration#value()
+	 */
+	String[] value() default {};
+
+	/**
+	 * {@link org.springframework.test.context.ContextConfiguration#locations()} for the parent {@link
+	 * ApplicationContext}.
+	 *
+	 * @see org.springframework.test.context.ContextConfiguration#locations()
+	 */
+	String[] locations() default {};
+
+	/**
+	 * {@link org.springframework.test.context.ContextConfiguration#classes()} for the parent {@link ApplicationContext}.
+	 *
+	 * @see org.springframework.test.context.ContextConfiguration#classes()
+	 */
+	Class<?>[] classes() default {};
+
+	/**
+	 * {@link org.springframework.test.context.ContextConfiguration#inheritLocations()} for the parent {@link
+	 * ApplicationContext}.
+	 *
+	 * @see org.springframework.test.context.ContextConfiguration#inheritLocations()
+	 */
+	boolean inheritLocations() default true;
+
+	/**
+	 * {@link org.springframework.test.context.ContextConfiguration#loader()} for the parent {@link ApplicationContext}.
+	 *
+	 * @see org.springframework.test.context.ContextConfiguration#loader()
+	 */
+	Class<? extends ContextLoader> loader() default ContextLoader.class;
+}

--- a/spring-test/src/main/java/org/springframework/test/context/SmartContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/SmartContextLoader.java
@@ -27,19 +27,19 @@ import org.springframework.context.ApplicationContext;
  * either resource locations or configuration classes. Furthermore, a
  * {@code SmartContextLoader} can set active bean definition profiles in the
  * context that it loads (see {@link MergedContextConfiguration#getActiveProfiles()}
- * and {@link #loadContext(MergedContextConfiguration)}).
+ * and {@link #loadContext(ApplicationContext, MergedContextConfiguration)}).
  *
  * <p>Clients of a {@code SmartContextLoader} should call
  * {@link #processContextConfiguration(ContextConfigurationAttributes)
  * processContextConfiguration()} prior to calling
- * {@link #loadContext(MergedContextConfiguration) loadContext()}. This gives a
+ * {@link #loadContext(ApplicationContext, MergedContextConfiguration) loadContext()}. This gives a
  * {@code SmartContextLoader} the opportunity to provide custom support for
  * modifying resource locations or detecting default resource locations or 
  * default configuration classes. The results of
  * {@link #processContextConfiguration(ContextConfigurationAttributes)
  * processContextConfiguration()} should be merged for all classes in the
  * hierarchy of the root test class and then supplied to
- * {@link #loadContext(MergedContextConfiguration) loadContext()}.
+ * {@link #loadContext(ApplicationContext, MergedContextConfiguration) loadContext()}.
  * 
  * <p>Even though {@code SmartContextLoader} extends {@code ContextLoader},
  * clients should favor {@code SmartContextLoader}-specific methods over those
@@ -97,7 +97,7 @@ public interface SmartContextLoader extends ContextLoader {
 	 * {@link org.springframework.beans.factory.annotation.Autowired @Autowired},
 	 * {@link javax.annotation.Resource @Resource}, and
 	 * {@link javax.inject.Inject @Inject}. In addition, concrete implementations
-	 * should set the active bean definition profiles in the context's 
+	 * should set the active bean definition profiles in the context's
 	 * {@link org.springframework.core.env.Environment Environment}.
 	 * <p>Any <code>ApplicationContext</code> loaded by a
 	 * {@code SmartContextLoader} <strong>must</strong> register a JVM
@@ -105,6 +105,7 @@ public interface SmartContextLoader extends ContextLoader {
 	 * instances will be automatically closed on JVM shutdown. This allows for
 	 * freeing of external resources held by beans within the context (e.g.,
 	 * temporary files).
+	 * @param parentApplicationContext parent application context. null if it doesn't have a parent.
 	 * @param mergedConfig the merged context configuration to use to load the
 	 * application context
 	 * @return a new application context
@@ -114,6 +115,6 @@ public interface SmartContextLoader extends ContextLoader {
 	 * @see org.springframework.test.context.MergedContextConfiguration#getActiveProfiles()
 	 * @see org.springframework.context.ConfigurableApplicationContext#getEnvironment()
 	 */
-	ApplicationContext loadContext(MergedContextConfiguration mergedConfig) throws Exception;
+	ApplicationContext loadContext(ApplicationContext parentApplicationContext, MergedContextConfiguration mergedConfig) throws Exception;
 
 }

--- a/spring-test/src/main/java/org/springframework/test/context/support/DelegatingSmartContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DelegatingSmartContextLoader.java
@@ -208,12 +208,13 @@ public class DelegatingSmartContextLoader implements SmartContextLoader {
 	 * {@code AnnotationConfigContextLoader} will load the {@code ApplicationContext}.</li>
 	 * </ul>
 	 * 
+	 * @param parentApplicationContext the parent application context. null if no parent is specified.
 	 * @param mergedConfig the merged context configuration to use to load the application context
 	 * @throws IllegalArgumentException if the supplied merged configuration is <code>null</code>
 	 * @throws IllegalStateException if neither candidate loader is capable of loading an
 	 * {@code ApplicationContext} from the supplied merged context configuration
 	 */
-	public ApplicationContext loadContext(MergedContextConfiguration mergedConfig) throws Exception {
+	public ApplicationContext loadContext(ApplicationContext parentApplicationContext, MergedContextConfiguration mergedConfig) throws Exception {
 		Assert.notNull(mergedConfig, "mergedConfig must not be null");
 
 		List<SmartContextLoader> candidates = Arrays.asList(xmlLoader, annotationConfigLoader);
@@ -225,7 +226,7 @@ public class DelegatingSmartContextLoader implements SmartContextLoader {
 				if (logger.isDebugEnabled()) {
 					logger.debug(String.format("Delegating to %s to load context from %s.", name(loader), mergedConfig));
 				}
-				return loader.loadContext(mergedConfig);
+				return loader.loadContext(parentApplicationContext, mergedConfig);
 			}
 		}
 
@@ -249,11 +250,11 @@ public class DelegatingSmartContextLoader implements SmartContextLoader {
 
 	/**
 	 * {@code DelegatingSmartContextLoader} does not support the
-	 * {@link ContextLoader#loadContext(String...) } method. Call
-	 * {@link #loadContext(MergedContextConfiguration)} instead.
+	 * {@link ContextLoader#loadContext(ApplicationContext, String...) } method. Call
+	 * {@link #loadContext(ApplicationContext, MergedContextConfiguration)} instead.
 	 * @throws UnsupportedOperationException
 	 */
-	public ApplicationContext loadContext(String... locations) throws Exception {
+	public ApplicationContext loadContext(ApplicationContext parentApplicationContext, String... locations) throws Exception {
 		throw new UnsupportedOperationException("DelegatingSmartContextLoader does not support the ContextLoader SPI. "
 				+ "Call loadContext(MergedContextConfiguration) instead.");
 	}

--- a/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
@@ -45,13 +45,13 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 	/**
 	 * Marks the {@link ApplicationContext application context} of the supplied
 	 * {@link TestContext test context} as
-	 * {@link TestContext#markApplicationContextDirty() dirty}, and sets the
+	 * {@link TestContext#markApplicationContextDirty(boolean) dirty}, and sets the
 	 * {@link DependencyInjectionTestExecutionListener#REINJECT_DEPENDENCIES_ATTRIBUTE
 	 * REINJECT_DEPENDENCIES_ATTRIBUTE} in the test context to <code>true</code>
 	 * .
 	 */
-	protected void dirtyContext(TestContext testContext) {
-		testContext.markApplicationContextDirty();
+	protected void dirtyContext(TestContext testContext, boolean dirtyParent) {
+		testContext.markApplicationContextDirty(dirtyParent);
 		testContext.setAttribute(DependencyInjectionTestExecutionListener.REINJECT_DEPENDENCIES_ATTRIBUTE, Boolean.TRUE);
 	}
 
@@ -63,7 +63,7 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 	 * mode} is set to {@link ClassMode#AFTER_EACH_TEST_METHOD
 	 * AFTER_EACH_TEST_METHOD}, the {@link ApplicationContext application
 	 * context} of the test context will be
-	 * {@link TestContext#markApplicationContextDirty() marked as dirty} and the
+	 * {@link TestContext#markApplicationContextDirty(boolean) marked as dirty} and the
 	 * {@link DependencyInjectionTestExecutionListener#REINJECT_DEPENDENCIES_ATTRIBUTE
 	 * REINJECT_DEPENDENCIES_ATTRIBUTE} in the test context will be set to
 	 * <code>true</code>.
@@ -88,16 +88,22 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 					+ methodDirtiesContext + "].");
 		}
 
-		if (methodDirtiesContext || (classDirtiesContext && classMode == ClassMode.AFTER_EACH_TEST_METHOD)) {
-			dirtyContext(testContext);
+		if (methodDirtiesContext) {
+			boolean dirtiesParent = testMethod.getAnnotation(DirtiesContext.class).parent();
+			dirtyContext(testContext, dirtiesParent);
 		}
+		else if (classMode == ClassMode.AFTER_EACH_TEST_METHOD) {
+			boolean dirtiesParent = classDirtiesContextAnnotation.parent();
+			dirtyContext(testContext, dirtiesParent);
+		}
+
 	}
 
 	/**
 	 * If the test class of the supplied {@link TestContext test context} is
 	 * annotated with {@link DirtiesContext &#064;DirtiesContext}, the
 	 * {@link ApplicationContext application context} of the test context will
-	 * be {@link TestContext#markApplicationContextDirty() marked as dirty} ,
+	 * be {@link TestContext#markApplicationContextDirty(boolean) marked as dirty} ,
 	 * and the
 	 * {@link DependencyInjectionTestExecutionListener#REINJECT_DEPENDENCIES_ATTRIBUTE
 	 * REINJECT_DEPENDENCIES_ATTRIBUTE} in the test context will be set to
@@ -113,7 +119,8 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 			logger.debug("After test class: context [" + testContext + "], dirtiesContext [" + dirtiesContext + "].");
 		}
 		if (dirtiesContext) {
-			dirtyContext(testContext);
+			boolean dirtiesParent = testClass.getAnnotation(DirtiesContext.class).parent();
+			dirtyContext(testContext, dirtiesParent);
 		}
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/context/ContextCacheKeyEqualityTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextCacheKeyEqualityTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.junit.runners.Parameterized.*;
+
+/**
+ * Verify the equality of {@link ContextCacheKey} class instances.
+ *
+ * {@link ContextCacheKey} is used as a key of {@link ContextCache}, so equality of {@link ContextCacheKey} is
+ * important.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.2
+ */
+@RunWith(Parameterized.class)
+public class ContextCacheKeyEqualityTests {
+
+	private boolean expectEqual;
+
+	private ContextCacheKey leftKey;
+
+	private ContextCacheKey rightKey;
+
+	public ContextCacheKeyEqualityTests(boolean expectEqual, ContextCacheKey leftKey, ContextCacheKey rightKey) {
+		this.expectEqual = expectEqual;
+		this.leftKey = leftKey;
+		this.rightKey = rightKey;
+	}
+
+	@Parameters
+	public static Collection<Object[]> getData() {
+		MergedContextConfiguration foo =
+				new MergedContextConfiguration(ContextCacheKeyEqualityTests.class, new String[]{}, new Class<?>[]{},
+						new String[]{}, null);
+		MergedContextConfiguration bar =
+				new MergedContextConfiguration(ContextCacheKeyEqualityTests.class, new String[]{}, new Class<?>[]{},
+						new String[]{}, null);
+		MergedContextConfiguration baz =
+				new MergedContextConfiguration(ContextCacheKeyEqualityTests.class, new String[]{"different"}, new Class<?>[]{},
+						new String[]{}, null);
+
+		assertThat(foo, equalTo(bar));
+		assertThat(bar, equalTo(foo));
+		assertThat(baz, not(equalTo(foo)));
+		assertThat(baz, not(equalTo(bar)));
+
+		// foo == bar != baz
+		return Arrays.asList(new Object[][]{
+
+				// expect to be equal, left cache key, right cache key
+				{true, new ContextCacheKey(foo, null), new ContextCacheKey(foo, null)},
+				{true, new ContextCacheKey(foo, null), new ContextCacheKey(bar, null)},
+				{true, new ContextCacheKey(foo, bar), new ContextCacheKey(foo, bar)},
+				{true, new ContextCacheKey(foo, bar), new ContextCacheKey(bar, foo)},
+				{true, new ContextCacheKey(null, null), new ContextCacheKey(null, null)},
+
+				{false, new ContextCacheKey(foo, null), new ContextCacheKey(baz, null)},
+				{false, new ContextCacheKey(foo, bar), new ContextCacheKey(foo, baz)},});
+	}
+
+	@Test
+	public void testEquality() {
+		if (expectEqual) {
+			assertThat(leftKey, equalTo(rightKey));
+		}
+		else {
+			assertThat(leftKey, not(equalTo(rightKey)));
+		}
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsTests.java
@@ -87,12 +87,12 @@ public class ContextLoaderUtilsTests {
 
 	@Test(expected = IllegalStateException.class)
 	public void resolveContextConfigurationAttributesWithConflictingLocations() {
-		ContextLoaderUtils.resolveContextConfigurationAttributes(ConflictingLocations.class);
+		ContextLoaderUtils.resolveContextConfigurationAttributes(ContextConfiguration.class, ConflictingLocations.class);
 	}
 
 	@Test
 	public void resolveContextConfigurationAttributesWithBareAnnotations() {
-		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(BareAnnotations.class);
+		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(ContextConfiguration.class, BareAnnotations.class);
 		assertNotNull(attributesList);
 		assertEquals(1, attributesList.size());
 		assertAttributes(attributesList.get(0), BareAnnotations.class, EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY,
@@ -101,7 +101,7 @@ public class ContextLoaderUtilsTests {
 
 	@Test
 	public void resolveContextConfigurationAttributesWithLocalAnnotationAndLocations() {
-		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(LocationsFoo.class);
+		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(ContextConfiguration.class, LocationsFoo.class);
 		assertNotNull(attributesList);
 		assertEquals(1, attributesList.size());
 		assertLocationsFooAttributes(attributesList.get(0));
@@ -109,7 +109,7 @@ public class ContextLoaderUtilsTests {
 
 	@Test
 	public void resolveContextConfigurationAttributesWithLocalAnnotationAndClasses() {
-		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(ClassesFoo.class);
+		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(ContextConfiguration.class, ClassesFoo.class);
 		assertNotNull(attributesList);
 		assertEquals(1, attributesList.size());
 		assertClassesFooAttributes(attributesList.get(0));
@@ -117,7 +117,7 @@ public class ContextLoaderUtilsTests {
 
 	@Test
 	public void resolveContextConfigurationAttributesWithLocalAndInheritedAnnotationsAndLocations() {
-		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(LocationsBar.class);
+		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(ContextConfiguration.class, LocationsBar.class);
 		assertNotNull(attributesList);
 		assertEquals(2, attributesList.size());
 		assertLocationsFooAttributes(attributesList.get(0));
@@ -126,7 +126,7 @@ public class ContextLoaderUtilsTests {
 
 	@Test
 	public void resolveContextConfigurationAttributesWithLocalAndInheritedAnnotationsAndClasses() {
-		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(ClassesBar.class);
+		List<ContextConfigurationAttributes> attributesList = ContextLoaderUtils.resolveContextConfigurationAttributes(ContextConfiguration.class, ClassesBar.class);
 		assertNotNull(attributesList);
 		assertEquals(2, attributesList.size());
 		assertClassesFooAttributes(attributesList.get(0));
@@ -135,13 +135,13 @@ public class ContextLoaderUtilsTests {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void buildMergedContextConfigurationWithoutAnnotation() {
-		ContextLoaderUtils.buildMergedContextConfiguration(Enigma.class, null);
+		ContextLoaderUtils.buildMergedContextConfiguration(ContextConfiguration.class, Enigma.class, null);
 	}
 
 	@Test
 	public void buildMergedContextConfigurationWithBareAnnotations() {
 		Class<BareAnnotations> testClass = BareAnnotations.class;
-		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(testClass, null);
+		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(ContextConfiguration.class, testClass, null);
 
 		assertMergedContextConfiguration(
 			mergedConfig,
@@ -153,7 +153,7 @@ public class ContextLoaderUtilsTests {
 	@Test
 	public void buildMergedContextConfigurationWithLocalAnnotationAndLocations() {
 		Class<?> testClass = LocationsFoo.class;
-		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(testClass, null);
+		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(ContextConfiguration.class, testClass, null);
 
 		assertMergedContextConfiguration(mergedConfig, testClass, new String[] { "classpath:/foo.xml" },
 			EMPTY_CLASS_ARRAY, DelegatingSmartContextLoader.class);
@@ -162,7 +162,7 @@ public class ContextLoaderUtilsTests {
 	@Test
 	public void buildMergedContextConfigurationWithLocalAnnotationAndClasses() {
 		Class<?> testClass = ClassesFoo.class;
-		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(testClass, null);
+		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(ContextConfiguration.class, testClass, null);
 
 		assertMergedContextConfiguration(mergedConfig, testClass, EMPTY_STRING_ARRAY,
 			new Class<?>[] { FooConfig.class }, DelegatingSmartContextLoader.class);
@@ -172,7 +172,7 @@ public class ContextLoaderUtilsTests {
 	public void buildMergedContextConfigurationWithLocalAnnotationAndOverriddenContextLoaderAndLocations() {
 		Class<?> testClass = LocationsFoo.class;
 		Class<? extends ContextLoader> expectedContextLoaderClass = GenericPropertiesContextLoader.class;
-		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(testClass,
+		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(ContextConfiguration.class, testClass,
 			expectedContextLoaderClass.getName());
 
 		assertMergedContextConfiguration(mergedConfig, testClass, new String[] { "classpath:/foo.xml" },
@@ -183,7 +183,7 @@ public class ContextLoaderUtilsTests {
 	public void buildMergedContextConfigurationWithLocalAnnotationAndOverriddenContextLoaderAndClasses() {
 		Class<?> testClass = ClassesFoo.class;
 		Class<? extends ContextLoader> expectedContextLoaderClass = GenericPropertiesContextLoader.class;
-		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(testClass,
+		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(ContextConfiguration.class, testClass,
 			expectedContextLoaderClass.getName());
 
 		assertMergedContextConfiguration(mergedConfig, testClass, EMPTY_STRING_ARRAY,
@@ -195,7 +195,7 @@ public class ContextLoaderUtilsTests {
 		Class<?> testClass = LocationsBar.class;
 		String[] expectedLocations = new String[] { "/foo.xml", "/bar.xml" };
 
-		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(testClass, null);
+		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(ContextConfiguration.class, testClass, null);
 		assertMergedContextConfiguration(mergedConfig, testClass, expectedLocations, EMPTY_CLASS_ARRAY,
 			AnnotationConfigContextLoader.class);
 	}
@@ -205,7 +205,7 @@ public class ContextLoaderUtilsTests {
 		Class<?> testClass = ClassesBar.class;
 		Class<?>[] expectedClasses = new Class<?>[] { FooConfig.class, BarConfig.class };
 
-		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(testClass, null);
+		MergedContextConfiguration mergedConfig = ContextLoaderUtils.buildMergedContextConfiguration(ContextConfiguration.class, testClass, null);
 		assertMergedContextConfiguration(mergedConfig, testClass, EMPTY_STRING_ARRAY, expectedClasses,
 			AnnotationConfigContextLoader.class);
 	}

--- a/spring-test/src/test/java/org/springframework/test/context/DirtiesContextParentTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/DirtiesContextParentTests.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.JUnitCoreUtils;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.junit.matchers.JUnitMatchers.*;
+
+/**
+ * Test to verify {@link DirtiesContext} parent=true closes parent context as well as child contexts which share the same
+ * parent context.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.2
+ */
+public class DirtiesContextParentTests {
+
+	private static Map<Class<? extends BaseTestClass>, ApplicationContext> map =
+			new HashMap<Class<? extends BaseTestClass>, ApplicationContext>();
+
+	/**
+	 * {@link @Before} annotation is required. Gradle test task also runs test classes defined as static in this class.
+	 * so before running the actual tests, need to cleanup the map.
+	 */
+	@Before
+	@After
+	public void cleanUp() {
+		map.clear(); // release hard reference to the app context
+	}
+
+	@Test
+	public void testClassLevelDirtiesContextWithParentTrue() {
+
+		JUnitCore jUnitCore = new JUnitCore();
+		// expects test class runs in this order...
+		Result result = jUnitCore.run(ClassLevelTestFoo.class, ClassLevelTestBar.class, ClassLevelTestBaz.class);
+		JUnitCoreUtils.verifyResult(result);
+
+		assertThat(map.size(), is(3));
+		assertThat(map.keySet(), hasItems(ClassLevelTestFoo.class, ClassLevelTestBar.class, ClassLevelTestBaz.class));
+
+		ConfigurableApplicationContext fooContext = (ConfigurableApplicationContext) map.get(ClassLevelTestFoo.class);
+		ConfigurableApplicationContext barContext = (ConfigurableApplicationContext) map.get(ClassLevelTestBar.class);
+		ConfigurableApplicationContext bazContext = (ConfigurableApplicationContext) map.get(ClassLevelTestBaz.class);
+
+		verifyAppContext(fooContext, true, true);
+		verifyAppContext(barContext, true, true);
+		verifyAppContext(bazContext, false, false);
+
+	}
+
+	@Test
+	public void testMethodLevelDirtiesContextWithParentTrue() {
+
+		JUnitCore jUnitCore = new JUnitCore();
+		// expects test class runs in this order...
+		Result result = jUnitCore.run(MethodLevelTestFoo.class, MethodLevelTestBar.class, MethodLevelTestBaz.class);
+		JUnitCoreUtils.verifyResult(result);
+
+		assertThat(map.size(), is(3));
+		assertThat(map.keySet(),
+				hasItems(MethodLevelTestFoo.class, MethodLevelTestBar.class, MethodLevelTestBaz.class));
+
+		ConfigurableApplicationContext fooContext = (ConfigurableApplicationContext) map.get(MethodLevelTestFoo.class);
+		ConfigurableApplicationContext barContext = (ConfigurableApplicationContext) map.get(MethodLevelTestBar.class);
+		ConfigurableApplicationContext bazContext = (ConfigurableApplicationContext) map.get(MethodLevelTestBaz.class);
+
+		verifyAppContext(fooContext, true, true);
+		verifyAppContext(barContext, true, true);
+		verifyAppContext(bazContext, false, false);
+	}
+
+	private void verifyAppContext(ConfigurableApplicationContext context, boolean isClosed, boolean isParentClosed) {
+		final boolean isActive = !isClosed;
+		final boolean isParentActive = !isParentClosed;
+
+		assertThat("context is null.", context, notNullValue());
+
+		ConfigurableApplicationContext parentContext = (ConfigurableApplicationContext) context.getParent();
+		assertThat("context is null.", parentContext, notNullValue());
+
+		assertThat("child context is active(not closed)", context.isActive(), equalTo(isActive));
+		assertThat("parent context is active(not closed)", parentContext.isActive(), equalTo(isParentActive));
+
+	}
+
+	@RunWith(SpringJUnit4ClassRunner.class)
+	@ParentContextConfiguration(classes = {Config.class})
+	@ContextConfiguration(classes = {Config.class})
+	public static abstract class BaseTestClass {
+
+		@Autowired
+		protected ApplicationContext applicationContext;
+
+	}
+
+	/** share the same parent context. */
+	public static class ClassLevelTestFoo extends BaseTestClass {
+
+		@Test
+		public void testFoo() {
+			map.put(getClass(), applicationContext);
+		}
+	}
+
+	/**
+	 * share the same parent context.
+	 *
+	 * DirtiesContext is set with parent=true. After running this test class, child contexts sharing the parent context and
+	 * parent context will be closed.
+	 */
+	@DirtiesContext(parent = true)
+	public static class ClassLevelTestBar extends BaseTestClass {
+
+		@Test
+		public void testBar() {
+			map.put(getClass(), applicationContext);
+		}
+
+	}
+
+	/** share the same parent context. */
+	public static class ClassLevelTestBaz extends BaseTestClass {
+
+		@Test
+		public void testBaz() {
+			map.put(getClass(), applicationContext);
+		}
+	}
+
+	/** share the same parent context. */
+	public static class MethodLevelTestFoo extends BaseTestClass {
+
+		@Test
+		public void testFoo() {
+			map.put(getClass(), applicationContext);
+		}
+	}
+
+	/**
+	 * share the same parent context.
+	 *
+	 * DirtiesContext is set with parent=true on the method.
+	 */
+	public static class MethodLevelTestBar extends BaseTestClass {
+
+		@Test
+		@DirtiesContext(parent = true)
+		public void testBar() {
+			map.put(getClass(), applicationContext);
+		}
+
+	}
+
+	/** share the same parent context. */
+	public static class MethodLevelTestBaz extends BaseTestClass {
+
+		@Test
+		public void testBaz() {
+			map.put(getClass(), applicationContext);
+		}
+	}
+
+	@Configuration
+	public static class Config {
+
+		@Bean
+		public String bean() {
+			return "bean";
+		}
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/ParentBeanAutoInjectionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ParentBeanAutoInjectionTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static junit.framework.Assert.*;
+import static org.springframework.test.context.ParentBeanAutoInjectionTests.*;
+
+/**
+ * Verify the bean injection from parent context.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.2
+ */
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ParentContextConfiguration(classes = {ParentConfig.class})
+@ContextConfiguration(classes = {ChildConfig.class})
+public class ParentBeanAutoInjectionTests {
+
+	@Autowired
+	@Qualifier("foo")
+	public String foo;
+
+	@Autowired
+	@Qualifier("bar")
+	public String bar;
+
+	/** verify a bean defined in parent app context gets injected into the test class. */
+	@Test
+	public void testParentDefinedBeanInjection() {
+
+		assertNotNull("bean foo(defined in parent context) must be injected", foo);
+		assertEquals("FOO", foo);
+
+		assertNotNull("bean bar(defined in child context) must be injected", bar);
+		assertEquals("BAR", bar);
+	}
+
+	@Configuration
+	public static class ParentConfig {
+
+		@Bean
+		public String foo() {
+			return "FOO";
+		}
+	}
+
+	@Configuration
+	public static class ChildConfig {
+
+		@Bean
+		public String bar() {
+			return "BAR";
+		}
+
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/ParentBeanReferenceTests-context.xml
+++ b/spring-test/src/test/java/org/springframework/test/context/ParentBeanReferenceTests-context.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        ">
+
+  <!--
+    Child ApplicationContext definition.
+
+    childBean has reference to the parentBean which is defined in parent application context.
+  -->
+
+	<bean id="childBean" class="org.springframework.test.context.ParentBeanReferenceTests$ChildBean">
+    <property name="parentBean" ref="parentBean"/>
+  </bean>
+
+</beans>

--- a/spring-test/src/test/java/org/springframework/test/context/ParentBeanReferenceTests-parent-context.xml
+++ b/spring-test/src/test/java/org/springframework/test/context/ParentBeanReferenceTests-parent-context.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        ">
+
+  <!-- Parent ApplicationContext definition -->
+
+	<bean id="parentBean" class="org.springframework.test.context.ParentBeanReferenceTests$ParentBean"/>
+
+</beans>

--- a/spring-test/src/test/java/org/springframework/test/context/ParentBeanReferenceTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ParentBeanReferenceTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.JUnitCoreUtils;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test parent application context reference from child application context.
+ *
+ * Child application context has a bean definition that references a bean that is defined in the parent application
+ * context.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.2
+ */
+
+public class ParentBeanReferenceTests {
+
+	@Test
+	public void testBeanReference() {
+		JUnitCore jUnitCore = new JUnitCore();
+		Result testResult = jUnitCore.run(ReferenceTests.class);
+		JUnitCoreUtils.verifyResult(testResult);
+	}
+
+	@RunWith(SpringJUnit4ClassRunner.class)
+	@ParentContextConfiguration("ParentBeanReferenceTests-parent-context.xml")
+	@ContextConfiguration("ParentBeanReferenceTests-context.xml")
+	public static final class ReferenceTests {
+
+		@Autowired
+		private ApplicationContext applicationContext;
+
+		@Test
+		public void testBeanReference() {
+			assertNotNull("applicationContext must be injected.", applicationContext);
+
+			assertTrue("ChildBean must exist in child app context.", applicationContext.containsLocalBean("childBean"));
+			assertFalse("ParentBean must NOT exist in child app context.",
+					applicationContext.containsLocalBean("parentBean"));
+
+			ApplicationContext parentContext = applicationContext.getParent();
+			assertNotNull("Parent App Context must exist", parentContext);
+			assertFalse("ChildBean must NOT exist in parent app context.",
+					parentContext.containsLocalBean("childBean"));
+			assertTrue("ParentBean must exist in parent app context.", parentContext.containsLocalBean("parentBean"));
+
+			ChildBean childBean = applicationContext.getBean("childBean", ChildBean.class);
+			ParentBean parentBean = parentContext.getBean("parentBean", ParentBean.class);
+			assertSame("Child bean must have injected parent bean.", parentBean, childBean.parentBean);
+
+		}
+
+	}
+
+	/** defined in ParentBeanReferenceTests-parent-context.xml. */
+	public static final class ParentBean {
+
+	}
+
+	/** defined in ParentBeanReferenceTests-context.xml. */
+	public static final class ChildBean {
+
+		public ParentBean parentBean;
+
+		public void setParentBean(ParentBean parentBean) {
+			this.parentBean = parentBean;
+		}
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/ParentContextConfigurationTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ParentContextConfigurationTests.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.JUnitCoreUtils;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.junit.runners.Parameterized.*;
+
+/**
+ * Verify the parent context exists when test class is annotated with {@link ParentContextConfiguration}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.2
+ */
+@RunWith(Parameterized.class)
+public class ParentContextConfigurationTests {
+
+	private Class<? extends Test> testClass;
+
+	@Parameters
+	public static Collection<Object[]> classesToTestData() {
+		return Arrays.asList(new Object[][]{{ChildWithAnnotationExtendingAnnotatedParentTestClass.class},
+				{ChildWithoutAnnotationExtendingAnnotatedParentTestClass.class},
+				{ChildWithAnnotationExtendingNonAnnotatedParentTestClass.class},
+				{ChildWithoutAnnotationExtendingNonAnnotatedParentTestClass.class},});
+	}
+
+	public ParentContextConfigurationTests(Class<? extends Test> testClass) {
+		this.testClass = testClass;
+	}
+
+	@Test
+	public void testParentContext() {
+		JUnitCore jUnitCore = new JUnitCore();
+		Result result = jUnitCore.run(testClass);
+		JUnitCoreUtils.verifyResult(result);
+	}
+
+	@RunWith(SpringJUnit4ClassRunner.class)
+	@ContextConfiguration(classes = {ChildConfig.class})
+	public static abstract class BaseTestClass {
+
+		@Autowired
+		protected ApplicationContext applicationContext;
+
+	}
+
+	/** parent test class which does NOT have annotation. */
+	public static abstract class ParentWithoutAnnotationTestClass extends BaseTestClass {
+
+	}
+
+	/** parent test class which has annotation. */
+	@ParentContextConfiguration(classes = {ParentConfig.class})
+	public static abstract class ParentWithAnnotationTestClass extends BaseTestClass {
+
+	}
+
+	/** child has annotation, parent has annotation. */
+	@ParentContextConfiguration(classes = {ParentConfig.class})
+	public static class ChildWithAnnotationExtendingAnnotatedParentTestClass extends ParentWithAnnotationTestClass {
+
+		@Test
+		public void test() {
+			verifyParentContextExist(applicationContext, true);
+		}
+	}
+
+	/** child does NOT have annotation, parent has annotation. */
+	public static class ChildWithoutAnnotationExtendingAnnotatedParentTestClass extends ParentWithAnnotationTestClass {
+
+		@Test
+		public void test() {
+			verifyParentContextExist(applicationContext, true);
+		}
+	}
+
+	/** child has annotation, parent does NOT have annotation. */
+	@ParentContextConfiguration(classes = {ParentConfig.class})
+	public static class ChildWithAnnotationExtendingNonAnnotatedParentTestClass
+			extends ParentWithoutAnnotationTestClass {
+
+		@Test
+		public void test() {
+			verifyParentContextExist(applicationContext, true);
+		}
+	}
+
+	/** child does NOT have annotation, parent does NOT have annotation. */
+	public static class ChildWithoutAnnotationExtendingNonAnnotatedParentTestClass
+			extends ParentWithoutAnnotationTestClass {
+
+		@Test
+		public void test() {
+			verifyParentContextExist(applicationContext, false);
+		}
+	}
+
+	private static void verifyParentContextExist(ApplicationContext childContext, boolean exist) {
+		assertThat("Child context must exist.", childContext, notNullValue());
+
+		assertThat("Child context has local fooChild bean", childContext.containsLocalBean("fooChild"), is(true));
+
+		ApplicationContext parentContext = childContext.getParent();
+		if (exist) {
+			assertThat("Parent context must exist.", parentContext, is(not(nullValue())));
+			assertThat("Parent context has local fooParent bean", parentContext.containsLocalBean("fooParent"),
+					is(true));
+		}
+		else {
+			assertThat("Parent context must NOT exist.", parentContext, is(nullValue()));
+		}
+	}
+
+	@Configuration
+	public static class ParentConfig {
+
+		@Bean(name = "fooParent")
+		public String foo() {
+			return "parent";
+		}
+	}
+
+	@Configuration
+	public static class ChildConfig {
+
+		@Bean(name = "fooChild")
+		public String foo() {
+			return "child";
+		}
+
+	}
+
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/JUnitCoreUtils.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/JUnitCoreUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4;
+
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+import static org.junit.Assert.*;
+
+/**
+ * Utility class for {@link org.junit.runner.JUnitCore}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.2
+ */
+public class JUnitCoreUtils {
+
+	/**
+	 * Verify {@link Result} instance returned from {@link org.junit.runner.JUnitCore} doesn't contain any failures.
+	 *
+	 * @param result test result to verify
+	 */
+	public static void verifyResult(Result result) {
+		if (!result.wasSuccessful()) {
+			StringBuilder sb = new StringBuilder("Invoked tests failed : ");
+			for (Failure failure : result.getFailures()) {
+				sb.append(failure.getMessage());
+				fail(sb.toString());
+			}
+		}
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/support/CustomizedGenericXmlContextLoaderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/CustomizedGenericXmlContextLoaderTests.java
@@ -50,7 +50,7 @@ public class CustomizedGenericXmlContextLoaderTests {
 				assertFalse("The context should not yet have been refreshed.", context.isActive());
 				builder.append(expectedContents);
 			}
-		}.loadContext("classpath:/org/springframework/test/context/support/CustomizedGenericXmlContextLoaderTests-context.xml");
+		}.loadContext(null, "classpath:/org/springframework/test/context/support/CustomizedGenericXmlContextLoaderTests-context.xml");
 
 		assertEquals("customizeContext() should have been called.", expectedContents, builder.toString());
 	}

--- a/spring-test/src/test/java/org/springframework/test/context/support/DelegatingSmartContextLoaderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/DelegatingSmartContextLoaderTests.java
@@ -109,19 +109,19 @@ public class DelegatingSmartContextLoaderTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void loadContextWithNullConfig() throws Exception {
 		MergedContextConfiguration mergedConfig = null;
-		loader.loadContext(mergedConfig);
+		loader.loadContext(null, mergedConfig);
 	}
 
 	@Test(expected = IllegalStateException.class)
 	public void loadContextWithoutLocationsAndConfigurationClasses() throws Exception {
 		MergedContextConfiguration mergedConfig = new MergedContextConfiguration(getClass(), EMPTY_STRING_ARRAY,
 			EMPTY_CLASS_ARRAY, EMPTY_STRING_ARRAY, loader);
-		loader.loadContext(mergedConfig);
+		loader.loadContext(null, mergedConfig);
 	}
 
 	private void assertApplicationContextLoadsAndContainsFooString(MergedContextConfiguration mergedConfig)
 			throws Exception {
-		ApplicationContext applicationContext = loader.loadContext(mergedConfig);
+		ApplicationContext applicationContext = loader.loadContext(null, mergedConfig);
 		assertNotNull(applicationContext);
 		assertEquals("foo", applicationContext.getBean(String.class));
 		assertTrue(applicationContext instanceof ConfigurableApplicationContext);
@@ -153,7 +153,7 @@ public class DelegatingSmartContextLoaderTests {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void loadContextFromLocations() throws Exception {
-		loader.loadContext(EMPTY_STRING_ARRAY);
+		loader.loadContext(null, EMPTY_STRING_ARRAY);
 	}
 
 


### PR DESCRIPTION
Hello,

I created "@ParentContextConfiguration" to support parent test contexts in spring-test framework.

Sample:

``` java
  @ParentContextConfiguration("parent-context.xml")
  @ContextConfiguration("child-context.xml")
  @RunWith(SpringJUnit4ClassRunner.class)
  public class SomeTests {

      @Autowired
      protected ApplicationContext applicationContext;

      // applicationContext.getParent() returns the parent app context
  }
```

Parent context will be shared across the test classes if they are annotated to use parent context and have same configurations(xml locations, configuration classes, etc). It uses existing context caching  mechanism.
I also added "parent" attribute to @DirtiesContext annotation in order to close the parent context if required. When "parent=true" is set on @DirtiesContext, DirtiesContextTestExecutionListener will close the parent application context as well as child contexts using the specified parent context.

Changes:
- created @ParentContextConfiguration to configure the parent application context.
- reused the @ContextConfigurationAttributes to represent both  @ContextConfiguration and @ParentContextConfiguration
- changed ContextLoader SPI to pass a parent ApplicationContext
- refactored ContextLoaderUtils to use "getConfigurationAttributes()" to resolve the context loader class and configuration attribute in a similar manner.
- created ContextCacheKey class which contains two MergedContextConfiguration (one for parent, one for child) as a key of ContextCache.
- added "parent" attribute on @DirtiesContext
- @DirtiesContext(parent=true) will remove parent app context and all child app contexts using that parent context from the cache
- unit tests

Issue: [SPR-5613](https://jira.springsource.org/browse/SPR-5613)  

Submitted the CLA 

Thanks,
