### PR TITLE
Improve performance of streaming rest requests

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/SimpleStreamingClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleStreamingClientHttpRequest.java
@@ -114,6 +114,11 @@ final class SimpleStreamingClientHttpRequest extends AbstractClientHttpRequest {
 		}
 
 		@Override
+		public void write(byte[] b, int off, int let) throws IOException {
+			out.write(b, off, let);
+		}
+		
+		@Override
 		public void close() throws IOException {
 		}
 	}


### PR DESCRIPTION
Ensure that the NonClosingOutputStream calls the underlying write
method directly when working with byte arrays.  This significantly
improves performance.

Issues: SPR-9530
