### PR TITLE
Allow custom ServletRequestAttributes handling

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/web/ServletTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/web/ServletTestExecutionListener.java
@@ -17,6 +17,7 @@
 package org.springframework.test.context.web;
 
 import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,6 +33,7 @@ import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.context.request.ServletWebRequest;
 
 /**
@@ -123,7 +125,13 @@ public class ServletTestExecutionListener extends AbstractTestExecutionListener 
 				MockServletContext mockServletContext = (MockServletContext) servletContext;
 				MockHttpServletRequest request = new MockHttpServletRequest(mockServletContext);
 				MockHttpServletResponse response = new MockHttpServletResponse();
-				ServletWebRequest servletWebRequest = new ServletWebRequest(request, response);
+				ServletWebRequest servletWebRequest = new ServletWebRequest(request, response) {
+					@Override
+					public ServletRequestAttributes getSubsequentRequestAttributes(HttpServletRequest request) {
+						// Always replace the initial request (SPR-10025)
+						return new ServletRequestAttributes(request);
+					}
+				};
 
 				RequestContextHolder.setRequestAttributes(servletWebRequest);
 

--- a/spring-web/src/main/java/org/springframework/web/context/request/ServletRequestAttributes.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/ServletRequestAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -259,4 +259,21 @@ public class ServletRequestAttributes extends AbstractRequestAttributes {
 		return this.request.toString();
 	}
 
+	/**
+	 * Returns the {@link ServletRequestAttributes} that should be used for any
+	 * {@link HttpServletRequest} that occurs after this one. This method determines how
+	 * any subsequent requests are handled and what attributes are exposed. By default
+	 * this method will return a new {@link ServletRequestAttributes} only if this
+	 * instance class equals {@link ServletRequestAttributes}. In other words, custom
+	 * subclasses of {@link ServletRequestAttributes} will never be replaced unless
+	 * they override this method.
+	 * @return A new {@link ServletRequestAttributes}, the current instance or {@code null}
+	 * @since 3.2.2
+	 */
+	public ServletRequestAttributes getSubsequentRequestAttributes(HttpServletRequest request) {
+		if(getClass().equals(ServletRequestAttributes.class)) {
+			return new ServletRequestAttributes(request);
+		}
+		return this;
+	}
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/FrameworkServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/FrameworkServlet.java
@@ -916,8 +916,11 @@ public abstract class FrameworkServlet extends HttpServletBean {
 
 		RequestAttributes previousAttributes = RequestContextHolder.getRequestAttributes();
 		ServletRequestAttributes requestAttributes = null;
-		if (previousAttributes == null || (previousAttributes instanceof ServletRequestAttributes)) {
+		if (previousAttributes == null) {
 			requestAttributes = new ServletRequestAttributes(request);
+		}
+		else if (previousAttributes instanceof ServletRequestAttributes) {
+			requestAttributes = ((ServletRequestAttributes) previousAttributes).getSubsequentRequestAttributes(request);
 		}
 
 		initContextHolders(request, localeContext, requestAttributes);


### PR DESCRIPTION
Add ServletRequestAttributes.getSubsequentRequestAttributes(...) method
that can be used to determine how subsequent HttpServletRequests should
be handled. The default implementation restores the behavior of Spring
3.1 in never replacing custom subclasses of ServletRequestAttributes.

The ServletTestExecutionListener from spring-test now override
getSubsequentRequestAttributes to ensure that the initial request
is alway replaced in the test context (see ).

Issue: 
