### PR TITLE
Add generic to TypeDescriptor.getAnnotation()

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/support/FormattingConversionService.java
+++ b/spring-context/src/main/java/org/springframework/format/support/FormattingConversionService.java
@@ -72,7 +72,7 @@ public class FormattingConversionService extends GenericConversionService
 		}
 		addFormatterForFieldType(fieldType, formatter);
 	}
-	
+
 	public void addFormatterForFieldType(Class<?> fieldType, Formatter<?> formatter) {
 		addConverter(new PrinterConverter(fieldType, formatter, this));
 		addConverter(new ParserConverter(fieldType, formatter, this));
@@ -105,7 +105,7 @@ public class FormattingConversionService extends GenericConversionService
 	private static class PrinterConverter implements GenericConverter {
 
 		private Class<?> fieldType;
-		
+
 		private TypeDescriptor printerObjectType;
 
 		@SuppressWarnings("rawtypes")
@@ -134,11 +134,11 @@ public class FormattingConversionService extends GenericConversionService
 			}
 			return this.printer.print(source, LocaleContextHolder.getLocale());
 		}
-		
+
 		private Class<?> resolvePrinterObjectType(Printer<?> printer) {
 			return GenericTypeResolver.resolveTypeArgument(printer.getClass(), Printer.class);
 		}
-		
+
 		public String toString() {
 			return this.fieldType.getName() + " -> " + String.class.getName() + " : " + this.printer;
 		}
@@ -148,7 +148,7 @@ public class FormattingConversionService extends GenericConversionService
 	private static class ParserConverter implements GenericConverter {
 
 		private Class<?> fieldType;
-		
+
 		private Parser<?> parser;
 
 		private ConversionService conversionService;
@@ -189,14 +189,14 @@ public class FormattingConversionService extends GenericConversionService
 			return String.class.getName() + " -> " + this.fieldType.getName() + ": " + this.parser;
 		}
 	}
-	
+
 
 	private class AnnotationPrinterConverter implements ConditionalGenericConverter {
-		
+
 		private Class<? extends Annotation> annotationType;
-		
+
 		private AnnotationFormatterFactory annotationFormatterFactory;
-		
+
 		private Class<?> fieldType;
 
 		public AnnotationPrinterConverter(Class<? extends Annotation> annotationType,
@@ -209,11 +209,11 @@ public class FormattingConversionService extends GenericConversionService
 		public Set<ConvertiblePair> getConvertibleTypes() {
 			return Collections.singleton(new ConvertiblePair(fieldType, String.class));
 		}
-		
+
 		public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
 			return sourceType.getAnnotation(annotationType) != null;
 		}
-		
+
 		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
 			AnnotationConverterKey converterKey = new AnnotationConverterKey(sourceType.getAnnotation(annotationType), sourceType.getObjectType());
 			GenericConverter converter = cachedPrinters.get(converterKey);
@@ -224,19 +224,19 @@ public class FormattingConversionService extends GenericConversionService
 			}
 			return converter.convert(source, sourceType, targetType);
 		}
-		
+
 		public String toString() {
 			return "@" + annotationType.getName() + " " + fieldType.getName() + " -> " + String.class.getName() + ": " + annotationFormatterFactory;
 		}
 	}
-	
+
 
 	private class AnnotationParserConverter implements ConditionalGenericConverter {
-		
+
 		private Class<? extends Annotation> annotationType;
-		
+
 		private AnnotationFormatterFactory annotationFormatterFactory;
-		
+
 		private Class<?> fieldType;
 
 		public AnnotationParserConverter(Class<? extends Annotation> annotationType,
@@ -249,11 +249,11 @@ public class FormattingConversionService extends GenericConversionService
 		public Set<ConvertiblePair> getConvertibleTypes() {
 			return Collections.singleton(new ConvertiblePair(String.class, fieldType));
 		}
-		
+
 		public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
 			return targetType.getAnnotation(annotationType) != null;
 		}
-		
+
 		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
 			AnnotationConverterKey converterKey = new AnnotationConverterKey(targetType.getAnnotation(annotationType), targetType.getObjectType());
 			GenericConverter converter = cachedParsers.get(converterKey);
@@ -264,32 +264,32 @@ public class FormattingConversionService extends GenericConversionService
 			}
 			return converter.convert(source, sourceType, targetType);
 		}
