### PR TITLE
SPR-7827 - first support for meta-annotations in integration test

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
@@ -17,9 +17,14 @@
 package org.springframework.core.annotation;
 
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -297,6 +302,54 @@ public abstract class AnnotationUtils {
 		Assert.notNull(annotationType, "Annotation type must not be null");
 		Assert.notNull(clazz, "Class must not be null");
 		return (clazz.isAnnotationPresent(annotationType) && !isAnnotationDeclaredLocally(annotationType, clazz));
+	}
+	
+	/**
+	 * Find all annotations of the given {@code annotationType}
+	 * 
+	 * <ul>
+	 * <li>in the given {@code clazz}</li>
+	 * <li>in the superclasses (if requested in the {@code includeSuperclasses} parameter)</li>
+	 * <li>in the annotations's annotations (if requested in the {@code traverseMetaAnnotations} parameter)</li>
+	 * </ul>
+	 * @param annotationType the Class object corresponding to the annotation type
+	 * @param clazz the Class object corresponding to the class on which to check for the annotation
+	 * @param traverseMetaAnnotations if the annotations should be checked as well
+	 * @param includeSuperclasses if the superclasses should be checked as well
+	 * @return a {@link Map} in form {@code Class} = {@code Annotation}
+	 */
+	public static<A extends Annotation> Map<Class<?>, A> extractAnnotations(Class<A> annotationType, Class<?> clazz, boolean traverseMetaAnnotations, boolean includeSuperclasses) {
+		Map<Class<?>, A> annotations = new HashMap<Class<?>, A>();
+
+		if (isAnnotationDeclaredLocally(annotationType, clazz)) {
+			annotations.put(clazz, clazz.getAnnotation(annotationType));
+		}
+
+		if (traverseMetaAnnotations) {
+			for (Annotation metaAnn : clazz.getAnnotations()) {
+
+				Class<? extends Annotation> metaAnnType = metaAnn.annotationType();
+				if (metaAnnType == Documented.class ||
+						metaAnnType == Target.class ||
+						metaAnnType == Inherited.class ||
+						metaAnnType == Retention.class) {
+					continue;
+				}
+
+				Map<Class<?>, A> metaAnnotations = extractAnnotations(annotationType, metaAnnType, traverseMetaAnnotations, includeSuperclasses);
+				annotations.putAll(metaAnnotations);
+			}
+		}
+
+		if (includeSuperclasses) {
+			Class<?> superclass = clazz.getSuperclass();
+			if (superclass != null && superclass != Object.class) {
+				Map<Class<?>, A> annotationsFromSuperclass = extractAnnotations(annotationType, superclass, traverseMetaAnnotations, includeSuperclasses);
+				annotations.putAll(annotationsFromSuperclass);
+			}
+		}
+
+		return annotations;
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,6 +192,31 @@ public abstract class ObjectUtils {
 			System.arraycopy(array, 0, newArr, 0, array.length);
 		}
 		newArr[newArr.length - 1] = obj;
+		return newArr;
+	}
+	
+	/**
+	 * Utility function that merge two arrays.
+	 * @param array1 the first given array
+	 * @param array2 the second one
+	 * @return an array containing the elements from both
+	 */
+	public static <A> A[] mergeArrays(A[] array1, A[] array2) {
+
+		if (ObjectUtils.isEmpty(array1)) {
+			return array2;
+		}
+		if (ObjectUtils.isEmpty(array2)) {
+			return array1;
+		}
+
+		Class<?> compType = array1.getClass().getComponentType();
+
+		int newArrLength = array1.length + array2.length;
+		@SuppressWarnings("unchecked")
+		A[] newArr = (A[]) Array.newInstance(compType, newArrLength);
+		System.arraycopy(array1, 0, newArr, 0, array1.length);
+		System.arraycopy(array2, 0, newArr, array1.length, array2.length);
 		return newArr;
 	}
 

