### PR TITLE
Added Java 7 instrumentation manifest attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -266,6 +266,9 @@ project("spring-instrument") {
 	jar {
 		manifest.attributes["Premain-Class"] =
 			"org.springframework.instrument.InstrumentationSavingAgent"
+		manifest.attributes["Can-Redefine-Classes"] = "true"
+		manifest.attributes["Can-Retransform-Classes"] = "true"
+		manifest.attributes["Can-Set-Native-Method-Prefix"] = "false"
 	}
 }
 


### PR DESCRIPTION
After upgrading to OpenJDK 7 I can't retransform classes using
    InstrumentationSavingAgent.getInstrumentation().addTransformer(t, true);

After some research I feel that spring-instrument is missing the required manifest attributes for Java 7 (see http://docs.oracle.com/javase/7/docs/api/java/lang/instrument/package-summary.html)

I'm neither an expert for instrumentation nor Gradle but I thought I'd give it a shot to at least start a discussion.
