### PR TITLE
Added <spring:argument> subtag for message/theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ spring-*/src/main/java/META-INF/MANIFEST.MF
 *.iml
 *.ipr
 *.iws
+*.idea
 out
 test-output
 atlassian-ide-plugin.xml

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/ArgumentAware.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/ArgumentAware.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.tags;
+
+import javax.servlet.jsp.JspTagException;
+
+/**
+ * Allows implementing tag to utilize nested {@code spring:argument} tags.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see ArgumentTag
+ */
+public interface ArgumentAware {
+	/**
+	 * Callback hook for nested spring:argument tags to pass their value
+	 * to the parent tag.
+	 * @param argument the result of the nested {@code spring:argument} tag
+	 */
+	void addArgument(Object argument) throws JspTagException;
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/ArgumentTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/ArgumentTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,22 +20,20 @@ import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.BodyTagSupport;
 
 /**
- * JSP tag for collecting name-value parameters and passing them to a
- * {@link ParamAware} ancestor in the tag hierarchy.
+ * JSP tag for collecting arguments and passing them to an
+ * {@link ArgumentAware} ancestor in the tag hierarchy.
  *
- * <p>This tag must be nested under a param aware tag.
+ * <p>This tag must be nested under an argument aware tag.
  *
- * @author Scott Andrews
- * @since 3.0
- * @see Param
- * @see UrlTag
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see MessageTag
+ * @see ThemeTag
  */
 @SuppressWarnings("serial")
-public class ParamTag extends BodyTagSupport {
+public class ArgumentTag extends BodyTagSupport {
 
-	private String name;
-
-	private String value;
+	private Object value;
 
 	private boolean valueSet;
 
@@ -43,52 +41,39 @@ public class ParamTag extends BodyTagSupport {
 
 	@Override
 	public int doEndTag() throws JspException {
-		Param param = new Param();
-		param.setName(this.name);
+		Object argument = null;
 		if (this.valueSet) {
-			param.setValue(this.value);
+			argument = this.value;
 		}
 		else if (getBodyContent() != null) {
 			// get the value from the tag body
-			param.setValue(getBodyContent().getString().trim());
+			argument = getBodyContent().getString().trim();
 		}
 
 		// find a param aware ancestor
-		ParamAware paramAwareTag = (ParamAware) findAncestorWithClass(this,
-				ParamAware.class);
-		if (paramAwareTag == null) {
+		ArgumentAware argumentAwareTag = (ArgumentAware) findAncestorWithClass(this,
+				ArgumentAware.class);
+		if (argumentAwareTag == null) {
 			throw new JspException(
-					"The param tag must be a descendant of a tag that supports parameters");
+					"The argument tag must be a descendant of a tag that supports arguments");
 		}
 
-		paramAwareTag.addParam(param);
+		argumentAwareTag.addArgument(argument);
 
 		return EVAL_PAGE;
 	}
 
-	// tag attribute accessors
+	// tag attribute mutators
 
 	/**
-	 * Sets the name of the parameter
+	 * Sets the value of the argument
 	 *
 	 * <p>
-	 * Required
-	 *
-	 * @param name the parameter name
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	/**
-	 * Sets the value of the parameter
-	 *
-	 * <p>
-	 * Optional. If not set, the tag's body content is evaluated
+	 * Optional. If not set, the tag's body content is evaluated.
 	 *
 	 * @param value the parameter value
 	 */
-	public void setValue(String value) {
+	public void setValue(Object value) {
 		this.value = value;
 		this.valueSet = true;
 	}
@@ -96,7 +81,6 @@ public class ParamTag extends BodyTagSupport {
 	@Override
 	public void release() {
 		super.release();
-		this.name = null;
 		this.value = null;
 		this.valueSet = false;
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/ThemeTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/ThemeTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,12 @@ import org.springframework.context.NoSuchMessageException;
  * <p>If "code" isn't set or cannot be resolved, "text" will be used
  * as default message.
  *
+ * <p>Uses of this tag may contain arguments specified with nested spring:argument tags.
+ * The {@link #setArguments(Object) 'arguments'} attribute can be used instead of nested
+ * spring:argument tags, but they may never be used together. If using the arguments
+ * attribute, the {@link #setArgumentSeparator(String) 'argumentSeparator'} attribute can
+ * indicate an argument delimiter other than the default (a comma).
+ *
  * @author Jean-Pierre Pawlak
  * @author Juergen Hoeller
  * @see org.springframework.ui.context.Theme
@@ -39,6 +45,7 @@ import org.springframework.context.NoSuchMessageException;
  * @see #setHtmlEscape
  * @see HtmlEscapeTag#setDefaultHtmlEscape
  * @see org.springframework.web.util.WebUtils#HTML_ESCAPE_CONTEXT_PARAM
+ * @see ArgumentTag
  */
 @SuppressWarnings("serial")
 public class ThemeTag extends MessageTag {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/UrlTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/UrlTag.java
@@ -57,7 +57,7 @@ import org.springframework.web.util.UriUtils;
  * over direct EL substitution as the values are URL encoded.  Failure to properly
  * encode URL can leave an application vulnerable to XSS and other injection attacks.
  *
- * <p>URLs can be HTML/XML escaped by setting the {@link #setHtmlEscape(String)
+ * <p>URLs can be HTML/XML escaped by setting the {@link #setHtmlEscape(boolean)
  * 'htmlEscape'} attribute to 'true'.  Detects an HTML escaping setting, either on
  * this tag instance, the page level, or the {@code web.xml} level. The default
  * is 'false'.  When setting the URL value into a variable, escaping is not recommended.

--- a/spring-webmvc/src/main/resources/META-INF/spring-form.tld
+++ b/spring-webmvc/src/main/resources/META-INF/spring-form.tld
@@ -5,7 +5,7 @@
 		version="2.0">
 
 	<description>Spring Framework JSP Form Tag Library</description>
-	<tlib-version>3.0</tlib-version>
+	<tlib-version>4.0</tlib-version>
 	<short-name>form</short-name>
 	<uri>http://www.springframework.org/tags/form</uri>
 

--- a/spring-webmvc/src/main/resources/META-INF/spring.tld
+++ b/spring-webmvc/src/main/resources/META-INF/spring.tld
@@ -5,7 +5,7 @@
 		version="2.0">
 
 	<description>Spring Framework JSP Tag Library</description>
-	<tlib-version>3.0</tlib-version>
+	<tlib-version>4.0</tlib-version>
 	<short-name>spring</short-name>
 	<uri>http://www.springframework.org/tags</uri>
 
@@ -56,6 +56,8 @@
 			Retrieves the message with the given code, or text if code isn't resolvable.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
+			Nested spring:argument tags can be used instead of the 'arguments' and
+			'argumentSeparator' attributes to specify message arguments.
 		</description>
 		<name>message</name>
 		<tag-class>org.springframework.web.servlet.tags.MessageTag</tag-class>
@@ -83,7 +85,8 @@
 			<description>Set optional message arguments for this tag, as a
 			(comma-)delimited String (each String argument can contain JSP EL),
 			an Object array (used as argument array), or a single Object (used
-			as single argument).</description>
+			as single argument). You can alternatively use nested spring:argument
+			tags.</description>
 			<name>arguments</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -139,6 +142,8 @@
 			Retrieves the theme message with the given code, or text if code isn't resolvable.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
+			Nested spring:argument tags can be used instead of the 'arguments' and
+			'argumentSeparator' attributes to specify message arguments.
 		</description>
 		<name>theme</name>
 		<tag-class>org.springframework.web.servlet.tags.ThemeTag</tag-class>
@@ -160,7 +165,8 @@
 			<description>Set optional message arguments for this tag, as a
 			(comma-)delimited String (each String argument can contain JSP EL),
 			an Object array (used as argument array), or a single Object (used
-			as single argument).</description>
+			as single argument). You can alternatively use nested spring:argument
+			tags.</description>
 			<name>arguments</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -208,6 +214,22 @@
 			<name>javaScriptEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+
+	<tag>
+		<description>Argument tag based on the JSTL fmt:param tag.  The purpose is to
+			support arguments inside the spring:message and spring:theme
+			tags.</description>
+		<name>argument</name>
+		<tag-class>org.springframework.web.servlet.tags.ArgumentTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description>The value of the argument.</description>
+			<name>value</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>java.lang.Object</type>
 		</attribute>
 	</tag>
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/ArgumentTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/ArgumentTagTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.tags;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.Tag;
+import javax.servlet.jsp.tagext.TagSupport;
+
+import org.springframework.mock.web.test.MockBodyContent;
+import org.springframework.mock.web.test.MockHttpServletResponse;
+
+/**
+ * Unit tests for ArgumentTag
+ *
+ * @author Nicholas Williams
+ */
+public class ArgumentTagTests extends AbstractTagTests {
+
+	private ArgumentTag tag;
+
+	private MockArgumentSupportTag parent;
+
+	@Override
+	protected void setUp() throws Exception {
+		PageContext context = createPageContext();
+		parent = new MockArgumentSupportTag();
+		tag = new ArgumentTag();
+		tag.setPageContext(context);
+		tag.setParent(parent);
+	}
+
+	public void testArgumentWithStringValue() throws JspException {
+		tag.setValue("value1");
+
+		int action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertEquals("value1", parent.getArgument());
+	}
+
+	public void testArgumentWithImplicitNullValue() throws JspException {
+		int action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertNull(parent.getArgument());
+	}
+
+	public void testArgumentWithExplicitNullValue() throws JspException {
+		tag.setValue(null);
+
+		int action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertNull(parent.getArgument());
+	}
+
+	public void testArgumentWithBodyValue() throws JspException {
+		tag.setBodyContent(new MockBodyContent("value2",
+				new MockHttpServletResponse()));
+
+		int action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertEquals("value2", parent.getArgument());
+	}
+
+	public void testArgumentWithValueThenReleaseThenBodyValue() throws JspException {
+		tag.setValue("value3");
+
+		int action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertEquals("value3", parent.getArgument());
+
+		tag.release();
+
+		parent = new MockArgumentSupportTag();
+		tag.setPageContext(createPageContext());
+		tag.setParent(parent);
+		tag.setBodyContent(new MockBodyContent("value4",
+				new MockHttpServletResponse()));
+
+		action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertEquals("value4", parent.getArgument());
+	}
+
+	@SuppressWarnings("serial")
+	private class MockArgumentSupportTag extends TagSupport implements ArgumentAware {
+
+		Object argument;
+
+		@Override
+		public void addArgument(Object argument) {
+			this.argument = argument;
+		}
+
+		private Object getArgument() {
+			return argument;
+		}
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/MessageTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/MessageTagTests.java
@@ -18,16 +18,15 @@ package org.springframework.web.servlet.tags;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspTagException;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
 
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.servlet.support.RequestContext;
 import org.springframework.web.servlet.support.RequestContextUtils;
@@ -51,6 +50,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setPageContext(pc);
 		tag.setMessage(new DefaultMessageSourceResolvable("test"));
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test message", message.toString());
 	}
 
@@ -67,6 +67,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setPageContext(pc);
 		tag.setCode("test");
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test message", message.toString());
 	}
 
@@ -83,6 +84,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setPageContext(pc);
 		tag.setCode(null);
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "null", message.toString());
 	}
 
@@ -100,6 +102,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setCode("testArgs");
 		tag.setArguments("arg1");
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test arg1 message {1}", message.toString());
 	}
 
@@ -117,6 +120,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setCode("testArgs");
 		tag.setArguments("arg1,arg2");
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test arg1 message arg2", message.toString());
 	}
 
@@ -135,6 +139,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setArguments("arg1,1;arg2,2");
 		tag.setArgumentSeparator(";");
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test arg1,1 message arg2,2", message.toString());
 	}
 
@@ -150,8 +155,9 @@ public class MessageTagTests extends AbstractTagTests {
 		};
 		tag.setPageContext(pc);
 		tag.setCode("testArgs");
-		tag.setArguments(new Object[] {"arg1", new Integer(5)});
+		tag.setArguments(new Object[] {"arg1", 5});
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test arg1 message 5", message.toString());
 	}
 
@@ -167,9 +173,70 @@ public class MessageTagTests extends AbstractTagTests {
 		};
 		tag.setPageContext(pc);
 		tag.setCode("testArgs");
-		tag.setArguments(new Integer(5));
+		tag.setArguments(5);
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test 5 message {1}", message.toString());
+	}
+
+	@SuppressWarnings("serial")
+	public void testMessageTagWithCodeAndArgumentAndNestedArgument() throws JspException {
+		PageContext pc = createPageContext();
+		final StringBuffer message = new StringBuffer();
+		MessageTag tag = new MessageTag() {
+			@Override
+			protected void writeMessage(String msg) {
+				message.append(msg);
+			}
+		};
+		tag.setPageContext(pc);
+		tag.setCode("testArgs");
+		tag.setArguments(5);
+		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		try {
+			tag.addArgument(7);
+			fail("Should be unable to use spring:argument when arguments attribute set");
+		}
+		catch (JspTagException e) {
+			assertEquals("Nothing should have been written", 0, message.length());
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public void testMessageTagWithCodeAndNestedArgument() throws JspException {
+		PageContext pc = createPageContext();
+		final StringBuffer message = new StringBuffer();
+		MessageTag tag = new MessageTag() {
+			@Override
+			protected void writeMessage(String msg) {
+				message.append(msg);
+			}
+		};
+		tag.setPageContext(pc);
+		tag.setCode("testArgs");
+		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		tag.addArgument(7);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
+		assertEquals("Correct message", "test 7 message {1}", message.toString());
+	}
+
+	@SuppressWarnings("serial")
+	public void testMessageTagWithCodeAndNestedArguments() throws JspException {
+		PageContext pc = createPageContext();
+		final StringBuffer message = new StringBuffer();
+		MessageTag tag = new MessageTag() {
+			@Override
+			protected void writeMessage(String msg) {
+				message.append(msg);
+			}
+		};
+		tag.setPageContext(pc);
+		tag.setCode("testArgs");
+		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		tag.addArgument("arg1");
+		tag.addArgument(6);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
+		assertEquals("Correct message", "test arg1 message 6", message.toString());
 	}
 
 	@SuppressWarnings("serial")
@@ -186,6 +253,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setCode("test");
 		tag.setText("testtext");
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test message", (message.toString()));
 	}
 
@@ -203,6 +271,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setText("test & text");
 		tag.setHtmlEscape(true);
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test &amp; text", message.toString());
 	}
 
@@ -220,6 +289,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setText("' test & text \\");
 		tag.setJavaScriptEscape(true);
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "\\' test & text \\\\", message.toString());
 	}
 
