### PR TITLE
Generate bracketless tag id in FreeMarker forms

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/freemarker/spring.ftl
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/freemarker/spring.ftl
@@ -157,7 +157,7 @@
  -->
 <#macro formInput path attributes="" fieldType="text">
     <@bind path/>
-    <input type="${fieldType}" id="${status.expression}" name="${status.expression}" value="<#if fieldType!="password">${stringStatusValue}</#if>" ${attributes}<@closeTag/>
+    <input type="${fieldType}" id="${status.expression?replace('[','')?replace(']','')}" name="${status.expression}" value="<#if fieldType!="password">${stringStatusValue}</#if>" ${attributes}<@closeTag/>
 </#macro>
 
 <#--
@@ -202,7 +202,7 @@
  -->
 <#macro formTextarea path attributes="">
     <@bind path/>
-    <textarea id="${status.expression}" name="${status.expression}" ${attributes}>${stringStatusValue}</textarea>
+    <textarea id="${status.expression?replace('[','')?replace(']','')}" name="${status.expression}" ${attributes}>${stringStatusValue}</textarea>
 </#macro>
 
 <#--
@@ -218,7 +218,7 @@
 -->
 <#macro formSingleSelect path options attributes="">
     <@bind path/>
-    <select id="${status.expression}" name="${status.expression}" ${attributes}>
+    <select id="${status.expression?replace('[','')?replace(']','')}" name="${status.expression}" ${attributes}>
         <#if options?is_hash>
             <#list options?keys as value>
             <option value="${value?html}"<@checkSelected value/>>${options[value]?html}</option>
@@ -244,7 +244,7 @@
 -->
 <#macro formMultiSelect path options attributes="">
     <@bind path/>
-    <select multiple="multiple" id="${status.expression}" name="${status.expression}" ${attributes}>
+    <select multiple="multiple" id="${status.expression?replace('[','')?replace(']','')}" name="${status.expression}" ${attributes}>
         <#list options?keys as value>
         <#assign isSelected = contains(status.actualValue?default([""]), value)>
         <option value="${value?html}"<#if isSelected> selected="selected"</#if>>${options[value]?html}</option>
@@ -267,7 +267,7 @@
 <#macro formRadioButtons path options separator attributes="">
     <@bind path/>
     <#list options?keys as value>
-    <#assign id="${status.expression}${value_index}">
+    <#assign id="${status.expression?replace('[','')?replace(']','')}${value_index}">
     <input type="radio" id="${id}" name="${status.expression}" value="${value?html}"<#if stringStatusValue == value> checked="checked"</#if> ${attributes}<@closeTag/>
     <label for="${id}">${options[value]?html}</label>${separator}
     </#list>
@@ -288,7 +288,7 @@
 <#macro formCheckboxes path options separator attributes="">
     <@bind path/>
     <#list options?keys as value>
-    <#assign id="${status.expression}${value_index}">
+    <#assign id="${status.expression?replace('[','')?replace(']','')}${value_index}">
     <#assign isSelected = contains(status.actualValue?default([""]), value)>
     <input type="checkbox" id="${id}" name="${status.expression}" value="${value?html}"<#if isSelected> checked="checked"</#if> ${attributes}<@closeTag/>
     <label for="${id}">${options[value]?html}</label>${separator}
@@ -307,7 +307,7 @@
 -->
 <#macro formCheckbox path attributes="">
 	<@bind path />
-    <#assign id="${status.expression}">
+    <#assign id="${status.expression?replace('[','')?replace(']','')}">
     <#assign isSelected = status.value?? && status.value?string=="true">
 	<input type="hidden" name="_${id}" value="on"/>
 	<input type="checkbox" id="${id}" name="${id}"<#if isSelected> checked="checked"</#if> ${attributes}/>

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/FreeMarkerMacroTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/FreeMarkerMacroTests.java
@@ -260,6 +260,11 @@ public class FreeMarkerMacroTests {
 		assertTrue("Wrong output: " + output, output.contains("<input type=\"checkbox\" id=\"jedi\" name=\"jedi\" checked=\"checked\" />"));
 	}
 
+	@Test
+	public void testForm17() throws Exception {
+		assertEquals("<input type=\"text\" id=\"spouses0.name\" name=\"spouses[0].name\" value=\"Fred\"     >", getMacroOutput("FORM17"));
+	}
+
 	private String getMacroOutput(String name) throws Exception {
 
 		String macro = fetchMacro(name);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/test.ftl
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/test.ftl
@@ -86,3 +86,6 @@ FORM15
 
 FORM16
 <@spring.formCheckbox "command.jedi"/>
+
+FORM17
+<@spring.formInput "command.spouses[0].name", ""/>


### PR DESCRIPTION
Before this change if FreeMarker Spring form macro was bound to a path
which contains square brackets, those brackets would also appear in id
of generated tag, making the id invalid.

As of this fix all FreeMarker Spring form macros generate tag with id
that does not contain square brackets.

Issue: SPR-8732

I have signed and agree to the terms of SpringSource Individual Contributor License Agreement.
