### PR TITLE
Add beforeConcurrentHandling support

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/async/CallableInterceptorChain.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/CallableInterceptorChain.java
@@ -26,6 +26,7 @@ import org.springframework.web.context.request.NativeWebRequest;
  * Assists with the invocation of {@link CallableProcessingInterceptor}'s.
  *
  * @author Rossen Stoyanchev
+ * @author Rob Winch
  * @since 3.2
  */
 class CallableInterceptorChain {
@@ -39,6 +40,12 @@ class CallableInterceptorChain {
 
 	public CallableInterceptorChain(List<CallableProcessingInterceptor> interceptors) {
 		this.interceptors = interceptors;
+	}
+
+	public void applyBeforeConcurrentHandling(NativeWebRequest request, Callable<?> task) throws Exception {
+		for (CallableProcessingInterceptor interceptor : this.interceptors) {
+			interceptor.beforeConcurrentHandling(request, task);
+		}
 	}
 
 	public void applyPreProcess(NativeWebRequest request, Callable<?> task) throws Exception {

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptor.java
@@ -39,6 +39,7 @@ import org.springframework.web.context.request.NativeWebRequest;
  * can select a value to be used to resume processing.
  *
  * @author Rossen Stoyanchev
+ * @author Rob Winch
  * @since 3.2
  */
 public interface CallableProcessingInterceptor {
@@ -47,6 +48,24 @@ public interface CallableProcessingInterceptor {
 
 	static final Object RESPONSE_HANDLED = new Object();
 
+	/**
+	 * Invoked <em>before</em> the start of concurrent handling in the original
+	 * thread in which the {@code Callable} is submitted for concurrent handling.
+	 *
+	 * <p>
+	 * This is useful for capturing the state of the current thread just prior to
+	 * invoking the {@link Callable}. Once the state is captured, it can then be
+	 * transfered to the new {@link Thread} in
+	 * {@link #preProcess(NativeWebRequest, Callable)}. Capturing the state of
+	 * Spring Security's SecurityContextHolder and migrating it to the new Thread
+	 * is a concrete example of where this is useful.
+	 * </p>
+	 *
+	 * @param request the current request
+	 * @param task the task for the current async request
+	 * @throws Exception in case of errors
+	 */
+	<T> void  beforeConcurrentHandling(NativeWebRequest request, Callable<T> task) throws Exception;
 
 	/**
 	 * Invoked <em>after</em> the start of concurrent handling in the async

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptorAdapter.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptorAdapter.java
@@ -24,9 +24,16 @@ import org.springframework.web.context.request.NativeWebRequest;
  * for simplified implementation of individual methods.
  *
  * @author Rossen Stoyanchev
+ * @author Rob Winch
  * @since 3.2
  */
 public abstract class CallableProcessingInterceptorAdapter implements CallableProcessingInterceptor {
+
+	/**
+	 * This implementation is empty.
+	 */
+	public <T> void beforeConcurrentHandling(NativeWebRequest request, Callable<T> task) throws Exception {
+	}
 
 	/**
 	 * This implementation is empty.

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/DeferredResultInterceptorChain.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/DeferredResultInterceptorChain.java
@@ -40,6 +40,12 @@ class DeferredResultInterceptorChain {
 		this.interceptors = interceptors;
 	}
 
+	public void applyBeforeConcurrentHandling(NativeWebRequest request, DeferredResult<?> deferredResult) throws Exception {
+		for (DeferredResultProcessingInterceptor interceptor : this.interceptors) {
+			interceptor.beforeConcurrentHandling(request, deferredResult);
+		}
+	}
+
 	public void applyPreProcess(NativeWebRequest request, DeferredResult<?> deferredResult) throws Exception {
 		for (DeferredResultProcessingInterceptor interceptor : this.interceptors) {
 			interceptor.preProcess(request, deferredResult);

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/DeferredResultProcessingInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/DeferredResultProcessingInterceptor.java
@@ -36,9 +36,21 @@ import org.springframework.web.context.request.NativeWebRequest;
  * method can set the {@code DeferredResult} in order to resume processing.
  *
  * @author Rossen Stoyanchev
+ * @author Rob Winch
  * @since 3.2
  */
 public interface DeferredResultProcessingInterceptor {
+
+	/**
+	 * Invoked immediately before the start of concurrent handling, in the same
+	 * thread that started it. This method may be used to capture state just prior
+	 * to the start of concurrent processing with the given {@code DeferredResult}.
+	 *
+	 * @param request the current request
+	 * @param deferredResult the DeferredResult for the current request
+	 * @throws Exception in case of errors
+	 */
+	<T> void  beforeConcurrentHandling(NativeWebRequest request, DeferredResult<T> deferredResult) throws Exception;
 
 	/**
 	 * Invoked immediately after the start of concurrent handling, in the same

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/DeferredResultProcessingInterceptorAdapter.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/DeferredResultProcessingInterceptorAdapter.java
@@ -22,9 +22,16 @@ import org.springframework.web.context.request.NativeWebRequest;
  * interface for simplified implementation of individual methods.
  *
  * @author Rossen Stoyanchev
+ * @author Rob Winch
  * @since 3.2
  */
 public abstract class DeferredResultProcessingInterceptorAdapter implements DeferredResultProcessingInterceptor {
+
+	/**
+	 * This implementation is empty.
+	 */
+	public <T> void beforeConcurrentHandling(NativeWebRequest request, DeferredResult<T> deferredResult) throws Exception {
+	}
 
 	/**
 	 * This implementation is empty.

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncManager.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncManager.java
@@ -249,12 +249,13 @@ public final class WebAsyncManager {
 	 * @param callable a unit of work to be executed asynchronously
 	 * @param processingContext additional context to save that can be accessed
 	 * via {@link #getConcurrentResultContext()}
+	 * @throws Exception If concurrent processing failed to start
 	 *
 	 * @see #getConcurrentResult()
 	 * @see #getConcurrentResultContext()
 	 */
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public void startCallableProcessing(final Callable<?> callable, Object... processingContext) {
+	public void startCallableProcessing(final Callable<?> callable, Object... processingContext) throws Exception {
 		Assert.notNull(callable, "Callable must not be null");
 		startCallableProcessing(new MvcAsyncTask(callable), processingContext);
 	}
@@ -267,8 +268,9 @@ public final class WebAsyncManager {
 	 * @param mvcAsyncTask an MvcAsyncTask containing the target {@code Callable}
 	 * @param processingContext additional context to save that can be accessed
 	 * via {@link #getConcurrentResultContext()}
+	 * @throws Exception If concurrent processing failed to start
 	 */
-	public void startCallableProcessing(final MvcAsyncTask<?> mvcAsyncTask, Object... processingContext) {
+	public void startCallableProcessing(final MvcAsyncTask<?> mvcAsyncTask, Object... processingContext) throws Exception {
 		Assert.notNull(mvcAsyncTask, "MvcAsyncTask must not be null");
 		Assert.state(this.asyncWebRequest != null, "AsyncWebRequest must not be null");
 
@@ -305,6 +307,8 @@ public final class WebAsyncManager {
 				interceptorChain.triggerAfterCompletion(asyncWebRequest, callable);
 			}
 		});
+
+		interceptorChain.applyBeforeConcurrentHandling(asyncWebRequest, callable);
 
 		startAsyncProcessing(processingContext);
 
@@ -356,12 +360,13 @@ public final class WebAsyncManager {
 	 * @param deferredResult the DeferredResult instance to initialize
 	 * @param processingContext additional context to save that can be accessed
 	 * via {@link #getConcurrentResultContext()}
+	 * @throws Exception If concurrent processing failed to start
 	 *
 	 * @see #getConcurrentResult()
 	 * @see #getConcurrentResultContext()
 	 */
 	public void startDeferredResultProcessing(
-			final DeferredResult<?> deferredResult, Object... processingContext) {
+			final DeferredResult<?> deferredResult, Object... processingContext) throws Exception {
 
 		Assert.notNull(deferredResult, "DeferredResult must not be null");
 		Assert.state(this.asyncWebRequest != null, "AsyncWebRequest must not be null");
@@ -394,6 +399,8 @@ public final class WebAsyncManager {
 				interceptorChain.triggerAfterCompletion(asyncWebRequest, deferredResult);
 			}
 		});
+
+		interceptorChain.applyBeforeConcurrentHandling(asyncWebRequest, deferredResult);
 
 		startAsyncProcessing(processingContext);
 

--- a/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTimeoutTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/async/WebAsyncManagerTimeoutTests.java
@@ -80,6 +80,7 @@ public class WebAsyncManagerTimeoutTests {
 		StubCallable callable = new StubCallable();
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, callable);
 		expect(interceptor.handleTimeout(this.asyncWebRequest, callable)).andReturn(RESULT_NONE);
 		interceptor.afterCompletion(this.asyncWebRequest, callable);
 		replay(interceptor);
@@ -123,6 +124,7 @@ public class WebAsyncManagerTimeoutTests {
 		StubCallable callable = new StubCallable();
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, callable);
 		expect(interceptor.handleTimeout(this.asyncWebRequest, callable)).andReturn(22);
 		replay(interceptor);
 
@@ -145,6 +147,7 @@ public class WebAsyncManagerTimeoutTests {
 		Exception exception = new Exception();
 
 		CallableProcessingInterceptor interceptor = createStrictMock(CallableProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, callable);
 		expect(interceptor.handleTimeout(this.asyncWebRequest, callable)).andThrow(exception);
 		replay(interceptor);
 
@@ -166,6 +169,7 @@ public class WebAsyncManagerTimeoutTests {
 		DeferredResult<Integer> deferredResult = new DeferredResult<Integer>();
 
 		DeferredResultProcessingInterceptor interceptor = createStrictMock(DeferredResultProcessingInterceptor.class);
+		interceptor.beforeConcurrentHandling(this.asyncWebRequest, deferredResult);
 		interceptor.preProcess(this.asyncWebRequest, deferredResult);
 		expect(interceptor.handleTimeout(this.asyncWebRequest, deferredResult)).andReturn(true);
 		interceptor.afterCompletion(this.asyncWebRequest, deferredResult);


### PR DESCRIPTION
Previously CallableProcessingInterceptor and
DeferredResultProcessingInterceptor did not have support for capturing
the state of the original Thread just prior to processing. This made it
difficult to transfer the state of one Thread (i.e. ThreadLocal) to the
Thread used to process the Callable.

This commit adds a new method to CallableProcessingInterceptor and
DeferredResultProcessingInterceptor named beforeConcurrentHandling
which will be invoked on the original Thread used to submit the Callable
or DeferredResult. This means the state of the original Thread can be
captured in beforeConcurrentHandling and transfered to the new Thread
in preProcess.

Issue: SPR-10052
