### PR TITLE
Fix HTTP MediaType header parsing with single-quoted parameters

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -376,7 +376,9 @@ public class MediaType implements Comparable<MediaType> {
 	}
 
 	private boolean isQuotedString(String s) {
-		return s.length() > 1 && s.startsWith("\"") && s.endsWith("\"") ;
+		return s.length() > 1 &&
+				((s.startsWith("\"") && s.endsWith("\"")) ||
+						(s.startsWith("'") && s.endsWith("'")));
 	}
 
 	private String unquote(String s) {

--- a/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
+++ b/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
@@ -181,6 +181,12 @@ public class MediaTypeTests {
 		assertEquals("\"v>alue\"", mediaType.getParameter("attr"));
 	}
 
+	@Test
+	public void parseMediaTypeSingleQuotedParameterValue() {
+		MediaType mediaType = MediaType.parseMediaType("audio/*;attr='v>alue'");
+		assertEquals("'v>alue'", mediaType.getParameter("attr"));
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void parseMediaTypeIllegalQuotedParameterValue() {
 		MediaType.parseMediaType("audio/*;attr=\"");


### PR DESCRIPTION
Addition to previous fix for double-quoted parameters

Issue: SPR-8917
