### PR TITLE
Fix excludes from configrations in merge-artifacts.gradle and make jcl-over-slf4j excludes more concise

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ configure(allprojects) {
         maven { url "http://repo.springsource.org/ebr-maven-external" }
     }
 
+    configurations.all*.exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
+
     dependencies {
         testCompile "org.hamcrest:hamcrest-all:1.3"
         testCompile "org.easymock:easymock:${easymockVersion}"
@@ -473,18 +475,9 @@ project('spring-webmvc') {
         compile(project(":spring-context-support"), optional) // for Velocity support
         compile(project(":spring-oxm"), optional) // for MarshallingView
         compile("org.apache.tiles:tiles-api:2.1.2", optional)
-        compile("org.apache.tiles:tiles-core:2.1.2") { dep ->
-            optional dep
-            exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
-        }
-        compile("org.apache.tiles:tiles-jsp:2.1.2") { dep ->
-            optional dep
-            exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
-        }
-        compile("org.apache.tiles:tiles-servlet:2.1.2") { dep ->
-            optional dep
-            exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
-        }
+        compile("org.apache.tiles:tiles-core:2.1.2", optional)
+        compile("org.apache.tiles:tiles-jsp:2.1.2", optional)
+        compile("org.apache.tiles:tiles-servlet:2.1.2", optional)
         compile("velocity-tools:velocity-tools-view:1.4", optional)
         compile("net.sourceforge.jexcelapi:jxl:2.6.3") { dep ->
             optional dep
@@ -531,18 +524,9 @@ project('spring-webmvc-tiles3') {
             optional dep
             exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
         }
-        compile("org.apache.tiles:tiles-servlet:3.0.1") { dep ->
-            optional dep
-            exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
-        }
-        compile("org.apache.tiles:tiles-jsp:3.0.1") { dep ->
-            optional dep
-            exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
-        }
-        compile("org.apache.tiles:tiles-el:3.0.1") { dep ->
-            optional dep
-            exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
-        }
+        compile("org.apache.tiles:tiles-servlet:3.0.1", optional)
+        compile("org.apache.tiles:tiles-jsp:3.0.1", optional)
+        compile("org.apache.tiles:tiles-el:3.0.1", optional)
         compile("org.apache.tomcat:tomcat-servlet-api:7.0.32", provided) // servlet-api 3.0
         compile project(":spring-web").sourceSets*.output // mock request & response
     }
@@ -621,9 +605,7 @@ project('spring-test-mvc') {
         testCompile("org.apache.tiles:tiles-core:3.0.1") {
             exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
         }
-        testCompile("org.apache.tiles:tiles-servlet:3.0.1") {
-            exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
-        }
+        testCompile "org.apache.tiles:tiles-servlet:3.0.1"
     }
 }
 

--- a/gradle/merge-artifacts.gradle
+++ b/gradle/merge-artifacts.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.artifacts.ExcludeRule
+
 /**
  * Will merge the artifacts of the current project into mergeIntoProject. For example, to
  * bundle spring-test-mvc in spring-test's jars. This script will perform the following
@@ -50,7 +52,11 @@ gradle.taskGraph.whenReady {
         def mapping = mergeFromProject.conf2ScopeMappings.getMapping([config])
         if(mapping.scope) {
             def newConfigName = mergeFromProject.name + "-"+ config.name
-            mergeIntoProject.configurations.add(newConfigName)
+            def newConfig = mergeIntoProject.configurations.add(newConfigName)
+            config.excludeRules.each { excludeRule ->
+                def excludeProperties = [(ExcludeRule.GROUP_KEY) : excludeRule.group, (ExcludeRule.MODULE_KEY) : excludeRule.module]
+                newConfig.exclude(excludeProperties)
+            }
             config.dependencies.each { dependency ->
                 mergeIntoProject.dependencies.add(newConfigName, dependency)
             }


### PR DESCRIPTION
The overall goal of the two commits in this pull request is to make jcl-over-sl4j excludes more concise. 
- In order to do this, a fix to merge-artifacts.gradle was made which ensures exclude rules were transfered from mergeFromProject to mergeIntoProject.
- Then we were able to exclude jcl-over-slf4j using excludes in the configurations instead of on each individual module.
