### PR TITLE
JibxMarshaller deletes comments

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/xml/StaxUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/StaxUtils.java
@@ -312,6 +312,15 @@ public abstract class StaxUtils {
 	/**
 	 * Return a {@link XMLStreamWriter} that writes to a {@link XMLEventWriter}.
 	 * @return a stream writer that writes to an event writer
+	 * @since 3.2
+	 */
+	public static XMLStreamWriter createEventStreamWriter(XMLEventWriter eventWriter) {
+		return new XMLEventStreamWriter(eventWriter, XMLEventFactory.newFactory());
+	}
+
+	/**
+	 * Return a {@link XMLStreamWriter} that writes to a {@link XMLEventWriter}.
+	 * @return a stream writer that writes to an event writer
 	 * @since 3.0.5
 	 */
 	public static XMLStreamWriter createEventStreamWriter(XMLEventWriter eventWriter, XMLEventFactory eventFactory) {

--- a/spring-core/src/main/java/org/springframework/util/xml/XMLEventStreamWriter.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/XMLEventStreamWriter.java
@@ -193,7 +193,7 @@ class XMLEventStreamWriter implements XMLStreamWriter {
 
 	private void writeStartElement(StartElement startElement) throws XMLStreamException {
 		eventWriter.add(startElement);
-		endElements.add(eventFactory.createEndElement(startElement.getName(), null));
+		endElements.add(eventFactory.createEndElement(startElement.getName(), startElement.getNamespaces()));
 	}
 
 	private void writeNamespace(Namespace namespace) throws XMLStreamException {

--- a/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamWriterTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamWriterTests.java
@@ -29,7 +29,7 @@ import static org.custommonkey.xmlunit.XMLAssert.*;
 public class XMLEventStreamWriterTests {
 
 	private static final String XML =
-			"<?pi content?><root xmlns='namespace'><prefix:child xmlns:prefix='namespace2'>content</prefix:child></root>"
+			"<?pi content?><root xmlns='namespace'><prefix:child xmlns:prefix='namespace2'><!--comment-->content</prefix:child></root>"
 			;
 
 	private XMLEventStreamWriter streamWriter;
@@ -52,6 +52,7 @@ public class XMLEventStreamWriterTests {
 		streamWriter.writeDefaultNamespace("namespace");
 		streamWriter.writeStartElement("prefix", "child", "namespace2");
 		streamWriter.writeNamespace("prefix", "namespace2");
+		streamWriter.writeComment("comment");
 		streamWriter.writeCharacters("content");
 		streamWriter.writeEndElement();
 		streamWriter.writeEndElement();

--- a/spring-oxm/src/main/java/org/springframework/oxm/jibx/JibxMarshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/jibx/JibxMarshaller.java
@@ -338,8 +338,8 @@ public class JibxMarshaller extends AbstractMarshaller implements InitializingBe
 
 	@Override
 	protected void marshalXmlEventWriter(Object graph, XMLEventWriter eventWriter) {
-		ContentHandler contentHandler = StaxUtils.createContentHandler(eventWriter);
-		marshalSaxHandlers(graph, contentHandler, null);
+		XMLStreamWriter streamWriter = StaxUtils.createEventStreamWriter(eventWriter);
+		marshalXmlStreamWriter(graph, streamWriter);
 	}
 
 


### PR DESCRIPTION
Prior to this commit, JibxMarshaller used a SAX ContentHandler to
marshal to StAX XMLEventWriters. After this commit, it uses a
XMLStreamWriter adapter.

Issue: SPR-9768
