### PR TITLE
Fix missing font for JasperReports tests on Linux

### DIFF
--- a/spring-webmvc/src/test/resources/jasperreports.properties
+++ b/spring-webmvc/src/test/resources/jasperreports.properties
@@ -1,0 +1,1 @@
+net.sf.jasperreports.awt.ignore.missing.font=true


### PR DESCRIPTION
JasperReports dependency has been upgraded to 5.0.4 as one of the
improvements coming with Spring 4.0. New JasperReports checks for
presence of fonts that reports use and throws JRFontNotFoundException
if either is not found. Before this fix mentioned exception was being
thrown from Spring tests verifying JasperReports support since they
reference Arial font which is not available by default on Linux
distributions. This caused build failures on Linux environments.

Issue can be solved by packaging font with report, using JasperReports
font extension support. Other way to handle this is by configuring
JasperReports to ignore missing font and fallback to what is available.

This patch fixes the issue by configuring JasperReports in Spring tests
to ignore missing font. It is chosen for practicallity, and because
actual report layout in existing unit tests is not of importance.

Issue: SPR-10438
