### PR TITLE
Fix constant name lookup for null name prefix

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/Constants.java
+++ b/spring-core/src/main/java/org/springframework/core/Constants.java
@@ -264,7 +264,7 @@ public class Constants {
 	 * @throws ConstantException if the value wasn't found
 	 */
 	public String toCode(Object value, String namePrefix) throws ConstantException {
-		String prefixToUse = (namePrefix != null ? namePrefix.trim().toUpperCase(Locale.ENGLISH) : null);
+		String prefixToUse = (namePrefix != null ? namePrefix.trim().toUpperCase(Locale.ENGLISH) : "");
 		for (Map.Entry<String, Object> entry : this.fieldCache.entrySet()) {
 			if (entry.getKey().startsWith(prefixToUse) && entry.getValue().equals(value)) {
 				return entry.getKey();

--- a/spring-core/src/test/java/org/springframework/core/ConstantsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/ConstantsTests.java
@@ -148,15 +148,24 @@ public class ConstantsTests extends TestCase {
 		assertEquals(c.toCode(new Integer(0), "D"), "DOG");
 		assertEquals(c.toCode(new Integer(0), "DO"), "DOG");
 		assertEquals(c.toCode(new Integer(0), "DoG"), "DOG");
+		assertEquals(c.toCode(new Integer(0), null), "DOG");
 		assertEquals(c.toCode(new Integer(66), ""), "CAT");
 		assertEquals(c.toCode(new Integer(66), "C"), "CAT");
 		assertEquals(c.toCode(new Integer(66), "ca"), "CAT");
 		assertEquals(c.toCode(new Integer(66), "cAt"), "CAT");
+		assertEquals(c.toCode(new Integer(66), null), "CAT");
 		assertEquals(c.toCode("", ""), "S1");
 		assertEquals(c.toCode("", "s"), "S1");
 		assertEquals(c.toCode("", "s1"), "S1");
+		assertEquals(c.toCode("", null), "S1");
 		try {
 			c.toCode("bogus", "bogus");
+			fail("Should have thrown ConstantException");
+		}
+		catch (ConstantException expected) {
+		}
+		try {
+			c.toCode("bogus", null);
 			fail("Should have thrown ConstantException");
 		}
 		catch (ConstantException expected) {


### PR DESCRIPTION
Even though javadoc fo Constants.toCode specifies that null value for
namePrefix parameter is allowed, before this change pasing null would
throw NullPointerException.

This change fixes constant name lookup for null name prefix as if empty
name prefix was used so that all names match, and lookup is performed
only by constant value. This way of handling null value for name prefix
is consistent with the rest of Constants class API.

Issue: SPR-8278

I have signed and agree to the terms in the SpringSource Individual Contributor License Agreement.
