### PR TITLE
Mark all IsFastEnough tests as performance tests

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/bind/ServletRequestUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/ServletRequestUtilsTests.java
@@ -388,6 +388,7 @@ public class ServletRequestUtilsTests {
 
 	@Test
 	public void testGetIntParameterWithDefaultValueHandlingIsFastEnough() {
+		Assume.group(TestGroup.PERFORMANCE);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		StopWatch sw = new StopWatch();
 		sw.start();


### PR DESCRIPTION
This patch marks remaining/missed tests as ones belonging to
performance tests group.

Issue: SPR-9984
