### PR TITLE
Avoid NPE when registering MethodFilter

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/StandardEvaluationContext.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/StandardEvaluationContext.java
@@ -227,7 +227,11 @@ public class StandardEvaluationContext implements EvaluationContext {
 	 */
 	public void registerMethodFilter(Class<?> type, MethodFilter filter) {
 		ensureMethodResolversInitialized();
-		reflectiveMethodResolver.registerMethodFilter(type,filter);
+		if (reflectiveMethodResolver!=null) {
+			reflectiveMethodResolver.registerMethodFilter(type,filter);
+		} else {
+			throw new IllegalStateException("Method filter cannot be set as the reflective method resolver is not in use");
+		}
 	}
 
 	private void ensurePropertyAccessorsInitialized() {

--- a/spring-expression/src/test/java/org/springframework/expression/spel/EvaluationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/EvaluationTests.java
@@ -18,15 +18,22 @@ package org.springframework.expression.spel;
 
 import static org.junit.Assert.*;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
 
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.expression.AccessException;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.EvaluationException;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.MethodExecutor;
+import org.springframework.expression.MethodFilter;
+import org.springframework.expression.MethodResolver;
 import org.springframework.expression.ParseException;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -569,6 +576,47 @@ public class EvaluationTests extends ExpressionTestCase {
 
 		exp = parser.parseExpression("NuLl");
 		assertNull(exp.getValue());
+	}
+
+	@Test
+	public void customMethodFilter() throws Exception {
+		StandardEvaluationContext context = new StandardEvaluationContext();
+
+		// Register a custom MethodResolver...
+		List<MethodResolver> customResolvers = new ArrayList<MethodResolver>();
+		customResolvers.add(new CustomMethodResolver());
+		context.setMethodResolvers(customResolvers);
+
+		// or simply...
+		// context.setMethodResolvers(new ArrayList<MethodResolver>());
+
+		// Register a custom MethodFilter...
+		MethodFilter filter = new CustomMethodFilter();
+		try {
+			context.registerMethodFilter(String.class, filter);
+			fail("should have failed");
+		} catch (IllegalStateException ise) {
+			assertEquals(
+					"Method filter cannot be set as the reflective method resolver is not in use",
+					ise.getMessage());
+		}
+	}
+
+	static class CustomMethodResolver implements MethodResolver {
+
+		public MethodExecutor resolve(EvaluationContext context,
+				Object targetObject, String name,
+				List<TypeDescriptor> argumentTypes) throws AccessException {
+			return null;
+		}
+	}
+
+	static class CustomMethodFilter implements MethodFilter {
+
+		public List<Method> filter(List<Method> methods) {
+			return null;
+		}
+
 	}
 
 }


### PR DESCRIPTION
The MethodFilter is only for use with the reflective method
resolver.  Now throw an IllegalStateException if the user
attempts to set a filter when they appear to be using custom
set of resolvers.

Issue: SPR-9621
