### PR TITLE
Fix SimpleJdbc{Call,Insert} Javadoc

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcCall.java
@@ -36,13 +36,13 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
  * when the stored procedure was created.
  *
  * <p>The meta data processing is based on the DatabaseMetaData provided by
- * the JDBC driver. Since we rely on the JDBC driver this "auto-detection"
+ * the JDBC driver. Since we rely on the JDBC driver, this "auto-detection"
  * can only be used for databases that are known to provide accurate meta data.
  * These currently include Derby, MySQL, Microsoft SQL Server, Oracle, DB2,
  * Sybase and PostgreSQL. For any other databases you are required to declare all
  * parameters explicitly. You can of course declare all parameters explicitly even
  * if the database provides the necessary meta data. In that case your declared
- * parameters will take precedence. You can also turn off any mete data processing
+ * parameters will take precedence. You can also turn off any meta data processing
  * if you want to use parameter names that do not match what is declared during
  * the stored procedure compilation.
  *
@@ -50,7 +50,7 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
  * {@link org.springframework.jdbc.core.JdbcTemplate}.
  *
  * <p>Many of the configuration methods return the current instance of the SimpleJdbcCall
- * to provide the ability to string multiple ones together in a "fluid" interface style.
+ * to provide the ability to chain multiple ones together in a "fluent" interface style.
  *
  * @author Thomas Risberg
  * @since 2.5

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsert.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsert.java
@@ -41,7 +41,7 @@ import org.springframework.jdbc.support.nativejdbc.NativeJdbcExtractor;
  * {@link org.springframework.jdbc.core.JdbcTemplate}.
  *
  * <p>Many of the configuration methods return the current instance of the SimpleJdbcInsert
- * to provide the ability to string multiple ones together in a "fluid" interface style.
+ * to provide the ability to chain multiple ones together in a "fluent" interface style.
  *
  * @author Thomas Risberg
  * @since 2.5


### PR DESCRIPTION
Just few documentation fixes.

Change "fluid" interface to "fluent" (which is a proper word to use - see http://en.wikipedia.org/wiki/Fluent_interface), change "string" to "chain" (which is more appropriate here), plus fix few typos in Javadoc.
