### PR TITLE
SPR-9216 - Add support for 301 redirects using UrlBasedViewResolver prefixes

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ModelAndViewMethodReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ModelAndViewMethodReturnValueHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class ModelAndViewMethodReturnValueHandler implements HandlerMethodReturn
 		if (mav.isReference()) {
 			String viewName = mav.getViewName();
 			mavContainer.setViewName(viewName);
-			if (viewName != null && viewName.startsWith("redirect:")) {
+			if (viewName != null && (viewName.startsWith("redirect:") || viewName.startsWith("permanentRedirect:"))) {
 				mavContainer.setRedirectModelScenario(true);
 			}
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ViewNameMethodReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ViewNameMethodReturnValueHandler.java
@@ -74,7 +74,7 @@ public class ViewNameMethodReturnValueHandler implements HandlerMethodReturnValu
 	 * reference; "false" otherwise.
 	 */
 	protected boolean isRedirectViewName(String viewName) {
-		return viewName.startsWith("redirect:");
+		return viewName.startsWith("redirect:") || viewName.startsWith("permanentRedirect:");
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ModelAndViewMethodReturnValueHandlerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ModelAndViewMethodReturnValueHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,20 @@ public class ModelAndViewMethodReturnValueHandlerTests {
 
 		ModelMap model = mavContainer.getModel();
 		assertEquals("redirect:viewName", mavContainer.getViewName());
+		assertEquals("attrValue", model.get("attrName"));
+		assertSame("RedirectAttributes should be used if controller redirects", redirectAttributes, model);
+	}
+	
+	@Test
+	public void handlePermanentRedirectAttributesWithViewInstance() throws Exception {
+		RedirectAttributesModelMap redirectAttributes  = new RedirectAttributesModelMap();
+		mavContainer.setRedirectModel(redirectAttributes);
+
+		ModelAndView mav = new ModelAndView("permanentRedirect:viewName", "attrName", "attrValue");
+		handler.handleReturnValue(mav, returnParamModelAndView, mavContainer, webRequest);
+
+		ModelMap model = mavContainer.getModel();
+		assertEquals("permanentRedirect:viewName", mavContainer.getViewName());
 		assertEquals("attrValue", model.get("attrName"));
 		assertSame("RedirectAttributes should be used if controller redirects", redirectAttributes, model);
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ViewNameMethodReturnValueHandlerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ViewNameMethodReturnValueHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,17 @@ public class ViewNameMethodReturnValueHandlerTests {
 		this.handler.handleReturnValue("redirect:testView", param, this.mavContainer, this.webRequest);
 
 		assertEquals("redirect:testView", this.mavContainer.getViewName());
+		assertSame("Should have switched to the RedirectModel", redirectModel, this.mavContainer.getModel());
+	}
+	
+	@Test
+	public void returnViewNamePermanentRedirect() throws Exception {
+		ModelMap redirectModel = new RedirectAttributesModelMap();
+		this.mavContainer.setRedirectModel(redirectModel);
+		MethodParameter param = createReturnValueParam("viewName");
+		this.handler.handleReturnValue("permanentRedirect:testView", param, this.mavContainer, this.webRequest);
+
+		assertEquals("permanentRedirect:testView", this.mavContainer.getViewName());
 		assertSame("Should have switched to the RedirectModel", redirectModel, this.mavContainer.getModel());
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ContentNegotiatingViewResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ContentNegotiatingViewResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -437,6 +437,38 @@ public class ContentNegotiatingViewResolverTests {
 		viewResolver.setDefaultViews(Arrays.asList(jsonView));
 		
 		String viewName = "redirect:anotherTest";
+		Locale locale = Locale.ENGLISH;
+
+		expect(xmlViewResolver.resolveViewName(viewName, locale)).andReturn(xmlView);
+		expect(jsonView.getContentType()).andReturn("application/json").anyTimes();
+
+		replay(xmlViewResolver, xmlView, jsonView);
+
+		View actualView = viewResolver.resolveViewName(viewName, locale);
+		assertEquals("Invalid view", RedirectView.class, actualView.getClass());
+
+		verify(xmlViewResolver, xmlView, jsonView);
+	}
+	
+	@Test
+	public void resolveViewNamePermanentRedirectView() throws Exception {
+		request.addHeader("Accept", "application/json");
+		request.setRequestURI("/test");
+
+		StaticWebApplicationContext webAppContext = new StaticWebApplicationContext();
+		webAppContext.setServletContext(new MockServletContext());
+		webAppContext.refresh();
+		
+		UrlBasedViewResolver urlViewResolver = new InternalResourceViewResolver();
+		urlViewResolver.setApplicationContext(webAppContext);
+		ViewResolver xmlViewResolver = createMock(ViewResolver.class);
+		viewResolver.setViewResolvers(Arrays.<ViewResolver>asList(xmlViewResolver, urlViewResolver));
+
+		View xmlView = createMock("application_xml", View.class);
+		View jsonView = createMock("application_json", View.class);
+		viewResolver.setDefaultViews(Arrays.asList(jsonView));
+		
+		String viewName = "permanentRedirect:anotherTest";
 		Locale locale = Locale.ENGLISH;
 
 		expect(xmlViewResolver.resolveViewName(viewName, locale)).andReturn(xmlView);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockRequestDispatcher;
@@ -154,6 +155,12 @@ public class ViewResolverTests {
 		view = vr.resolveViewName("redirect:myUrl", Locale.getDefault());
 		assertEquals("Correct view class", RedirectView.class, view.getClass());
 		assertEquals("Correct URL", "myUrl", ((RedirectView) view).getUrl());
+		assertSame("View not initialized as bean", wac, ((RedirectView) view).getApplicationContext());
+		
+		view = vr.resolveViewName("permanentRedirect:myUrl", Locale.getDefault());
+		assertEquals("Correct view class", RedirectView.class, view.getClass());
+		assertEquals("Correct URL", "myUrl", ((RedirectView) view).getUrl());
+		assertEquals("Correct Status Code", HttpStatus.MOVED_PERMANENTLY, ((RedirectView) view).getHttp11StatusCode(request, response, null));
 		assertSame("View not initialized as bean", wac, ((RedirectView) view).getApplicationContext());
 
 		view = vr.resolveViewName("forward:myUrl", Locale.getDefault());

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/FreeMarkerViewTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/FreeMarkerViewTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,6 +191,10 @@ public class FreeMarkerViewTests {
 		assertNull(view);
 
 		view = vr.resolveViewName("redirect:myUrl", Locale.getDefault());
+		assertEquals("Correct view class", RedirectView.class, view.getClass());
+		assertEquals("Correct URL", "myUrl", ((RedirectView) view).getUrl());
+		
+		view = vr.resolveViewName("permanentRedirect:myUrl", Locale.getDefault());
 		assertEquals("Correct view class", RedirectView.class, view.getClass());
 		assertEquals("Correct URL", "myUrl", ((RedirectView) view).getUrl());
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/velocity/VelocityViewResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/velocity/VelocityViewResolverTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.web.servlet.view.velocity;
 
 import static org.junit.Assert.assertEquals;
@@ -46,6 +62,10 @@ public class VelocityViewResolverTests {
 		assertNull(view);
 
 		view = vr.resolveViewName("redirect:myUrl", Locale.getDefault());
+		assertEquals("Correct view class", RedirectView.class, view.getClass());
+		assertEquals("Correct URL", "myUrl", ((RedirectView) view).getUrl());
+		
+		view = vr.resolveViewName("permanentRedirect:myUrl", Locale.getDefault());
 		assertEquals("Correct view class", RedirectView.class, view.getClass());
 		assertEquals("Correct URL", "myUrl", ((RedirectView) view).getUrl());
 


### PR DESCRIPTION
When returning the "redirect:" prefix from a method with a RequestMapping, the default behavior is to return a 302 redirect. It would be nice if there was a way to return a 301 or a 302 redirect based on the prefix used (e.g. "redirect:" or "permanentRedirect:"). 

For SEO, a 301 is more desirable than a 302, and it would be nice to have a way to conveniently return the 301 without having the method return a RedirectView with a 301 as it's StatusCode.

https://jira.springsource.org/browse/SPR-9216

 I should already have a SpringSource CLA form on file.
