### PR TITLE
Minor fix for javadoc of EnableAsync

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableAsync.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableAsync.java
@@ -72,6 +72,7 @@ import org.springframework.core.Ordered;
  *     }
  *
  *     &#064;Override
+ *     &#064;Bean
  *     public Executor getAsyncExecutor() {
  *         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
  *         executor.setCorePoolSize(7);


### PR DESCRIPTION
Currently if the code is simply copied from the javadoc example of EnableAsync the resulting ThreadPoolTaskExecutor is not managed bean. That may lead to confusion why isn't it destroyed when closing ApplicationContext.
