### PR TITLE
SPR-10711: Add recovery-interval to <jms:listener-container>

### DIFF
--- a/spring-beans/src/main/resources/META-INF/spring.schemas
+++ b/spring-beans/src/main/resources/META-INF/spring.schemas
@@ -9,6 +9,7 @@ http\://www.springframework.org/schema/tool/spring-tool-2.5.xsd=org/springframew
 http\://www.springframework.org/schema/tool/spring-tool-3.0.xsd=org/springframework/beans/factory/xml/spring-tool-3.0.xsd
 http\://www.springframework.org/schema/tool/spring-tool-3.1.xsd=org/springframework/beans/factory/xml/spring-tool-3.1.xsd
 http\://www.springframework.org/schema/tool/spring-tool-3.2.xsd=org/springframework/beans/factory/xml/spring-tool-3.2.xsd
+http\://www.springframework.org/schema/tool/spring-tool-4.0.xsd=org/springframework/beans/factory/xml/spring-tool-4.0.xsd
 http\://www.springframework.org/schema/tool/spring-tool.xsd=org/springframework/beans/factory/xml/spring-tool-3.2.xsd
 http\://www.springframework.org/schema/util/spring-util-2.0.xsd=org/springframework/beans/factory/xml/spring-util-2.0.xsd
 http\://www.springframework.org/schema/util/spring-util-2.5.xsd=org/springframework/beans/factory/xml/spring-util-2.5.xsd

