### PR TITLE
Add ability to check that attribute does not exist in Spring MVC test framework

### DIFF
--- a/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/result/ModelResultMatchers.java
+++ b/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/result/ModelResultMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,6 +86,21 @@ public class ModelResultMatchers {
 			}
 		};
 	}
+
+    /**
+     * Assert the given model attributes do not exist
+     */
+    public ResultMatcher attributeDoesNotExist(final String... names) {
+        return new ResultMatcher() {
+            @Override
+            public void match(MvcResult result) throws Exception {
+                ModelAndView mav = getModelAndView(result);
+                for (String name : names) {
+                    assertTrue("Model attribute '" + name + "' exists", mav.getModel().get(name) == null);
+                }
+            }
+        };
+    }
 
 	/**
 	 * Assert the given model attribute(s) have errors.

--- a/spring-test-mvc/src/test/java/org/springframework/test/web/servlet/result/ModelResultMatchersTests.java
+++ b/spring-test-mvc/src/test/java/org/springframework/test/web/servlet/result/ModelResultMatchersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,17 @@ public class ModelResultMatchersTests {
 		this.matchers.attributeExists("bad").match(this.mvcResult);
 	}
 
-	@Test
+    @Test
+    public void  attributeDoesNotExist() throws Exception {
+        this.matchers.attributeDoesNotExist("bad").match(this.mvcResult);
+    }
+
+    @Test(expected=AssertionError.class)
+    public void attributeDoesNotExist_doesExist() throws Exception {
+        this.matchers.attributeDoesNotExist("good").match(this.mvcResultWithError);
+    }
+
+    @Test
 	public void attribute_equal() throws Exception {
 		this.matchers.attribute("good", is("good")).match(this.mvcResult);
 	}


### PR DESCRIPTION
Added functionality to ModelResultMatchers to allow checking that a model attribute does not exist.

Issue: SPR-10509

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
