### PR TITLE
Add method that execute batch update by named param

### DIFF
--- a/spring-jdbc/src/test/java/org/springframework/jdbc/object/BatchSqlUpdateTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/object/BatchSqlUpdateTests.java
@@ -20,6 +20,8 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -70,6 +72,84 @@ public class BatchSqlUpdateTests {
 
 		update.update(ids[0]);
 		update.update(ids[1]);
+
+		if (flushThroughBatchSize) {
+			assertEquals(0, update.getQueueCount());
+			assertEquals(2, update.getRowsAffected().length);
+		}
+		else {
+			assertEquals(2, update.getQueueCount());
+			assertEquals(0, update.getRowsAffected().length);
+		}
+
+		int[] actualRowsAffected = update.flush();
+		assertEquals(0, update.getQueueCount());
+
+		if (flushThroughBatchSize) {
+			assertTrue("flush did not execute updates", actualRowsAffected.length == 0);
+		}
+		else {
+			assertTrue("executed 2 updates", actualRowsAffected.length == 2);
+			assertEquals(rowsAffected[0], actualRowsAffected[0]);
+			assertEquals(rowsAffected[1], actualRowsAffected[1]);
+		}
+
+		actualRowsAffected = update.getRowsAffected();
+		assertTrue("executed 2 updates", actualRowsAffected.length == 2);
+		assertEquals(rowsAffected[0], actualRowsAffected[0]);
+		assertEquals(rowsAffected[1], actualRowsAffected[1]);
+
+		update.reset();
+		assertEquals(0, update.getRowsAffected().length);
+
+		verify(preparedStatement).setObject(1, new Integer(ids[0]), Types.INTEGER);
+		verify(preparedStatement).setObject(1, new Integer(ids[1]), Types.INTEGER);
+		verify(preparedStatement, times(2)).addBatch();
+		verify(preparedStatement).close();
+	}
+	
+	@Test
+	public void testNamedParamBatchUpdateWithExplicitFlush() throws Exception {
+		doTestNamedParamBatchUpdate(false);
+	}
+
+	@Test
+	public void testNamedParamBatchUpdateWithFlushThroughBatchSize() throws Exception {
+		doTestNamedParamBatchUpdate(true);
+	}
+	
+	private void doTestNamedParamBatchUpdate(boolean flushThroughBatchSize) throws Exception {
+		final String sql2 = "UPDATE NOSUCHTABLE SET DATE_DISPATCHED = SYSDATE WHERE ID = ?";
+		final String sql = "UPDATE NOSUCHTABLE SET DATE_DISPATCHED = SYSDATE WHERE ID = :priceId";
+		final int[] ids = new int[] { 100, 200 };
+		final int[] rowsAffected = new int[] { 1, 2 };
+
+		Connection connection = mock(Connection.class);
+		DataSource dataSource = mock(DataSource.class);
+		given(dataSource.getConnection()).willReturn(connection);
+		PreparedStatement preparedStatement = mock(PreparedStatement.class);
+		given(preparedStatement.getConnection()).willReturn(connection);
+		given(preparedStatement.executeBatch()).willReturn(rowsAffected);
+
+		DatabaseMetaData mockDatabaseMetaData = mock(DatabaseMetaData.class);
+		given(mockDatabaseMetaData.supportsBatchUpdates()).willReturn(true);
+		given(connection.prepareStatement(sql2)).willReturn(preparedStatement);
+		given(connection.getMetaData()).willReturn(mockDatabaseMetaData);
+
+		BatchSqlUpdate update = new BatchSqlUpdate(dataSource, sql);
+		update.declareParameter(new SqlParameter("priceId",Types.INTEGER));
+		update.compile();
+		if (flushThroughBatchSize) {
+			update.setBatchSize(2);
+		}
+
+		Map<String, Integer> params = new HashMap<String, Integer>();
+		params.put("priceId", ids[0]);
+		Map<String, Integer> params2 = new HashMap<String, Integer>();
+		params2.put("priceId", ids[1]);
+		
+		update.updateByNamedParam(params);
+		update.updateByNamedParam(params2);
 
 		if (flushThroughBatchSize) {
 			assertEquals(0, update.getQueueCount());


### PR DESCRIPTION
Prior to this commit, BatchSqlUpdate class didn't override 
updateByNamedParam() method but overrided update() method only.

Now BatchSqlUpdate class support both method.
This change would make BatchSqlUpdate class more consistent
because parent SqlUpdate class supports both method.

To add new method, existing codes from SqlUpdate class and 
BatchSqlUpdate class were reused.

Issue: SPR-10435
