### PR TITLE
Add a factory class for handler interceptors

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/HandlerInterceptorsFactory.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/HandlerInterceptorsFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.support;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.handler.MappedInterceptor;
+
+/**
+ * Factory bean to generate list of HandlerMappings and MappedHandlers.
+ *
+ * MappedHandlers can be specified by url path to interceptors.
+ *
+ *
+ * <pre>
+ *  &lt;bean class="HandlerInterceptorsFactory" &gt;
+ *    &lt;property name="handlerInterceptors" ref="list-of-global-interceptors" &gt;
+ *    &lt;property name="interceptorsByPath" &gt;
+ *      &lt;map&gt;
+ *          &lt;entry key="/path/*" value-ref="list-of-interceptors"/&gt;
+ *      &lt;/map&gt;
+ *    &lt;/property&gt;
+ *    &lt;property name="additionalMappedInterceptors" ref="list-of-mapped-interceptors" &gt;
+ *  &lt;/bean&gt;
+ * </pre>
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.2
+ */
+public class HandlerInterceptorsFactory extends AbstractFactoryBean<List<Object>> {
+
+	private List<HandlerInterceptor> handlerInterceptors = new ArrayList<HandlerInterceptor>();
+
+	private Map<String, List<HandlerInterceptor>> interceptorsByPath =
+			new LinkedHashMap<String, List<HandlerInterceptor>>();
+
+	private List<MappedInterceptor> additionalMappedInterceptors = new ArrayList<MappedInterceptor>();
+
+	@Override
+	public Class<?> getObjectType() {
+		return List.class;
+	}
+
+	public HandlerInterceptorsFactory() {
+		super();
+	}
+
+	@Override
+	protected List<Object> createInstance() throws Exception {
+
+		final List<MappedInterceptor> mappedInterceptors = getMappedInterceptors();
+
+		final List<Object> interceptors = new ArrayList<Object>();
+		interceptors.addAll(mappedInterceptors);
+		interceptors.addAll(additionalMappedInterceptors);
+		interceptors.addAll(handlerInterceptors); // regular interceptors
+		return interceptors;
+
+	}
+
+	private List<MappedInterceptor> getMappedInterceptors() {
+
+		// convert (path -> interceptors) to (interceptor -> paths)
+		final Map<HandlerInterceptor, List<String>> map = new LinkedHashMap<HandlerInterceptor, List<String>>();
+		for (Map.Entry<String, List<HandlerInterceptor>> entry : interceptorsByPath.entrySet()) {
+			final String path = entry.getKey();
+			final List<HandlerInterceptor> interceptors = entry.getValue();
+
+			for (HandlerInterceptor interceptor : interceptors) {
+
+				List<String> paths = map.get(interceptor);
+				if (paths == null) {
+					paths = new ArrayList<String>();
+					map.put(interceptor, paths);
+				}
+
+				paths.add(path);
+			}
+		}
+
+		final List<MappedInterceptor> result = new ArrayList<MappedInterceptor>();
+
+		// create mapped interceptors
+		for (Map.Entry<HandlerInterceptor, List<String>> entry : map.entrySet()) {
+			final HandlerInterceptor interceptor = entry.getKey();
+			final List<String> paths = entry.getValue();
+
+			final MappedInterceptor mappedInterceptor =
+					new MappedInterceptor(paths.toArray(new String[paths.size()]), interceptor);
+
+			result.add(mappedInterceptor);
+		}
+
+		return result;
+
+	}
+
+	public void setInterceptorsByPath(Map<String, List<HandlerInterceptor>> interceptorsByPath) {
+		this.interceptorsByPath = interceptorsByPath;
+	}
+
+	public void setHandlerInterceptors(List<HandlerInterceptor> handlerInterceptors) {
+		this.handlerInterceptors = handlerInterceptors;
+	}
+
+	public void setAdditionalMappedInterceptors(List<MappedInterceptor> additionalMappedInterceptors) {
+		this.additionalMappedInterceptors = additionalMappedInterceptors;
+	}
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/support/HandlerInterceptorsFactoryTest.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/support/HandlerInterceptorsFactoryTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.support;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.handler.MappedInterceptor;
+
+import static org.easymock.EasyMock.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.collection.IsArray.*;
+import static org.junit.Assert.*;
+
+/** @author Tadaya Tsuyukubo */
+public class HandlerInterceptorsFactoryTest {
+
+	@Test
+	public void testCreateInstance() throws Exception {
+
+		HandlerInterceptor fooInterceptor = createMock(HandlerInterceptor.class);
+		HandlerInterceptor barInterceptor = createMock(HandlerInterceptor.class);
+		HandlerInterceptor bazInterceptor = createMock(HandlerInterceptor.class);
+
+		// list of handler interceptors: [foo,bar,baz]
+		List<HandlerInterceptor> handlerInterceptors = new ArrayList<HandlerInterceptor>();
+		handlerInterceptors.add(fooInterceptor);
+		handlerInterceptors.add(barInterceptor);
+		handlerInterceptors.add(bazInterceptor);
+
+		// create additional mapped interceptors: [foo,bar[
+		MappedInterceptor fooAdditional = new MappedInterceptor(new String[]{"/add/foo"}, fooInterceptor);
+		MappedInterceptor barAdditional = new MappedInterceptor(new String[]{"/add/bar"}, barInterceptor);
+		List<MappedInterceptor> additionalMappedInterceptors = new ArrayList<MappedInterceptor>();
+		additionalMappedInterceptors.add(fooAdditional);
+		additionalMappedInterceptors.add(barAdditional);
+
+		// create interceptorsByPath: "/foo" => [foo], "/foobar" => [foo,bar]
+		List<HandlerInterceptor> fooHandlers = new ArrayList<HandlerInterceptor>();
+		fooHandlers.add(fooInterceptor);
+		List<HandlerInterceptor> fooBarHandlers = new ArrayList<HandlerInterceptor>();
+		fooBarHandlers.add(fooInterceptor);
+		fooBarHandlers.add(barInterceptor);
+		Map<String, List<HandlerInterceptor>> interceptorsByPath = new HashMap<String, List<HandlerInterceptor>>();
+		interceptorsByPath.put("/foo", fooHandlers); // one interceptor
+		interceptorsByPath.put("/foobar", fooBarHandlers); // two interceptors
+
+		// prepare factory
+		HandlerInterceptorsFactory factory = new HandlerInterceptorsFactory();
+		factory.setHandlerInterceptors(handlerInterceptors);
+		factory.setAdditionalMappedInterceptors(additionalMappedInterceptors);
+		factory.setInterceptorsByPath(interceptorsByPath);
+		List<Object> interceptors = factory.createInstance();
+
+		// expected: [foo,bar,baz, mapped-foo => ["/add/foo"], mapped-bar => ["/add/bar"],
+		//           mapped-foo => ["/foo","/foobar"], mapped-bar => ["/foobar"]
+		assertThat("expected total size", interceptors.size(), is(7));
+
+		// verify normal handler interceptors
+		List<HandlerInterceptor> actualHandlerInterceptors = filterByClass(interceptors, HandlerInterceptor.class);
+		assertThat(actualHandlerInterceptors, hasItems(fooInterceptor, barInterceptor, bazInterceptor));
+		assertThat(actualHandlerInterceptors.size(), is(3));
+
+		// verify additional mapped interceptors
+		List<MappedInterceptor> actualMappedInterceptors = filterByClass(interceptors, MappedInterceptor.class);
+		assertThat(actualMappedInterceptors, hasItems(fooAdditional, barAdditional));
+		assertThat("expected num of MappedHandler", actualMappedInterceptors.size(), is(4));
+
+		// remove the additional mapped interceptors
+		actualMappedInterceptors.remove(fooAdditional);
+		actualMappedInterceptors.remove(barAdditional);
+
+		// sort by size of path patterns
+		Collections.sort(actualMappedInterceptors, new MappedInterceptorPatternSizeComparator());
+
+		// verify MappedInterceptors mapped by url path
+
+		// foo interceptor
+		MappedInterceptor firstMappedInterceptor = actualMappedInterceptors.get(0);
+		assertThat(firstMappedInterceptor.getInterceptor(), sameInstance(fooInterceptor));
+		assertThat(firstMappedInterceptor.getPathPatterns(), hasItemInArray("/foo"));
+		assertThat(firstMappedInterceptor.getPathPatterns(), hasItemInArray("/foobar"));
+		assertThat(firstMappedInterceptor.getPathPatterns().length, is(2));
+
+		// bar interceptor
+		MappedInterceptor secondMappedInterceptor = actualMappedInterceptors.get(1);
+		assertThat(secondMappedInterceptor.getInterceptor(), sameInstance(barInterceptor));
+		assertThat(secondMappedInterceptor.getPathPatterns(), array(is("/foobar")));
+
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> List<T> filterByClass(List<Object> interceptors, Class<T> clazz) {
+		// wish i could use google-guava
+		List<T> result = new ArrayList<T>();
+		for (Object interceptor : interceptors) {
+			if (clazz.isAssignableFrom(interceptor.getClass())) {
+				result.add((T) interceptor);
+			}
+		}
+		return result;
+	}
+
+	private static class MappedInterceptorPatternSizeComparator implements Comparator<MappedInterceptor> {
+
+		public int compare(MappedInterceptor left, MappedInterceptor right) {
+			int leftSize = left.getPathPatterns().length;
+			int rightSize = right.getPathPatterns().length;
+			if (leftSize == rightSize) {
+				return 0;
+			}
+			return leftSize < rightSize ? 1 : -1;
+		}
+	}
+
+}


### PR DESCRIPTION
A factory bean to create a list of HandlerInterceptors and MappedInterceptors, providing ability to map:
  url-path => handler-interceptors

It can also specify additional handler interceptors and mapped interceptors. 
Thus, result of this factory bean can directly be injected to RequestMappingHandlerMapping bean.

```
<bean class="org.springframework.web.servlet.support.HandlerInterceptorsFactory">
  <property name="interceptorsByPath">
    <map>
      <!--   url-path => list of interceptors  -->
      <entry key="/foo/*" value-ref="interceptorList"/>
      <entry key="/bar/*">
        <list>
          <bean class="SomeHandlerInterceptorImpl"/>
        </list>
      </entry>
    </map>
  </property>
  <property name="handlerInterceptors" ref="handler-interceptors" />
  <property name="additionalMappedInterceptors" ref="additional-mapped-interceptors"/>
</bean>
```
# Background

In spring3.1 style configuration, RequestMappingHandlerMapping uses MappedInterceptor which specify one handler interceptor to multiple paths, but not the other way, a path to multiple handler interceptors.

pre-spring3.1:
- url-path => handler-interceptors

spring3.1:
- handler-interceptor => url-paths

I have multiple SimpleUrlHandlerMapping beans in old version app, and having ability to specify interceptors by path saves a lot of time, rather than re-maping the existing path-to-interceptors mappings to interceptor-to-paths style.

JIRA: SPR-9361
CLA: submitted
