### PR TITLE
Extended test scenario for cached MethodExecutor invocation

### DIFF
--- a/spring-expression/src/test/java/org/springframework/expression/spel/CachedMethodExecutorTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/CachedMethodExecutorTests.java
@@ -45,8 +45,8 @@ public class CachedMethodExecutorTests {
 
 
 	@Test
-	public void testCachedExecution() throws Exception {
-		Expression expression = this.parser.parseExpression("echo(#something)");
+	public void testCachedExecutionForParameters() throws Exception {
+		Expression expression = this.parser.parseExpression("echo(#var)");
 
 		assertMethodExecution(expression, 42, "int: 42");
 		assertMethodExecution(expression, 42, "int: 42");
@@ -54,17 +54,30 @@ public class CachedMethodExecutorTests {
 		assertMethodExecution(expression, 42, "int: 42");
 	}
 
+	@Test
+	public void testCachedExecutionForTarget() throws Exception {
+		Expression expression = this.parser.parseExpression("#var.echo(42)");
+
+		assertMethodExecution(expression, new RootObject(), "int: 42");
+		assertMethodExecution(expression, new BaseObject(), "String: 42");
+		assertMethodExecution(expression, new RootObject(), "int: 42");
+	}
+
 	private void assertMethodExecution(Expression expression, Object var, String expected) {
-		this.context.setVariable("something", var);
+		this.context.setVariable("var", var);
 		assertEquals(expected, expression.getValue(this.context));
 	}
 
 
-	public static class RootObject {
+	public static class BaseObject {
 
 		public String echo(String value) {
 			return "String: " + value;
 		}
+
+	}
+
+	public static class RootObject extends BaseObject {
 
 		public String echo(int value) {
 			return "int: " + value;


### PR DESCRIPTION
This commit extends the unit test for caching MethodExecutors in the SpEL
by invoking the same method on different target objects that establish an
inheritance relation.
Currently this test fails.

Issue SPR-10657
