### PR TITLE
Parse variant in locale string only if necessary

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -686,7 +686,7 @@ public abstract class StringUtils {
 		validateLocalePart(language);
 		validateLocalePart(country);
 		String variant = "";
-		if (parts.length >= 2) {
+		if (parts.length > 2) {
 			// There is definitely a variant, and it is everything after the country
 			// code sans the separator between the country code and the variant.
 			int endIndexOfCountryCode = localeString.lastIndexOf(country) + country.length();


### PR DESCRIPTION
Before this change logic for parsing locale string would look for
variant even when it's clear that local string doesn't have variant
part.

With this patch locale string parsing is improved so that variant
processing gets skipped when not necessary.

Issue: SPR-10364
