### PR TITLE
SPR-10550 - Assign lowest priority to "/**" in AntPathMatcher

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -429,6 +429,16 @@ public class AntPathMatcher implements PathMatcher {
 			else if (pattern2EqualsPath) {
 				return 1;
 			}
+
+			//SPR-10550
+			if (pattern1.equals("/**") && pattern2.equals("/**")){
+				return 0;
+			}else if (pattern1.equals("/**")){
+				return 1;
+			}else if (pattern2.equals("/**")){
+				return -1;
+			}
+
 			int wildCardCount1 = getWildCardCount(pattern1);
 			int wildCardCount2 = getWildCardCount(pattern2);
 

--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -435,6 +435,11 @@ public class AntPathMatcherTests {
 		assertEquals(-1, comparator.compare("/hotels/{hotel}/booking", "/hotels/{hotel}/bookings/{booking}"));
 		assertEquals(1, comparator.compare("/hotels/{hotel}/bookings/{booking}", "/hotels/{hotel}/booking"));
 
+		//SPR-10550
+		assertEquals(-1, comparator.compare("/hotels/{hotel}/bookings/{booking}/cutomers/{customer}", "/**"));
+		assertEquals(1, comparator.compare("/**","/hotels/{hotel}/bookings/{booking}/cutomers/{customer}"));
+		assertEquals(0, comparator.compare("/**","/**"));
+
 		assertEquals(-1, comparator.compare("/hotels/{hotel}", "/hotels/*"));
 		assertEquals(1, comparator.compare("/hotels/*", "/hotels/{hotel}"));
 


### PR DESCRIPTION
Normally the pattern "/**" is used to handle the requests that don't match any of the other Servlet requests, therefore its priority should be the lowest.
This is a problem when there is a URI pattern with 3 or more PathVariable (i.e "/matches/{matchId}/periods/{periodId}/teams/{teamId}/results") then the default URI ("/**") takes precedence because the method compare is giving higher priority to the patterns with less brackets "{}" and wildcards "*".
Issue fixed adding a special treatment like the one null has.

Issue:SPR-10550
