### PR TITLE
Array type bean cannot be proxied because is is final class

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/AbstractAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/AbstractAutoProxyCreator.java
@@ -282,7 +282,7 @@ public abstract class AbstractAutoProxyCreator extends ProxyConfig
 			if (this.advisedBeans.containsKey(cacheKey)) {
 				return null;
 			}
-			if (isInfrastructureClass(beanClass) || shouldSkip(beanClass, beanName)) {
+			if (isInfrastructureClass(beanClass) || shouldSkip(beanClass, beanName) || beanClass.isArray()) {
 				this.advisedBeans.put(cacheKey, Boolean.FALSE);
 				return null;
 			}
@@ -363,7 +363,7 @@ public abstract class AbstractAutoProxyCreator extends ProxyConfig
 		if (Boolean.FALSE.equals(this.advisedBeans.get(cacheKey))) {
 			return bean;
 		}
-		if (isInfrastructureClass(bean.getClass()) || shouldSkip(bean.getClass(), beanName)) {
+		if (isInfrastructureClass(bean.getClass()) || shouldSkip(bean.getClass(), beanName) || bean.getClass().isArray()) {
 			this.advisedBeans.put(cacheKey, Boolean.FALSE);
 			return bean;
 		}


### PR DESCRIPTION
AnnotationAwareAspectJAutoProxyCreator(AbstractAutoProxyCreator) class
has wrapIfNecessary() method. In this method, Spring AOP tries to 
figure out whether current bean must be proxied or not.

Because array type bean is not skipped with current code, 
AnnotationAwareAspectJAutoProxyCreator tries to create proxy having 
interfaces which array class implements.(java.lang.Cloneable, etc)
Following Aspect could produce this with &lt;jdbc:embedded-database>.

@Around("target(org.springframework.core.io.Resource[])")

Maybe this is usage error case, but repro project attached in issue
(https://jira.springsource.org/browse/SPR-10793) shows side effect
of above situation(absence of array type skipment). 

Bean &lt;jdbc:embedded-database> has inner bean &lt;jdbc:script>, and inner
bean is type of org.springframework.core.io.Resource[]. Although
configured aspect was @Around("bean(foo)"), inner bean &lt;jdbc:script>
was proxied resulting java.lang.IllegalArgumentException: Cannot 
convert value of type [com.sun.proxy.$Proxy6 implementing...........

Invalid pointcut match was problem of aspectweaver, but if array type
bean can be skipped from wrapIfNecessary() method, this side effect 
could be eliminated.

Thank you.

Issue: SPR-10793
