### PR TITLE
Introduce strategy for BeanInfo creation

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanInfoFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanInfoFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+
+/**
+ * Strategy for creating {@link BeanInfo} instances.
+ *
+ * @author Arjen Poutsma
+ * @since 3.2
+ */
+public interface BeanInfoFactory {
+
+	/**
+	 * Indicates whether a bean with the given class is supported by this factory.
+	 *
+	 * @param beanClass the bean class
+	 * @return {@code true} if supported; {@code false} otherwise
+	 */
+	boolean supports(Class<?> beanClass);
+
+	/**
+	 * Returns the bean info for the given class.
+	 *
+	 * @param beanClass the bean class
+	 * @return the bean info
+	 * @throws IntrospectionException in case of exceptions
+	 */
+	BeanInfo getBeanInfo(Class<?> beanClass) throws IntrospectionException;
+
+}

--- a/spring-beans/src/main/java/org/springframework/beans/BeanWrapperImpl.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanWrapperImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -518,7 +518,7 @@ public class BeanWrapperImpl extends AbstractPropertyAccessor implements BeanWra
 
 	private Property property(PropertyDescriptor pd) {
 		GenericTypeAwarePropertyDescriptor typeAware = (GenericTypeAwarePropertyDescriptor) pd;
-		return new Property(typeAware.getBeanClass(), typeAware.getReadMethod(), typeAware.getWriteMethod());
+		return new Property(typeAware.getBeanClass(), typeAware.getReadMethod(), typeAware.getWriteMethod(), typeAware.getName());
 	}
 
 

--- a/spring-beans/src/test/java/org/springframework/beans/CachedIntrospectionResultsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/CachedIntrospectionResultsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,24 @@
 
 package org.springframework.beans;
 
-import static org.junit.Assert.*;
+import java.beans.BeanInfo;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
-import org.springframework.core.OverridingClassLoader;
-
 import test.beans.TestBean;
+
+import org.springframework.core.OverridingClassLoader;
 
 /**
  * @author Juergen Hoeller
  * @author Chris Beams
+ * @author Arjen Poutsma
  */
 public final class CachedIntrospectionResultsTests {
 
 	@Test
-	public void testAcceptClassLoader() throws Exception {
+	public void acceptClassLoader() throws Exception {
 		BeanWrapper bw = new BeanWrapperImpl(TestBean.class);
 		assertTrue(bw.isWritableProperty("name"));
 		assertTrue(bw.isWritableProperty("age"));
@@ -48,6 +51,14 @@ public final class CachedIntrospectionResultsTests {
 		assertFalse(CachedIntrospectionResults.classCache.containsKey(tbClass));
 
 		assertTrue(CachedIntrospectionResults.classCache.containsKey(TestBean.class));
+	}
+
+	@Test
+	public void customBeanInfoFactory() throws Exception {
+		CachedIntrospectionResults results = CachedIntrospectionResults.forClass(CachedIntrospectionResultsTests.class);
+		BeanInfo beanInfo = results.getBeanInfo();
+
+		assertTrue("Invalid BeanInfo instance", beanInfo instanceof DummyBeanInfoFactory.DummyBeanInfo);
 	}
 
 }

--- a/spring-beans/src/test/java/org/springframework/beans/DummyBeanInfoFactory.java
+++ b/spring-beans/src/test/java/org/springframework/beans/DummyBeanInfoFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans;
+
+import java.beans.BeanInfo;
+import java.beans.PropertyDescriptor;
+import java.beans.SimpleBeanInfo;
+
+public class DummyBeanInfoFactory implements BeanInfoFactory {
+
+	public boolean supports(Class<?> beanClass) {
+		return CachedIntrospectionResultsTests.class.equals(beanClass);
+	}
+
+	public BeanInfo getBeanInfo(Class<?> beanClass) {
+		return new DummyBeanInfo();
+	}
+
+	public static class DummyBeanInfo extends SimpleBeanInfo {
+
+		@Override
+		public PropertyDescriptor[] getPropertyDescriptors() {
+			return new PropertyDescriptor[0];
+		}
+	}
+
+}

--- a/spring-beans/src/test/resources/META-INF/spring.beanInfoFactories
+++ b/spring-beans/src/test/resources/META-INF/spring.beanInfoFactories
@@ -1,0 +1,3 @@
+# Dummy bean info factories file, used by CachedIntrospectionResultsTests
+
+org.springframework.beans.DummyBeanInfoFactory

--- a/spring-core/src/main/java/org/springframework/core/convert/Property.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/Property.java
@@ -57,11 +57,20 @@ public final class Property {
 
 
 	public Property(Class<?> objectType, Method readMethod, Method writeMethod) {
+		this(objectType, readMethod, writeMethod, null);
+	}
+
+	public Property(Class<?> objectType, Method readMethod, Method writeMethod, String name) {
 		this.objectType = objectType;
 		this.readMethod = readMethod;
 		this.writeMethod = writeMethod;
 		this.methodParameter = resolveMethodParameter();
-		this.name = resolveName();
+		if (name != null) {
+			this.name = name;
+		}
+		else {
+			this.name = resolveName();
+		}
 		this.annotations = resolveAnnotations();
 	}
 


### PR DESCRIPTION
Before this commit, the CachedIntrospectionResults was hard-coded to
create ExtendedBeanInfos for bean classes. The ExtendedBeanInfo support
the JavaBeans property contract only.

This commit introduces the BeanInfoFactory, a strategy for creating
BeanInfos. Through this strategy, it is possible to support
beans that do not necessarily implement the JavaBeans contract (i.e.
have a different getter or setter style).

BeanInfoFactories are are instantiated by the
CachedIntrospectionResults, which looks for
'META-INF/spring.beanInfoFactories' files on the class path. These files
contain one or more BeanInfoFactory class names. When a BeanInfo is to
be created, the CachedIntrospectionResults will iterate through the
factories, asking it to create a BeanInfo for the given bean class. If
none of the factories support it, an ExtendedBeanInfo is created as a
default.

This commit also contains a change to Property, allowing BeanWrapperImpl
to specify the property name at construction time (as opposed to using
Property#resolveName(), which supports the JavaBeans contract only).

Issue: SPR-9677
