### PR TITLE
merge-dist.gradle disables artifactoryPublish

### DIFF
--- a/merge-dist.gradle
+++ b/merge-dist.gradle
@@ -22,11 +22,13 @@ import org.gradle.plugins.ide.eclipse.model.ProjectDependency
 def mergeFromProject = project
 
 // invoking a task on mergeFromProject will invoke the task with the same name on mergeIntoProject
-def taskNamesToMerge = ['sourcesJar','jar','javadocJar','javadoc','install']
+def taskNamesToMerge = ['sourcesJar','jar','javadocJar','javadoc','install','artifactoryPublish']
 taskNamesToMerge.each { taskName ->
-    def taskToRemove = tasks.getByPath(taskName)
-    taskToRemove.enabled = false
-    taskToRemove.dependsOn mergeIntoProject."$taskName"
+    def taskToRemove = mergeFromProject.tasks.findByPath(taskName)
+    if(taskToRemove) {
+        taskToRemove.enabled = false
+        taskToRemove.dependsOn mergeIntoProject."$taskName"
+    }
 }
 
 // update mergeIntoProject artifacts to contain the mergeFromProject artifact contents


### PR DESCRIPTION
An attempt to fix the build which was resulting in the following:

```
05-Oct-2012 09:20:44    * What went wrong:
05-Oct-2012 09:20:44    A problem was found with the configuration of task ':spring-test-   mvc:artifactoryPublish'.
05-Oct-2012 09:20:44    > File '/opt/bamboo-home/xml-data/build-dir/SPR-B32X-JOB1/spring-test-mvc/build/poms/pom-default.xml' specified for property 'mavenDescriptor' does not exist.
```

Previously the project that was getting merged from would try to
execute the artifactoryPublish on the build box. This caused issues
since the mavenDescriptor did not exist.

The merge-dist.gradle now disables the artifactoryPublish task if it
exists (it will only exist on the build box).

Issue: SPR-9859, SPR-7951
