### PR TITLE
Implement java.io.Closeable

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/ConfigurableApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/ConfigurableApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.context;
+
+import java.io.Closeable;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -36,7 +38,7 @@ import org.springframework.core.env.Environment;
  * @author Chris Beams
  * @since 03.11.2003
  */
-public interface ConfigurableApplicationContext extends ApplicationContext, Lifecycle {
+public interface ConfigurableApplicationContext extends ApplicationContext, Lifecycle, Closeable {
 
 	/**
 	 * Any number of these characters are considered delimiters between

--- a/spring-web/src/main/java/org/springframework/http/client/ClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/ClientHttpResponse.java
@@ -17,6 +17,7 @@
 package org.springframework.http.client;
 
 import java.io.IOException;
+import java.io.Closeable;
 
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpStatus;
@@ -30,7 +31,7 @@ import org.springframework.http.HttpStatus;
  * @author Arjen Poutsma
  * @since 3.0
  */
-public interface ClientHttpResponse extends HttpInputMessage {
+public interface ClientHttpResponse extends HttpInputMessage, Closeable {
 
 	/**
 	 * Return the HTTP status code of the response.


### PR DESCRIPTION
Implement `java.io.Closeable` to allow:
- automatic invocation of the `close()` method when used within
  try-with-resources blocks
- usage with Apache Commons' `IOUtils.closeQuietly()` and
  Google Guava's `Closeables.closeQuietly()`

Issue: SPR-9962

This was created as a minor improvement that is generally applicable to anyone using the utilities described above or developing in Java 7 using try-with-resources. There is no behavioural change, nor any source or binary incompatibility - only the addition of the `java.io.Closeable` interface to existing interfaces that already define a `close()` method with the same semantics as those described by `Closeable`.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
