### PR TITLE
Added XStream CatchAllConverter

### DIFF
--- a/spring-oxm/src/main/java/org/springframework/oxm/xstream/CatchAllConverter.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/xstream/CatchAllConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.oxm.xstream;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * XStream {@link Converter} that supports all classes, but throws exceptions for
+ * (un)marshalling.
+ * <p>Main purpose of this class is to
+ * {@linkplain com.thoughtworks.xstream.XStream#registerConverter(com.thoughtworks.xstream.converters.Converter, int) register}
+ * this converter as a catchall last converter with a
+ * {@linkplain com.thoughtworks.xstream.XStream#PRIORITY_NORMAL normal}
+ * or higher priority, in addition to converters that explicitly support the domain
+ * classes that should be supported. As a result, default XStream converters with lower
+ * priorities and possible security vulnerabilities do not get invoked.
+ * <p>For instance:</p>
+ * <pre class="code">
+ * XStreamMarshaller unmarshaller = new XStreamMarshaller();
+ * unmarshaller.getXStream().registerConverter(new MyDomainClassConverter(), XStream.PRIORITY_VERY_HIGH);
+ * unmarshaller.getXStream().registerConverter(new CatchAllConverter(), XStream.PRIORITY_NORMAL);
+ * MyDomainClass o = unmarshaller.unmarshal(source);
+ * </pre
+ *
+ * @author Arjen Poutsma
+ * @since 4.0
+ */
+public class CatchAllConverter implements Converter {
+
+	@Override
+	public boolean canConvert(Class type) {
+		return true;
+	}
+
+	@Override
+	public void marshal(Object source, HierarchicalStreamWriter writer,
+			MarshallingContext context) {
+		throw new UnsupportedOperationException("marshalling not supported");
+	}
+
+	@Override
+	public Object unmarshal(HierarchicalStreamReader reader,
+			UnmarshallingContext context) {
+		throw new UnsupportedOperationException("unmarshalling not supported");
+	}
+}


### PR DESCRIPTION
Added XStream CatchAllConverter that supports all classes, but throws
exceptions for (un)marshalling.

Main purpose of this class is to register this converter as a catchall
last converter with a normal or higher priority in addition to
converters that explicitly  support the domain classes that should be
supported. As a result, default XStream  converters with lower
priorities and possible security vulnerabilities do not get invoked.
