### PR TITLE
Add beforeConcurrentHandling support

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/async/CallableInterceptorChain.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/CallableInterceptorChain.java
@@ -26,6 +26,7 @@ import org.springframework.web.context.request.NativeWebRequest;
  * Assists with the invocation of {@link CallableProcessingInterceptor}'s.
  *
  * @author Rossen Stoyanchev
+ * @author Rob Winch
  * @since 3.2
  */
 class CallableInterceptorChain {
@@ -39,6 +40,12 @@ class CallableInterceptorChain {
 
 	public CallableInterceptorChain(List<CallableProcessingInterceptor> interceptors) {
 		this.interceptors = interceptors;
+	}
+
+	public void applyBeforeConcurrentHandling(NativeWebRequest request, Callable<?> task) throws Exception {
+		for (CallableProcessingInterceptor interceptor : this.interceptors) {
+			interceptor.beforeConcurrentHandling(request, task);
+		}
 	}
 
 	public void applyPreProcess(NativeWebRequest request, Callable<?> task) throws Exception {

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptor.java
@@ -39,6 +39,7 @@ import org.springframework.web.context.request.NativeWebRequest;
  * can select a value to be used to resume processing.
  *
  * @author Rossen Stoyanchev
+ * @author Rob Winch
  * @since 3.2
  */
 public interface CallableProcessingInterceptor {
@@ -47,6 +48,24 @@ public interface CallableProcessingInterceptor {
 
 	static final Object RESPONSE_HANDLED = new Object();
 
+	/**
+	 * Invoked <em>before</em> the start of concurrent handling in the original
+	 * thread in which the {@code Callable} is submitted for concurrent handling.
+	 *
+	 * <p>
+	 * This is useful for capturing the state of the current thread just prior to
+	 * invoking the {@link Callable}. Once the state is captured, it can then be
+	 * transfered to the new {@link Thread} in
+	 * {@link #preProcess(NativeWebRequest, Callable)}. Capturing the state of
+	 * Spring Security's SecurityContextHolder and migrating it to the new Thread
+	 * is a concrete example of where this is useful.
+	 * </p>
+	 *
+	 * @param request the current request
+	 * @param task the task for the current async request
+	 * @throws Exception in case of errors
+	 */
+	<T> void  beforeConcurrentHandling(NativeWebRequest request, Callable<T> task) throws Exception;
 
 	/**
 	 * Invoked <em>after</em> the start of concurrent handling in the async

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptorAdapter.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptorAdapter.java
@@ -24,9 +24,16 @@ import org.springframework.web.context.request.NativeWebRequest;
  * for simplified implementation of individual methods.
  *
  * @author Rossen Stoyanchev
+ * @author Rob Winch
  * @since 3.2
  */
 public abstract class CallableProcessingInterceptorAdapter implements CallableProcessingInterceptor {
+
+	/**
+	 * This implementation is empty.
+	 */
+	public <T> void beforeConcurrentHandling(NativeWebRequest request, Callable<T> task) throws Exception {
+	}
 
 	/**
 	 * This implementation is empty.

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncManager.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncManager.java
@@ -308,6 +308,14 @@ public final class WebAsyncManager {
 
 		startAsyncProcessing(processingContext);
 
+		try {
+			interceptorChain.applyBeforeConcurrentHandling(asyncWebRequest, callable);
+		}
+		catch (Throwable t) {
+			setConcurrentResultAndDispatch(t);
+			return;
+		}
+
 		this.taskExecutor.submit(new Runnable() {
 			public void run() {
 				Object result = null;

--- a/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTests.java
@@ -118,6 +118,7 @@ public class WebAsyncManagerTests {
 		Callable<Object> task = new StubCallable(concurrentResult);
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, task);
 		interceptor.preProcess(this.asyncWebRequest, task);
 		interceptor.postProcess(this.asyncWebRequest, task, new Integer(concurrentResult));
 		replay(interceptor);
@@ -140,6 +141,7 @@ public class WebAsyncManagerTests {
 		Callable<Object> task = new StubCallable(concurrentResult);
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, task);
 		interceptor.preProcess(this.asyncWebRequest, task);
 		interceptor.postProcess(this.asyncWebRequest, task, concurrentResult);
 		replay(interceptor);
@@ -156,12 +158,34 @@ public class WebAsyncManagerTests {
 	}
 
 	@Test
+	public void startCallableProcessingBeforeConcurrentHandlingException() throws Exception {
+		Callable<Object> task = new StubCallable(21);
+		Exception exception = new Exception();
+
+		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, task);
+		expectLastCall().andThrow(exception);
+		replay(interceptor);
+
+		setupDefaultAsyncScenario();
+
+		this.asyncManager.registerCallableInterceptor("interceptor", interceptor);
+		this.asyncManager.startCallableProcessing(task);
+
+		assertTrue(this.asyncManager.hasConcurrentResult());
+		assertEquals(exception, this.asyncManager.getConcurrentResult());
+
+		verify(interceptor, this.asyncWebRequest);
+	}
+
+	@Test
 	public void startCallableProcessingPreProcessException() throws Exception {
 
 		Callable<Object> task = new StubCallable(21);
 		Exception exception = new Exception();
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, task);
 		interceptor.preProcess(this.asyncWebRequest, task);
 		expectLastCall().andThrow(exception);
 		replay(interceptor);
@@ -184,6 +208,7 @@ public class WebAsyncManagerTests {
 		Exception exception = new Exception();
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, task);
 		interceptor.preProcess(this.asyncWebRequest, task);
 		interceptor.postProcess(this.asyncWebRequest, task, 21);
 		expectLastCall().andThrow(exception);
@@ -207,11 +232,13 @@ public class WebAsyncManagerTests {
 		Exception exception = new Exception();
 
 		CallableProcessingInterceptor interceptor1 = createMock(CallableProcessingInterceptor.class);
+		interceptor1.beforeConcurrentHandling(this.asyncWebRequest, task);
 		interceptor1.preProcess(this.asyncWebRequest, task);
 		interceptor1.postProcess(this.asyncWebRequest, task, 21);
 		replay(interceptor1);
 
 		CallableProcessingInterceptor interceptor2 = createMock(CallableProcessingInterceptor.class);
+		interceptor2.beforeConcurrentHandling(this.asyncWebRequest, task);
 		interceptor2.preProcess(this.asyncWebRequest, task);
 		interceptor2.postProcess(this.asyncWebRequest, task, 21);
 		expectLastCall().andThrow(exception);

--- a/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTimeoutTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTimeoutTests.java
@@ -80,6 +80,7 @@ public class WebAsyncManagerTimeoutTests {
 		StubCallable callable = new StubCallable();
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, callable);
 		expect(interceptor.handleTimeout(this.asyncWebRequest, callable)).andReturn(RESULT_NONE);
 		interceptor.afterCompletion(this.asyncWebRequest, callable);
 		replay(interceptor);
@@ -123,6 +124,7 @@ public class WebAsyncManagerTimeoutTests {
 		StubCallable callable = new StubCallable();
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, callable);
 		expect(interceptor.handleTimeout(this.asyncWebRequest, callable)).andReturn(22);
 		replay(interceptor);
 
@@ -145,6 +147,7 @@ public class WebAsyncManagerTimeoutTests {
 		Exception exception = new Exception();
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, callable);
 		expect(interceptor.handleTimeout(this.asyncWebRequest, callable)).andThrow(exception);
 		replay(interceptor);
 


### PR DESCRIPTION
Previously it CallableProcessingInterceptor did not have support for
capturing the state of the original Thread just prior to processing.
This made it difficult to transfer the state of one Thread (i.e.
ThreadLocal) to the Thread used to process the Callable.

This commit adds a new method to CallableProcessingInterceptor named
beforeConcurrentHandling which will be invoked on the original Thread
used to submit the Callable just prior to the Callable being submitted
for processing. This means the state of the original Thread can be
captured in beforeConcurrentHandling and transfered to the new Thread
in preProcess.

Issue: SPR-10052
