### PR TITLE
Make StandaloneMockMvcBuilder interface consistent

### DIFF
--- a/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
+++ b/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,6 +208,13 @@ public class StandaloneMockMvcBuilder extends DefaultMockMvcBuilder<StandaloneMo
 	public StandaloneMockMvcBuilder setHandlerExceptionResolvers(List<HandlerExceptionResolver> exceptionResolvers) {
 		this.handlerExceptionResolvers = exceptionResolvers;
 		return this;
+	}
+	
+	/**
+	 * Set the HandlerExceptionResolver types to use.
+	 */
+	public StandaloneMockMvcBuilder setHandlerExceptionResolvers(List ... exceptionResolvers) {
+		return setHandlerExceptionResolvers(Arrays.asList(exceptionResolvers));
 	}
 
 	/**


### PR DESCRIPTION
The exception resolvers can now be set using a setter that expects
varargs, just like other infrastructure beans.

Issue: SPR-10279

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
