### PR TITLE
SPR-9897: add Yaml*FactoryBeans for Map and Properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,7 @@ project("spring-beans") {
 	dependencies {
 		compile(project(":spring-core"))
 		compile(files(project(":spring-core").cglibRepackJar))
+		optional("org.yaml:snakeyaml:1.11")
 		provided("javax.el:javax.el-api:2.2.4")
 		provided("javax.inject:javax.inject:1")
 		testCompile("log4j:log4j:1.2.17")

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlMapFactoryBean.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlMapFactoryBean.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.factory.config;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Factory for Map that reads from a YAML source. YAML is a nice human-readable format for configuration, and it has
+ * some useful hierarchical properties. It's more or less a superset of JSON, so it has a lot of similar features. If
+ * multiple resources are provided the later ones will override entries in the earlier ones hierarchically - that is all
+ * entries with the same nested key of type Map at any depth are merged. For example:
+ * 
+ * <pre>
+ * foo:
+ *   bar:
+ *    one: two
+ * three: four
+ * 
+ * <pre>
+ * 
+ * plus (later in the list)
+ * 
+ * <pre>
+ * foo:
+ *   bar:
+ *    one: 2
+ * five: six
+ * 
+ * <pre>
+ * 
+ * results in an effecive input of
+ * 
+ * <pre>
+ * foo:
+ *   bar:
+ *    one: 2
+ *    three: four
+ * five: six
+ * 
+ * <pre>
+ * 
+ * Note that the value of "foo" in the first document is not simply replaced with the value in the second, but its nested values are merged.
+ * 
+ * @author Dave Syer
+ * @since 3.2
+ * 
+ */
+public class YamlMapFactoryBean extends YamlProcessor implements FactoryBean<Map<String, Object>> {
+
+	private boolean singleton = true;
+
+	private Map<String, Object> instance;
+
+	public Map<String, Object> getObject() {
+		if (!singleton || instance == null) {
+			final Map<String, Object> result = new LinkedHashMap<String, Object>();
+			MatchCallback callback = new MatchCallback() {
+				public void process(Properties properties, Map<String, Object> map) {
+					merge(result, map);
+				}
+			};
+			process(callback);
+			instance = result;
+		}
+		return instance;
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private void merge(Map<String, Object> output, Map<String, Object> map) {
+		for (Entry<String, Object> entry : map.entrySet()) {
+			String key = entry.getKey();
+			Object value = entry.getValue();
+			Object existing = output.get(key);
+			if (value instanceof Map && existing instanceof Map) {
+				Map<String, Object> result = new LinkedHashMap<String, Object>((Map) existing);
+				merge(result, (Map) value);
+				output.put(key, result);
+			}
+			else {
+				output.put(key, value);
+			}
+		}
+	}
+
+	public Class<?> getObjectType() {
+		return Map.class;
+	}
+
+	/**
+	 * Set if a singleton should be created, or a new object on each request otherwise. Default is <code>true</code> (a
+	 * singleton).
+	 */
+	public void setSingleton(boolean singleton) {
+		this.singleton = singleton;
+	}
+
+	public boolean isSingleton() {
+		return singleton;
+	}
+
+}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.factory.config;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Base class for Yaml factories.
+ * 
+ * @author Dave Syer
+ * @since 3.2
+ * 
+ */
+public class YamlProcessor {
+
+	public interface MatchCallback {
+		void process(Properties properties, Map<String, Object> map);
+	}
+
+	private static final Log logger = LogFactory.getLog(YamlProcessor.class);
+
+	public static enum ResolutionMethod {
+		OVERRIDE, OVERRIDE_AND_IGNORE, FIRST_FOUND
+	}
+
+	private ResolutionMethod resolutionMethod = ResolutionMethod.OVERRIDE;
+
+	private Resource[] resources = new Resource[0];
+
+	private Map<String, String> documentMatchers = new HashMap<String, String>();
+
+	private boolean matchDefault = true;
+
+	/**
+	 * A map of document matchers allowing callers to selectively use only some of the documents in a YAML resource. In
+	 * YAML documents are separated by
+	 * <code>---<code> lines, and each document is converted to properties before the match is made. E.g.
+	 * 
+	 * <pre>
+	 * environment: dev
+	 * url: http://dev.bar.com
+	 * name: Developer Setup
+	 * ---
+	 * environment: prod
+	 * url:http://foo.bar.com
+	 * name: My Cool App
+	 * </pre>
+	 * 
+	 * when mapped with <code>documentMatchers = {"environment": "prod"}</code> would end up as
+	 * 
+	 * <pre>
+	 * environment=prod
+	 * url=http://foo.bar.com
+	 * name=My Cool App
+	 * url=http://dev.bar.com
+	 * </pre>
+	 * 
+	 * @param matchers a map of keys to value patterns (regular expressions)
+	 */
+	public void setDocumentMatchers(Map<String, String> matchers) {
+		this.documentMatchers = Collections.unmodifiableMap(matchers);
+	}
+
+	/**
+	 * Flag indicating that a document that contains none of the keys in the {@link #setDocumentMatchers(Map) document
+	 * matchers} will nevertheless match.
+	 * 
+	 * @param matchDefault the flag to set (default true)
+	 */
+	public void setMatchDefault(boolean matchDefault) {
+		this.matchDefault = matchDefault;
+	}
+
+	/**
+	 * Method to use for resolving resources. Each resource will be converted to a Map, so this property is used to
+	 * decide which map entries to keep in the final output from this factory. Possible values:
+	 * <ul>
+	 * <li><code>OVERRIDE</code> for replacing values from earlier in the list</li>
+	 * <li><code>FIRST_FOUND</code> if you want to take the first resource in the list that exists and use just that.</li>
+	 * </ul>
+	 * 
+	 * 
+	 * @param resolutionMethod the resolution method to set. Defaults to OVERRIDE.
+	 */
+	public void setResolutionMethod(ResolutionMethod resolutionMethod) {
+		this.resolutionMethod = resolutionMethod;
+	}
+
+	/**
+	 * @param resources the resources to set
+	 */
+	public void setResources(Resource[] resources) {
+		this.resources = resources;
+	}
+
+	/**
+	 * Provides an opportunity for subclasses to process the Yaml parsed from the supplied resources. Each resource is
+	 * parsed in turn and the documents inside checked against the {@link #setDocumentMatchers(Map) matchers}. If a
+	 * document matches it is passed into the callback, along with its representation as Properties. Depending on the
+	 * {@link #setResolutionMethod(ResolutionMethod)} not all of the documents will be parsed.
+	 * 
+	 * @param callback a callback to delegate to once matching documents are found
+	 */
+	protected void process(MatchCallback callback) {
+		Yaml yaml = new Yaml();
+		boolean found = false;
+		for (Resource resource : resources) {
+			try {
+				logger.info("Loading from YAML: " + resource);
+				int count = 0;
+				for (Object object : yaml.loadAll(resource.getInputStream())) {
+					if (resolutionMethod != ResolutionMethod.FIRST_FOUND || !found) {
+						@SuppressWarnings("unchecked")
+						Map<String, Object> map = (Map<String, Object>) object;
+						if (map != null) {
+							process(map, callback);
+							found = true;
+							count++;
+						}
+					}
+				}
+
+				logger.info("Loaded " + count + " document" + (count > 1 ? "s" : "") + " from YAML resource: "
+						+ resource);
+
+				if (resolutionMethod == ResolutionMethod.FIRST_FOUND && found) {
+					// No need to load any more resources
+					break;
+				}
+			}
+			catch (IOException e) {
+				if (resolutionMethod == ResolutionMethod.FIRST_FOUND
+						|| resolutionMethod == ResolutionMethod.OVERRIDE_AND_IGNORE) {
+					if (logger.isWarnEnabled()) {
+						logger.warn("Could not load map from " + resource + ": " + e.getMessage());
+					}
+				}
+				else {
+					throw new IllegalStateException(e);
+				}
+			}
+		}
+	}
+
+	private void process(Map<String, Object> map, MatchCallback callback) {
+		Properties properties = new Properties();
+		assignProperties(properties, map, null);
+		if (documentMatchers.isEmpty()) {
+			logger.debug("Merging document (no matchers set)" + map);
+			callback.process(properties, map);
+		}
+		else {
+			boolean keyFound = false;
+			boolean valueFound = false;
+			for (Entry<String, String> entry : documentMatchers.entrySet()) {
+				String key = entry.getKey();
+				String pattern = entry.getValue();
+				if (properties.containsKey(key)) {
+					keyFound = true;
+					String value = properties.getProperty(key);
+					if (value.matches(pattern)) {
+						logger.debug("Matched document with " + key + "=" + value + " (pattern=/" + pattern + "/): "
+								+ map);
+						callback.process(properties, map);
+						valueFound = true;
+						// No need to check for more matches
+						break;
+					}
+				}
+			}
+			if (!keyFound && matchDefault) {
+				logger.debug("Matched document with default matcher: " + map);
+				callback.process(properties, map);
+			}
+			else if (!valueFound) {
+				logger.debug("Unmatched document");
+			}
+		}
+	}
+
+	private void assignProperties(Properties properties, Map<String, Object> input, String path) {
+		for (Entry<String, Object> entry : input.entrySet()) {
+			String key = entry.getKey();
+			if (StringUtils.hasText(path)) {
+				if (key.startsWith("[")) {
+					key = path + key;
+				}
+				else {
+					key = path + "." + key;
+				}
+			}
+			Object value = entry.getValue();
+			if (value instanceof String) {
+				properties.put(key, value);
+			}
+			else if (value instanceof Map) {
+				// Need a compound key
+				@SuppressWarnings("unchecked")
+				Map<String, Object> map = (Map<String, Object>) value;
+				assignProperties(properties, map, key);
+			}
+			else if (value instanceof Collection) {
+				// Need a compound key
+				@SuppressWarnings("unchecked")
+				Collection<Object> collection = (Collection<Object>) value;
+				properties.put(key, StringUtils.collectionToCommaDelimitedString(collection));
+				int count = 0;
+				for (Object object : collection) {
+					assignProperties(properties, Collections.singletonMap("[" + (count++) + "]", object), key);
+				}
+			}
+			else {
+				properties.put(key, value == null ? "" : value);
+			}
+		}
+	}
+
+}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBean.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBean.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.factory.config;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Factory for Java Properties that reads from a YAML source. YAML is a nice human-readable format for configuration,
+ * and it has some useful hierarchical properties. It's more or less a superset of JSON, so it has a lot of similar
+ * features. The Properties created by this factory have nested paths for hierarchical objects, so for instance this
+ * YAML
+ * 
+ * <pre>
+ * environments:
+ *   dev:
+ *     url: http://dev.bar.com
+ *     name: Developer Setup
+ *   prod:
+ *     url: http://foo.bar.com
+ *     name: My Cool App
+ * </pre>
+ * 
+ * is transformed into these Properties:
+ * 
+ * <pre>
+ * environments.dev.url=http://dev.bar.com
+ * environments.dev.name=Developer Setup
+ * environments.prod.url=http://foo.bar.com
+ * environments.prod.name=My Cool App
+ * </pre>
+ * 
+ * Lists are represented as comma-separated values (useful for simple String values) and also as property keys with
+ * <code>[]</code> dereferencers, for example this YAML:
+ * 
+ * <pre>
+ * servers:
+ * - dev.bar.com
+ * - foo.bar.com
+ * </pre>
+ * 
+ * becomes java Properties like this:
+ * 
+ * <pre>
+ * servers=dev.bar.com,foo.bar.com
+ * servers[0]=dev.bar.com
+ * servers[1]=foo.bar.com
+ * </pre>
+ * 
+ * @author Dave Syer
+ * @since 3.2
+ * 
+ */
+public class YamlPropertiesFactoryBean extends YamlProcessor implements FactoryBean<Properties> {
+
+	private boolean singleton = true;
+
+	private Properties instance;
+
+	public Properties getObject() {
+		if (!singleton || instance == null) {
+			final Properties result = new Properties();
+			MatchCallback callback = new MatchCallback() {
+				public void process(Properties properties, Map<String, Object> map) {
+					result.putAll(properties);
+				}
+			};
+			process(callback);
+			instance = result;
+		}
+		return instance;
+	}
+
+	public Class<?> getObjectType() {
+		return Properties.class;
+	}
+
+	/**
+	 * Set if a singleton should be created, or a new object on each request otherwise. Default is <code>true</code> (a
+	 * singleton).
+	 */
+	public void setSingleton(boolean singleton) {
+		this.singleton = singleton;
+	}
+
+	public boolean isSingleton() {
+		return singleton;
+	}
+
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlMapFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlMapFactoryBeanTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.config;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.beans.factory.config.YamlProcessor.ResolutionMethod;
+import org.springframework.core.io.AbstractResource;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class YamlMapFactoryBeanTests {
+	
+	private YamlMapFactoryBean factory = new YamlMapFactoryBean();
+
+	@Test
+	public void testSetIgnoreResourceNotFound() throws Exception {
+		factory.setResolutionMethod(YamlMapFactoryBean.ResolutionMethod.OVERRIDE_AND_IGNORE);
+		factory.setResources(new FileSystemResource[] {new FileSystemResource("non-exsitent-file.yml")});
+		assertEquals(0, factory.getObject().size());
+	}
+
+	@Test(expected=IllegalStateException.class)
+	public void testSetBarfOnResourceNotFound() throws Exception {
+		factory.setResources(new FileSystemResource[] {new FileSystemResource("non-exsitent-file.yml")});
+		assertEquals(0, factory.getObject().size());
+	}
+
+	@Test
+	public void testGetObject() throws Exception {
+		factory.setResources(new ByteArrayResource[] {new ByteArrayResource("foo: bar".getBytes())});
+		assertEquals(1, factory.getObject().size());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testOverrideAndremoveDefaults() throws Exception {
+		factory.setResources(new ByteArrayResource[] {new ByteArrayResource("foo:\n  bar: spam".getBytes()), new ByteArrayResource("foo:\n  spam: bar".getBytes())});
+		assertEquals(1, factory.getObject().size());
+		assertEquals(2, ((Map<String, Object>) factory.getObject().get("foo")).size());
+	}
+
+	@Test
+	public void testFirstFound() throws Exception {
+		factory.setResolutionMethod(ResolutionMethod.FIRST_FOUND);
+		factory.setResources(new Resource[] {new AbstractResource() {
+			public String getDescription() {
+				return "non-existent";
+			}
+			public InputStream getInputStream() throws IOException {
+				throw new IOException("planned");
+			}
+		}, new ByteArrayResource("foo:\n  spam: bar".getBytes())});
+		assertEquals(1, factory.getObject().size());
+	}
+
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.factory.config;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Test;
+import org.springframework.beans.factory.config.YamlProcessor.ResolutionMethod;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class YamlPropertiesFactoryBeanTests {
+	
+	@Test
+	public void testLoadResource() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new Resource[] {new ByteArrayResource("foo: bar\nspam:\n  foo: baz".getBytes())});
+		Properties properties = factory.getObject();
+		assertEquals("bar", properties.get("foo"));
+		assertEquals("baz", properties.get("spam.foo"));
+	}
+
+	@Test
+	public void testLoadResourcesWithOverride() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new Resource[] {new ByteArrayResource("foo: bar\nspam:\n  foo: baz".getBytes()), new ByteArrayResource("foo:\n  bar: spam".getBytes())});
+		Properties properties = factory.getObject();
+		assertEquals("bar", properties.get("foo"));
+		assertEquals("baz", properties.get("spam.foo"));
+		assertEquals("spam", properties.get("foo.bar"));
+	}
+
+	@Test
+	public void testLoadResourceWithMultipleDocuments() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new Resource[] {new ByteArrayResource("foo: bar\nspam: baz\n---\nfoo: bag".getBytes())});
+		Properties properties = factory.getObject();
+		assertEquals("bag", properties.get("foo"));
+		assertEquals("baz", properties.get("spam"));
+	}
+
+	@Test
+	public void testLoadResourceWithSelectedDocuments() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new Resource[] {new ByteArrayResource("foo: bar\nspam: baz\n---\nfoo: bag\nspam: bad".getBytes())});
+		factory.setDocumentMatchers(Collections.singletonMap("foo", "bag"));
+		Properties properties = factory.getObject();
+		assertEquals("bag", properties.get("foo"));
+		assertEquals("bad", properties.get("spam"));
+	}
+
+	@Test
+	public void testLoadResourceWithDefaultMatch() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setMatchDefault(true);
+		factory.setResources(new Resource[] {new ByteArrayResource("one: two\n---\nfoo: bar\nspam: baz\n---\nfoo: bag\nspam: bad".getBytes())});
+		factory.setDocumentMatchers(Collections.singletonMap("foo", "bag"));
+		Properties properties = factory.getObject();
+		assertEquals("bag", properties.get("foo"));
+		assertEquals("bad", properties.get("spam"));
+		assertEquals("two", properties.get("one"));
+	}
+
+	@Test
+	public void testLoadResourceWithDefaultMatchSkippingMissedMatch() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setMatchDefault(true);
+		factory.setResources(new Resource[] {new ByteArrayResource("one: two\n---\nfoo: bag\nspam: bad\n---\nfoo: bar\nspam: baz".getBytes())});
+		factory.setDocumentMatchers(Collections.singletonMap("foo", "bag"));
+		Properties properties = factory.getObject();
+		assertEquals("bag", properties.get("foo"));
+		assertEquals("bad", properties.get("spam"));
+		assertEquals("two", properties.get("one"));
+	}
+
+	@Test
+	public void testLoadNonExistentResource() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResolutionMethod(ResolutionMethod.OVERRIDE_AND_IGNORE);
+		factory.setResources(new Resource[] {new ClassPathResource("no-such-file.yml")});
+		Properties properties = factory.getObject();
+		assertEquals(0, properties.size());
+	}
+
+	@Test
+	public void testLoadNull() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new Resource[] {new ByteArrayResource("foo: bar\nspam:".getBytes())});
+		Properties properties = factory.getObject();
+		assertEquals("bar", properties.get("foo"));
+		assertEquals("", properties.get("spam"));
+	}
+
+	@Test
+	public void testLoadArrayOfString() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new Resource[] {new ByteArrayResource("foo:\n- bar\n- baz".getBytes())});
+		Properties properties = factory.getObject();
+		assertEquals("bar", properties.get("foo[0]"));
+		assertEquals("baz", properties.get("foo[1]"));
+		assertEquals("bar,baz", properties.get("foo"));
+	}
+
+	@Test
+	public void testLoadArrayOfObject() throws Exception {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new Resource[] {new ByteArrayResource("foo:\n- bar:\n    spam: crap\n- baz\n- one: two\n  three: four".getBytes())});
+		Properties properties = factory.getObject();
+		// System.err.println(properties);
+		assertEquals("crap", properties.get("foo[0].bar.spam"));
+		assertEquals("baz", properties.get("foo[1]"));
+		assertEquals("two", properties.get("foo[2].one"));
+		assertEquals("four", properties.get("foo[2].three"));
+		assertEquals("{bar={spam=crap}},baz,{one=two, three=four}", properties.get("foo"));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testYaml() {
+		Yaml yaml = new Yaml();
+		Map<String, ?> map = (Map<String, Object>) yaml.loadAs("foo: bar\nspam:\n  foo: baz", Map.class);
+		assertEquals("bar", map.get("foo"));
+		assertEquals("baz", ((Map<String,Object>)map.get("spam")).get("foo"));
+	}
+
+}


### PR DESCRIPTION
YAML is a nice human-readable format for configuration,
and it has some useful hierarchical properties. It's more
or less a superset of JSON, so it has a lot of similar
properties. Some features:
- The Properties created have nested paths for
  hierarchical objects.
- A "document matcher" can be injected to select
  only some documents fomra multi-document input file.
- Yaml is loaded from an array of Resource[] and
  a strategy for the resolution and merging behaviour
  if multiple resources are presnet can be set
  (OVERRIDE, OVERRIDE_AND_IGNORE, FIRST_FOUND)
