### PR TITLE
Fix JibxMarshallerTests failing on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,7 @@ project('spring-oxm') {
         compile "commons-lang:commons-lang:2.5"
         compile("com.thoughtworks.xstream:xstream:1.3.1", optional)
         compile("com.sun.xml.bind:jaxb-impl:2.1.7", optional)
-        compile("org.jibx:jibx-run:1.1.5", optional)
+        compile("org.jibx:jibx-run:1.2.3", optional)
         compile("org.apache.xmlbeans:xmlbeans:2.4.0", optional)
         compile("org.codehaus.castor:castor-xml:1.3.2", optional)
         testCompile "org.codehaus.jettison:jettison:1.0.1"

--- a/spring-oxm/oxm.gradle
+++ b/spring-oxm/oxm.gradle
@@ -9,7 +9,7 @@ dependencies {
     castor "velocity:velocity:1.5"
     xjc "com.sun.xml:com.springsource.com.sun.tools.xjc:2.1.7"
     xmlbeans "org.apache.xmlbeans:com.springsource.org.apache.xmlbeans:2.4.0"
-    jibx "org.jibx:jibx-bind:1.1.5"
+    jibx "org.jibx:jibx-bind:1.2.3"
     jibx "bcel:bcel:5.1"
 }
 

--- a/spring-oxm/src/test/resources/org/springframework/oxm/jibx/binding.xml
+++ b/spring-oxm/src/test/resources/org/springframework/oxm/jibx/binding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<binding>
+<binding name="binding">
     <mapping name="flights" class="org.springframework.oxm.jibx.Flights">
         <namespace uri="http://samples.springframework.org/flight" default="elements"/>
         <collection field="flightList">


### PR DESCRIPTION
Before this change JibxMarshallerTests would fail on Windows with error
message explaining that JiBX compiler generated classes are not found
on classpath for binding with name 'binding'. Tests would execute well
on Linux.

Actual root cause of this bug is found to be in JiBX 1.1.5 release that
is used to build Spring. Binding name can be explicitly specified in
JiBX binding file. If omitted, when generating classes JiBX compiler as
fall-back mechanism tries to derive binding name from binding file
name. That logic had bug which gets manifested when configured binding
file path has mixed Windows and Linux style file separators, as in case
when mentioned JibxMarshallerTests are executed on Windows platform.

This pull request contains two commits for two different solutions for this
issue. See respective commit comments for more details.

Issue: SPR-8360

I have signed and agree to the terms in the SpringSource Individual Contributor License Agreement.
