### PR TITLE
Fix DefaultMockMvcBuilder fluent API generic type

### DIFF
--- a/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/setup/DefaultMockMvcBuilder.java
+++ b/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/setup/DefaultMockMvcBuilder.java
@@ -42,7 +42,7 @@ import org.springframework.web.servlet.DispatcherServlet;
  * @author Rob Winch
  * @since 3.2
  */
-public class DefaultMockMvcBuilder<Self extends MockMvcBuilder> extends MockMvcBuilderSupport
+public class DefaultMockMvcBuilder<Self extends DefaultMockMvcBuilder> extends MockMvcBuilderSupport
 		implements MockMvcBuilder {
 
 	private final WebApplicationContext webAppContext;

--- a/spring-test-mvc/src/test/java/org/springframework/test/web/servlet/setup/Spr10277Tests.java
+++ b/spring-test-mvc/src/test/java/org/springframework/test/web/servlet/setup/Spr10277Tests.java
@@ -1,0 +1,49 @@
+package org.springframework.test.web.servlet.setup;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+/**
+ * Test for SPR-10277 (Multiple method chaining when building MockMvc).
+ *
+ * @author Wesley Hall
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration
+public class Spr10277Tests {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Test
+    public void chainMultiple() {
+
+        //Reproduction code from https://jira.springsource.org/browse/SPR-10277
+        MockMvcBuilders
+                .webAppContextSetup(wac)
+                .addFilter( new CharacterEncodingFilter() )
+                .alwaysDo(print())
+                .defaultRequest(get("/").contextPath("/mywebapp"))
+                .build();
+
+
+    }
+
+    @Configuration
+    @EnableWebMvc
+    static class WebConfig extends WebMvcConfigurerAdapter {
+    }
+}


### PR DESCRIPTION
Changed upper bound of generic parameter for DefaultMockMvcBuilder from
MockMvcBuilder to DefaultMockMvcBuilder to allow for ongoing method
chaining in the fluent API style.

Prior to this commit there was a problem in that repeated chained calls made to the DefaultMockMvcBuilder class would result in the returning of an MockMvcBuilder typed reference. Since all the useful chaining methods are on the DefaultMockMvcBuilder subclass this resulted in the loss of any useful chained (fluent API) type usage of the builder class. The reason for this problem is that in chaining calls the compiler 'loses' the knowledge that the type being returned is actually a DefaultMockMvcBuilder and returns to the type specified in the 'extends' part of the generic type definition. By tightening the bounds of the generic type to 'extends DefaultMockMvcBuilder', clients of the class can continue to call methods on the returned reference and still have access to the DefaultMockMvcBuilder methods.

A test has been added matching the original example in the Jira issue, which now compiles successfully.

Issue: SPR-10277
