### PR TITLE
Fix transitive dependency issue with slf4j-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,9 +213,13 @@ project('spring-context') {
         compile("org.beanshell:bsh:2.0b4", optional)
         compile("org.codehaus.groovy:groovy-all:1.6.3", optional)
         compile("org.jruby:jruby:1.4.0", optional)
-        compile("org.hibernate:hibernate-validator:4.2.0.Final", optional)
+        compile("org.hibernate:hibernate-validator:4.2.0.Final") { dep ->
+            optional dep
+            exclude group: 'org.slf4j', module: 'slf4j-api'
+        }
         compile("joda-time:joda-time:1.6", optional)
         compile("net.sf.ehcache:ehcache-core:2.0.0", optional)
+        compile("org.slf4j:slf4j-api:${slf4jLog4jVersion}", optional)
         compile("org.codehaus.jsr166-mirror:jsr166:1.7.0", provided)
         testCompile "commons-dbcp:commons-dbcp:1.2.2"
         testCompile("javax.xml:jaxrpc-api:1.1")


### PR DESCRIPTION
Before this change, IDE settings generated via import-into-eclipse.sh
created a classpath dependency on slf4j-api version 1.6.1 and
slf4j-log4j12 version 1.5.10. As a result running tests inside the IDE
resulted in a NoSuchMethodException.

build.gradle sets the variable slf4jLog4jVersion to '1.5.10'. However,
the hibernate-validator dependency in spring-context pulls in
slf4j-api version 1.6.1. The change ensures the version specified in
the build script variable is used consistently. Whether it should be
1.5.10 or 1.6.1 is a separate concern.
