### PR TITLE
Instantiate a JdbcTemplate with a JDBC connection.

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -42,6 +42,7 @@ import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.SQLWarningException;
 import org.springframework.jdbc.datasource.ConnectionProxy;
 import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 import org.springframework.jdbc.support.JdbcAccessor;
 import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.jdbc.support.KeyHolder;
@@ -176,6 +177,30 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 		setDataSource(dataSource);
 		setLazyInit(lazyInit);
 		afterPropertiesSet();
+	}
+	
+	/**
+	 * Construct a new JdbcTemplate with a given connection.
+	 * <p>Note: uses a {@link SingleConnectionDataSource} internally.
+	 * Most people will use this constructor with the {@code suppressClose}
+	 * parameter set to true and would then better off use the other 
+	 * connection-based constructor.
+	 * @param connection connection used to execute queries
+	 * @param suppressClose whether or not closing the connection after use.
+	 */
+	public JdbcTemplate(Connection connection,boolean suppressClose) {
+		setDataSource(new SingleConnectionDataSource(connection, suppressClose));
+		afterPropertiesSet();
+	}
+
+	/**
+	 * Construct a new JdbcTemplate with a given connection.
+	 * <p>Note: uses a {@link SingleConnectionDataSource} internally, and
+	 * never closes the connection.
+	 * @param connection connection used to execute queries
+	 */
+	public JdbcTemplate(Connection connection) {
+		this(connection,true);
 	}
 
 


### PR DESCRIPTION
The given connection is wrapped into a SingleConnectionDataSource.
The suppressClose flag is accessible in a constructor for flexibility,
but another constructor needs only the JDBC connection, and sets the
suppressClose flag to true. Most people would use this second constructor.

Issue: SPR-10049

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