-		
+
 		public String toString() {
 			return String.class.getName() + " -> @" + annotationType.getName() + " " + fieldType.getName() + ": " + annotationFormatterFactory;
-		}	
+		}
 	}
 
 
 	private static class AnnotationConverterKey {
-		
+
 		private final Annotation annotation;
-		
+
 		private final Class<?> fieldType;
-		
+
 		public AnnotationConverterKey(Annotation annotation, Class<?> fieldType) {
 			this.annotation = annotation;
 			this.fieldType = fieldType;
 		}
-		
+
 		public Annotation getAnnotation() {
 			return annotation;
 		}
-		
+
 		public Class<?> getFieldType() {
 			return fieldType;
 		}
-		
+
 		public boolean equals(Object o) {
 			if (!(o instanceof AnnotationConverterKey)) {
 				return false;
@@ -297,10 +297,10 @@ public class FormattingConversionService extends GenericConversionService
 			AnnotationConverterKey key = (AnnotationConverterKey) o;
 			return this.annotation.equals(key.annotation) && this.fieldType.equals(key.fieldType);
 		}
-		
+
 		public int hashCode() {
 			return this.annotation.hashCode() + 29 * this.fieldType.hashCode();
 		}
 	}
-	
+
 }

--- a/spring-context/src/main/java/org/springframework/format/support/FormattingConversionService.java
+++ b/spring-context/src/main/java/org/springframework/format/support/FormattingConversionService.java
@@ -211,7 +211,7 @@ public class FormattingConversionService extends GenericConversionService
 		}
 
 		public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
-			return sourceType.getAnnotation(annotationType) != null;
+			return sourceType.hasAnnotation(annotationType);
 		}
 
 		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
@@ -251,7 +251,7 @@ public class FormattingConversionService extends GenericConversionService
 		}
 
 		public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
