### PR TITLE
Remove note on singleton scoped proxy raising BCE

### DIFF
--- a/src/reference/docbook/beans-scopes.xml
+++ b/src/reference/docbook/beans-scopes.xml
@@ -385,9 +385,7 @@
         <para>You <emphasis>do not</emphasis> need to use the
           <literal>&lt;aop:scoped-proxy/&gt;</literal> in conjunction with beans
           that are scoped as <literal>singletons</literal> or
-          <literal>prototypes</literal>. If you try to create a scoped proxy for
-          a singleton bean, the
-          <exceptionname>BeanCreationException</exceptionname> is raised.</para>
+          <literal>prototypes</literal>.</para>
       </note>
 
       <para>The configuration in the following example is only one line, but it


### PR DESCRIPTION
Before this change bean scopes chapter in Spring
reference documentation had a note which mentioned
that creating a scoped proxy for singleton bean
will throw BeanCreationException.

Since this is no longer the case, this change removes
mentioned note.

Issue: SPR-7940

I have signed and agree to the terms of SpringSource Individual Contributor License Agreement.
