### PR TITLE
SPR-10608 Add Path based resource

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/PathResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/PathResource.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.io;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.springframework.util.Assert;
+
+/**
+ * {@link Resource} implementation for {@code java.nio.file.Path} handles.
+ * 
+ * <p>
+ * Obviously supports resolution as File, and also as URL.
+ * Implements the extended {@link WritableResource} interface.
+ *
+ * @author Philippe Marschall
+ * @since 4.0
+ * @see java.nio.file.Path
+ */
+public class PathResource extends AbstractResource implements WritableResource {
+	
+	private final Path path;
+	
+
+	/**
+	 * Create a new FileResource from a File handle.
+	 * <p>Note: Unlike FileSystemResource When building relative resources
+	 * via {@link #createRelative}, the relative path will apply <i>at this level</i>:
+	 * e.g. Paths.get("C:/dir1/"), relative path "dir2" -> "C:/dir1/dir2"!
+	 * @param path a Path handle
+	 */
+	public PathResource(Path path) {
+		Assert.notNull(path, "Path must not be null");
+		this.path = path.normalize();
+	}
+	
+	/**
+	 * Create a new FileResource from a File handle.
+	 * <p>Note: Unlike FileSystemResource When building relative resources
+	 * via {@link #createRelative}, the relative path will apply <i>at this level</i>:
+	 * e.g. Paths.get("C:/dir1/"), relative path "dir2" -> "C:/dir1/dir2"!
+	 * @see java.nio.file.Paths#get(String, String...)
+	 * @param path a path
+	 */
+	public PathResource(String path) {
+		Assert.notNull(path, "Path must not be null");
+		this.path = Paths.get(path).normalize();
+	}
+	
+	/**
+	 * Create a new FileResource from a File handle.
+	 * <p>Note: Unlike FileSystemResource When building relative resources
+	 * via {@link #createRelative}, the relative path will apply <i>at this level</i>:
+	 * e.g. Paths.get("C:/dir1/"), relative path "dir2" -> "C:/dir1/dir2"!
+	 * @see java.nio.file.Paths#get(URI)
+	 * @param uri a path URI
+	 */
+	public PathResource(URI uri) {
+		Assert.notNull(uri, "URI must not be null");
+		this.path = Paths.get(uri).normalize();
+	}
+	
+	/**
+	 * Return the file path for this resource.
+	 */
+	public final String getPath() {
+		return this.path.toString();
+	}
+	
+
+	/**
+	 * This implementation returns whether the underlying file exists.
+	 * @see org.springframework.core.io.PathResource#exists()
+	 */
+	@Override
+	public boolean exists() {
+		return Files.exists(this.path);
+	}
+
+	/**
+	 * This implementation checks whether the underlying file is marked as readable
+	 * (and corresponds to an actual file with content, not to a directory).
+	 * @see java.nio.file.Files#isReadable(Path)
+	 * @see java.nio.file.Files#isDirectory(Path, java.nio.file.LinkOption...)
+	 */
+	@Override
+	public boolean isReadable() {
+		return (Files.isReadable(this.path) && !Files.isDirectory(this.path));
+	}
+
+	/**
+	 * This implementation opens a InputStream for the underlying file.
+	 * @see java.nio.file.spi.FileSystemProvider#newInputStream(Path, OpenOption...)
+	 */
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return Files.newInputStream(this.path);
+	}
+	
+	/**
+	 * This implementation returns a URL for the underlying file.
+	 * @see java.nio.file.Path#toUri()
+	 * @see java.net.URI#toURL()
+	 */
+	@Override
+	public URL getURL() throws IOException {
+		return this.path.toUri().toURL();
+	}
+
+	/**
+	 * This implementation returns a URI for the underlying file.
+	 * @see java.nio.file.Path#toUri()
+	 */
+	@Override
+	public URI getURI() throws IOException {
+		return this.path.toUri();
+	}
+	
+	/**
+	 * This implementation returns the underlying File reference.
+	 */
+	@Override
+	public File getFile() throws IOException {
+		try {
+			return this.path.toFile();
+		}
+		catch (UnsupportedOperationException e) {
+			// only Paths on the default file system can be converted to a File
+			// do exception translation for cases where conversion is not possilbe
+			throw new FileNotFoundException(this.path + " cannot be resolved to absolute file path");
+		}
+	}
+	
+	/**
+	 * This implementation returns the underlying File's length.
+	 */
+	@Override
+	public long contentLength() throws IOException {
+		return Files.size(this.path);
+	}
+	
+	/**
+	 * This implementation returns the underlying File's timestamp.
+	 * @see java.nio.file.Files#getLastModifiedTime(Path, LinkOption...)
+	 */
+	@Override
+	public long lastModified() throws IOException {
+		// we can not use the super class method since it uses conversion to a File and
+		// only Paths on the default file system can be converted to a File
+		return Files.getLastModifiedTime(path).toMillis();
+	}
+	
+	/**
+	 * This implementation creates a FileResource, applying the given path
+	 * relative to the path of the underlying file of this resource descriptor.
+	 * @see java.nio.file.Path#resolve(String)
+	 */
+	@Override
+	public Resource createRelative(String relativePath) throws IOException {
+		return new PathResource(this.path.resolve(relativePath));
+	}
+	
+	/**
+	 * This implementation returns the name of the file.
+	 * @see java.nio.file.Path#getFileName()
+	 */
+	@Override
+	public String getFilename() {
+		return this.path.getFileName().toString();
+	}
+	
+	@Override
+	public String getDescription() {
+		return "file [" + this.path.toAbsolutePath() + "]";
+	}
+
+	// implementation of WritableResource
+
+	/**
+	 * This implementation checks whether the underlying file is marked as writable
+	 * (and corresponds to an actual file with content, not to a directory).
+	 * @see java.nio.file.Files#isWritable(Path)
+	 * @see java.nio.file.Files#isDirectory(Path)
+	 */
+	@Override
+	public boolean isWritable() {
+		return Files.isWritable(this.path) && !Files.isDirectory(this.path);
+	}
+
+	/**
+	 * This implementation opens a OutputStream for the underlying file.
+	 * @see java.nio.file.spi.FileSystemProvider#newOutputStream(Path, OpenOption...)
+	 */
+	@Override
+	public OutputStream getOutputStream() throws IOException {
+		return Files.newOutputStream(path);
+	}
+
+
+	/**
+	 * This implementation compares the underlying Path references.
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		return (obj == this ||
+			(obj instanceof PathResource && this.path.equals(((PathResource) obj).path)));
+	}
+
+	/**
+	 * This implementation returns the hash code of the underlying Path reference.
+	 */
+	@Override
+	public int hashCode() {
+		return this.path.hashCode();
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/io/Resource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/Resource.java
@@ -42,6 +42,7 @@ import java.net.URL;
  * @see UrlResource
  * @see ByteArrayResource
  * @see InputStreamResource
+ * @see PathResource
  */
 public interface Resource extends InputStreamSource {
 

--- a/spring-core/src/test/java/org/springframework/core/io/PathResourceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/PathResourceTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.io;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for the {@link PathResource} class.
+ *
+ * @author Philippe Marschall
+ */
+public class PathResourceTests {
+
+	@Test
+	public void testExampleXml() throws IOException {
+		String path = "src/test/java/org/springframework/core/io/example.xml";
+		WritableResource resource = new PathResource(path);
+		
+		assertTrue("resource exists", resource.exists());
+		assertTrue("resource is readable", resource.isReadable());
+		assertTrue("resource is readable", resource.isWritable());
+		assertEquals("example.xml", resource.getFilename());
+		
+		long contentLength = resource.contentLength();
+		assertThat("contentLength", contentLength, greaterThan(100L));
+		assertThat("contentLength", contentLength, lessThan(1000L));
+		
+		assertEquals(new File(path), resource.getFile());
+		
+		assertEquals(resource, new PathResource(path));
+	}
+	
+	@Test
+	public void testParentFolder() throws IOException {
+		String path = "src/test/java/org/springframework/core/io/";
+		
+		WritableResource resource = new PathResource(path);
+		
+		assertTrue("resource exists", resource.exists());
+		assertFalse("resource is readable", resource.isReadable());
+		assertFalse("resource is readable", resource.isWritable());
+		assertEquals("io", resource.getFilename());
+		
+		assertEquals(new File(path), resource.getFile());
+		
+		assertEquals(resource, new PathResource(path));
+	}
+	
+	@Test
+	public void testCreateRelative() throws IOException {
+		String path = "src/test/java/org/springframework/core/io";
+		
+		String relativePath = "../example.xml";
+		Resource relativeResource = new PathResource(path).createRelative(relativePath);
+		PathResource expected = new PathResource(
+				"src/test/java/org/springframework/core/example.xml");
+		assertEquals(expected, relativeResource);
+		
+		path = path + "/";
+		
+		relativeResource = new PathResource(path).createRelative(relativePath);
+		assertEquals(expected, relativeResource);
+		
+	}
+	
+
+	@Test
+	public void testNotExistingFile() throws IOException {
+		String path = "src/test/java/DoesNotExist.xml";
+		WritableResource resource = new PathResource(path);
+		
+		assertFalse("resource exists", resource.exists());
+		assertFalse("resource is readable", resource.isReadable());
+		assertFalse("resource is readable", resource.isWritable());
+	}
+
+}


### PR DESCRIPTION
`FileSystemResource` uses the "old" `java.io.File` instead of the "new"
`java.nio.file.Path`. One of the disadvantages is that it only works with
the default file system and not with custom ones. Since the minimum
requirement is still Java 6 `FileSystemResource` can't be retrofitted
(and no `#getPath` can be added to `Resource`).
- add `PathResource`
- add `PathResourceTests`
- update `Resource` with a reference to `PathResource`

`PathResource` delegates to the underlying file system instead of
`StringUtils` like `FileSystemResource`. It has therefore slightly
different semantics. First when building relative resources via
`#createRelative` the relative path will apply to this path (like URL or
Unix). If the same switchable behavior like `FileSystemResource` is
wanted that could be done with a boolean switch. Second equality is
delegated to the underlying file system provider so it's
case-insensitive on Windows.

`PathResourceTests` contains only minimal tests
(`FileSystemResource` has no tests) as writing tests for
file code is tricky. I could write more elaborate tests using
https://github.com/marschall/memoryfilesystem if that's wanted and OK.

I did sign the Spring CLA

Issue: SPR-10608
