### PR TITLE
Add abstract WebApplicationInitializers

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/WebApplicationInitializer.java
+++ b/spring-web/src/main/java/org/springframework/web/WebApplicationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,9 @@ import javax.servlet.ServletException;
  *
  * }</pre>
  *
+ * As an alternative to the above, you can also extend from {@link
+ * org.springframework.web.servlet.support.AbstractDispatcherServletInitializer}.
+ *
  * As you can see, thanks to Servlet 3.0's new {@link ServletContext#addServlet} method
  * we're actually registering an <em>instance</em> of the {@code DispatcherServlet}, and
  * this means that the {@code DispatcherServlet} can now be treated like any other object
@@ -82,7 +85,7 @@ import javax.servlet.ServletException;
  * are free to create and work with your Spring application contexts as necessary before
  * injecting them into the {@code DispatcherServlet}.
  *
- * <p>Most major Spring Web componentry has been updated to support this style of
+ * <p>Most major Spring Web components has been updated to support this style of
  * registration.  You'll find that {@code DispatcherServlet}, {@code FrameworkServlet},
  * {@code ContextLoaderListener} and {@code DelegatingFilterProxy} all now support
  * constructor arguments. Even if a component (e.g. non-Spring, other third party) has not
@@ -131,6 +134,9 @@ import javax.servlet.ServletException;
  *
  * }</pre>
  *
+ * As an alternative to the above, you can also extend from {@link
+ * org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer}.
+ *
  * Remember that {@code WebApplicationInitializer} implementations are <em>detected
  * automatically</em> -- so you are free to package them within your application as you
  * see fit.
@@ -165,6 +171,10 @@ import javax.servlet.ServletException;
  * @author Chris Beams
  * @since 3.1
  * @see SpringServletContainerInitializer
