### PR TITLE
Fix FreeMarker form checbox macro generated names

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/freemarker/spring.ftl
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/freemarker/spring.ftl
@@ -309,8 +309,8 @@
 	<@bind path />
     <#assign id="${status.expression?replace('[','')?replace(']','')}">
     <#assign isSelected = status.value?? && status.value?string=="true">
-	<input type="hidden" name="_${id}" value="on"/>
-	<input type="checkbox" id="${id}" name="${id}"<#if isSelected> checked="checked"</#if> ${attributes}/>
+	<input type="hidden" name="_${status.expression}" value="on"/>
+	<input type="checkbox" id="${id}" name="${status.expression}"<#if isSelected> checked="checked"</#if> ${attributes}/>
 </#macro>
 
 <#--

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/FreeMarkerMacroTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/FreeMarkerMacroTests.java
@@ -107,7 +107,7 @@ public class FreeMarkerMacroTests {
 		fv.setApplicationContext(wac);
 		fv.setExposeSpringMacroHelpers(true);
 
-		Map model = new HashMap();
+		Map<String, Object> model = new HashMap<String, Object>();
 		model.put("tb", new TestBean("juergen", 99));
 		fv.render(model, request, response);
 	}
@@ -126,7 +126,7 @@ public class FreeMarkerMacroTests {
 		fv.setApplicationContext(wac);
 		fv.setExposeSpringMacroHelpers(true);
 
-		Map model = new HashMap();
+		Map<String, Object> model = new HashMap<String, Object>();
 		model.put(FreeMarkerView.SPRING_MACRO_REQUEST_CONTEXT_ATTRIBUTE, helperTool);
 
 		try {
@@ -265,6 +265,13 @@ public class FreeMarkerMacroTests {
 		assertEquals("<input type=\"text\" id=\"spouses0.name\" name=\"spouses[0].name\" value=\"Fred\"     >", getMacroOutput("FORM17"));
 	}
 
+	@Test
+	public void testForm18() throws Exception {
+		String output = getMacroOutput("FORM18");
+		assertTrue("Wrong output: " + output, output.startsWith("<input type=\"hidden\" name=\"_spouses[0].jedi\" value=\"on\"/>"));
+		assertTrue("Wrong output: " + output, output.contains("<input type=\"checkbox\" id=\"spouses0.jedi\" name=\"spouses[0].jedi\" checked=\"checked\" />"));
+	}
+
 	private String getMacroOutput(String name) throws Exception {
 
 		String macro = fetchMacro(name);
@@ -274,30 +281,32 @@ public class FreeMarkerMacroTests {
 		FileCopyUtils.copy("<#import \"spring.ftl\" as spring />\n" + macro, new FileWriter(resource.getPath()));
 
 		DummyMacroRequestContext rc = new DummyMacroRequestContext(request);
-		Map msgMap = new HashMap();
+		Map<String, String> msgMap = new HashMap<String, String>();
 		msgMap.put("hello", "Howdy");
 		msgMap.put("world", "Mundo");
 		rc.setMessageMap(msgMap);
-		Map themeMsgMap = new HashMap();
+		Map<String, String> themeMsgMap = new HashMap<String, String>();
 		themeMsgMap.put("hello", "Howdy!");
 		themeMsgMap.put("world", "Mundo!");
 		rc.setThemeMessageMap(themeMsgMap);
 		rc.setContextPath("/springtest");
 
-		TestBean tb = new TestBean("Darren", 99);
-		tb.setSpouse(new TestBean("Fred"));
-		tb.setJedi(true);
-		request.setAttribute("command", tb);
+		TestBean darren = new TestBean("Darren", 99);
+		TestBean fred = new TestBean("Fred");
+		fred.setJedi(true);
+		darren.setSpouse(fred);
+		darren.setJedi(true);
+		request.setAttribute("command", darren);
 
-		HashMap names = new HashMap();
+		Map<String, String> names = new HashMap<String, String>();
 		names.put("Darren", "Darren Davison");
 		names.put("John", "John Doe");
 		names.put("Fred", "Fred Bloggs");
 		names.put("Rob&Harrop", "Rob Harrop");
 
 		Configuration config = fc.getConfiguration();
-		Map model = new HashMap();
-		model.put("command", tb);
+		Map<String, Object> model = new HashMap<String, Object>();
+		model.put("command", darren);
 		model.put("springMacroRequestContext", rc);
 		model.put("msgArgs", new Object[] { "World" });
 		model.put("nameOptionMap", names);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/test.ftl
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/test.ftl
@@ -89,3 +89,6 @@ FORM16
 
 FORM17
 <@spring.formInput "command.spouses[0].name", ""/>
+
+FORM18
+<@spring.formCheckbox "command.spouses[0].jedi" />


### PR DESCRIPTION
In Spring 3.2 a fix was implemented for all Spring Freemarker form
macros so that generated form input fields have valid bracketless IDs.
In the fix a regression was introduced manifesting in formCheckbox
macro no longer generating appropriate names for checkbox and hidden
input field.

This change fixes mentioned regression issue.

Issue: SPR-8732
