### PR TITLE
Support symbolic boolean operators for OR and AND

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
@@ -169,7 +169,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 	//logicalOrExpression : logicalAndExpression (OR^ logicalAndExpression)*;
 	private SpelNodeImpl eatLogicalOrExpression() {
 		SpelNodeImpl expr = eatLogicalAndExpression();
-		while (peekIdentifierToken("or")) {
+		while (peekIdentifierToken("or") || peekToken(TokenKind.SYMBOLIC_OR)) {
 			Token t = nextToken(); //consume OR
 			SpelNodeImpl rhExpr = eatLogicalAndExpression();
 			checkRightOperand(t,rhExpr);
@@ -181,7 +181,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 	// logicalAndExpression : relationalExpression (AND^ relationalExpression)*;
 	private SpelNodeImpl eatLogicalAndExpression() {
 		SpelNodeImpl expr = eatRelationalExpression();
-		while (peekIdentifierToken("and")) {
+		while (peekIdentifierToken("and") || peekToken(TokenKind.SYMBOLIC_AND)) {
 			Token t = nextToken();// consume 'AND'
 			SpelNodeImpl rhExpr = eatRelationalExpression();
 			checkRightOperand(t,rhExpr);

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/TokenKind.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/TokenKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ enum TokenKind {
 	DIV("/"), GE(">="), GT(">"), LE("<="), LT("<"), EQ("=="), NE("!="),
 	MOD("%"), NOT("!"), ASSIGN("="), INSTANCEOF("instanceof"), MATCHES("matches"), BETWEEN("between"),
 	SELECT("?["),   POWER("^"),
-	ELVIS("?:"), SAFE_NAVI("?."), BEAN_REF("@")
+	ELVIS("?:"), SAFE_NAVI("?."), BEAN_REF("@"), SYMBOLIC_OR("||"), SYMBOLIC_AND("&&")
 	;
 	 
 	char[] tokenChars;

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -128,6 +128,16 @@ class Tokenizer {
 						pushCharToken(TokenKind.ASSIGN);
 					}
 					break;
+				case '&':
+					if (isTwoCharToken(TokenKind.SYMBOLIC_AND)) {
+						pushPairToken(TokenKind.SYMBOLIC_AND);
+					}
+					break;
+				case '|':
+					if (isTwoCharToken(TokenKind.SYMBOLIC_OR)) {
+						pushPairToken(TokenKind.SYMBOLIC_OR);
+					}
+					break;					
 				case '?':
 					if (isTwoCharToken(TokenKind.SELECT)) {
 						pushPairToken(TokenKind.SELECT);

--- a/spring-expression/src/test/java/org/springframework/expression/spel/standard/SpelParserTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/standard/SpelParserTests.java
@@ -228,6 +228,25 @@ public class SpelParserTests {
 		expr = new SpelExpressionParser().parseRaw("!(false or true)");
 		assertEquals(Boolean.FALSE, expr.getValue(Boolean.class));
 	}
+	
+	@Test
+	public void booleanOperators_symbolic_spr9614() throws EvaluationException, ParseException {
+		SpelExpression expr = new SpelExpressionParser().parseRaw("true");
+		assertEquals(Boolean.TRUE, expr.getValue(Boolean.class));
+		expr = new SpelExpressionParser().parseRaw("false");
+		assertEquals(Boolean.FALSE, expr.getValue(Boolean.class));
+		expr = new SpelExpressionParser().parseRaw("false && false");
+		assertEquals(Boolean.FALSE, expr.getValue(Boolean.class));
+		expr = new SpelExpressionParser().parseRaw("true && (true || false)");
+		assertEquals(Boolean.TRUE, expr.getValue(Boolean.class));
+		expr = new SpelExpressionParser().parseRaw("true && true || false");
+		assertEquals(Boolean.TRUE, expr.getValue(Boolean.class));
+		expr = new SpelExpressionParser().parseRaw("!true");
+		assertEquals(Boolean.FALSE, expr.getValue(Boolean.class));
+		expr = new SpelExpressionParser().parseRaw("!(false || true)");
+		assertEquals(Boolean.FALSE, expr.getValue(Boolean.class));
+	}
+
 
 	@Test
 	public void stringLiterals() throws EvaluationException, ParseException {


### PR DESCRIPTION
The tokenizer is modified to recognize && and || as symbolic
boolean operators.  The parser is then modified to allow the
use of either the textual or symbolic operators.

Issue: SPR-9614
