### PR TITLE
[SPR-10412] Support generics in JmsTemplate

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/support/converter/MessageConverter.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/converter/MessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 
 package org.springframework.jms.support.converter;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.Session;
 
 /**
  * Strategy interface that specifies a converter between Java objects and JMS messages.
@@ -34,26 +31,6 @@ import javax.jms.Session;
  * @see org.springframework.jms.remoting.JmsInvokerClientInterceptor#setMessageConverter
  * @see org.springframework.jms.remoting.JmsInvokerServiceExporter#setMessageConverter
  */
-public interface MessageConverter {
-
-	/**
-	 * Convert a Java object to a JMS Message using the supplied session
-	 * to create the message object.
-	 * @param object the object to convert
-	 * @param session the Session to use for creating a JMS Message
-	 * @return the JMS Message
-	 * @throws javax.jms.JMSException if thrown by JMS API methods
-	 * @throws MessageConversionException in case of conversion failure
-	 */
-	Message toMessage(Object object, Session session) throws JMSException, MessageConversionException;
-
-	/**
-	 * Convert from a JMS Message to a Java object.
-	 * @param message the message to convert
-	 * @return the converted Java object
-	 * @throws javax.jms.JMSException if thrown by JMS API methods
-	 * @throws MessageConversionException in case of conversion failure
-	 */
-	Object fromMessage(Message message) throws JMSException, MessageConversionException;
+public interface MessageConverter<T> extends MessageDecoder<T>, MessageEncoder<T> {
 
 }

--- a/spring-jms/src/main/java/org/springframework/jms/support/converter/MessageDecoder.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/converter/MessageDecoder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2004-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jms.support.converter;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+
+/**
+ * Strategy interface that specifies a converter from JMS messages to Java objects.
+ * 
+ * @author Philippe Marschall
+ * @since 5.3
+ */
+public interface MessageDecoder<T> {
+	
+	/**
+	 * Convert from a JMS Message to a Java object.
+	 * @param message the message to convert
+	 * @return the converted Java object
+	 * @throws javax.jms.JMSException if thrown by JMS API methods
+	 * @throws MessageConversionException in case of conversion failure
+	 */
+	T fromMessage(Message message) throws JMSException, MessageConversionException;
+
+}

--- a/spring-jms/src/main/java/org/springframework/jms/support/converter/MessageEncoder.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/converter/MessageEncoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jms.support.converter;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+
+
+/**
+ * Strategy interface that specifies a converter from Java objects to JMS messages.
+ * 
+ * @author Philippe Marschall
+ * @since 5.3
+ */
+public interface MessageEncoder<T> {
+	
+	/**
+	 * Convert a Java object to a JMS Message using the supplied session
+	 * to create the message object.
+	 * @param object the object to convert
+	 * @param session the Session to use for creating a JMS Message
+	 * @return the JMS Message
+	 * @throws javax.jms.JMSException if thrown by JMS API methods
+	 * @throws MessageConversionException in case of conversion failure
+	 */
+	Message toMessage(T object, Session session) throws JMSException, MessageConversionException;
+
+}

--- a/spring-jms/src/main/java/org/springframework/jms/support/converter/SimpleMessageConverter.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/converter/SimpleMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import org.springframework.util.ObjectUtils;
  * @see org.springframework.jms.core.JmsTemplate#convertAndSend
  * @see org.springframework.jms.core.JmsTemplate#receiveAndConvert
  */
-public class SimpleMessageConverter implements MessageConverter {
+public class SimpleMessageConverter implements MessageConverter<Object> {
 
 	/**
 	 * This implementation creates a TextMessage for a String, a


### PR DESCRIPTION
The `#convertAndSend` and `#receiveAndConvert` methods and the
`MessageConverter` interface currently are not type safe. Everywhere
`Object` is passed around casts have to be made.

This pull request tries to address the issue by:
- split `MessageConverter` into two interfaces, `MessageDecoder` and
  `MessageEncoder` so that Java 8 lambdas can be used
- add generics to `MessageConverter`, `MessageDecoder` and
  `MessageEncoder`
- for every `#convertAndSend` method add a new one that has a
  `MessageEncoder` as a second argument
- for every `#receiveAndConvert` method add a new one that
  has a `MessageDecoder` as a second argument
- add generics to the new `#convertAndSend` and
  `#receiveAndConvert` methods

MessageConverter and MessageDecoder are not be best names but the best
ones I could come up with.

Maybe `MessageConverter` and `MessageDecoder` should be annotated with
`java.lang.FunctionalInterface` but this would have to be done over the
entire code base eg. `org.springframework.jdbc.core.RowMapper`.

As usual, I'm not one hundred percent certain when it comes to wild
cards.

And tests are missing.

Issue: SPR-10412
https://jira.springsource.org/browse/SPR-10412
