### PR TITLE
SPR-9541: Provide PersistenceExceptionTranslator for EclipseLink exceptions

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkExceptionTranslator.java
+++ b/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkExceptionTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import org.springframework.dao.support.PersistenceExceptionTranslator;
  * @author Jan Stamer
  * @since 3.2
  * @see org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor
- */public class EclipseLinkExceptionTranslator implements PersistenceExceptionTranslator {
+ */
+public class EclipseLinkExceptionTranslator implements PersistenceExceptionTranslator {
 
 	public DataAccessException translateExceptionIfPossible(RuntimeException ex) {
 		if (ex instanceof EclipseLinkException) {

--- a/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkExceptionTranslator.java
+++ b/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkExceptionTranslator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.eclipselink;
+
+import org.eclipse.persistence.exceptions.EclipseLinkException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
+
+/**
+ * {@link PersistenceExceptionTranslator} capable of translating {@link EclipseLinkException}
+ * instances to Spring's {@link DataAccessException} hierarchy.
+ *
+ * @author Jan Stamer
+ * @since 3.2
+ * @see org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor
+ */public class EclipseLinkExceptionTranslator implements PersistenceExceptionTranslator {
+
+	public DataAccessException translateExceptionIfPossible(RuntimeException ex) {
+		if (ex instanceof EclipseLinkException) {
+			return convertEclipseLinkAccessException((EclipseLinkException) ex);
+		}
+		return null;
+	}
+
+	/**
+	 * Convert the given EclipseLinkException to an appropriate exception from
+	 * the {@code org.springframework.dao} hierarchy.
+	 * @param ex EclipseLinkException that occurred
+	 * @return a corresponding DataAccessException
+	 * @see SessionFactoryUtils#convertEclipseLinkAccessException
+	 */
+	protected DataAccessException convertEclipseLinkAccessException(EclipseLinkException ex) {
+		return EclipseLinkUtils.convertEclipseLinkAccessException(ex);
+	}
+
+}

--- a/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkSystemException.java
+++ b/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkSystemException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkSystemException.java
+++ b/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkSystemException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.eclipselink;
+
+import org.eclipse.persistence.exceptions.EclipseLinkException;
+import org.springframework.dao.UncategorizedDataAccessException;
+
+/**
+ * EclipseLink-specific subclass of UncategorizedDataAccessException, for
+ * EclipseLink system errors that do not match any concrete
+ * <code>org.springframework.dao</code> exceptions.
+ * 
+ * @author Jan Stamer
+ * @since 3.2
+ * @see EclipseLinkUtils#convertEclipseLinkAccessException(EclipseLinkException)
+ */
+public class EclipseLinkSystemException extends UncategorizedDataAccessException {
+
+	/**
+	 * Create a new HibernateSystemException, wrapping an arbitrary
+	 * HibernateException.
+	 * @param cause the HibernateException thrown
+	 */
+	public EclipseLinkSystemException(EclipseLinkException cause) {
+		super(cause != null ? cause.getMessage() : null, cause);
+	}
+
+}

--- a/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkUtils.java
+++ b/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkUtils.java
+++ b/spring-orm/src/main/java/org/springframework/orm/eclipselink/EclipseLinkUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.eclipselink;
+
+import org.eclipse.persistence.exceptions.EclipseLinkException;
+import org.springframework.dao.DataAccessException;
+
+/**
+ * Helper class featuring methods for Eclipse Link. Also provides support for
+ * exception translation.
+ * 
+ * @author Jan Stamer
+ * @since 3.2
+ */
+public abstract class EclipseLinkUtils {
+
+	/**
+	 * Convert the given EclipseLinkException to an appropriate exception from
+	 * the <code>org.springframework.dao</code> hierarchy.
+	 * @param ex EclipseLinkException that occured
+	 * @return the corresponding DataAccessException instance
+	 * @see EclipseLinkExceptionTranslator#convertEclipseLinkAccessException(EclipseLinkException)
+	 */
+	public static DataAccessException convertEclipseLinkAccessException(EclipseLinkException ex) {
+		return new EclipseLinkSystemException(ex);
+	}
+
+}

--- a/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkExceptionTranslatorTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkExceptionTranslatorTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.eclipselink;
+
+import junit.framework.TestCase;
+
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.springframework.dao.DataAccessException;
+
+/**
+ * @author Jan Stamer
+ * @since 25.06.2012
+ */
+public class EclipseLinkExceptionTranslatorTests extends TestCase {
+
+	public void testWithWrongException() {
+	   EclipseLinkExceptionTranslator exceptionTranslator = new EclipseLinkExceptionTranslator();
+	   assertNull(exceptionTranslator.translateExceptionIfPossible(new IllegalArgumentException()));
+	}
+	
+	public void testWithEclipseLinkException() {
+	   EclipseLinkExceptionTranslator exceptionTranslator = new EclipseLinkExceptionTranslator();
+	   assertNotNull(exceptionTranslator.translateExceptionIfPossible(DatabaseException.databaseAccessorNotConnected()));
+	   assertTrue(exceptionTranslator.translateExceptionIfPossible(DatabaseException.databaseAccessorNotConnected()) instanceof DataAccessException);
+	}
+
+}

--- a/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkExceptionTranslatorTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkExceptionTranslatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,19 @@ import org.springframework.dao.DataAccessException;
 
 /**
  * @author Jan Stamer
- * @since 25.06.2012
+ * @since 3.2
  */
 public class EclipseLinkExceptionTranslatorTests extends TestCase {
 
 	public void testWithWrongException() {
-	   EclipseLinkExceptionTranslator exceptionTranslator = new EclipseLinkExceptionTranslator();
-	   assertNull(exceptionTranslator.translateExceptionIfPossible(new IllegalArgumentException()));
+		EclipseLinkExceptionTranslator exceptionTranslator = new EclipseLinkExceptionTranslator();
+		assertNull(exceptionTranslator.translateExceptionIfPossible(new IllegalArgumentException()));
 	}
-	
+
 	public void testWithEclipseLinkException() {
-	   EclipseLinkExceptionTranslator exceptionTranslator = new EclipseLinkExceptionTranslator();
-	   assertNotNull(exceptionTranslator.translateExceptionIfPossible(DatabaseException.databaseAccessorNotConnected()));
-	   assertTrue(exceptionTranslator.translateExceptionIfPossible(DatabaseException.databaseAccessorNotConnected()) instanceof DataAccessException);
+		EclipseLinkExceptionTranslator exceptionTranslator = new EclipseLinkExceptionTranslator();
+		assertNotNull(exceptionTranslator.translateExceptionIfPossible(DatabaseException.databaseAccessorNotConnected()));
+		assertTrue(exceptionTranslator.translateExceptionIfPossible(DatabaseException.databaseAccessorNotConnected()) instanceof DataAccessException);
 	}
 
 }

--- a/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkSytemExceptionTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkSytemExceptionTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.eclipselink;
+
+import junit.framework.TestCase;
+
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.hibernate.HibernateException;
+
+/**
+ * @author Jan Stamer
+ * @since 25.06.2012
+ */
+public class EclipseLinkSytemExceptionTests extends TestCase {
+
+	public void testWithNull() {
+	   EclipseLinkSystemException exception = new EclipseLinkSystemException(null);
+	   assertNull(exception.getCause());
+	   assertNull(exception.getMessage());
+	}
+
+	public void testCreateWithCause() {
+      DatabaseException dbExceptionWithCause = new DatabaseException("my custom exception cause") {
+	   };
+	   EclipseLinkSystemException elSystemException = new EclipseLinkSystemException(dbExceptionWithCause);
+      assertEquals(dbExceptionWithCause, elSystemException.getCause());
+      assertTrue(elSystemException.getMessage().contains("my custom exception cause"));
+	}
+	
+	public void testCreateWithNullCause() throws HibernateException {
+	   DatabaseException dbExceptionWithCause = new DatabaseException((String) null) {
+	   };
+	   EclipseLinkSystemException elSystemException = new EclipseLinkSystemException(dbExceptionWithCause);
+	   assertEquals(dbExceptionWithCause, elSystemException.getCause());
+	   assertTrue(elSystemException.getMessage().contains("null"));
+	}
+
+}

--- a/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkSytemExceptionTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkSytemExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,30 +23,30 @@ import org.hibernate.HibernateException;
 
 /**
  * @author Jan Stamer
- * @since 25.06.2012
+ * @since 3.2
  */
 public class EclipseLinkSytemExceptionTests extends TestCase {
 
 	public void testWithNull() {
-	   EclipseLinkSystemException exception = new EclipseLinkSystemException(null);
-	   assertNull(exception.getCause());
-	   assertNull(exception.getMessage());
+		EclipseLinkSystemException exception = new EclipseLinkSystemException(null);
+		assertNull(exception.getCause());
+		assertNull(exception.getMessage());
 	}
 
 	public void testCreateWithCause() {
-      DatabaseException dbExceptionWithCause = new DatabaseException("my custom exception cause") {
-	   };
-	   EclipseLinkSystemException elSystemException = new EclipseLinkSystemException(dbExceptionWithCause);
-      assertEquals(dbExceptionWithCause, elSystemException.getCause());
-      assertTrue(elSystemException.getMessage().contains("my custom exception cause"));
+		DatabaseException dbExceptionWithCause = new DatabaseException("my custom exception cause") {
+		};
+		EclipseLinkSystemException elSystemException = new EclipseLinkSystemException(dbExceptionWithCause);
+		assertEquals(dbExceptionWithCause, elSystemException.getCause());
+		assertTrue(elSystemException.getMessage().contains("my custom exception cause"));
 	}
-	
+
 	public void testCreateWithNullCause() throws HibernateException {
-	   DatabaseException dbExceptionWithCause = new DatabaseException((String) null) {
-	   };
-	   EclipseLinkSystemException elSystemException = new EclipseLinkSystemException(dbExceptionWithCause);
-	   assertEquals(dbExceptionWithCause, elSystemException.getCause());
-	   assertTrue(elSystemException.getMessage().contains("null"));
+		DatabaseException dbExceptionWithCause = new DatabaseException((String) null) {
+		};
+		EclipseLinkSystemException elSystemException = new EclipseLinkSystemException(dbExceptionWithCause);
+		assertEquals(dbExceptionWithCause, elSystemException.getCause());
+		assertTrue(elSystemException.getMessage().contains("null"));
 	}
 
 }

--- a/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkUtilsTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,16 +23,16 @@ import org.springframework.dao.DataAccessException;
 
 /**
  * @author Jan Stamer
- * @since 25.06.2012
+ * @since 3.2
  */
 public class EclipseLinkUtilsTests extends TestCase {
 
-   public void testWithNull() {
-      assertTrue(EclipseLinkUtils.convertEclipseLinkAccessException(null) instanceof DataAccessException);
-   }
-	
+	public void testWithNull() {
+		assertTrue(EclipseLinkUtils.convertEclipseLinkAccessException(null) instanceof DataAccessException);
+	}
+
 	public void testWithEclipseLinkException() {
-	   assertTrue(EclipseLinkUtils.convertEclipseLinkAccessException(DatabaseException.databaseAccessorNotConnected()) instanceof DataAccessException);
+		assertTrue(EclipseLinkUtils.convertEclipseLinkAccessException(DatabaseException.databaseAccessorNotConnected()) instanceof DataAccessException);
 	}
 
 }

--- a/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkUtilsTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/eclipselink/EclipseLinkUtilsTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.eclipselink;
+
+import junit.framework.TestCase;
+
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.springframework.dao.DataAccessException;
+
+/**
+ * @author Jan Stamer
+ * @since 25.06.2012
+ */
+public class EclipseLinkUtilsTests extends TestCase {
+
+   public void testWithNull() {
+      assertTrue(EclipseLinkUtils.convertEclipseLinkAccessException(null) instanceof DataAccessException);
+   }
+	
+	public void testWithEclipseLinkException() {
+	   assertTrue(EclipseLinkUtils.convertEclipseLinkAccessException(DatabaseException.databaseAccessorNotConnected()) instanceof DataAccessException);
+	}
+
+}


### PR DESCRIPTION
For Hibernate there is an implementation of the interface PersistenceExceptionTranslator to translate Hibernate exceptions to Spring DataAccess exceptions. This would also be good for EclipseLink.

Issue: SPR-9541
