### PR TITLE
Fix MBeanServerFactoryBean tests failing on JDK 7

### DIFF
--- a/spring-context/src/test/java/org/springframework/jmx/support/MBeanServerFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/jmx/support/MBeanServerFactoryBeanTests.java
@@ -89,11 +89,16 @@ public class MBeanServerFactoryBeanTests extends TestCase {
 		MBeanServerFactoryBean bean = new MBeanServerFactoryBean();
 		bean.setAgentId("");
 		bean.afterPropertiesSet();
+		MBeanServer server = null;
 		try {
-			assertSame(ManagementFactory.getPlatformMBeanServer(), bean.getObject());
+			server = ManagementFactory.getPlatformMBeanServer();
+			assertSame(server, bean.getObject());
 		}
 		finally {
 			bean.destroy();
+			if (server != null) {
+				MBeanServerFactory.releaseMBeanServer(server);
+			}
 		}
 	}
 


### PR DESCRIPTION
Before this fix, an MBeanServerFactoryBean unit test would fail when
build is run on JDK 7. Root cause was found to be that another
MBeanServerFactoryBean unit test did not properly cleanup state after
it's execution.

This fix resolves the issue by cleaning up state of problematic unit
test.

Issue: SPR-10030
