### PR TITLE
Allow usage of injection annotations as meta-annotations.

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Autowired.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Autowired.java
@@ -59,12 +59,13 @@ import java.lang.annotation.Target;
  *
  * @author Juergen Hoeller
  * @author Mark Fisher
+ * @author Oliver Gierke
  * @since 2.5
  * @see AutowiredAnnotationBeanPostProcessor
  * @see Qualifier
  * @see Value
  */
-@Target({ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD})
+@Target({ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Autowired {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
@@ -55,6 +55,7 @@ import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.Ordered;
 import org.springframework.core.PriorityOrdered;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
@@ -96,6 +97,7 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Juergen Hoeller
  * @author Mark Fisher
+ * @author Oliver Gierke
  * @since 2.5
  * @see #setAutowiredAnnotationType
  * @see Autowired
@@ -372,7 +374,7 @@ public class AutowiredAnnotationBeanPostProcessor extends InstantiationAwareBean
 
 	private Annotation findAutowiredAnnotation(AccessibleObject ao) {
 		for (Class<? extends Annotation> type : this.autowiredAnnotationTypes) {
-			Annotation annotation = ao.getAnnotation(type);
+			Annotation annotation = AnnotationUtils.getAnnotation(ao, type);
 			if (annotation != null) {
 				return annotation;
 			}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Value.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Value.java
@@ -43,13 +43,14 @@ import java.lang.annotation.Target;
  * class (which, by default, checks for the presence of this annotation).
  *
  * @author Juergen Hoeller
+ * @author Oliver Gierke
  * @since 3.0
  * @see AutowiredAnnotationBeanPostProcessor
  * @see Autowired
  * @see org.springframework.beans.factory.config.BeanExpressionResolver
  * @see org.springframework.beans.factory.support.AutowireCandidateResolver#getSuggestedValue
  */
-@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Value {

--- a/spring-beans/src/test/java/org/springframework/beans/factory/annotation/InjectionAnnotationsAsMetaAnnotationsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/annotation/InjectionAnnotationsAsMetaAnnotationsTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.factory.annotation;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+
+/**
+ * Test cases for using injection annotations ({@link Autowired}, {@link Value}) as meta-annotations.
+ *
+ * @author Oliver Gierke
+ */
+public class InjectionAnnotationsAsMetaAnnotationsTests {
+
+	@Test
+	public void valueInjectionWorksForAtValueUsedAsMetaAnnotation() {
+
+		Dependency dependency = new Dependency();
+
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerSingleton("foo", 1);
+		beanFactory.registerSingleton("dependency", dependency);
+		beanFactory.registerBeanDefinition("client", new RootBeanDefinition(Client.class));
+
+		AutowiredAnnotationBeanPostProcessor postProcessor = new AutowiredAnnotationBeanPostProcessor();
+		postProcessor.setBeanFactory(beanFactory);
+		beanFactory.addBeanPostProcessor(postProcessor);
+
+		Client client = beanFactory.getBean(Client.class);
+		assertThat(client.value, is(1));
+		assertThat(client.dependency, is(dependency));
+	}
+
+	@Target(ElementType.FIELD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Value("foo")
+	@interface MySpecialValue {
+
+	}
+
+	@Target(ElementType.FIELD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Autowired
+	@interface MySpecialAutowired {
+
+	}
+
+	static class Client {
+
+		@MySpecialValue
+		Integer value;
+
+		@MySpecialAutowired
+		Dependency dependency;
+	}
+
+	static class Dependency {
+
+	}
+}


### PR DESCRIPTION
@Autowired and @Inject can now be used as meta-annotations to create
semantic annotations. Assume a library is exposing special primitive
values as Spring beans under registered names like 'foo.bar'. They could
be used by clients using @Value("foo.bar"), which is reasonable but error-
prone. After this change, the library can go ahead and define a special
annotation as follows:

@Target(ElementType.FIELD)
@Retention(RetentionPolicy.RUNTIME)
@Value("foo.bar")
public @interface MySpecialValue { }

This allows clients to use @MySpecialValue for injection and thus prevent
potential typos. For @Autowired this essentially now allows for qualified
auto wiring being wrappable into a

@Target(ElementType.FIELD)
@Retention(RetentionPolicy.RUNTIME)
@Qualifier("myQualifier")
@Autowired
public @interface MyQualifiedAutowire { }

Issue: SPR-9890
