### PR TITLE
Fixed replaced-method/arg-type to allow the body element to be used.

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
@@ -827,7 +827,13 @@ public class BeanDefinitionParserDelegate {
 				// Look for arg-type match elements.
 				List<Element> argTypeEles = DomUtils.getChildElementsByTagName(replacedMethodEle, ARG_TYPE_ELEMENT);
 				for (Element argTypeEle : argTypeEles) {
-					replaceOverride.addTypeIdentifier(argTypeEle.getAttribute(ARG_TYPE_MATCH_ATTRIBUTE));
+                    String match = argTypeEle.getAttribute(ARG_TYPE_MATCH_ATTRIBUTE);
+                    // if the 'match' attribute is empty then check the content and use that if not blank
+                    // relates to SPR-9812
+                    if( !StringUtils.hasText(match) && StringUtils.hasText(argTypeEle.getTextContent()) ) {
+                        match = argTypeEle.getTextContent().trim();
+                    }
+                    replaceOverride.addTypeIdentifier(match);
 				}
 				replaceOverride.setSource(extractSource(replacedMethodEle));
 				overrides.addOverride(replaceOverride);

--- a/spring-beans/src/test/java/test/beans/NoOpMethodReplacer.java
+++ b/spring-beans/src/test/java/test/beans/NoOpMethodReplacer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.beans;
+
+import org.springframework.beans.factory.support.MethodReplacer;
+
+import java.lang.reflect.Method;
+
+/**
+ * No operation method replacer implementation.
+ *
+ * <p>This is used to test the replaced-method parsing in isn't actually invoked</p>
+ */
+public class NoOpMethodReplacer implements MethodReplacer {
+
+    public Object reimplement(Object obj, Method method, Object[] args) throws Throwable {
+        return null;
+    }
+}

--- a/spring-beans/src/test/java/test/beans/TestBean.java
+++ b/spring-beans/src/test/java/test/beans/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -433,5 +433,15 @@ public class TestBean implements BeanNameAware, BeanFactoryAware, ITestBean, IOt
 	public String toString() {
 		return this.name;
 	}
+
+    // following are used to help verify the MethodOverride parsing.
+
+    public void replaceMe(String someParam) {
+        throw new UnsupportedOperationException("Please don't call be");
+    }
+
+    public void replaceMe(int anotherParam) {
+        throw new UnsupportedOperationException("Please don't call be");
+    }
 
 }

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/replacedMethodSubElements.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/replacedMethodSubElements.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="noOpMethodReplacer" class="test.beans.NoOpMethodReplacer"/>
+
+  <bean id="testBean" class="test.beans.TestBean">
+
+    <replaced-method name="replaceMe" replacer="noOpMethodReplacer">
+      <!-- use of the content rather than the match attribute-->
+      <arg-type>String</arg-type>
+    </replaced-method>
+
+    <replaced-method name="setAge" replacer="noOpMethodReplacer">
+      <!-- both attribute and content can be specified .. the match attribute takes
+           precedence -->
+      <arg-type match="int">String</arg-type>
+    </replaced-method>
+  </bean>
+</beans>


### PR DESCRIPTION
When parsing the 'replace-method' sub elements use the body content
of the 'arg-type' when the 'match' attribute is empty.

This means that the following are the same:
<replaced-method>
    <arg-type>int</arg-type>
</replaced-method>

<replaced-method>
    <arg-type match="int"/>
</replaced-method>

Before the <arg-type>int</arg-type> would have been accepted as
<arg-type/> and which matches all methods with a single argument.

This style appears to be used in the Appress Pro spring book
and while it either hasn't worked like this in a while (or ever) it
seems reasonable to handle it. An alternative would be to either
change the xsd or throw an exception on finding body content in the
'arg-type' element.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.

Issue: SPR-9812

updating the headers and copyright notice
