### PR TITLE
Update WebMvcConfigurationSupport.java

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -371,15 +371,15 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 		messageConverters.add(new XmlAwareFormHttpMessageConverter());
 
 		ClassLoader classLoader = getClass().getClassLoader();
+		if (ClassUtils.isPresent("com.sun.syndication.feed.WireFeed", classLoader)) {
+			messageConverters.add(new AtomFeedHttpMessageConverter());
+			messageConverters.add(new RssChannelHttpMessageConverter());
+		}
 		if (ClassUtils.isPresent("javax.xml.bind.Binder", classLoader)) {
 			messageConverters.add(new Jaxb2RootElementHttpMessageConverter());
 		}
 		if (ClassUtils.isPresent("org.codehaus.jackson.map.ObjectMapper", classLoader)) {
 			messageConverters.add(new MappingJacksonHttpMessageConverter());
-		}
-		if (ClassUtils.isPresent("com.sun.syndication.feed.WireFeed", classLoader)) {
-			messageConverters.add(new AtomFeedHttpMessageConverter());
-			messageConverters.add(new RssChannelHttpMessageConverter());
 		}
 	}
 	


### PR DESCRIPTION
We should place rss & atom converters before jackson converter, because currently com.sun.syndication.feed.rss.Channel and com.sun.syndication.feed.atom.Feed and converted to json by default which isn't quite right and intuitive.