--- a/spring-core/src/test/java/org/springframework/util/ObjectUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ObjectUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2006 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -653,6 +653,56 @@ public final class ObjectUtilsTests extends TestCase {
 		int actual = ObjectUtils.nullSafeHashCode(array);
 		assertEquals(expected, actual);
 		assertTrue(array.hashCode() != actual);
+	}
+
+	public void testMergeArraysWithBothNulls() {
+		assertNull(ObjectUtils.mergeArrays(null, null));
+	}
+
+	public void testMergeArraysWithFirstNull() {
+		String[] second = new String[] {"c", "d"};
+		String[] merged = ObjectUtils.mergeArrays(null, second);
+		assertNotNull(merged);
+		assertArrayEquals(second, merged);
+	}
+
+	public void testMergeArraysWithSecondNull() {
+		String[] first = new String[] {"a", "b", "x"};
+		String[] merged = ObjectUtils.mergeArrays(first, null);
+		assertNotNull(merged);
+		assertArrayEquals(first, merged);
+	}
+
+	public void testMergeArraysWithBothEvaluated() {
+		String[] first = new String[] {"a", "b", "x"};
+		String[] second = new String[] {"c", "d"};
+		String[] expected = new String[] {"a", "b", "x", "c", "d"};
+		String[] merged = ObjectUtils.mergeArrays(first, second);
+		assertNotNull(merged);
+		assertArrayEquals(expected, merged);
+	}
+
+	public void testMergeArraysWithDifferentClasses() {
+		String[] firstStr = new String[] {"a", "b", "x"};
+		Object[] firstObj = new Object[] {"a", "b", "x"};
+		String[] secondStr = new String[] {"c", "d"};
+		Object[] secondObj = new Object[] {"c", "d"};
+		String[] expected = new String[] {"a", "b", "x", "c", "d"};
+
+		Object[] merged = ObjectUtils.mergeArrays(firstObj, secondStr);
+		assertNotNull(merged);
+		assertArrayEquals(expected, merged);
+
+		merged = ObjectUtils.mergeArrays(firstStr, secondObj);
+		assertNotNull(merged);
+		assertArrayEquals(expected, merged);
+	}
+
+	private void assertArrayEquals(Object[] expected, Object[] actual) {
+		assertEquals(expected.length, actual.length);
+		for (int i = 0; i < expected.length; i++) {
+			assertEquals(expected[i], actual[i]);
+		}
 	}
 
 }

