### PR TITLE
UriComponentsBuilder now parses empty fragment correctly.

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -48,6 +48,7 @@ import org.springframework.web.util.HierarchicalUriComponents.PathComponent;
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
  * @author Phillip Webb
+ * @author Oliver Gierke
  * @since 3.1
  * @see #newInstance()
  * @see #fromPath(String)
@@ -204,7 +205,10 @@ public class UriComponentsBuilder {
 				builder.path(path);
 				builder.query(query);
 			}
-			builder.fragment(fragment);
+			
+			if (StringUtils.hasText(fragment)) {
+				builder.fragment(fragment);
+			}
 
 			return builder;
 		}

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -28,11 +28,14 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
 
 /**
  * @author Arjen Poutsma
  * @author Phillip Webb
+ * @author Oliver Gierke
  */
 public class UriComponentsBuilderTests {
 
@@ -353,5 +356,12 @@ public class UriComponentsBuilderTests {
 	    assertThat(UriComponentsBuilder.fromUriString("http://example.com/abc/").pathSegment("x", "y", "z").build().toString(), equalTo("http://example.com/abc/x/y/z"));
 		assertThat(UriComponentsBuilder.fromUriString("http://example.com/abc/").path("/x/").path("/y/z").build().toString(), equalTo("http://example.com/abc/x/y/z"));
 		assertThat(UriComponentsBuilder.fromUriString("http://example.com/abc/").pathSegment("x").path("y").build().toString(), equalTo("http://example.com/abc/x/y"));
+	}
+	
+	@Test
+	public void parsesEmptyFragment() {
+		UriComponents components = UriComponentsBuilder.fromUriString("/example#").build();
+		assertThat(components.getFragment(), is(nullValue()));
+		assertThat(components.toString(), equalTo("/example"));
 	}
 }


### PR DESCRIPTION
Previously, UriComponentsBuilder.fromUriString(…) threw an exception in
case an empty fragment was provided (e.g. /example#). Added a check for 
an empty fragment and prevent the invocation of fragment(…).

Issue: SPR-10363
