### PR TITLE
SPR-4675: add explicit test for null return from aop advice

### DIFF
--- a/spring-aop/src/test/java/org/springframework/aop/framework/NullPrimitiveTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/framework/NullPrimitiveTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+import static org.junit.Assert.assertEquals;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.aop.AopInvocationException;
+
+/**
+ * Test for SPR-4675. A null value returned from around advice is very hard to debug if the caller expects a primitive.
+ * 
+ * @author Dave Syer
+ * 
+ */
+public class NullPrimitiveTests {
+	
+	@Rule
+	public ExpectedException expected = ExpectedException.none(); 
+
+	static interface Foo {
+		int getValue();
+	}
+
+	@Test
+	public void testNullPrimitiveWithJdkProxy() {
+
+		class SimpleFoo implements Foo {
+			public int getValue() {
+				return 100;
+			}
+		}
+
+		SimpleFoo target = new SimpleFoo();
+		ProxyFactory factory = new ProxyFactory(target);
+		factory.addAdvice(new MethodInterceptor() {
+			public Object invoke(MethodInvocation invocation) throws Throwable {
+				return null;
+			}
+		});
+		
+		Foo foo = (Foo) factory.getProxy();
+		
+		expected.expect(AopInvocationException.class);
+		expected.expectMessage("Foo.getValue()");
+		assertEquals(0, foo.getValue());
+
+	}
+
+	public static class Bar {
+		public int getValue() {
+			return 100;
+		}
+	}
+
+	@Test
+	public void testNullPrimitiveWithCglibProxy() {
+
+		Bar target = new Bar();
+		ProxyFactory factory = new ProxyFactory(target);
+		factory.addAdvice(new MethodInterceptor() {
+			public Object invoke(MethodInvocation invocation) throws Throwable {
+				return null;
+			}
+		});
+		
+		Bar bar = (Bar) factory.getProxy();
+		
+		expected.expect(AopInvocationException.class);
+		expected.expectMessage("Bar.getValue()");
+		assertEquals(0, bar.getValue());
+
+	}
+
+}


### PR DESCRIPTION
When around advice returns null and the caller is expecting a
primitive it is _really_ hard to debug.  Adding an explicit
check for this in the aop proxy and throwing a Spring exception
seems like the best solution.
