### PR TITLE
Add jdk6Test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,17 @@ configure(allprojects) {
 		testCompile("org.hamcrest:hamcrest-all:1.3")
 		testCompile("org.easymock:easymock:${easymockVersion}")
 	}
+
+	if(project.hasProperty("jdk6Home")) {
+		task jdk6Test(type: Test, dependsOn: test) {
+			testClassesDir = test.testClassesDir
+			classpath  = test.classpath
+			executable = "${jdk6Home}/bin/java"
+			testReportDir = project.file("${project.buildDir}/reports-jdk6/")
+			testResultsDir = project.file("${project.buildDir}/test-results-jdk6/")
+		}
+		check.dependsOn jdk6Test
+	}
 }
 
 configure(subprojects) { subproject ->
@@ -251,7 +262,7 @@ project("spring-context") {
 		testCompile("javax.inject:com.springsource.org.atinject.tck:1.0.0")
 	}
 
-	test {
+	project.tasks.withType(Test) {
 		jvmArgs = ["-disableassertions:org.aspectj.weaver.UnresolvedType"] // SPR-7989
 	}
 }


### PR DESCRIPTION
# Note about the commit

If someone does not have jdk6Home configured the tests will be skipped. This may not be ideal, but I felt it was better than requiring local developers configure the property. If this is not the case, let me know and I can make jdk6Home a required property so that we can always run the jdk6Test task.

/cc @cbeams @jhoeller @philwebb
# Commit Message

Previously the build was unable to build against JDK 7, test against
JDK 7, and test against JDK 6.

This commit allows setting of a gradle property [1] named jdk6Home.
Upon setting the jdk6Home property tests will be ran against JDK 6 as
well. One option for setting the property is to include jdk6Home
property in ~/.gradle/gradle.properties. For example the content of
the file might look like:

```
jdk6Home=jdk6Home=/usr/lib/jvm/jdk1.6.0_32
```

An alternative is configure jdk6Home from the commandline as shown below:

```
gradle build -Pjdk6Home=/usr/lib/jvm/jdk1.6.0_32
```

[1] http://gradle.org/docs/current/userguide/tutorial_this_and_that.html#sec:gradle_properties_and_system_properties
