### PR TITLE
diagnose View Rendering exceptions in DispatcherServlet.render()

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -1194,7 +1194,14 @@ public class DispatcherServlet extends FrameworkServlet {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Rendering view [" + view + "] in DispatcherServlet with name '" + getServletName() + "'");
 		}
-		view.render(mv.getModelInternal(), request, response);
+		try {
+			view.render(mv.getModelInternal(), request, response);
+		} catch (Exception x) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Error rendering view [" + view + "] in DispatcherServlet with name '" + getServletName() + "'", x);
+			}
+			throw x;
+		}
 	}
 
 	/**


### PR DESCRIPTION
SPR-10340 proposed fix

Diagnose View-rendering, JSP exceptions etc in DispatcherServlet.render(). There is already existing DEBUG logging before rendering the view, so it is a minor & sensible improvement to log any failure that then occurs.

This is logged at DEBUG level to avoid interfering with existing production logging, but provide necessary diagnostic information during software development/ engineering.

Discussing with Rossen Stoyanchev -- I note the other option of a flag in AbstractView or JstlView, but there is no very easy way to configure such a flag, since these are created from UrlBasedViewResolver, with limited knowledge of View subclasses & only partial coverage of View & Resolver subtypes. There is the possibility for the developer to define a bean-factory BeanPostProcessor, but this seems very  unlikely to be in effect by default.

My suggestion would therefore be to augment the existing 'DEBUG' logging in DispatcherServlet to include reporting View rendering exceptions, similar to how many other conditions (Controller exceptions & forwarding to error views, HandlerInterceptor exceptions) are already logged.
