### PR TITLE
SimpleJdbcCall: Function return type (REF CURSOR) should be resolved properly.

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -379,7 +379,7 @@ public class CallMetaDataContext {
 					else {
 						String returnNameToUse =(StringUtils.hasLength(meta.getParameterName()) ?
 								parNameToUse : getFunctionReturnName());
-						workParameters.add(new SqlOutParameter(returnNameToUse, meta.getSqlType()));
+						workParameters.add(this.metaDataProvider.createDefaultOutParameter(returnNameToUse, meta));
 						if (isFunction()) {
 							setFunctionReturnName(returnNameToUse);
 							outParameterNames.add(returnNameToUse);


### PR DESCRIPTION
If you need to call Oracle function like this:
`function get_foo() return ref cursor;`
you will get java.sql.SQLException: Invalid column type: 1111

For regular parameters (not for return type) there is a workaround for ref cursor (see CallMetaDataContext.java:394)

I have done this also for return type.
