### PR TITLE
Async Request Processing Callable Code Error 

### DIFF
--- a/src/reference/docbook/mvc.xml
+++ b/src/reference/docbook/mvc.xml
@@ -2420,7 +2420,7 @@ public String myHandleMethod(WebRequest webRequest, Model model) {
 public Callable&lt;String&gt; processUpload(final MultipartFile file) {
 
   return new Callable&lt;String&gt;() {
-    public Object call() throws Exception {
+    public String call() throws Exception {
       // ...
       return "someView";
     }


### PR DESCRIPTION
The java.util.concurrent.Callable code example in the "Asynchronous Request Processing" section had a "call()" method return type of "Object" when it should be "String".
