### PR TITLE
Fixed JavaDoc for MockRestServiceServer

### DIFF
--- a/spring-test-mvc/src/main/java/org/springframework/test/web/client/MockRestServiceServer.java
+++ b/spring-test-mvc/src/main/java/org/springframework/test/web/client/MockRestServiceServer.java
@@ -50,6 +50,7 @@ import org.springframework.web.client.support.RestGatewaySupport;
  * &#47;&#47; Use the hotel instance...
  *
  * mockServer.verify();
+ * </pre>
  *
  * <p>To create an instance of this class, use {@link #createServer(RestTemplate)}
  * and provide the {@code RestTemplate} to set up for the mock testing.


### PR DESCRIPTION
The JavaDoc for MockRestServiceServer was improperly showing fixed-space font following a code example because the &lt;pre&gt; element didn't have a closing tag. I added a closing &lt;/pre&gt; tag to fix.
