### PR TITLE
Add MockFilterChain support Filter's and Servlet

### DIFF
--- a/spring-orm/src/test/java/org/springframework/mock/web/MockFilterChain.java
+++ b/spring-orm/src/test/java/org/springframework/mock/web/MockFilterChain.java
@@ -16,7 +16,16 @@
 
 package org.springframework.mock.web;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.RandomAccess;
+
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
@@ -29,6 +38,7 @@ import org.springframework.util.Assert;
  * custom {@link javax.servlet.Filter} implementations.
  *
  * @author Juergen Hoeller
+ * @author Rob Winch
  * @since 2.0.3
  * @see MockFilterConfig
  * @see PassThroughFilterChain
@@ -39,32 +49,153 @@ public class MockFilterChain implements FilterChain {
 
 	private ServletResponse response;
 
+	private final List<Filter> filters;
+
+	private int index = 0;
 
 	/**
-	 * Records the request and response.
+	 * Registers a single do-nothing {@link Filter} implementation. This means multiple invocations of
+	 * {@link #doFilter(ServletRequest, ServletResponse)} will result in an {@link IllegalStateException}.
 	 */
-	public void doFilter(ServletRequest request, ServletResponse response) {
+	public MockFilterChain() {
+		this(new FilterAdapter());
+	}
+
+	/**
+	 * Create a {@link FilterChain} with one or more {@link Filter}s.
+	 *
+	 * @param filters the {@link Filter}'s to use in this  {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Filter... filters) {
+		Assert.notEmpty(filters, "filters cannot be null or empty. Got "+filters);
+		this.filters = createFilters(filters);
+	}
+
+	/**
+	 * Creates a FilterChain with {@link Servlet}
+	 *
+	 * @param servlet the {@link Servlet} to use in this {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Servlet servlet) {
+		this(new ServletFilterProxy(servlet));
+	}
+
+	/**
+	 * Creates a FilterChain with one or more {@link Filter}s and a {@link Servlet}. The {@link Filter}s will be invoked
+	 * first and then the {@link Servlet}.
+	 *
+	 * @param servlet the {@link Servlet} to use in this {@link FilterChain}
+	 * @param filters the {@link Filter}'s to use in this {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Servlet servlet, Filter... filters) {
+		this.filters = createFilters(filters);
+		this.filters.add(new ServletFilterProxy(servlet));
+	}
+
+	/**
+	 * Invokes the next registered {@link Filter} or the {@link Servlet}. Records the request and response.
+	 *
+	 * @throws ServletException
+	 * @throws IOException
+	 * @throws IllegalStateException if all of the registered {@link Filter} and {@link Servlet} implementations have
+	 * been invoked.
+	 */
+	public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
 		Assert.notNull(request, "Request must not be null");
 		Assert.notNull(response, "Response must not be null");
-		if (this.request != null) {
-			throw new IllegalStateException("This FilterChain has already been called!");
+		if (index == filters.size()) {
+			throw new IllegalStateException("Cannot invoke doFilter with index "
+					+ index + " due to too many invocations of doFilter. Original chain is " + filters);
 		}
+		else {
+			Filter nextFilter = filters.get(index);
+			index++;
+
+			nextFilter.doFilter(request, response, this);
+		}
+
 		this.request = request;
 		this.response = response;
 	}
 
 	/**
-	 * Return the request that {@link #doFilter} has been called with.
+	 * Return the most recent request that {@link #doFilter} has been called with.
 	 */
 	public ServletRequest getRequest() {
 		return this.request;
 	}
 
 	/**
-	 * Return the response that {@link #doFilter} has been called with.
+	 * Return the most recent response that {@link #doFilter} has been called with.
 	 */
 	public ServletResponse getResponse() {
 		return this.response;
 	}
 
+	/**
+	 * Validates the filters and creates a List<Filter> from them that implements {@link RandomAccess} and can be
+	 * modified.
+	 * @param filters
+	 * @return
+	 */
+	private static List<Filter> createFilters(Filter...filters) {
+		Assert.notNull(filters, "filters cannot be null");
+		Assert.noNullElements(filters, "fiters cannot contain null values");
+		List<Filter> result = new ArrayList<Filter>(filters.length + 1);
+		for(Filter filter : filters) {
+			result.add(filter);
+		}
+		return result;
+	}
+
+	/**
+	 * A do nothing implementation of {@link Filter}. Subclasses can selectively implement only methods of interest.
+	 *
+	 * @author Rob Winch
+	 *
+	 */
+	private static class FilterAdapter implements Filter {
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+				ServletException {
+		}
+
+		public void init(FilterConfig filterConfig) throws ServletException {
+		}
+
+		public void destroy() {
+		}
+	}
+
+	/**
+	 * Adapts a {@link Servlet#service(ServletRequest, ServletResponse)} to be invoked by
+	 * {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)}. This simplifies the implementation of
+	 * {@link #doFilter(ServletRequest, ServletResponse, FilterChain)}.
+	 *
+	 * @author Rob Winch
+	 *
+	 */
+	private static class ServletFilterProxy extends FilterAdapter {
+		private final Servlet delegateServlet;
+
+		private ServletFilterProxy(Servlet servlet) {
+			Assert.notNull(servlet, "servlet cannot be null");
+			this.delegateServlet = servlet;
+		}
+
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+				ServletException {
+			delegateServlet.service(request, response);
+		}
+
+		@Override
+		public String toString() {
+			return delegateServlet.toString();
+		}
+	}
 }

--- a/spring-test/src/main/java/org/springframework/mock/web/MockFilterChain.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockFilterChain.java
@@ -16,7 +16,16 @@
 
 package org.springframework.mock.web;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.RandomAccess;
+
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
@@ -29,6 +38,7 @@ import org.springframework.util.Assert;
  * custom {@link javax.servlet.Filter} implementations.
  *
  * @author Juergen Hoeller
+ * @author Rob Winch
  * @since 2.0.3
  * @see MockFilterConfig
  * @see PassThroughFilterChain
@@ -39,32 +49,153 @@ public class MockFilterChain implements FilterChain {
 
 	private ServletResponse response;
 
+	private final List<Filter> filters;
+
+	private int index = 0;
 
 	/**
-	 * Records the request and response.
+	 * Registers a single do-nothing {@link Filter} implementation. This means multiple invocations of
+	 * {@link #doFilter(ServletRequest, ServletResponse)} will result in an {@link IllegalStateException}.
 	 */
-	public void doFilter(ServletRequest request, ServletResponse response) {
+	public MockFilterChain() {
+		this(new FilterAdapter());
+	}
+
+	/**
+	 * Create a {@link FilterChain} with one or more {@link Filter}s.
+	 *
+	 * @param filters the {@link Filter}'s to use in this  {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Filter... filters) {
+		Assert.notEmpty(filters, "filters cannot be null or empty. Got "+filters);
+		this.filters = createFilters(filters);
+	}
+
+	/**
+	 * Creates a FilterChain with {@link Servlet}
+	 *
+	 * @param servlet the {@link Servlet} to use in this {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Servlet servlet) {
+		this(new ServletFilterProxy(servlet));
+	}
+
+	/**
+	 * Creates a FilterChain with one or more {@link Filter}s and a {@link Servlet}. The {@link Filter}s will be invoked
+	 * first and then the {@link Servlet}.
+	 *
+	 * @param servlet the {@link Servlet} to use in this {@link FilterChain}
+	 * @param filters the {@link Filter}'s to use in this {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Servlet servlet, Filter... filters) {
+		this.filters = createFilters(filters);
+		this.filters.add(new ServletFilterProxy(servlet));
+	}
+
+	/**
+	 * Invokes the next registered {@link Filter} or the {@link Servlet}. Records the request and response.
+	 *
+	 * @throws ServletException
+	 * @throws IOException
+	 * @throws IllegalStateException if all of the registered {@link Filter} and {@link Servlet} implementations have
+	 * been invoked.
+	 */
+	public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
 		Assert.notNull(request, "Request must not be null");
 		Assert.notNull(response, "Response must not be null");
-		if (this.request != null) {
-			throw new IllegalStateException("This FilterChain has already been called!");
+		if (index == filters.size()) {
+			throw new IllegalStateException("Cannot invoke doFilter with index "
+					+ index + " due to too many invocations of doFilter. Original chain is " + filters);
 		}
+		else {
+			Filter nextFilter = filters.get(index);
+			index++;
+
+			nextFilter.doFilter(request, response, this);
+		}
+
 		this.request = request;
 		this.response = response;
 	}
 
 	/**
-	 * Return the request that {@link #doFilter} has been called with.
+	 * Return the most recent request that {@link #doFilter} has been called with.
 	 */
 	public ServletRequest getRequest() {
 		return this.request;
 	}
 
 	/**
-	 * Return the response that {@link #doFilter} has been called with.
+	 * Return the most recent response that {@link #doFilter} has been called with.
 	 */
 	public ServletResponse getResponse() {
 		return this.response;
 	}
 
+	/**
+	 * Validates the filters and creates a List<Filter> from them that implements {@link RandomAccess} and can be
+	 * modified.
+	 * @param filters
+	 * @return
+	 */
+	private static List<Filter> createFilters(Filter...filters) {
+		Assert.notNull(filters, "filters cannot be null");
+		Assert.noNullElements(filters, "fiters cannot contain null values");
+		List<Filter> result = new ArrayList<Filter>(filters.length + 1);
+		for(Filter filter : filters) {
+			result.add(filter);
+		}
+		return result;
+	}
+
+	/**
+	 * A do nothing implementation of {@link Filter}. Subclasses can selectively implement only methods of interest.
+	 *
+	 * @author Rob Winch
+	 *
+	 */
+	private static class FilterAdapter implements Filter {
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+				ServletException {
+		}
+
+		public void init(FilterConfig filterConfig) throws ServletException {
+		}
+
+		public void destroy() {
+		}
+	}
+
+	/**
+	 * Adapts a {@link Servlet#service(ServletRequest, ServletResponse)} to be invoked by
+	 * {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)}. This simplifies the implementation of
+	 * {@link #doFilter(ServletRequest, ServletResponse, FilterChain)}.
+	 *
+	 * @author Rob Winch
+	 *
+	 */
+	private static class ServletFilterProxy extends FilterAdapter {
+		private final Servlet delegateServlet;
+
+		private ServletFilterProxy(Servlet servlet) {
+			Assert.notNull(servlet, "servlet cannot be null");
+			this.delegateServlet = servlet;
+		}
+
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+				ServletException {
+			delegateServlet.service(request, response);
+		}
+
+		@Override
+		public String toString() {
+			return delegateServlet.toString();
+		}
+	}
 }

--- a/spring-test/src/test/java/org/springframework/mock/web/MockFilterChainTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockFilterChainTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.mock.web;
+
+import static org.easymock.EasyMock.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import javax.servlet.Filter;
+import javax.servlet.Servlet;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Rob Winch
+ *
+ */
+public class MockFilterChainTests {
+
+	@Test(expected=IllegalArgumentException.class)
+	public void constructorNullFilters() {
+		new MockFilterChain((Filter[])null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void constructorFiltersContainsNull() {
+		new MockFilterChain((Filter)null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void constructorFiltersEmpty() {
+		new MockFilterChain(new Filter[] {});
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void constructorNullServlet() {
+		new MockFilterChain((Servlet)null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void constructorServletNullFilters() {
+		new MockFilterChain(createMock(Servlet.class), (Filter[]) null);
+	}
+
+	@Test
+	public void constructorServletEmptyFilters() {
+		new MockFilterChain(createMock(Servlet.class), new Filter[] {});
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void constructorServletFiltersContainsNull() {
+		new MockFilterChain(createMock(Servlet.class), (Filter) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void doFilterNullRequest() throws Exception {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+		chain.doFilter(null, response);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void doFilterNullResponse() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockFilterChain chain = new MockFilterChain();
+		chain.doFilter(request, null);
+	}
+
+	@Test
+	public void doFilterDefaultConstructor() throws Exception {
+		ServletRequest request = new MockHttpServletRequest();
+		ServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+		chain.doFilter(request, response);
+		assertThat(chain.getRequest(), is(request));
+		assertThat(chain.getResponse(), is(response));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void doFilterDefaultConstructorMultiple() throws Exception {
+		ServletRequest request = new MockHttpServletRequest();
+		ServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+		chain.doFilter(request, response);
+		chain.doFilter(request, response);
+	}
+
+	@Test
+	public void doFilterConstructorFilters() throws Exception {
+		Filter filter1 = createMock(Filter.class);
+		Filter filter2 = createMock(Filter.class);
+
+		ServletRequest request = new MockHttpServletRequest();
+		ServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain(filter1, filter2);
+		filter1.doFilter(request, response, chain);
+		filter2.doFilter(request, response, chain);
+		replay(filter1, filter2);
+
+		chain.doFilter(request, response);
+		chain.doFilter(request, response);
+
+		verify(filter1,filter2);
+
+		try {
+			chain.doFilter(request, response);
+			fail("Expected Exception");
+		} catch(IllegalStateException success) {}
+	}
+
+	@Test
+	public void doFilterConstructorServletFilters() throws Exception {
+		Servlet servlet = createMock(Servlet.class);
+		Filter filter1 = createMock(Filter.class);
+		Filter filter2 = createMock(Filter.class);
+
+		ServletRequest request = new MockHttpServletRequest();
+		ServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain(servlet, filter1, filter2);
+		filter1.doFilter(request, response, chain);
+		filter2.doFilter(request, response, chain);
+		servlet.service(request, response);
+		replay(servlet, filter1, filter2);
+
+		chain.doFilter(request, response);
+		chain.doFilter(request, response);
+		chain.doFilter(request, response);
+
+		verify(servlet,filter1,filter2);
+
+		try {
+			chain.doFilter(request, response);
+			fail("Expected Exception");
+		} catch(IllegalStateException success) {}
+	}
+
+
+	@Test
+	public void doFilterConstructorServlet() throws Exception {
+		Servlet servlet = createMock(Servlet.class);
+
+		ServletRequest request = new MockHttpServletRequest();
+		ServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain(servlet);
+		servlet.service(request, response);
+		replay(servlet);
+
+		chain.doFilter(request, response);
+
+		verify(servlet);
+
+		try {
+			chain.doFilter(request, response);
+			fail("Expected Exception");
+		} catch(IllegalStateException success) {}
+	}
+}

--- a/spring-web/src/test/java/org/springframework/mock/web/MockFilterChain.java
+++ b/spring-web/src/test/java/org/springframework/mock/web/MockFilterChain.java
@@ -16,7 +16,16 @@
 
 package org.springframework.mock.web;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.RandomAccess;
+
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
@@ -29,6 +38,7 @@ import org.springframework.util.Assert;
  * custom {@link javax.servlet.Filter} implementations.
  *
  * @author Juergen Hoeller
+ * @author Rob Winch
  * @since 2.0.3
  * @see MockFilterConfig
  * @see PassThroughFilterChain
@@ -39,32 +49,153 @@ public class MockFilterChain implements FilterChain {
 
 	private ServletResponse response;
 
+	private final List<Filter> filters;
+
+	private int index = 0;
 
 	/**
-	 * Records the request and response.
+	 * Registers a single do-nothing {@link Filter} implementation. This means multiple invocations of
+	 * {@link #doFilter(ServletRequest, ServletResponse)} will result in an {@link IllegalStateException}.
 	 */
-	public void doFilter(ServletRequest request, ServletResponse response) {
+	public MockFilterChain() {
+		this(new FilterAdapter());
+	}
+
+	/**
+	 * Create a {@link FilterChain} with one or more {@link Filter}s.
+	 *
+	 * @param filters the {@link Filter}'s to use in this  {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Filter... filters) {
+		Assert.notEmpty(filters, "filters cannot be null or empty. Got "+filters);
+		this.filters = createFilters(filters);
+	}
+
+	/**
+	 * Creates a FilterChain with {@link Servlet}
+	 *
+	 * @param servlet the {@link Servlet} to use in this {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Servlet servlet) {
+		this(new ServletFilterProxy(servlet));
+	}
+
+	/**
+	 * Creates a FilterChain with one or more {@link Filter}s and a {@link Servlet}. The {@link Filter}s will be invoked
+	 * first and then the {@link Servlet}.
+	 *
+	 * @param servlet the {@link Servlet} to use in this {@link FilterChain}
+	 * @param filters the {@link Filter}'s to use in this {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Servlet servlet, Filter... filters) {
+		this.filters = createFilters(filters);
+		this.filters.add(new ServletFilterProxy(servlet));
+	}
+
+	/**
+	 * Invokes the next registered {@link Filter} or the {@link Servlet}. Records the request and response.
+	 *
+	 * @throws ServletException
+	 * @throws IOException
+	 * @throws IllegalStateException if all of the registered {@link Filter} and {@link Servlet} implementations have
+	 * been invoked.
+	 */
+	public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
 		Assert.notNull(request, "Request must not be null");
 		Assert.notNull(response, "Response must not be null");
-		if (this.request != null) {
-			throw new IllegalStateException("This FilterChain has already been called!");
+		if (index == filters.size()) {
+			throw new IllegalStateException("Cannot invoke doFilter with index "
+					+ index + " due to too many invocations of doFilter. Original chain is " + filters);
 		}
+		else {
+			Filter nextFilter = filters.get(index);
+			index++;
+
+			nextFilter.doFilter(request, response, this);
+		}
+
 		this.request = request;
 		this.response = response;
 	}
 
 	/**
-	 * Return the request that {@link #doFilter} has been called with.
+	 * Return the most recent request that {@link #doFilter} has been called with.
 	 */
 	public ServletRequest getRequest() {
 		return this.request;
 	}
 
 	/**
-	 * Return the response that {@link #doFilter} has been called with.
+	 * Return the most recent response that {@link #doFilter} has been called with.
 	 */
 	public ServletResponse getResponse() {
 		return this.response;
 	}
 
+	/**
+	 * Validates the filters and creates a List<Filter> from them that implements {@link RandomAccess} and can be
+	 * modified.
+	 * @param filters
+	 * @return
+	 */
+	private static List<Filter> createFilters(Filter...filters) {
+		Assert.notNull(filters, "filters cannot be null");
+		Assert.noNullElements(filters, "fiters cannot contain null values");
+		List<Filter> result = new ArrayList<Filter>(filters.length + 1);
+		for(Filter filter : filters) {
+			result.add(filter);
+		}
+		return result;
+	}
+
+	/**
+	 * A do nothing implementation of {@link Filter}. Subclasses can selectively implement only methods of interest.
+	 *
+	 * @author Rob Winch
+	 *
+	 */
+	private static class FilterAdapter implements Filter {
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+				ServletException {
+		}
+
+		public void init(FilterConfig filterConfig) throws ServletException {
+		}
+
+		public void destroy() {
+		}
+	}
+
+	/**
+	 * Adapts a {@link Servlet#service(ServletRequest, ServletResponse)} to be invoked by
+	 * {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)}. This simplifies the implementation of
+	 * {@link #doFilter(ServletRequest, ServletResponse, FilterChain)}.
+	 *
+	 * @author Rob Winch
+	 *
+	 */
+	private static class ServletFilterProxy extends FilterAdapter {
+		private final Servlet delegateServlet;
+
+		private ServletFilterProxy(Servlet servlet) {
+			Assert.notNull(servlet, "servlet cannot be null");
+			this.delegateServlet = servlet;
+		}
+
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+				ServletException {
+			delegateServlet.service(request, response);
+		}
+
+		@Override
+		public String toString() {
+			return delegateServlet.toString();
+		}
+	}
 }

--- a/spring-webmvc/src/test/java/org/springframework/mock/web/MockFilterChain.java
+++ b/spring-webmvc/src/test/java/org/springframework/mock/web/MockFilterChain.java
@@ -16,7 +16,16 @@
 
 package org.springframework.mock.web;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.RandomAccess;
+
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
@@ -29,6 +38,7 @@ import org.springframework.util.Assert;
  * custom {@link javax.servlet.Filter} implementations.
  *
  * @author Juergen Hoeller
+ * @author Rob Winch
  * @since 2.0.3
  * @see MockFilterConfig
  * @see PassThroughFilterChain
@@ -39,32 +49,153 @@ public class MockFilterChain implements FilterChain {
 
 	private ServletResponse response;
 
+	private final List<Filter> filters;
+
+	private int index = 0;
 
 	/**
-	 * Records the request and response.
+	 * Registers a single do-nothing {@link Filter} implementation. This means multiple invocations of
+	 * {@link #doFilter(ServletRequest, ServletResponse)} will result in an {@link IllegalStateException}.
 	 */
-	public void doFilter(ServletRequest request, ServletResponse response) {
+	public MockFilterChain() {
+		this(new FilterAdapter());
+	}
+
+	/**
+	 * Create a {@link FilterChain} with one or more {@link Filter}s.
+	 *
+	 * @param filters the {@link Filter}'s to use in this  {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Filter... filters) {
+		Assert.notEmpty(filters, "filters cannot be null or empty. Got "+filters);
+		this.filters = createFilters(filters);
+	}
+
+	/**
+	 * Creates a FilterChain with {@link Servlet}
+	 *
+	 * @param servlet the {@link Servlet} to use in this {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Servlet servlet) {
+		this(new ServletFilterProxy(servlet));
+	}
+
+	/**
+	 * Creates a FilterChain with one or more {@link Filter}s and a {@link Servlet}. The {@link Filter}s will be invoked
+	 * first and then the {@link Servlet}.
+	 *
+	 * @param servlet the {@link Servlet} to use in this {@link FilterChain}
+	 * @param filters the {@link Filter}'s to use in this {@link FilterChain}
+	 *
+	 * @since 3.2
+	 */
+	public MockFilterChain(Servlet servlet, Filter... filters) {
+		this.filters = createFilters(filters);
+		this.filters.add(new ServletFilterProxy(servlet));
+	}
+
+	/**
+	 * Invokes the next registered {@link Filter} or the {@link Servlet}. Records the request and response.
+	 *
+	 * @throws ServletException
+	 * @throws IOException
+	 * @throws IllegalStateException if all of the registered {@link Filter} and {@link Servlet} implementations have
+	 * been invoked.
+	 */
+	public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
 		Assert.notNull(request, "Request must not be null");
 		Assert.notNull(response, "Response must not be null");
-		if (this.request != null) {
-			throw new IllegalStateException("This FilterChain has already been called!");
+		if (index == filters.size()) {
+			throw new IllegalStateException("Cannot invoke doFilter with index "
+					+ index + " due to too many invocations of doFilter. Original chain is " + filters);
 		}
+		else {
+			Filter nextFilter = filters.get(index);
+			index++;
+
+			nextFilter.doFilter(request, response, this);
+		}
+
 		this.request = request;
 		this.response = response;
 	}
 
 	/**
-	 * Return the request that {@link #doFilter} has been called with.
+	 * Return the most recent request that {@link #doFilter} has been called with.
 	 */
 	public ServletRequest getRequest() {
 		return this.request;
 	}
 
 	/**
-	 * Return the response that {@link #doFilter} has been called with.
+	 * Return the most recent response that {@link #doFilter} has been called with.
 	 */
 	public ServletResponse getResponse() {
 		return this.response;
 	}
 
+	/**
+	 * Validates the filters and creates a List<Filter> from them that implements {@link RandomAccess} and can be
+	 * modified.
+	 * @param filters
+	 * @return
+	 */
+	private static List<Filter> createFilters(Filter...filters) {
+		Assert.notNull(filters, "filters cannot be null");
+		Assert.noNullElements(filters, "fiters cannot contain null values");
+		List<Filter> result = new ArrayList<Filter>(filters.length + 1);
+		for(Filter filter : filters) {
+			result.add(filter);
+		}
+		return result;
+	}
+
+	/**
+	 * A do nothing implementation of {@link Filter}. Subclasses can selectively implement only methods of interest.
+	 *
+	 * @author Rob Winch
+	 *
+	 */
+	private static class FilterAdapter implements Filter {
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+				ServletException {
+		}
+
+		public void init(FilterConfig filterConfig) throws ServletException {
+		}
+
+		public void destroy() {
+		}
+	}
+
+	/**
+	 * Adapts a {@link Servlet#service(ServletRequest, ServletResponse)} to be invoked by
+	 * {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)}. This simplifies the implementation of
+	 * {@link #doFilter(ServletRequest, ServletResponse, FilterChain)}.
+	 *
+	 * @author Rob Winch
+	 *
+	 */
+	private static class ServletFilterProxy extends FilterAdapter {
+		private final Servlet delegateServlet;
+
+		private ServletFilterProxy(Servlet servlet) {
+			Assert.notNull(servlet, "servlet cannot be null");
+			this.delegateServlet = servlet;
+		}
+
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+				ServletException {
+			delegateServlet.service(request, response);
+		}
+
+		@Override
+		public String toString() {
+			return delegateServlet.toString();
+		}
+	}
 }


### PR DESCRIPTION
Working on Spring Test MVC we have the need for a `MockFilterChain` that will invoke `Filter`'s and/or a `Servlet`. Since this is something that others would likely want, we thought it would be best to update the `MockFilterChain` provided by Spring Framework.

One item that should be highlighted is that the `doFilter` method signature now has throws `IOException`, `ServletException`. While both `Exception`s are on the `FilterChain` interface, this is non-passive for any user invoking `new MockFilterChain().doFilter()` since they would need to handle the newly added `Exception`s. However, since this is to only impact test code and is impossible to miss (due to the compiler) and easily fixable it was thought to be better than wrapping the `Exception`s with a `RuntimeException`.

Currently the MockFilterChain
- Performs basic validation on the request/response
- Makes the request/response available as members
- Ensures doFilter is only invoked once

This commit adds the ability to allow the MockFilterChain to invoke
a List of Filter's and/or a Servlet.

Issue: SPR-9745
