### PR TITLE
Update spring-web/src/main/java/org/springframework/http/converter/Strin...

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/StringHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/StringHttpMessageConverter.java
@@ -41,7 +41,7 @@ import org.springframework.util.FileCopyUtils;
  */
 public class StringHttpMessageConverter extends AbstractHttpMessageConverter<String> {
 
-	public static final Charset DEFAULT_CHARSET = Charset.forName("ISO-8859-1");
+	public static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
 
 	private final Charset defaultCharset;
 


### PR DESCRIPTION
...gHttpMessageConverter.java

Change the default charset from "ISO-8859-1" to "UTF-8" in the class StringHttpMessageConverter.
Because if response body has Chinese, there will have Garbage characters.
