### PR TITLE
Rename MvcAsyncTask to WebAsyncTask

### DIFF
--- a/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/result/RequestResultMatchers.java
+++ b/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/result/RequestResultMatchers.java
@@ -28,7 +28,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.web.context.request.async.DeferredResult;
-import org.springframework.web.context.request.async.MvcAsyncTask;
+import org.springframework.web.context.request.async.WebAsyncTask;
 
 /**
  * Factory for assertions on the request. An instance of this class is
@@ -96,7 +96,7 @@ public class RequestResultMatchers {
 	/**
 	 * Assert the result from asynchronous processing.
 	 * This method can be used when a controller method returns {@link Callable}
-	 * or {@link MvcAsyncTask}. The value matched is the value returned from the
+	 * or {@link WebAsyncTask}. The value matched is the value returned from the
 	 * {@code Callable} or the exception raised.
 	 */
 	public <T> ResultMatcher asyncResult(final Object expectedResult) {

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncManager.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncManager.java
@@ -256,38 +256,38 @@ public final class WebAsyncManager {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void startCallableProcessing(final Callable<?> callable, Object... processingContext) {
 		Assert.notNull(callable, "Callable must not be null");
-		startCallableProcessing(new MvcAsyncTask(callable), processingContext);
+		startCallableProcessing(new WebAsyncTask(callable), processingContext);
 	}
 
 	/**
-	 * Use the given {@link MvcAsyncTask} to configure the task executor as well as
+	 * Use the given {@link WebAsyncTask} to configure the task executor as well as
 	 * the timeout value of the {@code AsyncWebRequest} before delegating to
 	 * {@link #startCallableProcessing(Callable, Object...)}.
 	 *
-	 * @param mvcAsyncTask an MvcAsyncTask containing the target {@code Callable}
+	 * @param webAsyncTask an WebAsyncTask containing the target {@code Callable}
 	 * @param processingContext additional context to save that can be accessed
 	 * via {@link #getConcurrentResultContext()}
 	 */
-	public void startCallableProcessing(final MvcAsyncTask<?> mvcAsyncTask, Object... processingContext) {
-		Assert.notNull(mvcAsyncTask, "MvcAsyncTask must not be null");
+	public void startCallableProcessing(final WebAsyncTask<?> webAsyncTask, Object... processingContext) {
+		Assert.notNull(webAsyncTask, "WebAsyncTask must not be null");
 		Assert.state(this.asyncWebRequest != null, "AsyncWebRequest must not be null");
 
-		Long timeout = mvcAsyncTask.getTimeout();
+		Long timeout = webAsyncTask.getTimeout();
 		if (timeout != null) {
 			this.asyncWebRequest.setTimeout(timeout);
 		}
 
-		AsyncTaskExecutor executor = mvcAsyncTask.getExecutor();
+		AsyncTaskExecutor executor = webAsyncTask.getExecutor();
 		if (executor != null) {
 			this.taskExecutor = executor;
 		}
 
 		List<CallableProcessingInterceptor> interceptors = new ArrayList<CallableProcessingInterceptor>();
-		interceptors.add(mvcAsyncTask.getInterceptor());
+		interceptors.add(webAsyncTask.getInterceptor());
 		interceptors.addAll(this.callableInterceptors.values());
 		interceptors.add(timeoutCallableInterceptor);
 
-		final Callable<?> callable = mvcAsyncTask.getCallable();
+		final Callable<?> callable = webAsyncTask.getCallable();
 		final CallableInterceptorChain interceptorChain = new CallableInterceptorChain(interceptors);
 
 		this.asyncWebRequest.addTimeoutHandler(new Runnable() {

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncTask.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncTask.java
@@ -28,7 +28,7 @@ import org.springframework.web.context.request.NativeWebRequest;
  * @author Rossen Stoyanchev
  * @since 3.2
  */
-public class MvcAsyncTask<V> {
+public class WebAsyncTask<V> {
 
 	private final Callable<V> callable;
 
@@ -46,43 +46,43 @@ public class MvcAsyncTask<V> {
 
 
 	/**
-	 * Create an {@code MvcAsyncTask} wrapping the given {@link Callable}.
+	 * Create an {@code WebAsyncTask} wrapping the given {@link Callable}.
 	 * @param callable the callable for concurrent handling
 	 */
-	public MvcAsyncTask(Callable<V> callable) {
+	public WebAsyncTask(Callable<V> callable) {
 		this(null, null, null, callable);
 	}
 
 	/**
-	 * Create an {@code MvcAsyncTask} with a timeout value and a {@link Callable}.
+	 * Create an {@code WebAsyncTask} with a timeout value and a {@link Callable}.
 	 * @param timeout timeout value in milliseconds
 	 * @param callable the callable for concurrent handling
 	 */
-	public MvcAsyncTask(long timeout, Callable<V> callable) {
+	public WebAsyncTask(long timeout, Callable<V> callable) {
 		this(timeout, null, null, callable);
 	}
 
 	/**
-	 * Create an {@code MvcAsyncTask} with a timeout value, an executor name, and a {@link Callable}.
+	 * Create an {@code WebAsyncTask} with a timeout value, an executor name, and a {@link Callable}.
 	 * @param timeout timeout value in milliseconds; ignored if {@code null}
 	 * @param callable the callable for concurrent handling
 	 */
-	public MvcAsyncTask(Long timeout, String executorName, Callable<V> callable) {
+	public WebAsyncTask(Long timeout, String executorName, Callable<V> callable) {
 		this(timeout, null, executorName, callable);
 		Assert.notNull(executor, "Executor name must not be null");
 	}
 
 	/**
-	 * Create an {@code MvcAsyncTask} with a timeout value, an executor instance, and a Callable.
+	 * Create an {@code WebAsyncTask} with a timeout value, an executor instance, and a Callable.
 	 * @param timeout timeout value in milliseconds; ignored if {@code null}
 	 * @param callable the callable for concurrent handling
 	 */
-	public MvcAsyncTask(Long timeout, AsyncTaskExecutor executor, Callable<V> callable) {
+	public WebAsyncTask(Long timeout, AsyncTaskExecutor executor, Callable<V> callable) {
 		this(timeout, executor, null, callable);
 		Assert.notNull(executor, "Executor must not be null");
 	}
 
-	private MvcAsyncTask(Long timeout, AsyncTaskExecutor executor, String executorName, Callable<V> callable) {
+	private WebAsyncTask(Long timeout, AsyncTaskExecutor executor, String executorName, Callable<V> callable) {
 		Assert.notNull(callable, "Callable must not be null");
 		this.callable = callable;
 		this.timeout = timeout;
@@ -123,7 +123,7 @@ public class MvcAsyncTask<V> {
 
 	/**
 	 * A {@link BeanFactory} to use to resolve an executor name. Applications are
-	 * not expected to have to set this property when {@code MvcAsyncTask} is used in a
+	 * not expected to have to set this property when {@code WebAsyncTask} is used in a
 	 * Spring MVC controller.
 	 */
 	public void setBeanFactory(BeanFactory beanFactory) {

--- a/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTests.java
@@ -244,7 +244,7 @@ public class WebAsyncManagerTests {
 		replay(this.asyncWebRequest);
 
 		@SuppressWarnings("unchecked")
-		MvcAsyncTask<Object> asyncTask = new MvcAsyncTask<Object>(1000L, executor, createMock(Callable.class));
+		WebAsyncTask<Object> asyncTask = new WebAsyncTask<Object>(1000L, executor, createMock(Callable.class));
 		this.asyncManager.startCallableProcessing(asyncTask);
 
 		verify(executor, this.asyncWebRequest);

--- a/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTimeoutTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTimeoutTests.java
@@ -101,14 +101,14 @@ public class WebAsyncManagerTimeoutTests {
 	public void startCallableProcessingTimeoutAndResumeThroughCallback() throws Exception {
 
 		StubCallable callable = new StubCallable();
-		MvcAsyncTask<Object> mvcAsyncTask = new MvcAsyncTask<Object>(callable);
-		mvcAsyncTask.onTimeout(new Callable<Object>() {
+		WebAsyncTask<Object> webAsyncTask = new WebAsyncTask<Object>(callable);
+		webAsyncTask.onTimeout(new Callable<Object>() {
 			public Object call() throws Exception {
 				return 7;
 			}
 		});
 
-		this.asyncManager.startCallableProcessing(mvcAsyncTask);
+		this.asyncManager.startCallableProcessing(webAsyncTask);
 
 		this.asyncWebRequest.onTimeout(ASYNC_EVENT);
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/AsyncSupportConfigurer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/AsyncSupportConfigurer.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Callable;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.util.Assert;
-import org.springframework.web.context.request.async.MvcAsyncTask;
+import org.springframework.web.context.request.async.WebAsyncTask;
 import org.springframework.web.context.request.async.CallableProcessingInterceptor;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.context.request.async.DeferredResultProcessingInterceptor;
@@ -50,7 +50,7 @@ public class AsyncSupportConfigurer {
 	/**
 	 * Set the default {@link AsyncTaskExecutor} to use when a controller method
 	 * returns a {@link Callable}. Controller methods can override this default on
-	 * a per-request basis by returning an {@link MvcAsyncTask}.
+	 * a per-request basis by returning an {@link WebAsyncTask}.
 	 *
 	 * <p>By default a {@link SimpleAsyncTaskExecutor} instance is used and it's
 	 * highly recommended to change that default in production since the simple

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AsyncTaskMethodReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AsyncTaskMethodReturnValueHandler.java
@@ -19,13 +19,13 @@ package org.springframework.web.servlet.mvc.method.annotation;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.context.request.async.MvcAsyncTask;
+import org.springframework.web.context.request.async.WebAsyncTask;
 import org.springframework.web.context.request.async.WebAsyncUtils;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
- * Handles return values of type {@link MvcAsyncTask}.
+ * Handles return values of type {@link WebAsyncTask}.
  *
  * @author Rossen Stoyanchev
  * @since 3.2
@@ -41,7 +41,7 @@ public class AsyncTaskMethodReturnValueHandler implements HandlerMethodReturnVal
 
 	public boolean supportsReturnType(MethodParameter returnType) {
 		Class<?> paramType = returnType.getParameterType();
-		return MvcAsyncTask.class.isAssignableFrom(paramType);
+		return WebAsyncTask.class.isAssignableFrom(paramType);
 	}
 
 	public void handleReturnValue(Object returnValue,
@@ -53,9 +53,9 @@ public class AsyncTaskMethodReturnValueHandler implements HandlerMethodReturnVal
 			return;
 		}
 
-		MvcAsyncTask<?> mvcAsyncTask = (MvcAsyncTask<?>) returnValue;
-		mvcAsyncTask.setBeanFactory(this.beanFactory);
-		WebAsyncUtils.getAsyncManager(webRequest).startCallableProcessing(mvcAsyncTask, mavContainer);
+		WebAsyncTask<?> webAsyncTask = (WebAsyncTask<?>) returnValue;
+		webAsyncTask.setBeanFactory(this.beanFactory);
+		WebAsyncUtils.getAsyncManager(webRequest).startCallableProcessing(webAsyncTask, mavContainer);
 	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -63,7 +63,7 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.context.request.async.MvcAsyncTask;
+import org.springframework.web.context.request.async.WebAsyncTask;
 import org.springframework.web.context.request.async.AsyncWebRequest;
 import org.springframework.web.context.request.async.CallableProcessingInterceptor;
 import org.springframework.web.context.request.async.DeferredResultProcessingInterceptor;
@@ -348,7 +348,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter i
 	/**
 	 * Set the default {@link AsyncTaskExecutor} to use when a controller method
 	 * return a {@link Callable}. Controller methods can override this default on
-	 * a per-request basis by returning an {@link MvcAsyncTask}.
+	 * a per-request basis by returning an {@link WebAsyncTask}.
 	 * <p>By default a {@link SimpleAsyncTaskExecutor} instance is used.
 	 * It's recommended to change that default in production as the simple executor
 	 * does not re-use threads.


### PR DESCRIPTION
The name MvcAsyncTask is misleading because the class is part of Spring
Web as apposed to Spring MVC. This is also inconsistent with the other
async classes which use Web instead of Mvc.

This commit changes MvcAsyncTask to WebAsyncTask making it more
consistent with the jar it is found in and the other async classes.

Issue: SPR-10051
