### PR TITLE
Support inferred base package for @ComponentScan

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ComponentScan.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ComponentScan.java
@@ -30,7 +30,9 @@ import org.springframework.core.type.filter.TypeFilter;
  * Provides support parallel with Spring XML's {@code <context:component-scan>} element.
  *
  * <p>One of {@link #basePackageClasses()}, {@link #basePackages()} or its alias
- * {@link #value()} must be specified.
+ * {@link #value()} may be specified to define specific packages to scan.  If specific
+ * packages are not defined scanning will occur from the package of the
+ * class with this annotation.
  *
  * <p>Note that the {@code <context:component-scan>} element has an
  * {@code annotation-config} attribute, however this annotation does not. This is because

--- a/spring-context/src/main/java/org/springframework/context/annotation/ComponentScanAnnotationParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ComponentScanAnnotationParser.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.core.type.filter.AssignableTypeFilter;
 import org.springframework.core.type.filter.TypeFilter;
@@ -44,6 +45,8 @@ import org.springframework.util.StringUtils;
  * @see ComponentScanBeanDefinitionParser
  */
 class ComponentScanAnnotationParser {
+
+	private static final String PACKAGE_SEPARATOR = ".";
 
 	private final ResourceLoader resourceLoader;
 
@@ -65,7 +68,7 @@ class ComponentScanAnnotationParser {
 	}
 
 
-	public Set<BeanDefinitionHolder> parse(AnnotationAttributes componentScan) {
+	public Set<BeanDefinitionHolder> parse(AnnotationMetadata metadata, AnnotationAttributes componentScan) {
 		ClassPathBeanDefinitionScanner scanner =
 			new ClassPathBeanDefinitionScanner(registry, componentScan.getBoolean("useDefaultFilters"));
 
@@ -118,10 +121,16 @@ class ComponentScanAnnotationParser {
 		}
 
 		if (basePackages.isEmpty()) {
-			throw new IllegalStateException("At least one base package must be specified");
+			basePackages.add(getPackageName(metadata));
 		}
 
 		return scanner.doScan(basePackages.toArray(new String[]{}));
+	}
+
+	private String getPackageName(AnnotationMetadata metadata) {
+		String className = metadata.getClassName();
+		int lastDotIndex = className.lastIndexOf(PACKAGE_SEPARATOR);
+		return (lastDotIndex != -1 ? className.substring(0, lastDotIndex) : "");
 	}
 
 	private List<TypeFilter> typeFiltersFor(AnnotationAttributes filterAttributes) {

--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
@@ -211,7 +211,7 @@ class ConfigurationClassParser {
 		AnnotationAttributes componentScan = attributesFor(metadata, ComponentScan.class);
 		if (componentScan != null) {
 			// the config class is annotated with @ComponentScan -> perform the scan immediately
-			Set<BeanDefinitionHolder> scannedBeanDefinitions = this.componentScanParser.parse(componentScan);
+			Set<BeanDefinitionHolder> scannedBeanDefinitions = this.componentScanParser.parse(metadata, componentScan);
 
 			// check the set of scanned definitions for any further config classes and parse recursively if necessary
 			for (BeanDefinitionHolder holder : scannedBeanDefinitions) {

--- a/spring-context/src/test/java/example/scannable_implicitbasepackage/ComponentScanAnnotatedConfigWithImplicitBasePackage.java
+++ b/spring-context/src/test/java/example/scannable_implicitbasepackage/ComponentScanAnnotatedConfigWithImplicitBasePackage.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.scannable_implicitbasepackage;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Phillip Webb
+ */
+@Configuration
+@ComponentScan
+public class ComponentScanAnnotatedConfigWithImplicitBasePackage {
+}

--- a/spring-context/src/test/java/example/scannable_implicitbasepackage/ScannedComponent.java
+++ b/spring-context/src/test/java/example/scannable_implicitbasepackage/ScannedComponent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.scannable_implicitbasepackage;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Phillip Webb
+ */
+@Component
+public class ScannedComponent {
+
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/ComponentScanAnnotationIntegrationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ComponentScanAnnotationIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 
 import java.io.IOException;
@@ -47,6 +45,7 @@ import example.scannable.DefaultNamedComponent;
 import example.scannable.FooService;
 import example.scannable.MessageBean;
 import example.scannable.ScopedProxyTestBean;
+import example.scannable_implicitbasepackage.ComponentScanAnnotatedConfigWithImplicitBasePackage;
 import example.scannable_scoped.CustomScopeAnnotationBean;
 import example.scannable_scoped.MyScope;
 
@@ -94,6 +93,18 @@ public class ComponentScanAnnotationIntegrationTests {
 	}
 
 	@Test
+	public void viaContextRegistration_FromPackageOfConfigClass() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.register(ComponentScanAnnotatedConfigWithImplicitBasePackage.class);
+		ctx.refresh();
+		ctx.getBean(ComponentScanAnnotatedConfigWithImplicitBasePackage.class);
+		assertThat("config class bean not found", ctx.containsBeanDefinition("componentScanAnnotatedConfigWithImplicitBasePackage"), is(true));
+		assertThat("@ComponentScan annotated @Configuration class registered directly against " +
+				"AnnotationConfigApplicationContext did not trigger component scanning as expected",
+				ctx.containsBean("scannedComponent"), is(true));
+	}
+
+	@Test
 	public void viaBeanRegistration() {
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
 		bf.registerBeanDefinition("componentScanAnnotatedConfig",
@@ -108,18 +119,6 @@ public class ComponentScanAnnotationIntegrationTests {
 		assertThat("@ComponentScan annotated @Configuration class registered " +
 				"as bean definition did not trigger component scanning as expected",
 				ctx.containsBean("fooServiceImpl"), is(true));
-	}
-
-	@Test
-	public void invalidComponentScanDeclaration_noPackagesSpecified() {
-		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
-		ctx.register(ComponentScanWithNoPackagesConfig.class);
-		try {
-			ctx.refresh();
-			fail("Expected exception when parsing @ComponentScan definition that declares no packages");
-		} catch (IllegalStateException ex) {
-			assertThat(ex.getMessage(), containsString("At least one base package must be specified"));
-		}
 	}
 
 	@Test


### PR DESCRIPTION
If the @ComponentScan annotation does not defined basePackage,
basePackageClasses or value scanning will occur from the
configuration class.

Issue: SPR-9586
