### PR TITLE
Passing lookup-method args to bean constructor

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactory.java
@@ -170,7 +170,7 @@ public interface BeanFactory {
 	 * overriding the specified default arguments (if any) in the bean definition.
 	 * @param name the name of the bean to retrieve
 	 * @param args arguments to use if creating a prototype using explicit arguments to a
-	 * static factory method. It is invalid to use a non-null args value in any other case.
+	 * static factory method.
 	 * @return an instance of the bean
 	 * @throws NoSuchBeanDefinitionException if there's no such bean definition
 	 * @throws BeanDefinitionStoreException if arguments have been given but

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/CglibSubclassingInstantiationStrategy.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/CglibSubclassingInstantiationStrategy.java
@@ -157,7 +157,7 @@ public class CglibSubclassingInstantiationStrategy extends SimpleInstantiationSt
 			public Object intercept(Object obj, Method method, Object[] args, MethodProxy mp) throws Throwable {
 				// Cast is safe, as CallbackFilter filters are used selectively.
 				LookupOverride lo = (LookupOverride) beanDefinition.getMethodOverrides().getOverride(method);
-				return owner.getBean(lo.getBeanName());
+				return owner.getBean(lo.getBeanName(), args);
 			}			
 		}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/LookupOverride.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/LookupOverride.java
@@ -61,7 +61,7 @@ public class LookupOverride extends MethodOverride {
 	 */
 	@Override
 	public boolean matches(Method method) {
-		return (method.getName().equals(getMethodName()) && method.getParameterTypes().length == 0);
+		return (method.getName().equals(getMethodName()));
 	}
 
 

--- a/spring-beans/src/test/java/org/springframework/beans/factory/support/LookupMethodTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/support/LookupMethodTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.support;
+
+import junit.framework.TestCase;
+
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ClassPathResource;
+
+import test.beans.AbstractBean;
+import test.beans.TestBean;
+
+/**
+ * Tests the use of lookup-method
+ * @author Karl Pietrzak
+ */
+public class LookupMethodTests extends TestCase {
+	
+
+	private DefaultListableBeanFactory beanFactory;
+
+	protected void setUp() throws Exception {
+		final ClassPathResource resource = new ClassPathResource("/org/springframework/beans/factory/xml/lookupMethodBeanTests.xml", getClass());
+		this.beanFactory = new DefaultListableBeanFactory();
+		final XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(this.beanFactory);
+		reader.loadBeanDefinitions(resource);
+	}
+
+	/**
+	 * lookup method's bean has no constructor arguments
+	 */
+	public void testWithoutConstructorArg() {
+		AbstractBean bean = (AbstractBean)this.beanFactory.getBean("abstractBean");
+		assertNotNull(bean);
+		final Object expected = bean.get();
+		assertEquals(TestBean.class, expected.getClass());
+	}
+
+	/**
+	 * Creates a new instance of {@link TestBean} using the constructor which takes a single <code>String</code>
+	 */
+	public void testWithOneConstructorArg() {
+		AbstractBean bean = (AbstractBean)this.beanFactory.getBean("abstractBean");
+		assertNotNull(bean);
+		final TestBean expected = bean.getOneArgument("haha");
+		assertEquals(TestBean.class, expected.getClass());
+		assertEquals("haha", expected.getName());
+	}
+	
+	/**
+	 * Creates a new instance of {@link TestBean} using the constructor which takes a <code>String</code> and an <code>int</code>
+	 */
+	public void testWithTwoConstructorArg() {
+		AbstractBean bean = (AbstractBean)this.beanFactory.getBean("abstractBean");
+		assertNotNull(bean);
+		final TestBean expected = bean.getTwoArguments("haha", 72);
+		assertEquals(TestBean.class, expected.getClass());
+		assertEquals("haha", expected.getName());
+		assertEquals(72, expected.getAge());
+	}
+	
+	/**
+	 *  {@link TestBean} doesn't have a constructor that takes a <code>String</code> and two <code>int</code>'s
+	 */
+	public void testWithThreeArgsShouldFail() {
+		AbstractBean bean = (AbstractBean)this.beanFactory.getBean("abstractBean");
+		assertNotNull(bean);
+		try {
+			bean.getThreeArguments("name", 1, 2);
+			fail("TestBean does not have a three arg constructor so this should not have worked");
+		} catch (AbstractMethodError e) {
+			
+		}
+	}
+}

--- a/spring-beans/src/test/java/test/beans/AbstractBean.java
+++ b/spring-beans/src/test/java/test/beans/AbstractBean.java
@@ -1,0 +1,19 @@
+package test.beans;
+
+import org.springframework.beans.factory.support.LookupMethodTests;
+
+/**
+ * A simple bean used for testing <code>lookup-method</code> constructors.
+ * 
+ * The actual test class which uses this bean is {@link LookupMethodTests}
+ * @author kpietrzak
+ *
+ */
+public abstract class AbstractBean {
+	
+	public abstract TestBean get();
+	public abstract TestBean getOneArgument(String name);
+	public abstract TestBean getTwoArguments(String name, int age);
+	public abstract TestBean getThreeArguments(String name, int age, int anotherArg);
+
+}

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/lookupMethodBeanTests.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/lookupMethodBeanTests.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+
+
+	<bean id="abstractBean" class="test.beans.AbstractBean" >
+		<lookup-method name="get" bean="test"/>
+		<lookup-method name="getOneArgument" bean="test"/>
+		<lookup-method name="getTwoArguments" bean="test"/>
+	</bean>
+	
+	<bean id="test" class="test.beans.TestBean" scope="prototype">
+	</bean>
+</beans>


### PR DESCRIPTION
<lookup-method/> should allow specifying any number of parameters.
These parameters should be passed directly to the constructor of the
newly created bean.

Previously <lookup-method/> had to be parameterless. Now if you provide
any parameters to that method, they are passes directly (1 to 1) to the
bean constructor, just like if they were declared using
<constructor-arg/>. The idea was originally suggested here:

http://nurkiewicz.blogspot.com/2010/08/creating-prototype-spring-beans-on.html

This change is based entirely on a patch provided by Karl Pietrzak.

I submitted CLA.

Issue: SPR-7431
