### PR TITLE
Enable SpEL to support array refs in T() construct

### DIFF
--- a/org.springframework.expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java
+++ b/org.springframework.expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.expression.spel.ast;
 
+import java.lang.reflect.Array;
+
 import org.springframework.expression.EvaluationException;
 import org.springframework.expression.TypedValue;
 import org.springframework.expression.spel.ExpressionState;
@@ -27,8 +29,15 @@ import org.springframework.expression.spel.ExpressionState;
  */
 public class TypeReference extends SpelNodeImpl {
 
+	private int dimensions;
+
 	public TypeReference(int pos,SpelNodeImpl qualifiedId) {
+		this(pos,qualifiedId,0);
+	}
+
+	public TypeReference(int pos,SpelNodeImpl qualifiedId,int dims) {
 		super(pos,qualifiedId);
+		this.dimensions = dims;
 	}
 
 	@Override
@@ -39,10 +48,24 @@ public class TypeReference extends SpelNodeImpl {
 			TypeCode tc = TypeCode.valueOf(typename.toUpperCase());
 			if (tc != TypeCode.OBJECT) {
 				// it is a primitive type
-				return new TypedValue(tc.getType());
+				Class<?> clazz = tc.getType();
+				clazz = makeArrayIfNecessary(clazz);
+				return new TypedValue(clazz);
 			}
 		}
-		return new TypedValue(state.findType(typename));
+		Class<?> clazz = state.findType(typename);
+		clazz = makeArrayIfNecessary(clazz);
+		return new TypedValue(clazz);
+	}
+	
+	private Class makeArrayIfNecessary(Class clazz) {
+		if (dimensions!=0) {
+			for (int i=0;i<dimensions;i++) {
+				Object o = Array.newInstance(clazz, 0);
+				clazz = o.getClass();
+			}
+		}
+		return clazz;
 	}
 
 	@Override
@@ -50,6 +73,9 @@ public class TypeReference extends SpelNodeImpl {
 		StringBuilder sb = new StringBuilder();
 		sb.append("T(");
 		sb.append(getChild(0).toStringAST());
+		for (int d=0;d<dimensions;d++) {
+			sb.append("[]");
+		}
 		sb.append(")");
 		return sb.toString();
 	}

--- a/org.springframework.expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
+++ b/org.springframework.expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -497,8 +497,14 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 			eatToken(TokenKind.LPAREN);
 			SpelNodeImpl node = eatPossiblyQualifiedId();
 			// dotted qualified id
+			// Are there array dimensions?
+			int dims = 0;
+			while (peekToken(TokenKind.LSQUARE,true)) {
+				eatToken(TokenKind.RSQUARE);
+				dims++;
+			}
 			eatToken(TokenKind.RPAREN);
-			constructedNodes.push(new TypeReference(toPos(typeName),node));
+			constructedNodes.push(new TypeReference(toPos(typeName),node,dims));
 			return true;
 		}
 		return false;

--- a/org.springframework.expression/src/test/java/org/springframework/expression/spel/SpringEL300Tests.java
+++ b/org.springframework.expression/src/test/java/org/springframework/expression/spel/SpringEL300Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1191,6 +1191,37 @@ public class SpringEL300Tests extends ExpressionTestCase {
 		public Map<String, String> getThirdContext() {return thirdContext;}
 		public Map<String, String> getFourthContext() {return fourthContext;}
 	}
+
+	
+	@Test
+	public void testArray() {
+		ExpressionParser parser = new SpelExpressionParser();
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		Expression expression = null;
+		Object result = null;
+
+		expression = parser.parseExpression("new java.lang.Long[0].class");
+		result = expression.getValue(context, "");
+		assertEquals("Equal assertion failed: ", "class [Ljava.lang.Long;", result.toString());
+		
+		expression = parser.parseExpression("T(java.lang.Long[])");
+		result = expression.getValue(context, "");
+		assertEquals("Equal assertion failed: ", "class [Ljava.lang.Long;", result.toString());
+		
+		expression = parser.parseExpression("T(java.lang.String[][][])");
+		result = expression.getValue(context, "");
+		assertEquals("Equal assertion failed: ", "class [[[Ljava.lang.String;", result.toString());
+		assertEquals("T(java.lang.String[][][])",((SpelExpression)expression).toStringAST());
+		
+		expression = parser.parseExpression("new int[0].class");
+		result = expression.getValue(context, "");
+		assertEquals("Equal assertion failed: ", "class [I", result.toString());
+
+		expression = parser.parseExpression("T(int[][])");
+		result = expression.getValue(context, "");
+		assertEquals("Equal assertion failed: ", "class [[I", result.toString());
+	}
+	
 
 }
 


### PR DESCRIPTION
This allows SpEL to support this syntax kind of syntax:
"T(foo.Bar[])".  Without the change SpEL will not allow
the use of [] in the T().

Issue: SPR-9203
