### PR TITLE
Use the body content of the element 'arg-type' as if the 'match' attribute is empty

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
@@ -827,7 +827,13 @@ public class BeanDefinitionParserDelegate {
 				// Look for arg-type match elements.
 				List<Element> argTypeEles = DomUtils.getChildElementsByTagName(replacedMethodEle, ARG_TYPE_ELEMENT);
 				for (Element argTypeEle : argTypeEles) {
-					replaceOverride.addTypeIdentifier(argTypeEle.getAttribute(ARG_TYPE_MATCH_ATTRIBUTE));
+                    String match = argTypeEle.getAttribute(ARG_TYPE_MATCH_ATTRIBUTE);
+                    // if the 'match' attribute is empty then check the content and use that if not blank
+                    // relates to SPR-9812
+                    if( !StringUtils.hasText(match) && StringUtils.hasText(argTypeEle.getTextContent()) ) {
+                        match = argTypeEle.getTextContent().trim();
+                    }
+                    replaceOverride.addTypeIdentifier(match);
 				}
 				replaceOverride.setSource(extractSource(replacedMethodEle));
 				overrides.addOverride(replaceOverride);

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReaderTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReaderTests.java
@@ -16,15 +16,16 @@
 
 package org.springframework.beans.factory.xml;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import junit.framework.TestCase;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.*;
+import org.springframework.util.ReflectionUtils;
 import org.xml.sax.InputSource;
 
 import org.springframework.beans.factory.BeanDefinitionStoreException;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
@@ -154,4 +155,35 @@ public class XmlBeanDefinitionReaderTests extends TestCase {
 		assertNotNull(bean);
 	}
 
+
+    /**
+     * Verifies that the arg-type sub element of replaced-method is parsed correctly.
+     *
+     * This relates to SPR-9812.
+     *
+     */
+    public void testReplaceMethodSubElements(){
+        SimpleBeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();;
+        ClassPathResource classPathResource = new ClassPathResource("replacedMethodSubElements.xml", getClass());
+        Resource resource = classPathResource;
+        new XmlBeanDefinitionReader(registry).loadBeanDefinitions(resource);
+        GenericBeanDefinition beanDefinition = (GenericBeanDefinition) registry.getBeanDefinition("testBean");
+        assertNotNull(beanDefinition);
+
+        MethodOverrides methodOverrides = beanDefinition.getMethodOverrides();
+        assertEquals("Unexpected number of method overrides for testBean", 2, methodOverrides.getOverrides().size());
+
+        Method replaceMeString = ReflectionUtils.findMethod( TestBean.class, "replaceMe", String.class );
+        Method replaceMeInt = ReflectionUtils.findMethod( TestBean.class, "replaceMe", int.class );
+
+        // check that the override responds to replaceMe(String) but not replaceMe(int)
+        // this indicates that the match attribute (specified via <arg-type>String</arg-type>
+        // is the same as <arg-type match="String"/>
+        assertNotNull(methodOverrides.getOverride( replaceMeString ));
+        assertNull(methodOverrides.getOverride( replaceMeInt ));
+
+        // check that the setInt(int) is still override
+        Method setAgeInt = ReflectionUtils.findMethod( TestBean.class, "setAge", int.class );
+        assertNotNull( methodOverrides.getOverride(setAgeInt) );
+    }
 }

--- a/spring-beans/src/test/java/test/beans/NoOpMethodReplacer.java
+++ b/spring-beans/src/test/java/test/beans/NoOpMethodReplacer.java
@@ -1,0 +1,17 @@
+package test.beans;
+
+import org.springframework.beans.factory.support.MethodReplacer;
+
+import java.lang.reflect.Method;
+
+/**
+ * No operation method replacer implementation.
+ *
+ * <p>This is used to test the replaced-method parsing in isn't actually invoked</p>
+ */
+public class NoOpMethodReplacer implements MethodReplacer {
+
+    public Object reimplement(Object obj, Method method, Object[] args) throws Throwable {
+        return null;
+    }
+}

--- a/spring-beans/src/test/java/test/beans/TestBean.java
+++ b/spring-beans/src/test/java/test/beans/TestBean.java
@@ -434,4 +434,14 @@ public class TestBean implements BeanNameAware, BeanFactoryAware, ITestBean, IOt
 		return this.name;
 	}
 
+    // following are used to help verify the MethodOverride parsing.
+
+    public void replaceMe(String someParam) {
+        throw new UnsupportedOperationException("Please don't call be");
+    }
+
+    public void replaceMe(int anotherParam) {
+        throw new UnsupportedOperationException("Please don't call be");
+    }
+
 }

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/replacedMethodSubElements.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/replacedMethodSubElements.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="noOpMethodReplacer" class="test.beans.NoOpMethodReplacer"/>
+
+  <bean id="testBean" class="test.beans.TestBean">
+
+    <replaced-method name="replaceMe" replacer="noOpMethodReplacer">
+      <!-- use of the content rather than the match attribute-->
+      <arg-type>String</arg-type>
+    </replaced-method>
+
+    <replaced-method name="setAge" replacer="noOpMethodReplacer">
+      <!-- both attribute and content can be specified .. the match attribute takes
+           precedence -->
+      <arg-type match="int">String</arg-type>
+    </replaced-method>
+  </bean>
+</beans>


### PR DESCRIPTION
This means that the following are the same:
<replaced-method>
    <arg-type>int</arg-type>
</replaced-method>

<replaced-method>
    <arg-type match="int"/>
</replaced-method>

Before the <arg-type>int</arg-type> would have been accepted as <arg-type/> and which matches all methods with a single argument.

Issue: SPR-9812
