### PR TITLE
Improving method validation support for BV 1.1

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationPostProcessor.java
@@ -83,7 +83,12 @@ public class MethodValidationPostProcessor extends AbstractAdvisingBeanPostProce
 	 * <p>Default is the default ValidatorFactory's default Validator.
 	 */
 	public void setValidator(Validator validator) {
-		this.validator = validator;
+		if(validator instanceof ValidatorFactory) {
+			this.validator = ((ValidatorFactory) validator).getValidator();
+		}
+		else {
+			this.validator = validator;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Updated `MethodValidationPostProcessor` to get the underlying `Validator` so that `forExecutables` can be called if the `LocalValidatorFactoryBean` is the provided validator. This is necessary because `LocalValidatorFactoryBean` does not implement `forExecutables`. This improves support for Bean Validation 1.1.

Issue: SPR-10644
