### PR TITLE
SPR-9912

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ResourceDatabasePopulator.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ResourceDatabasePopulator.java
@@ -223,20 +223,25 @@ public class ResourceDatabasePopulator implements DatabasePopulator {
 	 * @throws IOException in case of I/O errors
 	 */
 	private String readScript(EncodedResource resource) throws IOException {
-		LineNumberReader lnr = new LineNumberReader(resource.getReader());
-		String currentStatement = lnr.readLine();
-		StringBuilder scriptBuilder = new StringBuilder();
-		while (currentStatement != null) {
-			if (StringUtils.hasText(currentStatement) &&
-					(this.commentPrefix != null && !currentStatement.startsWith(this.commentPrefix))) {
-				if (scriptBuilder.length() > 0) {
-					scriptBuilder.append('\n');
-				}
-				scriptBuilder.append(currentStatement);
-			}
-			currentStatement = lnr.readLine();
-		}
-		maybeAddSeparatorToScript(scriptBuilder);
+        LineNumberReader lnr = new LineNumberReader(resource.getReader());
+        StringBuilder scriptBuilder = new StringBuilder();
+        try {
+            String currentStatement = lnr.readLine();
+            while (currentStatement != null) {
+                if (StringUtils.hasText(currentStatement) &&
+                        (this.commentPrefix != null && !currentStatement.startsWith(this.commentPrefix))) {
+                    if (scriptBuilder.length() > 0) {
+                        scriptBuilder.append('\n');
+                    }
+                    scriptBuilder.append(currentStatement);
+                }
+                currentStatement = lnr.readLine();
+            }
+            maybeAddSeparatorToScript(scriptBuilder);
+        }
+        finally {
+            lnr.close();
+        }
 		return scriptBuilder.toString();
 	}
 


### PR DESCRIPTION
Fix for SPR-9912 - ResourceDatabasePopulator.readScript() - the reader is not closed after reading a script

https://jira.springsource.org/browse/SPR-9912

I was looking for something straightforward to jump in with. 

I wasn't sure how to create a unit test to verify the behavior. 

I was able to hook up to yourkit and see that the original code
left 2 files open, but the updated code only leaves 2. 

If anyone has a good way to unit/integration test it. I'll be happy
to dig in on it. 

Thanks, 
Eric
