### PR TITLE
Support 'unless' expression for cache veto

### DIFF
--- a/spring-aspects/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.cache.annotation.Caching;
 
 /**
  * @author Costin Leau
+ * @author Phillip Webb
  */
 @Cacheable("default")
 public class AnnotatedClassCacheableService implements CacheableService<Object> {
@@ -38,6 +39,10 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 
 	public Object conditional(int field) {
 		return null;
+	}
+
+	public Object unless(int arg) {
+		return arg;
 	}
 
 	@CacheEvict("default")

--- a/spring-aspects/src/test/java/org/springframework/cache/config/CacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/CacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package org.springframework.cache.config;
  * Basic service interface.
  *
  * @author Costin Leau
+ * @author Phillip Webb
  */
 public interface CacheableService<T> {
 
@@ -38,6 +39,8 @@ public interface CacheableService<T> {
 	void invalidateEarly(Object arg1, Object arg2);
 
 	T conditional(int field);
+
+	T unless(int arg);
 
 	T key(Object arg1, Object arg2);
 

--- a/spring-aspects/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
@@ -27,6 +27,7 @@ import org.springframework.cache.annotation.Caching;
  * Simple cacheable service
  *
  * @author Costin Leau
+ * @author Phillip Webb
  */
 public class DefaultCacheableService implements CacheableService<Long> {
 
@@ -76,6 +77,12 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	@Cacheable(value = "default", condition = "#classField == 3")
 	public Long conditional(int classField) {
 		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", unless = "#result > 10")
+	public Long unless(int arg) {
+		return (long) arg;
 	}
 
 	@Override

--- a/spring-context/src/main/java/org/springframework/cache/annotation/CachePut.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/CachePut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.cache.Cache;
  * always causes the method to be invoked and its result to be placed into the cache.
  *
  * @author Costin Leau
+ * @author Phillip Webb
  * @since 3.1
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
@@ -58,4 +59,13 @@ public @interface CachePut {
 	 * <p>Default is "", meaning the method result is always cached.
 	 */
 	String condition() default "";
+
+	/**
+	 * Spring Expression Language (SpEL) attribute used to veto the cache update.
+	 * <p>Unlike {@link #condition()}, this expression is evaluated after the method
+	 * has been called and can therefore refer to the {@code result}. Default is "",
+	 * meaning that caching is never vetoed.
+	 * @since 3.2
+	 */
+	String unless() default "";
 }

--- a/spring-context/src/main/java/org/springframework/cache/annotation/Cacheable.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/Cacheable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import java.lang.annotation.Target;
  * returned instance is used as the cache value.
  *
  * @author Costin Leau
+ * @author Phillip Webb
  * @since 3.1
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
@@ -56,4 +57,13 @@ public @interface Cacheable {
 	 * <p>Default is "", meaning the method is always cached.
 	 */
 	String condition() default "";
+
+	/**
+	 * Spring Expression Language (SpEL) attribute used to veto method caching.
+	 * <p>Unlike {@link #condition()}, this expression is evaluated after the method
+	 * has been called and can therefore refer to the {@code result}. Default is "",
+	 * meaning that caching is never vetoed.
+	 * @since 3.2
+	 */
+	String unless() default "";
 }

--- a/spring-context/src/main/java/org/springframework/cache/annotation/SpringCacheAnnotationParser.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/SpringCacheAnnotationParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.ObjectUtils;
  * @author Costin Leau
  * @author Juergen Hoeller
  * @author Chris Beams
+ * @author Phillip Webb
  * @since 3.1
  */
 @SuppressWarnings("serial")
@@ -82,6 +83,7 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		CacheableOperation cuo = new CacheableOperation();
 		cuo.setCacheNames(caching.value());
 		cuo.setCondition(caching.condition());
+		cuo.setUnless(caching.unless());
 		cuo.setKey(caching.key());
 		cuo.setName(ae.toString());
 		return cuo;
@@ -102,6 +104,7 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		CachePutOperation cuo = new CachePutOperation();
 		cuo.setCacheNames(caching.value());
 		cuo.setCondition(caching.condition());
+		cuo.setUnless(caching.unless());
 		cuo.setKey(caching.key());
 		cuo.setName(ae.toString());
 		return cuo;

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheEvictOperation.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheEvictOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ public class CacheEvictOperation extends CacheOperation {
 
 	private boolean cacheWide = false;
 	private boolean beforeInvocation = false;
+
 
 	public void setCacheWide(boolean cacheWide) {
 		this.cacheWide = cacheWide;

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheOperation.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,10 +119,10 @@ public abstract class CacheOperation {
 		result.append(this.name);
 		result.append("] caches=");
 		result.append(this.cacheNames);
-		result.append(" | condition='");
-		result.append(this.condition);
-		result.append("' | key='");
+		result.append(" | key='");
 		result.append(this.key);
+		result.append("' | condition='");
+		result.append(this.condition);
 		result.append("'");
 		return result;
 	}

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CachePutOperation.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CachePutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,28 @@ package org.springframework.cache.interceptor;
  * Class describing a cache 'put' operation.
  *
  * @author Costin Leau
+ * @author Phillip Webb
  * @since 3.1
  */
 public class CachePutOperation extends CacheOperation {
 
+	private String unless;
+
+
+	public String getUnless() {
+		return unless;
+	}
+
+	public void setUnless(String unless) {
+		this.unless = unless;
+	}
+
+	@Override
+	protected StringBuilder getOperationDescription() {
+		StringBuilder sb = super.getOperationDescription();
+		sb.append(" | unless='");
+		sb.append(this.unless);
+		sb.append("'");
+		return sb;
+	}
 }

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheableOperation.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheableOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,28 @@ package org.springframework.cache.interceptor;
  * Class describing a cache 'cacheable' operation.
  *
  * @author Costin Leau
+ * @author Phillip Webb
  * @since 3.1
  */
 public class CacheableOperation extends CacheOperation {
 
+	private String unless;
+
+
+	public String getUnless() {
+		return unless;
+	}
+
+	public void setUnless(String unless) {
+		this.unless = unless;
+	}
+
+	@Override
+	protected StringBuilder getOperationDescription() {
+		StringBuilder sb = super.getOperationDescription();
+		sb.append(" | unless='");
+		sb.append(this.unless);
+		sb.append("'");
+		return sb;
+	}
 }

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/ExpressionEvaluator.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/ExpressionEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,49 +35,84 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * <p>Performs internal caching for performance reasons.
  *
  * @author Costin Leau
+ * @author Phillip Webb
  * @since 3.1
  */
 class ExpressionEvaluator {
+
+	public static final Object NO_RESULT = new Object();
 
 	private final SpelExpressionParser parser = new SpelExpressionParser();
 
 	// shared param discoverer since it caches data internally
 	private final ParameterNameDiscoverer paramNameDiscoverer = new LocalVariableTableParameterNameDiscoverer();
 
+	private final Map<String, Expression> keyCache = new ConcurrentHashMap<String, Expression>(64);
+
 	private final Map<String, Expression> conditionCache = new ConcurrentHashMap<String, Expression>(64);
 
-	private final Map<String, Expression> keyCache = new ConcurrentHashMap<String, Expression>(64);
+	private final Map<String, Expression> unlessCache = new ConcurrentHashMap<String, Expression>(64);
 
 	private final Map<String, Method> targetMethodCache = new ConcurrentHashMap<String, Method>(64);
 
 
-	public EvaluationContext createEvaluationContext(
-			Collection<Cache> caches, Method method, Object[] args, Object target, Class<?> targetClass) {
-
-		CacheExpressionRootObject rootObject =
-				new CacheExpressionRootObject(caches, method, args, target, targetClass);
-		return new LazyParamAwareEvaluationContext(rootObject,
-				this.paramNameDiscoverer, method, args, targetClass, this.targetMethodCache);
+	/**
+	 * Create an {@link EvaluationContext} without a return value.
+	 * @see #createEvaluationContext(Collection, Method, Object[], Object, Class, Object)
+	 */
+	public EvaluationContext createEvaluationContext(Collection<Cache> caches,
+			Method method, Object[] args, Object target, Class<?> targetClass) {
+		return createEvaluationContext(caches, method, args, target, targetClass,
+				NO_RESULT);
 	}
 
-	public boolean condition(String conditionExpression, Method method, EvaluationContext evalContext) {
-		String key = toString(method, conditionExpression);
-		Expression condExp = this.conditionCache.get(key);
-		if (condExp == null) {
-			condExp = this.parser.parseExpression(conditionExpression);
-			this.conditionCache.put(key, condExp);
+	/**
+	 * Create an {@link EvaluationContext}.
+	 *
+	 * @param caches the current caches
+	 * @param method the method
+	 * @param args the method arguments
+	 * @param target the target object
+	 * @param targetClass the target class
+	 * @param result the return value (can be {@code null}) or
+	 *        {@link #NO_RESULT} if there is no return at this time
+	 * @return the evalulation context
+	 */
+	public EvaluationContext createEvaluationContext(Collection<Cache> caches,
+			Method method, Object[] args, Object target, Class<?> targetClass,
+			final Object result) {
+		CacheExpressionRootObject rootObject = new CacheExpressionRootObject(caches,
+				method, args, target, targetClass);
+		LazyParamAwareEvaluationContext evaluationContext = new LazyParamAwareEvaluationContext(rootObject,
+				this.paramNameDiscoverer, method, args, targetClass, this.targetMethodCache);
+		if(result != NO_RESULT) {
+			evaluationContext.setVariable("result", result);
 		}
-		return condExp.getValue(evalContext, boolean.class);
+		return evaluationContext;
 	}
 
 	public Object key(String keyExpression, Method method, EvaluationContext evalContext) {
-		String key = toString(method, keyExpression);
-		Expression keyExp = this.keyCache.get(key);
-		if (keyExp == null) {
-			keyExp = this.parser.parseExpression(keyExpression);
-			this.keyCache.put(key, keyExp);
+		return getExpression(this.keyCache, keyExpression, method).getValue(evalContext);
+	}
+
+	public boolean condition(String conditionExpression, Method method, EvaluationContext evalContext) {
+		return getExpression(this.conditionCache, conditionExpression, method).getValue(
+				evalContext, boolean.class);
+	}
+
+	public boolean unless(String unlessExpression, Method method, EvaluationContext evalContext) {
+		return getExpression(this.unlessCache, unlessExpression, method).getValue(
+				evalContext, boolean.class);
+	}
+
+	private Expression getExpression(Map<String, Expression> cache, String expression, Method method) {
+		String key = toString(method, expression);
+		Expression rtn = cache.get(key);
+		if (rtn == null) {
+			rtn = this.parser.parseExpression(expression);
+			cache.put(key, rtn);
 		}
-		return keyExp.getValue(evalContext);
+		return rtn;
 	}
 
 	private String toString(Method method, String expression) {

--- a/spring-context/src/main/resources/org/springframework/cache/config/spring-cache-3.2.xsd
+++ b/spring-context/src/main/resources/org/springframework/cache/config/spring-cache-3.2.xsd
@@ -36,7 +36,7 @@
 				<xsd:annotation>
 					<xsd:documentation source="java:org.springframework.cache.CacheManager"><![CDATA[
 	The bean name of the CacheManager that is to be used to retrieve the backing caches.
-	
+
 	This attribute is not required, and only needs to be specified
 	explicitly if the bean name of the desired CacheManager
 	is not 'cacheManager'.
@@ -52,7 +52,7 @@
 				<xsd:annotation>
 					<xsd:documentation source="java:org.springframework.cache.interceptor.KeyGenerator"><![CDATA[
 	The bean name of the KeyGenerator that is to be used to retrieve the backing caches.
-	
+
 	This attribute is not required, and only needs to be specified
 	explicitly if the default strategy (DefaultKeyGenerator) is not sufficient.
 					]]></xsd:documentation>
@@ -150,7 +150,7 @@
 						<xsd:annotation>
 							<xsd:documentation source="java:org.springframework.cache.interceptor.KeyGenerator"><![CDATA[
 	The bean name of the KeyGenerator that is to be used to retrieve the backing caches.
-	
+
 	This attribute is not required, and only needs to be specified
 	explicitly if the default strategy (DefaultKeyGenerator) is not sufficient.
 							]]></xsd:documentation>
@@ -160,7 +160,7 @@
 								</tool:annotation>
 							</xsd:appinfo>
 						</xsd:annotation>
-					</xsd:attribute>					
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -194,16 +194,42 @@
 	example, 'get*', 'handle*', '*Order', 'on*Event', etc.]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		
+
 	</xsd:complexType>
-	
+
 	<xsd:complexType name="definitionsType">
 		<xsd:complexContent>
 			<xsd:extension base="basedefinitionType">
 				<xsd:sequence>
 				  <xsd:choice minOccurs="0" maxOccurs="unbounded">
-					<xsd:element name="cacheable" minOccurs="0" maxOccurs="unbounded" type="basedefinitionType"/>
-					<xsd:element name="cache-put" minOccurs="0" maxOccurs="unbounded" type="basedefinitionType"/>					
+					<xsd:element name="cacheable" minOccurs="0" maxOccurs="unbounded">
+						<xsd:complexType>
+							<xsd:complexContent>
+								<xsd:extension base="basedefinitionType">
+									<xsd:attribute name="unless" type="xsd:string" use="optional">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+	The SpEL expression used to veto the method caching.]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:attribute>
+								</xsd:extension>
+							</xsd:complexContent>
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="cache-put" minOccurs="0" maxOccurs="unbounded">
+						<xsd:complexType>
+							<xsd:complexContent>
+								<xsd:extension base="basedefinitionType">
+									<xsd:attribute name="unless" type="xsd:string" use="optional">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+	The SpEL expression used to veto the method caching.]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:attribute>
+								</xsd:extension>
+							</xsd:complexContent>
+						</xsd:complexType>
+					</xsd:element>
 					<xsd:element name="cache-evict" minOccurs="0" maxOccurs="unbounded">
 						<xsd:complexType>
 							<xsd:complexContent>
@@ -217,16 +243,16 @@
 									<xsd:attribute name="before-invocation" type="xsd:boolean" use="optional">
 										<xsd:annotation>
 											<xsd:documentation><![CDATA[
-	Whether the eviction should occur after the method is successfully 
+	Whether the eviction should occur after the method is successfully
 	invoked (default) or before.]]></xsd:documentation>
 										</xsd:annotation>
 									</xsd:attribute>
-									
+
 								</xsd:extension>
 							</xsd:complexContent>
 						</xsd:complexType>
 					</xsd:element>
-				  </xsd:choice>			
+				  </xsd:choice>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/spring-context/src/test/java/org/springframework/cache/config/AbstractAnnotationTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/AbstractAnnotationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2011 the original author or authors.
+ * Copyright 2010-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.cache.config;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
 
 import java.util.Collection;
@@ -33,6 +35,7 @@ import org.springframework.context.ApplicationContext;
  *
  * @author Costin Leau
  * @author Chris Beams
+ * @author Phillip Webb
  */
 public abstract class AbstractAnnotationTests {
 
@@ -185,6 +188,15 @@ public abstract class AbstractAnnotationTests {
 		Object r4 = service.conditional(3);
 
 		assertSame(r3, r4);
+	}
+
+	public void testUnlessExpression(CacheableService<?> service) throws Exception {
+		Cache cache = cm.getCache("default");
+		cache.clear();
+		service.unless(10);
+		service.unless(11);
+		assertThat(cache.get(10).get(), equalTo((Object) 10L));
+		assertThat(cache.get(11), nullValue());
 	}
 
 	public void testKeyExpression(CacheableService<?> service) throws Exception {
@@ -439,6 +451,16 @@ public abstract class AbstractAnnotationTests {
 	@Test
 	public void testConditionalExpression() throws Exception {
 		testConditionalExpression(cs);
+	}
+
+	@Test
+	public void testUnlessExpression() throws Exception {
+		testUnlessExpression(cs);
+	}
+
+	@Test
+	public void testClassCacheUnlessExpression() throws Exception {
+		testUnlessExpression(cs);
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.cache.annotation.Caching;
 
 /**
  * @author Costin Leau
+ * @author Phillip Webb
  */
 @Cacheable("default")
 public class AnnotatedClassCacheableService implements CacheableService<Object> {
@@ -40,6 +41,12 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	@Override
 	public Object conditional(int field) {
 		return null;
+	}
+
+	@Override
+	@Cacheable(value = "default", unless = "#result > 10")
+	public Object unless(int arg) {
+		return arg;
 	}
 
 	@Override

--- a/spring-context/src/test/java/org/springframework/cache/config/CacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/CacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package org.springframework.cache.config;
  * Basic service interface.
  *
  * @author Costin Leau
+ * @author Phillip Webb
  */
 public interface CacheableService<T> {
 
@@ -38,6 +39,8 @@ public interface CacheableService<T> {
 	void invalidateEarly(Object arg1, Object arg2);
 
 	T conditional(int field);
+
+	T unless(int arg);
 
 	T key(Object arg1, Object arg2);
 

--- a/spring-context/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.cache.annotation.Caching;
  * Simple cacheable service
  *
  * @author Costin Leau
+ * @author Phillip Webb
  */
 public class DefaultCacheableService implements CacheableService<Long> {
 
@@ -76,6 +77,12 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	@Cacheable(value = "default", condition = "#classField == 3")
 	public Long conditional(int classField) {
 		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", unless = "#result > 10")
+	public Long unless(int arg) {
+		return (long) arg;
 	}
 
 	@Override

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
@@ -3,7 +3,7 @@
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
        		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
 
@@ -11,6 +11,7 @@
 		<cache:caching cache="default">
 			<cache:cacheable method="cache"/>
 			<cache:cacheable method="conditional" condition="#classField == 3"/>
+			<cache:cacheable method="unless" unless="#result > 10"/>
 			<cache:cacheable method="key" key="#p0"/>
 			<cache:cacheable method="nam*" key="#root.methodName"/>
 			<cache:cacheable method="rootVars" key="#root.methodName + #root.method.name + #root.targetClass + #root.target"/>
@@ -54,6 +55,7 @@
 			<cache:cacheable method="rootVars" key="#root.methodName + #root.method.name + #root.targetClass + #root.target"/>
 			<cache:cacheable method="cache"/>
 			<cache:cacheable method="conditional"/>
+			<cache:cacheable method="unless"/>
 			<cache:cacheable method="null*"/>
 		</cache:caching>
 		<cache:caching>
@@ -80,9 +82,9 @@
 			<cache:cache-evict method="multiConditionalCacheAndEvict" cache="secondary"/>
 			<cache:cache-put method="multiUpdate" cache="primary"/>
 			<cache:cache-put method="multiUpdate" cache="secondary"/>
-		</cache:caching>		
+		</cache:caching>
 	</cache:advice>
-		
+
 	<aop:config>
 		<aop:advisor advice-ref="cacheAdviceInterface" pointcut="execution(* *..DefaultCacheableService.*(..))" order="1"/>
 		<aop:advisor advice-ref="cacheAdviceClass" pointcut="execution(* *..AnnotatedClassCacheableService.*(..))" order="1"/>
@@ -98,12 +100,12 @@
 			</set>
 		</property>
 	</bean>
-	
+
 	<bean id="keyGenerator" class="org.springframework.cache.config.SomeKeyGenerator"/>
 
 	<bean id="debugInterceptor" class="org.springframework.aop.interceptor.DebugInterceptor"/>
-	
+
 	<bean id="service" class="org.springframework.cache.config.DefaultCacheableService"/>
-	
+
 	<bean id="classService" class="org.springframework.cache.config.AnnotatedClassCacheableService"/>
 </beans>

--- a/src/reference/docbook/cache.xml
+++ b/src/reference/docbook/cache.xml
@@ -152,6 +152,13 @@ public Book findBook(ISBN isbn, boolean checkWarehouse, boolean includeUsed)</pr
 
             <programlisting language="java"><![CDATA[@Cacheable(value="book", condition="#name.length < 32")
 public Book findBook(String name)]]></programlisting>
+
+            <para>In addition the <literal>conditional</literal> parameter, the <literal>unless</literal> parameter can be used to veto the adding of a value to the cache. Unlike
+            <literal>conditional</literal>, <literal>unless</literal> <literal>SpEL</literal> expressions are evalulated <emphasis>after</emphasis> the method has been called. Expanding
+            on the previous example - perhaps we only want to cache paperback books:</para>
+
+            <programlisting language="java"><![CDATA[@Cacheable(value="book", condition="#name.length < 32", unless="#result.hardback")
+public Book findBook(String name)]]></programlisting>
         </section>
 
         <section xml:id="cache-spel-context">
@@ -217,6 +224,13 @@ public Book findBook(String name)]]></programlisting>
                             the argument names are also available under the <literal><![CDATA[a<#arg>]]></literal> where
                             <emphasis><![CDATA[#arg]]></emphasis> stands for the argument index (starting from 0).</entry>
                             <entry><screen>iban</screen> or <screen>a0</screen> (one can also use <screen>p0</screen> or <literal><![CDATA[p<#arg>]]></literal> notation as an alias).</entry>
+                        </row>
+                        <row>
+                            <entry>result</entry>
+                            <entry>evaluation context</entry>
+                            <entry>The result of the method call (the value to be cached). Only available in '<literal>unless</literal>' expressions and '<literal>cache evict</literal>'
+                            expression (when <literal>beforeInvocation</literal> is <literal>false</literal>).</entry>
+                            <entry><screen>#result</screen></entry>
                         </row>
                     </tbody>
                  </tgroup>


### PR DESCRIPTION
Allow @Cachable, @CachePut and equivalent XML configuration to provide
a SpEL expression that can be used to veto putting an item into the
cache. Unlike 'condition' the 'unless' parameter is evaluated after
the method has been called and can therefore reference the #result.

For example:

```
@Cacheable(value="book",
    condition="#name.length < 32",
    unless="#result.hardback")
```

This commit also allows #result to be referenced from @CacheEvict
expressions as long as 'beforeInvocation' is false.

Issue: 
