### PR TITLE
Fixed unit tests failing on Windows

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/io/PathResourceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/PathResourceTests.java
@@ -22,10 +22,12 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+
 import org.springframework.util.FileCopyUtils;
 
 import static org.hamcrest.Matchers.*;
@@ -37,14 +39,18 @@ import static org.mockito.BDDMockito.*;
  *
  * @author Philippe Marschall
  * @author Phillip Webb
+ * @author Nicholas Williams
  */
 public class PathResourceTests {
 
 	private static final String TEST_DIR = "src/test/java/org/springframework/core/io";
+	private static final String TEST_DIR_PLATFORM = TEST_DIR.replace('/', File.separatorChar);
 
 	private static final String TEST_FILE = "src/test/java/org/springframework/core/io/example.properties";
+	private static final String TEST_FILE_PLATFORM = TEST_FILE.replace('/', File.separatorChar);
 
 	private static final String NON_EXISTING_FILE = "src/test/java/org/springframework/core/io/doesnotexist.properties";
+	private static final String NON_EXISTING_FILE_PLATFORM = NON_EXISTING_FILE.replace('/', File.separatorChar);
 
 
 	@Rule
@@ -77,109 +83,109 @@ public class PathResourceTests {
 
 	@Test
 	public void createFromPath() throws Exception {
-		Path path = Paths.get(TEST_FILE);
+		Path path = Paths.get(TEST_FILE_PLATFORM);
 		PathResource resource = new PathResource(path);
-		assertThat(resource.getPath(), equalTo(TEST_FILE));
+		assertThat(resource.getPath(), equalTo(TEST_FILE_PLATFORM));
 	}
 
 	@Test
 	public void createFromString() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
-		assertThat(resource.getPath(), equalTo(TEST_FILE));
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
+		assertThat(resource.getPath(), equalTo(TEST_FILE_PLATFORM));
 	}
 
 	@Test
 	public void createFromUri() throws Exception {
-		File file = new File(TEST_FILE);
+		File file = new File(TEST_FILE_PLATFORM);
 		PathResource resource = new PathResource(file.toURI());
 		assertThat(resource.getPath(), equalTo(file.getAbsoluteFile().toString()));
 	}
 
 	@Test
 	public void getPathForFile() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
-		assertThat(resource.getPath(), equalTo(TEST_FILE));
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
+		assertThat(resource.getPath(), equalTo(TEST_FILE_PLATFORM));
 	}
 
 	@Test
 	public void getPathForDir() throws Exception {
-		PathResource resource = new PathResource(TEST_DIR);
-		assertThat(resource.getPath(), equalTo(TEST_DIR));
+		PathResource resource = new PathResource(TEST_DIR_PLATFORM);
+		assertThat(resource.getPath(), equalTo(TEST_DIR_PLATFORM));
 	}
 
 	@Test
 	public void fileExists() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
 		assertThat(resource.exists(), equalTo(true));
 	}
 
 	@Test
 	public void dirExists() throws Exception {
-		PathResource resource = new PathResource(TEST_DIR);
+		PathResource resource = new PathResource(TEST_DIR_PLATFORM);
 		assertThat(resource.exists(), equalTo(true));
 	}
 
 	@Test
 	public void fileDoesNotExist() throws Exception {
-		PathResource resource = new PathResource(NON_EXISTING_FILE);
+		PathResource resource = new PathResource(NON_EXISTING_FILE_PLATFORM);
 		assertThat(resource.exists(), equalTo(false));
 	}
 
 	@Test
 	public void fileIsReadable() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
 		assertThat(resource.isReadable(), equalTo(true));
 	}
 
 	@Test
 	public void doesNotExistIsNotReadable() throws Exception {
-		PathResource resource = new PathResource(NON_EXISTING_FILE);
+		PathResource resource = new PathResource(NON_EXISTING_FILE_PLATFORM);
 		assertThat(resource.isReadable(), equalTo(false));
 	}
 
 	@Test
 	public void directoryIsNotReadable() throws Exception {
-		PathResource resource = new PathResource(TEST_DIR);
+		PathResource resource = new PathResource(TEST_DIR_PLATFORM);
 		assertThat(resource.isReadable(), equalTo(false));
 	}
 
 	@Test
 	public void getInputStream() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
 		byte[] bytes = FileCopyUtils.copyToByteArray(resource.getInputStream());
 		assertThat(bytes.length, greaterThan(0));
 	}
 
 	@Test
 	public void getInputStreamForDir() throws Exception {
-		PathResource resource = new PathResource(TEST_DIR);
+		PathResource resource = new PathResource(TEST_DIR_PLATFORM);
 		thrown.expect(FileNotFoundException.class);
 		resource.getInputStream();
 	}
 
 	@Test
 	public void getInputStreamDoesNotExist() throws Exception {
-		PathResource resource = new PathResource(NON_EXISTING_FILE);
+		PathResource resource = new PathResource(NON_EXISTING_FILE_PLATFORM);
 		thrown.expect(FileNotFoundException.class);
 		resource.getInputStream();
 	}
 
 	@Test
 	public void getUrl() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
