### PR TITLE
Added TimeZone support to Spring i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ spring-*/src/main/java/META-INF/MANIFEST.MF
 *.iml
 *.ipr
 *.iws
+*.idea
 out
 test-output
 atlassian-ide-plugin.xml

--- a/spring-beans/src/main/java/org/springframework/beans/PropertyEditorRegistrySupport.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyEditorRegistrySupport.java
@@ -65,6 +65,7 @@ import org.springframework.beans.propertyeditors.TimeZoneEditor;
 import org.springframework.beans.propertyeditors.URIEditor;
 import org.springframework.beans.propertyeditors.URLEditor;
 import org.springframework.beans.propertyeditors.UUIDEditor;
+import org.springframework.beans.propertyeditors.ZoneIdEditor;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourceArrayPropertyEditor;
@@ -199,6 +200,17 @@ public class PropertyEditorRegistrySupport implements PropertyEditorRegistry {
 		this.defaultEditors.put(Properties.class, new PropertiesEditor());
 		this.defaultEditors.put(Resource[].class, new ResourceArrayPropertyEditor());
 		this.defaultEditors.put(TimeZone.class, new TimeZoneEditor());
+		if (ClassUtils.isPresent("java.time.ZoneId", PropertyEditorRegistrySupport.class.getClassLoader())) {
+			try {
+				this.defaultEditors.put(
+						ClassUtils.forName("java.time.ZoneId", PropertyEditorRegistrySupport.class.getClassLoader()),
+						new ZoneIdEditor()
+				);
+			}
+			catch (ClassNotFoundException e) {
+				throw new IllegalStateException("ZoneId present but unable to load.", e);
+			}
+		}
 		this.defaultEditors.put(URI.class, new URIEditor());
 		this.defaultEditors.put(URL.class, new URLEditor());
 		this.defaultEditors.put(UUID.class, new UUIDEditor());

--- a/spring-beans/src/main/java/org/springframework/beans/propertyeditors/ZoneIdEditor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/propertyeditors/ZoneIdEditor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.propertyeditors;
+
+import java.beans.PropertyEditorSupport;
+import java.time.ZoneId;
+
+/**
+ * Editor for {@code java.time.ZoneId}, translating timezone IDs into
+ * ZoneId objects.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see java.time.ZoneId
+ */
+public class ZoneIdEditor extends PropertyEditorSupport {
+
+	@Override
+	public void setAsText(String text) throws IllegalArgumentException {
+		setValue(ZoneId.of(text));
+	}
+
+	@Override
+	public String getAsText() {
+		Object value = getValue();
+		return (value != null ? value.toString() : "");
+	}
+
+}

--- a/spring-beans/src/test/java/org/springframework/beans/propertyeditors/ZoneIdEditorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/propertyeditors/ZoneIdEditorTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.propertyeditors;
+
+import java.time.ZoneId;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Nicholas Williams
+ */
+public class ZoneIdEditorTests extends TestCase {
+
+	public void testAmericaChicago() {
+		ZoneIdEditor editor = new ZoneIdEditor();
+		editor.setAsText("America/Chicago");
+
+		ZoneId zoneId = (ZoneId) editor.getValue();
+		assertNotNull("The zone ID should not be null.", zoneId);
+		assertEquals("The zone ID is not correct.", ZoneId.of("America/Chicago"), zoneId);
+
+		assertEquals("The text version is not correct.", "America/Chicago", editor.getAsText());
+	}
+
+	public void testAmericaLosAngeles() {
+		ZoneIdEditor editor = new ZoneIdEditor();
+		editor.setAsText("America/Los_Angeles");
+
+		ZoneId zoneId = (ZoneId) editor.getValue();
+		assertNotNull("The zone ID should not be null.", zoneId);
+		assertEquals("The zone ID is not correct.", ZoneId.of("America/Los_Angeles"), zoneId);
+
+		assertEquals("The text version is not correct.", "America/Los_Angeles", editor.getAsText());
+	}
+
+	public void testGetNullAsText() {
+		ZoneIdEditor editor = new ZoneIdEditor();
+
+		assertEquals("The returned value is not correct.", "", editor.getAsText());
+	}
+
+	public void testGetValueAsText() {
+		ZoneIdEditor editor = new ZoneIdEditor();
+		editor.setValue(ZoneId.of("America/New_York"));
+
+		assertEquals("The text version is not correct.", "America/New_York", editor.getAsText());
+	}
+
+}

--- a/spring-context/src/main/java/org/springframework/context/i18n/SimpleTimeZoneContext.java
+++ b/spring-context/src/main/java/org/springframework/context/i18n/SimpleTimeZoneContext.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.i18n;
+
+import java.util.TimeZone;
+
+import org.springframework.util.Assert;
+
+/**
+ * Simple implementation of the {@link TimeZoneContext} interface,
+ * always returning a specified {@code TimeZone}.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ */
+public class SimpleTimeZoneContext implements TimeZoneContext {
+
+	private final TimeZone timeZone;
+
+
+	/**
+	 * Create a new SimpleTimeZoneContext that exposes the specified TimeZone.
+	 * Every {@link #getTimeZone()} will return this Locale.
+	 * @param timeZone the TimeZone to expose
+	 */
+	public SimpleTimeZoneContext(TimeZone timeZone) {
+		Assert.notNull(timeZone, "Time zone must not be null");
+		this.timeZone = timeZone;
+	}
+
+
+	@Override
+	public TimeZone getTimeZone() {
+		return this.timeZone;
+	}
+
+	@Override
+	public String toString() {
+		return this.timeZone.getID();
+	}
+
+}

--- a/spring-context/src/main/java/org/springframework/context/i18n/TimeZoneContext.java
+++ b/spring-context/src/main/java/org/springframework/context/i18n/TimeZoneContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.i18n;
+
+import java.util.TimeZone;
+
+/**
+ * Strategy interface for determining the current TimeZone.
+ *
+ * <p>A TimeZoneContext instance can be associated with a thread
+ * via the TimeZoneContextHolder class.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see TimeZoneContextHolder
+ * @see java.util.TimeZone
+ */
+public interface TimeZoneContext {
+
+	/**
+	 * Return the current TimeZone, which can be fixed or determined dynamically,
+	 * depending on the implementation strategy.
+	 */
+	TimeZone getTimeZone();
+
+}

--- a/spring-context/src/main/java/org/springframework/context/i18n/TimeZoneContextHolder.java
+++ b/spring-context/src/main/java/org/springframework/context/i18n/TimeZoneContextHolder.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.i18n;
+
+import java.util.TimeZone;
+
+import org.springframework.core.NamedInheritableThreadLocal;
+import org.springframework.core.NamedThreadLocal;
+
+/**
+ * Simple holder class that associates a TimeZoneContext instance
+ * with the current thread. The TimeZoneContext will be inherited
+ * by any child threads spawned by the current thread if the
+ * {@code inheritable} flag is set to {@code true}.
+ *
+ * <p>Used as a central holder for the current TimeZone in Spring,
+ * wherever necessary.
+ * DispatcherServlet automatically exposes its current TimeZone here.
+ * Other applications can expose theirs too, to make other classes
+ * automatically use that TimeZone.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see TimeZoneContext
+ * @see org.springframework.context.support.MessageSourceAccessor
+ * @see org.springframework.web.servlet.DispatcherServlet
+ */
+public abstract class TimeZoneContextHolder {
+
+	private static final ThreadLocal<TimeZoneContext> timeZoneContextHolder =
+			new NamedThreadLocal<TimeZoneContext>("Time zone context");
+
+	private static final ThreadLocal<TimeZoneContext> inheritableTimeZoneContextHolder =
+			new NamedInheritableThreadLocal<TimeZoneContext>("Time zone context");
+
+
+	/**
+	 * Reset the TimeZoneContext for the current thread.
+	 */
+	public static void resetTimeZoneContext() {
+		timeZoneContextHolder.remove();
+		inheritableTimeZoneContextHolder.remove();
+	}
+
+	/**
+	 * Associate the given TimeZoneContext with the current thread,
+	 * <i>not</i> exposing it as inheritable for child threads.
+	 * @param timeZoneContext the current TimeZoneContext
+	 */
+	public static void setTimeZoneContext(TimeZoneContext timeZoneContext) {
+		setTimeZoneContext(timeZoneContext, false);
+	}
+
+	/**
+	 * Associate the given TimeZone with the current thread.
+	 * @param timeZoneContext the current TimeZoneContext,
+	 * or {@code null} to reset the thread-bound context
+	 * @param inheritable whether to expose the TimeZoneContext as inheritable
+	 * for child threads (using an {@link InheritableThreadLocal})
+	 */
+	public static void setTimeZoneContext(TimeZoneContext timeZoneContext, boolean inheritable) {
+		if (timeZoneContext == null) {
+			resetTimeZoneContext();
+		}
+		else {
+			if (inheritable) {
+				inheritableTimeZoneContextHolder.set(timeZoneContext);
+				timeZoneContextHolder.remove();
+			}
+			else {
+				timeZoneContextHolder.set(timeZoneContext);
+				inheritableTimeZoneContextHolder.remove();
+			}
+		}
+	}
+
+	/**
+	 * Return the TimeZoneContext associated with the current thread, if any.
+	 * @return the current TimeZoneContext, or {@code null} if none
+	 */
+	public static TimeZoneContext getTimeZoneContext() {
+		TimeZoneContext timeZoneContext = timeZoneContextHolder.get();
+		if (timeZoneContext == null) {
+			timeZoneContext = inheritableTimeZoneContextHolder.get();
+		}
+		return timeZoneContext;
+	}
+
+	/**
+	 * Associate the given TimeZone with the current thread.
+	 * <p>Will implicitly create a TimeZoneContext for the given TimeZone,
+	 * <i>not</i> exposing it as inheritable for child threads.
+	 * @param timeZone the current TimeZone, or {@code null} to reset
+	 * the thread-bound context
+	 * @see SimpleTimeZoneContext#SimpleTimeZoneContext(TimeZone)
+	 */
+	public static void setTimeZone(TimeZone timeZone) {
+		setTimeZone(timeZone, false);
+	}
+
+	/**
+	 * Associate the given TimeZone with the current thread.
+	 * <p>Will implicitly create a TimeZoneContext for the given TimeZone.
+	 * @param timeZone the current TimeZone, or {@code null} to reset
+	 * the thread-bound context
+	 * @param inheritable whether to expose the TimeZoneContext as inheritable
+	 * for child threads (using an {@link InheritableThreadLocal})
+	 * @see SimpleTimeZoneContext#SimpleTimeZoneContext(TimeZone)
+	 */
+	public static void setTimeZone(TimeZone timeZone, boolean inheritable) {
+		TimeZoneContext timeZoneContext =
+				(timeZone != null ? new SimpleTimeZoneContext(timeZone) : null);
+		setTimeZoneContext(timeZoneContext, inheritable);
+	}
+
+	/**
+	 * Return the TimeZone associated with the current thread, if any,
+	 * or the system default TimeZone otherwise.
+	 * @return the current TimeZone, or the system default TimeZone if no
+	 * specific TimeZone has been associated with the current thread
+	 * @see TimeZoneContext#getTimeZone() ()
+	 * @see TimeZone#getDefault()
+	 */
+	public static TimeZone getTimeZone() {
+		TimeZoneContext timeZoneContext = getTimeZoneContext();
+		return (timeZoneContext != null ? timeZoneContext.getTimeZone() : TimeZone.getDefault());
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/context/i18n/SimpleTimeZoneContextTests.java
+++ b/spring-context/src/test/java/org/springframework/context/i18n/SimpleTimeZoneContextTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.i18n;
+
+import java.util.TimeZone;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Nicholas Williams
+ */
+public class SimpleTimeZoneContextTests extends TestCase {
+
+	public void testNullConstructorArgumentFails() {
+		try {
+			new SimpleTimeZoneContext(null);
+			fail("Expected IllegalArgumentException, got no exception.");
+		}
+		catch (IllegalArgumentException e) {
+			// good
+		}
+	}
+
+	public void testTimeZonePropertyAmericaChicago() {
+		TimeZone timeZone = TimeZone.getTimeZone("America/Chicago");
+
+		SimpleTimeZoneContext context = new SimpleTimeZoneContext(timeZone);
+
+		assertNotNull("The time zone should not be null.", context.getTimeZone());
+		assertEquals("The time zone is not correct.", "America/Chicago", context.getTimeZone().getID());
+		assertEquals("The string is not correct.", "America/Chicago", context.toString());
+	}
+
+	public void testTimeZonePropertyAmericaLosAngeles() {
+		TimeZone timeZone = TimeZone.getTimeZone("America/Los_Angeles");
+
+		SimpleTimeZoneContext context = new SimpleTimeZoneContext(timeZone);
+
+		assertNotNull("The time zone should not be null.", context.getTimeZone());
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", context.getTimeZone().getID());
+		assertEquals("The string is not correct.", "America/Los_Angeles", context.toString());
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/context/i18n/TimeZoneContextHolderTests.java
+++ b/spring-context/src/test/java/org/springframework/context/i18n/TimeZoneContextHolderTests.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.i18n;
+
+import java.util.TimeZone;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Nicholas Williams
+ */
+public class TimeZoneContextHolderTests extends TestCase {
+
+	private static final String SYSTEM_ID = TimeZone.getDefault().getID();
+
+	private static final String ALTERNATE_ID1 = SYSTEM_ID.equals("America/Chicago") ?
+			"America/Los_Angeles" : "America/Chicago";
+
+	private static final String ALTERNATE_ID2 = SYSTEM_ID.equals("America/New_York") ?
+			"America/Anchorage" : "America/New_York";
+
+	@Override
+	protected void tearDown() throws Exception {
+		TimeZoneContextHolder.resetTimeZoneContext();
+		super.tearDown();
+	}
+
+	public void testSetTimeZoneImplicitlyNotInheritable() throws Throwable {
+		TimeZoneContextHolder.setTimeZone(TimeZone.getTimeZone(ALTERNATE_ID1));
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID1,
+				TimeZoneContextHolder.getTimeZone().getID());
+
+		runInSeparateThreadAndWait(new Runnable() {
+			@Override
+			public void run() {
+				assertNotNull("The time zone should not be null.",
+						TimeZoneContextHolder.getTimeZone());
+				assertEquals("The time zone is not correct.", SYSTEM_ID,
+						TimeZoneContextHolder.getTimeZone().getID());
+				TimeZoneContextHolder.resetTimeZoneContext();
+			}
+		});
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID1,
+				TimeZoneContextHolder.getTimeZone().getID());
+	}
+
+	public void testSetTimeZoneExplicitlyNotInheritable() throws Throwable {
+		TimeZoneContextHolder.setTimeZone(TimeZone.getTimeZone(ALTERNATE_ID2), false);
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID2,
+				TimeZoneContextHolder.getTimeZone().getID());
+
+		runInSeparateThreadAndWait(new Runnable() {
+			@Override
+			public void run() {
+				assertNotNull("The time zone should not be null.",
+						TimeZoneContextHolder.getTimeZone());
+				assertEquals("The time zone is not correct.", SYSTEM_ID,
+						TimeZoneContextHolder.getTimeZone().getID());
+				TimeZoneContextHolder.resetTimeZoneContext();
+			}
+		});
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID2,
+				TimeZoneContextHolder.getTimeZone().getID());
+	}
+
+	public void testSetTimeZoneInheritable() throws Throwable {
+		TimeZoneContextHolder.setTimeZone(TimeZone.getTimeZone(ALTERNATE_ID1), true);
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID1,
+				TimeZoneContextHolder.getTimeZone().getID());
+
+		runInSeparateThreadAndWait(new Runnable() {
+			@Override
+			public void run() {
+				assertNotNull("The time zone should not be null.",
+						TimeZoneContextHolder.getTimeZone());
+				assertEquals("The time zone is not correct.", ALTERNATE_ID1,
+						TimeZoneContextHolder.getTimeZone().getID());
+				TimeZoneContextHolder.resetTimeZoneContext();
+				assertNotNull("The time zone should not be null.",
+						TimeZoneContextHolder.getTimeZone());
+				assertEquals("The time zone is not correct.", SYSTEM_ID,
+						TimeZoneContextHolder.getTimeZone().getID());
+			}
+		});
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID1,
+				TimeZoneContextHolder.getTimeZone().getID());
+	}
+
+	public void testSetTimeZoneNotInheritableChangeInOtherThread() throws Throwable {
+		TimeZoneContextHolder.setTimeZone(TimeZone.getTimeZone(ALTERNATE_ID1), false);
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID1,
+				TimeZoneContextHolder.getTimeZone().getID());
+
+		runInSeparateThreadAndWait(new Runnable() {
+			@Override
+			public void run() {
+				assertNotNull("The time zone should not be null.",
+						TimeZoneContextHolder.getTimeZone());
+				assertEquals("The time zone is not correct.", SYSTEM_ID,
+						TimeZoneContextHolder.getTimeZone().getID());
+
+				TimeZoneContextHolder.setTimeZone(TimeZone.getTimeZone(ALTERNATE_ID2), true);
+				assertNotNull("The time zone should not be null.",
+						TimeZoneContextHolder.getTimeZone());
+				assertEquals("The time zone is not correct.", ALTERNATE_ID2,
+						TimeZoneContextHolder.getTimeZone().getID());
+			}
+		});
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID1,
+				TimeZoneContextHolder.getTimeZone().getID());
+	}
+
+	public void testSetTimeZoneInheritableChangeInOtherThread() throws Throwable {
+		TimeZoneContextHolder.setTimeZone(TimeZone.getTimeZone(ALTERNATE_ID2), true);
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID2,
+				TimeZoneContextHolder.getTimeZone().getID());
+
+		runInSeparateThreadAndWait(new Runnable() {
+			@Override
+			public void run() {
+				assertNotNull("The time zone should not be null.",
+						TimeZoneContextHolder.getTimeZone());
+				assertEquals("The time zone is not correct.", ALTERNATE_ID2,
+						TimeZoneContextHolder.getTimeZone().getID());
+
+				TimeZoneContextHolder.setTimeZone(TimeZone.getTimeZone(ALTERNATE_ID1), true);
+				assertNotNull("The time zone should not be null.",
+						TimeZoneContextHolder.getTimeZone());
+				assertEquals("The time zone is not correct.", ALTERNATE_ID1,
+						TimeZoneContextHolder.getTimeZone().getID());
+			}
+		});
+
+		assertNotNull("The time zone should not be null.",
+				TimeZoneContextHolder.getTimeZone());
+		assertEquals("The time zone is not correct.", ALTERNATE_ID2,
+				TimeZoneContextHolder.getTimeZone().getID());
+	}
+
+	private static void runInSeparateThreadAndWait(Runnable runnable) throws Throwable {
+		TestUncaughtExceptionHandler handler = new TestUncaughtExceptionHandler();
+
+		Thread thread = new Thread(runnable);
+		thread.setUncaughtExceptionHandler(handler);
+		thread.start();
+
+		int slept = 0;
+		while (slept < 1000) {
+			if (thread.getState() == Thread.State.TERMINATED) {
+				handler.throwIfCaught();
+				return;
+			}
+			Thread.sleep(50L);
+			slept += 50;
+		}
+
+		fail("Waited too long for thread to stop.");
+	}
+
+	private static final class TestUncaughtExceptionHandler
+			implements Thread.UncaughtExceptionHandler {
+
+		private Throwable caught;
+
+		@Override
+		public void uncaughtException(Thread t, Throwable e) {
+			this.caught = e;
+		}
+
+		public void throwIfCaught() throws Throwable {
+			if(this.caught != null)
+				throw caught;
+		}
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.TimeZone;
 import java.util.TreeSet;
 
 /**
@@ -63,6 +65,9 @@ public abstract class StringUtils {
 	private static final String CURRENT_PATH = ".";
 
 	private static final char EXTENSION_SEPARATOR = '.';
+
+	private final static Set<String> VALID_TIME_ZONE_IDS =
+			new HashSet<String>(Arrays.asList(TimeZone.getAvailableIDs()));
 
 
 	//---------------------------------------------------------------------
@@ -697,6 +702,14 @@ public abstract class StringUtils {
 			}
 		}
 		return (language.length() > 0 ? new Locale(language, country, variant) : null);
+	}
+
+	public static TimeZone parseTimeZoneString(String timeZoneString) {
+		if (timeZoneString == null || timeZoneString.length() == 0 ||
+				!VALID_TIME_ZONE_IDS.contains(timeZoneString)) {
+			return null;
+		}
+		return TimeZone.getTimeZone(timeZoneString);
 	}
 
 	private static void validateLocalePart(String localePart) {

--- a/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
+++ b/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
@@ -41,6 +41,7 @@ import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.TimeZoneResolver;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
@@ -49,6 +50,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.handler.MappedInterceptor;
 import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+import org.springframework.web.servlet.i18n.FixedTimeZoneResolver;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.servlet.support.SessionFlashMapManager;
@@ -100,6 +102,8 @@ public class StandaloneMockMvcBuilder extends DefaultMockMvcBuilder<StandaloneMo
 	private List<ViewResolver> viewResolvers;
 
 	private LocaleResolver localeResolver = new AcceptHeaderLocaleResolver();
+
+	private TimeZoneResolver timeZoneResolver = new FixedTimeZoneResolver();
 
 	private FlashMapManager flashMapManager = null;
 
@@ -246,6 +250,15 @@ public class StandaloneMockMvcBuilder extends DefaultMockMvcBuilder<StandaloneMo
 	}
 
 	/**
+	 * Provide a TimeZoneResolver instance.
+	 * If not provided, the default one used is {@link FixedTimeZoneResolver}.
+	 */
+	public StandaloneMockMvcBuilder setTimeZoneResolver(TimeZoneResolver timeZoneResolver) {
+		this.timeZoneResolver = timeZoneResolver;
+		return this;
+	}
+
+	/**
 	 * Provide a custom FlashMapManager instance.
 	 * If not provided, {@code SessionFlashMapManager} is used by default.
 	 */
@@ -300,6 +313,7 @@ public class StandaloneMockMvcBuilder extends DefaultMockMvcBuilder<StandaloneMo
 
 		cxt.addBeans(initViewResolvers(cxt));
 		cxt.addBean(DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME, this.localeResolver);
+		cxt.addBean(DispatcherServlet.TIME_ZONE_RESOLVER_BEAN_NAME, this.timeZoneResolver);
 		cxt.addBean(DispatcherServlet.THEME_RESOLVER_BEAN_NAME, new FixedThemeResolver());
 		cxt.addBean(DispatcherServlet.REQUEST_TO_VIEW_NAME_TRANSLATOR_BEAN_NAME, new DefaultRequestToViewNameTranslator());
 

--- a/spring-web/src/main/java/org/springframework/web/context/request/RequestContextListener.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/RequestContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,9 @@ import org.springframework.context.i18n.LocaleContextHolder;
  * <p>Alternatively, Spring's {@link org.springframework.web.filter.RequestContextFilter}
  * and Spring's {@link org.springframework.web.servlet.DispatcherServlet} also expose
  * the same request context to the current thread. In contrast to this listener,
- * advanced options are available there (e.g. "threadContextInheritable").
+ * advanced options are available there (e.g. "threadContextInheritable"). Unlike
+ * {@code DispatcherServlet}, this listener cannot expose the time zone through
+ * {@link org.springframework.context.i18n.TimeZoneContextHolder}.
  *
  * <p>This listener is mainly for use with third-party servlets, e.g. the JSF FacesServlet.
  * Within Spring's own web support, DispatcherServlet's processing is perfectly sufficient.

--- a/spring-web/src/main/java/org/springframework/web/filter/RequestContextFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/RequestContextFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,9 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  *
  * <p>Alternatively, Spring's {@link org.springframework.web.context.request.RequestContextListener}
  * and Spring's {@link org.springframework.web.servlet.DispatcherServlet} also expose
- * the same request context to the current thread.
+ * the same request context to the current thread. Unlike {@code DispatcherServlet}, this
+ * filter cannot expose the time zone through
+ * {@link org.springframework.context.i18n.TimeZoneContextHolder}.
  *
  * <p>This filter is mainly for use with third-party servlets, e.g. the JSF FacesServlet.
  * Within Spring's own web support, DispatcherServlet's processing is perfectly sufficient.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.properties
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.properties
@@ -4,6 +4,8 @@
 
 org.springframework.web.servlet.LocaleResolver=org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver
 
+org.springframework.web.servlet.TimeZoneResolver=org.springframework.web.servlet.i18n.FixedTimeZoneResolver
+
 org.springframework.web.servlet.ThemeResolver=org.springframework.web.servlet.theme.FixedThemeResolver
 
 org.springframework.web.servlet.HandlerMapping=org.springframework.web.servlet.handler.BeanNameUrlHandlerMapping,\

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/TimeZoneResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/TimeZoneResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet;
+
+import java.util.TimeZone;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Interface for web-based time zone resolution strategies that allows for
+ * both time zone resolution via the request and time zone modification via
+ * request and response.
+ *
+ * <p>This interface allows for implementations based on request, session,
+ * cookies, etc. There is no default implementation as there is no standard for
+ * determining time zones from requests, but there are several implementations
+ * in the {@link org.springframework.web.servlet.i18n} package.
+ *
+ * <p>Use {@link org.springframework.web.servlet.support.RequestContext#getTimeZone()}
+ * to retrieve the current time zone in controllers or views, independent of the
+ * actual resolution strategy.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see org.springframework.web.servlet.support.RequestContext#getTimeZone
+ */
+public interface TimeZoneResolver {
+
+	/**
+	 * Resolve the current time zone via the given request. Should return a default time
+	 * zone as a fallback in any case.
+	 * @param request the request to resolve the time zone for
+	 * @return the current time zone (never {@code null})
+	 */
+	TimeZone resolveTimeZone(HttpServletRequest request);
+
+	/**
+	 * Set the current time zone to the given one.
+	 * @param request the request to be used for time zone modification
+	 * @param response the response to be used for time zone modification
+	 * @param timeZone the new time zone, or {@code null} to clear the time zone
+	 * @throws UnsupportedOperationException if the TimeZoneResolver implementation
+	 * does not support dynamic changing of the theme
+	 */
+	void setTimeZone(HttpServletRequest request, HttpServletResponse response,
+					 TimeZone timeZone);
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractTimeZoneResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractTimeZoneResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+
+import org.springframework.util.Assert;
+import org.springframework.web.servlet.TimeZoneResolver;
+
+/**
+ * Abstract base class for {@link TimeZoneResolver} implementations.
+ * Provides support for a default time zone.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ */
+public abstract class AbstractTimeZoneResolver implements TimeZoneResolver {
+
+	/**
+	 * Out-of-the-box value for the default time zone (the system default time zone).
+	 */
+	public final static TimeZone ORIGINAL_DEFAULT_TIME_ZONE = TimeZone.getDefault();
+
+
+	private TimeZone defaultTimeZone = ORIGINAL_DEFAULT_TIME_ZONE;
+
+
+	/**
+	 * Set a default time zone that this resolver will fall back to if no other time zone
+	 * is found.
+	 *
+	 * @param defaultTimeZone the default time zone to fall back to.
+	 */
+	public void setDefaultTimeZone(TimeZone defaultTimeZone) {
+		Assert.notNull(defaultTimeZone, "The default time zone cannot be null.");
+		this.defaultTimeZone = defaultTimeZone;
+	}
+
+	/**
+	 * Return the default time zone that this resolver is supposed to fall back to, if
+	 * any.
+	 */
+	protected TimeZone getDefaultTimeZone() {
+		return this.defaultTimeZone;
+	}
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieTimeZoneResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieTimeZoneResolver.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.TimeZoneResolver;
+import org.springframework.web.util.CookieGenerator;
+import org.springframework.web.util.WebUtils;
+
+/**
+ * {@link TimeZoneResolver} implementation that uses a cookie sent back to the user
+ * in case of a custom setting, with a fallback to the specified default time zone.
+ *
+ * <p>This is particularly useful for stateless applications without user sessions.
+ *
+ * <p>Custom controllers can thus override the user's time zone by calling
+ * {@link #setTimeZone}, for example responding to a time zone change request.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see #setDefaultTimeZone
+ * @see #setTimeZone
+ */
+public class CookieTimeZoneResolver extends CookieGenerator implements TimeZoneResolver {
+
+	/**
+	 * The name of the request attribute that holds the time zone.
+	 * <p>Only used for overriding a cookie value if the time zone has been
+	 * changed in the course of the current request! Use
+	 * {@link org.springframework.web.servlet.support.RequestContext#getTimeZone}
+	 * to retrieve the current time zone in controllers or views.
+	 * @see org.springframework.web.servlet.support.RequestContext#getTimeZone
+	 * @see org.springframework.web.servlet.support.RequestContextUtils#getTimeZone
+	 */
+	public static final String TIME_ZONE_REQUEST_ATTRIBUTE_NAME =
+			CookieTimeZoneResolver.class.getName() + ".TIME_ZONE";
+
+	/**
+	 * The default cookie name used if none is explicitly set.
+	 */
+	public static final String DEFAULT_COOKIE_NAME =
+			CookieTimeZoneResolver.class.getName() + ".TIME_ZONE";
+
+
+	private TimeZone defaultTimeZone = AbstractTimeZoneResolver.ORIGINAL_DEFAULT_TIME_ZONE;
+
+
+	/**
+	 * Creates a new instance of the {@code CookieTimeZoneResolver} class
+	 * using the {@link #DEFAULT_COOKIE_NAME default cookie name}.
+	 */
+	public CookieTimeZoneResolver() {
+		this.setCookieName(DEFAULT_COOKIE_NAME);
+	}
+
+
+	/**
+	 * Set a default time zone that this resolver will fall back to if no other time zone
+	 * is found.
+	 *
+	 * @param defaultTimeZone the default time zone to fall back to.
+	 */
+	public void setDefaultTimeZone(TimeZone defaultTimeZone) {
+		Assert.notNull(defaultTimeZone, "The default time zone cannot be null.");
+		this.defaultTimeZone = defaultTimeZone;
+	}
+
+	/**
+	 * Return the default time zone that this resolver is supposed to fall back to, if
+	 * any.
+	 */
+	protected TimeZone getDefaultTimeZone() {
+		return this.defaultTimeZone;
+	}
+
+	@Override
+	public TimeZone resolveTimeZone(HttpServletRequest request) {
+		// Check request for pre-parsed or preset time zone.
+		TimeZone timeZone = (TimeZone) request.getAttribute(TIME_ZONE_REQUEST_ATTRIBUTE_NAME);
+		if (timeZone != null) {
+			return timeZone;
+		}
+
+		// Retrieve and parse cookie value.
+		Cookie cookie = WebUtils.getCookie(request, getCookieName());
+		if (cookie != null) {
+			timeZone = StringUtils.parseTimeZoneString(cookie.getValue());
+			if (logger.isDebugEnabled()) {
+				logger.debug("Parsed cookie value [" + cookie.getValue() +
+						"] into time zone '" + timeZone.getID() + "'");
+			}
+			if (timeZone != null) {
+				request.setAttribute(TIME_ZONE_REQUEST_ATTRIBUTE_NAME, timeZone);
+				return timeZone;
+			}
+		}
+
+		return this.getDefaultTimeZone();
+	}
+
+	@Override
+	public void setTimeZone(HttpServletRequest request, HttpServletResponse response, TimeZone timeZone) {
+		if (timeZone != null) {
+			// Set request attribute and add cookie.
+			request.setAttribute(TIME_ZONE_REQUEST_ATTRIBUTE_NAME, timeZone);
+			addCookie(response, timeZone.getID());
+		}
+		else {
+			// Set request attribute to fallback time zone and remove cookie.
+			request.setAttribute(TIME_ZONE_REQUEST_ATTRIBUTE_NAME, this.getDefaultTimeZone());
+			removeCookie(response);
+		}
+	}
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/FixedTimeZoneResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/FixedTimeZoneResolver.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * {@link org.springframework.web.servlet.TimeZoneResolver} implementation
+ * that always returns a fixed default time zone. Default is the current
+ * JVM's default time zone.
+ *
+ * <p>Note: Does not support {@code setTimeZone}, as the fixed time zone
+ * cannot be changed.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see #setDefaultTimeZone
+ */
+public class FixedTimeZoneResolver extends AbstractTimeZoneResolver {
+
+	/**
+	 * Create a default FixedTimeZoneResolver, exposing a configured default
+	 * time zone (or the JVM's default time zone as fallback).
+	 * @see #setDefaultTimeZone(java.util.TimeZone)
+	 */
+	public FixedTimeZoneResolver() {
+
+	}
+
+	/**
+	 * Create a FixedTimeZoneResolver that exposes the given time zone.
+	 * @param timeZone the time zone to expose
+	 */
+	public FixedTimeZoneResolver(TimeZone timeZone) {
+		setDefaultTimeZone(timeZone);
+	}
+
+
+	@Override
+	public TimeZone resolveTimeZone(HttpServletRequest request) {
+		TimeZone timeZone = getDefaultTimeZone();
+		if (timeZone == null) {
+			timeZone = TimeZone.getDefault();
+		}
+		return timeZone;
+	}
+
+	@Override
+	public void setTimeZone(HttpServletRequest request, HttpServletResponse response,
+							TimeZone timeZone) {
+		throw new UnsupportedOperationException(
+				"Cannot change fixed time zone - use a different time zone resolution strategy");
+	}
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/HeaderTimeZoneResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/HeaderTimeZoneResolver.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Implementation of TimeZoneResolver that uses an HTTP header to resolve the time zone
+ * that the user wants to use. The default header is {@code Accept-Timezone}, but this
+ * does not imply that this is a standard HTTP header. There is no standard HTTP time
+ * zone header. This class uses {@code Accept-Timezone} as the default to follow the
+ * convention set by the official HTTP header {@code Accept-Language} used by
+ * {@link AcceptHeaderLocaleResolver}.
+ *
+ * <p>For HTTP clients to use a custom time zone header, they must be configured to do so.
+ * You cannot do this with most browsers, so this resolver is most useful for endpoints
+ * expected to be accessed by non-browser clients, such as web service endpoints.
+ *
+ * <p>Note: Does not support {@code setLocale}, since the header
+ * can only be changed through changing the client's settings.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ */
+public class HeaderTimeZoneResolver extends AbstractTimeZoneResolver {
+
+	/**
+	 * The default header name, which is {@code Accept-Timezone}. This should not be
+	 * construed to mean that this is a standard HTTP header; there is no standard HTTP
+	 * time zone header.
+	 */
+	public static final String DEFAULT_HEADER_NAME = "Accept-Timezone";
+
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private String headerName = DEFAULT_HEADER_NAME;
+
+
+	public String getHeaderName() {
+		return headerName;
+	}
+
+	public void setHeaderName(String headerName) {
+		Assert.hasLength(headerName, "The header name cannot be empty.");
+		this.headerName = headerName;
+	}
+
+	@Override
+	public TimeZone resolveTimeZone(HttpServletRequest request) {
+		String timeZoneHeader = request.getHeader(this.headerName);
+		if (timeZoneHeader != null) {
+			TimeZone timeZone = StringUtils.parseTimeZoneString(timeZoneHeader);
+			if (timeZone != null) {
+				return timeZone;
+			}
+			else if (logger.isInfoEnabled()) {
+				logger.info("Failed to parse parameter value [" + timeZoneHeader +
+						"] into time zone.");
+			}
+		}
+		return this.getDefaultTimeZone();
+	}
+
+	@Override
+	public void setTimeZone(HttpServletRequest request, HttpServletResponse response,
+							TimeZone timeZone) {
+		throw new UnsupportedOperationException(
+				"Cannot change HTTP time zone header - use a different time zone resolution strategy");
+	}
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/SessionTimeZoneResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/SessionTimeZoneResolver.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.util.WebUtils;
+
+/**
+ * Implementation of TimeZoneResolver that uses a time zone attribute in the user's
+ * session in case of a custom setting, with a fallback to the specified default
+ * time zone.
+ *
+ * <p>This is most appropriate if the application needs user sessions anyway,
+ * that is, when the HttpSession does not have to be created for the time zone.
+ *
+ * <p>Custom controllers can override the user's time zone by calling
+ * {@code setTimeZone}, e.g. responding to a time zone change request.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see #setDefaultTimeZone
+ * @see #setTimeZone
+ */
+public class SessionTimeZoneResolver extends AbstractTimeZoneResolver {
+
+	/**
+	 * Name of the session attribute that holds the time zone.
+	 * Only used internally by this implementation.
+	 * Use {@code RequestContext(Utils).getTimeZone()}
+	 * to retrieve the current time zone in controllers or views.
+	 * @see org.springframework.web.servlet.support.RequestContext#getTimeZone()
+	 * @see org.springframework.web.servlet.support.RequestContextUtils#getTimeZone
+	 */
+	public static final String TIME_ZONE_SESSION_ATTRIBUTE_NAME =
+			SessionTimeZoneResolver.class.getName() + ".TIME_ZONE";
+
+
+	@Override
+	public TimeZone resolveTimeZone(HttpServletRequest request) {
+		TimeZone timeZone = (TimeZone) WebUtils.getSessionAttribute(request, TIME_ZONE_SESSION_ATTRIBUTE_NAME);
+		if (timeZone != null) {
+			return timeZone;
+		}
+		return this.getDefaultTimeZone();
+	}
+
+	@Override
+	public void setTimeZone(HttpServletRequest request, HttpServletResponse response,
+							TimeZone timeZone) {
+		WebUtils.setSessionAttribute(request, TIME_ZONE_SESSION_ATTRIBUTE_NAME, timeZone);
+	}
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/TimeZoneChangeInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/TimeZoneChangeInterceptor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.TimeZoneResolver;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.support.RequestContextUtils;
+
+/**
+ * Interceptor that allows for changing the current time zone on every request,
+ * via a configurable request parameter.
+ *
+ * @author Nicholas Williams
+ * @since 4.0
+ * @see org.springframework.web.servlet.TimeZoneResolver
+ */
+public class TimeZoneChangeInterceptor extends HandlerInterceptorAdapter {
+
+	/**
+	 * Default name of the time zone specification parameter: "timezone".
+	 */
+	public static final String DEFAULT_PARAM_NAME = "timezone";
+
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private String paramName = DEFAULT_PARAM_NAME;
+
+
+	/**
+	 * Set the name of the parameter that contains a time zone specification
+	 * in a time zone change request. Default is "timezone".
+	 */
+	public void setParamName(String paramName) {
+		Assert.hasLength(paramName, "The parameter name cannot be blank.");
+		this.paramName = paramName;
+	}
+
+	/**
+	 * Return the name of the parameter that contains a time zone specification
+	 * in a time zone change request.
+	 */
+	public String getParamName() {
+		return this.paramName;
+	}
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+			throws ServletException {
+		String newTimeZone = request.getParameter(this.paramName);
+		if (newTimeZone != null) {
+			TimeZone timeZone = StringUtils.parseTimeZoneString(newTimeZone);
+			if (timeZone != null) {
+				TimeZoneResolver timeZoneResolver = RequestContextUtils.getTimeZoneResolver(request);
+				if (timeZoneResolver == null) {
+					throw new IllegalStateException("No TimeZoneResolver found: not in a DispatcherServlet request?");
+				}
+				timeZoneResolver.setTimeZone(request, response, timeZone);
+			}
+			else if (logger.isInfoEnabled()) {
+				logger.info("Failed to parse parameter value [" + newTimeZone +
+						"] into time zone.");
+			}
+		}
+		// Proceed in any case.
+		return true;
+	}
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/JstlUtils.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/JstlUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.web.servlet.support;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
-
+import java.util.TimeZone;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -80,6 +80,8 @@ public abstract class JstlUtils {
 	public static void exposeLocalizationContext(HttpServletRequest request, MessageSource messageSource) {
 		Locale jstlLocale = RequestContextUtils.getLocale(request);
 		Config.set(request, Config.FMT_LOCALE, jstlLocale);
+		TimeZone jstlTimeZone = RequestContextUtils.getTimeZone(request);
+		Config.set(request, Config.FMT_TIME_ZONE, jstlTimeZone);
 		if (messageSource != null) {
 			LocalizationContext jstlContext = new SpringLocalizationContext(messageSource, request);
 			Config.set(request, Config.FMT_LOCALIZATION_CONTEXT, jstlContext);
@@ -95,6 +97,7 @@ public abstract class JstlUtils {
 	 */
 	public static void exposeLocalizationContext(RequestContext requestContext) {
 		Config.set(requestContext.getRequest(), Config.FMT_LOCALE, requestContext.getLocale());
+		Config.set(requestContext.getRequest(), Config.FMT_TIME_ZONE, requestContext.getTimeZone());
 		MessageSource messageSource = getJstlAwareMessageSource(
 				requestContext.getServletContext(), requestContext.getMessageSource());
 		LocalizationContext jstlContext = new SpringLocalizationContext(messageSource, requestContext.getRequest());
@@ -141,6 +144,6 @@ public abstract class JstlUtils {
 			}
 			return RequestContextUtils.getLocale(this.request);
 		}
-	};
+	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/RequestContextUtils.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/RequestContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.web.servlet.support;
 
 import java.util.Locale;
 import java.util.Map;
-
+import java.util.TimeZone;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
@@ -32,13 +32,14 @@ import org.springframework.web.servlet.FlashMap;
 import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.ThemeResolver;
+import org.springframework.web.servlet.TimeZoneResolver;
 
 /**
  * Utility class for easy access to request-specific state which has been
  * set by the {@link org.springframework.web.servlet.DispatcherServlet}.
  *
  * <p>Supports lookup of current WebApplicationContext, LocaleResolver,
- * Locale, ThemeResolver, Theme, and MultipartResolver.
+ * Locale, TimeZoneResolver, TimeZone, ThemeResolver, Theme, and MultipartResolver.
  *
  * @author Juergen Hoeller
  * @since 03.03.2003
@@ -114,6 +115,34 @@ public abstract class RequestContextUtils {
 		}
 		else {
 			return request.getLocale();
+		}
+	}
+
+	/**
+	 * Return the TimeZoneResolver that has been bound to the request by the
+	 * DispatcherServlet.
+	 * @param request current HTTP request
+	 * @return the current TimeZoneResolver, or {@code null} if not found
+	 */
+	public static TimeZoneResolver getTimeZoneResolver(HttpServletRequest request) {
+		return (TimeZoneResolver) request.getAttribute(DispatcherServlet.TIME_ZONE_RESOLVER_ATTRIBUTE);
+	}
+
+	/**
+	 * Retrieves the current time zone from the given request,
+	 * using the TimeZoneResolver bound to the request by the DispatcherServlet
+	 * (if available), or null if no resolver is found.
+	 * @param request current HTTP request
+	 * @return the current time zone from the TimeZoneResolver, or {@code null} if no resolver
+	 * @see #getTimeZoneResolver(javax.servlet.http.HttpServletRequest)
+	 */
+	public static TimeZone getTimeZone(HttpServletRequest request) {
+		TimeZoneResolver timeZoneResolver = getTimeZoneResolver(request);
+		if (timeZoneResolver != null) {
+			return timeZoneResolver.resolveTimeZone(request);
+		}
+		else {
+			return null;
 		}
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/jasperreports/AbstractJasperReportsView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/jasperreports/AbstractJasperReportsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -572,6 +572,7 @@ public abstract class AbstractJasperReportsView extends AbstractUrlBasedView {
 	 * MessageSourceResourceBundle adapter for the Spring ApplicationContext,
 	 * analogous to the {@code JstlUtils.exposeLocalizationContext} method.
 	 * @see org.springframework.web.servlet.support.RequestContextUtils#getLocale
+	 * @see org.springframework.web.servlet.support.RequestContextUtils#getTimeZone
 	 * @see org.springframework.context.support.MessageSourceResourceBundle
 	 * @see #getApplicationContext()
 	 * @see net.sf.jasperreports.engine.JRParameter#REPORT_LOCALE
@@ -582,6 +583,9 @@ public abstract class AbstractJasperReportsView extends AbstractUrlBasedView {
 		RequestContext rc = new RequestContext(request, getServletContext());
 		if (!model.containsKey(JRParameter.REPORT_LOCALE)) {
 			model.put(JRParameter.REPORT_LOCALE, rc.getLocale());
+		}
+		if (!model.containsKey(JRParameter.REPORT_TIME_ZONE)) {
+			model.put(JRParameter.REPORT_TIME_ZONE, rc.getTimeZone());
 		}
 		JasperReport report = getReport();
 		if ((report == null || report.getResourceBundle() == null) &&

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/velocity/VelocityView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/velocity/VelocityView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.web.servlet.view.velocity;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -139,6 +140,7 @@ public class VelocityView extends AbstractTemplateView {
 	 * Spring uses a special locale-aware subclass of DateTool.
 	 * @see org.apache.velocity.tools.generic.DateTool
 	 * @see org.springframework.web.servlet.support.RequestContextUtils#getLocale
+	 * @see org.springframework.web.servlet.support.RequestContextUtils#getTimeZone
 	 * @see org.springframework.web.servlet.LocaleResolver
 	 */
 	public void setDateToolAttribute(String dateToolAttribute) {
@@ -410,7 +412,8 @@ public class VelocityView extends AbstractTemplateView {
 		if (this.dateToolAttribute != null || this.numberToolAttribute != null) {
 			Locale locale = RequestContextUtils.getLocale(request);
 			if (this.dateToolAttribute != null) {
-				velocityContext.put(this.dateToolAttribute, new LocaleAwareDateTool(locale));
+				TimeZone timeZone = RequestContextUtils.getTimeZone(request);
+				velocityContext.put(this.dateToolAttribute, new LocaleAwareDateTool(locale, timeZone));
 			}
 			if (this.numberToolAttribute != null) {
 				velocityContext.put(this.numberToolAttribute, new LocaleAwareNumberTool(locale));
@@ -531,18 +534,30 @@ public class VelocityView extends AbstractTemplateView {
 	 * Subclass of DateTool from Velocity Tools, using a passed-in Locale
 	 * (usually the RequestContext Locale) instead of the default Locale.N
 	 * @see org.springframework.web.servlet.support.RequestContextUtils#getLocale
+	 * @see org.springframework.web.servlet.support.RequestContextUtils#getTimeZone
 	 */
 	private static class LocaleAwareDateTool extends DateTool {
 
 		private final Locale locale;
 
-		private LocaleAwareDateTool(Locale locale) {
+		private final TimeZone timeZone;
+
+		private LocaleAwareDateTool(Locale locale, TimeZone timeZone) {
 			this.locale = locale;
+			this.timeZone = timeZone;
 		}
 
 		@Override
 		public Locale getLocale() {
 			return this.locale;
+		}
+
+		@Override
+		public TimeZone getTimeZone() {
+			if (this.timeZone != null) {
+				return this.timeZone;
+			}
+			return super.getTimeZone();
 		}
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
@@ -18,6 +18,7 @@ package org.springframework.web.servlet;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.TimeZone;
 import javax.servlet.Servlet;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -340,6 +341,29 @@ public class DispatcherServletTests extends TestCase {
 		request.addUserRole("role2");
 		request.addParameter("locale", "en");
 		request.addParameter("locale2", "en_CA");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		complexDispatcherServlet.service(request, response);
+		assertTrue("Not forwarded", response.getForwardedUrl() == null);
+	}
+
+	public void testTimeZoneChangeInterceptor1() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest(getServletContext(), "GET", "/timezone.do");
+		request.addUserRole("role2");
+		request.addParameter("timezone", "America/Denver");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		complexDispatcherServlet.service(request, response);
+		assertEquals(200, response.getStatus());
+		assertEquals("forwarded to failed", "failed0.jsp", response.getForwardedUrl());
+		assertTrue("Exception exposed", request.getAttribute("exception").getClass().equals(ServletException.class));
+	}
+
+	public void testTimeZoneChangeInterceptor2() throws Exception {
+		String id = TimeZone.getDefault().getID().equals("America/Chicago") ?
+				"America/Los_Angeles" : "America/Chicago";
+		MockHttpServletRequest request = new MockHttpServletRequest(getServletContext(), "GET", "/timezone.do");
+		request.addUserRole("role2");
+		request.addParameter("timezone", "America/Denver");
+		request.addParameter("timezone2", id);
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		complexDispatcherServlet.service(request, response);
 		assertTrue("Not forwarded", response.getForwardedUrl() == null);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/CookieTimeZoneResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/CookieTimeZoneResolverTests.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+
+import javax.servlet.http.Cookie;
+
+import junit.framework.TestCase;
+
+import org.springframework.mock.web.test.MockHttpServletRequest;
+import org.springframework.mock.web.test.MockHttpServletResponse;
+
+/**
+ * @author Nicholas Williams
+ */
+public class CookieTimeZoneResolverTests extends TestCase {
+
+	private static final TimeZone SYSTEM = TimeZone.getDefault();
+
+	private static final String SYSTEM_ID = SYSTEM.getID();
+
+	public void testResolveAmericaChicagoTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME, "America/Chicago"));
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+
+		request.setCookies();
+		assertEquals("The cookies are not right.", 0, request.getCookies().length);
+
+		timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testResolveAmericaLosAngelesTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME, "America/Los_Angeles"));
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+
+		request.setCookies();
+		assertEquals("The cookies are not right.", 0, request.getCookies().length);
+
+		timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testResolveSystemDefaultTimeZoneWithBadCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME, "America/Fake"));
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveSetDefaultTimeZoneWithBadCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME, "America/Fake"));
+
+		String targetId = SYSTEM_ID.equals("America/Chicago") ? "America/Los_Angeles" : "America/Chicago";
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone(targetId));
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", targetId, timeZone.getID());
+	}
+
+	public void testResolveAmericaChicagoTimeZoneWithCustomCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie("foo1", "America/Chicago"));
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setCookieName("foo1");
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+
+		request.setCookies();
+		assertEquals("The cookies are not right.", 0, request.getCookies().length);
+
+		timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testResolveAmericaLosAngelesTimeZoneWithCustomCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie("bar2", "America/Los_Angeles"));
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setCookieName("bar2");
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+
+		request.setCookies();
+		assertEquals("The cookies are not right.", 0, request.getCookies().length);
+
+		timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testResolveSystemDefaultTimeZoneWithBadCustomCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie("foo1", "America/Fake"));
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setCookieName("foo1");
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveSetDefaultTimeZoneWithBadCustomCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie("bar2", "America/Fake"));
+
+		String targetId = SYSTEM_ID.equals("America/Chicago") ? "America/Los_Angeles" : "America/Chicago";
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone(targetId));
+		resolver.setCookieName("bar2");
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", targetId, timeZone.getID());
+	}
+
+	public void testResolveSystemDefaultTimeZoneWithNoCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveSetDefaultTimeZoneWithNoCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		String targetId = SYSTEM_ID.equals("America/Chicago") ? "America/Los_Angeles" : "America/Chicago";
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone(targetId));
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", targetId, timeZone.getID());
+	}
+
+	public void testSetAndResolveAmericaChicagoTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Chicago");
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setTimeZone(request, response, setZone);
+
+		Cookie cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "America/Chicago", cookie.getValue());
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testSetAndResolveAmericaLosAngelesTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Los_Angeles");
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setTimeZone(request, response, setZone);
+
+		Cookie cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "America/Los_Angeles", cookie.getValue());
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testSetAndResolveAmericaChicagoTimeZoneWithCustomCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Chicago");
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setCookieName("foo1");
+		resolver.setTimeZone(request, response, setZone);
+
+		Cookie cookie = response.getCookie("foo1");
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "America/Chicago", cookie.getValue());
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testSetAndResolveAmericaLosAngelesTimeZoneWithCustomCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Los_Angeles");
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setCookieName("bar2");
+		resolver.setTimeZone(request, response, setZone);
+
+		Cookie cookie = response.getCookie("bar2");
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "America/Los_Angeles", cookie.getValue());
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testSetToChicagoThenNullResolveSystemDefaultTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Chicago");
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setTimeZone(request, response, setZone);
+
+		Cookie cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "America/Chicago", cookie.getValue());
+
+		response = new MockHttpServletResponse();
+		resolver.setTimeZone(request, response, null);
+
+		cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "", cookie.getValue());
+		assertEquals("The cookie has the wrong max age.", 0, cookie.getMaxAge());
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testSetToLosAngelesThenNullResolveSystemDefaultTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Los_Angeles");
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setTimeZone(request, response, setZone);
+
+		Cookie cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "America/Los_Angeles", cookie.getValue());
+
+		response = new MockHttpServletResponse();
+		resolver.setTimeZone(request, response, null);
+
+		cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "", cookie.getValue());
+		assertEquals("The cookie has the wrong max age.", 0, cookie.getMaxAge());
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testSetToChicagoThenNullResolveSetDefaultTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Chicago");
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone("America/New_York"));
+		resolver.setTimeZone(request, response, setZone);
+
+		Cookie cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "America/Chicago", cookie.getValue());
+
+		response = new MockHttpServletResponse();
+		resolver.setTimeZone(request, response, null);
+
+		cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "", cookie.getValue());
+		assertEquals("The cookie has the wrong max age.", 0, cookie.getMaxAge());
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/New_York", timeZone.getID());
+	}
+
+	public void testSetToLosAngelesThenNullResolveSetDefaultTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Los_Angeles");
+
+		CookieTimeZoneResolver resolver = new CookieTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone("America/Denver"));
+		resolver.setTimeZone(request, response, setZone);
+
+		Cookie cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "America/Los_Angeles", cookie.getValue());
+
+		response = new MockHttpServletResponse();
+		resolver.setTimeZone(request, response, null);
+
+		cookie = response.getCookie(CookieTimeZoneResolver.DEFAULT_COOKIE_NAME);
+		assertNotNull("The cookie should not be null.", cookie);
+		assertEquals("The cookie value is not correct.", "", cookie.getValue());
+		assertEquals("The cookie has the wrong max age.", 0, cookie.getMaxAge());
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Denver", timeZone.getID());
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/FixedTimeZoneResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/FixedTimeZoneResolverTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Nicholas Williams
+ */
+public class FixedTimeZoneResolverTests extends TestCase {
+
+	private static final TimeZone SYSTEM = TimeZone.getDefault();
+
+	private static final String SYSTEM_ID = SYSTEM.getID();
+
+	public void testResolveSystemDefaultTimeZone() {
+		FixedTimeZoneResolver resolver = new FixedTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(null);
+
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveAmericaChicagoTimeZone() {
+		FixedTimeZoneResolver resolver = new FixedTimeZoneResolver(TimeZone.getTimeZone("America/Chicago"));
+		TimeZone timeZone = resolver.resolveTimeZone(null);
+
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testResolveAmericaLosAngelesTimeZone() {
+		FixedTimeZoneResolver resolver = new FixedTimeZoneResolver(TimeZone.getTimeZone("America/Los_Angeles"));
+		TimeZone timeZone = resolver.resolveTimeZone(null);
+
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testSetDefaultResolveAmericaChicagoTimeZone() {
+		FixedTimeZoneResolver resolver = new FixedTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone("America/Chicago"));
+		TimeZone timeZone = resolver.resolveTimeZone(null);
+
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testSetDefaultResolveAmericaLosAngelesTimeZone() {
+		FixedTimeZoneResolver resolver = new FixedTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+		TimeZone timeZone = resolver.resolveTimeZone(null);
+
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testCantSetTimeZone() {
+		FixedTimeZoneResolver resolver = new FixedTimeZoneResolver();
+		try {
+			resolver.setTimeZone(null, null, null);
+			fail("You should not be able to set the time zone on the fixed resolver.");
+		} catch (UnsupportedOperationException e) {
+			// good
+		}
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/HeaderTimeZoneResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/HeaderTimeZoneResolverTests.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+
+import junit.framework.TestCase;
+
+import org.springframework.mock.web.test.MockHttpServletRequest;
+
+/**
+ * @author Nicholas Williams
+ */
+public class HeaderTimeZoneResolverTests extends TestCase {
+
+	private static final TimeZone SYSTEM = TimeZone.getDefault();
+
+	private static final String SYSTEM_ID = SYSTEM.getID();
+
+	public void testResolveAmericaChicagoTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(HeaderTimeZoneResolver.DEFAULT_HEADER_NAME, "America/Chicago");
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testResolveAmericaLosAngelesTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(HeaderTimeZoneResolver.DEFAULT_HEADER_NAME, "America/Los_Angeles");
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testResolveSystemDefaultTimeZoneWithBadHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(HeaderTimeZoneResolver.DEFAULT_HEADER_NAME, "America/Fake");
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveSetDefaultTimeZoneWithBadHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(HeaderTimeZoneResolver.DEFAULT_HEADER_NAME, "America/Fake");
+
+		String targetId = SYSTEM_ID.equals("America/Chicago") ? "America/Los_Angeles" : "America/Chicago";
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone(targetId));
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", targetId, timeZone.getID());
+	}
+
+	public void testResolveAmericaChicagoTimeZoneWithCustomHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("foo1", "America/Chicago");
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		resolver.setHeaderName("foo1");
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testResolveLosAngelesTimeZoneWithCustomHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("bar2", "America/Los_Angeles");
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		resolver.setHeaderName("bar2");
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testResolveSystemDefaultTimeZoneWithBadCustomHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("foo1", "America/Fake");
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		resolver.setHeaderName("foo1");
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveSetDefaultTimeZoneWithBadCustomHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("bar2", "America/Fake");
+
+		String targetId = SYSTEM_ID.equals("America/Chicago") ? "America/Los_Angeles" : "America/Chicago";
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone(targetId));
+		resolver.setHeaderName("bar2");
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", targetId, timeZone.getID());
+	}
+
+	public void testResolveSystemDefaultTimeZoneWithNoHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveSetDefaultTimeZoneWithNoHeader() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		String targetId = SYSTEM_ID.equals("America/Chicago") ? "America/Los_Angeles" : "America/Chicago";
+
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone(targetId));
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", targetId, timeZone.getID());
+	}
+
+	public void testCantSetTimeZone() {
+		HeaderTimeZoneResolver resolver = new HeaderTimeZoneResolver();
+		try {
+			resolver.setTimeZone(null, null, null);
+			fail("You should not be able to set the time zone on the header resolver.");
+		} catch (UnsupportedOperationException e) {
+			// good
+		}
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/SessionTimeZoneResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/SessionTimeZoneResolverTests.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+
+import junit.framework.TestCase;
+
+import org.springframework.mock.web.test.MockHttpServletRequest;
+import org.springframework.mock.web.test.MockHttpServletResponse;
+
+/**
+ * @author Nicholas Williams
+ */
+public class SessionTimeZoneResolverTests extends TestCase {
+
+	private static final TimeZone SYSTEM = TimeZone.getDefault();
+
+	private static final String SYSTEM_ID = SYSTEM.getID();
+
+	public void testResolveAmericaChicagoTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.getSession().setAttribute(
+				SessionTimeZoneResolver.TIME_ZONE_SESSION_ATTRIBUTE_NAME,
+				TimeZone.getTimeZone("America/Chicago")
+		);
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testResolveAmericaLosAngelesTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.getSession().setAttribute(
+				SessionTimeZoneResolver.TIME_ZONE_SESSION_ATTRIBUTE_NAME,
+				TimeZone.getTimeZone("America/Los_Angeles")
+		);
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testResolveSystemDefaultTimeZoneWithoutAttribute() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.getSession().setAttribute("foo", "bar");
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveSetDefaultTimeZoneWithoutAttribute() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.getSession().setAttribute("foo", "bar");
+
+		String targetId = SYSTEM_ID.equals("America/Chicago") ? "America/Los_Angeles" : "America/Chicago";
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone(targetId));
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", targetId, timeZone.getID());
+	}
+
+	public void testResolveSystemDefaultTimeZoneWithoutSession() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testResolveSetDefaultTimeZoneWithoutSession() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		String targetId = SYSTEM_ID.equals("America/Chicago") ? "America/Los_Angeles" : "America/Chicago";
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone(targetId));
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", targetId, timeZone.getID());
+	}
+
+	public void testSetAndResolveAmericaChicagoTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Chicago");
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		resolver.setTimeZone(request, response, setZone);
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Chicago", timeZone.getID());
+	}
+
+	public void testSetAndResolveAmericaLosAngelesTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Los_Angeles");
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		resolver.setTimeZone(request, response, setZone);
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Los_Angeles", timeZone.getID());
+	}
+
+	public void testSetToChicagoThenNullResolveSystemDefaultTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Chicago");
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		resolver.setTimeZone(request, response, setZone);
+		resolver.setTimeZone(request, response, null);
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testSetToLosAngelesThenNullResolveSystemDefaultTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Los_Angeles");
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		resolver.setTimeZone(request, response, setZone);
+		resolver.setTimeZone(request, response, null);
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", SYSTEM_ID, timeZone.getID());
+	}
+
+	public void testSetToChicagoThenNullResolveSetDefaultTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Chicago");
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone("America/New_York"));
+		resolver.setTimeZone(request, response, setZone);
+		resolver.setTimeZone(request, response, null);
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/New_York", timeZone.getID());
+	}
+
+	public void testSetToLosAngelesThenNullResolveSetDefaultTimeZone() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		TimeZone setZone = TimeZone.getTimeZone("America/Los_Angeles");
+
+		SessionTimeZoneResolver resolver = new SessionTimeZoneResolver();
+		resolver.setDefaultTimeZone(TimeZone.getTimeZone("America/Denver"));
+		resolver.setTimeZone(request, response, setZone);
+		resolver.setTimeZone(request, response, null);
+
+		TimeZone timeZone = resolver.resolveTimeZone(request);
+		assertNotNull("The time zone should not be null.", timeZone);
+		assertEquals("The time zone is not correct.", "America/Denver", timeZone.getID());
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/TimeZoneChangeInterceptorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/TimeZoneChangeInterceptorTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.i18n;
+
+import java.util.TimeZone;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import junit.framework.TestCase;
+
+import org.springframework.mock.web.test.MockHttpServletRequest;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.TimeZoneResolver;
+
+/**
+ * @author Nicholas Williams
+ */
+public class TimeZoneChangeInterceptorTests extends TestCase {
+
+	public void testParamName() {
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+
+		assertEquals("The param name is not correct.", "timezone", interceptor.getParamName());
+
+		interceptor.setParamName("fooTz1");
+		assertEquals("The param name did not change.", "fooTz1", interceptor.getParamName());
+	}
+
+	public void testPreHandleNoParameter() throws ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+		assertTrue("The return value is not correct.", interceptor.preHandle(request, null, null));
+	}
+
+	public void testPreHandleBadParameter() throws ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(TimeZoneChangeInterceptor.DEFAULT_PARAM_NAME, "America/Fake");
+
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+		assertTrue("The return value is not correct.", interceptor.preHandle(request, null, null));
+	}
+
+	public void testPreHandleNoResolver() throws ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(TimeZoneChangeInterceptor.DEFAULT_PARAM_NAME, "America/Chicago");
+
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+		try {
+			interceptor.preHandle(request, null, null);
+			fail("Expected IllegalStateException, got no exception.");
+		}
+		catch (IllegalStateException e) {
+			// good
+		}
+	}
+
+	public void testPreHandleNoResolverWithCustomParam() throws ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("foo1", "America/Chicago");
+
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+		interceptor.setParamName("foo1");
+		try {
+			interceptor.preHandle(request, null, null);
+			fail("Expected IllegalStateException, got no exception.");
+		}
+		catch (IllegalStateException e) {
+			// good
+		}
+	}
+
+	public void testPreHandleAmericaChicago() throws ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(TimeZoneChangeInterceptor.DEFAULT_PARAM_NAME, "America/Chicago");
+
+		MockTimeZoneResolver resolver = new MockTimeZoneResolver();
+		request.setAttribute(DispatcherServlet.TIME_ZONE_RESOLVER_ATTRIBUTE, resolver);
+
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+		assertTrue("The return value is not correct.", interceptor.preHandle(request, null, null));
+
+		assertSame("The request is not correct.", request, resolver.getSetTimeZoneRequest());
+		assertEquals("The time zone is not correct.", "America/Chicago",
+				resolver.getSetTimeZoneTimeZone().getID());
+	}
+
+	public void testPreHandleAmericaLosAngeles() throws ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(TimeZoneChangeInterceptor.DEFAULT_PARAM_NAME, "America/Los_Angeles");
+
+		MockTimeZoneResolver resolver = new MockTimeZoneResolver();
+		request.setAttribute(DispatcherServlet.TIME_ZONE_RESOLVER_ATTRIBUTE, resolver);
+
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+		assertTrue("The return value is not correct.", interceptor.preHandle(request, null, null));
+
+		assertSame("The request is not correct.", request, resolver.getSetTimeZoneRequest());
+		assertEquals("The time zone is not correct.", "America/Los_Angeles",
+				resolver.getSetTimeZoneTimeZone().getID());
+	}
+
+	public void testPreHandleAmericaChicagoWithCustomParam() throws ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("foo1", "America/Chicago");
+
+		MockTimeZoneResolver resolver = new MockTimeZoneResolver();
+		request.setAttribute(DispatcherServlet.TIME_ZONE_RESOLVER_ATTRIBUTE, resolver);
+
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+		interceptor.setParamName("foo1");
+		assertTrue("The return value is not correct.", interceptor.preHandle(request, null, null));
+
+		assertSame("The request is not correct.", request, resolver.getSetTimeZoneRequest());
+		assertEquals("The time zone is not correct.", "America/Chicago",
+				resolver.getSetTimeZoneTimeZone().getID());
+	}
+
+	public void testPreHandleAmericaLosAngelesWithCustomParam() throws ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("bar2", "America/Los_Angeles");
+
+		MockTimeZoneResolver resolver = new MockTimeZoneResolver();
+		request.setAttribute(DispatcherServlet.TIME_ZONE_RESOLVER_ATTRIBUTE, resolver);
+
+		TimeZoneChangeInterceptor interceptor = new TimeZoneChangeInterceptor();
+		interceptor.setParamName("bar2");
+		assertTrue("The return value is not correct.", interceptor.preHandle(request, null, null));
+
+		assertSame("The request is not correct.", request, resolver.getSetTimeZoneRequest());
+		assertEquals("The time zone is not correct.", "America/Los_Angeles",
+				resolver.getSetTimeZoneTimeZone().getID());
+	}
+
+
+	private static class MockTimeZoneResolver implements TimeZoneResolver {
+
+		private HttpServletRequest setTimeZoneRequest;
+
+		private TimeZone setTimeZoneTimeZone;
+
+		@Override
+		public TimeZone resolveTimeZone(HttpServletRequest request) {
+			throw new UnsupportedOperationException("Can't resolve time zone in this mock.");
+		}
+
+		@Override
+		public void setTimeZone(HttpServletRequest request, HttpServletResponse response, TimeZone timeZone) {
+			this.setTimeZoneRequest = request;
+			this.setTimeZoneTimeZone = timeZone;
+		}
+
+		private HttpServletRequest getSetTimeZoneRequest() {
+			return setTimeZoneRequest;
+		}
+
+		private TimeZone getSetTimeZoneTimeZone() {
+			return setTimeZoneTimeZone;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Added support to Spring Framework i18n for use `TimeZone`s. This
support is based largely off the `Locale` support. The `TimeZoneResolver`
interface parallels the `LocaleResolver` interface and so do most of
its implementations. The `TimeZoneChangeInterceptor` mirrors the
`LocaleChangeInterceptor`. Use of the `TimeZoneContextHolder` is the same
as using the `LocaleContextHolder`, and the `RequestContext` and
`RequestContextUtils` classes have `TimeZone`-related methods that mirror
the `Locale`-related methods.

As it does with `LocaleResolver`, `DispatcherServlet` now exposes a
`TimeZoneResolver` and context. The `JstlUtils` take into account and
expose `TimeZone`s to the target JSP context, just like with `Locale`s,
so that `<fmt:formatDate>` and the like can take advantage of the
selected `TimeZone`. The Velocity and Jasper Report views have also
been updated to use the `TimeZone` (they were the only other view types
whose 3rd party libraries consumed `TimeZone`s but Spring was ignoring
that).

Everything was set up so that out-of-the-box, Spring and everything
it affects continue to use the System Default time zone without
configuration to the contrary. This way, behavior should not change
for users that don't set up `TimeZone` support.

This change includes 69 unit tests to back up my changes. I have also
thoroughly functionally tested the changes in my target application.
All new classes are well-documented with JavaDoc and the JavaDoc of
classes affected by these changes have been updated as appropriate.

Issue: SPR-1528
