### PR TITLE
AnnotationAwareOrderComparator now exposes INSTANCE constant.

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationAwareOrderComparator.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationAwareOrderComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2006 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,14 @@ import org.springframework.core.Ordered;
  * annotation value (if any).
  *
  * @author Juergen Hoeller
+ * @author Oliver Gierke
  * @since 2.0.1
  * @see org.springframework.core.Ordered
  * @see Order
  */
 public class AnnotationAwareOrderComparator extends OrderComparator {
+
+	public static AnnotationAwareOrderComparator INSTANCE = new AnnotationAwareOrderComparator();
 
 	@Override
 	protected int getOrder(Object obj) {

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationAwareOrderComparatorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationAwareOrderComparatorTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.core.annotation;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AnnotationAwareOrderComparator}.
+ * 
+ * @author Oliver Gierke
+ */
+public class AnnotationAwareOrderComparatorTests {
+
+	@Test
+	public void instanceVariableIsAnAnnotationAwareOrderComparator() {
+		assertThat(AnnotationAwareOrderComparator.INSTANCE, is(instanceOf(AnnotationAwareOrderComparator.class)));
+	}
+}


### PR DESCRIPTION
The INSTANCE constant you could refer to on
AnnotationAwareOrderComparator actually referred to the constant declared
in OrderAwareComparator. Thus AnnotationAwareOrderComparator.INSTANCE
did not actually return an AnnotationAwareOrderComparator but an
OrderAwareComparator only. This commit introduces a dedicated constant
on AnnotationAwareOrderComparator to avoid this glitch.

Issue: SPR-10038
