### PR TITLE
Make spring-aspects depend on aspectjweaver instead of aspectjrt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -645,7 +645,7 @@ project('spring-aspects') {
         compile(project(":spring-orm"), optional) // for JPA exception translation support
         aspects project(":spring-orm")
         ajc "org.aspectj:aspectjtools:${aspectjVersion}"
-        compile "org.aspectj:aspectjrt:${aspectjVersion}"
+        compile "org.aspectj:aspectjweaver:${aspectjVersion}"
         testCompile project(":spring-core") // for CodeStyleAspect
         compile project(":spring-beans") // for 'p' namespace visibility
         testCompile project(":spring-test")


### PR DESCRIPTION
aspectjrt is a subset of aspectjweaver & without the weaver jar aspects do not work.
As issue SPR-8896 is fixed this should also be reflected in the pom.

Issue: SPR-10072 "POM of spring-aspects should have a dependency on aspectjweaver and not aspectjrt"

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
