### PR TITLE
Rm buildSrc/src/main/groovy from Eclipse Sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -690,14 +690,6 @@ configure(rootProject) {
 	apply plugin: "groovy"
 	apply from: "${gradleScriptDir}/jdiff.gradle"
 
-	eclipse.classpath.file.whenMerged { classpath ->
-		def sourceFolder = new org.gradle.plugins.ide.eclipse.model.SourceFolder(
-			"buildSrc/src/main/groovy", null)
-		if(!classpath.entries.contains(sourceFolder)) {
-			classpath.entries.add(0, sourceFolder)
-		}
-	}
-
 	reference {
 		sourceDir = file("src/reference/docbook")
 		pdfFilename = "spring-framework-reference.pdf"


### PR DESCRIPTION
Previously buildSrc/src/main/groovy was a source folder within Eclipse.
This caused build errors due to missing dependencies for Gradle.

This commit removes buildSrc/src/main/groovy from the source folders
within Eclipse to prevent errors from being displayed.
