### PR TITLE
Add a setter for wsdl document as Resource.

### DIFF
--- a/spring-web/src/main/java/org/springframework/remoting/jaxws/LocalJaxWsServiceFactory.java
+++ b/spring-web/src/main/java/org/springframework/remoting/jaxws/LocalJaxWsServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 package org.springframework.remoting.jaxws;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.Executor;
 import javax.xml.namespace.QName;
 import javax.xml.ws.Service;
 import javax.xml.ws.handler.HandlerResolver;
 
+import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
 /**
@@ -58,6 +60,16 @@ public class LocalJaxWsServiceFactory {
 		this.wsdlDocumentUrl = wsdlDocumentUrl;
 	}
 
+	/**
+	 * Set the WSDL document URL as a {@link Resource}.
+	 *  
+	 * @throws IOException
+	 */
+	public void setWsdlDocumentResource(Resource wsdlDocumentResource) throws IOException {
+		Assert.notNull(wsdlDocumentResource, "WSDL Resource must not be null.");
+		this.wsdlDocumentUrl = wsdlDocumentResource.getURL();
+	}
+	
 	/**
 	 * Return the URL of the WSDL document that describes the service.
 	 */


### PR DESCRIPTION
For a project we included the wsdl and xsd files inside the META-INF/wsdl directory to be able to set this  we needed a classpath / jar URL to be set. Using the Resource abstraction from Spring makes this very easy.

Issue: SPR-9909

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
