### PR TITLE
SPR-10422 Updated the methodReference

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/MethodReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/MethodReference.java
@@ -51,6 +51,10 @@ public class MethodReference extends SpelNodeImpl {
 		this.name = methodName;
 		this.nullSafe = nullSafe;
 	}
+	
+	public String getName() {
+		return name;
+	}
 
 	class MethodValueRef implements ValueRef {
 


### PR DESCRIPTION
MethodReference nodes we miss a method to get method name out of it (while there is a private member for the same)
