### PR TITLE
Add support for MethodExecutor in FunctionReference

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/FunctionReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/FunctionReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.lang.reflect.Modifier;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.expression.AccessException;
 import org.springframework.expression.EvaluationException;
+import org.springframework.expression.MethodExecutor;
 import org.springframework.expression.TypeConverter;
 import org.springframework.expression.TypedValue;
 import org.springframework.expression.spel.ExpressionState;
@@ -31,16 +33,16 @@ import org.springframework.expression.spel.support.ReflectionHelper;
 import org.springframework.util.ReflectionUtils;
 
 /**
- * A function reference is of the form "#someFunction(a,b,c)". Functions may be defined in the context prior to the
- * expression being evaluated or within the expression itself using a lambda function definition. For example: Lambda
- * function definition in an expression: "(#max = {|x,y|$x>$y?$x:$y};max(2,3))" Calling context defined function:
- * "#isEven(37)". Functions may also be static java methods, registered in the context prior to invocation of the
- * expression.
+ * A function reference is of the form "#someFunction(a,b,c)". Functions must be
+ * registered in the evaluation context prior to the invocation of the expression.
+ * A function may either be a static java {@link Method} or an instance of a
+ * {@link MethodExecutor} which will be executed with a target parameter <code>null</code>.
  *
  * <p>Functions are very simplistic, the arguments are not part of the definition (right now),
  * so the names must be unique.
  *
  * @author Andy Clement
+ * @author Oliver Becker
  * @since 3.0
  */
 public class FunctionReference extends SpelNodeImpl {
@@ -48,35 +50,41 @@ public class FunctionReference extends SpelNodeImpl {
 	private final String name;
 
 	public FunctionReference(String functionName, int pos, SpelNodeImpl... arguments) {
-		super(pos,arguments);
+		super(pos, arguments);
 		name = functionName;
 	}
 
 	@Override
 	public TypedValue getValueInternal(ExpressionState state) throws EvaluationException {
-		TypedValue o = state.lookupVariable(name);
+		TypedValue o = state.lookupVariable(this.name);
 		if (o == null) {
-			throw new SpelEvaluationException(getStartPosition(), SpelMessage.FUNCTION_NOT_DEFINED, name);
+			throw new SpelEvaluationException(getStartPosition(), SpelMessage.FUNCTION_NOT_DEFINED, this.name);
 		}
 
-		// Two possibilities: a lambda function or a Java static method registered as a function
-		if (!(o.getValue() instanceof Method)) {
-			throw new SpelEvaluationException(SpelMessage.FUNCTION_REFERENCE_CANNOT_BE_INVOKED, name, o.getClass());
-		}
+		Object value = o.getValue();
 		try {
-			return executeFunctionJLRMethod(state, (Method) o.getValue());
+			// Two possibilities: a Java static method or a MethodExecutor instance
+			if (value instanceof Method) {
+				return executeFunctionJLRMethod(state, (Method) value);
+			} else if (value instanceof MethodExecutor) {
+				return executeFunctionMethodExecutor(state, (MethodExecutor) value);
+			}
 		}
 		catch (SpelEvaluationException se) {
 			se.setPosition(getStartPosition());
 			throw se;
 		}
+
+		throw new SpelEvaluationException(getStartPosition(),
+				SpelMessage.FUNCTION_REFERENCE_CANNOT_BE_INVOKED,
+				this.name, value == null ? null : value.getClass());
 	}
 
 	/**
 	 * Execute a function represented as a java.lang.reflect.Method.
 	 *
 	 * @param state the expression evaluation state
-	 * @param the java method to invoke
+	 * @param method the java method to invoke
 	 * @return the return value of the invoked Java method
 	 * @throws EvaluationException if there is any problem invoking the method
 	 */
@@ -89,9 +97,8 @@ public class FunctionReference extends SpelNodeImpl {
 		}
 		// Only static methods can be called in this way
 		if (!Modifier.isStatic(method.getModifiers())) {
-			throw new SpelEvaluationException(getStartPosition(), SpelMessage.FUNCTION_MUST_BE_STATIC, method
-					.getDeclaringClass().getName()
-					+ "." + method.getName(), name);
+			throw new SpelEvaluationException(getStartPosition(), SpelMessage.FUNCTION_MUST_BE_STATIC,
+					method.getDeclaringClass().getName() + "." + method.getName(), this.name);
 		}
 
 		// Convert arguments if necessary and remap them for varargs if required
@@ -106,7 +113,7 @@ public class FunctionReference extends SpelNodeImpl {
 		try {
 			ReflectionUtils.makeAccessible(method);
 			Object result = method.invoke(method.getClass(), functionArgs);
-			return new TypedValue(result, new TypeDescriptor(new MethodParameter(method,-1)).narrow(result));
+			return new TypedValue(result, new TypeDescriptor(new MethodParameter(method, -1)).narrow(result));
 		}
 		catch (Exception ex) {
 			throw new SpelEvaluationException(getStartPosition(), ex, SpelMessage.EXCEPTION_DURING_FUNCTION_CALL,
@@ -114,13 +121,32 @@ public class FunctionReference extends SpelNodeImpl {
 		}
 	}
 
+	/**
+	 * Execute a function represented as a {@link MethodExecutor}.
+	 *
+	 * @param state the expression evaluation state
+	 * @param executor the MethodExecutor to be invoked
+	 * @return the return value of the invoked executor
+	 */
+	private TypedValue executeFunctionMethodExecutor(ExpressionState state, MethodExecutor executor) {
+		try {
+			// there is no target instance, so pass null
+			return executor.execute(state.getEvaluationContext(), null, getArguments(state));
+		}
+		catch (AccessException ex) {
+			throw new SpelEvaluationException(getStartPosition(), ex,
+					SpelMessage.EXCEPTION_DURING_FUNCTION_CALL, this.name, ex.getMessage());
+		}
+	}
+
 	@Override
 	public String toStringAST() {
-		StringBuilder sb = new StringBuilder("#").append(name);
+		StringBuilder sb = new StringBuilder("#").append(this.name);
 		sb.append("(");
 		for (int i = 0; i < getChildCount(); i++) {
-			if (i > 0)
+			if (i > 0) {
 				sb.append(",");
+			}
 			sb.append(getChild(i).toStringAST());
 		}
 		sb.append(")");
@@ -131,6 +157,7 @@ public class FunctionReference extends SpelNodeImpl {
 
 	/**
 	 * Compute the arguments to the function, they are the children of this expression node.
+	 *
 	 * @return an array of argument values for the function call
 	 */
 	private Object[] getArguments(ExpressionState state) throws EvaluationException {


### PR DESCRIPTION
This commit enhances FunctionReference to also support MethodExecutor
instances for evaluation (besides static java.lang.reflect.Method
instances). This enables dynamic SpEL function definitions where the
function to be executed is not known at compile time.

Additionally this commit
- removes all mentions of lambda function definitions in comments since
  they are not implemented
- fixes the type name in the message of the thrown
  SpelEvaluationException in case the value of the function has the wrong
  type and cannot be executed

Issue SPR-10589
