### PR TITLE
Add caching to WebAsyncUtils to avoid excessive use of reflection. (SPR-10673)

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncUtils.java
@@ -36,6 +36,8 @@ public abstract class WebAsyncUtils {
 
 	public static final String WEB_ASYNC_MANAGER_ATTRIBUTE = WebAsyncManager.class.getName() + ".WEB_ASYNC_MANAGER";
 
+	private static Constructor<?> asyncWebRequestConstructor;
+
 	/**
 	 * Obtain the {@link WebAsyncManager} for the current request, or if not
 	 * found, create and associate it with the request.
@@ -80,14 +82,30 @@ public abstract class WebAsyncUtils {
 
 	private static AsyncWebRequest createStandardServletAsyncWebRequest(HttpServletRequest request, HttpServletResponse response) {
 		try {
-			String className = "org.springframework.web.context.request.async.StandardServletAsyncWebRequest";
-			Class<?> clazz = ClassUtils.forName(className, WebAsyncUtils.class.getClassLoader());
-			Constructor<?> constructor = clazz.getConstructor(HttpServletRequest.class, HttpServletResponse.class);
+			Constructor<?> constructor = getAsyncWebRequestConstructor();
 			return (AsyncWebRequest) BeanUtils.instantiateClass(constructor, request, response);
 		}
 		catch (Throwable t) {
 			throw new IllegalStateException("Failed to instantiate StandardServletAsyncWebRequest", t);
 		}
+	}
+
+	/**
+	 * Get the constructor for StandardServletAsyncWebRequest, initialise the cached version if not initialised.
+	 *
+	 * @return a Constructor for StandardServletAsyncWebRequest.
+	 * @throws ClassNotFoundException
+	 * @throws NoSuchMethodException
+	 */
+	private static Constructor<?> getAsyncWebRequestConstructor() throws ClassNotFoundException, NoSuchMethodException
+	{
+		if (asyncWebRequestConstructor == null)
+		{
+			String className = "org.springframework.web.context.request.async.StandardServletAsyncWebRequest";
+			Class<?> clazz = ClassUtils.forName(className, WebAsyncUtils.class.getClassLoader());
+			asyncWebRequestConstructor = clazz.getConstructor(HttpServletRequest.class, HttpServletResponse.class);
+		}
+		return asyncWebRequestConstructor;
 	}
 
 }


### PR DESCRIPTION
Add caching to WebAsyncUtils to avoid excessive use of reflection when loading "org.springframework.web.context.request.async.StandardServletAsyncWebRequest"
