### PR TITLE
SPR-9275 Cache Abstraction Exception Handling

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/support/FailSafeCache.java
+++ b/spring-context/src/main/java/org/springframework/cache/support/FailSafeCache.java
@@ -1,0 +1,60 @@
+package org.springframework.cache.support;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+
+public class FailSafeCache implements Cache {
+
+	private static final Logger log = LoggerFactory.getLogger(FailSafeCache.class);
+	
+	private Cache underlyingCache;
+	
+	public FailSafeCache(Cache underlyingCache) {
+		this.underlyingCache = underlyingCache;
+	}
+
+	public String getName() {
+		return this.underlyingCache.getName();
+	}
+
+	public Object getNativeCache() {
+		return this.underlyingCache.getNativeCache();
+	}
+
+	public ValueWrapper get(Object key) {
+		ValueWrapper result = null;
+		try {
+			result = this.underlyingCache.get(key);
+		} catch(Exception e) {
+			log.error("Failed to get key: {}", key, e);
+		}
+		return result;
+	}
+
+	public void put(Object key, Object value) {
+		try {
+			this.underlyingCache.put(key, value);
+		} catch(Exception e) {
+			if(log.isErrorEnabled()) {
+				log.error("Failed to put key/value: '{'" + key + ", {" + value + "} in the cache", e);
+			}
+		}
+	}
+
+	public void evict(Object key) {
+		try {
+			this.underlyingCache.evict(key);
+		} catch(Exception e) {
+			log.error("Failed to evict key: '{}'", key, e);
+		}
+	}
+
+	public void clear() {
+		try {
+			this.underlyingCache.clear();
+		} catch(Exception e) {
+			log.error("Failed to clear cache", e);
+		}
+	}
+}

--- a/spring-context/src/test/java/org/springframework/cache/support/AbstractCacheManagerTest.java
+++ b/spring-context/src/test/java/org/springframework/cache/support/AbstractCacheManagerTest.java
@@ -1,0 +1,54 @@
+package org.springframework.cache.support;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+public class AbstractCacheManagerTest {
+
+	private AbstractCacheManager uut;
+	
+	private static final String CACHE_NAME = "test";
+
+	private class AbstractCacheManagerImpl extends AbstractCacheManager {
+
+		@Override
+		protected Collection<? extends Cache> loadCaches() {
+			Collection<Cache> caches = new LinkedHashSet<Cache>();
+			caches.add(new ConcurrentMapCache(CACHE_NAME));
+			return caches;
+		}
+	}
+	
+	@Before
+	public void setup() {
+		uut = new AbstractCacheManagerImpl();
+	}
+	
+	@Test
+	public void testName() throws Exception {
+		uut.afterPropertiesSet();
+		
+		Cache cache = uut.getCache(CACHE_NAME);
+		
+		assertTrue(cache instanceof ConcurrentMapCache);
+		assertFalse(cache instanceof FailSafeCache);
+	}
+	
+	@Test
+	public void testName2() {
+		uut.setGracefullyHandleExceptions(true);
+		uut.afterPropertiesSet();
+		
+		Cache cache = uut.getCache(CACHE_NAME);
+		
+		assertTrue(cache instanceof FailSafeCache);
+	}
+}

