### PR TITLE
Support Gradle/maven with multi version artifacts

### DIFF
--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -16,10 +16,10 @@ def customizePom(pom, gradleProject) {
     pom.whenConfigured { generatedPom ->
         // respect 'optional' and 'provided' dependencies
         gradleProject.optionalDeps.each { dep ->
-            generatedPom.dependencies.find { it.artifactId == dep.name }?.optional = true
+            generatedPom.dependencies.findAll { it.artifactId == dep.name }*.optional = true
         }
         gradleProject.providedDeps.each { dep ->
-            generatedPom.dependencies.find { it.artifactId == dep.name }?.scope = 'provided'
+            generatedPom.dependencies.findAll { it.artifactId == dep.name }*.scope = 'provided'
         }
 
         // eliminate test-scoped dependencies (no need in maven central poms)


### PR DESCRIPTION
Previously the publish-maven.gradle only supported having a single
artifact be marked as optional or provided. This causes problems now
that we are building modules that support multiple versions of an
artifact. For example, we have multiple versions of tiles-jsp that both
need marked as optional.

This updates publish-maven.gradle to find all the artifacts and mark
them as optional as apposed to the first entry.
