### PR TITLE
Replace MaxPermSize use in build scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -962,7 +962,7 @@ configure(rootProject) {
 		gradleVersion = "1.6"
 
 		doLast() {
-			def gradleOpts = "-XX:MaxPermSize=1024m -Xmx1024m"
+			def gradleOpts = "-XX:MaxMetaspaceSize=1024m -Xmx1024m"
 			def gradleBatOpts = "$gradleOpts -XX:MaxHeapSize=256m"
 			File wrapperFile = file("gradlew")
 			wrapperFile.text = wrapperFile.text.replace("DEFAULT_JVM_OPTS=",

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 ##############################################################################
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-GRADLE_OPTS="-XX:MaxPermSize=1024m -Xmx1024m $GRADLE_OPTS"
+GRADLE_OPTS="-XX:MaxMetaspaceSize=1024m -Xmx1024m $GRADLE_OPTS"
 DEFAULT_JVM_OPTS=""
 
 APP_NAME="Gradle"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -9,7 +9,7 @@
 if "%OS%"=="Windows_NT" setlocal
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set GRADLE_OPTS=-XX:MaxPermSize=1024m -Xmx1024m -XX:MaxHeapSize=256m %GRADLE_OPTS%
+set GRADLE_OPTS=-XX:MaxMetaspaceSize=1024m -Xmx1024m -XX:MaxHeapSize=256m %GRADLE_OPTS%
 set DEFAULT_JVM_OPTS=
 
 set DIRNAME=%~dp0


### PR DESCRIPTION
Since JDK 8 is required to build Spring framework 4, and permanent
generation is gone from Java 8, to eliminate warnings about no longer
available MaxPermSize switch, it should be removed or replaced with new
MaxMetaspaceSize switch.

This fix replaces old with new switch to limit the amount of native
memory used for class metadata.

Issue: SPR-10571
