### PR TITLE
SPR-7905 - Support wildcard style media types in JSON converters

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/MappingJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/MappingJackson2HttpMessageConverter.java
@@ -69,7 +69,7 @@ public class MappingJackson2HttpMessageConverter extends AbstractHttpMessageConv
 	 * Construct a new {@code MappingJackson2HttpMessageConverter}.
 	 */
 	public MappingJackson2HttpMessageConverter() {
-		super(new MediaType("application", "json", DEFAULT_CHARSET));
+		super(new MediaType("application", "json", DEFAULT_CHARSET), new MediaType("application", "*+json", DEFAULT_CHARSET));
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/converter/json/MappingJacksonHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/MappingJacksonHttpMessageConverter.java
@@ -69,7 +69,7 @@ public class MappingJacksonHttpMessageConverter extends AbstractHttpMessageConve
 	 * Construct a new {@code MappingJacksonHttpMessageConverter}.
 	 */
 	public MappingJacksonHttpMessageConverter() {
-		super(new MediaType("application", "json", DEFAULT_CHARSET));
+		super(new MediaType("application", "json", DEFAULT_CHARSET), new MediaType("application", "*+json", DEFAULT_CHARSET));
 	}
 
 	/**

--- a/spring-web/src/test/java/org/springframework/http/converter/json/AbstractMappingJacksonHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/AbstractMappingJacksonHttpMessageConverterTests.java
@@ -44,6 +44,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 public abstract class AbstractMappingJacksonHttpMessageConverterTests<T extends HttpMessageConverter<Object>> {
 
 	protected static final String NEWLINE_SYSTEM_PROPERTY = System.getProperty("line.separator");
+	protected static final MediaType JSON_MICROFORMAT = new MediaType("application", "vnd.test-micro-type+json");
 
 
 	private T converter;
@@ -69,6 +70,18 @@ public abstract class AbstractMappingJacksonHttpMessageConverterTests<T extends 
 	public void canWrite() {
 		assertTrue(converter.canWrite(MyBean.class, new MediaType("application", "json")));
 		assertTrue(converter.canWrite(Map.class, new MediaType("application", "json")));
+	}
+
+	@Test
+	public void canReadMicroformatSpr7905() {
+		assertTrue("Cannot read MyBean as microformat", converter.canRead(MyBean.class, JSON_MICROFORMAT));
+		assertTrue("Cannot read Map as microformat", converter.canRead(Map.class, JSON_MICROFORMAT));
+	}
+
+	@Test
+	public void canWriteMicroformatSpr7905() {
+		assertTrue("Cannot write MyBean as microformat", converter.canWrite(MyBean.class, JSON_MICROFORMAT));
+		assertTrue("Cannot write Map as microformat", converter.canWrite(Map.class, JSON_MICROFORMAT));
 	}
 
 	@Test


### PR DESCRIPTION
Add "application/*+json" to supported media types for both Jackson message
converters. Test cases included.

Issue: SPR-7905

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
