### PR TITLE
Fix typo in ref docs

### DIFF
--- a/src/reference/docbook/expressions.xml
+++ b/src/reference/docbook/expressions.xml
@@ -458,7 +458,7 @@ Boolean b = simple.booleanList.get(0);
 
   @Autowired
   public void configure(MovieFinder movieFinder,
-                        @Value("#{ systemProperties['user.region'] }"} String defaultLocale) {
+                        @Value("#{ systemProperties['user.region'] }") String defaultLocale) {
       this.movieFinder = movieFinder;
       this.defaultLocale = defaultLocale;
   }
@@ -474,7 +474,7 @@ Boolean b = simple.booleanList.get(0);
 
   @Autowired
   public MovieRecommender(CustomerPreferenceDao customerPreferenceDao,
-                          @Value("#{systemProperties['user.country']}"} String defaultLocale) {
+                          @Value("#{systemProperties['user.country']}") String defaultLocale) {
       this.customerPreferenceDao = customerPreferenceDao;
       this.defaultLocale = defaultLocale;
   }


### PR DESCRIPTION
Fix typo in ref docs

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
