### PR TITLE
Add support for Objenesis proxy creation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,10 +166,12 @@ project("spring-core") {
 	// further transformed by the JarJar task to depend on org.springframework.asm; this
 	// avoids including two different copies of asm unnecessarily.
 	def cglibVersion = "3.0"
+	def objenesisVersion = "2.0"
 
 	configurations {
 		jarjar
 		cglib
+		objenesis
 	}
 
 	task cglibRepackJar(type: Jar) { repackJar ->
@@ -195,8 +197,28 @@ project("spring-core") {
 		}
 	}
 
+	task objenesisRepackJar(type: Jar) { repackJar ->
+		repackJar.baseName = "spring-objenesis-repack"
+		repackJar.version = objenesisVersion
+
+		doLast() {
+			project.ant {
+				taskdef name: "jarjar", classname: "com.tonicsystems.jarjar.JarJarTask",
+					classpath: configurations.jarjar.asPath
+				jarjar(destfile: repackJar.archivePath) {
+					configurations.objenesis.each { originalJar ->
+						zipfileset(src: originalJar)
+					}
+					// repackage org.objenesis => org.springframework.objenesis
+					rule(pattern: "org.objenesis.**", result: "org.springframework.objenesis.@1")
+				}
+			}
+		}
+	}
+
 	dependencies {
 		cglib("cglib:cglib:${cglibVersion}@jar")
+		objenesis("org.objenesis:objenesis:${objenesisVersion}@jar")
 		jarjar("com.googlecode.jarjar:jarjar:1.3")
 
 		compile(files(cglibRepackJar))
@@ -215,6 +237,11 @@ project("spring-core") {
 		dependsOn cglibRepackJar
 		from(zipTree(cglibRepackJar.archivePath)) {
 			include "org/springframework/cglib/**"
+		}
+
+		dependsOn objenesisRepackJar
+		from(zipTree(objenesisRepackJar.archivePath)) {
+			include "org/springframework/objenesis/**"
 		}
 	}
 }
@@ -237,6 +264,7 @@ project("spring-aop") {
 	dependencies {
 		compile(project(":spring-core"))
 		compile(files(project(":spring-core").cglibRepackJar))
+		compile(files(project(":spring-core").objenesisRepackJar))
 		compile(project(":spring-beans"))
 		compile("aopalliance:aopalliance:1.0")
 		optional("com.jamonapi:jamon:2.4")

--- a/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
@@ -79,7 +79,7 @@ import org.springframework.util.ObjectUtils;
  * @see DefaultAopProxyFactory
  */
 @SuppressWarnings("serial")
-final class CglibAopProxy implements AopProxy, Serializable {
+class CglibAopProxy implements AopProxy, Serializable {
 
 	// Constants for CGLIB callback array indices
 	private static final int AOP_PROXY = 0;
@@ -111,7 +111,6 @@ final class CglibAopProxy implements AopProxy, Serializable {
 	private transient Map<String, Integer> fixedInterceptorMap;
 
 	private transient int fixedInterceptorOffset;
-
 
 	/**
 	 * Create a new CglibAopProxy for the given AOP configuration.
@@ -185,29 +184,20 @@ final class CglibAopProxy implements AopProxy, Serializable {
 			enhancer.setSuperclass(proxySuperClass);
 			enhancer.setStrategy(new MemorySafeUndeclaredThrowableStrategy(UndeclaredThrowableException.class));
 			enhancer.setInterfaces(AopProxyUtils.completeProxiedInterfaces(this.advised));
-			enhancer.setInterceptDuringConstruction(false);
 
 			Callback[] callbacks = getCallbacks(rootClass);
-			enhancer.setCallbacks(callbacks);
-			enhancer.setCallbackFilter(new ProxyCallbackFilter(
-					this.advised.getConfigurationOnlyCopy(), this.fixedInterceptorMap, this.fixedInterceptorOffset));
-
 			Class<?>[] types = new Class[callbacks.length];
+			
 			for (int x = 0; x < types.length; x++) {
 				types[x] = callbacks[x].getClass();
 			}
+			
 			enhancer.setCallbackTypes(types);
+			enhancer.setCallbackFilter(new ProxyCallbackFilter(
+					this.advised.getConfigurationOnlyCopy(), this.fixedInterceptorMap, this.fixedInterceptorOffset));
 
 			// Generate the proxy class and create a proxy instance.
-			Object proxy;
-			if (this.constructorArgs != null) {
-				proxy = enhancer.create(this.constructorArgTypes, this.constructorArgs);
-			}
-			else {
-				proxy = enhancer.create();
-			}
-
-			return proxy;
+			return createProxyClassAndInstance(enhancer, callbacks);
 		}
 		catch (CodeGenerationException ex) {
 			throw new AopConfigException("Could not generate CGLIB subclass of class [" +
@@ -225,6 +215,15 @@ final class CglibAopProxy implements AopProxy, Serializable {
 			// TargetSource.getTarget() failed
 			throw new AopConfigException("Unexpected AOP exception", ex);
 		}
+	}
+	
+	protected Object createProxyClassAndInstance(Enhancer enhancer, Callback[] callbacks) {
+
+		enhancer.setInterceptDuringConstruction(false);
+		enhancer.setCallbacks(callbacks);
+
+		return this.constructorArgs == null ? enhancer.create() : enhancer.create(
+				this.constructorArgTypes, this.constructorArgs);
 	}
 
 	/**

--- a/spring-aop/src/main/java/org/springframework/aop/framework/DefaultAopProxyFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/DefaultAopProxyFactory.java
@@ -59,7 +59,7 @@ public class DefaultAopProxyFactory implements AopProxyFactory, Serializable {
 			if (targetClass.isInterface()) {
 				return new JdkDynamicAopProxy(config);
 			}
-			return CglibProxyFactory.createCglibProxy(config);
+			return new ObjenesisCGlibAopProxy(config);
 		}
 		else {
 			return new JdkDynamicAopProxy(config);
@@ -75,17 +75,4 @@ public class DefaultAopProxyFactory implements AopProxyFactory, Serializable {
 		Class[] interfaces = config.getProxiedInterfaces();
 		return (interfaces.length == 0 || (interfaces.length == 1 && SpringProxy.class.equals(interfaces[0])));
 	}
-
-
-	/**
-	 * Inner factory class used to just introduce a CGLIB dependency
-	 * when actually creating a CGLIB proxy.
-	 */
-	private static class CglibProxyFactory {
-
-		public static AopProxy createCglibProxy(AdvisedSupport advisedSupport) {
-			return new CglibAopProxy(advisedSupport);
-		}
-	}
-
 }

--- a/spring-aop/src/main/java/org/springframework/aop/framework/ObjenesisCGlibAopProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/ObjenesisCGlibAopProxy.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+
+import org.springframework.cglib.proxy.Callback;
+import org.springframework.cglib.proxy.Enhancer;
+import org.springframework.cglib.proxy.Factory;
+import org.springframework.objenesis.ObjenesisException;
+import org.springframework.objenesis.ObjenesisStd;
+
+/**
+ * Objenesis based extension of {@link CglibAopProxy} to create proxy instances without
+ * invoking the constructor of the class.
+ * 
+ * @author Oliver Gierke
+ * @since 4.0
+ */
+class ObjenesisCGlibAopProxy extends CglibAopProxy {
+
+	private final ObjenesisStd objenesis;
+
+	/**
+	 * Creates a new {@link ObjenesisCGlibAopProxy} using the given {@link AdvisedSupport}.
+	 * 
+	 * @param config must not be {@literal null}.
+	 */
+	public ObjenesisCGlibAopProxy(AdvisedSupport config) {
+
+		super(config);
+		this.objenesis = new ObjenesisStd(true);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected Object createProxyClassAndInstance(Enhancer enhancer, Callback[] callbacks) {
+
+		try {
+			Factory factory = (Factory) objenesis.newInstance(enhancer.createClass());
+			factory.setCallbacks(callbacks);
+			return factory;
+		} catch (ObjenesisException e) {
+			// Fallback to CGLib on unsupported JVMs
+			// TODO: Logging
+			return super.createProxyClassAndInstance(enhancer, callbacks);
+		}
+	}
+}

--- a/spring-aop/src/test/java/org/springframework/aop/framework/ClassWithConstructor.java
+++ b/spring-aop/src/test/java/org/springframework/aop/framework/ClassWithConstructor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+public class ClassWithConstructor {
+
+	public ClassWithConstructor(Object object) {
+
+	}
+
+	public void method() {
+
+	}
+}

--- a/spring-context/src/test/java/org/springframework/aop/framework/CglibProxyTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/CglibProxyTests.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Assume;
 import org.junit.Test;
 import org.springframework.aop.ClassFilter;
 import org.springframework.aop.MethodMatcher;
@@ -41,6 +42,7 @@ import org.springframework.tests.aop.advice.CountingBeforeAdvice;
 import org.springframework.tests.aop.interceptor.NopInterceptor;
 import org.springframework.tests.sample.beans.ITestBean;
 import org.springframework.tests.sample.beans.TestBean;
+import org.springframework.util.ClassUtils;
 
 import test.mixin.LockMixinAdvisor;
 
@@ -133,31 +135,6 @@ public final class CglibProxyTests extends AbstractAopProxyTests implements Seri
 
 		TestBean tb = (TestBean) proxy;
 		assertEquals(32, tb.getAge());
-	}
-
-	@Test
-	public void testCglibProxyingGivesMeaningfulExceptionIfAskedToProxyNonvisibleClass() {
-
-		@SuppressWarnings("unused")
-		class YouCantSeeThis {
-			void hidden() {
-			}
-		}
-
-		YouCantSeeThis mine = new YouCantSeeThis();
-		try {
-			ProxyFactory pf = new ProxyFactory(mine);
-			pf.getProxy();
-			fail("Shouldn't be able to proxy non-visible class with CGLIB");
-		}
-		catch (AopConfigException ex) {
-			// Check that stack trace is preserved
-			assertTrue(ex.getCause() instanceof CodeGenerationException ||
-					ex.getCause() instanceof IllegalArgumentException);
-			// Check that error message is helpful
-			assertTrue(ex.getMessage().indexOf("final") != -1);
-			assertTrue(ex.getMessage().indexOf("visible") != -1);
-		}
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/aop/framework/ClassWithComplexConstructor.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/ClassWithComplexConstructor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+/**
+ * 
+ * @author Oliver Gierke
+ */
+@Component
+public class ClassWithComplexConstructor {
+
+	private final Dependency dependency;
+	
+	@Autowired
+	public ClassWithComplexConstructor(Dependency dependency) {
+		Assert.notNull(dependency);
+		this.dependency = dependency;
+	}
+	
+	public Dependency getDependency() {
+		return dependency;
+	}
+	
+	public void method() {
+		this.dependency.method();
+	}
+}

--- a/spring-context/src/test/java/org/springframework/aop/framework/Dependency.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/Dependency.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+import org.springframework.stereotype.Component;
+
+@Component class Dependency {
+
+	private int value = 0;
+	
+	public void method() {
+		value++;
+	}
+	
+	public int getValue() {
+		return value;
+	}
+}

--- a/spring-context/src/test/java/org/springframework/aop/framework/ObjenesisProxyTests-context.xml
+++ b/spring-context/src/test/java/org/springframework/aop/framework/ObjenesisProxyTests-context.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
+
+	<context:component-scan base-package="org.springframework.aop.framework" />
+
+	<aop:config>
+		<aop:advisor advice-ref="debugInterceptor" pointcut="bean(classWithComplexConstructor)" />
+	</aop:config>
+
+
+	<bean id="debugInterceptor"
+		class="org.springframework.aop.interceptor.DebugInterceptor" />
+
+
+</beans>

--- a/spring-context/src/test/java/org/springframework/aop/framework/ObjenesisProxyTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/ObjenesisProxyTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+import org.junit.Test;
+import org.springframework.aop.interceptor.DebugInterceptor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Integration test for Objenesis proxy creation.
+ * 
+ * @author Oliver Gierke
+ */
+public class ObjenesisProxyTests {
+	
+	@Test
+	public void appliesAspectToClassWithComplexConstructor() {
+
+		@SuppressWarnings("resource")
+		ApplicationContext context = new ClassPathXmlApplicationContext("ObjenesisProxyTests-context.xml", getClass());
+		
+		ClassWithComplexConstructor bean = context.getBean(ClassWithComplexConstructor.class);
+		bean.method();
+		
+		DebugInterceptor interceptor = context.getBean(DebugInterceptor.class);
+		assertThat(interceptor.getCount(), is(1L));
+		assertThat(bean.getDependency().getValue(), is(1));
+	}
+}


### PR DESCRIPTION
Extended `DefaultAopProxyFactory` to create Objenesis based proxies if the library is on the classpath. This allows classes without a default constructor being CGLib proxied.

Open issues:
- Make sure spring-context tests run against plain CGLib _and_ CGLib + Objenesis (it only does the latter as of this change)

Issue: SPR-10594
