### PR TITLE
Fix for SPR-9323 (NPE in WebSphere) 

### DIFF
--- a/org.springframework.core/src/main/java/org/springframework/core/io/UrlResource.java
+++ b/org.springframework.core/src/main/java/org/springframework/core/io/UrlResource.java
@@ -17,6 +17,7 @@
 package org.springframework.core.io;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -122,7 +123,11 @@ public class UrlResource extends AbstractFileResolvingResource {
 		URLConnection con = this.url.openConnection();
 		ResourceUtils.useCachesIfNecessary(con);
 		try {
-			return con.getInputStream();
+			InputStream is=con.getInputStream();
+			if (is == null) {
+				throw new FileNotFoundException("Could not open " + getDescription());
+			}
+			return is;
 		}
 		catch (IOException ex) {
 			// Close the HTTP connection (if applicable).


### PR DESCRIPTION
This is a fix for https://jira.springsource.org/browse/SPR-9323 .

It's causing this bug in Grails 2.x: http://jira.grails.org/browse/GRAILS-8791 that breaks WebSphere App Server 6.1 compatibility.