--- a/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -182,7 +183,7 @@ abstract class ContextLoaderUtils {
 
 	/**
 	 * Resolve the list of {@link ContextConfigurationAttributes configuration
-	 * attributes} for the supplied {@link Class class} and its superclasses.
+	 * attributes} for the supplied {@link Class class} and its superclasses, and the meta-annotations.
 	 *
 	 * <p>Note that the {@link ContextConfiguration#inheritLocations
 	 * inheritLocations} and {@link ContextConfiguration#inheritInitializers()
@@ -193,8 +194,8 @@ abstract class ContextLoaderUtils {
 	 *
 	 * @param testClass the class for which to resolve the configuration attributes (must
 	 * not be {@code null})
-	 * @return the list of configuration attributes for the specified class, ordered <em>bottom-up</em>
-	 * (i.e., as if we were traversing up the class hierarchy); never {@code null}
+	 * @return the list of configuration attributes for the specified class (including the meta-annotations),
+	 *  ordered <em>bottom-up</em> (i.e., as if we were traversing up the class hierarchy); never {@code null}
 	 * @throws IllegalArgumentException if the supplied class is {@code null} or
 	 * if {@code @ContextConfiguration} is not <em>present</em> on the supplied class
 	 */
@@ -204,27 +205,60 @@ abstract class ContextLoaderUtils {
 		final List<ContextConfigurationAttributes> attributesList = new ArrayList<ContextConfigurationAttributes>();
 
 		Class<ContextConfiguration> annotationType = ContextConfiguration.class;
-		Class<?> declaringClass = findAnnotationDeclaringClass(annotationType, testClass);
+		Class<?> declaringClass = testClass;
 		Assert.notNull(declaringClass, String.format(
 			"Could not find an 'annotation declaring class' for annotation type [%s] and class [%s]",
 			annotationType.getName(), testClass.getName()));
 
-		while (declaringClass != null) {
-			ContextConfiguration contextConfiguration = declaringClass.getAnnotation(annotationType);
-			if (logger.isTraceEnabled()) {
-				logger.trace(String.format("Retrieved @ContextConfiguration [%s] for declaring class [%s].",
-					contextConfiguration, declaringClass.getName()));
+		while (declaringClass != null && declaringClass != Object.class) {
+
+			Map<Class<?>, ContextConfiguration> contextConfigurations = extractAnnotations(ContextConfiguration.class, declaringClass, true, false);
+
+			if (!contextConfigurations.isEmpty()) {
+
+				if (logger.isTraceEnabled()) {
+
+					if (contextConfigurations.containsKey(declaringClass)) {
+						logger.trace(String.format("Found @ContextConfiguration for declaring class [%s].",
+						declaringClass.getName()));
+					} else if (! contextConfigurations.isEmpty()) {
+						logger.trace(String.format("No @ContextConfiguration for declaring class [%s], but present in its annotations.",
+						declaringClass.getName()));
+					}
+
+					for (Class<?> key : contextConfigurations.keySet()) {
+						logger.trace(String.format("Retrieved @ContextConfiguration [%s] for declaring class [%s].",
+						contextConfigurations.get(key), key));
+					}
+				}
+
+				ContextConfigurationAttributes attributes = null;
+				ContextConfiguration contextConfigurationForDeclaringClass = contextConfigurations.remove(declaringClass);
+
+				if (contextConfigurationForDeclaringClass != null) {
+					// using standard constructor
+					attributes = new ContextConfigurationAttributes(declaringClass,	contextConfigurationForDeclaringClass);
+				} else {
+					// using defaults
+					//(this is the case with no direct @ContextConfiguration, but meta-annotations presents)
+					attributes = new ContextConfigurationAttributes(declaringClass, null, null, true, null, true, ContextLoader.class);
+				}
+
+				for (Class<?> key : contextConfigurations.keySet()) {
+					attributes.addConfigurationFromMetaAnnotations(key, contextConfigurations.get(key));
+				}
+
+				if (logger.isTraceEnabled()) {
+					logger.trace("Resolved context configuration attributes: " + attributes);
+				}
+
+				attributesList.add(attributes);
+
+			} else {
+				logger.trace(String.format("No @ContextConfiguration for declaring class [%s] or its annotations.", declaringClass.getName()));
 			}
 
-			ContextConfigurationAttributes attributes = new ContextConfigurationAttributes(declaringClass,
-				contextConfiguration);
-			if (logger.isTraceEnabled()) {
-				logger.trace("Resolved context configuration attributes: " + attributes);
-			}
-
-			attributesList.add(attributes);
-
-			declaringClass = findAnnotationDeclaringClass(annotationType, declaringClass.getSuperclass());
+			declaringClass = declaringClass.getSuperclass();
 		}
 
 		return attributesList;

--- a/spring-test/src/main/java/org/springframework/test/context/TestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/TestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@
 package org.springframework.test.context;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.AttributeAccessorSupport;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.Assert;
 
@@ -84,9 +86,9 @@ public class TestContext extends AttributeAccessorSupport {
 		Assert.notNull(contextCache, "ContextCache must not be null");
 
 		MergedContextConfiguration mergedContextConfiguration;
-		ContextConfiguration contextConfiguration = testClass.getAnnotation(ContextConfiguration.class);
+		Map<Class<?>, ContextConfiguration> extractAnnotations = AnnotationUtils.extractAnnotations(ContextConfiguration.class, testClass, true, true);
 
-		if (contextConfiguration == null) {
+		if (extractAnnotations.isEmpty()) {
 			if (logger.isInfoEnabled()) {
 				logger.info(String.format("@ContextConfiguration not found for class [%s]", testClass));
 			}
@@ -94,8 +96,9 @@ public class TestContext extends AttributeAccessorSupport {
 		}
 		else {
 			if (logger.isTraceEnabled()) {
-				logger.trace(String.format("Retrieved @ContextConfiguration [%s] for class [%s]", contextConfiguration,
-					testClass));
+				for (Class<?> k : extractAnnotations.keySet()) {
+					logger.trace(String.format("Retrieved @ContextConfiguration [%s] for class [%s]", extractAnnotations.get(k), k));
+				}
 			}
 			mergedContextConfiguration = ContextLoaderUtils.buildMergedContextConfiguration(testClass,
 				defaultContextLoaderClassName);

--- a/spring-test/src/main/java/org/springframework/test/context/support/AbstractContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/AbstractContextLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.test.context.support;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -79,6 +80,8 @@ public abstract class AbstractContextLoader implements SmartContextLoader {
 	 * processed locations are then
 	 * {@link ContextConfigurationAttributes#setLocations(String[]) set} in
 	 * the supplied configuration attributes.
+	 * 
+	 * <p>This method also include the configurations from meta-annotations.
 	 *
 	 * <p>Can be overridden in subclasses &mdash; for example, to process
 	 * annotated classes instead of resource locations.
@@ -89,6 +92,16 @@ public abstract class AbstractContextLoader implements SmartContextLoader {
 	public void processContextConfiguration(ContextConfigurationAttributes configAttributes) {
 		String[] processedLocations = processLocations(configAttributes.getDeclaringClass(),
 			configAttributes.getLocations());
+
+		Map<Class<?>, String[]> extendedLocations = configAttributes.getExtendedLocations();
+
+		for (Class<?> extraConfigurationClass : extendedLocations.keySet()) {
+			String[] extraLocations = extendedLocations.get(extraConfigurationClass);
+			String[] extraProcessedLocations = processLocations(extraConfigurationClass, extraLocations);
+			// TODO: is OK to not-checking possible duplications?
+			processedLocations = ObjectUtils.mergeArrays(processedLocations,  extraProcessedLocations);
+		}
+
 		configAttributes.setLocations(processedLocations);
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/ExternalAnnotationTest.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/ExternalAnnotationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration tests which verify the behavior of a class whose configuration
+ * is divided in:
+ * <ul>
+ * <li>a @{@link SecondAnnotation} annotation (which declares a @{@link ContextConfiguration})</li>
+ * <li>a @{@link ThirdAnnotation} annotation (which is annotated in the @{@link SecondAnnotation} and declares a @{@link ContextConfiguration})</li>
+ * </ul>
+ *  The ApplicationContext is divided in that files, and the declared beans depends on each others.
+ * @author Giovanni Dall'Oglio Risso
+ * @since 3.2.1
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SecondAnnotation
+public class ExternalAnnotationTest {
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	public void verifyExtendedAnnotationAutowiredFields() {
+
+		assertNotNull("The applicationContext should have been autowired.", applicationContext);
+		
+		Map<String, Person> personBeans = applicationContext.getBeansOfType(Person.class);
+
+		assertNotNull("The applicationContext should have beans of type Person.", personBeans);
+		assertEquals("The applicationContext should have 2 beans of type Person.", 2, personBeans.size());
+
+		Person person2 = personBeans.get("p2");
+		Person person3 = personBeans.get("p3");
+		
+		assertNotNull(person2);
+		assertNotNull(person3);
+
+		assertEquals("Person 2", person2.getName());
+		assertEquals("Person 3", person3.getName());
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/FirstAnnotation.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/FirstAnnotation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.test.context.ContextConfiguration;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ContextConfiguration(locations={"classpath:org/springframework/test/context/configuration/FirstAnnotation-context.xml"})
+public @interface FirstAnnotation {
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/MultiAnnotationTest.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/MultiAnnotationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Integration tests which verify the behavior of a class whose configurations is
+ * divided in:
+ * <ul>
+ * <li>a @{@link ContextConfiguration} as direct annotation</li>
+ * <li>a @{@link FirstAnnotation} annotation (which declares a @{@link ContextConfiguration})</li>
+ * <li>a @{@link SecondAnnotation} annotation (which declares a @{@link ContextConfiguration})</li>
+ * <li>a @{@link ThirdAnnotation} annotation (which is annotated in the @{@link SecondAnnotation} and declares a @{@link ContextConfiguration})</li>
+ * </ul>
+ * The ApplicationContext is divided in that files, and the declared beans depends on each others.
+ * 
+ * @author Giovanni Dall'Oglio Risso
+ * @since 3.2.1
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@FirstAnnotation
+@SecondAnnotation
+public class MultiAnnotationTest  {
+
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	public void verifyExtendedAnnotationAutowiredFields() {
+
+		assertNotNull("The applicationContext should have been autowired.", applicationContext);
+		
+		Map<String, Person> personBeans = applicationContext.getBeansOfType(Person.class);
+
+		assertNotNull("The applicationContext should have beans of type Person.", personBeans);
+		assertEquals("The applicationContext should have 4 beans of type Person.", 4, personBeans.size());
+
+		Person person1 = personBeans.get("p1");
+		Person person2 = personBeans.get("p2");
+		Person person3 = personBeans.get("p3");
+		Person personM = personBeans.get("pM");
+
+		assertNotNull(person1);
+		assertNotNull(person2);
+		assertNotNull(person3);
+		assertNotNull(personM);
+
+		assertEquals("Person 1", person1.getName());
+		assertEquals("Person 2", person2.getName());
+		assertEquals("Person 3", person3.getName());
+		assertEquals("Person Multi", personM.getName());
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/Person.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/Person.java
@@ -1,0 +1,14 @@
+package org.springframework.test.context.configuration;
+
+public class Person {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/SecondAnnotation.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/SecondAnnotation.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.test.context.ContextConfiguration;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ContextConfiguration(locations={"classpath:org/springframework/test/context/configuration/SecondAnnotation-ctx.xml"})
+@ThirdAnnotation
+public @interface SecondAnnotation {
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/ThirdAnnotation.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/ThirdAnnotation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.test.context.ContextConfiguration;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ContextConfiguration
+public @interface ThirdAnnotation {
+
+}

--- a/spring-test/src/test/resources/org/springframework/test/context/configuration/FirstAnnotation-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/configuration/FirstAnnotation-context.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+
+	<bean id="p1" class="org.springframework.test.context.configuration.Person">
+		<property name="name" value="Person 1" />
+	</bean>
+
+</beans>

--- a/spring-test/src/test/resources/org/springframework/test/context/configuration/MultiAnnotationTest-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/configuration/MultiAnnotationTest-context.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+
+	<bean id="pM" class="org.springframework.test.context.configuration.Person">
+		<property name="name" value="Person Multi" />
+	</bean>
+
+</beans>

--- a/spring-test/src/test/resources/org/springframework/test/context/configuration/SecondAnnotation-ctx.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/configuration/SecondAnnotation-ctx.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+
+	<bean id="p2" class="org.springframework.test.context.configuration.Person">
+		<property name="name" value="Person 2" />
+	</bean>
+
+</beans>

--- a/spring-test/src/test/resources/org/springframework/test/context/configuration/ThirdAnnotation-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/configuration/ThirdAnnotation-context.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+
+	<bean id="p3" class="org.springframework.test.context.configuration.Person">
+		<property name="name" value="Person 3" />
+	</bean>
+
+</beans>

--- a/src/reference/docbook/testing.xml
+++ b/src/reference/docbook/testing.xml
@@ -1665,6 +1665,74 @@ public class ExtendedTest extends BaseTest {
     <lineannotation>// class body...</lineannotation>
 }</programlisting>
         </section>
+		
+		 <section xml:id="testcontext-ctx-management-metaannotations">
+          <title>Context Configuration and meta-annotations</title>
+
+          <para>A mechanism similar to inheritance of Context Configuration described
+		  in paragraph <link linkend="testcontext-ctx-management-inheritance">Context
+		  configuration inheritance</link> was first introduced in version 3.2.1:
+          it allows to create custom annotations with a
+		  <interfacename>@ContextConfiguration</interfacename>.
+		  Then it is possible to mix (in test classes) the explicit configuration
+		  (via <interfacename>@ContextConfiguration</interfacename> annotations)
+		  with the just defined custom annotations.</para>
+
+          <para>On the Spring side, it will be as if there were a single
+		  <interfacename>@ContextConfiguration</interfacename>, composed by the union of all the 
+		  <interfacename>@ContextConfiguration</interfacename> presents on that class, 
+		  on its annotations, on second level annotations, etc.</para>
+		  
+          <para>Inheritance of <interfacename>@ContextConfiguration</interfacename>
+		  works as described in paragraph <link linkend="testcontext-ctx-management-inheritance">
+		  Context configuration inheritance</link>.</para>
+
+          <para>A quick sample:</para>
+		  
+<programlisting language="java">
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+<emphasis role="bold">@ContextConfiguration(locations = "HsqlDb-Environment.xml")</emphasis> // ok, you can use profiles instead
+<emphasis role="bold">public @interface HsqldbEnvironment</emphasis> {
+}
+
+---------------
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+<emphasis role="bold">@ContextConfiguration</emphasis> // using default location if present [ IntegrationTest-context.xml ]
+<emphasis role="bold">public @interface IntegrationTest</emphasis> {
+}
+
+---------------
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+<emphasis role="bold">@ContextConfiguration(locations = {"Batch-Environment.xml", "Batch-Test-Environment.xml"})</emphasis> // specific configuration
+<emphasis role="bold">@IntegrationTest</emphasis>
+<emphasis role="bold">public @interface BatchIntegrationTest</emphasis> {
+}
+
+---------------
+
+@RunWith(SpringJUnit4ClassRunner.class)
+<emphasis role="bold">@ContextConfiguration(locations = "FirstJob.xml")</emphasis> // the job definition
+<emphasis role="bold">@BatchIntegrationTest</emphasis>
+<emphasis role="bold">@HsqldbEnvironment</emphasis>
+public class FirstJobIntegrationTest {
+
+// In this case, the Application Context is built merging this files:
+//     * FirstJob.xml                             [from actual class]
+//     * Batch-Environment.xml                    [from BatchIntegrationTest annotation]
+//     * Batch-Test-Environment.xml               [from BatchIntegrationTest annotation]
+//     * IntegrationTest-context.xml (if present) [from IntegrationTest annotation, implied by BatchIntegrationTest annotation]
+//     * HsqlDb-Environment.xml                   [from HsqldbEnvironment annotation]
+
+	[...]
+
+}
+</programlisting>
+		</section>
 
         <section xml:id="testcontext-ctx-management-env-profiles">
           <title>Context configuration with environment profiles</title>


### PR DESCRIPTION
related to issue: https://jira.springsource.org/browse/SPR-7827

prior this commit, there was no support for meta-annotations in the Spring Intergation tests, now the @ContextConfiguration annotation is searched also in meta-annotations.

Eg: you can write:

``` java
@ContextConfiguration([...]) // config for HSQLDB environment
public @interface InRamEnvironment
```

``` java
@ContextConfiguration([...]) // config for common-core part
public @interface CommonCoreIntegrationTest
```

``` java
@CommonCoreIntegrationTest
@InRamEnvironment
public class OneBatchTest {

[...] // actual test methods
}
```
