### PR TITLE
Support @EnableMBeanExport with @Configuration

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/config/MBeanExportBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/MBeanExportBeanDefinitionParser.java
@@ -62,11 +62,11 @@ class MBeanExportBeanDefinitionParser extends AbstractBeanDefinitionParser {
 	@Override
 	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(AnnotationMBeanExporter.class);
-		
+
 		// Mark as infrastructure bean and attach source location.
 		builder.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 		builder.getRawBeanDefinition().setSource(parserContext.extractSource(element));
-		
+
 		String defaultDomain = element.getAttribute(DEFAULT_DOMAIN_ATTRIBUTE);
 		if (StringUtils.hasText(defaultDomain)) {
 			builder.addPropertyValue("defaultDomain", defaultDomain);

--- a/spring-context/src/main/java/org/springframework/context/config/MBeanExportBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/MBeanExportBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.jmx.export.annotation.AnnotationMBeanExporter;
-import org.springframework.jmx.support.MBeanRegistrationSupport;
+import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.util.StringUtils;
 
 /**
@@ -84,14 +84,14 @@ class MBeanExportBeanDefinitionParser extends AbstractBeanDefinitionParser {
 		}
 
 		String registration = element.getAttribute(REGISTRATION_ATTRIBUTE);
-		int registrationBehavior = MBeanRegistrationSupport.REGISTRATION_FAIL_ON_EXISTING;
+		RegistrationPolicy registrationPolicy = RegistrationPolicy.FAIL_ON_EXISTING;
 		if (REGISTRATION_IGNORE_EXISTING.equals(registration)) {
-			registrationBehavior = MBeanRegistrationSupport.REGISTRATION_IGNORE_EXISTING;
+			registrationPolicy = RegistrationPolicy.IGNORE_EXISTING;
 		}
 		else if (REGISTRATION_REPLACE_EXISTING.equals(registration)) {
-			registrationBehavior = MBeanRegistrationSupport.REGISTRATION_REPLACE_EXISTING;
+			registrationPolicy = RegistrationPolicy.REPLACE_EXISTING;
 		}
-		builder.addPropertyValue("registrationBehavior", registrationBehavior);
+		builder.addPropertyValue("registrationPolicy", registrationPolicy);
 
 		return builder.getBeanDefinition();
 	}

--- a/spring-context/src/main/java/org/springframework/jmx/export/annotation/EnableMBeanExport.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/annotation/EnableMBeanExport.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jmx.export.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.jmx.support.RegistrationPolicy;
+
+/**
+ * Enables default exporting of all standard {@code MBean}s from the Spring context, as
+ * well as well all {@code @ManagedResource} annotated beans.
+ *
+ * <p>The resulting MBeanExporter bean is defined under the name "mbeanExporter".
+ * Alternatively, consider defining a custom {@link AnnotationMBeanExporter} bean
+ * explicitly.
+ *
+ * <p>This annotation is modeled after and functionally equivalent to Spring XML's
+ * {@code <context:mbean-export/>} element.
+ *
+ * @author Phillip Webb
+ * @since 3.2
+ * @see MBeanExportConfiguration
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(MBeanExportConfiguration.class)
+public @interface EnableMBeanExport {
+
+	/**
+	 * The default domain to use when generating JMX ObjectNames.
+	 */
+	String defaultDomain() default "";
+
+	/**
+	 * The bean name of the MBeanServer to which MBeans should be exported. Default is to
+	 * use the platform's default MBeanServer.
+	 */
+	String server() default "";
+
+	/**
+	 * The policy to use when attempting to register an MBean under an
+	 * {@link javax.management.ObjectName} that already exists. Defaults to
+	 * {@link RegistrationPolicy#FAIL_ON_EXISTING}.
+	 */
+	RegistrationPolicy registration() default RegistrationPolicy.FAIL_ON_EXISTING;
+}

--- a/spring-context/src/main/java/org/springframework/jmx/export/annotation/MBeanExportConfiguration.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/annotation/MBeanExportConfiguration.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jmx.export.annotation;
+
+import java.util.Map;
+
+import javax.management.MBeanServer;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportAware;
+import org.springframework.context.annotation.Role;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.jmx.support.WebSphereMBeanServerFactoryBean;
+import org.springframework.jndi.JndiObjectFactoryBean;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@code @Configuration} class that registers a {@link AnnotationMBeanExporter} bean.
+ *
+ * <p>This configuration class is automatically imported when using the
+ * {@link EnableMBeanExport} annotation. See {@code @EnableMBeanExport} Javadoc for
+ * complete usage details.
+ *
+ * @author Phillip Webb
+ * @since 3.2
+ * @see EnableMBeanExport
+ */
+@Configuration
+public class MBeanExportConfiguration implements ImportAware, BeanFactoryAware {
+
+	private static final String MBEAN_EXPORTER_BEAN_NAME = "mbeanExporter";
+
+	private AnnotationAttributes attributes;
+
+	private BeanFactory beanFactory;
+
+
+	public void setImportMetadata(AnnotationMetadata importMetadata) {
+		Map<String, Object> map = importMetadata.getAnnotationAttributes(EnableMBeanExport.class.getName());
+		this.attributes = AnnotationAttributes.fromMap(map);
+		Assert.notNull(this.attributes, "@EnableMBeanExport is not present on "
+				+ "importing class " + importMetadata.getClassName());
+	}
+
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+
+	@Bean(name=MBEAN_EXPORTER_BEAN_NAME)
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+	public AnnotationMBeanExporter mbeanExporter() {
+		AnnotationMBeanExporter exporter = new AnnotationMBeanExporter();
+		setupDomain(exporter);
+		setupServer(exporter);
+		setupRegistrationPolicy(exporter);
+		return exporter;
+	}
+
+	private void setupDomain(AnnotationMBeanExporter exporter) {
+		String defaultDomain = this.attributes.getString("defaultDomain");
+		if (StringUtils.hasText(defaultDomain)) {
+			exporter.setDefaultDomain(defaultDomain);
+		}
+	}
+
+	private void setupServer(AnnotationMBeanExporter exporter) {
+		String server = this.attributes.getString("server");
+		if (StringUtils.hasText(server)) {
+			exporter.setServer(this.beanFactory.getBean(server, MBeanServer.class));
+		} else {
+			SpecialEnvironment specialEnvironment = SpecialEnvironment.get();
+			if(specialEnvironment != null) {
+				exporter.setServer(specialEnvironment.getServer());
+			}
+		}
+	}
+
+	private void setupRegistrationPolicy(AnnotationMBeanExporter exporter) {
+		RegistrationPolicy registrationPolicy = this.attributes.getEnum("registration");
+		exporter.setRegistrationPolicy(registrationPolicy);
+	}
+
+
+	private static enum SpecialEnvironment {
+
+		WEBLOGIC("weblogic.management.Helper") {
+			@Override
+			public FactoryBean<?> getServerFactory() {
+				JndiObjectFactoryBean factory = new JndiObjectFactoryBean();
+				factory.setJndiName("java:comp/env/jmx/runtime");
+				return factory;
+			}
+		},
+
+		WEBSPHERE("com.ibm.websphere.management.AdminServiceFactory") {
+			@Override
+			public FactoryBean<?> getServerFactory() {
+				return new WebSphereMBeanServerFactoryBean();
+			}
+		};
+
+		private final String identifyingClass;
+
+		private SpecialEnvironment(String identifyingClass) {
+			this.identifyingClass = identifyingClass;
+		}
+
+		public MBeanServer getServer() {
+			Object server;
+			try {
+				server = getServerFactory().getObject();
+				Assert.isInstanceOf(MBeanServer.class, server);
+				return (MBeanServer) server;
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+		}
+
+		protected abstract FactoryBean<?> getServerFactory();
+
+		public static SpecialEnvironment get() {
+			ClassLoader classLoader = MBeanExportConfiguration.class.getClassLoader();
+			for (SpecialEnvironment environment : values()) {
+				if(ClassUtils.isPresent(environment.identifyingClass, classLoader)) {
+					return environment;
+				}
+			}
+			return null;
+		}
+	}
+}

--- a/spring-context/src/main/java/org/springframework/jmx/support/RegistrationPolicy.java
+++ b/spring-context/src/main/java/org/springframework/jmx/support/RegistrationPolicy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jmx.support;
+
+/**
+ * Indicates registration behavior when attempting to register an MBean that already
+ * exists.
+ *
+ * @author Phillip Webb
+ * @since 3.2
+ */
+public enum RegistrationPolicy {
+
+	/**
+	 * Registration should fail when attempting to register an MBean under a name that
+	 * already exists.
+	 */
+	FAIL_ON_EXISTING,
+
+	/**
+	 * Registration should ignore the affected MBean when attempting to register an MBean
+	 * under a name that already exists.
+	 */
+	IGNORE_EXISTING,
+
+	/**
+	 * Registration should replace the affected MBean when attempting to register an MBean
+	 * under a name that already exists.
+	 */
+	REPLACE_EXISTING
+
+}

--- a/spring-context/src/test/java/org/springframework/jmx/export/MBeanExporterTests.java
+++ b/spring-context/src/test/java/org/springframework/jmx/export/MBeanExporterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.modelmbean.ModelMBeanInfo;
 
-import org.junit.Ignore;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.TestBean;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -48,6 +47,7 @@ import org.springframework.jmx.export.assembler.MBeanInfoAssembler;
 import org.springframework.jmx.export.assembler.SimpleReflectiveMBeanInfoAssembler;
 import org.springframework.jmx.export.naming.SelfNaming;
 import org.springframework.jmx.support.ObjectNameManager;
+import org.springframework.jmx.support.RegistrationPolicy;
 
 import test.interceptor.NopInterceptor;
 
@@ -324,7 +324,7 @@ public final class MBeanExporterTests extends AbstractMBeanServerTests {
 		MBeanExporter exporter = new MBeanExporter();
 		exporter.setServer(server);
 		exporter.setBeans(beans);
-		exporter.setRegistrationBehavior(MBeanExporter.REGISTRATION_REPLACE_EXISTING);
+		exporter.setRegistrationPolicy(RegistrationPolicy.REPLACE_EXISTING);
 
 		exporter.afterPropertiesSet();
 

--- a/spring-context/src/test/java/org/springframework/jmx/export/MBeanExporterTests.java
+++ b/spring-context/src/test/java/org/springframework/jmx/export/MBeanExporterTests.java
@@ -53,7 +53,7 @@ import test.interceptor.NopInterceptor;
 
 /**
  * Integration tests for the {@link MBeanExporter} class.
- * 
+ *
  * @author Rob Harrop
  * @author Juergen Hoeller
  * @author Rick Evans

--- a/spring-context/src/test/java/org/springframework/jmx/export/annotation/AnnotationTestBeanFactory.java
+++ b/spring-context/src/test/java/org/springframework/jmx/export/annotation/AnnotationTestBeanFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.jmx.IJmxTestBean;
 /**
  * @author Juergen Hoeller
  */
-public class AnnotationTestBeanFactory implements FactoryBean<IJmxTestBean> {
+public class AnnotationTestBeanFactory implements FactoryBean<FactoryCreatedAnnotationTestBean> {
 
 	private final FactoryCreatedAnnotationTestBean instance = new FactoryCreatedAnnotationTestBean();
 
@@ -30,7 +30,7 @@ public class AnnotationTestBeanFactory implements FactoryBean<IJmxTestBean> {
 		this.instance.setName("FACTORY");
 	}
 
-	public IJmxTestBean getObject() throws Exception {
+	public FactoryCreatedAnnotationTestBean getObject() throws Exception {
 		return this.instance;
 	}
 

--- a/spring-context/src/test/java/org/springframework/jmx/export/annotation/EnableMBeanExportConfigurationTests.java
+++ b/spring-context/src/test/java/org/springframework/jmx/export/annotation/EnableMBeanExportConfigurationTests.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jmx.export.annotation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.jmx.export.MBeanExporterTests;
+import org.springframework.jmx.export.TestDynamicMBean;
+import org.springframework.jmx.support.MBeanServerFactoryBean;
+import org.springframework.jmx.support.ObjectNameManager;
+import org.springframework.jmx.support.RegistrationPolicy;
+
+/**
+ * Tests for {@link EnableMBeanExport} and {@link MBeanExportConfiguration}.
+ *
+ * @author Phillip Webb
+ * @see AnnotationLazyInitMBeanTests
+ */
+public class EnableMBeanExportConfigurationTests {
+
+	@Test
+	public void testLazyNaming() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(
+				LazyNamingConfiguration.class);
+		try {
+			MBeanServer server = (MBeanServer) ctx.getBean("server");
+			ObjectName oname = ObjectNameManager.getInstance("bean:name=testBean4");
+			assertNotNull(server.getObjectInstance(oname));
+			String name = (String) server.getAttribute(oname, "Name");
+			assertEquals("Invalid name returned", "TEST", name);
+		}
+		finally {
+			ctx.close();
+		}
+	}
+
+	@Test
+	public void testLazyAssembling() throws Exception {
+		AnnotationConfigApplicationContext ctx =
+				new AnnotationConfigApplicationContext(LazyAssemblingConfiguration.class);
+		try {
+			MBeanServer server = (MBeanServer) ctx.getBean("server");
+
+			ObjectName oname = ObjectNameManager.getInstance("bean:name=testBean4");
+			assertNotNull(server.getObjectInstance(oname));
+			String name = (String) server.getAttribute(oname, "Name");
+			assertEquals("Invalid name returned", "TEST", name);
+
+			oname = ObjectNameManager.getInstance("bean:name=testBean5");
+			assertNotNull(server.getObjectInstance(oname));
+			name = (String) server.getAttribute(oname, "Name");
+			assertEquals("Invalid name returned", "FACTORY", name);
+
+			oname = ObjectNameManager.getInstance("spring:mbean=true");
+			assertNotNull(server.getObjectInstance(oname));
+			name = (String) server.getAttribute(oname, "Name");
+			assertEquals("Invalid name returned", "Rob Harrop", name);
+
+			oname = ObjectNameManager.getInstance("spring:mbean=another");
+			assertNotNull(server.getObjectInstance(oname));
+			name = (String) server.getAttribute(oname, "Name");
+			assertEquals("Invalid name returned", "Juergen Hoeller", name);
+		}
+		finally {
+			ctx.close();
+		}
+	}
+
+	@Test
+	public void testComponentScan() throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(
+				ComponentScanConfiguration.class);
+		try {
+			MBeanServer server = (MBeanServer) ctx.getBean("server");
+			ObjectName oname = ObjectNameManager.getInstance("bean:name=testBean4");
+			assertNotNull(server.getObjectInstance(oname));
+			String name = (String) server.getAttribute(oname, "Name");
+			assertNull(name);
+		} finally {
+			ctx.close();
+		}
+	}
+
+	@Configuration
+	@EnableMBeanExport(server = "server")
+	static class LazyNamingConfiguration {
+
+		@Bean
+		public MBeanServerFactoryBean server() throws Exception {
+			return new MBeanServerFactoryBean();
+		}
+
+		@Bean
+		@Lazy
+		public AnnotationTestBean testBean() {
+			AnnotationTestBean bean = new AnnotationTestBean();
+			bean.setName("TEST");
+			bean.setAge(100);
+			return bean;
+		}
+	}
+
+	@Configuration
+	@EnableMBeanExport(server="server", registration=RegistrationPolicy.REPLACE_EXISTING)
+	static class LazyAssemblingConfiguration {
+
+		@Bean
+		public MBeanServerFactoryBean server() throws Exception {
+			return new MBeanServerFactoryBean();
+		}
+
+		@Bean(name="bean:name=testBean4")
+		@Lazy
+		public AnnotationTestBean testBean4() {
+			AnnotationTestBean bean = new AnnotationTestBean();
+			bean.setName("TEST");
+			bean.setAge(100);
+			return bean;
+		}
+
+		@Bean(name="bean:name=testBean5")
+		public AnnotationTestBeanFactory testBean5() throws Exception {
+			return new AnnotationTestBeanFactory();
+		}
+
+		@Bean(name="spring:mbean=true")
+		@Lazy
+		public TestDynamicMBean dynamic() {
+			return new TestDynamicMBean();
+		}
+
+		@Bean(name="spring:mbean=another")
+		@Lazy
+		public MBeanExporterTests.Person person() {
+			MBeanExporterTests.Person person = new MBeanExporterTests.Person();
+			person.setName("Juergen Hoeller");
+			return person;
+		}
+
+		@Bean
+		@Lazy
+		public Object notLoadable() throws Exception {
+			return Class.forName("does.not.exist").newInstance();
+		}
+	}
+
+	@Configuration
+	@ComponentScan(excludeFilters={@ComponentScan.Filter(value=Configuration.class)})
+	@EnableMBeanExport(server = "server")
+	static class ComponentScanConfiguration {
+
+		@Bean
+		public MBeanServerFactoryBean server() throws Exception {
+			return new MBeanServerFactoryBean();
+		}
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/jmx/export/annotation/componentScan.xml
+++ b/spring-context/src/test/java/org/springframework/jmx/export/annotation/componentScan.xml
@@ -9,6 +9,8 @@
 
   <bean id="server" class="org.springframework.jmx.support.MBeanServerFactoryBean"/>
 
-  <context:component-scan base-package="org.springframework.jmx.export.annotation"/>
+  <context:component-scan base-package="org.springframework.jmx.export.annotation">
+  	<context:exclude-filter type="annotation" expression="org.springframework.context.annotation.Configuration"/>
+  </context:component-scan>
 
 </beans>

--- a/spring-context/src/test/java/org/springframework/jmx/export/annotation/lazyAssembling.xml
+++ b/spring-context/src/test/java/org/springframework/jmx/export/annotation/lazyAssembling.xml
@@ -7,8 +7,6 @@
 
 	<context:mbean-export server="server" registration="replaceExisting"/>
 
-	<context:mbean-export server="server" registration="replaceExisting"/>
-
 	<bean id="server" class="org.springframework.jmx.support.MBeanServerFactoryBean"/>
 
 	<bean name="bean:name=testBean4" class="org.springframework.jmx.export.annotation.AnnotationTestBean" lazy-init="true">


### PR DESCRIPTION
Add support for @EnableMBeanExport annotation allowing @Configuration
classes to easily export all MBeans and @ManagedResources from the
Spring application context.  The annotation is functionally equivalent
to the XML context:mbean-export/ element.

Issue: SPR-8943
