### PR TITLE
SPR-9692: Change to match converter to interface before Enum in GenericConversionService

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
@@ -351,7 +351,7 @@ public class GenericConversionService implements ConfigurableConversionService {
 					return converter;
 				}
 				Class<?> superClass = currentClass.getSuperclass();
-				if (superClass != null && superClass != Object.class) {
+				if (superClass != null && superClass != Object.class && superClass != Enum.class) {
 					classQueue.addFirst(superClass);
 				}
 				for (Class<?> interfaceType : currentClass.getInterfaces()) {
@@ -365,6 +365,14 @@ public class GenericConversionService implements ConfigurableConversionService {
 					return converter;
 				}
 			}
+			if (sourceObjectType.isEnum()) {
+				Map<Class<?>, MatchableConverters> converters = getTargetConvertersForSource(Enum.class);
+				GenericConverter converter = getMatchingConverterForTarget(sourceType, targetType, converters);
+				if (converter != null) {
+					return converter;
+				}
+			}
+			
 			Map<Class<?>, MatchableConverters> objectConverters = getTargetConvertersForSource(Object.class);
 			return getMatchingConverterForTarget(sourceType, targetType, objectConverters);				
 		}
@@ -430,7 +438,7 @@ public class GenericConversionService implements ConfigurableConversionService {
 					return converter;
 				}
 				Class<?> superClass = currentClass.getSuperclass();
-				if (superClass != null && superClass != Object.class) {
+				if (superClass != null && superClass != Object.class && superClass != Enum.class) {
 					classQueue.addFirst(superClass);
 				}
 				for (Class<?> interfaceType : currentClass.getInterfaces()) {
@@ -440,6 +448,12 @@ public class GenericConversionService implements ConfigurableConversionService {
 			for (Class<?> interfaceType : interfaces) {
 				MatchableConverters matchable = converters.get(interfaceType);
 				GenericConverter converter = matchConverter(matchable, sourceType, targetType);
+				if (converter != null) {
+					return converter;
+				}
+			}
+			if (targetObjectType.isEnum()) {
+				GenericConverter converter = matchConverter(converters.get(Enum.class), sourceType, targetType);
 				if (converter != null) {
 					return converter;
 				}

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -43,6 +43,7 @@ import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterFactory;
 import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.io.DescriptiveResource;
 import org.springframework.core.io.Resource;
@@ -589,5 +590,80 @@ public class GenericConversionServiceTests {
 		assertFalse(pair.equals(pairOpposite));
 		assertFalse(pair.hashCode() == pairOpposite.hashCode());
 	}
+	
+	// SPR-9692
+	@Test
+	public void testStringToEnumWithInterfaceConversion() {
+		conversionService.addConverterFactory(new StringToEnumConverterFactory());
+		conversionService.addConverterFactory(new StringToMyEnumInterfaceConverterFactory());
+		MyEnum result = conversionService.convert("1", MyEnum.class);
+		assertEquals(MyEnum.A, result);
+	}
+	
+	@Test
+	public void testEnumWithInterfaceToStringConversion() {
+		conversionService.addConverter(new EnumToStringConverter());
+		conversionService.addConverter(new MyEnumInterfaceToStringConverter<MyEnum>());
+		String result = conversionService.convert(MyEnum.A, String.class);
+		assertEquals("1", result);
+	}
+	
+	interface MyEnumInterface {
+		String getCode();
+	}	
+	
+	public static enum MyEnum implements MyEnumInterface {
+		A("1"), B("2");
+		
+		private String code;
+		
+		MyEnum(String code) {
+			this.code = code;
+		}
+		
+		public String getCode() {
+			return code;
+		}
+	}
+	
+	public static class MyEnumInterfaceToStringConverter<T extends MyEnumInterface> implements Converter<T, String> {
+		public String convert(T source) {	
+			return source.getCode();
+		}
+	}
 
+	public static class StringToMyEnumInterfaceConverterFactory implements ConverterFactory<String, MyEnumInterface> {
+		
+		public <T extends MyEnumInterface> Converter<String, T> getConverter(Class<T> targetType) {
+			return new StringToMyEnumInterfaceConverter(targetType);
+		}
+		
+		private static class StringToMyEnumInterfaceConverter<T extends Enum & MyEnumInterface> implements Converter<String, T> {
+			private final Class<T> enumType;
+
+			public StringToMyEnumInterfaceConverter(Class<T> enumType) {
+				this.enumType = enumType;
+			}
+
+			public T convert(String source) {
+				for (T value : enumType.getEnumConstants()) {
+					if (value.getCode().equals(source)) {
+						return value;
+					}
+				}
+				return null;
+			}
+		}
+	}
+	
+	private static class StringToMyEnumInterfaceConverter implements Converter<String, MyEnumInterface> {
+		public MyEnumInterface convert(String source) {
+			for (MyEnumInterface value : MyEnum.values()) {
+				if (value.getCode().equals(source)) {
+					return value;
+				}
+			}
+			return null;
+		}
+	}	
 }


### PR DESCRIPTION
GenericConversionService changed to not match converter to Enum.class
before trying to match converter to an interface.

Prior to this commit a converter would be matched to the superclass of
an enum (which will always be Enum.class) ignoring converters matching
the interface.

Enum.class will now be ignored when retrieving superclasses and only
after trying to match converters to interfaces will it try to match
converters to Enum (just before trying to match to Object).

This is the behaviour encountered prior to 3.1.0.

Issue: SPR-9692

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
