### PR TITLE
Have JiBX unmarshal using configured encoding

### DIFF
--- a/spring-oxm/src/main/java/org/springframework/oxm/jibx/JibxMarshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/jibx/JibxMarshaller.java
@@ -349,7 +349,7 @@ public class JibxMarshaller extends AbstractMarshaller implements InitializingBe
 	protected Object unmarshalInputStream(InputStream inputStream) throws XmlMappingException, IOException {
 		try {
 			IUnmarshallingContext unmarshallingContext = createUnmarshallingContext();
-			return unmarshallingContext.unmarshalDocument(inputStream, null);
+			return unmarshallingContext.unmarshalDocument(inputStream, encoding);
 		}
 		catch (JiBXException ex) {
 			throw convertJibxException(ex, false);

--- a/spring-oxm/src/test/java/org/springframework/oxm/jibx/FlightType.java
+++ b/spring-oxm/src/test/java/org/springframework/oxm/jibx/FlightType.java
@@ -18,7 +18,17 @@ package org.springframework.oxm.jibx;
 
 public class FlightType {
 
+	protected String airline;
+	
     protected long number;
+
+    public String getAirline() {
+    	return this.airline;
+    }
+
+    public void setAirline(String airline) {
+    	this.airline = airline;
+    }
 
     public long getNumber() {
         return this.number;

--- a/spring-oxm/src/test/java/org/springframework/oxm/jibx/JibxUnmarshallerTests.java
+++ b/spring-oxm/src/test/java/org/springframework/oxm/jibx/JibxUnmarshallerTests.java
@@ -18,8 +18,13 @@ package org.springframework.oxm.jibx;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Ignore;
 
+import java.io.ByteArrayInputStream;
+
+import javax.xml.transform.stream.StreamSource;
+
+import org.junit.Ignore;
+import org.junit.Test;
 import org.springframework.oxm.AbstractUnmarshallerTests;
 import org.springframework.oxm.Unmarshaller;
 
@@ -30,6 +35,10 @@ import org.springframework.oxm.Unmarshaller;
  * not occur by default. The Gradle build should succeed, however.
  */
 public class JibxUnmarshallerTests extends AbstractUnmarshallerTests {
+
+	protected static final String INPUT_STRING_WITH_SPECIAL_CHARACTERS =
+			"<tns:flights xmlns:tns=\"http://samples.springframework.org/flight\">" +
+					"<tns:flight><tns:airline>Air Liberté</tns:airline><tns:number>42</tns:number></tns:flight></tns:flights>";
 
 	@Override
 	protected Unmarshaller createUnmarshaller() throws Exception {
@@ -58,6 +67,19 @@ public class JibxUnmarshallerTests extends AbstractUnmarshallerTests {
 	@Ignore
 	public void unmarshalPartialStaxSourceXmlStreamReader() throws Exception {
 		// JiBX does not support reading XML fragments, hence the override here
+	}
+
+	@Test
+	public void unmarshalStreamSourceInputStreamUsingNonDefaultEncoding() throws Exception {
+		String encoding = "ISO-8859-1";
+		((JibxMarshaller)unmarshaller).setEncoding(encoding);
+		
+		StreamSource source = new StreamSource(new ByteArrayInputStream(INPUT_STRING_WITH_SPECIAL_CHARACTERS.getBytes(encoding)));
+		Object flights = unmarshaller.unmarshal(source);
+		testFlights(flights);
+		
+		FlightType flight = ((Flights)flights).getFlight(0);
+		assertEquals("Airline is invalid", "Air Liberté", flight.getAirline());
 	}
 
 }

--- a/spring-oxm/src/test/resources/org/springframework/oxm/jibx/binding.xml
+++ b/spring-oxm/src/test/resources/org/springframework/oxm/jibx/binding.xml
@@ -8,6 +8,7 @@
     </mapping>
     <mapping name="flight" class="org.springframework.oxm.jibx.FlightType">
         <namespace uri="http://samples.springframework.org/flight" default="elements"/>
+        <value name="airline" field="airline" usage="optional"/>
         <value name="number" field="number" usage="required"/>
     </mapping>
 </binding>


### PR DESCRIPTION
Before this change JibxMarshaller did not use configured encoding when
unmarshalling XML. This caused issues when content being unmarshalled
was not encoded using default encoding.

This change fixes the issue by passing configured encoding to JiBX so
it gets used when unmarshalling instead of the default encoding.

Issue: SPR-7865

I have signed and agree to the terms of SpringSource Individual Contributor License Agreement.
