### PR TITLE
Add ActiveProfileResolver and 'resolver' attribute to @ActiveProfiles (SPR-10338)

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/ActiveProfiles.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ActiveProfiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import java.lang.annotation.Target;
  * @see SmartContextLoader
  * @see MergedContextConfiguration
  * @see ContextConfiguration
+ * @see ActiveProfilesResolver
  * @see org.springframework.context.ApplicationContext
  * @see org.springframework.context.annotation.Profile
  */
@@ -47,8 +48,8 @@ public @interface ActiveProfiles {
 	 * Alias for {@link #profiles}.
 	 *
 	 * <p>This attribute may <strong>not</strong> be used in conjunction
-	 * with {@link #profiles}, but it may be used <em>instead</em> of
-	 * {@link #profiles}.
+	 * with {@link #profiles} neither {@link #resolver}, but it may be used
+	 * <em>instead</em> of {@link #profiles}.
 	 */
 	String[] value() default {};
 
@@ -56,8 +57,8 @@ public @interface ActiveProfiles {
 	 * The bean definition profiles to activate.
 	 *
 	 * <p>This attribute may <strong>not</strong> be used in conjunction
-	 * with {@link #value}, but it may be used <em>instead</em> of
-	 * {@link #value}.
+	 * with {@link #value} neither {@link #resolver}, but it may be used <em>instead</em>
+	 * of {@link #value}.
 	 */
 	String[] profiles() default {};
 
@@ -105,5 +106,22 @@ public @interface ActiveProfiles {
 	 * @see ContextConfiguration#inheritLocations
 	 */
 	boolean inheritProfiles() default true;
+
+	/**
+	 * {@link ActiveProfilesResolver} implementation class to use for resolving active
+	 * profiles for the test at runtime.
+	 *
+	 * <p>Implementation of {@link ActiveProfilesResolver} will not be registered as bean
+	 * and may <strong>not</strong> access {@code ApplicationContext} in any way.
+	 *
+	 * <p>This attribute may <strong>not</strong> be used in conjunction
+	 * with {@link #value} neither {@link #profiles}, but it may be used <em>instead</em>
+	 * of them.
+	 *
+	 * @since 3.2.2
+	 * @see ActiveProfilesResolver
+	 * @see ActiveProfilesResolver#resolve(Class)
+	 */
+	Class<? extends ActiveProfilesResolver> resolver() default ActiveProfilesResolver.class;
 
 }

--- a/spring-test/src/main/java/org/springframework/test/context/ActiveProfilesResolver.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ActiveProfilesResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+/**
+ * {@code ActiveProfiles} is an interface that is used together with
+ * {@link ActiveProfiles#resolver} to decide which <em>active bean definition
+ * profiles</em> should be used when loading an
+ * {@link org.springframework.context.ApplicationContext ApplicationContext}
+ * for test classes.
+ *
+ * <p>{@link ActiveProfiles#resolver} attribute may <strong>not</strong> be used in
+ * conjunction with {@link ActiveProfiles#value} neither {@link ActiveProfiles#profiles}
+ * for the same {@link ActiveProfiles} annotation, but it may be used <em>instead</em>
+ * of them.
+ *
+ * <p>If it is required to mix compile-time and runtime profile declarations, then it is
+ * possible:
+ * <ul>
+ * 		<li>To move compile-time profiles to the base class annotated by {@link
+ * ActiveProfiles}. </li>
+ *		<li>To create a custom additional class-level annotation and take it
+ * into account in custom {@code ActiveProfilesResolver} implementation.
+ * 		</li>
+ * </ul>
+ *
+ * <p>{@code ActiveProfiles} instance created by framework is a plain <em>POJO</em>.
+ *
+ * <p>Concrete implementations must provide a {@code public} no-args constructor.
+ *
+ * @author Michail Nikolaev
+ * @see ActiveProfiles
+ * @see org.springframework.test.context.ActiveProfiles#resolver
+ * @since 3.2.2
+ */
+public interface ActiveProfilesResolver {
+	/**
+	 * Resolves bean definition profiles to be used for test.
+	 *
+	 * @param testClass class of test
+	 * @return profiles to use for loading {@code ApplicationContext} (never {@code
+	 * null})
+	 * @see ActiveProfiles#resolver
+	 * @see ActiveProfiles#inheritProfiles
+	 */
+	String[] resolve(Class<?> testClass);
+}

--- a/spring-test/src/test/java/org/springframework/test/context/TestContextCacheKeyTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/TestContextCacheKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,8 @@ public class TestContextCacheKeyTests {
 		loadAppCtxAndAssertCacheStats(FooBarProfilesTestCase.class, 1, 3, 1);
 		loadAppCtxAndAssertCacheStats(FooBarProfilesTestCase.class, 1, 4, 1);
 		loadAppCtxAndAssertCacheStats(BarFooProfilesTestCase.class, 1, 5, 1);
+		// Profiles loaded using resolver should be used in hash
+		loadAppCtxAndAssertCacheStats(BarFooProfilesResolvedTestCase.class, 1, 6, 1);
 	}
 
 
@@ -97,6 +99,18 @@ public class TestContextCacheKeyTests {
 	@ActiveProfiles({ "bar", "foo" })
 	@ContextConfiguration(classes = Config.class, loader = AnnotationConfigContextLoader.class)
 	private static class BarFooProfilesTestCase {
+	}
+
+	public static class FooBarActiveProfilesResolver implements ActiveProfilesResolver {
+		@Override
+		public String[] resolve(Class<?> testClass) {
+			return new String[] {"foo", "bar"};
+		}
+	}
+
+	@ActiveProfiles(resolver = FooBarActiveProfilesResolver.class)
+	@ContextConfiguration(classes = Config.class, loader = AnnotationConfigContextLoader.class)
+	private static class BarFooProfilesResolvedTestCase {
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/SpringJUnit4TestSuite.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/SpringJUnit4TestSuite.java
@@ -37,7 +37,9 @@ import org.springframework.test.context.junit4.annotation.ExplicitConfigClassesI
 import org.springframework.test.context.junit4.orm.HibernateSessionFlushingTests;
 import org.springframework.test.context.junit4.profile.annotation.DefaultProfileAnnotationConfigTests;
 import org.springframework.test.context.junit4.profile.annotation.DevProfileAnnotationConfigTests;
+import org.springframework.test.context.junit4.profile.annotation.DevProfileResolverAnnotationConfigTests;
 import org.springframework.test.context.junit4.profile.xml.DefaultProfileXmlConfigTests;
+import org.springframework.test.context.junit4.profile.xml.DevProfileResolverXmlConfigTests;
 import org.springframework.test.context.junit4.profile.xml.DevProfileXmlConfigTests;
 
 /**
@@ -77,8 +79,10 @@ StandardJUnit4FeaturesTests.class,//
 	DefaultLoaderBeanOverridingExplicitConfigClassesInheritedTests.class,//
 	DefaultProfileAnnotationConfigTests.class,//
 	DevProfileAnnotationConfigTests.class,//
+	DevProfileResolverAnnotationConfigTests.class,//
 	DefaultProfileXmlConfigTests.class,//
 	DevProfileXmlConfigTests.class,//
+	DevProfileResolverXmlConfigTests.class,//
 	ExpectedExceptionSpringRunnerTests.class,//
 	TimedSpringRunnerTests.class,//
 	RepeatedSpringRunnerTests.class,//

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/profile/annotation/DevProfileResolverAnnotationConfigTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/profile/annotation/DevProfileResolverAnnotationConfigTests.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Copyright 2002-2013 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.test.context.junit4.profile.annotation;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ActiveProfilesResolver;
+
+/**
+ * @author Michail Nikolaev
+ * @since 3.2.2
+ */
+@ActiveProfiles(resolver = DevProfileResolverAnnotationConfigTests.class,
+		inheritProfiles = false)
+public class DevProfileResolverAnnotationConfigTests extends
+		DevProfileAnnotationConfigTests implements ActiveProfilesResolver {
+	@Override
+	public String[] resolve(Class<?> testClass) {
+		return new String[] {"dev"};
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/profile/annotation/ProfileAnnotationConfigTestSuite.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/profile/annotation/ProfileAnnotationConfigTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ import org.junit.runners.Suite.SuiteClasses;
 // Note: the following 'multi-line' layout is for enhanced code readability.
 @SuiteClasses({//
 DefaultProfileAnnotationConfigTests.class,//
-	DevProfileAnnotationConfigTests.class //
+	DevProfileAnnotationConfigTests.class, //
+	DevProfileResolverAnnotationConfigTests.class
 })
 public class ProfileAnnotationConfigTestSuite {
 }

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/profile/importresource/DevProfileResolverAnnotationConfigTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/profile/importresource/DevProfileResolverAnnotationConfigTests.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Copyright 2002-2013 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.test.context.junit4.profile.importresource;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ActiveProfilesResolver;
+
+/**
+ * @author Michail Nikolaev
+ * @since 3.2.2
+ */
+@ActiveProfiles(resolver = DevProfileResolverAnnotationConfigTests.class,
+		inheritProfiles = false)
+public class DevProfileResolverAnnotationConfigTests extends
+		DevProfileAnnotationConfigTests implements ActiveProfilesResolver{
+	@Override
+	public String[] resolve(Class<?> testClass) {
+		return new String[] {"dev"};
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/profile/resolver/ClassNameActiveProfilesConfig.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/profile/resolver/ClassNameActiveProfilesConfig.java
@@ -1,0 +1,29 @@
+/*
+ *
+ *  * Copyright 2002-2013 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.test.context.junit4.profile.resolver;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Michail Nikolaev
+ * @since 3.2.2
+ */
+@Configuration
+public class ClassNameActiveProfilesConfig {
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/profile/resolver/ClassNameActiveProfilesResolver.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/profile/resolver/ClassNameActiveProfilesResolver.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  * Copyright 2002-2013 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.test.context.junit4.profile.resolver;
+
+import org.springframework.test.context.ActiveProfilesResolver;
+
+/**
+ * @author Michail Nikolaev
+ * @since 3.2.2
+ */
+public class ClassNameActiveProfilesResolver implements ActiveProfilesResolver {
+	@Override
+	public String[] resolve(Class<?> testClass) {
+		return new String[] {testClass.getSimpleName().toLowerCase()};
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/profile/resolver/ClassNameActiveProfilesResolverTest.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/profile/resolver/ClassNameActiveProfilesResolverTest.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * Copyright 2002-2013 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.test.context.junit4.profile.resolver;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import javax.inject.Inject;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Michail Nikolaev
+ * @since 3.2.2
+ */
+@ActiveProfiles(resolver = ClassNameActiveProfilesResolver.class)
+@ContextConfiguration(classes = ClassNameActiveProfilesConfig.class, loader = AnnotationConfigContextLoader.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ClassNameActiveProfilesResolverTest {
+	@Inject
+	private ApplicationContext applicationContext;
+	@Test
+	public void test() {
+		assertTrue(Arrays.asList(applicationContext.getEnvironment().getActiveProfiles
+				()).contains(getClass().getSimpleName().toLowerCase()));
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/profile/xml/DevProfileResolverXmlConfigTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/profile/xml/DevProfileResolverXmlConfigTests.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  * Copyright 2002-2013 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.test.context.junit4.profile.xml;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ActiveProfilesResolver;
+
+/**
+ * @author Michail Nikolaev
+ * @since 3.2.2
+ */
+@ActiveProfiles(resolver = DevProfileResolverXmlConfigTests.class, inheritProfiles = false)
+public class DevProfileResolverXmlConfigTests extends DevProfileXmlConfigTests
+		implements ActiveProfilesResolver {
+	@Override
+	public String[] resolve(Class<?> testClass) {
+		return new String[] {"dev"};
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/profile/xml/ProfileXmlConfigTestSuite.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/profile/xml/ProfileXmlConfigTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ import org.junit.runners.Suite.SuiteClasses;
 // Note: the following 'multi-line' layout is for enhanced code readability.
 @SuiteClasses({//
 DefaultProfileXmlConfigTests.class,//
-	DevProfileXmlConfigTests.class //
+	DevProfileXmlConfigTests.class, //
+	DevProfileResolverXmlConfigTests.class//
 })
 public class ProfileXmlConfigTestSuite {
 }

--- a/src/dist/changelog.txt
+++ b/src/dist/changelog.txt
@@ -41,6 +41,7 @@ Changes in version 3.2.2 (2013-03-11)
 * MappingJackson(2)JsonView allows subclasses to access the ObjectMapper and to override content writing (SPR-7619)
 * Log4jWebConfigurer supports resolving placeholders against ServletContext init-parameters as well (SPR-10284)
 * consistent use of LinkedHashMaps and independent getAttributeNames Enumeration in Servlet/Portlet mocks (SPR-10224)
+* added ActiveProfilesResolver and "resolver" property to ActiveProfiles (SPR-10338)
 
 
 Changes in version 3.2.1 (2013-01-24)

--- a/src/reference/docbook/testing.xml
+++ b/src/reference/docbook/testing.xml
@@ -56,8 +56,8 @@
         <interfacename>Environment</interfacename> and
         <interfacename>PropertySource</interfacename> abstractions introduced
         in Spring 3.1 (see <xref
-        linkend="new-in-3.1-environment-abstraction" /> and <xref
-        linkend="new-in-3.1-property-source-abstraction" />).
+        linkend="new-in-3.1-environment-abstraction"/> and <xref
+        linkend="new-in-3.1-property-source-abstraction"/>).
         <classname>MockEnvironment</classname> and
         <classname>MockPropertySource</classname> are useful for developing
         <emphasis>out-of-container</emphasis> tests for code that depends on
@@ -435,8 +435,8 @@
       <para>The <literal>spring-jdbc</literal> module provides support for
       configuring and launching an embedded database which can be used in
       integration tests that interact with a database. For details, see <xref
-      linkend="jdbc-embedded-database-support" /> and <xref
-      linkend="jdbc-embedded-database-dao-testing" />.</para>
+      linkend="jdbc-embedded-database-support"/> and <xref
+      linkend="jdbc-embedded-database-dao-testing"/>.</para>
     </section>
 
     <section xml:id="integration-testing-annotations">
@@ -600,7 +600,11 @@ public class DeveloperIntegrationTests {
             <note>
               <para><interfacename>@ActiveProfiles</interfacename> provides
               support for <emphasis>inheriting</emphasis> active bean
-              definition profiles declared by superclasses by default.</para>
+              definition profiles declared by superclasses by default. Also,
+              it is possible to determine active profiles at
+              <emphasis>runtime</emphasis> by providing
+              <interfacename>ActiveProfilesResolver</interfacename>
+              implementation.</para>
             </note>
 
             <para>See <link
@@ -1322,7 +1326,7 @@ public class MyWebAppTest {
           <interfacename>@Autowired</interfacename> is provided by the
           <classname>DependencyInjectionTestExecutionListener</classname>
           which is configured by default (see <xref
-          linkend="testcontext-fixture-di" />).</para>
+          linkend="testcontext-fixture-di"/>).</para>
         </tip>
 
         <para>Test classes that use the TestContext framework do not need to
@@ -1420,7 +1424,7 @@ public class MyTest {
 
           <para>To load an <interfacename>ApplicationContext</interfacename>
           for your tests using <emphasis>annotated classes</emphasis> (see
-          <xref linkend="beans-java" />), annotate your test class with
+          <xref linkend="beans-java"/>), annotate your test class with
           <interfacename>@ContextConfiguration</interfacename> and configure
           the <literal>classes</literal> attribute with an array that contains
           references to annotated classes.</para>
@@ -1489,7 +1493,7 @@ public class OrderServiceTest {
           <interfacename>@Configuration</interfacename> classes to configure
           specific Spring-managed components for your tests, or vice versa. As
           mentioned in <xref
-          linkend="integration-testing-annotations-spring" /> the TestContext
+          linkend="integration-testing-annotations-spring"/> the TestContext
           framework does not allow you to declare <emphasis>both</emphasis>
           via <interfacename>@ContextConfiguration</interfacename>, but this
           does not mean that you cannot use both.</para>
@@ -1872,7 +1876,114 @@ public class TransferServiceTest {
           <interfacename>@ContextConfiguration </interfacename>annotation. The
           body of the test class itself remains completely unchanged.</para>
 
-          <!-- TODO Consider documenting inheritance for active profiles. -->
+            <para>Often the same profiles are used for most of test classes in
+                a project. To avoid duplicating
+                <interfacename>@ActiveProfiles</interfacename>
+                annotation it is
+                possible to move declaration to the base class for tests.
+            </para>
+
+            <programlisting language="java">package com.bank.service;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+    classes = {
+        TransferServiceConfig.class,
+        StandaloneDataConfig.class,
+        JndiDataConfig.class})
+@ActiveProfiles("dev")
+public abstract class AbstractIntegrationTest {
+}
+            </programlisting>
+
+            <programlisting language="java">package com.bank.service;
+
+public class TransferServiceTest extend AbstractIntegrationTest {
+    @Autowired // "dev" profile inherited
+    private TransferService transferService;
+
+    @Test
+    public void testTransferService() {
+        // test the transferService
+    }
+}
+            </programlisting>
+
+            <para>Also
+                <interfacename>@ActiveProfiles</interfacename>
+                supports
+                <methodname>inheritProfiles</methodname>
+                property to disable active
+                profiles inheritance for some test.
+            </para>
+
+            <programlisting language="java">package com.bank.service;
+
+@ActiveProfiles(profiles = "production", inheritProfiles = false)
+public class ProductionTransferServiceTest extend AbstractIntegrationTest {
+    // "dev" provife overridden to "production"
+}
+            </programlisting>
+
+            <para>Furthermore, sometimes it is required to resolve active
+                profiles for test at runtime. There are several possible reasons for it:
+            </para>
+
+            <itemizedlist>
+                <listitem>
+                    <para>
+                        Usage of different active profiles for different operation
+                        systems
+                    </para>
+                </listitem>
+
+                <listitem>
+                    <para>
+                        Usage of special active profiles for continuous integration
+                        building servers
+                    </para>
+                </listitem>
+
+                <listitem>
+                    <para>
+                        Resolving profiles using different environment settings,
+                        custom class-level, package-level annotations and so
+                        on
+                    </para>
+                </listitem>
+            </itemizedlist>
+
+            <para>
+                <interfacename>ActiveProfilesResolver</interfacename>
+                and
+                <methodname>resolver</methodname>
+                attribute in
+                <interfacename>@ActiveProfiles</interfacename>
+                allow to specify
+                concrete
+                <interfacename>@ActiveProfiles</interfacename>
+                implementation instead of using
+                <methodname>profiles</methodname>
+                attribute. Refer to the respective
+                Javadoc for further information.
+                <programlisting language="java">package com.bank.service;
+
+@ActiveProfiles(resolver = OperationSystemActiveProfilesResolver.class, inheritProfiles = false)
+public class ProductionTransferServiceTest extend AbstractIntegrationTest {
+    // "dev" provife overridden to current operation system name
+}
+                </programlisting>
+                <programlisting language="java">package com.bank.service.test;
+
+public class OperationSystemActiveProfilesResolver implements ActiveProfilesResolver {
+    @Override
+    String[] resolve(Class&lt;?&gt; testClass) {
+        // ...
+        return new String[] {operationSystem};
+    }
+}
+                </programlisting>
+            </para>
         </section>
 
         <section xml:id="testcontext-ctx-management-web">
@@ -2171,7 +2282,7 @@ public class WacTests {
           your test class or test method with
           <interfacename>@DirtiesContext</interfacename> (see the discussion
           of <interfacename>@DirtiesContext</interfacename> in <xref
-          linkend="integration-testing-annotations-spring" />). This instructs
+          linkend="integration-testing-annotations-spring"/>). This instructs
           Spring to remove the context from the cache and rebuild the
           application context before executing the next test. Note that
           support for the <interfacename>@DirtiesContext</interfacename>
@@ -2623,7 +2734,7 @@ public class FictitiousTransactionalTest {
 
 }</programlisting>
 
-        <anchor xml:id="testcontext-tx-false-positives" />
+        <anchor xml:id="testcontext-tx-false-positives"/>
 
         <note>
           <title>Avoid false positives when testing ORM code</title>


### PR DESCRIPTION
Implementation of https://jira.springsource.org/browse/SPR-10338 previously discussed here - https://github.com/SpringSource/spring-framework/issues/240

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.

Updated code, javadoc, reference manual, changelog

If it will hard to merge I may resubmit later.

![Javadoc 1](https://f.cloud.github.com/assets/2277142/222024/c2727400-85b0-11e2-9e61-04acda76ba5e.PNG)
![Javadoc 2](https://f.cloud.github.com/assets/2277142/222028/c69619c4-85b0-11e2-88f8-f04878161b68.PNG)
![Reference manual](https://f.cloud.github.com/assets/2277142/222029/cb4aa4ee-85b0-11e2-9e7c-a91becdf0cc5.PNG)

Issue: SPR-10338
