### PR TITLE
Make GRADLE-1116 workaround more generic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.plugins.ide.eclipse.model.ProjectDependency
+
 buildscript {
     repositories {
         maven { url 'http://repo.springsource.org/plugins-release' }
@@ -8,20 +10,21 @@ buildscript {
 }
 
 configure(allprojects) {
-    apply plugin: 'java'
-    apply plugin: 'eclipse'
-    apply plugin: 'idea'
-
-    group = 'org.springframework'
-
-    sourceCompatibility=1.5
-    targetCompatibility=1.5
-
     ext.aspectjVersion = '1.6.12'
     ext.hsqldbVersion='1.8.0.10'
     ext.junitVersion = '4.11.20120805.1225' // temporary use of snapshot; spring-test
                                             // still builds against on 4.10
     ext.gradleScriptDir = "${rootProject.projectDir}/gradle"
+
+    apply plugin: 'java'
+    apply plugin: 'eclipse'
+    apply plugin: 'idea'
+    apply from: "${gradleScriptDir}/ide.gradle"
+
+    group = 'org.springframework'
+
+    sourceCompatibility=1.5
+    targetCompatibility=1.5
 
     [compileJava, compileTestJava]*.options*.compilerArgs = ['-Xlint:none']
 
@@ -37,13 +40,6 @@ configure(allprojects) {
     dependencies {
         testCompile "org.hamcrest:hamcrest-all:1.3"
         testCompile "org.easymock:easymock:2.5.1"
-    }
-
-    // servlet-api (2.5) and tomcat-servlet-api (3.0) classpath entries should not be
-    // exported to dependent projects in Eclipse to avoid false compilation errors due
-    // to changing APIs across these versions
-    eclipse.classpath.file.whenMerged { classpath ->
-        classpath.entries.findAll { entry -> entry.path.contains('servlet-api') }*.exported = false
     }
 }
 

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -1,0 +1,26 @@
+import org.gradle.plugins.ide.eclipse.model.ProjectDependency
+
+eclipse.classpath.file.whenMerged { classpath ->
+    // servlet-api (2.5) and tomcat-servlet-api (3.0) classpath entries should not be
+    // exported to dependent projects in Eclipse to avoid false compilation errors due
+    // to changing APIs across these versions
+    classpath.entries.findAll { entry -> entry.path.contains('servlet-api') }*.exported = false
+
+    // GRADLE-1116
+    def regexp = /.*?\/([^\/]+)\/build\/[^\/]+\/(?:main|test)/ // only match those that end in main or test (avoids removing necessary entries like build/classes/jaxb)
+    def projectOutputDependencies = classpath.entries.findAll { entry -> entry.path =~ regexp }
+    projectOutputDependencies.each { entry ->
+        def matcher = (entry.path =~ regexp)
+        if(matcher) {
+            def projectName = matcher[0][1]
+            def path = "/${projectName}"
+            if(!classpath.entries.find { e -> e instanceof ProjectDependency && e.path == path }) {
+                def dependency = new ProjectDependency(path, project(":${projectName}").path)
+                dependency.exported = true
+                classpath.entries.add(dependency)
+            }
+            classpath.entries.remove(entry)
+        }
+    }
+    classpath.entries.removeAll { entry -> (entry.path =~ /(?!.*?repack.*\.jar).*?\/([^\/]+)\/build\/libs\/[^\/]+\.jar/) }
+}

--- a/gradle/merge-artifacts.gradle
+++ b/gradle/merge-artifacts.gradle
@@ -1,5 +1,3 @@
-import org.gradle.plugins.ide.eclipse.model.ProjectDependency
-
 /**
  * Will merge the artifacts of the current project into mergeIntoProject. For example, to
  * bundle spring-test-mvc in spring-test's jars. This script will perform the following
@@ -41,14 +39,6 @@ mergeIntoProject."jar" {
 mergeIntoProject."javadoc" {
     source += mergeFromProject.javadoc.source
     classpath += mergeFromProject.javadoc.classpath
-}
-
-// GRADLE-1116
-mergeFromProject.eclipse.classpath.file.whenMerged { classpath ->
-    classpath.entries.removeAll { entry -> entry.path.contains("/${mergeIntoProject.name}/build/") }
-    def dependency = new ProjectDependency("/${mergeIntoProject.name}", mergeIntoProject.path)
-    dependency.exported = true
-    classpath.entries.add(dependency)
 }
 
 // Update mergeIntoProject to contain additional configurations that contains all the dependencies from mergeFromProject


### PR DESCRIPTION
Some errors have been introduced that occur when importing a project that has not yet been built that are due to GRADLE-1116. To see the issues you can run import a fresh clone or perform the following before importing.

```
  git clean -dfx
```

Previously the workaround for GRADLE-1116 only worked for the
merge-dist.gradle projects

Now the workaround is more generic and fixes errors that have since
been introduced when performing a fresh import into Eclipse.
