### PR TITLE
Introduced TypeInformation abstraction to enable generic autowiring.

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactoryUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactoryUtils.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.support.TypeMatchUtils;
+import org.springframework.beans.type.ClassTypeInformation;
+import org.springframework.beans.type.TypeInformation;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -39,6 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Rod Johnson
  * @author Juergen Hoeller
  * @author Chris Beams
+ * @author Oliver Gierke
  * @since 04.07.2003
  */
 public abstract class BeanFactoryUtils {
@@ -160,6 +164,12 @@ public abstract class BeanFactoryUtils {
 		return result;
 	}
 
+	@SuppressWarnings("unchecked")
+	public static String[] beanNamesForTypeIncludingAncestors(
+			ListableBeanFactory lbf, Class type, boolean includeNonSingletons, boolean allowEagerInit) {
+		return beanNamesForTypeIncludingAncestors(lbf, ClassTypeInformation.from(type), includeNonSingletons, allowEagerInit);
+	}
+
 	/**
 	 * Get all bean names for the given type, including those defined in ancestor
 	 * factories. Will return unique names in case of overridden bean definitions.
@@ -181,10 +191,11 @@ public abstract class BeanFactoryUtils {
 	 * @return the array of matching bean names, or an empty array if none
 	 */
 	public static String[] beanNamesForTypeIncludingAncestors(
-			ListableBeanFactory lbf, Class type, boolean includeNonSingletons, boolean allowEagerInit) {
+			ListableBeanFactory lbf, TypeInformation<?> type, boolean includeNonSingletons, boolean allowEagerInit) {
 
 		Assert.notNull(lbf, "ListableBeanFactory must not be null");
-		String[] result = lbf.getBeanNamesForType(type, includeNonSingletons, allowEagerInit);
+		String[] result = TypeMatchUtils.getBeanNamesForType(type, includeNonSingletons, allowEagerInit, lbf);
+
 		if (lbf instanceof HierarchicalBeanFactory) {
 			HierarchicalBeanFactory hbf = (HierarchicalBeanFactory) lbf;
 			if (hbf.getParentBeanFactory() instanceof ListableBeanFactory) {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -108,6 +108,7 @@ import org.springframework.util.StringUtils;
  * @author Costin Leau
  * @author Chris Beams
  * @author Sam Brannen
+ * @author Oliver Gierke
  * @since 13.02.2004
  * @see RootBeanDefinition
  * @see DefaultListableBeanFactory
@@ -1213,7 +1214,10 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 					MethodParameter methodParam = BeanUtils.getWriteMethodParameter(pd);
 					// Do not allow eager init for type matching in case of a prioritized post-processor.
 					boolean eager = !PriorityOrdered.class.isAssignableFrom(bw.getWrappedClass());
-					DependencyDescriptor desc = new AutowireByTypeDependencyDescriptor(methodParam, eager);
+					DependencyDescriptor desc = new AutowireByTypeDependencyDescriptor(methodParam, eager, bw.getWrappedClass());
+					if (!desc.shouldBeAutowired()) {
+						continue;
+					}
 					Object autowiredArgument = resolveDependency(desc, beanName, autowiredBeanNames, converter);
 					if (autowiredArgument != null) {
 						pvs.add(propertyName, autowiredArgument);
@@ -1233,7 +1237,6 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 			}
 		}
 	}
-
 
 	/**
 	 * Return an array of non-simple bean properties that are unsatisfied.
@@ -1669,8 +1672,8 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 	@SuppressWarnings("serial")
 	private static class AutowireByTypeDependencyDescriptor extends DependencyDescriptor {
 
-		public AutowireByTypeDependencyDescriptor(MethodParameter methodParameter, boolean eager) {
-			super(methodParameter, false, eager);
+		public AutowireByTypeDependencyDescriptor(MethodParameter methodParameter, boolean eager, Class<?> sourceBeanClass) {
+			super(methodParameter, false, eager, sourceBeanClass);
 		}
 
 		@Override

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/TypeMatchUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/TypeMatchUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.factory.support;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.type.TypeInformation;
+import org.springframework.util.Assert;
+
+/**
+ * Utility class for {@link TypeInformation} based type matching.
+ * 
+ * @author Oliver Gierke
+ */
+public class TypeMatchUtils {
+
+	/**
+	 * Uses the native {@link AbstractBeanFactory#isTypeMatch(String, TypeInformation)} method in case the given
+	 * {@link BeanFactory} is one or falls back to the plain {@link BeanFactory#isTypeMatch(String, Class)}. The latter
+	 * will result in less generics-awareness for ongoing type resolution.
+	 * 
+	 * @param beanName must not be {@literal null} or empty.
+	 * @param type must not be {@literal null}.
+	 * @param beanFactory must not be {@literal null}.
+	 * @return
+	 */
+	public static boolean isTypeMatch(String beanName, TypeInformation<?> type, BeanFactory beanFactory) {
+
+		Assert.notNull(type, "TypeInformation must not be null!");
+		Assert.notNull(beanFactory, "BeanFactory must not be null!");
+		Assert.hasText(beanName, "Bean name must not be null!");
+
+		if (beanFactory instanceof AbstractBeanFactory) {
+			return ((AbstractBeanFactory) beanFactory).isTypeMatch(beanName, type);
+		}
+
+		return beanFactory.isTypeMatch(beanName, type.getType());
+	}
+
+	/**
+	 * Returns the bean names for all beans matching the given {@link TypeInformation}.
+	 * Will forward the {@link TypeInformation} if the given {@link BeanFactory} is a
+	 * {@link DefaultListableBeanFactory} and fall back to the raw type otherwise.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param includeNonSingletons
+	 * @param allowEagerInit
+	 * @param beanFactory must not be {@literal null}.
+	 * @return
+	 */
+	public static String[] getBeanNamesForType(TypeInformation<?> type, boolean includeNonSingletons,
+			boolean allowEagerInit, ListableBeanFactory beanFactory) {
+		
+		Assert.notNull(type, "TypeInformation must not be null!");
+		Assert.notNull(beanFactory, "ListableBeanFactory must not be null!");
+
+		if (beanFactory instanceof ConfigurableListableBeanFactory) {
+			return ((DefaultListableBeanFactory) beanFactory).getBeanNamesForType(type, includeNonSingletons, allowEagerInit);					
+		}
+		
+		return beanFactory.getBeanNamesForType(type.getType(), includeNonSingletons, allowEagerInit);
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/ClassTypeInformation.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/ClassTypeInformation.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.core.GenericTypeResolver;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ConcurrentReferenceHashMap;
+
+/**
+ * {@link TypeInformation} for a plain {@link Class}.
+ * 
+ * @author Oliver Gierke
+ */
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class ClassTypeInformation<S> extends TypeDiscoverer<S> {
+
+	public static final TypeInformation<Collection> COLLECTION = new ClassTypeInformation(Collection.class);
+	public static final TypeInformation<List> LIST = new ClassTypeInformation(List.class);
+	public static final TypeInformation<Set> SET = new ClassTypeInformation(Set.class);
+	public static final TypeInformation<Map> MAP = new ClassTypeInformation(Map.class);
+	public static final TypeInformation<Object> OBJECT = new ClassTypeInformation(Object.class);
+
+	private static final Map<Class<?>, Reference<TypeInformation<?>>> CACHE = new ConcurrentReferenceHashMap<Class<?>, Reference<TypeInformation<?>>>();
+
+	static {
+		for (TypeInformation<?> info : Arrays.asList(COLLECTION, LIST, SET, MAP, OBJECT)) {
+			CACHE.put(info.getType(), new WeakReference<TypeInformation<?>>(info));
+		}
+	}
+
+	private final Class<S> type;
+
+	/**
+	 * Simple factory method to easily create new instances of {@link ClassTypeInformation}.
+	 * 
+	 * @param <S>
+	 * @param type
+	 * @return
+	 */
+	public static <S> TypeInformation<S> from(Class<S> type) {
+
+		type = type == null ? (Class<S>) Object.class : type;
+
+		Reference<TypeInformation<?>> cachedReference = CACHE.get(type);
+		TypeInformation<?> cachedTypeInfo = cachedReference == null ? null : cachedReference.get();
+
+		if (cachedTypeInfo != null) {
+			return (TypeInformation<S>) cachedTypeInfo;
+		}
+
+		TypeInformation<S> result = new ClassTypeInformation<S>(type);
+		CACHE.put(type, new WeakReference<TypeInformation<?>>(result));
+		return result;
+	}
+
+	/**
+	 * Creates a {@link TypeInformation} from the given method's return type.
+	 * 
+	 * @param method
+	 * @return
+	 */
+	public static <S> TypeInformation<S> fromReturnTypeOf(Method method) {
+		return new ClassTypeInformation(method.getDeclaringClass()).createInfo(method.getGenericReturnType());
+	}
+
+	/**
+	 * Creates {@link ClassTypeInformation} for the given type.
+	 * 
+	 * @param type
+	 */
+	ClassTypeInformation(Class<S> type) {
+		this(type, GenericTypeResolver.getTypeVariableMap(type));
+	}
+
+	ClassTypeInformation(Class<S> type, Map<TypeVariable, Type> typeVariableMap) {
+		super(ClassUtils.getUserClass(type), typeVariableMap);
+		this.type = type;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#getType()
+	 */
+	@Override
+	public Class<S> getType() {
+		return type;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#isAssignableFrom(org.springframework.data.util.TypeInformation)
+	 */
+	@Override
+	public boolean isAssignableFrom(TypeInformation<?> target) {
+		return ClassUtils.isAssignable(getType(), target.getType());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeDiscoverer#isRawType()
+	 */
+	@Override
+	public boolean isRawType() {
+
+		List<Type> genericTypes = new ArrayList<Type>();
+		genericTypes.addAll(Arrays.asList(type.getGenericInterfaces()));
+		genericTypes.add(type.getGenericSuperclass());
+
+		for (Type genericType : genericTypes) {
+			if (genericType instanceof ParameterizedType) {
+				for (Type arguments : ((ParameterizedType) genericType).getActualTypeArguments()) {
+					if(!(arguments instanceof Class)) {
+						return true;
+					}
+				}
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/GenericArrayTypeInformation.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/GenericArrayTypeInformation.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Type;
+
+/**
+ * Special {@link TypeDiscoverer} handling {@link GenericArrayType}s.
+ * 
+ * @author Oliver Gierke
+ */
+class GenericArrayTypeInformation<S> extends ParentTypeAwareTypeInformation<S> {
+	
+	private final GenericArrayType type;
+
+	/**
+	 * Creates a new {@link GenericArrayTypeInformation} for the given {@link GenericArrayTypeInformation} and
+	 * {@link TypeDiscoverer}.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param parent must not be {@literal null}.
+	 */
+	protected GenericArrayTypeInformation(GenericArrayType type, TypeDiscoverer<?> parent) {
+		
+		super(type, parent, parent.getTypeVariableMap());
+		this.type = type;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#getType()
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public Class<S> getType() {
+		return (Class<S>) Array.newInstance(resolveType(type.getGenericComponentType()), 0).getClass();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#getComponentType()
+	 */
+	@Override
+	public TypeInformation<?> getComponentType() {
+
+		Type componentType = type.getGenericComponentType();
+		return createInfo(componentType);
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/ParameterizedTypeInformation.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/ParameterizedTypeInformation.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.core.GenericTypeResolver;
+
+/**
+ * Base class for all types that include parameterization of some kind. Crucial as we have to take note of the parent
+ * class we will have to resolve generic parameters against.
+ * 
+ * @author Oliver Gierke
+ */
+class ParameterizedTypeInformation<T> extends ParentTypeAwareTypeInformation<T> {
+	
+	private final ParameterizedType type;
+	private TypeInformation<?> componentType;
+
+	/**
+	 * Creates a new {@link ParameterizedTypeInformation} for the given {@link Type} and parent {@link TypeDiscoverer}.
+	 * 
+	 * @param type must not be {@literal null}
+	 * @param parent must not be {@literal null}
+	 */
+	public ParameterizedTypeInformation(ParameterizedType type, TypeDiscoverer<?> parent) {
+		
+		super(type, parent, null);
+		this.type = type;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#getMapValueType()
+	 */
+	@Override
+	public TypeInformation<?> getMapValueType() {
+
+		if (Map.class.equals(getType())) {
+			Type[] arguments = type.getActualTypeArguments();
+			return createInfo(arguments[1]);
+		}
+
+		Class<?> rawType = getType();
+
+		Set<Type> supertypes = new HashSet<Type>();
+		supertypes.add(rawType.getGenericSuperclass());
+		supertypes.addAll(Arrays.asList(rawType.getGenericInterfaces()));
+
+		for (Type supertype : supertypes) {
+			Class<?> rawSuperType = GenericTypeResolver.resolveType(supertype, getTypeVariableMap());
+			if (Map.class.isAssignableFrom(rawSuperType)) {
+				ParameterizedType parameterizedSupertype = (ParameterizedType) supertype;
+				Type[] arguments = parameterizedSupertype.getActualTypeArguments();
+				return createInfo(arguments[1]);
+			}
+		}
+
+		return super.getMapValueType();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#getTypeParameters()
+	 */
+	@Override
+	public List<TypeInformation<?>> getTypeArguments() {
+
+		List<TypeInformation<?>> result = new ArrayList<TypeInformation<?>>();
+
+		for (Type argument : type.getActualTypeArguments()) {
+			result.add(createInfo(argument));
+		}
+
+		return result;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#isAssignableFrom(org.springframework.data.util.TypeInformation)
+	 */
+	@Override
+	public boolean isAssignableFrom(TypeInformation<?> target) {
+
+		if (this.equals(target)) {
+			return true;
+		}
+
+		Class<T> rawType = getType();
+		Class<?> rawTargetType = target.getType();
+
+		if (!rawType.isAssignableFrom(rawTargetType)) {
+			return false;
+		}
+
+		TypeInformation<?> otherTypeInformation = rawType.equals(rawTargetType) ? target : target
+				.getSuperTypeInformation(rawType);
+
+		List<TypeInformation<?>> myParameters = getTypeArguments();
+		List<TypeInformation<?>> typeParameters = otherTypeInformation.getTypeArguments();
+
+		if (myParameters.size() != typeParameters.size()) {
+			return false;
+		}
+
+		for (int i = 0; i < myParameters.size(); i++) {
+			if (!myParameters.get(i).resolvesTo(typeParameters.get(i))) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#getComponentType()
+	 */
+	@Override
+	public TypeInformation<?> getComponentType() {
+
+		if (componentType == null) {
+			this.componentType = createInfo(type.getActualTypeArguments()[0]);
+		}
+
+		return this.componentType;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.ParentTypeAwareTypeInformation#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+
+		if (obj == this) {
+			return true;
+		}
+
+		if (!(obj instanceof ParameterizedTypeInformation)) {
+			return false;
+		}
+
+		ParameterizedTypeInformation<?> that = (ParameterizedTypeInformation<?>) obj;
+
+		if (this.isResolvedCompletely() && that.isResolvedCompletely()) {
+			return this.type.equals(that.type);
+		}
+
+		return super.equals(obj);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.ParentTypeAwareTypeInformation#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		return super.hashCode() + (isResolvedCompletely() ? this.type.hashCode() : 0);
+	}
+
+	private boolean isResolvedCompletely() {
+
+		Type[] types = type.getActualTypeArguments();
+
+		if (types.length == 0) {
+			return false;
+		}
+
+		for (Type type : types) {
+
+			TypeInformation<?> info = createInfo(type);
+
+			if (info instanceof ParameterizedTypeInformation) {
+				if (!((ParameterizedTypeInformation<?>) info).isResolvedCompletely()) {
+					return false;
+				}
+			}
+
+			if (!(info instanceof ClassTypeInformation)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/ParentTypeAwareTypeInformation.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/ParentTypeAwareTypeInformation.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+
+import org.springframework.util.ObjectUtils;
+
+/**
+ * Base class for {@link TypeInformation} implementations that need parent type awareness.
+ * 
+ * @author Oliver Gierke
+ */
+public abstract class ParentTypeAwareTypeInformation<S> extends TypeDiscoverer<S> {
+	
+	private final TypeDiscoverer<?> parent;
+
+	/**
+	 * Creates a new {@link ParentTypeAwareTypeInformation}.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param parent must not be {@literal null}.
+	 * @param map
+	 */
+	@SuppressWarnings("rawtypes")
+	protected ParentTypeAwareTypeInformation(Type type, TypeDiscoverer<?> parent, Map<TypeVariable, Type> map) {
+		
+		super(type, map);
+		this.parent = parent;
+	}
+
+	/**
+	 * Considers the parent's type variable map before invoking the super class method.
+	 * 
+	 * @return
+	 */
+	@Override
+	@SuppressWarnings("rawtypes")
+	protected Map<TypeVariable, Type> getTypeVariableMap() {
+		return parent == null ? super.getTypeVariableMap() : parent.getTypeVariableMap();
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#createInfo(java.lang.reflect.Type)
+	 */
+	@Override
+	protected TypeInformation<?> createInfo(Type fieldType) {
+
+		if (parent.getType().equals(fieldType)) {
+			return parent;
+		}
+
+		return super.createInfo(fieldType);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+
+		if (!super.equals(obj)) {
+			return false;
+		}
+
+		if (!this.getClass().equals(obj.getClass())) {
+			return false;
+		}
+
+		ParentTypeAwareTypeInformation<?> that = (ParentTypeAwareTypeInformation<?>) obj;
+		return this.parent == null ? that.parent == null : this.parent.equals(that.parent);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeDiscoverer#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		return super.hashCode() + 31 * ObjectUtils.nullSafeHashCode(parent);
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/TypeDiscoverer.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/TypeDiscoverer.java
@@ -1,0 +1,502 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import static org.springframework.util.ObjectUtils.*;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.core.GenericTypeResolver;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Basic {@link TypeDiscoverer} that contains basic functionality to discover property types.
+ * 
+ * @author Oliver Gierke
+ */
+class TypeDiscoverer<S> implements TypeInformation<S> {
+	
+	private final Type type;
+	@SuppressWarnings("rawtypes")
+	private final Map<TypeVariable, Type> typeVariableMap;
+	private final Map<String, TypeInformation<?>> fieldTypes = new ConcurrentHashMap<String, TypeInformation<?>>();
+
+	private Class<S> resolvedType;
+	
+	/**
+	 * Creates a ne {@link TypeDiscoverer} for the given type, type variable map and parent.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param typeVariableMap
+	 */
+	@SuppressWarnings("rawtypes")
+	protected TypeDiscoverer(Type type, Map<TypeVariable, Type> typeVariableMap) {
+
+		Assert.notNull(type);
+		this.type = type;
+		this.typeVariableMap = typeVariableMap;
+	}
+
+	/**
+	 * Returns the type variable map. Will traverse the parents up to the root on and use it's map.
+	 * 
+	 * @return
+	 */
+	@SuppressWarnings("rawtypes")
+	protected Map<TypeVariable, Type> getTypeVariableMap() {
+
+		return typeVariableMap;
+	}
+
+	/**
+	 * Creates {@link TypeInformation} for the given {@link Type}.
+	 * 
+	 * @param fieldType
+	 * @return
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	protected TypeInformation<?> createInfo(Type fieldType) {
+
+		if (fieldType.equals(this.type)) {
+			return this;
+		}
+
+		if (fieldType instanceof Class) {
+			return new ClassTypeInformation((Class<?>) fieldType);
+		}
+
+		Map<TypeVariable, Type> variableMap = GenericTypeResolver.getTypeVariableMap(resolveType(fieldType));
+
+		if (fieldType instanceof ParameterizedType) {
+			ParameterizedType parameterizedType = (ParameterizedType) fieldType;
+			return new ParameterizedTypeInformation(parameterizedType, this);
+		}
+
+		if (fieldType instanceof TypeVariable) {
+			TypeVariable<?> variable = (TypeVariable<?>) fieldType;
+			return new TypeVariableTypeInformation(variable, type, this, variableMap);
+		}
+
+		if (fieldType instanceof GenericArrayType) {
+			return new GenericArrayTypeInformation((GenericArrayType) fieldType, this);
+		}
+
+		if (fieldType instanceof WildcardType) {
+			WildcardType wildcard = (WildcardType) fieldType;
+			return new WildcardTypeInformation(wildcard, this);
+		}
+
+		throw new IllegalArgumentException();
+	}
+
+	/**
+	 * Resolves the given type into a plain {@link Class}.
+	 * 
+	 * @param type
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	protected Class<S> resolveType(Type type) {
+		return (Class<S>) GenericTypeResolver.resolveType(type, getTypeVariableMap());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getParameterTypes(java.lang.reflect.Constructor)
+	 */
+	public List<TypeInformation<?>> getParameterTypes(Constructor<?> constructor) {
+
+		Assert.notNull(constructor);
+		List<TypeInformation<?>> result = new ArrayList<TypeInformation<?>>();
+
+		for (Type type : constructor.getGenericParameterTypes()) {
+			result.add(createInfo(type));
+		}
+
+		return result;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getProperty(java.lang.String)
+	 */
+	public TypeInformation<?> getProperty(String fieldname) {
+
+		int separatorIndex = fieldname.indexOf('.');
+
+		if (separatorIndex == -1) {
+			if (fieldTypes.containsKey(fieldname)) {
+				return fieldTypes.get(fieldname);
+			}
+
+			TypeInformation<?> propertyInformation = getPropertyInformation(fieldname);
+			if (propertyInformation != null) {
+				fieldTypes.put(fieldname, propertyInformation);
+			}
+			return propertyInformation;
+		}
+
+		String head = fieldname.substring(0, separatorIndex);
+		TypeInformation<?> info = fieldTypes.get(head);
+		return info == null ? null : info.getProperty(fieldname.substring(separatorIndex + 1));
+	}
+
+	/**
+	 * Returns the {@link TypeInformation} for the given atomic field. Will inspect fields first and return the type of a
+	 * field if available. Otherwise it will fall back to a {@link PropertyDescriptor}.
+	 * 
+	 * @see #getGenericType(PropertyDescriptor)
+	 * @param fieldname
+	 * @return
+	 */
+	private TypeInformation<?> getPropertyInformation(String fieldname) {
+
+		Class<?> type = getType();
+		Field field = ReflectionUtils.findField(type, fieldname);
+
+		if (field != null) {
+			return createInfo(field.getGenericType());
+		}
+
+		PropertyDescriptor descriptor = BeanUtils.getPropertyDescriptor(type, fieldname);
+		return descriptor == null ? null : createInfo(getGenericType(descriptor));
+	}
+
+	/**
+	 * Returns the generic type for the given {@link PropertyDescriptor}. Will inspect its read method followed by the
+	 * first parameter of the write method.
+	 * 
+	 * @param descriptor must not be {@literal null}
+	 * @return
+	 */
+	private static Type getGenericType(PropertyDescriptor descriptor) {
+
+		Method method = descriptor.getReadMethod();
+
+		if (method != null) {
+			return method.getGenericReturnType();
+		}
+
+		method = descriptor.getWriteMethod();
+
+		if (method == null) {
+			return null;
+		}
+
+		Type[] parameterTypes = method.getGenericParameterTypes();
+		return parameterTypes.length == 0 ? null : parameterTypes[0];
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getType()
+	 */
+	public Class<S> getType() {
+		
+		if (this.resolvedType == null) {
+			this.resolvedType = resolveType(type);
+		}
+		
+		return this.resolvedType;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeInformation#isRawType()
+	 */
+	public boolean isRawType() {
+		return getComponentType() == null;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getActualType()
+	 */
+	public TypeInformation<?> getActualType() {
+
+		if (isMap()) {
+			return getMapValueType();
+		}
+
+		if (isCollectionLike()) {
+			return getComponentType();
+		}
+
+		List<TypeInformation<?>> arguments = getTypeArguments();
+
+		if (arguments.isEmpty()) {
+			return this;
+		}
+
+		return arguments.get(arguments.size() - 1);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#isMap()
+	 */
+	public boolean isMap() {
+		return Map.class.isAssignableFrom(getType());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getMapValueType()
+	 */
+	public TypeInformation<?> getMapValueType() {
+
+		if (isMap()) {
+			return getTypeArgument(getType(), Map.class, 1);
+		}
+
+		List<TypeInformation<?>> arguments = getTypeArguments();
+
+		if (arguments.size() > 1) {
+			return arguments.get(1);
+		}
+
+		return null;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#isCollectionLike()
+	 */
+	public boolean isCollectionLike() {
+
+		Class<?> rawType = getType();
+
+		if (rawType.isArray() || Iterable.class.equals(rawType)) {
+			return true;
+		}
+
+		return Collection.class.isAssignableFrom(rawType);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getComponentType()
+	 */
+	public TypeInformation<?> getComponentType() {
+
+		Class<S> rawType = getType();
+
+		if (rawType.isArray()) {
+			return createInfo(rawType.getComponentType());
+		}
+
+		if (isMap()) {
+			return getTypeArgument(rawType, Map.class, 0);
+		}
+		
+		if (Collection.class.isAssignableFrom(rawType)) {
+			return getTypeArgument(rawType, Collection.class, 0);
+		}
+
+		if (Iterable.class.isAssignableFrom(rawType)) {
+			return getTypeArgument(rawType, Iterable.class, 0);
+		}
+
+		List<TypeInformation<?>> arguments = getTypeArguments();
+
+		if (arguments.size() > 0) {
+			return arguments.get(0);
+		}
+
+		return null;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getReturnType(java.lang.reflect.Method)
+	 */
+	public TypeInformation<?> getReturnType(Method method) {
+
+		Assert.notNull(method);
+		return createInfo(method.getGenericReturnType());
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getMethodParameterTypes(java.lang.reflect.Method)
+	 */
+	public List<TypeInformation<?>> getParameterTypes(Method method) {
+
+		Assert.notNull(method);
+
+		Type[] parameterTypes = method.getGenericParameterTypes();
+		List<TypeInformation<?>> result = new ArrayList<TypeInformation<?>>(parameterTypes.length);
+
+		for (Type type : parameterTypes) {
+			result.add(createInfo(type));
+		}
+
+		return result;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getSuperTypeInformation(java.lang.Class)
+	 */
+	public TypeInformation<?> getSuperTypeInformation(Class<?> superType) {
+
+		Class<?> type = getType();
+
+		if (!superType.isAssignableFrom(type)) {
+			return null;
+		}
+
+		if (getType().equals(superType)) {
+			return this;
+		}
+
+		List<Type> candidates = new ArrayList<Type>();
+
+		Type genericSuperclass = type.getGenericSuperclass();
+		if (genericSuperclass != null) {
+			candidates.add(genericSuperclass);
+		}
+		candidates.addAll(Arrays.asList(type.getGenericInterfaces()));
+
+		for (Type candidate : candidates) {
+
+			TypeInformation<?> candidateInfo = createInfo(candidate);
+
+			if (superType.equals(candidateInfo.getType())) {
+				return candidateInfo;
+			} else {
+				TypeInformation<?> nestedSuperType = candidateInfo.getSuperTypeInformation(superType);
+				if (nestedSuperType != null) {
+					return nestedSuperType;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#getTypeParameters()
+	 */
+	public List<TypeInformation<?>> getTypeArguments() {
+		return Collections.emptyList();
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeInformation#isAssignableFrom(java.lang.Class)
+	 */
+	public boolean isAssignableFrom(Class<?> target) {
+		return isAssignableFrom(ClassTypeInformation.from(target));
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.util.TypeInformation#isAssignableFrom(org.springframework.data.util.TypeInformation)
+	 */
+	public boolean isAssignableFrom(TypeInformation<?> target) {
+		
+		if (target instanceof ClassTypeInformation) {
+			return getType().isAssignableFrom(target.getType());
+		}
+		
+		return isAssignableFrom(target.getSuperTypeInformation(getType()));
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeInformation#resolvesTo(org.springframework.beans.type.TypeInformation)
+	 */
+	public boolean resolvesTo(TypeInformation<?> target) {
+		
+		if (target instanceof ClassTypeInformation) {
+			return getType().equals(target.getType());
+		}
+		
+		return resolvesTo(target.getSuperTypeInformation(getType()));
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeInformation#isAssignableFrom(java.lang.Object)
+	 */
+	public boolean isAssignableFromValue(Object value) {
+		return value == null ? false : isAssignableFrom(value.getClass());
+	}
+
+	private TypeInformation<?> getTypeArgument(Class<?> type, Class<?> bound, int index) {
+
+		Class<?>[] arguments = GenericTypeResolver.resolveTypeArguments(type, bound);
+		return arguments == null ? null : createInfo(arguments[index]);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
+
+		if (obj == null) {
+			return false;
+		}
+
+		if (!this.getClass().equals(obj.getClass())) {
+			return false;
+		}
+
+		TypeDiscoverer<?> that = (TypeDiscoverer<?>) obj;
+
+		boolean typeEqual = nullSafeEquals(this.type, that.type);
+		boolean typeVariableMapEqual = nullSafeEquals(this.typeVariableMap, that.typeVariableMap);
+
+		return typeEqual && typeVariableMapEqual;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+
+		int result = 17;
+		result += nullSafeHashCode(type);
+		result += nullSafeHashCode(typeVariableMap);
+		return result;
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/TypeInformation.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/TypeInformation.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2008-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Interface to access property types and resolving generics on the way. Starting with a {@link ClassTypeInformation}
+ * you can travers properties using {@link #getProperty(String)} to access type information.
+ * 
+ * @author Oliver Gierke
+ */
+public interface TypeInformation<S> {
+
+	/**
+	 * Returns the {@link TypeInformation}s for the parameters of the given {@link Constructor}.
+	 * 
+	 * @param constructor must not be {@literal null}.
+	 * @return
+	 */
+	List<TypeInformation<?>> getParameterTypes(Constructor<?> constructor);
+
+	/**
+	 * Returns the property information for the property with the given name. Supports proeprty traversal through dot
+	 * notation.
+	 * 
+	 * @param fieldname
+	 * @return
+	 */
+	TypeInformation<?> getProperty(String fieldname);
+
+	/**
+	 * Returns whether the type can be considered a collection, which means it's a container of elements, e.g. a
+	 * {@link java.util.Collection} and {@link java.lang.reflect.Array} or anything implementing {@link Iterable}. If this
+	 * returns {@literal true} you can expect {@link #getComponentType()} to return a non-{@literal null} value.
+	 * 
+	 * @return
+	 */
+	boolean isCollectionLike();
+
+	/**
+	 * Returns the component type for {@link java.util.Collection}s or the key type for {@link java.util.Map}s.
+	 * 
+	 * @return
+	 */
+	TypeInformation<?> getComponentType();
+
+	/**
+	 * Returns whether the property is a {@link java.util.Map}. If this returns {@literal true} you can expect
+	 * {@link #getComponentType()} as well as {@link #getMapValueType()} to return something not {@literal null}.
+	 * 
+	 * @return
+	 */
+	boolean isMap();
+
+	/**
+	 * Returns whether the current {@link TypeInformation} is a raw type, which means it's either a paramterized type
+	 * itself or extends a parameterized one and does <em>not</em> bind all generic parameters.
+	 *
+	 * @return
+	 */
+	boolean isRawType();
+
+	/**
+	 * Will return the type of the value in case the underlying type is a {@link java.util.Map}.
+	 * 
+	 * @return
+	 */
+	TypeInformation<?> getMapValueType();
+
+	/**
+	 * Returns the type of the property. Will resolve generics and the generic context of
+	 * 
+	 * @return
+	 */
+	Class<S> getType();
+
+	/**
+	 * Transparently returns the {@link java.util.Map} value type if the type is a {@link java.util.Map}, returns the
+	 * component type if the type {@link #isCollectionLike()} or the simple type if none of this applies.
+	 * 
+	 * @return
+	 */
+	TypeInformation<?> getActualType();
+
+	/**
+	 * Returns a {@link TypeInformation} for the return type of the given {@link Method}. Will potentially resolve
+	 * generics information against the current types type parameter bindings.
+	 * 
+	 * @param method must not be {@literal null}.
+	 * @return
+	 */
+	TypeInformation<?> getReturnType(Method method);
+
+	/**
+	 * Returns the {@link TypeInformation}s for the parameters of the given {@link Method}.
+	 * 
+	 * @param method must not be {@literal null}.
+	 * @return
+	 */
+	List<TypeInformation<?>> getParameterTypes(Method method);
+
+	/**
+	 * Returns the {@link TypeInformation} for the given raw super type.
+	 * 
+	 * @param superType must not be {@literal null}.
+	 * @return the {@link TypeInformation} for the given raw super type or {@literal null} in case the current
+	 *         {@link TypeInformation} does not implement the given type.
+	 */
+	TypeInformation<?> getSuperTypeInformation(Class<?> superType);
+
+	/**
+	 * Returns whether the current {@link TypeInformation} can be safely assigned to the given one. Mimics semantics of
+	 * {@link Class#isAssignableFrom(Class)} but takes generics into account. Thus it will allow to detect that a
+	 * {@code List<Long>} is assignable to {@code List<? extends Number>}.
+	 * 
+	 * @param target
+	 * @return
+	 */
+	boolean isAssignableFrom(TypeInformation<?> target);
+
+	/**
+	 * Returns whether the current {@link TypeInformation} can be safely assigned to the {@link TypeInformation} of the
+	 * given object.
+	 * 
+	 * @param value
+	 * @return
+	 */
+	boolean isAssignableFromValue(Object value);
+
+	/**
+	 * Returns whether the current {@link TypeInformation} ca be safely assigned to the given {@link Class}.
+	 * 
+	 * @param target
+	 * @return
+	 */
+	boolean isAssignableFrom(Class<?> target);
+
+	/**
+	 * Returns whether the current {@link TypeInformation} eventually resolves to the given one.
+	 * 
+	 * @param target
+	 * @return
+	 */
+	boolean resolvesTo(TypeInformation<?> target);
+
+	/**
+	 * Returns the {@link TypeInformation} for the type arguments of the current {@link TypeInformation}.
+	 * 
+	 * @return
+	 */
+	List<TypeInformation<?>> getTypeArguments();
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/TypeVariableTypeInformation.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/TypeVariableTypeInformation.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2011-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import static org.springframework.util.ObjectUtils.*;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+
+import org.springframework.util.Assert;
+
+/**
+ * Special {@link TypeDiscoverer} to determine the actual type for a {@link TypeVariable}. Will consider the context the
+ * {@link TypeVariable} is being used in.
+ * 
+ * @author Oliver Gierke
+ */
+class TypeVariableTypeInformation<T> extends ParentTypeAwareTypeInformation<T> {
+	
+	private final TypeVariable<?> variable;
+	private final Type owningType;
+
+	/**
+	 * Creates a bew {@link TypeVariableTypeInformation} for the given {@link TypeVariable} owning {@link Type} and parent
+	 * {@link TypeDiscoverer}.
+	 * 
+	 * @param variable must not be {@literal null}
+	 * @param owningType must not be {@literal null}
+	 * @param parent
+	 */
+	@SuppressWarnings("rawtypes")
+	public TypeVariableTypeInformation(TypeVariable<?> variable, Type owningType, TypeDiscoverer<?> parent,
+			Map<TypeVariable, Type> map) {
+
+		super(variable, parent, map);
+		Assert.notNull(variable);
+		this.variable = variable;
+		this.owningType = owningType;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.data.document.mongodb.TypeDiscovererTest.TypeDiscoverer#getType()
+	 */
+	@Override
+	public Class<T> getType() {
+
+		int index = getIndex(variable);
+
+		if (owningType instanceof ParameterizedType && index != -1) {
+			Type fieldType = ((ParameterizedType) owningType).getActualTypeArguments()[index];
+			return resolveType(fieldType);
+		}
+
+		return resolveType(variable);
+	}
+
+	/**
+	 * Returns the index of the type parameter binding the given {@link TypeVariable}.
+	 * 
+	 * @param variable
+	 * @return
+	 */
+	private int getIndex(TypeVariable<?> variable) {
+
+		Class<?> rawType = resolveType(owningType);
+		TypeVariable<?>[] typeParameters = rawType.getTypeParameters();
+
+		for (int i = 0; i < typeParameters.length; i++) {
+			if (variable.equals(typeParameters[i])) {
+				return i;
+			}
+		}
+
+		return -1;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.ParentTypeAwareTypeInformation#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		
+		if (!super.equals(obj)) {
+			return false;
+		}
+
+		TypeVariableTypeInformation<?> that = (TypeVariableTypeInformation<?>) obj;
+		return nullSafeEquals(this.owningType, that.owningType) && nullSafeEquals(this.variable, that.variable);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.ParentTypeAwareTypeInformation#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		
+		int result = super.hashCode();
+		result += 31 * nullSafeHashCode(this.owningType);
+		result += 31 * nullSafeHashCode(this.variable);
+		return result;
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/WildcardTypeInformation.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/WildcardTypeInformation.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+
+/**
+ * {@link TypeInformation} implementation for {@link WildcardType}s. 
+ * 
+ * @author Oliver Gierke
+ */
+public class WildcardTypeInformation<T> extends ParentTypeAwareTypeInformation<T> {
+
+	private final TypeInformation<?> type;
+	private final boolean isLowerBound;
+
+	/**
+	 * Creates a new {@link WildcardTypeInformation}.
+	 * 
+	 * @param type must not be {@literal null}.
+	 * @param parent must not be {@literal null}.
+	 */
+	protected WildcardTypeInformation(WildcardType type, TypeDiscoverer<?> parent) {
+
+		super(type, parent, null);
+
+		Type[] bounds = type.getLowerBounds();
+
+		if (bounds.length > 0) {
+			this.type = createInfo(bounds[0]);
+			this.isLowerBound = true;
+			return;
+		}
+
+		bounds = type.getUpperBounds();
+
+		if (bounds.length > 0) {
+			this.type = createInfo(bounds[0]);
+			this.isLowerBound = false;
+			return;
+		}
+
+		throw new IllegalArgumentException(String.format("Cannot detect bounds for type %s!", type));
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeDiscoverer#getType()
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public Class<T> getType() {
+		return (Class<T>) this.type.getType();
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeDiscoverer#getComponentType()
+	 */
+	@Override
+	public TypeInformation<?> getComponentType() {
+		return type.getComponentType();
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeDiscoverer#getMapValueType()
+	 */
+	@Override
+	public TypeInformation<?> getMapValueType() {
+		return this.type.getMapValueType();
+	}
+	
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeDiscoverer#resolvesTo(org.springframework.beans.type.TypeInformation)
+	 */
+	@Override
+	public boolean resolvesTo(TypeInformation<?> target) {
+		return isAssignableFrom(target);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.type.TypeDiscoverer#isAssignableFrom(org.springframework.beans.type.TypeInformation)
+	 */
+	@Override
+	public boolean isAssignableFrom(TypeInformation<?> target) {
+		return isLowerBound ? target.isAssignableFrom(type) : type.isAssignableFrom(target);
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/type/package-info.java
+++ b/spring-beans/src/main/java/org/springframework/beans/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Core utility APIs such as a type information framework to resolve generic types.
+ */
+package org.springframework.beans.type;

--- a/spring-beans/src/test/java/org/springframework/beans/type/ClassTypeInformationUnitTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/type/ClassTypeInformationUnitTests.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright 2011-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.springframework.beans.type.ClassTypeInformation.*;
+
+import java.lang.reflect.Method;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ClassTypeInformation}.
+ * 
+ * @author Oliver Gierke
+ */
+public class ClassTypeInformationUnitTests {
+
+	@Test
+	public void discoversTypeForSimpleGenericField() {
+
+		TypeInformation<ConcreteType> discoverer = ClassTypeInformation.from(ConcreteType.class);
+		assertEquals(ConcreteType.class, discoverer.getType());
+		TypeInformation<?> content = discoverer.getProperty("content");
+		assertEquals(String.class, content.getType());
+		assertNull(content.getComponentType());
+		assertNull(content.getMapValueType());
+	}
+
+	@Test
+	public void discoversTypeForNestedGenericField() {
+
+		TypeInformation<ConcreteWrapper> discoverer = ClassTypeInformation.from(ConcreteWrapper.class);
+		assertEquals(ConcreteWrapper.class, discoverer.getType());
+		TypeInformation<?> wrapper = discoverer.getProperty("wrapped");
+		assertEquals(GenericType.class, wrapper.getType());
+		TypeInformation<?> content = wrapper.getProperty("content");
+
+		assertEquals(String.class, content.getType());
+		assertEquals(String.class, discoverer.getProperty("wrapped").getProperty("content").getType());
+		assertEquals(String.class, discoverer.getProperty("wrapped.content").getType());
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void discoversBoundType() {
+
+		TypeInformation<GenericTypeWithBound> information = ClassTypeInformation.from(GenericTypeWithBound.class);
+		assertEquals(Person.class, information.getProperty("person").getType());
+	}
+
+	@Test
+	public void discoversBoundTypeForSpecialization() {
+
+		TypeInformation<SpecialGenericTypeWithBound> information = ClassTypeInformation
+				.from(SpecialGenericTypeWithBound.class);
+		assertEquals(SpecialPerson.class, information.getProperty("person").getType());
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void discoversBoundTypeForNested() {
+
+		TypeInformation<AnotherGenericType> information = ClassTypeInformation.from(AnotherGenericType.class);
+		assertEquals(GenericTypeWithBound.class, information.getProperty("nested").getType());
+		assertEquals(Person.class, information.getProperty("nested.person").getType());
+	}
+
+	@Test
+	public void discoversArraysAndCollections() {
+		TypeInformation<StringCollectionContainer> information = ClassTypeInformation.from(StringCollectionContainer.class);
+
+		TypeInformation<?> property = information.getProperty("array");
+		assertEquals(property.getComponentType().getType(), String.class);
+
+		Class<?> type = property.getType();
+		assertEquals(String[].class, type);
+		assertThat(type.isArray(), is(true));
+
+		property = information.getProperty("foo");
+		assertEquals(Collection[].class, property.getType());
+		assertEquals(Collection.class, property.getComponentType().getType());
+		assertEquals(String.class, property.getComponentType().getComponentType().getType());
+
+		property = information.getProperty("rawSet");
+		assertEquals(Set.class, property.getType());
+		assertEquals(Object.class, property.getComponentType().getType());
+		assertNull(property.getMapValueType());
+	}
+
+	@Test
+	public void discoversMapValueType() {
+
+		TypeInformation<StringMapContainer> information = ClassTypeInformation.from(StringMapContainer.class);
+		TypeInformation<?> genericMap = information.getProperty("genericMap");
+		assertEquals(Map.class, genericMap.getType());
+		assertEquals(String.class, genericMap.getMapValueType().getType());
+
+		TypeInformation<?> map = information.getProperty("map");
+		assertEquals(Map.class, map.getType());
+		assertEquals(Calendar.class, map.getMapValueType().getType());
+	}
+
+	@Test
+	public void typeInfoDoesNotEqualForGenericTypesWithDifferentParent() {
+
+		TypeInformation<ConcreteWrapper> first = ClassTypeInformation.from(ConcreteWrapper.class);
+		TypeInformation<AnotherConcreteWrapper> second = ClassTypeInformation.from(AnotherConcreteWrapper.class);
+
+		assertFalse(first.getProperty("wrapped").equals(second.getProperty("wrapped")));
+	}
+
+	@Test
+	public void handlesPropertyFieldMismatchCorrectly() {
+
+		TypeInformation<PropertyGetter> from = ClassTypeInformation.from(PropertyGetter.class);
+
+		TypeInformation<?> property = from.getProperty("_name");
+		assertThat(property, is(notNullValue()));
+		assertThat(property.getType(), is(typeCompatibleWith(String.class)));
+
+		property = from.getProperty("name");
+		assertThat(property, is(notNullValue()));
+		assertThat(property.getType(), is(typeCompatibleWith(byte[].class)));
+	}
+
+	/**
+	 * @see DATACMNS-77
+	 */
+	@Test
+	public void returnsSameInstanceForCachedClass() {
+
+		TypeInformation<PropertyGetter> info = ClassTypeInformation.from(PropertyGetter.class);
+		assertThat(ClassTypeInformation.from(PropertyGetter.class), is(sameInstance(info)));
+	}
+
+	/**
+	 * @see DATACMNS-39
+	 */
+	@Test
+	public void resolvesWildCardTypeCorrectly() {
+
+		TypeInformation<ClassWithWildCardBound> information = ClassTypeInformation.from(ClassWithWildCardBound.class);
+
+		TypeInformation<?> property = information.getProperty("wildcard");
+		assertThat(property.isCollectionLike(), is(true));
+		assertThat(property.getComponentType().getType(), is(typeCompatibleWith(String.class)));
+
+		property = information.getProperty("complexWildcard");
+		assertThat(property.isCollectionLike(), is(true));
+
+		TypeInformation<?> component = property.getComponentType();
+		assertThat(component.isCollectionLike(), is(true));
+		assertThat(component.getComponentType().getType(), is(typeCompatibleWith(String.class)));
+	}
+
+	@Test
+	public void resolvesTypeParametersCorrectly() {
+
+		TypeInformation<ConcreteType> information = ClassTypeInformation.from(ConcreteType.class);
+		TypeInformation<?> superTypeInformation = information.getSuperTypeInformation(GenericType.class);
+
+		List<TypeInformation<?>> parameters = superTypeInformation.getTypeArguments();
+		assertThat(parameters, hasSize(2));
+		assertThat(parameters.get(0).getType(), is((Object) String.class));
+		assertThat(parameters.get(1).getType(), is((Object) Object.class));
+	}
+
+	@Test
+	public void resolvesNestedInheritedTypeParameters() {
+
+		TypeInformation<SecondExtension> information = ClassTypeInformation.from(SecondExtension.class);
+		TypeInformation<?> superTypeInformation = information.getSuperTypeInformation(Base.class);
+
+		List<TypeInformation<?>> parameters = superTypeInformation.getTypeArguments();
+		assertThat(parameters, hasSize(1));
+		assertThat(parameters.get(0).getType(), is((Object) String.class));
+	}
+
+	@Test
+	public void discoveresMethodParameterTypesCorrectly() throws Exception {
+
+		TypeInformation<SecondExtension> information = ClassTypeInformation.from(SecondExtension.class);
+		Method method = SecondExtension.class.getMethod("foo", Base.class);
+		List<TypeInformation<?>> informations = information.getParameterTypes(method);
+		TypeInformation<?> returnTypeInformation = information.getReturnType(method);
+
+		assertThat(informations, hasSize(1));
+		assertThat(informations.get(0).getType(), is((Object) Base.class));
+		assertThat(informations.get(0), is((Object) returnTypeInformation));
+	}
+
+	@Test
+	public void discoversImplementationBindingCorrectlyForString() throws Exception {
+
+		TypeInformation<TypedClient> information = from(TypedClient.class);
+		Method method = TypedClient.class.getMethod("stringMethod", GenericInterface.class);
+
+		TypeInformation<?> parameterType = information.getParameterTypes(method).get(0);
+
+		TypeInformation<StringImplementation> stringInfo = from(StringImplementation.class);
+		assertThat(parameterType.isAssignableFrom(stringInfo), is(true));
+		assertThat(stringInfo.getSuperTypeInformation(GenericInterface.class), is((Object) parameterType));
+		assertThat(parameterType.isAssignableFrom(from(LongImplementation.class)), is(false));
+		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(
+				GenericInterface.class)), is(true));
+	}
+
+	@Test
+	public void discoversImplementationBindingCorrectlyForLong() throws Exception {
+
+		TypeInformation<TypedClient> information = from(TypedClient.class);
+		Method method = TypedClient.class.getMethod("longMethod", GenericInterface.class);
+
+		TypeInformation<?> parameterType = information.getParameterTypes(method).get(0);
+
+		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class)), is(false));
+		assertThat(parameterType.isAssignableFrom(from(LongImplementation.class)), is(true));
+		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(
+				GenericInterface.class)), is(false));
+	}
+
+	@Test
+	public void discoversImplementationBindingCorrectlyForNumber() throws Exception {
+
+		TypeInformation<TypedClient> information = from(TypedClient.class);
+		Method method = TypedClient.class.getMethod("boundToNumberMethod", GenericInterface.class);
+
+		TypeInformation<?> parameterType = information.getParameterTypes(method).get(0);
+
+		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class)), is(false));
+		assertThat(parameterType.isAssignableFrom(from(LongImplementation.class)), is(true));
+		assertThat(parameterType.isAssignableFrom(from(StringImplementation.class).getSuperTypeInformation(
+				GenericInterface.class)), is(false));
+	}
+
+	@Test
+	public void returnsComponentTypeForMultiDimensionalArrayCorrectly() {
+
+		TypeInformation<?> information = from(String[][].class);
+		assertThat(information.getType(), is((Object) String[][].class));
+		assertThat(information.getComponentType().getType(), is((Object) String[].class));
+		assertThat(information.getActualType().getActualType().getType(), is((Object) String.class));
+	}
+
+	@Test
+	public void discoversAssignableGenericType() {
+
+		TypeInformation<ConcreteWrapper> information = ClassTypeInformation.from(ConcreteWrapper.class);
+		TypeInformation<?> wrappedType = information.getProperty("wrapped");
+
+		assertThat(wrappedType.isAssignableFrom(ClassTypeInformation.from(ConcreteType.class)), is(true));
+	}
+
+	@Test
+	public void discoveresAssignableWildcardedGenericType() {
+
+		TypeInformation<AnotherConcreteWrapper> information = ClassTypeInformation.from(AnotherConcreteWrapper.class);
+		TypeInformation<?> wrappedType = information.getProperty("wrapped");
+
+		assertThat(wrappedType.isAssignableFrom(ClassTypeInformation.from(AnotherConcreteType.class)), is(true));
+	}
+
+	@Test
+	public void discoversRawParameters() throws Exception {
+
+		Method method = Sample.class.getMethod("setFoo", Collection.class);
+		TypeInformation<?> parameterType = from(Sample.class).getParameterTypes(method).get(0);
+		assertThat(parameterType.getComponentType(), is(nullValue()));
+
+		method = Sample.class.getMethod("setBar", Collection.class);
+		parameterType = from(Sample.class).getParameterTypes(method).get(0);
+		assertThat(parameterType.getComponentType(), is(notNullValue()));
+
+		method = Sample.class.getMethod("setFooBar", StringCollection.class);
+		parameterType = from(Sample.class).getParameterTypes(method).get(0);
+		assertThat(parameterType.getComponentType(), is(notNullValue()));
+	}
+
+	@Test
+	public void returnsMapValueTypeForActualTypeIfTypeIsMap() {
+		assertActualType(Locale.class, from(CustomMap.class));
+	}
+
+	@Test
+	public void returnsCollctionElementTypeForActualTypeIfTypeIsCollection() {
+		assertActualType(String.class, from(StringCollection.class));
+	}
+
+	@Test
+	public void returnsItselfAsActualTypeForCustomGenericType() {
+		assertActualType(ParameterizedType.class, from(ParameterizedType.class));
+	}
+
+	private void assertActualType(Class<?> type, TypeInformation<?> source) {
+
+		TypeInformation<?> actualType = source.getActualType();
+		assertThat(actualType, is(notNullValue()));
+		assertEquals(actualType.getType(), type);
+	}
+
+	static class StringMapContainer extends MapContainer<String> {
+
+	}
+
+	static class MapContainer<T> {
+		Map<String, T> genericMap;
+		Map<String, Calendar> map;
+	}
+
+	static class StringCollectionContainer extends CollectionContainer<String> {
+
+	}
+
+	@SuppressWarnings("rawtypes")
+	static class CollectionContainer<T> {
+
+		T[] array;
+		Collection<T>[] foo;
+		Set<String> set;
+		Set rawSet;
+	}
+
+	static class GenericTypeWithBound<T extends Person> {
+
+		T person;
+	}
+
+	static class AnotherGenericType<T extends Person, S extends GenericTypeWithBound<T>> {
+		S nested;
+	}
+
+	static class SpecialGenericTypeWithBound extends GenericTypeWithBound<SpecialPerson> {
+
+	}
+
+	static abstract class SpecialPerson extends Person {
+		protected SpecialPerson(Integer ssn, String firstName, String lastName) {
+			super(ssn, firstName, lastName);
+		}
+	}
+
+	static class GenericType<T, S> {
+
+		Long index;
+		T content;
+	}
+
+	static class ConcreteType extends GenericType<String, Object> {
+
+	}
+
+	static class AnotherConcreteType extends GenericType<Long, Object> {
+
+	}
+
+	static class GenericWrapper<S> {
+
+		GenericType<S, Object> wrapped;
+		GenericType<? extends S, Object> wildcardWrapped;
+	}
+
+	static class ConcreteWrapper extends GenericWrapper<String> {
+
+	}
+
+	static class AnotherConcreteWrapper extends GenericWrapper<Long> {
+
+	}
+
+	static class PropertyGetter {
+		private String _name;
+
+		public byte[] getName() {
+			return _name.getBytes();
+		}
+	}
+
+	static class ClassWithWildCardBound {
+		List<? extends String> wildcard;
+		List<? extends Collection<? extends String>> complexWildcard;
+	}
+
+	static class Base<T> {
+
+	}
+
+	static class FirstExtension<T> extends Base<String> {
+
+		public Base<GenericWrapper<T>> foo(Base<GenericWrapper<T>> param) {
+			return null;
+		}
+	}
+
+	static class SecondExtension extends FirstExtension<Long> {
+
+	}
+
+	interface GenericInterface<T> {
+
+	}
+
+	interface TypedClient {
+
+		void stringMethod(GenericInterface<String> param);
+
+		void longMethod(GenericInterface<Long> param);
+
+		void boundToNumberMethod(GenericInterface<? extends Number> param);
+	}
+
+	interface CustomMap extends Map<String, Locale> {
+
+	}
+
+	interface StringCollection extends Collection<String> {
+
+	}
+
+	interface Sample {
+
+		@SuppressWarnings("rawtypes")
+		void setFoo(Collection collection);
+
+		void setBar(Collection<String> collection);
+
+		void setFooBar(StringCollection collection);
+	}
+
+	class StringImplementation implements GenericInterface<String> {
+
+	}
+
+	class LongImplementation implements GenericInterface<Long> {
+
+	}
+
+	static interface ThreeGenericTypes<S, T, U> {
+
+	}
+
+	static interface ParameterizedType extends ThreeGenericTypes<String, Integer, Long> {
+
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/type/GenericTypeWiringTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/type/GenericTypeWiringTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+
+/**
+ * @author Oliver Gierke
+ */
+public class GenericTypeWiringTests {
+
+	DefaultListableBeanFactory factory;
+
+	@Before
+	public void setUp() {
+
+		factory = new DefaultListableBeanFactory();
+		factory.registerSingleton("stringType", new StringType());
+		factory.registerSingleton("integerType", new IntegerType());
+
+		AutowiredAnnotationBeanPostProcessor processor = new AutowiredAnnotationBeanPostProcessor();
+		processor.setBeanFactory(factory);
+		factory.addBeanPostProcessor(processor);
+	}
+
+	@Test
+	public void injectsGenericProperties() {
+
+		factory.registerBeanDefinition("client", new RootBeanDefinition(PropertyWiredClient.class));
+
+		PropertyWiredClient client = factory.getBean(PropertyWiredClient.class);
+		assertThat(client.integerType, is(instanceOf(IntegerType.class)));
+		assertThat(client.stringType, is(instanceOf(StringType.class)));
+		assertThat(client.stringTypes.size(), is(1));
+	}
+
+	@Test
+	public void injectsGenericConstructorArguments() {
+
+		factory.registerBeanDefinition("constructorClient", new RootBeanDefinition(ConstructorWiredClient.class));
+
+		ConstructorWiredClient client = factory.getBean(ConstructorWiredClient.class);
+		assertThat(client.integerType, is(instanceOf(IntegerType.class)));
+		assertThat(client.stringType, is(instanceOf(StringType.class)));
+		assertThat(client.stringTypes.size(), is(1));
+	}
+
+	@Test
+	public void infersGenericPropertyFromSuperClass() {
+
+		factory.registerBeanDefinition("client", new RootBeanDefinition(GenericStringClient.class));
+		GenericStringClient client = factory.getBean(GenericStringClient.class);
+
+		assertThat(client.property, is(instanceOf(StringType.class)));
+		assertThat(client.subClassProperty, is(instanceOf(StringType.class)));
+	}
+
+	@Test
+	public void injectsSubtypeButNotConreteReference() {
+
+		factory.registerBeanDefinition("client", new RootBeanDefinition(GenericNumberClient.class));
+		GenericNumberClient client = factory.getBean(GenericNumberClient.class);
+
+		assertThat(client.subClassProperty, is(instanceOf(IntegerType.class)));
+		assertThat(client.property, is(nullValue()));
+	}
+	
+	@Test
+	public void doesNotInjectSubTypeIntoGenericTypeWithParentTypeParameter() {
+
+		factory.registerBeanDefinition("client", new RootBeanDefinition(GenericIntegerClient.class));
+		GenericIntegerClient client = factory.getBean(GenericIntegerClient.class);
+
+		assertThat(client.subClassProperty, is(instanceOf(IntegerType.class)));
+		assertThat(client.property, is(instanceOf(IntegerType.class)));
+	}
+
+	interface GenericType<T> {
+
+	}
+
+	static class StringType implements GenericType<String> {
+
+	}
+
+	static class IntegerType implements GenericType<Integer> {
+
+	}
+
+	static abstract class GenericClient<T> {
+
+		@Autowired
+		GenericType<? extends T> subClassProperty;
+
+		@Autowired(required = false)
+		GenericType<T> property;
+	}
+
+	static class GenericStringClient extends GenericClient<String> {
+
+	}
+
+	static class GenericNumberClient extends GenericClient<Number> {
+
+	}
+
+	static class GenericIntegerClient extends GenericClient<Integer> {
+
+	}
+
+	static class PropertyWiredClient {
+
+		@Autowired
+		GenericType<String> stringType;
+
+		@Autowired
+		GenericType<Integer> integerType;
+
+		@Autowired
+		List<GenericType<String>> stringTypes;
+
+		GenericType<GenericType<String>> wrappedStringType;
+	}
+
+	static class ConstructorWiredClient {
+
+		GenericType<String> stringType;
+		GenericType<Integer> integerType;
+		List<GenericType<String>> stringTypes;
+
+		@Autowired
+		public ConstructorWiredClient(GenericType<String> stringType, GenericType<Integer> integerType,
+				List<GenericType<String>> stringTypes) {
+
+			this.integerType = integerType;
+			this.stringType = stringType;
+			this.stringTypes = stringTypes;
+		}
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/type/ParameterizedTypeUnitTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/type/ParameterizedTypeUnitTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2011-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Unit tests for {@link ParameterizedTypeInformation}.
+ * 
+ * @author Oliver Gierke
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ParameterizedTypeUnitTests {
+
+	@Mock
+	ParameterizedType one;
+
+	@Before
+	public void setUp() {
+		when(one.getActualTypeArguments()).thenReturn(new Type[0]);
+	}
+
+	@Test
+	public void considersTypeInformationsWithDifferingParentsNotEqual() {
+
+		TypeDiscoverer<String> stringParent = new TypeDiscoverer<String>(String.class, null);
+		TypeDiscoverer<Object> objectParent = new TypeDiscoverer<Object>(Object.class, null);
+
+		ParameterizedTypeInformation<Object> first = new ParameterizedTypeInformation<Object>(one, stringParent);
+		ParameterizedTypeInformation<Object> second = new ParameterizedTypeInformation<Object>(one, objectParent);
+
+		assertFalse(first.equals(second));
+	}
+
+	@Test
+	public void considersTypeInformationsWithSameParentsNotEqual() {
+
+		TypeDiscoverer<String> stringParent = new TypeDiscoverer<String>(String.class, null);
+
+		ParameterizedTypeInformation<Object> first = new ParameterizedTypeInformation<Object>(one, stringParent);
+		ParameterizedTypeInformation<Object> second = new ParameterizedTypeInformation<Object>(one, stringParent);
+
+		assertTrue(first.equals(second));
+	}
+
+	/**
+	 * @see DATACMNS-88
+	 */
+	@Test
+	public void resolvesMapValueTypeCorrectly() {
+
+		TypeInformation<Foo> type = ClassTypeInformation.from(Foo.class);
+		TypeInformation<?> propertyType = type.getProperty("param");
+		assertThat(propertyType.getProperty("value").getType(), is(typeCompatibleWith(String.class)));
+		assertThat(propertyType.getMapValueType().getType(), is(typeCompatibleWith(String.class)));
+
+		propertyType = type.getProperty("param2");
+		assertThat(propertyType.getProperty("value").getType(), is(typeCompatibleWith(String.class)));
+		assertThat(propertyType.getMapValueType().getType(), is(typeCompatibleWith(Locale.class)));
+	}
+
+	@SuppressWarnings("serial")
+	class Localized<S> extends HashMap<Locale, S> {
+		S value;
+	}
+
+	@SuppressWarnings("serial")
+	class Localized2<S> extends HashMap<S, Locale> {
+		S value;
+	}
+
+	class Foo {
+		Localized<String> param;
+		Localized2<String> param2;
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/type/Person.java
+++ b/spring-beans/src/test/java/org/springframework/beans/type/Person.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011 by the original author(s).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.type;
+
+/**
+ * @author Jon Brisbin <jbrisbin@vmware.com>
+ */
+public abstract class Person {
+
+	private Integer ssn;
+	private String firstName;
+	private String lastName;
+
+	protected Person(Integer ssn, String firstName, String lastName) {
+		this.ssn = ssn;
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+
+	public Integer getSsn() {
+		return ssn;
+	}
+
+	public void setSsn(Integer ssn) {
+		this.ssn = ssn;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+}

--- a/spring-beans/src/test/java/org/springframework/beans/type/TypeDiscovererUnitTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/type/TypeDiscovererUnitTests.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2011-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans.type;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Unit tests for {@link TypeDiscoverer}.
+ * 
+ * @author Oliver Gierke
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TypeDiscovererUnitTests {
+
+	@Mock
+	@SuppressWarnings("rawtypes")
+	Map<TypeVariable, Type> firstMap;
+
+	@Mock
+	@SuppressWarnings("rawtypes")
+	Map<TypeVariable, Type> secondMap;
+
+	@Test(expected = IllegalArgumentException.class)
+	public void rejectsNullType() {
+		new TypeDiscoverer<Object>(null, null);
+	}
+
+	@Test
+	public void isNotEqualIfTypesDiffer() {
+
+		TypeDiscoverer<Object> objectTypeInfo = new TypeDiscoverer<Object>(Object.class, null);
+		TypeDiscoverer<String> stringTypeInfo = new TypeDiscoverer<String>(String.class, null);
+
+		assertFalse(objectTypeInfo.equals(stringTypeInfo));
+	}
+
+	@Test
+	public void isNotEqualIfTypeVariableMapsDiffer() {
+
+		assertFalse(firstMap.equals(secondMap));
+
+		TypeDiscoverer<Object> first = new TypeDiscoverer<Object>(Object.class, firstMap);
+		TypeDiscoverer<Object> second = new TypeDiscoverer<Object>(Object.class, secondMap);
+
+		assertFalse(first.equals(second));
+	}
+
+	@Test
+	public void dealsWithTypesReferencingThemselves() {
+
+		TypeInformation<SelfReferencing> information = new ClassTypeInformation<SelfReferencing>(SelfReferencing.class);
+		TypeInformation<?> first = information.getProperty("parent").getMapValueType();
+		TypeInformation<?> second = first.getProperty("map").getMapValueType();
+		assertEquals(first, second);
+	}
+
+	@Test
+	public void dealsWithTypesReferencingThemselvesInAMap() {
+
+		TypeInformation<SelfReferencingMap> information = new ClassTypeInformation<SelfReferencingMap>(
+				SelfReferencingMap.class);
+		TypeInformation<?> mapValueType = information.getProperty("map").getMapValueType();
+		assertEquals(mapValueType, information);
+	}
+
+	@Test
+	public void returnsComponentAndValueTypesForMapExtensions() {
+		TypeInformation<?> discoverer = new TypeDiscoverer<Object>(CustomMap.class, null);
+		assertEquals(Locale.class, discoverer.getMapValueType().getType());
+		assertEquals(String.class, discoverer.getComponentType().getType());
+	}
+
+	@Test
+	public void returnsComponentTypeForCollectionExtension() {
+		TypeDiscoverer<CustomCollection> discoverer = new TypeDiscoverer<CustomCollection>(CustomCollection.class, null);
+		TypeInformation<?> componentType = discoverer.getComponentType();
+		assertThat(componentType, is(notNullValue()));
+		assertEquals(String.class, componentType.getType());
+	}
+
+	@Test
+	public void returnsComponentTypeForArrays() {
+		TypeDiscoverer<String[]> discoverer = new TypeDiscoverer<String[]>(String[].class, null);
+		assertEquals(String.class, discoverer.getComponentType().getType());
+	}
+
+	/**
+	 * @see DATACMNS-57
+	 */
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void discoveresConstructorParameterTypesCorrectly() throws NoSuchMethodException, SecurityException {
+
+		TypeDiscoverer<GenericConstructors> discoverer = new TypeDiscoverer<GenericConstructors>(GenericConstructors.class,
+				null);
+		Constructor<GenericConstructors> constructor = GenericConstructors.class.getConstructor(List.class, Locale.class);
+		List<TypeInformation<?>> types = discoverer.getParameterTypes(constructor);
+		assertThat(types.size(), is(2));
+		assertThat(types.get(0).getType(), equalTo((Class) List.class));
+		assertThat(types.get(0).getComponentType().getType(), is(equalTo((Class) String.class)));
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void returnsNullForComponentAndValueTypesForRawMaps() {
+		TypeDiscoverer<Map> discoverer = new TypeDiscoverer<Map>(Map.class, null);
+		assertThat(discoverer.getComponentType(), is(nullValue()));
+		assertThat(discoverer.getMapValueType(), is(nullValue()));
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void returnsNullForComponentAndValueTypesForRawCollections() {
+
+		TypeDiscoverer<Collection> discoverer = new TypeDiscoverer<Collection>(Collection.class, null);
+		assertThat(discoverer.getComponentType(), is(nullValue()));
+	}
+
+	/**
+	 * @see DATACMNS-167
+	 */
+	@Test
+	@SuppressWarnings("rawtypes")
+	public void doesNotConsiderTypeImplementingIterableACollection() {
+
+		TypeDiscoverer<Person> discoverer = new TypeDiscoverer<Person>(Person.class, null);
+		TypeInformation reference = ClassTypeInformation.from(Address.class);
+
+		TypeInformation<?> addresses = discoverer.getProperty("addresses");
+		assertThat(addresses.isCollectionLike(), is(false));
+		assertThat(addresses.getComponentType(), is(reference));
+
+		TypeInformation<?> adressIterable = discoverer.getProperty("addressIterable");
+		assertThat(adressIterable.isCollectionLike(), is(true));
+		assertThat(adressIterable.getComponentType(), is(reference));
+	}
+
+	class Person {
+
+		Addresses addresses;
+		Iterable<Address> addressIterable;
+	}
+
+	abstract class Addresses implements Iterable<Address> {
+
+	}
+
+	class Address {
+
+	}
+
+	class SelfReferencing {
+
+		Map<String, SelfReferencingMap> parent;
+	}
+
+	class SelfReferencingMap {
+		Map<String, SelfReferencingMap> map;
+	}
+
+	interface CustomMap extends Map<String, Locale> {
+
+	}
+
+	interface CustomCollection extends Collection<String> {
+
+	}
+
+	public static class GenericConstructors {
+
+		public GenericConstructors(List<String> first, Locale second) {
+
+		}
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/tests/sample/beans/TestBean.java
+++ b/spring-beans/src/test/java/org/springframework/tests/sample/beans/TestBean.java
@@ -492,7 +492,7 @@ public class TestBean implements BeanNameAware, BeanFactoryAware, ITestBean, IOt
 
 	@Override
 	public String toString() {
-		return this.name;
+		return String.format("TestBean [name : %s]", this.name);
 	}
 
 }


### PR DESCRIPTION
Introduced closed TypeInformation API from Spring Data Commons to enable carrying type 
information including generics through code and resolving injection points based on generic 
type references. Introduced method overloads in BeanFactory implementations using 
TypeInformation instead of Class to make sure we keep generics information of the injection 
point around.

Upgraded to Hamcrest 1.3 and introduced Mockito dependency in 1.8.5.

Issue: SPR-9965
