### PR TITLE
Add additional test for daylight savings glitch

### DIFF
--- a/spring-context/src/test/java/org/springframework/scheduling/support/CronTriggerTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/support/CronTriggerTests.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
 import org.springframework.scheduling.TriggerContext;
 
 import static org.junit.Assert.*;
@@ -56,7 +55,7 @@ public class CronTriggerTests {
 	@Parameters
 	public static List<Object[]> getParameters() {
 		List<Object[]> list = new ArrayList<Object[]>();
-		list.add(new Object[] { new Date(), TimeZone.getDefault() });
+		list.add(new Object[] { new Date(), TimeZone.getTimeZone("PST") });
 		list.add(new Object[] { new Date(), TimeZone.getTimeZone("CET") });
 		return list;
 	}
@@ -694,6 +693,26 @@ public class CronTriggerTests {
 		assertEquals(calendar.getTime(), date = trigger.nextExecutionTime(context3));
 	}
 
+	@Test
+	public void testDaylightSavingMissingHour() throws Exception {
+		// This trigger has to be somewhere in between 2am and 3am
+		CronTrigger trigger = new CronTrigger("0 10 2 * * *", timeZone);
+		calendar.set(Calendar.DAY_OF_MONTH, 31);
+		calendar.set(Calendar.MONTH, Calendar.MARCH);
+		calendar.set(Calendar.YEAR, 2013);
+		calendar.set(Calendar.HOUR_OF_DAY, 1);
+		calendar.set(Calendar.SECOND, 54);
+		Date date = calendar.getTime();
+		TriggerContext context1 = getTriggerContext(date);
+		if (timeZone.equals(TimeZone.getTimeZone("CET"))) {
+			// Clocks go forward an hour so 2am doesn't exist in CET for this date
+			calendar.add(Calendar.DAY_OF_MONTH, 1);
+		}
+		calendar.add(Calendar.HOUR_OF_DAY, 1);
+		calendar.set(Calendar.MINUTE, 10);
+		calendar.set(Calendar.SECOND, 0);
+		assertEquals(calendar.getTime(), date = trigger.nextExecutionTime(context1));
+	}
 
 	private void assertMatchesNextSecond(CronTrigger trigger, Calendar calendar) {
 		Date date = calendar.getTime();


### PR DESCRIPTION
The problem was that clocks go forward _at_ 2am, so 2am doesn't exist once a
year.  Users might be surprised that their cron trigger doesn't go off one
night, but that is arguably correct (and what happens now).  The test can be 
modified if we decide to change the trigger behaviour.
