### PR TITLE
Fixed potential NullPointerException in SharedEntityManagerCreator.

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/SharedEntityManagerCreator.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/SharedEntityManagerCreator.java
@@ -46,6 +46,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Juergen Hoeller
  * @author Rod Johnson
+ * @author Oliver Gierke
  * @since 2.0
  * @see org.springframework.orm.jpa.LocalEntityManagerFactoryBean
  * @see org.springframework.orm.jpa.JpaTransactionManager
@@ -87,7 +88,9 @@ public abstract class SharedEntityManagerCreator {
 
 		Class emIfc = (emf instanceof EntityManagerFactoryInfo ?
 				((EntityManagerFactoryInfo) emf).getEntityManagerInterface() : EntityManager.class);
-		return createSharedEntityManager(emf, properties, synchronizedWithTransaction, emIfc);
+		Class[] interfaces = emIfc == null ? new Class[0] : new Class[] { emIfc };
+
+		return createSharedEntityManager(emf, properties, synchronizedWithTransaction, interfaces);
 	}
 
 	/**

--- a/spring-orm/src/test/java/org/springframework/orm/jpa/SharedEntityManagerCreatorTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/jpa/SharedEntityManagerCreatorTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.jpa;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link SharedEntityManagerCreator}.
+ * 
+ * @author Oliver Gierke
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SharedEntityManagerCreatorTests {
+
+	@Mock
+	MyEntityManagerFactory info;
+
+	@Test
+	public void proxyingWorksIfInfoReturnsNullEntityManagerInterface() {
+
+		when(info.getEntityManagerInterface()).thenReturn(null);
+		assertThat(SharedEntityManagerCreator.createSharedEntityManager(info),
+				is(notNullValue()));
+	}
+
+	interface MyEntityManagerFactory extends EntityManagerFactory,
+			EntityManagerFactoryInfo {
+
+	}
+}


### PR DESCRIPTION
SharedEntityManagerCreator.createSharedEntityManager(EntityManagerFactory,
Map, boolean) now correctly forwards an empty array in case the
EntityManagerFactoryInfo returns null for the call to
….getEntityManagerInterface().

Previously the varargs invocation had turned null into an array with a
null value which caused a NullPointerException in the call to
Proxy.newProxyInstance(…) further down the call stack

Issue: SPR-10678