@@ -238,6 +308,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setHtmlEscape(true);
 		tag.setJavaScriptEscape(true);
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "&#39; test &amp; text \\\\", message.toString());
 	}
 
@@ -249,6 +320,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setVar("testvar");
 		tag.setScope("page");
 		tag.doStartTag();
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("text & text", pc.getAttribute("testvar"));
 		tag.release();
 
@@ -257,6 +329,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setCode("test");
 		tag.setVar("testvar2");
 		tag.doStartTag();
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test message", pc.getAttribute("testvar2"));
 		tag.release();
 	}
@@ -268,6 +341,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setText("text & text");
 		tag.setVar("testvar");
 		tag.doStartTag();
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("text & text", pc.getAttribute("testvar"));
 		tag.release();
 
@@ -277,6 +351,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setVar("testvar");
 
 		tag.doStartTag();
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("Correct message", "test message", pc.getAttribute("testvar"));
 	}
 
@@ -291,6 +366,7 @@ public class MessageTagTests extends AbstractTagTests {
 		tag.setCode("test");
 		tag.setVar("testvar2");
 		tag.doStartTag();
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 	}
 
 	public void testRequestContext() throws ServletException {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/ParamTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/ParamTagTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class ParamTagTests extends AbstractTagTests {
 		assertEquals("value", parent.getParam().getValue());
 	}
 
-	public void testParamWithNullValue() throws JspException {
+	public void testParamWithImplicitNullValue() throws JspException {
 		tag.setName("name");
 
 		int action = tag.doEndTag();
@@ -75,6 +75,43 @@ public class ParamTagTests extends AbstractTagTests {
 		assertEquals(Tag.EVAL_PAGE, action);
 		assertEquals("name", parent.getParam().getName());
 		assertNull(parent.getParam().getValue());
+	}
+
+	public void testParamWithExplicitNullValue() throws JspException {
+		tag.setName("name");
+		tag.setValue(null);
+
+		int action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertEquals("name", parent.getParam().getName());
+		assertNull(parent.getParam().getValue());
+	}
+
+	public void testParamWithValueThenReleaseThenBodyValue() throws JspException {
+		tag.setName("name1");
+		tag.setValue("value1");
+
+		int action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertEquals("name1", parent.getParam().getName());
+		assertEquals("value1", parent.getParam().getValue());
+
+		tag.release();
+
+		parent = new MockParamSupportTag();
+		tag.setPageContext(createPageContext());
+		tag.setParent(parent);
+		tag.setName("name2");
+		tag.setBodyContent(new MockBodyContent("value2",
+				new MockHttpServletResponse()));
+
+		action = tag.doEndTag();
+
+		assertEquals(Tag.EVAL_PAGE, action);
+		assertEquals("name2", parent.getParam().getName());
+		assertEquals("value2", parent.getParam().getValue());
 	}
 
 	public void testParamWithNoParent() {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/ThemeTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/ThemeTagTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public class ThemeTagTests extends AbstractTagTests {
 		tag.setPageContext(pc);
 		tag.setCode("themetest");
 		assertTrue("Correct doStartTag return value", tag.doStartTag() == Tag.EVAL_BODY_INCLUDE);
+		assertEquals("Correct doEndTag return value", Tag.EVAL_PAGE, tag.doEndTag());
 		assertEquals("theme test message", message.toString());
 	}
 


### PR DESCRIPTION
Added a new `<spring:argument>` tag meant for nesting within
`<spring:message>` and `<spring:theme>`. The tag is based on the
`<fmt:param>` tag and uses conventions found throughout other Spring tags.
Ten new unit tests and over a dozen changed unit tests accompany the
changes, which are detailed below.

Itemized Changes:
- Incremented version number of tag libraries to 4.0.
- Added `<spring:argument>` tag to `spring.tld`.
- Updated documentation for message and theme tags in `spring.tld`.
- Added `o.s.web.servlet.tags.ArgumentTag` class to handle tag. Added 5
  unit tests to test behavior.
- Added `o.s.web.servlet.tags.ArgumentAware` to mark tags supporting
  arguments.
- Updated `o.s.web.servlet.tags.MessageTag` to implement `ArgumentAware`
  and permit either nested argument tags or the `arguments` attribute, but
  not both. Also updated JavaDoc. Added three unit tests to test behavior.
  Updated over a dozen other unit tests to test behavior.
- Updated `o.s.web.servlet.tags.ThemeTag` JavaDoc.
- Fixed an `@link` error in the JavaDoc for `o.s.web.servlet.tags.UrlTag`
- `o.s.web.servlet.tags.ParamTag` was susceptible to problems in
  containers that pool tags. It wasn't resetting values when the
  release method was called, so if a user used multiple `<spring:param>`
  tags and mixed using the `value` attribute and tag body, it's possible
  that the value used might not be correct. This would be very
  difficult to duplicate. I just noticed it while making the similar
  `ArgumentTag` and decided it should be fixed while I was in there.
  I also added two additional unit tests to test this behavior change.

Issue: SPR-9678
