### PR TITLE
Fix array varargs conversion error in SpEL expression

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveMethodExecutor.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveMethodExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,17 @@ class ReflectiveMethodExecutor implements MethodExecutor {
 						this.argsRequiringConversion, this.varargsPosition);
 			}
 			if (this.method.isVarArgs()) {
-				arguments = ReflectionHelper.setupArgumentsForVarargsInvocation(this.method.getParameterTypes(), arguments);
+				
+				 if (arguments.length == 0) {
+					 arguments = ReflectionHelper.setupArgumentsForVarargsInvocation(this.method.getParameterTypes(), arguments);
+				 }
+				 else {
+						Class lastArgumentType = arguments[arguments.length-1].getClass();
+						int varargsCount = arguments.length - this.varargsPosition;
+						if(!lastArgumentType.isArray() || varargsCount > 1) {
+							arguments = ReflectionHelper.setupArgumentsForVarargsInvocation(this.method.getParameterTypes(), arguments);
+						}				 
+				 }				
 			}
 			ReflectionUtils.makeAccessible(this.method);
 			Object value = this.method.invoke(target, arguments);

--- a/spring-expression/src/test/java/org/springframework/expression/spel/support/Spr10781Tests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/support/Spr10781Tests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.expression.spel.support;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.ExpressionTestCase;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests invocation of methods.
+ *
+ * @author Seungryong Lee
+ */
+public class Spr10781Tests extends ExpressionTestCase {
+	
+	@Test
+	@SuppressWarnings("unchecked")	
+	public void testVarargsInvocationSpr10781() {
+		
+		List<String> stringList0 = Arrays.asList(new String[]{"a", "b"});
+		assertEquals(2, stringList0.size()); // return 2
+
+		ExpressionParser parser = new SpelExpressionParser();
+		Expression exp = parser.parseExpression("T(java.util.Arrays).asList('a','b')");
+		List<String> stringList1 = (List<String>) exp.getValue();
+		assertEquals(2, stringList1.size());
+		
+		exp = parser.parseExpression("T(java.util.Arrays).asList(new String[]{'a','b'})");
+		List<String> stringList2 = (List<String>) exp.getValue();
+		assertEquals(2, stringList2.size()); // return 1
+		
+        exp = parser.parseExpression("T(java.util.Arrays).asList(new Integer[]{1,2}, new Integer[]{1,2} )");
+		List intArrayList = (List) exp.getValue();
+		assertEquals(2, intArrayList.size());
+	}
+}


### PR DESCRIPTION
Array varargs convert failed SpEL Expression ( Arrays.asList etc ) 

That is,

```
// sucess
List<String> list1 = Arrays.asList(new String[]{"a","b"});
assertEquals(2, list1.size()); // return 2

// error
ExpressionParser parser = new SpelExpressionParser();
Expression exp = parser.parseExpression("T(java.util.Arrays).asList(new String[]{"a","b"})");
List<String> list2= (List<String>) exp.getValue();
assertEquals(2, list2.size()); // return 1
```

So, Added arrary varargs checking in ReflectiveMethodExecutor#execute as following diff

https://github.com/spring-projects/spring-framework/pull/329/files

thanks

Issue: SPR-10781
