### PR TITLE
SPR-10329 StringToEnumConvertFactory issue

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToEnumConverterFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToEnumConverterFactory.java
@@ -18,6 +18,7 @@ package org.springframework.core.convert.support;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.ConverterFactory;
+import org.springframework.util.Assert;
 
 /**
  * Converts from a String to a java.lang.Enum by calling {@link Enum#valueOf(Class, String)}.
@@ -29,7 +30,12 @@ import org.springframework.core.convert.converter.ConverterFactory;
 final class StringToEnumConverterFactory implements ConverterFactory<String, Enum> {
 
 	public <T extends Enum> Converter<String, T> getConverter(Class<T> targetType) {
-		return new StringToEnum(targetType);
+        if (targetType.isEnum()) {
+            return new StringToEnum(targetType);
+        }
+        else {
+            return getConverter((Class<T>) targetType.getSuperclass());
+        }
 	}
 
 	private class StringToEnum<T extends Enum> implements Converter<String, T> {
@@ -37,7 +43,8 @@ final class StringToEnumConverterFactory implements ConverterFactory<String, Enu
 		private final Class<T> enumType;
 
 		public StringToEnum(Class<T> enumType) {
-			this.enumType = enumType;
+            Assert.isTrue(enumType.isEnum(), "Class " + enumType + " is not an enum type.");
+            this.enumType = enumType;
 		}
 
 		public T convert(String source) {

--- a/spring-core/src/test/java/org/springframework/core/convert/support/StringToEnumConverterFactoryTest.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/StringToEnumConverterFactoryTest.java
@@ -1,0 +1,31 @@
+package org.springframework.core.convert.support;
+
+import org.junit.Test;
+import org.springframework.core.convert.converter.Converter;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Ståle Undheim <su@ums.no>
+ */
+public class StringToEnumConverterFactoryTest {
+
+enum EnumWithSubclass {
+    VALUE1 {
+        String get() { return "XXX"; }
+    },
+    VALUE2 {
+        String get() { return "YYY"; }
+    };
+
+    abstract String get();
+}
+
+    @Test
+    public void testConvertToEnumWithSubclass() throws Exception {
+        Converter<String,? extends EnumWithSubclass> converter =
+                new StringToEnumConverterFactory().getConverter(EnumWithSubclass.VALUE1.getClass());
+        EnumWithSubclass enumValue = converter.convert("VALUE1");
+        assertEquals(enumValue, EnumWithSubclass.VALUE1);
+    }
+}


### PR DESCRIPTION
This is a fix to an issue with the StringToEnumConvertFactory when the
class used is getClass() on a value off an enum, where the values have
implementations.
