### PR TITLE
Eliminate JavaDoc generation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ configure(allprojects) { project ->
 		"http://docs.oracle.com/javase/6/docs/api",
 		"http://docs.oracle.com/javaee/6/api",
 		"http://portals.apache.org/pluto/portlet-2.0-apidocs/",
-		"http://commons.apache.org/lang/api-2.5",
+		"http://commons.apache.org/lang/javadocs/api-2.5",
 		"http://commons.apache.org/codec/apidocs",
 		"http://docs.jboss.org/jbossas/javadoc/4.0.5/connector",
 		"http://docs.jboss.org/jbossas/javadoc/7.1.2.Final",
@@ -89,7 +89,7 @@ configure(allprojects) { project ->
 		"http://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs",
 		"http://ibatis.apache.org/docs/java/dev",
 		"http://tiles.apache.org/framework/apidocs",
-		"http://commons.apache.org/dbcp/api-1.2.2",
+		"http://commons.apache.org/dbcp/javadocs/api-1.2.2",
 	] as String[]
 }
 

--- a/spring-test/src/main/java/org/springframework/mock/web/MockServletContext.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockServletContext.java
@@ -245,7 +245,7 @@ public class MockServletContext implements ServletContext {
 	/**
 	 * This method uses the Java Activation framework, which returns
 	 * "application/octet-stream" when the mime type is unknown (i.e. it never returns
-	 * {@code null}). In order to maintain the {@link ServletContext#getMimeType(String)
+	 * {@code null}). In order to maintain the {@link ServletContext#getMimeType(String)}
 	 * contract, as of version 3.2.2, this method returns null if the mimeType is
 	 * "application/octet-stream".
 	 */

--- a/spring-test/src/main/java/org/springframework/test/context/TestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/TestContext.java
@@ -167,7 +167,7 @@ public class TestContext extends AttributeAccessorSupport {
 	 * context} associated with this test context is <em>dirty</em> and should be
 	 * discarded. Do this if a test has modified the context &mdash; for example,
 	 * by replacing a bean definition or modifying the state of a singleton bean.
-	 * @deprecated As of Spring 3.2.2, use {@link #markApplicationContextDirty(HierarchyMode)} instead.
+	 * @deprecated As of Spring 3.2.2, use {@link #markApplicationContextDirty(DirtiesContext.HierarchyMode)} instead.
 	 */
 	@Deprecated
 	public void markApplicationContextDirty() {

--- a/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
@@ -51,7 +51,7 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 	 * REINJECT_DEPENDENCIES_ATTRIBUTE} in the test context to {@code true}.
 	 * @param testContext the test context whose application context should
 	 * marked as dirty
-	 * @deprecated as of Spring 3.2.2, use {@link #dirtyContext(TestContext, HierarchyMode)} instead.
+	 * @deprecated as of Spring 3.2.2, use {@link #dirtyContext(TestContext, DirtiesContext.HierarchyMode)} instead.
 	 */
 	@Deprecated
 	protected void dirtyContext(TestContext testContext) {
@@ -62,7 +62,7 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 	/**
 	 * Marks the {@linkplain ApplicationContext application context} of the supplied
 	 * {@linkplain TestContext test context} as {@linkplain
-	 * TestContext#markApplicationContextDirty(HierarchyMode) dirty} and sets the
+	 * TestContext#markApplicationContextDirty(DirtiesContext.HierarchyMode) dirty} and sets the
 	 * {@link DependencyInjectionTestExecutionListener#REINJECT_DEPENDENCIES_ATTRIBUTE
 	 * REINJECT_DEPENDENCIES_ATTRIBUTE} in the test context to {@code true}.
 	 * @param testContext the test context whose application context should


### PR DESCRIPTION
Spring JavaDoc generation used to produce several warnings due to few
broken external API JavaDoc links in Gradle build script, and a few
errors in Spring JavaDoc itself.

This patch eliminates mentioned JavaDoc generation warnings.

Issue: SPR-10373