-			return targetType.getAnnotation(annotationType) != null;
+			return targetType.hasAnnotation(annotationType);
 		}
 
 		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {

--- a/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
@@ -133,7 +133,7 @@ public class TypeDescriptor {
 	 * Useful for Converting to typed Maps.
 	 * For example, a Map&lt;String, String&gt; could be converted to a Map&lt;Id, EmailAddress&gt; by converting to a targetType built with this method:
 	 * The method call to construct such a TypeDescriptor would look something like: map(Map.class, TypeDescriptor.valueOf(Id.class), TypeDescriptor.valueOf(EmailAddress.class));
-	 * @param mapType the map type, which must implement {@link Map}.
+	 * @param mapType the map type, which must implement {@link Map}
 	 * @param keyTypeDescriptor a descriptor for the map's key type, used to convert map keys
 	 * @param valueTypeDescriptor the map's value type, used to convert map values
 	 * @return the map type descriptor
@@ -152,12 +152,12 @@ public class TypeDescriptor {
 	 * If the methodParameter is a Map<Integer, String> and the nesting level is 1, the nested type descriptor will be String, derived from the map value.
 	 * If the methodParameter is a List<Map<Integer, String>> and the nesting level is 2, the nested type descriptor will be String, derived from the map value.
 	 * Returns null if a nested type cannot be obtained because it was not declared.
-	 * For example, if the method parameter is a List&lt;?&gt;, the nested type descriptor returned will be null.
+	 * For example, if the method parameter is a List&lt;?&gt;, the nested type descriptor returned will be <tt>null</tt>.
 	 * @param methodParameter the method parameter with a nestingLevel of 1
-	 * @param nestingLevel the nesting level of the collection/array element or map key/value declaration within the method parameter.
-	 * @return the nested type descriptor at the specified nesting level, or null if it could not be obtained.
-	 * @throws IllegalArgumentException if the nesting level of the input {@link MethodParameter} argument is not 1.
-	 * @throws IllegalArgumentException if the types up to the specified nesting level are not of collection, array, or map types.
+	 * @param nestingLevel the nesting level of the collection/array element or map key/value declaration within the method parameter
+	 * @return the nested type descriptor at the specified nesting level, or null if it could not be obtained
+	 * @throws IllegalArgumentException if the nesting level of the input {@link MethodParameter} argument is not 1
+	 * @throws IllegalArgumentException if the types up to the specified nesting level are not of collection, array, or map types
 	 */
 	public static TypeDescriptor nested(MethodParameter methodParameter, int nestingLevel) {
 		if (methodParameter.getNestingLevel() != 1) {
@@ -175,9 +175,9 @@ public class TypeDescriptor {
 	 * Returns <code>null</code> if a nested type cannot be obtained because it was not declared.
 	 * For example, if the field is a <code>List&lt;?&gt;</code>, the nested type descriptor returned will be <code>null</code>.
 	 * @param field the field
-	 * @param nestingLevel the nesting level of the collection/array element or map key/value declaration within the field.
+	 * @param nestingLevel the nesting level of the collection/array element or map key/value declaration within the field
 	 * @return the nested type descriptor at the specified nestingLevel, or null if it could not be obtained
-	 * @throws IllegalArgumentException if the types up to the specified nesting level are not of collection, array, or map types.
+	 * @throws IllegalArgumentException if the types up to the specified nesting level are not of collection, array, or map types
 	 */
 	public static TypeDescriptor nested(Field field, int nestingLevel) {
 		return nested(new FieldDescriptor(field), nestingLevel);
@@ -192,9 +192,9 @@ public class TypeDescriptor {
 	 * Returns <code>null</code> if a nested type cannot be obtained because it was not declared.
 	 * For example, if the property is a <code>List&lt;?&gt;</code>, the nested type descriptor returned will be <code>null</code>.
 	 * @param property the property
-	 * @param nestingLevel the nesting level of the collection/array element or map key/value declaration within the property.
+	 * @param nestingLevel the nesting level of the collection/array element or map key/value declaration within the property
 	 * @return the nested type descriptor at the specified nestingLevel, or <code>null</code> if it could not be obtained
-	 * @throws IllegalArgumentException if the types up to the specified nesting level are not of collection, array, or map types.
+	 * @throws IllegalArgumentException if the types up to the specified nesting level are not of collection, array, or map types
 	 */
 	public static TypeDescriptor nested(Property property, int nestingLevel) {
 		return nested(new BeanPropertyDescriptor(property), nestingLevel);
@@ -210,7 +210,6 @@ public class TypeDescriptor {
 	public static TypeDescriptor forObject(Object source) {
 		return (source != null ? valueOf(source.getClass()) : null);
 	}
-
 
 	/**
 	 * The type of the backing class, method parameter, field, or property described by this TypeDescriptor.
@@ -266,7 +265,7 @@ public class TypeDescriptor {
 
 	/**
 	 * The annotations associated with this type descriptor, if any.
-	 * @return the annotations, or an empty array if none.
+	 * @return the annotations, or an empty array if none
 	 */
 	public Annotation[] getAnnotations() {
 		return this.annotations;
@@ -274,7 +273,8 @@ public class TypeDescriptor {
 
 	/**
 	 * Obtain the annotation associated with this type descriptor of the specified type.
-	 * @return the annotation, or null if no such annotation exists on this type descriptor.
+	 * @param annotationType the annotation type
+	 * @return the annotation, or null if no such annotation exists on this type descriptor
 	 */
 	public Annotation getAnnotation(Class<? extends Annotation> annotationType) {
 		for (Annotation annotation : getAnnotations()) {
@@ -292,7 +292,7 @@ public class TypeDescriptor {
 	 * <p>
 	 * For arrays, collections, and maps, element and key/value types are checked if declared.
 	 * For example, a List&lt;String&gt; field value is assignable to a Collection&lt;CharSequence&gt; field, but List&lt;Number&gt; is not assignable to List&lt;Integer&gt;.
-	 * @return true if this type is assignable to the type represented by the provided type descriptor.
+	 * @return true if this type is assignable to the type represented by the provided type descriptor
 	 * @see #getObjectType()
 	 */
 	public boolean isAssignableTo(TypeDescriptor typeDescriptor) {
@@ -335,7 +335,7 @@ public class TypeDescriptor {
 	 * If this type is an array, returns the array's component type.
 	 * If this type is a {@link Collection} and it is parameterized, returns the Collection's element type.
 	 * If the Collection is not parameterized, returns null indicating the element type is not declared.
-	 * @return the array component type or Collection element type, or <code>null</code> if this type is a Collection but its element type is not parameterized.
+	 * @return the array component type or Collection element type, or <code>null</code> if this type is a Collection but its element type is not parameterized
 	 * @throws IllegalStateException if this type is not a java.util.Collection or Array type
 	 */
 	public TypeDescriptor getElementTypeDescriptor() {
@@ -370,8 +370,8 @@ public class TypeDescriptor {
 	/**
 	 * If this type is a {@link Map} and its key type is parameterized, returns the map's key type.
 	 * If the Map's key type is not parameterized, returns null indicating the key type is not declared.
-	 * @return the Map key type, or <code>null</code> if this type is a Map but its key type is not parameterized.
-	 * @throws IllegalStateException if this type is not a java.util.Map.
+	 * @return the Map key type, or <code>null</code> if this type is a Map but its key type is not parameterized
+	 * @throws IllegalStateException if this type is not a java.util.Map
 	 */
 	public TypeDescriptor getMapKeyTypeDescriptor() {
 		assertMap();
@@ -386,7 +386,7 @@ public class TypeDescriptor {
 	 * Annotation and nested type context will be preserved in the narrowed TypeDescriptor that is returned.
 	 * @param mapKey the map key
 	 * @return the map key type descriptor
-	 * @throws IllegalStateException if this type is not a java.util.Map.
+	 * @throws IllegalStateException if this type is not a java.util.Map
 	 * @see #narrow(Object)
 	 */
 	public TypeDescriptor getMapKeyTypeDescriptor(Object mapKey) {
@@ -396,8 +396,8 @@ public class TypeDescriptor {
 	/**
 	 * If this type is a {@link Map} and its value type is parameterized, returns the map's value type.
 	 * If the Map's value type is not parameterized, returns null indicating the value type is not declared.
-	 * @return the Map value type, or <code>null</code> if this type is a Map but its value type is not parameterized.
-	 * @throws IllegalStateException if this type is not a java.util.Map.
+	 * @return the Map value type, or <code>null</code> if this type is a Map but its value type is not parameterized
+	 * @throws IllegalStateException if this type is not a java.util.Map
 	 */
 	public TypeDescriptor getMapValueTypeDescriptor() {
 		assertMap();
@@ -412,18 +412,18 @@ public class TypeDescriptor {
 	 * Annotation and nested type context will be preserved in the narrowed TypeDescriptor that is returned.
 	 * @param mapValue the map value
 	 * @return the map value type descriptor
-	 * @throws IllegalStateException if this type is not a java.util.Map.
+	 * @throws IllegalStateException if this type is not a java.util.Map
 	 */
 	public TypeDescriptor getMapValueTypeDescriptor(Object mapValue) {
-		return narrow(mapValue, getMapValueTypeDescriptor());		
+		return narrow(mapValue, getMapValueTypeDescriptor());
 	}
 
 
 	// deprecations in Spring 3.1
-	
+
 	/**
 	 * Returns the value of {@link TypeDescriptor#getType() getType()} for the {@link #getElementTypeDescriptor() elementTypeDescriptor}.
-	 * @deprecated in Spring 3.1 in favor of {@link #getElementTypeDescriptor()}.
+	 * @deprecated in Spring 3.1 in favor of {@link #getElementTypeDescriptor()}
 	 * @throws IllegalStateException if this type is not a java.util.Collection or Array type
 	 */
 	@Deprecated
@@ -433,8 +433,8 @@ public class TypeDescriptor {
 
 	/**
 	 * Returns the value of {@link TypeDescriptor#getType() getType()} for the {@link #getMapKeyTypeDescriptor() getMapKeyTypeDescriptor}.
-	 * @deprecated in Spring 3.1 in favor of {@link #getMapKeyTypeDescriptor()}.
-	 * @throws IllegalStateException if this type is not a java.util.Map.
+	 * @deprecated in Spring 3.1 in favor of {@link #getMapKeyTypeDescriptor()}
+	 * @throws IllegalStateException if this type is not a java.util.Map
 	 */
 	@Deprecated
 	public Class<?> getMapKeyType() {
@@ -443,8 +443,8 @@ public class TypeDescriptor {
 
 	/**
 	 * Returns the value of {@link TypeDescriptor#getType() getType()} for the {@link #getMapValueTypeDescriptor() getMapValueTypeDescriptor}.
-	 * @deprecated in Spring 3.1 in favor of {@link #getMapValueTypeDescriptor()}.
-	 * @throws IllegalStateException if this type is not a java.util.Map.
+	 * @deprecated in Spring 3.1 in favor of {@link #getMapValueTypeDescriptor()}
+	 * @throws IllegalStateException if this type is not a java.util.Map
 	 */
 	@Deprecated
 	public Class<?> getMapValueType() {
@@ -521,7 +521,7 @@ public class TypeDescriptor {
 		}
 		else {
 			return (value != null ? new TypeDescriptor(value.getClass(), null, null, null, this.annotations) : null);
-		}		
+		}
 	}
 
 	private boolean isNestedAssignable(TypeDescriptor nestedTypeDescriptor, TypeDescriptor otherNestedTypeDescriptor) {

--- a/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
@@ -272,14 +272,24 @@ public class TypeDescriptor {
 	}
 
 	/**
+	 * Determine if this type descriptor has the specified annotation.
+	 * @param annotationType the annotation type
+	 * @return <tt>true</tt> if the annotation is present
+	 */
+	public boolean hasAnnotation(Class<? extends Annotation> annotationType) {
+		return getAnnotation(annotationType) != null;
+	}
+
+	/**
 	 * Obtain the annotation associated with this type descriptor of the specified type.
 	 * @param annotationType the annotation type
 	 * @return the annotation, or null if no such annotation exists on this type descriptor
 	 */
-	public Annotation getAnnotation(Class<? extends Annotation> annotationType) {
+	@SuppressWarnings("unchecked")
+	public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
 		for (Annotation annotation : getAnnotations()) {
 			if (annotation.annotationType().equals(annotationType)) {
-				return annotation;
+				return (T) annotation;
 			}
 		}
 		return null;

--- a/spring-core/src/test/java/org/springframework/core/convert/TypeDescriptorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/TypeDescriptorTests.java
@@ -191,15 +191,17 @@ public class TypeDescriptorTests {
 		assertEquals(String.class, t1.getType());
 		assertEquals(1, t1.getAnnotations().length);
 		assertNotNull(t1.getAnnotation(ParameterAnnotation.class));
+		assertTrue(t1.hasAnnotation(ParameterAnnotation.class));
+		assertEquals(123, t1.getAnnotation(ParameterAnnotation.class).value());
 	}
 
 	@Target({ElementType.PARAMETER})
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ParameterAnnotation {
-
+		int value();
 	}
 
-	public void testAnnotatedMethod(@ParameterAnnotation String parameter) {
+	public void testAnnotatedMethod(@ParameterAnnotation(123) String parameter) {
 
 	}
 
@@ -297,6 +299,7 @@ public class TypeDescriptorTests {
 		assertEquals(List.class, desc.getType());
 		assertEquals(Integer.class, desc.getElementTypeDescriptor().getType());
 		assertNotNull(desc.getAnnotation(MethodAnnotation1.class));
+		assertTrue(desc.hasAnnotation(MethodAnnotation1.class));
 	}
 
 	public static class GenericClass<T> {

--- a/spring-core/src/test/java/org/springframework/core/convert/TypeDescriptorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/TypeDescriptorTests.java
@@ -72,11 +72,11 @@ public class TypeDescriptorTests {
 		assertFalse(desc.isCollection());
 		assertFalse(desc.isMap());
 	}
-	
+
 	public void testParameterPrimitive(int primitive) {
-		
+
 	}
-	
+
 	@Test
 	public void parameterScalar() throws Exception {
 		TypeDescriptor desc = new TypeDescriptor(new MethodParameter(getClass().getMethod("testParameterScalar", String.class), 0));
@@ -90,9 +90,9 @@ public class TypeDescriptorTests {
 		assertFalse(desc.isArray());
 		assertFalse(desc.isMap());
 	}
-	
+
 	public void testParameterScalar(String value) {
-		
+
 	}
 
 	@Test
@@ -117,7 +117,7 @@ public class TypeDescriptorTests {
 	}
 
 	public void testParameterList(List<List<Map<Integer, Enum<?>>>> list) {
-		
+
 	}
 
 	@Test
@@ -131,13 +131,13 @@ public class TypeDescriptorTests {
 		assertTrue(!desc.isPrimitive());
 		assertEquals(0, desc.getAnnotations().length);
 		assertTrue(desc.isCollection());
-		assertFalse(desc.isArray());		
+		assertFalse(desc.isArray());
 		assertNull(desc.getElementTypeDescriptor());
 		assertFalse(desc.isMap());
 	}
 
 	public void testParameterListNoParamTypes(List list) {
-		
+
 	}
 
 	@Test
@@ -158,9 +158,9 @@ public class TypeDescriptorTests {
 	}
 
 	public void testParameterArray(Integer[] array) {
-		
+
 	}
-	
+
 	@Test
 	public void parameterMap() throws Exception {
 		MethodParameter methodParameter = new MethodParameter(getClass().getMethod("testParameterMap", Map.class), 0);
@@ -182,7 +182,7 @@ public class TypeDescriptorTests {
 	}
 
 	public void testParameterMap(Map<Integer, List<String>> map) {
-		
+
 	}
 
 	@Test
@@ -196,33 +196,33 @@ public class TypeDescriptorTests {
 	@Target({ElementType.PARAMETER})
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ParameterAnnotation {
-		
+
 	}
-	
+
 	public void testAnnotatedMethod(@ParameterAnnotation String parameter) {
-		
+
 	}
 
 	@Test
 	public void propertyComplex() throws Exception {
-		Property property = new Property(getClass(), getClass().getMethod("getComplexProperty"), getClass().getMethod("setComplexProperty", Map.class));		
+		Property property = new Property(getClass(), getClass().getMethod("getComplexProperty"), getClass().getMethod("setComplexProperty", Map.class));
 		TypeDescriptor desc = new TypeDescriptor(property);
 		assertEquals(String.class, desc.getMapKeyTypeDescriptor().getType());
 		assertEquals(Integer.class, desc.getMapValueTypeDescriptor().getElementTypeDescriptor().getElementTypeDescriptor().getType());
 	}
-	
+
 	public Map<String, List<List<Integer>>> getComplexProperty() {
 		return null;
 	}
-	
+
 	public void setComplexProperty(Map<String, List<List<Integer>>> complexProperty) {
-		
+
 	}
 
 	@Test
 	public void propertyGenericType() throws Exception {
 		GenericType<Integer> genericBean = new IntegerType();
-		Property property = new Property(getClass(), genericBean.getClass().getMethod("getProperty"), genericBean.getClass().getMethod("setProperty", Integer.class));		
+		Property property = new Property(getClass(), genericBean.getClass().getMethod("getProperty"), genericBean.getClass().getMethod("setProperty", Integer.class));
 		TypeDescriptor desc = new TypeDescriptor(property);
 		assertEquals(Integer.class, desc.getType());
 	}
@@ -230,7 +230,7 @@ public class TypeDescriptorTests {
 	@Test
 	public void propertyTypeCovariance() throws Exception {
 		GenericType<Number> genericBean = new NumberType();
-		Property property = new Property(getClass(), genericBean.getClass().getMethod("getProperty"), genericBean.getClass().getMethod("setProperty", Number.class));		
+		Property property = new Property(getClass(), genericBean.getClass().getMethod("getProperty"), genericBean.getClass().getMethod("setProperty", Number.class));
 		TypeDescriptor desc = new TypeDescriptor(property);
 		assertEquals(Integer.class, desc.getType());
 	}
@@ -238,7 +238,7 @@ public class TypeDescriptorTests {
 	@Test
 	public void propertyGenericTypeList() throws Exception {
 		GenericType<Integer> genericBean = new IntegerType();
-		Property property = new Property(getClass(), genericBean.getClass().getMethod("getListProperty"), genericBean.getClass().getMethod("setListProperty", List.class));		
+		Property property = new Property(getClass(), genericBean.getClass().getMethod("getListProperty"), genericBean.getClass().getMethod("setListProperty", List.class));
 		TypeDescriptor desc = new TypeDescriptor(property);
 		assertEquals(List.class, desc.getType());
 		assertEquals(Integer.class, desc.getElementTypeDescriptor().getType());
@@ -246,15 +246,15 @@ public class TypeDescriptorTests {
 
 	public interface GenericType<T> {
 		T getProperty();
-	
+
 		void setProperty(T t);
 
 		List<T> getListProperty();
-		
+
 		void setListProperty(List<T> t);
-		
+
  	}
-	
+
 	public class IntegerType implements GenericType<Integer> {
 
 		public Integer getProperty() {
@@ -292,19 +292,19 @@ public class TypeDescriptorTests {
 	@Test
 	public void propertyGenericClassList() throws Exception {
 		IntegerClass genericBean = new IntegerClass();
-		Property property = new Property(genericBean.getClass(), genericBean.getClass().getMethod("getListProperty"), genericBean.getClass().getMethod("setListProperty", List.class));		
+		Property property = new Property(genericBean.getClass(), genericBean.getClass().getMethod("getListProperty"), genericBean.getClass().getMethod("setListProperty", List.class));
 		TypeDescriptor desc = new TypeDescriptor(property);
 		assertEquals(List.class, desc.getType());
 		assertEquals(Integer.class, desc.getElementTypeDescriptor().getType());
 		assertNotNull(desc.getAnnotation(MethodAnnotation1.class));
 	}
-	
+
 	public static class GenericClass<T> {
-		
+
 		public T getProperty() {
 			return null;
 		}
-		
+
 		public void setProperty(T t) {
 		}
 
@@ -312,19 +312,19 @@ public class TypeDescriptorTests {
 		public List<T> getListProperty() {
 			return null;
 		}
-		
+
 		public void setListProperty(List<T> t) {
 		}
-		
+
 	}
-	
+
 	public static class IntegerClass extends GenericClass<Integer> {
-		
+
 	}
 
 	@Test
 	public void property() throws Exception {
-		Property property = new Property(getClass(), getClass().getMethod("getProperty"), getClass().getMethod("setProperty", Map.class));		
+		Property property = new Property(getClass(), getClass().getMethod("getProperty"), getClass().getMethod("setProperty", Map.class));
 		TypeDescriptor desc = new TypeDescriptor(property);
 		assertEquals(Map.class, desc.getType());
 		assertEquals(Integer.class, desc.getMapKeyTypeDescriptor().getElementTypeDescriptor().getType());
@@ -338,7 +338,7 @@ public class TypeDescriptorTests {
 	public Map<List<Integer>, List<Long>> getProperty() {
 		return property;
 	}
-	
+
 	@MethodAnnotation2
 	public void setProperty(Map<List<Integer>, List<Long>> property) {
 		this.property = property;
@@ -346,23 +346,23 @@ public class TypeDescriptorTests {
 
 	@MethodAnnotation3
 	private Map<List<Integer>, List<Long>> property;
-	
+
 	@Target({ElementType.METHOD})
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface MethodAnnotation1 {
-		
+
 	}
 
 	@Target({ElementType.METHOD})
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface MethodAnnotation2 {
-		
+
 	}
 
 	@Target({ElementType.FIELD})
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface MethodAnnotation3 {
-		
+
 	}
 
 	@Test
@@ -375,9 +375,9 @@ public class TypeDescriptorTests {
 		assertEquals(Integer.class, typeDescriptor.getType());
 		assertEquals(Integer.class, typeDescriptor.getObjectType());
 	}
-	
+
 	public Integer fieldScalar;
-	
+
 	@Test
 	public void fieldList() throws Exception {
 		TypeDescriptor typeDescriptor = new TypeDescriptor(TypeDescriptorTests.class.getDeclaredField("listOfString"));
@@ -441,7 +441,7 @@ public class TypeDescriptorTests {
 		assertEquals(Integer.class, desc.getMapKeyTypeDescriptor().getElementTypeDescriptor().getType());
 		assertEquals(Long.class, desc.getMapValueTypeDescriptor().getElementTypeDescriptor().getType());
 	}
-	
+
 	public Map<List<Integer>, List<Long>> fieldMap;
 
 	@Test
@@ -457,7 +457,7 @@ public class TypeDescriptorTests {
 	@Target({ElementType.FIELD})
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface FieldAnnotation {
-		
+
 	}
 
 	@Test
@@ -481,7 +481,7 @@ public class TypeDescriptorTests {
 		assertEquals(Integer.TYPE, typeDescriptor.getType());
 		assertEquals(Integer.class, typeDescriptor.getObjectType());
 	}
-	
+
 	@Test
 	public void valueOfArray() throws Exception {
 		TypeDescriptor typeDescriptor = TypeDescriptor.valueOf(int[].class);
@@ -552,23 +552,23 @@ public class TypeDescriptorTests {
 	}
 
 	public void test1(List<String> param1) {
-		
+
 	}
 
 	public void test2(List<List<String>> param1) {
-		
+
 	}
-	
+
 	public void test3(Map<Integer, String> param1) {
-		
+
 	}
 
 	public void test4(List<Map<Integer, String>> param1) {
-		
+
 	}
 
 	public void test5(String param1) {
-		
+
 	}
 
 	@Test
@@ -581,7 +581,7 @@ public class TypeDescriptorTests {
 	}
 
 	public void test6(List<List> param1) {
-		
+
 	}
 
 	@Test
@@ -602,9 +602,9 @@ public class TypeDescriptorTests {
 	public List<Map<Integer, String>> getTest4() {
 		return null;
 	}
-	
+
 	public void setTest4(List<Map<Integer, String>> test4) {
-		
+
 	}
 
 	@Test
@@ -657,7 +657,7 @@ public class TypeDescriptorTests {
 
 	@Test
 	public void mapNested() {
-		TypeDescriptor desc = TypeDescriptor.map(Map.class, TypeDescriptor.valueOf(String.class), 
+		TypeDescriptor desc = TypeDescriptor.map(Map.class, TypeDescriptor.valueOf(String.class),
 				TypeDescriptor.map(Map.class, TypeDescriptor.valueOf(String.class), TypeDescriptor.valueOf(Integer.class)));
 		assertEquals(Map.class, desc.getType());
 		assertEquals(Map.class, desc.getObjectType());
@@ -696,9 +696,9 @@ public class TypeDescriptorTests {
 		List<Integer> value = new ArrayList<Integer>(3);
 		desc = desc.elementTypeDescriptor(value);
 		assertEquals(Integer.class, desc.getElementTypeDescriptor().getType());
-		assertNotNull(desc.getAnnotation(FieldAnnotation.class));		
+		assertNotNull(desc.getAnnotation(FieldAnnotation.class));
 	}
-	
+
 	@FieldAnnotation
 	public List<List<Integer>> listPreserveContext;
 
@@ -738,7 +738,7 @@ public class TypeDescriptorTests {
 		List<Integer> value = new ArrayList<Integer>(3);
 		desc = desc.getMapValueTypeDescriptor(value);
 		assertEquals(Integer.class, desc.getElementTypeDescriptor().getType());
-		assertNotNull(desc.getAnnotation(FieldAnnotation.class));		
+		assertNotNull(desc.getAnnotation(FieldAnnotation.class));
 	}
 
 	@Test
@@ -755,7 +755,7 @@ public class TypeDescriptorTests {
 		assertEquals(t3, t4);
 		assertEquals(t5, t6);
 		assertEquals(t7, t8);
-		
+
 		TypeDescriptor t9 = new TypeDescriptor(getClass().getField("listField"));
 		TypeDescriptor t10 = new TypeDescriptor(getClass().getField("listField"));
 		assertEquals(t9, t10);
@@ -764,17 +764,17 @@ public class TypeDescriptorTests {
 		TypeDescriptor t12 = new TypeDescriptor(getClass().getField("mapField"));
 		assertEquals(t11, t12);
 	}
-	
+
 	@Test
 	public void isAssignableTypes() {
-		assertTrue(TypeDescriptor.valueOf(Integer.class).isAssignableTo(TypeDescriptor.valueOf(Number.class)));		
+		assertTrue(TypeDescriptor.valueOf(Integer.class).isAssignableTo(TypeDescriptor.valueOf(Number.class)));
 		assertFalse(TypeDescriptor.valueOf(Number.class).isAssignableTo(TypeDescriptor.valueOf(Integer.class)));
-		assertFalse(TypeDescriptor.valueOf(String.class).isAssignableTo(TypeDescriptor.valueOf(String[].class)));		
+		assertFalse(TypeDescriptor.valueOf(String.class).isAssignableTo(TypeDescriptor.valueOf(String[].class)));
 	}
 
 	@Test
 	public void isAssignableElementTypes() throws Exception {
-		assertTrue(new TypeDescriptor(getClass().getField("listField")).isAssignableTo(new TypeDescriptor(getClass().getField("listField"))));		
+		assertTrue(new TypeDescriptor(getClass().getField("listField")).isAssignableTo(new TypeDescriptor(getClass().getField("listField"))));
 		assertTrue(new TypeDescriptor(getClass().getField("notGenericList")).isAssignableTo(new TypeDescriptor(getClass().getField("listField"))));
 		assertTrue(new TypeDescriptor(getClass().getField("listField")).isAssignableTo(new TypeDescriptor(getClass().getField("notGenericList"))));
 		assertFalse(new TypeDescriptor(getClass().getField("isAssignableElementTypes")).isAssignableTo(new TypeDescriptor(getClass().getField("listField"))));
@@ -782,15 +782,15 @@ public class TypeDescriptorTests {
 	}
 
 	public List notGenericList;
-	
+
 	public List<Number> isAssignableElementTypes;
-	
+
 	@Test
 	public void isAssignableMapKeyValueTypes() throws Exception {
-		assertTrue(new TypeDescriptor(getClass().getField("mapField")).isAssignableTo(new TypeDescriptor(getClass().getField("mapField"))));		
+		assertTrue(new TypeDescriptor(getClass().getField("mapField")).isAssignableTo(new TypeDescriptor(getClass().getField("mapField"))));
 		assertTrue(new TypeDescriptor(getClass().getField("notGenericMap")).isAssignableTo(new TypeDescriptor(getClass().getField("mapField"))));
 		assertTrue(new TypeDescriptor(getClass().getField("mapField")).isAssignableTo(new TypeDescriptor(getClass().getField("notGenericMap"))));
-		assertFalse(new TypeDescriptor(getClass().getField("isAssignableMapKeyValueTypes")).isAssignableTo(new TypeDescriptor(getClass().getField("mapField"))));		
+		assertFalse(new TypeDescriptor(getClass().getField("isAssignableMapKeyValueTypes")).isAssignableTo(new TypeDescriptor(getClass().getField("mapField"))));
 		assertTrue(TypeDescriptor.valueOf(Map.class).isAssignableTo(new TypeDescriptor(getClass().getField("mapField"))));
 	}
 


### PR DESCRIPTION
Use generics for TypeDescriptor.getAnnotation() to work in the
same way as Method.getAnnotation().

Add hasAnnotation method and update existing conditional converters
to make use of it.

Cleanup JavaDoc formatting a little.

Issue: SPR-9744
