### PR TITLE
Javadoc patch for RequestMapping (SPR-9483)

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMapping.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMapping.java
@@ -331,8 +331,9 @@ public @interface RequestMapping {
 
 	/**
 	 * The consumable media types of the mapped request, narrowing the primary mapping.
-	 * <p>The format is a sequence of media types ("text/plain", "application/*),
+	 * <p>The format is a media type or sequence of media types,
 	 * with a request only mapped if the {@code Content-Type} matches one of these media types.
+         * Examples: {@code consumes = "text/plain"} <code>consumes = {"text/plain", "application/*"}</code>
 	 * Expressions can be negated by using the "!" operator, as in "!text/plain", which matches
 	 * all requests with a {@code Content-Type} other than "text/plain".
 	 * <p><b>Supported at the type level as well as at the method level!</b>
@@ -345,8 +346,9 @@ public @interface RequestMapping {
 
 	/**
 	 * The producible media types of the mapped request, narrowing the primary mapping.
-	 * <p>The format is a sequence of media types ("text/plain", "application/*),
-	 * with a request only mapped if the {@code Accept} matches one of these media types.
+	 * <p>The format is a media type or sequence of media types,
+	 * with a request only mapped if the {@code Content-Type} matches one of these media types.
+         * Examples: {@code produces = "text/plain"} <code>produces = {"text/plain", "application/*"}</code>
 	 * Expressions can be negated by using the "!" operator, as in "!text/plain", which matches
 	 * all requests with a {@code Accept} other than "text/plain".
 	 * <p><b>Supported at the type level as well as at the method level!</b>


### PR DESCRIPTION
Updated Javadoc for RequestMapping as suggested in 
https://jira.springsource.org/browse/SPR-9483

```
 * <p>The format is a media type or sequence of media types,
 * with a request only mapped if the {@code Content-Type} matches one of these media types.
     * Examples: {@code consumes = "text/plain"} <code>consumes = {"text/plain", "application/*"}</code>
```

similar for produces.

Update 06/13/2012:
I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
