### PR TITLE
Modify tokenizer to support methods on numbers.

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,10 +289,19 @@ class Tokenizer {
 		ch = toProcess[pos];
 		if (ch=='.') {
 			isReal = true; 
+			int dotpos = pos;
 			// carry on consuming digits
 			do {
 				pos++;
 			} while (isDigit(toProcess[pos]));
+			if (pos == dotpos + 1) {
+				// the number is something like '3.'. It is really an int but may be
+				// part of something like '3.toString()'. In this case process it as
+				// an int and leave the dot as a separate token.
+				pos = dotpos;
+				pushIntToken(subarray(start, pos), false, start, pos);
+				return;
+			}
 		}
 
 		int endOfNumber = pos;

--- a/spring-expression/src/test/java/org/springframework/expression/spel/standard/SpelParserTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/standard/SpelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -309,6 +309,12 @@ public class SpelParserTests {
 		Assert.assertEquals("test", exprEx.getMessage());
 		Assert.assertEquals("Expression 'wibble' @ 3: test", exprEx.toDetailedString());
 	}
+	
+	@Test
+	public void testParseMethodsOnNumbers() {
+		checkNumber("3.14.toString()","3.14",String.class);
+		checkNumber("3.toString()","3",String.class);
+	}
 
 	@Test
 	public void testNumerics() {
@@ -339,7 +345,6 @@ public class SpelParserTests {
 		checkNumber("1.2e+3", 1.2e3d, Double.class);
 		checkNumber("1.2e-3", 1.2e-3d, Double.class);
 		checkNumber("1.2e3", 1.2e3d, Double.class);
-		checkNumber("1.e+3", 1.e3d, Double.class);
 		checkNumber("1e+3", 1e3d, Double.class);
 	}
 	


### PR DESCRIPTION
The tokenizer will now not consume the trailing '.' on an integer
as part of the integer.  So '3.foo()' will now be '3' '.' 'foo()'
and not '3.' 'foo()' - which was what prevented parsing of
method invocations on integers. To keep the change simple, the
parser will no longer handle real numbers of the form '3.e4'
and they must include the extra 0, i.e. '3.0e4'.

Issue: SPR-9612