--- a/spring-context/src/test/java/org/springframework/cache/support/FailSafeCacheTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/support/FailSafeCacheTests.java
@@ -1,0 +1,135 @@
+package org.springframework.cache.support;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueWrapper;
+import org.springframework.cache.support.FailSafeCache;
+import org.springframework.cache.support.SimpleValueWrapper;
+
+public class FailSafeCacheTests {
+
+	private Cache uut;
+	
+	private Cache mockUnderlyingCache;
+	
+	private Object mockKey;
+	
+	private Object mockValue;
+
+	@Before
+	public void setup() {
+		mockUnderlyingCache = createMock(Cache.class);
+		uut = new FailSafeCache(mockUnderlyingCache);
+		
+		mockKey = new Object();
+		mockValue = new Object();
+	}
+
+	@After
+	public void tearDown() {
+		verify(mockUnderlyingCache);
+	}
+	
+	@Test
+	public void clearShouldDelegateToUnderlyingCache() {
+		mockUnderlyingCache.clear();
+		replay(mockUnderlyingCache);
+		
+		uut.clear();
+	}
+	
+	@Test
+	public void clearShouldFailGracefullyWhenUnderlyingCacheThrowsException() {
+		mockUnderlyingCache.clear();
+		expectLastCall().andThrow(new RuntimeException("Simulated Exception"));
+		replay(mockUnderlyingCache);
+		
+		uut.clear();
+	}
+	
+	@Test
+	public void evictShouldDelegateToUnderlyingCache() {
+		mockUnderlyingCache.evict(mockKey);
+		replay(mockUnderlyingCache);
+		
+		uut.evict(mockKey);
+	}
+	
+	@Test
+	public void evictShouldFailGracefullyWhenUnderlyingCacheThrowsException() {
+		mockUnderlyingCache.evict(mockKey);
+		expectLastCall().andThrow(new RuntimeException("Simulated Exception"));
+		replay(mockUnderlyingCache);
+		
+		uut.evict(mockKey);
+	}
+	
+	@Test
+	public void putShouldDelegateToUnderlyingCache() {
+		mockUnderlyingCache.put(mockKey, mockValue);
+		replay(mockUnderlyingCache);
+		
+		uut.put(mockKey, mockValue);
+	}
+	
+	@Test
+	public void putShouldFailGracefullyWhenUnderlyingCacheThrowsException() {
+		mockUnderlyingCache.put(mockKey, mockValue);
+		expectLastCall().andThrow(new RuntimeException("Simulated Exception"));
+		replay(mockUnderlyingCache);
+		
+		uut.put(mockKey, mockValue);
+	}
+	
+	@Test
+	public void getShouldDelegateToUnderlyingCache() {
+		ValueWrapper expectedValueWrapper = new SimpleValueWrapper(null);
+		expect(mockUnderlyingCache.get(mockKey)).andReturn(expectedValueWrapper);
+		replay(mockUnderlyingCache);
+		
+		ValueWrapper valueWrapper = uut.get(mockKey);
+		
+		assertEquals(expectedValueWrapper, valueWrapper);
+	}
+	
+	@Test
+	public void getShouldReturnNullWhenUnderlyingCacheThrowsException() {
+		expect(mockUnderlyingCache.get(mockKey)).andThrow(new RuntimeException("Simulated Exception"));
+		replay(mockUnderlyingCache);
+
+		ValueWrapper valueWrapper = uut.get(mockKey);
+		
+		assertNull(valueWrapper);
+	}
+	
+	@Test
+	public void getNativeCacheShouldDelegateToUnderlyingCache() {
+		Object expectedNativeCache = new Object();
+		expect(mockUnderlyingCache.getNativeCache()).andReturn(expectedNativeCache);
+		replay(mockUnderlyingCache);
+		
+		Object nativeCache = uut.getNativeCache();
+		
+		assertEquals(expectedNativeCache, nativeCache);
+	}
+	
+	@Test
+	public void getNameShouldDelegateToUnderlyingCache() {
+		String expectedName = "Expected Name";
+		expect(mockUnderlyingCache.getName()).andReturn(expectedName);
+		replay(mockUnderlyingCache);
+		
+		String name = uut.getName();
+		assertEquals(expectedName, name);
+	}
+}


### PR DESCRIPTION
Introduced FailSafeCache.

FailSafeCache is intended to wrap existing cache implementations and
gracefully handle any Exceptions thrown by the native cache.  The
AbstractCacheManager is responsible for wrapping the native cache(s) IF
the gracefullyHandleExceptions property is _true_.  Otherwise, the
behavior of the AbstractCacheManager remains unchanged.

Issue: SPR-9275

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
