### PR TITLE
[SPR-9719] Improve TypeUtils.isAssignable recognize TypeVariable types

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/TypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/TypeUtils.java
@@ -19,8 +19,10 @@ package org.springframework.util;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -73,7 +75,6 @@ public abstract class TypeUtils {
 			}
 			else if(rhsType instanceof TypeVariable) {
 				Type[] types = ((TypeVariable<?>)rhsType).getBounds();
-
 
 				for(int i=0; i<types.length; i++) {
 					if(isAssignable(lhsClass, types[i])) return true;

--- a/spring-core/src/main/java/org/springframework/util/TypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/TypeUtils.java
@@ -71,6 +71,13 @@ public abstract class TypeUtils {
 
 				return isAssignable(lhsClass.getComponentType(), rhsComponent);
 			}
+			else if(rhsType instanceof TypeVariable) {
+				Type[] types = ((TypeVariable<?>)rhsType).getBounds();
+
+				for(int i=0; i<types.length; i++) {
+					if(isAssignable(lhsClass, types[i])) return true;
+				}
+			}
 		}
 
 		// parameterized types are only assignable to other parameterized types and class types

--- a/spring-core/src/main/java/org/springframework/util/TypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/TypeUtils.java
@@ -74,6 +74,7 @@ public abstract class TypeUtils {
 			else if(rhsType instanceof TypeVariable) {
 				Type[] types = ((TypeVariable<?>)rhsType).getBounds();
 
+
 				for(int i=0; i<types.length; i++) {
 					if(isAssignable(lhsClass, types[i])) return true;
 				}

--- a/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
@@ -56,6 +56,7 @@ public class TypeUtilsTests {
 
 	public static List<? extends Number>[] openArray;
 
+	private <T extends Serializable> void typeTestMethod(T arg) {}
 
 	@Test
 	public void withClasses() {
@@ -125,4 +126,9 @@ public class TypeUtilsTests {
 		assertTrue(TypeUtils.isAssignable(openArrayType, arrayType));
 	}
 
+	@Test
+	public void withTypeVariableType() throws Exception {
+		Type[] paramTypes = TypeUtilsTest.class.getDeclaredMethod("typeTestMethod", Serializable.class).getGenericParameterTypes();;
+		assertTrue(TypeUtils.isAssignable(Object.class, paramTypes[0]));
+	}
 }

--- a/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
@@ -19,6 +19,7 @@ package org.springframework.util;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;

--- a/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
@@ -130,5 +130,6 @@ public class TypeUtilsTests {
 	public void withTypeVariableType() throws Exception {
 		Type[] paramTypes = TypeUtilsTest.class.getDeclaredMethod("typeTestMethod", Serializable.class).getGenericParameterTypes();;
 		assertTrue(TypeUtils.isAssignable(Object.class, paramTypes[0]));
+
 	}
 }

--- a/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
@@ -19,7 +19,6 @@ package org.springframework.util;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;

--- a/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/TypeUtilsTests.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.io.Serializable;
 
 import org.junit.Test;
 
@@ -128,8 +129,7 @@ public class TypeUtilsTests {
 
 	@Test
 	public void withTypeVariableType() throws Exception {
-		Type[] paramTypes = TypeUtilsTest.class.getDeclaredMethod("typeTestMethod", Serializable.class).getGenericParameterTypes();;
+		Type[] paramTypes = TypeUtilsTests.class.getDeclaredMethod("typeTestMethod", Serializable.class).getGenericParameterTypes();
 		assertTrue(TypeUtils.isAssignable(Object.class, paramTypes[0]));
-
 	}
 }


### PR DESCRIPTION
I add th code in TypeUtils and TypeUtilsTest.

In isAssignable method, the case when parameter is TypeVariable is added.

This is reported in Jira SPR-9719: TypeUtils.isAssignable does not recognize TypeVariable types

After checking if lhsType is instanceof Class<?>, rhsType will be check TypeVariable.

else if(rhsType instanceof TypeVariable) {
   Type[] types = ((TypeVariable<?>)rhsType).getBounds();

```
for(int i=0; i<types.length; i++) {
   if(isAssignable(lhsClass, types[i])) return true;
}
```

}

Please consider this.

I hope that I can contribute.
Thanks.
