### PR TITLE
Include **/*.aj files in *-sources.jar files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,8 @@ configure(subprojects) { subproject ->
 
     task sourcesJar(type: Jar, dependsOn:classes) {
         classifier = 'sources'
-        from sourceSets.main.allJava
+        from sourceSets.main.allJava.srcDirs
+        include '**/*.java', '**/*.aj'
     }
 
     task javadocJar(type: Jar) {


### PR DESCRIPTION
Previously only *_/_.java sources files were included in the sources
jars. This is not ideal for the spring-aspects jar nor does it match
prior versions of the sources jars.

Now *_/_.aj files are included in addition to the *_/_.java files.

Issue: SPR-9576

Note: I have verified this by building the source jars without the change and then diffing with the change. The difference is that the *.aj files appears in the *-sources.jar files.
