### PR TITLE
SPR-10851: Clean stack trace from SQLExceptionTranslator

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -350,7 +350,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 			// in the case when the exception translator hasn't been initialized yet.
 			DataSourceUtils.releaseConnection(con, getDataSource());
 			con = null;
-			throw getExceptionTranslator().translate("ConnectionCallback", getSql(action), ex);
+			throw (DataAccessException) getExceptionTranslator().translate("ConnectionCallback", getSql(action), ex).fillInStackTrace();
 		}
 		finally {
 			DataSourceUtils.releaseConnection(con, getDataSource());
@@ -409,7 +409,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 			stmt = null;
 			DataSourceUtils.releaseConnection(con, getDataSource());
 			con = null;
-			throw getExceptionTranslator().translate("StatementCallback", getSql(action), ex);
+			throw (DataAccessException) getExceptionTranslator().translate("StatementCallback", getSql(action), ex).fillInStackTrace();
 		}
 		finally {
 			JdbcUtils.closeStatement(stmt);
@@ -656,7 +656,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 			ps = null;
 			DataSourceUtils.releaseConnection(con, getDataSource());
 			con = null;
-			throw getExceptionTranslator().translate("PreparedStatementCallback", sql, ex);
+			throw (DataAccessException) getExceptionTranslator().translate("PreparedStatementCallback", sql, ex).fillInStackTrace();
 		}
 		finally {
 			if (psc instanceof ParameterDisposer) {
@@ -1137,7 +1137,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 			cs = null;
 			DataSourceUtils.releaseConnection(con, getDataSource());
 			con = null;
-			throw getExceptionTranslator().translate("CallableStatementCallback", sql, ex);
+			throw (DataAccessException) getExceptionTranslator().translate("CallableStatementCallback", sql, ex).fillInStackTrace();
 		}
 		finally {
 			if (csc instanceof ParameterDisposer) {

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate3/HibernateTemplate.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate3/HibernateTemplate.java
@@ -410,10 +410,10 @@ public class HibernateTemplate extends HibernateAccessor implements HibernateOpe
 			return result;
 		}
 		catch (HibernateException ex) {
-			throw convertHibernateAccessException(ex);
+			throw (DataAccessException) convertHibernateAccessException(ex).fillInStackTrace();
 		}
 		catch (SQLException ex) {
-			throw convertJdbcAccessException(ex);
+			throw (DataAccessException) convertJdbcAccessException(ex).fillInStackTrace();
 		}
 		catch (RuntimeException ex) {
 			// Callback code threw application exception...

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate3/HibernateTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate3/HibernateTransactionManager.java
@@ -640,7 +640,7 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 					session.flush();
 				}
 				catch (HibernateException ex) {
-					throw convertHibernateAccessException(ex);
+					throw (DataAccessException) convertHibernateAccessException(ex).fillInStackTrace();
 				}
 				finally {
 					session.setFlushMode(FlushMode.MANUAL);
@@ -659,13 +659,13 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 		try {
 			txObject.getSessionHolder().getTransaction().commit();
 		}
-		catch (org.hibernate.TransactionException ex) {
+		catch (TransactionException ex) {
 			// assumably from commit call to the underlying JDBC connection
 			throw new TransactionSystemException("Could not commit Hibernate transaction", ex);
 		}
 		catch (HibernateException ex) {
 			// assumably failed to flush changes to database
-			throw convertHibernateAccessException(ex);
+			throw (DataAccessException) convertHibernateAccessException(ex).fillInStackTrace();
 		}
 	}
 
@@ -679,12 +679,12 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 		try {
 			txObject.getSessionHolder().getTransaction().rollback();
 		}
-		catch (org.hibernate.TransactionException ex) {
+		catch (TransactionException ex) {
 			throw new TransactionSystemException("Could not roll back Hibernate transaction", ex);
 		}
 		catch (HibernateException ex) {
 			// Shouldn't really happen, as a rollback doesn't cause a flush.
-			throw convertHibernateAccessException(ex);
+			throw (DataAccessException) convertHibernateAccessException(ex).fillInStackTrace();
 		}
 		finally {
 			if (!txObject.isNewSession() && !this.hibernateManagedSession) {
@@ -897,7 +897,7 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 				this.sessionHolder.getSession().flush();
 			}
 			catch (HibernateException ex) {
-				throw convertHibernateAccessException(ex);
+				throw (DataAccessException) convertHibernateAccessException(ex).fillInStackTrace();
 			}
 		}
 	}

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate3/SpringSessionSynchronization.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate3/SpringSessionSynchronization.java
@@ -134,7 +134,7 @@ class SpringSessionSynchronization implements TransactionSynchronization, Ordere
 			getCurrentSession().flush();
 		}
 		catch (HibernateException ex) {
-			throw translateException(ex);
+			throw (DataAccessException) translateException(ex).fillInStackTrace();
 		}
 	}
 
@@ -150,7 +150,7 @@ class SpringSessionSynchronization implements TransactionSynchronization, Ordere
 					session.flush();
 				}
 				catch (HibernateException ex) {
-					throw translateException(ex);
+					throw (DataAccessException) translateException(ex).fillInStackTrace();
 				}
 			}
 		}

--- a/spring-orm/src/main/java/org/springframework/orm/jdo/JdoTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jdo/JdoTransactionManager.java
@@ -440,7 +440,7 @@ public class JdoTransactionManager extends AbstractPlatformTransactionManager
 		}
 		catch (JDOException ex) {
 			// Assumably failed to flush changes to database.
-			throw convertJdoAccessException(ex);
+			throw (DataAccessException) convertJdoAccessException(ex).fillInStackTrace();
 		}
 	}
 
@@ -584,7 +584,7 @@ public class JdoTransactionManager extends AbstractPlatformTransactionManager
 				this.persistenceManagerHolder.getPersistenceManager().flush();
 			}
 			catch (JDOException ex) {
-				throw convertJdoAccessException(ex);
+				throw (DataAccessException) convertJdoAccessException(ex).fillInStackTrace();
 			}
 		}
 	}


### PR DESCRIPTION
Removed error-irrelevant translation stack frames from exception stack trace after exceptions were created by an SQLExceptionTranslator.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