+ * @see org.springframework.web.context.AbstractContextLoaderInitializer
+ * @see org.springframework.web.servlet.support.AbstractDispatcherServletInitializer
+ * @see org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer
+ * @since 3.1
  */
 public interface WebApplicationInitializer {
 

--- a/spring-web/src/main/java/org/springframework/web/context/AbstractContextLoaderInitializer.java
+++ b/spring-web/src/main/java/org/springframework/web/context/AbstractContextLoaderInitializer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.context;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.web.WebApplicationInitializer;
+
+/**
+ * Base class for {@link org.springframework.web.WebApplicationInitializer}
+ * implementations that register a {@link ContextLoaderListener} in the servlet context.
+ *
+ * <p>The only method to be implemented by subclasses is {@link
+ * #createRootApplicationContext()}, which gets invoked from {@link
+ * #addContextLoaderListener(javax.servlet.ServletContext)}.
+ *
+ * @author Arjen Poutsma
+ * @since 3.2
+ */
+public abstract class AbstractContextLoaderInitializer
+		implements WebApplicationInitializer {
+
+	/** Logger available to subclasses. */
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	public void onStartup(ServletContext servletContext) throws ServletException {
+		addContextLoaderListener(servletContext);
+	}
+
+	/**
+	 * Adds a {@link ContextLoaderListener} to the given servlet context. The {@code
+	 * ContextLoaderListener} is initialized with the application context returned from the
+	 * {@link #createRootApplicationContext()} template method.
+	 *
+	 * @param servletContext the servlet context to register the listener with
+	 */
+	protected void addContextLoaderListener(ServletContext servletContext) {
+		WebApplicationContext rootAppContext = createRootApplicationContext();
+		if (rootAppContext != null) {
+			servletContext.addListener(new ContextLoaderListener(rootAppContext));
+		}
+		else {
+			logger.warn("No ContextLoaderListener registered, as " +
+					"createRootApplicationContext() did not return an application context");
+		}
+	}
+
+	/**
+	 * Abstract template method that creates and returns a root application context.
+	 *
+	 * <p>The returned context is used as a <strong>root</strong> context, i.e. it is passed
+	 * on to {@link ContextLoaderListener#ContextLoaderListener(WebApplicationContext)}. As
+	 * such, it typically contains middle-tier services, data sources, etc.
+	 *
+	 * @return the root application context, or {@code null} if a root context is not
+	 *         desired
+	 */
+	protected abstract WebApplicationContext createRootApplicationContext();
+
+}

--- a/spring-web/src/test/java/org/springframework/web/context/ContextLoaderInitializerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/ContextLoaderInitializerTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2005-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.context;
+
+import java.util.EventListener;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletException;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.support.StaticWebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+/**
+ * Test case for {@link AbstractContextLoaderInitializer}.
+ *
+ * @author Arjen Poutsma
+ */
+public class ContextLoaderInitializerTests {
+
+	private static final String BEAN_NAME = "myBean";
+
+	private AbstractContextLoaderInitializer initializer;
+
+	private MockServletContext servletContext;
+
+	private EventListener eventListener;
+
+	@Before
+	public void setUp() throws Exception {
+		servletContext = new MyMockServletContext();
+		initializer = new MyContextLoaderInitializer();
+		eventListener = null;
+	}
+
+	@Test
+	public void register() throws ServletException {
+		initializer.onStartup(servletContext);
+
+		assertTrue(eventListener instanceof ContextLoaderListener);
+		ContextLoaderListener cll = (ContextLoaderListener) eventListener;
+		cll.contextInitialized(new ServletContextEvent(servletContext));
+
+		WebApplicationContext applicationContext = WebApplicationContextUtils
+				.getRequiredWebApplicationContext(servletContext);
+
+		assertTrue(applicationContext.containsBean(BEAN_NAME));
+		assertTrue(applicationContext.getBean(BEAN_NAME) instanceof MyBean);
+	}
+
+	private class MyMockServletContext extends MockServletContext {
+
+		@Override
+		public <T extends EventListener> void addListener(T listener) {
+			eventListener = listener;
+		}
+
+	}
+
+	private static class MyContextLoaderInitializer
+			extends AbstractContextLoaderInitializer {
+
+		@Override
+		protected WebApplicationContext createRootApplicationContext() {
+			StaticWebApplicationContext rootContext = new StaticWebApplicationContext();
+			rootContext.registerSingleton(BEAN_NAME, MyBean.class);
+			return rootContext;
+		}
+	}
+
+	private static class MyBean {
+
+	}
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractAnnotationConfigDispatcherServletInitializer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractAnnotationConfigDispatcherServletInitializer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.support;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+/**
+ * Base class for {@link org.springframework.web.WebApplicationInitializer
+ * WebApplicationInitializer} implementations that register one or more {@link
+ * org.springframework.web.servlet.DispatcherServlet DispatcherServlet}s in the servlet
+ * context based on annotated classes, e.g. {@link org.springframework.context.annotation.Configuration
+ * &#064Configuration} classes.
+ *
+ * <p>Concrete implementations are required to implement {@link #getRootConfigClasses()},
+ * {@link #getServletConfigClasses()}, as well as {@link #getServletMappings()}. Further
+ * template and customization methods are provided by {@link AbstractDispatcherServletInitializer}.
+ *
+ * @author Arjen Poutsma
+ * @since 3.2
+ */
+public abstract class AbstractAnnotationConfigDispatcherServletInitializer
+		extends AbstractDispatcherServletInitializer {
+
+	@Override
+	protected WebApplicationContext createRootApplicationContext() {
+		Class<?>[] rootConfigClasses = getRootConfigClasses();
+		if (!ObjectUtils.isEmpty(rootConfigClasses)) {
+			AnnotationConfigWebApplicationContext rootAppContext =
+					new AnnotationConfigWebApplicationContext();
+			rootAppContext.register(rootConfigClasses);
+			return rootAppContext;
+		}
+		else {
+			return null;
+		}
+	}
+
+	@Override
+	protected WebApplicationContext createServletApplicationContext() {
+		AnnotationConfigWebApplicationContext servletAppContext =
+				new AnnotationConfigWebApplicationContext();
+		Class<?>[] servletConfigClasses = getServletConfigClasses();
+		Assert.notEmpty(servletConfigClasses,
+				"getServletConfigClasses did not return" + "any configuration classes");
+
+		servletAppContext.register(servletConfigClasses);
+		return servletAppContext;
+	}
+
+	/**
+	 * Abstract template method that returns {@link org.springframework.context.annotation.Configuration
+	 * &#064Configuration} classes for the root application context.
+	 *
+	 * @return the configuration classes for the root application context, or {@code null} if
+	 *         a root context is not desired
+	 */
+	protected abstract Class<?>[] getRootConfigClasses();
+
+	/**
+	 * Abstract template method that returns {@link org.springframework.context.annotation.Configuration
+	 * &#064Configuration} classes for the servlet application context.
+	 *
+	 * @return the configuration classes for the servlet application context
+	 */
+	protected abstract Class<?>[] getServletConfigClasses();
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractDispatcherServletInitializer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractDispatcherServletInitializer.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.support;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+
+import org.springframework.util.Assert;
+import org.springframework.web.context.AbstractContextLoaderInitializer;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+/**
+ * Base class for {@link org.springframework.web.WebApplicationInitializer
+ * WebApplicationInitializer} implementations that register a {@link DispatcherServlet} in
+ * the servlet context.
+ *
+ * <p>Concrete implementations are required to implement {@link
+ * #createServletApplicationContext()}, as well as {@link #getServletMappings()}, both of
+ * which gets invoked from {@link #addDispatcherServlet}. Further
+ * customization can be achieved by overriding {@link #customizeRegistration(ServletRegistration.Dynamic)}.
+ *
+ * <p>Because this class extends from {@link AbstractContextLoaderInitializer}, concrete
+ * implementations are also required to implement {@link #createRootApplicationContext()}
+ * to set up a <strong>root</strong> or <strong>parent</strong> application context. If a
+ * root context is not desired, implementations can simply return {@code null} in the
+ * {@code createRootApplicationContext()} implementation.
+ *
+ * @author Arjen Poutsma
+ * @since 3.2
+ */
+public abstract class AbstractDispatcherServletInitializer
+		extends AbstractContextLoaderInitializer {
+
+	/** The default servlet name. Can be changed by overriding {@link #getServletName}. */
+	public static final String DEFAULT_SERVLET_NAME = "dispatcher";
+
+	@Override
+	public void onStartup(ServletContext servletContext) throws ServletException {
+		super.onStartup(servletContext);
+
+		addDispatcherServlet(servletContext);
+	}
+
+	/**
+	 * Adds a {@link DispatcherServlet} to the given servlet context.
+	 *
+	 * <p>This method will create a {@code DispatcherServlet} with the name returned by
+	 * {@link #getServletName()}, initializing it with the application context returned from
+	 * {@link #createServletApplicationContext()}, and mapping it to the patterns returned
+	 * from {@link #getServletMappings()}.
+	 *
+	 * <p>Further customization can be achieved by overriding {@link
+	 * #customizeRegistration(ServletRegistration.Dynamic)}.
+	 *
+	 * @param servletContext the servlet context to register the listener with
+	 */
+	protected void addDispatcherServlet(ServletContext servletContext) {
+		String servletName = getServletName();
+		Assert.hasLength(servletName,
+				"getServletName() should not return an empty string");
+
+		WebApplicationContext servletAppContext = createServletApplicationContext();
+		Assert.notNull(servletAppContext,
+				"createServletApplicationContext() did not return an application " +
+						"context for servlet [" + servletName + "]");
+
+		DispatcherServlet dispatcherServlet = new DispatcherServlet(servletAppContext);
+
+		ServletRegistration.Dynamic registration =
+				servletContext.addServlet(servletName, dispatcherServlet);
+
+		registration.setLoadOnStartup(1);
+		registration.addMapping(getServletMappings());
+
+		customizeRegistration(registration);
+	}
+
+	/**
+	 * Returns the name under which the {@link DispatcherServlet} will be registered.
+	 * Defaults to {@link #DEFAULT_SERVLET_NAME}.
+	 *
+	 * @return the servlet names
+	 */
+	protected String getServletName() {
+		return DEFAULT_SERVLET_NAME;
+	}
+
+	/**
+	 * Abstract template method that creates and returns a servlet application context.
+	 *
+	 * <p>The returned context is used as a <strong>servlet</strong> context, i.e. it is
+	 * passed on to {@link DispatcherServlet#DispatcherServlet(WebApplicationContext)} As
+	 * such, it typically contains controllers, view resolvers, locale resolvers, and other
+	 * web-related beans.
+	 *
+	 * @return the application context for the servlet
+	 */
+	protected abstract WebApplicationContext createServletApplicationContext();
+
+	/**
+	 * Abstract template method that returns the mappings for the servlet with the given
+	 * name.
+	 *
+	 * @return the servlet mappings for the servlet
+	 */
+	protected abstract String[] getServletMappings();
+
+	/**
+	 * Template method that allows for further registration customization of the servlet.
+	 *
+	 * <p>The default implementation is empty.
+	 *
+	 * @param registration the registration to be customized
+	 */
+	protected void customizeRegistration(ServletRegistration.Dynamic registration) {
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/support/AnnotationConfigDispatcherServletInitializerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/support/AnnotationConfigDispatcherServletInitializerTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.support;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+/**
+ * Test case for {@link AbstractAnnotationConfigDispatcherServletInitializer}.
+ *
+ * @author Arjen Poutsma
+ */
+public class AnnotationConfigDispatcherServletInitializerTests {
+
+	private static final String SERVLET_NAME = "myservlet";
+
+	private static final String ROLE_NAME = "role";
+
+	private static final String SERVLET_MAPPING = "/myservlet";
+
+	private AbstractDispatcherServletInitializer initializer;
+
+	private MockServletContext servletContext;
+
+	private Map<String, Servlet> servlets;
+
+	private Map<String, MockDynamic> registrations;
+
+	@Before
+	public void setUp() throws Exception {
+		servletContext = new MyMockServletContext();
+		initializer = new MyAnnotationConfigDispatcherServletInitializer();
+		servlets = new LinkedHashMap<String, Servlet>(2);
+		registrations = new LinkedHashMap<String, MockDynamic>(2);
+	}
+
+	@Test
+	public void register() throws ServletException {
+		initializer.onStartup(servletContext);
+
+		assertEquals(1, servlets.size());
+		assertNotNull(servlets.get(SERVLET_NAME));
+
+		DispatcherServlet servlet = (DispatcherServlet) servlets.get(SERVLET_NAME);
+		WebApplicationContext servletContext = servlet.getWebApplicationContext();
+		((AnnotationConfigWebApplicationContext) servletContext).refresh();
+
+		assertTrue(servletContext.containsBean("bean"));
+		assertTrue(servletContext.getBean("bean") instanceof MyBean);
+
+		assertEquals(1, registrations.size());
+		assertNotNull(registrations.get(SERVLET_NAME));
+
+		MockDynamic registration = registrations.get(SERVLET_NAME);
+		assertEquals(Collections.singleton(SERVLET_MAPPING), registration.getMappings());
+		assertEquals(1, registration.getLoadOnStartup());
+		assertEquals(ROLE_NAME, registration.getRunAsRole());
+	}
+
+	private class MyMockServletContext extends MockServletContext {
+
+		@Override
+		public ServletRegistration.Dynamic addServlet(String servletName,
+		                                              Servlet servlet) {
+			servlets.put(servletName, servlet);
+			MockDynamic registration = new MockDynamic();
+			registrations.put(servletName, registration);
+			return registration;
+		}
+	}
+
+	private static class MyAnnotationConfigDispatcherServletInitializer
+			extends AbstractAnnotationConfigDispatcherServletInitializer {
+
+		@Override
+		protected String getServletName() {
+			return SERVLET_NAME;
+		}
+
+		@Override
+		protected Class<?>[] getServletConfigClasses() {
+			return new Class[]{MyConfiguration.class};
+		}
+
+		@Override
+		protected String[] getServletMappings() {
+			return new String[]{"/myservlet"};
+		}
+
+		@Override
+		protected void customizeRegistration(ServletRegistration.Dynamic registration) {
+			registration.setRunAsRole("role");
+		}
+
+		@Override
+		protected Class<?>[] getRootConfigClasses() {
+			return null;
+		}
+
+	}
+
+	private static class MyBean {
+
+	}
+
+	@Configuration
+	private static class MyConfiguration {
+
+		public MyConfiguration() {
+		}
+
+		@Bean
+		public MyBean bean() {
+			return new MyBean();
+		}
+
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/support/DispatcherServletInitializerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/support/DispatcherServletInitializerTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.support;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.StaticWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+/**
+ * Test case for {@link AbstractDispatcherServletInitializer}.
+ *
+ * @author Arjen Poutsma
+ */
+public class DispatcherServletInitializerTests {
+
+	private static final String SERVLET_NAME = "myservlet";
+
+	private static final String ROLE_NAME = "role";
+
+	private static final String SERVLET_MAPPING = "/myservlet";
+
+	private AbstractDispatcherServletInitializer initializer;
+
+	private MockServletContext servletContext;
+
+	private Map<String, Servlet> servlets;
+
+	private Map<String, MockDynamic> registrations;
+
+	@Before
+	public void setUp() throws Exception {
+		servletContext = new MyMockServletContext();
+		initializer = new MyDispatcherServletInitializer();
+		servlets = new LinkedHashMap<String, Servlet>(2);
+		registrations = new LinkedHashMap<String, MockDynamic>(2);
+	}
+
+	@Test
+	public void register() throws ServletException {
+		initializer.onStartup(servletContext);
+
+		assertEquals(1, servlets.size());
+		assertNotNull(servlets.get(SERVLET_NAME));
+
+		DispatcherServlet servlet = (DispatcherServlet) servlets.get(SERVLET_NAME);
+		WebApplicationContext servletContext = servlet.getWebApplicationContext();
+
+		assertTrue(servletContext.containsBean("bean"));
+		assertTrue(servletContext.getBean("bean") instanceof MyBean);
+
+		assertEquals(1, registrations.size());
+		assertNotNull(registrations.get(SERVLET_NAME));
+
+		MockDynamic registration = registrations.get(SERVLET_NAME);
+		assertEquals(Collections.singleton(SERVLET_MAPPING), registration.getMappings());
+		assertEquals(1, registration.getLoadOnStartup());
+		assertEquals(ROLE_NAME, registration.getRunAsRole());
+	}
+
+	private class MyMockServletContext extends MockServletContext {
+
+		@Override
+		public ServletRegistration.Dynamic addServlet(String servletName,
+		                                              Servlet servlet) {
+			servlets.put(servletName, servlet);
+			MockDynamic registration = new MockDynamic();
+			registrations.put(servletName, registration);
+			return registration;
+		}
+	}
+
+	private static class MyDispatcherServletInitializer
+			extends AbstractDispatcherServletInitializer {
+
+		@Override
+		protected String getServletName() {
+			return SERVLET_NAME;
+		}
+
+		@Override
+		protected WebApplicationContext createServletApplicationContext() {
+			StaticWebApplicationContext servletContext =
+					new StaticWebApplicationContext();
+			servletContext.registerSingleton("bean", MyBean.class);
+			return servletContext;
+		}
+
+		@Override
+		protected String[] getServletMappings() {
+			return new String[]{"/myservlet"};
+		}
+
+		@Override
+		protected void customizeRegistration(ServletRegistration.Dynamic registration) {
+			registration.setRunAsRole("role");
+		}
+
+		@Override
+		protected WebApplicationContext createRootApplicationContext() {
+			return null;
+		}
+	}
+
+	private static class MyBean {
+
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/support/MockDynamic.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/support/MockDynamic.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.support;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.ServletRegistration;
+import javax.servlet.ServletSecurityElement;
+
+class MockDynamic implements ServletRegistration.Dynamic {
+
+	private int loadOnStartup;
+
+	private Set<String> mappings = new LinkedHashSet<String>();
+
+	private String roleName;
+
+	public int getLoadOnStartup() {
+		return loadOnStartup;
+	}
+
+	public void setLoadOnStartup(int loadOnStartup) {
+		this.loadOnStartup = loadOnStartup;
+	}
+
+	public void setRunAsRole(String roleName) {
+		this.roleName = roleName;
+	}
+
+	public Set<String> addMapping(String... urlPatterns) {
+		mappings.addAll(Arrays.asList(urlPatterns));
+		return mappings;
+	}
+
+	public Collection<String> getMappings() {
+		return mappings;
+	}
+
+	public String getRunAsRole() {
+		return roleName;
+	}
+
+	// not implemented
+	public void setAsyncSupported(boolean isAsyncSupported) {
+	}
+
+	public String getName() {
+		return null;
+	}
+
+	public void setMultipartConfig(MultipartConfigElement multipartConfig) {
+	}
+
+	public Set<String> setServletSecurity(ServletSecurityElement constraint) {
+		return null;
+	}
+
+	public String getClassName() {
+		return null;
+	}
+
+	public boolean setInitParameter(String name, String value) {
+		return false;
+	}
+
+	public String getInitParameter(String name) {
+		return null;
+	}
+
+	public Set<String> setInitParameters(Map<String, String> initParameters) {
+		return null;
+	}
+
+	public Map<String, String> getInitParameters() {
+		return null;
+	}
+}


### PR DESCRIPTION
These two commits adds three abstract WebApplicationInitializers, to be used
for a typical setup of a Spring Web application.
- AbstractContextLoaderInitializer provides an abstract base class for
  setting up the ContextLoaderListener.
- AbstractDispatcherServletInitializer provides an abstract base class
  for setting up one or more DispatcherServlets, with an optional root
  context.
- AbstractAnnotationConfigDispatcherServletInitializer provides an
  abstract base class for setting up DispatcherServlets based on
  Configuration classes.

Some points for discussion:
- Packaging: I wasn't sure where to put these classes, and I am fully open for suggestions.
- Naming: I am happy about `AbstractContextLoaderInitializer` and `AbstractDispatcherServletInitializer`, but less happy about `AbstractAnnotationConfigDispatcherServletInitializer`. Open for suggestions as well.
- There are a couple of TODOs, where we have the opportunity to pass a ServletContext to a template method. I wasn't sure if the context was needed, so I left it out.

Also, this seems to have turned into two commits, while the goal was to have one. Blame my git ignorance.
