### PR TITLE
SPR-9898 Fixed mvc-config-enable closing <beans/> tag.

### DIFF
--- a/src/reference/docbook/mvc.xml
+++ b/src/reference/docbook/mvc.xml
@@ -4580,7 +4580,7 @@ public class WebConfig {
 
     &lt;mvc:annotation-driven /&gt;
 
-&lt;beans&gt;</programlisting>
+&lt;/beans&gt;</programlisting>
 	
       <para>The above registers a
       <classname>RequestMappingHandlerMapping</classname>, a 


### PR DESCRIPTION
Corrected the closing <beans/> tag in the mvc-config-enable sections MVC XML namespace example.
