### PR TITLE
Compare Kind references before checking log levels

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJWeaverMessageHandler.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJWeaverMessageHandler.java
@@ -51,36 +51,32 @@ public class AspectJWeaverMessageHandler implements IMessageHandler {
 	public boolean handleMessage(IMessage message) throws AbortException {
 		Kind messageKind = message.getKind();
 
-		if (LOGGER.isDebugEnabled() || LOGGER.isTraceEnabled()) {
-			if (messageKind == IMessage.DEBUG) {
+		if (messageKind == IMessage.DEBUG) {
+			if (LOGGER.isDebugEnabled() || LOGGER.isTraceEnabled()) {
 				LOGGER.debug(makeMessageFor(message));
 				return true;
 			}
 		}
-
-		if (LOGGER.isInfoEnabled()) {
-			if ((messageKind == IMessage.INFO) || (messageKind == IMessage.WEAVEINFO)) {
+		else if ((messageKind == IMessage.INFO) || (messageKind == IMessage.WEAVEINFO)) {
+			if (LOGGER.isInfoEnabled()) {
 				LOGGER.info(makeMessageFor(message));
 				return true;
 			}
 		}
-
-		if (LOGGER.isWarnEnabled()) {
-			if (messageKind == IMessage.WARNING) {
+		else if (messageKind == IMessage.WARNING) {
+			if (LOGGER.isWarnEnabled()) {
 				LOGGER.warn(makeMessageFor(message));
 				return true;
 			}
 		}
-
-		if (LOGGER.isErrorEnabled()) {
-			if (messageKind == IMessage.ERROR) {
+		else if (messageKind == IMessage.ERROR) {
+			if (LOGGER.isErrorEnabled()) {
 				LOGGER.error(makeMessageFor(message));
 				return true;
 			}
 		}
-
-		if (LOGGER.isFatalEnabled()) {
-			if (messageKind == IMessage.ABORT) {
+		else if (messageKind == IMessage.ABORT) {
+			if (LOGGER.isFatalEnabled()) {
 				LOGGER.fatal(makeMessageFor(message));
 				return true;
 			}


### PR DESCRIPTION
Assuming reference comparisons are much quicker than checking
the resolved logger level via the isFooEnabled() methods, reverse
the nested `if()` tests. Also, since the reference can match only
one of the instances, use `else if` to short-circuit the search.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
