### PR TITLE
Clean up stack trace before rethrowing JDBC exceptions handled by AbstractFallbackSQLExceptionTranslator

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -350,7 +350,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 			// in the case when the exception translator hasn't been initialized yet.
 			DataSourceUtils.releaseConnection(con, getDataSource());
 			con = null;
-			throw getExceptionTranslator().translate("ConnectionCallback", getSql(action), ex);
+			throw (DataAccessException) getExceptionTranslator().translate("ConnectionCallback", getSql(action), ex).fillInStackTrace();
 		}
 		finally {
 			DataSourceUtils.releaseConnection(con, getDataSource());
@@ -409,7 +409,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 			stmt = null;
 			DataSourceUtils.releaseConnection(con, getDataSource());
 			con = null;
-			throw getExceptionTranslator().translate("StatementCallback", getSql(action), ex);
+			throw (DataAccessException) getExceptionTranslator().translate("StatementCallback", getSql(action), ex).fillInStackTrace();
 		}
 		finally {
 			JdbcUtils.closeStatement(stmt);
@@ -656,7 +656,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 			ps = null;
 			DataSourceUtils.releaseConnection(con, getDataSource());
 			con = null;
-			throw getExceptionTranslator().translate("PreparedStatementCallback", sql, ex);
+			throw (DataAccessException) getExceptionTranslator().translate("PreparedStatementCallback", sql, ex).fillInStackTrace();
 		}
 		finally {
 			if (psc instanceof ParameterDisposer) {
@@ -1137,7 +1137,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 			cs = null;
 			DataSourceUtils.releaseConnection(con, getDataSource());
 			con = null;
-			throw getExceptionTranslator().translate("CallableStatementCallback", sql, ex);
+			throw (DataAccessException) getExceptionTranslator().translate("CallableStatementCallback", sql, ex).fillInStackTrace();
 		}
 		finally {
 			if (csc instanceof ParameterDisposer) {


### PR DESCRIPTION
Removed error-irrelevant translation stack frames from exception stack trace after exceptions were created by an AbstractFallbackSQLExceptionTranslator:

When debugging Spring-JDBC entires, I find it distracting that the top entries always refer to an AbstractFallbackSQLExceptionTranslator which is only called after an error occured and which simply translates a "raw" exception into a richer exception. Therefore, I suggest that these stack entries are removed before the enriched exception is rethrown by the JdbcTemplate.

It is a detail, but I believe the exception stack trace should not polluted with details that merely reflect an implementation detail.
