### PR TITLE
Fix scope of model attributes when including JSP

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -1282,6 +1282,11 @@ public class DispatcherServlet extends FrameworkServlet {
 			}
 		}
 
+		// Need to add attributes that were removed in inlude.
+		for(Object o : attributesSnapshot.keySet()) {
+			attrsToCheck.add(o.toString());
+		}
+
 		// Iterate over the attributes to check, restoring the original value
 		// or removing the attribute, respectively, if appropriate.
 		for (String attrName : attrsToCheck) {


### PR DESCRIPTION
Prior to this commit, setting model attribute in controller of
included JSP would result in overwriting the value in parent model if
the set value was null.

This is because the method
DispatcherServlet.restoreAttributesAfterInclude restores after include
only those attributes that are currently present in request, but
setting the value to null in child controller leads to removing of the
attribute from request.

Now the removed attributes are added back after include.

Issue: SPR-10360

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
