### PR TITLE
Support WritableResource property values

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/support/ResourceEditorRegistrar.java
+++ b/spring-beans/src/main/java/org/springframework/beans/support/ResourceEditorRegistrar.java
@@ -22,8 +22,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 
-import org.xml.sax.InputSource;
-
 import org.springframework.beans.PropertyEditorRegistrar;
 import org.springframework.beans.PropertyEditorRegistry;
 import org.springframework.beans.PropertyEditorRegistrySupport;
@@ -40,8 +38,10 @@ import org.springframework.core.io.ContextResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceEditor;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.WritableResource;
 import org.springframework.core.io.support.ResourceArrayPropertyEditor;
 import org.springframework.core.io.support.ResourcePatternResolver;
+import org.xml.sax.InputSource;
 
 /**
  * PropertyEditorRegistrar implementation that populates a given
@@ -113,6 +113,7 @@ public class ResourceEditorRegistrar implements PropertyEditorRegistrar {
 	public void registerCustomEditors(PropertyEditorRegistry registry) {
 		ResourceEditor baseEditor = new ResourceEditor(this.resourceLoader, this.propertyResolver);
 		doRegisterEditor(registry, Resource.class, baseEditor);
+		doRegisterEditor(registry, WritableResource.class, baseEditor);
 		doRegisterEditor(registry, ContextResource.class, baseEditor);
 		doRegisterEditor(registry, InputStream.class, new InputStreamEditor(baseEditor));
 		doRegisterEditor(registry, InputSource.class, new InputSourceEditor(baseEditor));

--- a/spring-beans/src/test/java/org/springframework/beans/propertyeditors/CustomEditorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/propertyeditors/CustomEditorTests.java
@@ -1477,7 +1477,6 @@ public class CustomEditorTests {
 		assertEquals("Invalid Charset conversion", name, editor.getAsText());
 	}
 
-
 	private static class TestBeanEditor extends PropertyEditorSupport {
 
 		@Override

--- a/spring-core/src/main/java/org/springframework/core/io/DefaultResourceLoader.java
+++ b/spring-core/src/main/java/org/springframework/core/io/DefaultResourceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,15 @@
 
 package org.springframework.core.io;
 
+import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -95,6 +99,10 @@ public class DefaultResourceLoader implements ResourceLoader {
 			try {
 				// Try to parse the location as a URL...
 				URL url = new URL(location);
+				try {
+					return new FileSystemResource(ResourceUtils.getFile(url));
+				} catch(Exception ex) {
+				}
 				return new UrlResource(url);
 			}
 			catch (MalformedURLException ex) {

--- a/spring-core/src/test/java/org/springframework/core/io/ResourceEditorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/ResourceEditorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,16 @@
 package org.springframework.core.io;
 
 import java.beans.PropertyEditor;
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.hamcrest.Matchers.*;
 
 import static org.junit.Assert.*;
-import org.junit.Test;
-import org.springframework.core.env.StandardEnvironment;
 
 /**
  * Unit tests for the {@link ResourceEditor} class.
@@ -30,6 +36,9 @@ import org.springframework.core.env.StandardEnvironment;
  * @author Dave Syer
  */
 public final class ResourceEditorTests {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@Test
 	public void sunnyDay() throws Exception {
@@ -85,6 +94,16 @@ public final class ResourceEditorTests {
 		finally {
 			System.getProperties().remove("test.prop");
 		}
+	}
+
+	@Test
+	public void writableFileResource() throws Exception {
+		PropertyEditor editor = new ResourceEditor();
+		File file = temporaryFolder.newFile();
+		editor.setAsText("file:"+file.getPath());
+		Resource resolved = (Resource) editor.getValue();
+		assertEquals(file, resolved.getFile());
+		assertThat(resolved, instanceOf(WritableResource.class));
 	}
 
 }


### PR DESCRIPTION
Update DefaultResourceLoader to always attempt FileResource resolution
before URLResource, allowing casting of the result to WritableResource.

Also update ResourceEditorRegistrar to register a property editor for
WritableResources.

Issue: 
