### PR TITLE
Add splitIndex Javadoc option to the root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -574,6 +574,7 @@ configure(rootProject) {
         options.author = true
         options.header = rootProject.description
         options.overview = 'src/api/overview.html'
+        options.splitIndex = true
         options.links(
             'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
         )


### PR DESCRIPTION
Splits the very large index page with all classes into individual pages
organized by first letter.

Issue: SPR-4984
