### PR TITLE
Eliminate Gradle 1.6 deprecation warnings

### DIFF
--- a/buildSrc/src/main/groovy/org/springframework/build/gradle/DetectSplitPackagesPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/springframework/build/gradle/DetectSplitPackagesPlugin.groovy
@@ -49,7 +49,7 @@ import org.gradle.api.tasks.TaskAction
 public class DetectSplitPackagesPlugin implements Plugin<Project> {
 	public void apply(Project project) {
 		def tasks = project.tasks
-		Task detectSplitPackages = tasks.add("detectSplitPackages", DetectSplitPackagesTask.class)
+		Task detectSplitPackages = tasks.create("detectSplitPackages", DetectSplitPackagesTask.class)
 		if (tasks.asMap.containsKey("check")) {
 			tasks.getByName("check").dependsOn detectSplitPackages
 		}

--- a/buildSrc/src/main/groovy/org/springframework/build/gradle/MergePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/springframework/build/gradle/MergePlugin.groovy
@@ -67,8 +67,8 @@ class MergePlugin implements Plugin<Project> {
 		project.plugins.apply(IdeaPlugin)
 
 		MergeModel model = project.extensions.create("merge", MergeModel)
-		project.configurations.add("merging")
-		Configuration runtimeMerge = project.configurations.add("runtimeMerge")
+		project.configurations.create("merging")
+		Configuration runtimeMerge = project.configurations.create("runtimeMerge")
 
 		// Ensure the IDE can reference merged projects
 		project.eclipse.classpath.plusConfigurations += [runtimeMerge]
@@ -121,7 +121,7 @@ class MergePlugin implements Plugin<Project> {
 		project.configurations.each { configuration ->
 			Conf2ScopeMapping mapping = project.conf2ScopeMappings.getMapping([configuration])
 			if(mapping.scope) {
-				Configuration intoConfiguration = project.merge.into.configurations.add(
+				Configuration intoConfiguration = project.merge.into.create(
 					project.name + "-" + configuration.name)
 				configuration.excludeRules.each {
 					configuration.exclude([
@@ -153,6 +153,13 @@ class MergePlugin implements Plugin<Project> {
 			}
 		});
 	}
+
+//	private Configuration createConfiguration(Project project, String name) {
+//		if (project.configurations.respondsTo('create', String)) {
+//			return project.configurations.create(name)
+//		}
+//		project.configurations.add(name)
+//	}
 }
 
 class MergeModel {


### PR DESCRIPTION
Recently Spring framework build has been updated to use Gradle 1.6.
With the new version some of the Gradle APIs have been deprecated.
These deprecated APIs have been used by Spring build specific Gradle
plugins, which resulted in deprecation warnings in build output.

This patch changes Spring build specific Gradle plugins to use new
Gradle APIs instead of deprecated ones.

Even after this change build still produces warnings about Gradle
deprecated APIs being used. These come from Spring shared Gradle
plugins and other 3rd party Gradle plugins in use, like Gradle
Artifactory Plugin (GAP), which are still not updated to Gradle 1.6.
Related tickets for updating of these plugins to Gradle 1.6 are
GRADLE-53 and GAP-144, and once they get resolved Spring framework
build should further be updated.

Issue: SPR-10572
