### PR TITLE
Support specifying time zone for @Scheduled cron

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -21,6 +21,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.TimeZone;
 
 /**
  * Annotation that marks a method to be scheduled. Exactly one of the
@@ -56,6 +57,15 @@ public @interface Scheduled {
 	 * @see org.springframework.scheduling.support.CronSequenceGenerator
 	 */
 	String cron() default "";
+
+	/**
+	 * A time zone for which cron expression will be resolved.
+	 * When left unspecified defaults to default {@link TimeZone}.
+	 * @return a time zone id
+	 * @see org.springframework.scheduling.support.CronSequenceGenerator
+	 * @see java.util.TimeZone
+	 */
+	String timezone() default "";
 
 	/**
 	 * Execute the annotated method with a fixed period between the end

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -165,6 +165,7 @@ public class ScheduledAnnotationBeanPostProcessor
 							String timezoneId = annotation.timezone();
 							if (!"".equals(timezoneId)) {
 								TimeZone timezone = TimeZone.getTimeZone(timezoneId);
+								Assert.isTrue(timezoneId.equals(timezone.getID()), "Invalid timezone \"" + timezoneId + "\" - given timezone ID could not be understood.");
 								registrar.addCronTask(new CronTask(runnable, new CronTrigger(cron, timezone)));
 							} else {
 								registrar.addCronTask(new CronTask(runnable, cron));

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -19,6 +19,7 @@ package org.springframework.scheduling.annotation;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.springframework.aop.support.AopUtils;
@@ -36,6 +37,7 @@ import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.IntervalTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.ScheduledMethodRunnable;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
@@ -160,7 +162,13 @@ public class ScheduledAnnotationBeanPostProcessor
 							if (embeddedValueResolver != null) {
 								cron = embeddedValueResolver.resolveStringValue(cron);
 							}
-							registrar.addCronTask(new CronTask(runnable, cron));
+							String timezoneId = annotation.timezone();
+							if (!"".equals(timezoneId)) {
+								TimeZone timezone = TimeZone.getTimeZone(timezoneId);
+								registrar.addCronTask(new CronTask(runnable, new CronTrigger(cron, timezone)));
+							} else {
+								registrar.addCronTask(new CronTask(runnable, cron));
+							}
 						}
 						// At this point we don't need to differentiate between initial delay set or not anymore
 						if (initialDelay < 0) {

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
@@ -22,8 +22,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.Properties;
+import java.util.TimeZone;
 
 import org.junit.Test;
 
@@ -33,10 +36,14 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.IntervalTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.ScheduledMethodRunnable;
+import org.springframework.scheduling.support.SimpleTriggerContext;
 import org.springframework.tests.Assume;
 import org.springframework.tests.TestGroup;
 
@@ -154,6 +161,51 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 		assertEquals(target, targetObject);
 		assertEquals("cron", targetMethod.getName());
 		assertEquals("*/7 * * * * ?", task.getExpression());
+		Thread.sleep(10000);
+	}
+
+	@Test
+	public void cronTaskWithTimezone() throws InterruptedException {
+		Assume.group(TestGroup.LONG_RUNNING);
+
+		StaticApplicationContext context = new StaticApplicationContext();
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(
+				ScheduledAnnotationBeanPostProcessorTests.CronWithTimezoneTestBean.class);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+		Object postProcessor = context.getBean("postProcessor");
+		Object target = context.getBean("target");
+		ScheduledTaskRegistrar registrar = (ScheduledTaskRegistrar)
+				new DirectFieldAccessor(postProcessor).getPropertyValue("registrar");
+		@SuppressWarnings("unchecked")
+		List<CronTask> cronTasks = (List<CronTask>)
+				new DirectFieldAccessor(registrar).getPropertyValue("cronTasks");
+		assertEquals(1, cronTasks.size());
+		CronTask task = cronTasks.get(0);
+		ScheduledMethodRunnable runnable = (ScheduledMethodRunnable) task.getRunnable();
+		Object targetObject = runnable.getTarget();
+		Method targetMethod = runnable.getMethod();
+		assertEquals(target, targetObject);
+		assertEquals("cron", targetMethod.getName());
+		assertEquals("0 0 0-4,6-23 * * ?", task.getExpression());
+		Trigger trigger = task.getTrigger();
+		assertNotNull(trigger);
+		assertTrue(trigger instanceof CronTrigger);
+		CronTrigger cronTrigger = (CronTrigger) trigger;
+		Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT+10"));
+		cal.clear();
+		cal.set(2013, 3, 15, 4, 0); // 15-04-2013 4:00 GMT+10
+		Date lastScheduledExecutionTime = cal.getTime();
+		Date lastActualExecutionTime = cal.getTime();
+		cal.add(Calendar.MINUTE, 30); // 4:30
+		Date lastCompletionTime = cal.getTime();
+		TriggerContext triggerContext = new SimpleTriggerContext(lastScheduledExecutionTime, lastActualExecutionTime, lastCompletionTime);
+		cal.add(Calendar.MINUTE, 30);
+		cal.add(Calendar.HOUR_OF_DAY, 1); // 6:00
+		Date nextExecutionTime = cronTrigger.nextExecutionTime(triggerContext);
+		assertEquals(cal.getTime(), nextExecutionTime); // assert that 6:00 is next execution time
 		Thread.sleep(10000);
 	}
 
@@ -407,6 +459,16 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 	static class CronTestBean {
 
 		@Scheduled(cron="*/7 * * * * ?")
+		public void cron() throws IOException {
+			throw new IOException("no no no");
+		}
+
+	}
+
+
+	static class CronWithTimezoneTestBean {
+
+		@Scheduled(cron="0 0 0-4,6-23 * * ?", timezone = "GMT+10")
 		public void cron() throws IOException {
 			throw new IOException("no no no");
 		}

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
@@ -209,6 +209,20 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 		Thread.sleep(10000);
 	}
 
+	@Test(expected = BeanCreationException.class)
+	public void cronTaskWithInvalidTimezone() throws InterruptedException {
+		Assume.group(TestGroup.LONG_RUNNING);
+
+		StaticApplicationContext context = new StaticApplicationContext();
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(
+				ScheduledAnnotationBeanPostProcessorTests.CronWithInvalidTimezoneTestBean.class);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+		Thread.sleep(10000);
+	}
+
 	@Test
 	public void metaAnnotationWithFixedRate() {
 		StaticApplicationContext context = new StaticApplicationContext();
@@ -469,6 +483,16 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 	static class CronWithTimezoneTestBean {
 
 		@Scheduled(cron="0 0 0-4,6-23 * * ?", timezone = "GMT+10")
+		public void cron() throws IOException {
+			throw new IOException("no no no");
+		}
+
+	}
+
+
+	static class CronWithInvalidTimezoneTestBean {
+
+		@Scheduled(cron="0 0 0-4,6-23 * * ?", timezone = "FOO")
 		public void cron() throws IOException {
 			throw new IOException("no no no");
 		}


### PR DESCRIPTION
Using @Scheduled annotation one can declaratively configure desired
method execution schedule, via a cron expression. Some of the cron
expressions can evaluate to a time zone sensitive value. So far a
default Java timezone would always be used, even though a different one
might be desired.

This patch adds support for explicitly specifying time zone for which
cron expression should be resolved. One does that by configuring new
timezone attribute of @Scheduled annotation to ID of desired time zone.

Issue: SPR-10456
