### PR TITLE
Add MemorySafeUndeclaredThrowableStrategy

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.springframework.cglib.proxy.Factory;
 import org.springframework.cglib.proxy.MethodInterceptor;
 import org.springframework.cglib.proxy.MethodProxy;
 import org.springframework.cglib.proxy.NoOp;
-import org.springframework.cglib.transform.impl.UndeclaredThrowableStrategy;
+import org.springframework.cglib.transform.impl.MemorySafeUndeclaredThrowableStrategy;
 
 import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.MethodInvocation;
@@ -183,7 +183,7 @@ final class CglibAopProxy implements AopProxy, Serializable {
 				}
 			}
 			enhancer.setSuperclass(proxySuperClass);
-			enhancer.setStrategy(new UndeclaredThrowableStrategy(UndeclaredThrowableException.class));
+			enhancer.setStrategy(new MemorySafeUndeclaredThrowableStrategy(UndeclaredThrowableException.class));
 			enhancer.setInterfaces(AopProxyUtils.completeProxiedInterfaces(this.advised));
 			enhancer.setInterceptDuringConstruction(false);
 

--- a/spring-core/src/main/java/org/springframework/cglib/transform/impl/MemorySafeUndeclaredThrowableStrategy.java
+++ b/spring-core/src/main/java/org/springframework/cglib/transform/impl/MemorySafeUndeclaredThrowableStrategy.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cglib.transform.impl;
+
+import org.springframework.cglib.core.ClassGenerator;
+import org.springframework.cglib.core.DefaultGeneratorStrategy;
+import org.springframework.cglib.core.TypeUtils;
+import org.springframework.cglib.transform.ClassTransformer;
+import org.springframework.cglib.transform.MethodFilter;
+import org.springframework.cglib.transform.MethodFilterTransformer;
+import org.springframework.cglib.transform.TransformingClassGenerator;
+
+/**
+ * Memory safe variant of {@link UndeclaredThrowableStrategy} ported from the latest
+ * as yet unreleased cglib code.
+ */
+public class MemorySafeUndeclaredThrowableStrategy extends DefaultGeneratorStrategy {
+
+	private static final MethodFilter TRANSFORM_FILTER = new MethodFilter() {
+		public boolean accept(int access, String name, String desc, String signature,
+				String[] exceptions) {
+			return !TypeUtils.isPrivate(access) && name.indexOf('$') < 0;
+		}
+	};
+
+
+	private Class wrapper;
+
+
+	public MemorySafeUndeclaredThrowableStrategy(Class wrapper) {
+		this.wrapper = wrapper;
+	}
+
+
+	protected ClassGenerator transform(ClassGenerator cg) throws Exception {
+		ClassTransformer tr = new UndeclaredThrowableTransformer(wrapper);
+		tr = new MethodFilterTransformer(TRANSFORM_FILTER, tr);
+		return new TransformingClassGenerator(cg, tr);
+	}
+}


### PR DESCRIPTION
Port the latest unreleased UndeclaredThrowableStrategy implementation
from cglib to fix a memory-leak present in v3.

Issue: 
