### PR TITLE
fix-typo on gradlew.bat

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -9,7 +9,7 @@
 if "%OS%"=="Windows_NT" setlocal
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set GRADLE_OPTS=-XX:MaxPermSize=1024m -Xmx1024m -XX:MaxHeapSize=256 %GRADLE_OPTS%
+set GRADLE_OPTS=-XX:MaxPermSize=1024m -Xmx1024m -XX:MaxHeapSize=256m %GRADLE_OPTS%
 set DEFAULT_JVM_OPTS=
 
 set DIRNAME=%~dp0


### PR DESCRIPTION
Correct typo error on gradlew.bat, since VM default memory unit is bytes, and VM would report too small initial heap size.

Hope this helps.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
