### PR TITLE
Remove default for LifecycleGroup.lifecycleBeans

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -302,7 +302,7 @@ public class DefaultLifecycleProcessor implements LifecycleProcessor, BeanFactor
 
 		private final List<LifecycleGroupMember> members = new ArrayList<LifecycleGroupMember>();
 
-		private Map<String, ? extends Lifecycle> lifecycleBeans = getLifecycleBeans();
+		private final Map<String, ? extends Lifecycle> lifecycleBeans;
 
 		private volatile int smartMemberCount;
 


### PR DESCRIPTION
It is overwritten by the constructor and thus unused.
Since the value is never modified, it is now final.

Issue: SPR-10388

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
