### PR TITLE
Fix ResourceHttpMessageConverter to not throw NullPointerException

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
@@ -138,8 +138,12 @@ public class ResourceHttpMessageConverter extends AbstractHttpMessageConverter<R
 		}
 
 		public static MediaType getMediaType(Resource resource) {
-			String mediaType = fileTypeMap.getContentType(resource.getFilename());
-			return (StringUtils.hasText(mediaType) ? MediaType.parseMediaType(mediaType) : null);
+			if(resource.getFilename() == null) {
+				return null;
+			} else {
+				String mediaType = fileTypeMap.getContentType(resource.getFilename());
+				return (StringUtils.hasText(mediaType) ? MediaType.parseMediaType(mediaType) : null);
+			}
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/converter/ResourceHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/ResourceHttpMessageConverterTests.java
@@ -17,11 +17,13 @@
 package org.springframework.http.converter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
@@ -68,6 +70,15 @@ public class ResourceHttpMessageConverterTests {
 		assertEquals("Invalid content-type", MediaType.IMAGE_JPEG,
 				outputMessage.getHeaders().getContentType());
 		assertEquals("Invalid content-length", body.getFile().length(), outputMessage.getHeaders().getContentLength());
+	}
+	
+	@Test
+	public void writeByteArray() throws IOException {
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+		byte[] byteArray = {1, 2, 3};
+		Resource body = new ByteArrayResource(byteArray);
+		converter.write(body, null, outputMessage);
+		assertTrue(Arrays.equals(byteArray, outputMessage.getBodyAsBytes()));
 	}
 
 }


### PR DESCRIPTION
for Resource implementation in which getFilename() returns null

ResourceHttpMessageConverter tries to use the filename to determine the
media type, but for Resource implementations such as ByteArrayResource
it is null, which causes NullPointerException. The fix checks whether
getFilename returns null before attempting to determine the media type
by it.

The problem was originally reported in Spring Social Google in an
attempt to use ByteArrayResource in the method that uploads
to Google Drive.

Issue: SPR-10848