--- a/spring-jms/src/main/java/org/springframework/jms/config/JmsListenerContainerParser.java
+++ b/spring-jms/src/main/java/org/springframework/jms/config/JmsListenerContainerParser.java
@@ -48,6 +48,8 @@ class JmsListenerContainerParser extends AbstractListenerContainerParser {
 	private static final String CACHE_ATTRIBUTE = "cache";
 
 	private static final String RECEIVE_TIMEOUT_ATTRIBUTE = "receive-timeout";
+	
+	private static final String RECOVERY_INTERVAL_ATTRIBUTE = "recovery-interval";
 
 
 	@Override
@@ -163,6 +165,11 @@ class JmsListenerContainerParser extends AbstractListenerContainerParser {
 		String phase = containerEle.getAttribute(PHASE_ATTRIBUTE);
 		if (StringUtils.hasText(phase)) {
 			containerDef.getPropertyValues().add("phase", phase);
+		}
+
+		String recoveryInterval = containerEle.getAttribute(RECOVERY_INTERVAL_ATTRIBUTE);
+		if (StringUtils.hasText(recoveryInterval)) {
+			containerDef.getPropertyValues().add("recoveryInterval", recoveryInterval);
 		}
 
 		return containerDef;

--- a/spring-jms/src/main/resources/META-INF/spring.schemas
+++ b/spring-jms/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/jms/spring-jms-2.5.xsd=org/springframewor
 http\://www.springframework.org/schema/jms/spring-jms-3.0.xsd=org/springframework/jms/config/spring-jms-3.0.xsd
 http\://www.springframework.org/schema/jms/spring-jms-3.1.xsd=org/springframework/jms/config/spring-jms-3.1.xsd
 http\://www.springframework.org/schema/jms/spring-jms-3.2.xsd=org/springframework/jms/config/spring-jms-3.2.xsd
+http\://www.springframework.org/schema/jms/spring-jms-4.0.xsd=org/springframework/jms/config/spring-jms-4.0.xsd
 http\://www.springframework.org/schema/jms/spring-jms.xsd=org/springframework/jms/config/spring-jms-3.2.xsd

--- a/spring-jms/src/main/resources/org/springframework/jms/config/spring-jms-4.0.xsd
+++ b/spring-jms/src/main/resources/org/springframework/jms/config/spring-jms-4.0.xsd
@@ -251,6 +251,14 @@
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="recovery-interval" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specify the interval between recovery attempts, in milliseconds.
+	The default is 5000 ms, that is, 5 seconds.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 

--- a/spring-jms/src/test/java/org/springframework/jms/config/JmsNamespaceHandlerTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/config/JmsNamespaceHandlerTests.java
@@ -163,6 +163,24 @@ public class JmsNamespaceHandlerTests {
 		assertEquals(77, phase4);
 		assertEquals(Integer.MAX_VALUE, defaultPhase);
 	}
+	
+	@Test
+	public void testRecoveryInterval() {
+		long recoveryInterval1 = getRecoveryInterval("listener1");
+		long recoveryInterval2 = getRecoveryInterval("listener2");
+		long recoveryInterval3 = getRecoveryInterval(DefaultMessageListenerContainer.class.getName() + "#0");
+		
+		assertEquals(1000L, recoveryInterval1);
+		assertEquals(1000L, recoveryInterval2);
+		assertEquals(DefaultMessageListenerContainer.DEFAULT_RECOVERY_INTERVAL, recoveryInterval3);
+	}
+
+	private long getRecoveryInterval(String containerBeanName) {
+		DefaultMessageListenerContainer container = this.context.getBean(containerBeanName, DefaultMessageListenerContainer.class);
+		Long recoveryInterval = (Long) new DirectFieldAccessor(container).getPropertyValue("recoveryInterval");
+		return recoveryInterval.longValue();
+	}
+	
 
 	private MessageListener getListener(String containerBeanName) {
 		DefaultMessageListenerContainer container = this.context.getBean(containerBeanName, DefaultMessageListenerContainer.class);

--- a/spring-jms/src/test/java/org/springframework/jms/config/jmsNamespaceHandlerTests.xml
+++ b/spring-jms/src/test/java/org/springframework/jms/config/jmsNamespaceHandlerTests.xml
@@ -3,12 +3,13 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:jms="http://www.springframework.org/schema/jms"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-3.1.xsd">
+				http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-4.0.xsd">
 
 	<jms:listener-container connection-factory="testConnectionFactory" task-executor="testTaskExecutor"
 			destination-resolver="testDestinationResolver" message-converter="testMessageConverter"
 			transaction-manager="testTransactionManager" error-handler="testErrorHandler"
-			concurrency="1-2" prefetch="50" receive-timeout="100" phase="99">
+			concurrency="1-2" prefetch="50" receive-timeout="100" phase="99"
+			recovery-interval="1000">
 		<jms:listener id="listener1" destination="testDestination" ref="testBean1" method="setName"/>
 		<jms:listener id="listener2" destination="testDestination" ref="testBean2" method="setName" response-destination="responseDestination"/>
 	</jms:listener-container>

--- a/src/reference/docbook/jms.xml
+++ b/src/reference/docbook/jms.xml
@@ -1087,6 +1087,16 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
           </row>
 
           <row>
+            <entry>container-class</entry>
+
+            <entry><para>A custom listener container implementation class
+            as fully qualified class name. Default is Spring's standard
+            <classname>DefaultMessageListenerContainer</classname> or
+            <classname>SimpleMessageListenerContainer</classname>,
+            according to the "container-type" attribute.</para></entry>
+          </row>
+
+          <row>
             <entry>connection-factory</entry>
 
             <entry><para>A reference to the JMS
@@ -1119,6 +1129,15 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
             <interfacename>MessageConverter</interfacename> strategy for
             converting JMS Messages to listener method arguments. Default is a
             <classname>SimpleMessageConverter</classname>.</para></entry>
+          </row>
+
+          <row>
+            <entry>error-handler</entry>
+
+            <entry><para>A reference to an 
+            <interfacename>ErrorHandler</interfacename> strategy for handling
+            any uncaught Exceptions that may occur during the execution of the
+            <interfacename>MessageListener</interfacename>.</para></entry>
           </row>
 
           <row>
@@ -1194,6 +1213,32 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
             <entry><para>The maximum number of messages to load into a single
             session. Note that raising this number might lead to starvation of
             concurrent consumers!</para></entry>
+          </row>
+
+          <row>
+            <entry>receive-timeout</entry>
+
+            <entry><para>The timeout to use for receive calls (in milliseconds).
+			The default is <literal>1000</literal> ms (1 sec); <literal>-1</literal>
+			indicates no timeout at all.</para></entry>
+          </row>
+
+          <row>
+            <entry>phase</entry>
+
+            <entry><para>The lifecycle phase within which this container should
+            start and stop. The lower the value the earlier this container will
+            start and the later it will stop. The default is 
+            <literal>Integer.MAX_VALUE</literal> meaning the container will start
+            as late as possible and stop as soon as possible.</para></entry>
+          </row>
+
+          <row>
+            <entry>recovery-interval</entry>
+
+            <entry><para>Specify the interval between recovery attempts, in
+            milliseconds. The default is <literal>5000</literal> ms, that is,
+            5 seconds.</para></entry>
           </row>
         </tbody>
       </tgroup>
@@ -1325,6 +1370,16 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
             <entry><para>The maximum number of messages to load into a single
             session. Note that raising this number might lead to starvation of
             concurrent consumers!</para></entry>
+          </row>
+
+          <row>
+            <entry>phase</entry>
+
+            <entry><para>The lifecycle phase within which this container should
+            start and stop. The lower the value the earlier this container will
+            start and the later it will stop. The default is 
+            <literal>Integer.MAX_VALUE</literal> meaning the container will start
+            as late as possible and stop as soon as possible.</para></entry>
           </row>
         </tbody>
       </tgroup>


### PR DESCRIPTION
Added recovery-interval attribute to the jms:listener-container
element in the JMS schema. Updated jms namespace documentation
to include recovery-interval attribute, as well as other attributes
missing from the documentation (e.g. container-class, error-handler,
receive-timeout, phase).

The entries in spring.schemas for the 4.0 schemas were missing,
so I added entries for spring-tool-4.0 and spring-jms-4.0 (needed to 
get unit test to pass). I did not add 4.0 entries for the other schemas,
and assume they will be done at a later time.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.

Issue: SPR-10711
