### PR TITLE
Maps no longer created unless copy is required

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/MapToMapConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/MapToMapConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package org.springframework.core.convert.support;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -62,18 +64,25 @@ final class MapToMapConverter implements ConditionalGenericConverter {
 		if (!copyRequired && sourceMap.isEmpty()) {
 			return sourceMap;
 		}
-		Map<Object, Object> targetMap = CollectionFactory.createMap(targetType.getType(), sourceMap.size());
+		List<MapEntry> targetEntries = new ArrayList<MapEntry>(sourceMap.size());
 		for (Map.Entry<Object, Object> entry : sourceMap.entrySet()) {
 			Object sourceKey = entry.getKey();
 			Object sourceValue = entry.getValue();
 			Object targetKey = convertKey(sourceKey, sourceType, targetType.getMapKeyTypeDescriptor());
 			Object targetValue = convertValue(sourceValue, sourceType, targetType.getMapValueTypeDescriptor());
-			targetMap.put(targetKey, targetValue);
+			targetEntries.add(new MapEntry(targetKey, targetValue));
 			if (sourceKey != targetKey || sourceValue != targetValue) {
 				copyRequired = true;
 			}
 		}
-		return (copyRequired ? targetMap : sourceMap);
+		if(!copyRequired) {
+			return sourceMap;
+		}
+		Map<Object, Object> targetMap = CollectionFactory.createMap(targetType.getType(), sourceMap.size());
+		for (MapEntry entry : targetEntries) {
+			entry.addToMap(targetMap);
+		}
+		return targetMap;
 	}
 
 	// internal helpers
@@ -100,6 +109,21 @@ final class MapToMapConverter implements ConditionalGenericConverter {
 			return sourceValue;
 		}
 		return this.conversionService.convert(sourceValue, sourceType.getMapValueTypeDescriptor(sourceValue), targetType);
