### PR TITLE
Use parameter names during MBeanInfo assembly

### DIFF
--- a/spring-context/src/main/java/org/springframework/jmx/export/assembler/MetadataMBeanInfoAssembler.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/assembler/MetadataMBeanInfoAssembler.java
@@ -256,7 +256,7 @@ public class MetadataMBeanInfoAssembler extends AbstractReflectiveMBeanInfoAssem
 	protected MBeanParameterInfo[] getOperationParameters(Method method, String beanKey) {
 		ManagedOperationParameter[] params = this.attributeSource.getManagedOperationParameters(method);
 		if (params == null || params.length == 0) {
-			return new MBeanParameterInfo[0];
+			return super.getOperationParameters(method, beanKey);
 		}
 
 		MBeanParameterInfo[] parameterInfo = new MBeanParameterInfo[params.length];

--- a/spring-context/src/test/java/org/springframework/jmx/export/assembler/MethodNameBasedMBeanInfoAssemblerTests.java
+++ b/spring-context/src/test/java/org/springframework/jmx/export/assembler/MethodNameBasedMBeanInfoAssemblerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.jmx.export.assembler;
 
+import javax.management.MBeanOperationInfo;
 import javax.management.modelmbean.ModelMBeanAttributeInfo;
 import javax.management.modelmbean.ModelMBeanInfo;
 
@@ -54,6 +55,13 @@ public class MethodNameBasedMBeanInfoAssemblerTests extends AbstractJmxAssembler
 
 		assertTrue(attr.isReadable());
 		assertFalse(attr.isWritable());
+	}
+	
+	public void testSetNameParameterIsNamed() throws Exception {
+		ModelMBeanInfo info = getMBeanInfoFromAssembler();
+
+		MBeanOperationInfo operationSetAge = info.getOperation("setName");
+		assertEquals("name", operationSetAge.getSignature()[0].getName());
 	}
 
 	@Override


### PR DESCRIPTION
MBean parameter names behaviour - should use class debug info
(LocalVariableTable) when available to expose meaningful
parameter names - AbstractReflectiveMBeanInfoAssembler

Issue: SPR-9985

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