-		assertTrue(resource.getURL().toString().endsWith(TEST_FILE));
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
+		assertThat(resource.getURL().toString(), Matchers.endsWith(TEST_FILE));
 	}
 
 	@Test
 	public void getUri() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
-		assertTrue(resource.getURI().toString().endsWith(TEST_FILE));
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
+		assertThat(resource.getURI().toString(), Matchers.endsWith(TEST_FILE));
 	}
 
 	@Test
 	public void getFile() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
-		File file = new File(TEST_FILE);
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
+		File file = new File(TEST_FILE_PLATFORM);
 		assertThat(resource.getFile().getAbsoluteFile(), equalTo(file.getAbsoluteFile()));
 	}
 
@@ -195,59 +201,59 @@ public class PathResourceTests {
 
 	@Test
 	public void contentLength() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
-		File file = new File(TEST_FILE);
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
+		File file = new File(TEST_FILE_PLATFORM);
 		assertThat(resource.contentLength(), equalTo(file.length()));
 	}
 
 	@Test
 	public void contentLengthForDirectory() throws Exception {
-		PathResource resource = new PathResource(TEST_DIR);
-		File file = new File(TEST_DIR);
+		PathResource resource = new PathResource(TEST_DIR_PLATFORM);
+		File file = new File(TEST_DIR_PLATFORM);
 		assertThat(resource.contentLength(), equalTo(file.length()));
 	}
 
 	@Test
 	public void lastModified() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
-		File file = new File(TEST_FILE);
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
+		File file = new File(TEST_FILE_PLATFORM);
 		assertThat(resource.lastModified(), equalTo(file.lastModified()));
 	}
 
 	@Test
 	public void createRelativeFromDir() throws Exception {
-		Resource resource = new PathResource(TEST_DIR).createRelative("example.properties");
-		assertThat(resource, equalTo((Resource) new PathResource(TEST_FILE)));
+		Resource resource = new PathResource(TEST_DIR_PLATFORM).createRelative("example.properties");
+		assertThat(resource, equalTo((Resource) new PathResource(TEST_FILE_PLATFORM)));
 	}
 
 	@Test
 	public void createRelativeFromFile() throws Exception {
-		Resource resource = new PathResource(TEST_FILE).createRelative("../example.properties");
-		assertThat(resource, equalTo((Resource) new PathResource(TEST_FILE)));
+		Resource resource = new PathResource(TEST_FILE_PLATFORM).createRelative("../example.properties");
+		assertThat(resource, equalTo((Resource) new PathResource(TEST_FILE_PLATFORM)));
 	}
 
 	@Test
 	public void filename() throws Exception {
-		Resource resource = new PathResource(TEST_FILE);
+		Resource resource = new PathResource(TEST_FILE_PLATFORM);
 		assertThat(resource.getFilename(), equalTo("example.properties"));
 	}
 
 	@Test
 	public void description() throws Exception {
-		Resource resource = new PathResource(TEST_FILE);
+		Resource resource = new PathResource(TEST_FILE_PLATFORM);
 		assertThat(resource.getDescription(), containsString("path ["));
-		assertThat(resource.getDescription(), containsString(TEST_FILE));
+		assertThat(resource.getDescription(), containsString(TEST_FILE_PLATFORM));
 	}
 
 	@Test
 	public void fileIsWritable() throws Exception {
-		PathResource resource = new PathResource(TEST_FILE);
+		PathResource resource = new PathResource(TEST_FILE_PLATFORM);
 		assertThat(resource.isWritable(), equalTo(true));
 	}
 
 	@Test
 	public void directoryIsNotWritable() throws Exception {
-		PathResource resource = new PathResource(TEST_DIR);
+		PathResource resource = new PathResource(TEST_DIR_PLATFORM);
 		assertThat(resource.isWritable(), equalTo(false));
 	}
 
@@ -261,6 +267,7 @@ public class PathResourceTests {
 	@Test
 	public void doesNotExistOutputStream() throws Exception {
 		File file = temporaryFolder.newFile("test");
+		//noinspection ResultOfMethodCallIgnored
 		file.delete();
 		PathResource resource = new PathResource(file.toPath());
 		FileCopyUtils.copy("test".getBytes(), resource.getOutputStream());
@@ -269,7 +276,7 @@ public class PathResourceTests {
 
 	@Test
 	public void directoryOutputStream() throws Exception {
-		PathResource resource = new PathResource(TEST_DIR);
+		PathResource resource = new PathResource(TEST_DIR_PLATFORM);
 		thrown.expect(FileNotFoundException.class);
 		resource.getOutputStream();
 	}


### PR DESCRIPTION
There were several unit tests introduced in SPR-10608 (commit: 2313c9a007fe4c48f11b08806b852ced7fbff13d). Some of these tests fail on Windows because they rely on asserting file names containing forward slashes, which is not platform independent. These failures have now been resolved.

Issues: SPR-10770, SPR-10608