+	}
+
+	private static class MapEntry {
+
+		private Object key;
+		private Object value;
+
+		public MapEntry(Object key, Object value) {
+			this.key = key;
+			this.value = value;
+		}
+
+		public void addToMap(Map<Object, Object> map) {
+			map.put(key, value);
+		}
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/convert/support/MapToMapConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/MapToMapConverter.java
@@ -51,7 +51,7 @@ final class MapToMapConverter implements ConditionalGenericConverter {
 	public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
 		return canConvertKey(sourceType, targetType) && canConvertValue(sourceType, targetType);
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
 		if (source == null) {
@@ -75,19 +75,19 @@ final class MapToMapConverter implements ConditionalGenericConverter {
 		}
 		return (copyRequired ? targetMap : sourceMap);
 	}
-	
+
 	// internal helpers
 
 	private boolean canConvertKey(TypeDescriptor sourceType, TypeDescriptor targetType) {
 		return ConversionUtils.canConvertElements(sourceType.getMapKeyTypeDescriptor(),
 				targetType.getMapKeyTypeDescriptor(), this.conversionService);
 	}
-	
+
 	private boolean canConvertValue(TypeDescriptor sourceType, TypeDescriptor targetType) {
 		return ConversionUtils.canConvertElements(sourceType.getMapValueTypeDescriptor(),
 				targetType.getMapValueTypeDescriptor(), this.conversionService);
 	}
-	
+
 	private Object convertKey(Object sourceKey, TypeDescriptor sourceType, TypeDescriptor targetType) {
 		if (targetType == null) {
 			return sourceKey;

--- a/spring-core/src/test/java/org/springframework/core/convert/support/MapToMapConverterTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/MapToMapConverterTests.java
@@ -55,7 +55,7 @@ public class MapToMapConverterTests {
 		}
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
 		assertTrue(conversionService.canConvert(sourceType, targetType));
-		@SuppressWarnings("unchecked")		
+		@SuppressWarnings("unchecked")
 		Map<Integer, Integer> result = (Map<Integer, Integer>) conversionService.convert(map, sourceType, targetType);
 		assertFalse(map.equals(result));
 		assertEquals((Integer) 9, result.get(1));
@@ -79,7 +79,7 @@ public class MapToMapConverterTests {
 		map.put("1", "9");
 		map.put("2", "37");
 		TypeDescriptor sourceType = new TypeDescriptor(getClass().getField("notGenericMapSource"));
-		TypeDescriptor targetType = new TypeDescriptor(getClass().getField("scalarMapTarget"));		
+		TypeDescriptor targetType = new TypeDescriptor(getClass().getField("scalarMapTarget"));
 		assertTrue(conversionService.canConvert(sourceType, targetType));
 		try {
 			conversionService.convert(map, sourceType, targetType);
@@ -88,15 +88,15 @@ public class MapToMapConverterTests {
 		}
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
 		assertTrue(conversionService.canConvert(sourceType, targetType));
-		@SuppressWarnings("unchecked")		
+		@SuppressWarnings("unchecked")
 		Map<Integer, Integer> result = (Map<Integer, Integer>) conversionService.convert(map, sourceType, targetType);
 		assertFalse(map.equals(result));
 		assertEquals((Integer) 9, result.get(1));
-		assertEquals((Integer) 37, result.get(2));		
+		assertEquals((Integer) 37, result.get(2));
 	}
-	
+
 	public Map notGenericMapSource;
-	
+
 	@Test
 	public void collectionMap() throws Exception {
 		Map<String, List<String>> map = new HashMap<String, List<String>>();
@@ -109,11 +109,11 @@ public class MapToMapConverterTests {
 			conversionService.convert(map, sourceType, targetType);
 		} catch (ConversionFailedException e) {
 			assertTrue(e.getCause() instanceof ConverterNotFoundException);
-		}		
+		}
 		conversionService.addConverter(new CollectionToCollectionConverter(conversionService));
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
 		assertTrue(conversionService.canConvert(sourceType, targetType));
-		@SuppressWarnings("unchecked")		
+		@SuppressWarnings("unchecked")
 		Map<Integer, List<Integer>> result = (Map<Integer, List<Integer>>) conversionService.convert(map, sourceType, targetType);
 		assertFalse(map.equals(result));
 		assertEquals(Arrays.asList(9, 12), result.get(1));
@@ -134,12 +134,12 @@ public class MapToMapConverterTests {
 			conversionService.convert(map, sourceType, targetType);
 			fail("Should have failed");
 		} catch (ConverterNotFoundException e) {
-			
+
 		}
 		conversionService.addConverter(new CollectionToCollectionConverter(conversionService));
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
 		assertTrue(conversionService.canConvert(sourceType, targetType));
-		@SuppressWarnings("unchecked")		
+		@SuppressWarnings("unchecked")
 		Map<Integer, List<Integer>> result = (Map<Integer, List<Integer>>) conversionService.convert(map, sourceType, targetType);
 		assertFalse(map.equals(result));
 		assertEquals(Arrays.asList(9, 12), result.get(1));
@@ -167,7 +167,7 @@ public class MapToMapConverterTests {
 		assertTrue(conversionService.canConvert(Map.class, Map.class));
 		assertSame(map, conversionService.convert(map, Map.class));
 	}
-	
+
 	@Test
 	public void emptyMap() throws Exception {
 		Map<String, String> map = new HashMap<String, String>();

--- a/spring-core/src/test/java/org/springframework/core/convert/support/MapToMapConverterTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/MapToMapConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.core.convert.support;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -199,5 +200,27 @@ public class MapToMapConverterTests {
 	}
 
 	public LinkedHashMap<String, String> emptyMapDifferentTarget;
+
+	@Test
+	public void noDefaultConstructorCopyNotRequired() throws Exception {
+		// SPR-9284
+		NoDefaultConstructorMap<String, Integer> map = new NoDefaultConstructorMap<String,Integer>(
+				Collections.<String, Integer> singletonMap("1", 1));
+		TypeDescriptor sourceType = TypeDescriptor.map(NoDefaultConstructorMap.class,
+				TypeDescriptor.valueOf(String.class), TypeDescriptor.valueOf(Integer.class));
+		TypeDescriptor targetType = TypeDescriptor.map(NoDefaultConstructorMap.class,
+				TypeDescriptor.valueOf(String.class), TypeDescriptor.valueOf(Integer.class));
+		assertTrue(conversionService.canConvert(sourceType, targetType));
+		@SuppressWarnings("unchecked")
+		Map<String, Integer> result = (Map<String, Integer>) conversionService.convert(map, sourceType, targetType);
+		assertEquals(map, result);
+		assertEquals(NoDefaultConstructorMap.class, result.getClass());
+	}
+
+	public static class NoDefaultConstructorMap<K, V> extends HashMap<K, V> {
+		public NoDefaultConstructorMap(Map<? extends K, ? extends V> m) {
+			super(m);
+		}
+	}
 
 }


### PR DESCRIPTION
Allow MapToMap conversion to work when the target map does not have a
default constructor (as long as a new map copy is not required).

Issue: SPR-9284
