### PR TITLE
Avoid monitor contention inside MethodParameter.getParameterAnnotations()

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/MethodParameterTests.java
+++ b/spring-core/src/test/java/org/springframework/core/MethodParameterTests.java
@@ -16,11 +16,20 @@
 
 package org.springframework.core;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.Assert.*;
 
 /**
@@ -76,10 +85,33 @@ public class MethodParameterTests {
 		assertEquals(stringParameter.hashCode(), methodParameter.hashCode());
 		assertTrue(longParameter.hashCode() != methodParameter.hashCode());
 	}
+	
+	@Test
+	public void testGetMethodParamaterAnnotations() {
+		Method method = stringParameter.getMethod();
+		Annotation[][] expectedAnnotations = method.getParameterAnnotations(); 
+		assertEquals(2, expectedAnnotations.length);
+		assertEquals(DummyAnnotation.class, expectedAnnotations[0][0].annotationType());
+		
+		//start with empty cache
+		MethodParameter.getMethodParamAnnotationsCache().clear();
+		
+		//check correctness		
+		assertArrayEquals(expectedAnnotations, MethodParameter.getMethodParameterAnnotations(method));
+		//check that return value's been cached
+		assertArrayEquals(expectedAnnotations, MethodParameter.getMethodParamAnnotationsCache().get(method));
+	}
 
 
-	public int method(String p1, long p2) {
+	public int method(@DummyAnnotation String p1, long p2) {
 		return 42;
 	}
+	
+	@Target({ CONSTRUCTOR, PARAMETER })
+	@Retention(RUNTIME)
+	public @interface DummyAnnotation {
+
+	}
+
 
 }


### PR DESCRIPTION
MethodParameter.getParameterAnnotations() calls
Method.getParameterAnnotations() on every invocation. Latter ends up
contending for a monitor inside (Sun) JDK code. Fix by caching values
returned by Method.getParameterAnnotations() in a static ConcurrentMap

Issue: SPR-9298
