### PR TITLE
Fix annotation search ending too early

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
@@ -132,12 +132,12 @@ public abstract class AnnotationUtils {
 			try {
 				Method equivalentMethod = cl.getDeclaredMethod(method.getName(), method.getParameterTypes());
 				annotation = getAnnotation(equivalentMethod, annotationType);
-				if (annotation == null) {
-					annotation = searchOnInterfaces(method, annotationType, cl.getInterfaces());
-				}
 			}
 			catch (NoSuchMethodException ex) {
-				// We're done...
+				// No equivalent method found
+			}
+			if (annotation == null) {
+				annotation = searchOnInterfaces(method, annotationType, cl.getInterfaces());
 			}
 		}
 		return annotation;

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2006 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -219,6 +219,14 @@ public class AnnotationUtilsTests {
 		assertNotNull(order);
 	}
 
+	@Test
+	public void testFindAnnotationFromInterfaceWhenSuperDoesNotImplementMethod() throws Exception {
+		
+		Method method = SubOfAbstractImplementsInterfaceWithAnnotatedMethod.class.getMethod("foo");
+		Order order = findAnnotation(method, Order.class);
+		assertNotNull(order);
+	}
+
 
 	@Component(value="meta1")
 	@Retention(RetentionPolicy.RUNTIME)
@@ -348,6 +356,15 @@ public class AnnotationUtilsTests {
 	}
 
 	public static class SubOfImplementsInterfaceWithAnnotatedMethod extends ImplementsInterfaceWithAnnotatedMethod {
+
+		public void foo() {
+		}
+	}
+
+	public abstract static class AbstractDoesNotImplementInterfaceWithAnnotatedMethod implements InterfaceWithAnnotatedMethod {
+	}
+
+	public static class SubOfAbstractImplementsInterfaceWithAnnotatedMethod extends AbstractDoesNotImplementInterfaceWithAnnotatedMethod {
 
 		public void foo() {
 		}


### PR DESCRIPTION
At AnnotationUtils.findAnnotation(Method, Class), the search for method
annotation fails if:
- the original method does not have the annotation
- an abstract superclass does not have an equivalent method declared
- an interface implemented by the superclass has the method and
  the annotation - it is not found

This happened because of the try-catch block being too wide. Therefore,
cl.getDeclaredMethod() can throw NoSuchMethodException and skip
the searchOnInterfaces() call prematurely.

The try-catch block was made narrower to allow searchOnInterfaces()
to run even if the abstract class does not have the method declared
at all.

Issue: SPR-9342

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
