### PR TITLE
Use correct header for version in CONNECTED frame 

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompProtocolHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompProtocolHandler.java
@@ -185,10 +185,10 @@ public class StompProtocolHandler implements SubProtocolHandler {
 
 		Set<String> acceptVersions = connectHeaders.getAcceptVersion();
 		if (acceptVersions.contains("1.2")) {
-			connectedHeaders.setAcceptVersion("1.2");
+			connectedHeaders.setVersion("1.2");
 		}
 		else if (acceptVersions.contains("1.1")) {
-			connectedHeaders.setAcceptVersion("1.1");
+			connectedHeaders.setVersion("1.1");
 		}
 		else if (acceptVersions.isEmpty()) {
 			// 1.0


### PR DESCRIPTION
Previously, the negotiated version was included in the CONNECTED frame using the `accept-version` header. This is incorrect – it should be `version` header that's used.

I think this one's worth fixing for M3.
