### PR TITLE
Fix for slf4j dependency issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ configure(allprojects) {
     targetCompatibility=1.5
 
     ext.slf4jLog4jVersion = '1.5.10'
+    ext.aspectjVersion = '1.6.12'
 
     [compileJava, compileTestJava]*.options*.compilerArgs = ['-Xlint:none']
 
@@ -133,7 +134,7 @@ project('spring-core') {
             builtBy project(":spring-asm").jar
         }
         compile "commons-logging:commons-logging:1.1.1"
-        compile("org.aspectj:aspectjweaver:1.6.8", optional)
+        compile("org.aspectj:aspectjweaver:${aspectjVersion}", optional)
         compile("net.sf.jopt-simple:jopt-simple:3.0") { dep ->
             optional dep
             exclude group: 'org.apache.ant', module: 'ant'
@@ -219,6 +220,10 @@ project('spring-context') {
         testCompile "commons-dbcp:commons-dbcp:1.2.2"
         testCompile("javax.xml:jaxrpc-api:1.1")
         testCompile("javax.inject:com.springsource.org.atinject.tck:1.0.0")
+    }
+
+    test {
+        jvmArgs = ['-disableassertions:org.aspectj.weaver.UnresolvedType'] // SPR-7989
     }
 }
 
@@ -439,8 +444,8 @@ project('spring-aspects') {
     dependencies {
         compile project(":spring-orm")
         aspects project(":spring-orm")
-        ajc "org.aspectj:aspectjtools:1.6.8"
-        compile "org.aspectj:aspectjrt:1.6.8"
+        ajc "org.aspectj:aspectjtools:${aspectjVersion}"
+        compile "org.aspectj:aspectjrt:${aspectjVersion}"
         testCompile project(":spring-test")
     }
     eclipse.project {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ configure(allprojects) {
     sourceCompatibility=1.5
     targetCompatibility=1.5
 
-    slf4jLog4jVersion = '1.5.10'
+    ext.slf4jLog4jVersion = '1.5.10'
 
     [compileJava, compileTestJava]*.options*.compilerArgs = ['-Xlint:none']
 
@@ -85,7 +85,7 @@ configure(subprojects) { subproject ->
 
 project("spring-asm") {
     description = 'Spring ASM'
-    asmVersion = '2.2.3'
+    ext.asmVersion = '2.2.3'
 
     configurations {
         asm
@@ -542,7 +542,7 @@ configure(rootProject) {
         description = "Builds -${classifier} archive, containing all jars and docs, " +
                       "suitable for community download page."
 
-        baseDir = "${project.name}-${project.version}";
+        def baseDir = "${project.name}-${project.version}";
 
         from('src/dist') {
             include 'readme.txt'
@@ -581,7 +581,7 @@ configure(rootProject) {
 
     task wrapper(type: Wrapper) {
         description = 'Generates gradlew[.bat] scripts'
-        gradleVersion = '1.0-milestone-8a'
+        gradleVersion = '1.0-rc-1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 23 13:43:17 CET 2012
+#Sat Apr 14 10:56:11 EEST 2012
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.0-milestone-8a-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.0-rc-1-bin.zip

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'maven'
 
-optionalDeps = []
-providedDeps = []
+ext.optionalDeps = []
+ext.providedDeps = []
 
-optional = { optionalDeps << it }
-provided = { providedDeps << it }
+ext.optional = { optionalDeps << it }
+ext.provided = { providedDeps << it }
 
 install {
     repositories.mavenInstaller {

--- a/spring-oxm/oxm.gradle
+++ b/spring-oxm/oxm.gradle
@@ -13,15 +13,15 @@ dependencies {
     jibx "bcel:bcel:5.1"
 }
 
-genSourcesDir = "${buildDir}/generated-sources"
-flightSchema = "${projectDir}/src/test/resources/org/springframework/oxm/flight.xsd"
+ext.genSourcesDir = "${buildDir}/generated-sources"
+ext.flightSchema = "${projectDir}/src/test/resources/org/springframework/oxm/flight.xsd"
 
 task genCastor {
-    orderSchema = "${projectDir}/src/test/resources/org/springframework/oxm/order.xsd"
-    castorBuilderProperties = "${projectDir}/src/test/castor/castorbuilder.properties"
+    def orderSchema = "${projectDir}/src/test/resources/org/springframework/oxm/order.xsd"
+    def castorBuilderProperties = "${projectDir}/src/test/castor/castorbuilder.properties"
 
-    sourcesDir = "${genSourcesDir}/castor"
-    classesDir = "${buildDir}/classes/castor"
+    ext.sourcesDir = "${genSourcesDir}/castor"
+    ext.classesDir = "${buildDir}/classes/castor"
 
     inputs.files flightSchema, orderSchema, castorBuilderProperties
     outputs.dir classesDir
@@ -56,8 +56,8 @@ task genCastor {
 }
 
 task genJaxb {
-    sourcesDir = "${genSourcesDir}/jaxb"
-    classesDir = "${buildDir}/classes/jaxb"
+    ext.sourcesDir = "${genSourcesDir}/jaxb"
+    ext.classesDir = "${buildDir}/classes/jaxb"
 
     inputs.files flightSchema
     outputs.dir classesDir
@@ -92,7 +92,7 @@ task genJaxb {
 }
 
 task genXmlbeans {
-    classesDir = "${buildDir}/classes/xmlbeans"
+    ext.classesDir = "${buildDir}/classes/xmlbeans"
 
     inputs.files flightSchema
     outputs.dir classesDir
@@ -112,7 +112,7 @@ task genXmlbeans {
 
 // add jibx binding to the normal test compilation process
 compileTestJava {
-    bindingXml = "${projectDir}/src/test/resources/org/springframework/oxm/jibx/binding.xml"
+    def bindingXml = "${projectDir}/src/test/resources/org/springframework/oxm/jibx/binding.xml"
 
     doLast() {
         project.ant {

--- a/src/dist/changelog.txt
+++ b/src/dist/changelog.txt
@@ -5,6 +5,7 @@ http://www.springsource.org
 Changes in version 3.2 M1
 -------------------------------------
 
+* upgraded to AspectJ 1.6.12
 * better handling on failure to parse invalid 'Content-Type' or 'Accept' headers
 * handle a controller method's return value based on the actual returned value (vs declared type)
 * fix issue with combining identical controller and method level request mapping paths

--- a/src/reference/docbook/beans.xml
+++ b/src/reference/docbook/beans.xml
@@ -86,7 +86,7 @@ The footnote should x-ref to first section in that chapter but I can't find the 
       ><classname>FileSystemXmlApplicationContext</classname></ulink>.
       <!-- MLP: Beverly to review --> While XML has been the traditional format
       for defining configuration metadata you can instruct the container to use
-      Java annotations or code as the metadata format by providng a small amount
+      Java annotations or code as the metadata format by providing a small amount
       of XML configuration to declaratively enable support for these additional
       metadata formats.</para>
 


### PR DESCRIPTION
Before this change, IDE settings generated via import-into-eclipse.sh
created a classpath dependency on slf4j-api version 1.6.1 and
slf4j-log4j12 version 1.5.10. As a result running tests inside the IDE
resulted in a NoSuchMethodException.

build.gradle sets the variable slf4jLog4jVersion to '1.5.10'. However,
the hibernate-validator dependency in spring-context pulls in
slf4j-api version 1.6.1. The change ensures the version specified in
the build script variable is used consistently. Whether it should be
1.5.10 or 1.6.1 is a separate concern.
