### PR TITLE
[SPR-10870] DefaultKeyGenerator needs to consider varargs parameter

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/DefaultKeyGenerator.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/DefaultKeyGenerator.java
@@ -48,11 +48,17 @@ public class DefaultKeyGenerator implements KeyGenerator {
 
 	@Override
 	public Object generate(Object target, Method method, Object... params) {
-		if (params.length == 1) {
+		if (!method.isVarArgs() && params.length == 1) {
 			return (params[0] == null ? NULL_PARAM_KEY : params[0]);
 		}
 		if (params.length == 0) {
 			return NO_PARAM_KEY;
+		}
+		if (method.isVarArgs()) {
+			params = mergeVarArgs(params);
+			if (params.length == 1) {
+				return (params[0] == null ? NULL_PARAM_KEY : params[0]);
+			}
 		}
 		int hashCode = 17;
 		for (Object object : params) {
@@ -60,5 +66,19 @@ public class DefaultKeyGenerator implements KeyGenerator {
 		}
 		return Integer.valueOf(hashCode);
 	}
-
+	
+	private Object[] mergeVarArgs(Object[] params) {
+		if(params.length == 1) {
+			return (Object[]) params[0];
+		}
+		Object[] varArgs = (Object[]) params[params.length-1];
+		Object[] newArgs = new Object[params.length - 1 + varArgs.length];
+		for (int i = 0; i < params.length-1; i++) {
+			newArgs[i] = params[i];
+		}
+		for (int i = params.length-1; i < newArgs.length; i++) {
+			newArgs[i] = varArgs[i-params.length+1];
+		}
+		return newArgs;
+	}
 }


### PR DESCRIPTION
DefaultKeyGenerator generates cache key through below method.

```
public Object generate(Object target, Method m, Object... params) {
... some other code ...
int hashCode = 17;
for (Object object : params) {
    hashCode = 31 * hashCode + 
             (object == null ? NULL_PARAM_KEY : object.hashCode());
}
```

The last parameter 'params' has different form according to signature 
of @Cacheable method. That is, if the signature is like below and 
clinicService.findVets("arg1", "arg2"); method is invoked.

```
@Cacheable(value="vets")
public Collection<Vet> findVets(String args1, String args2) {
}
```

then actual data structure of 'params' is like 
new Object[]{"arg1", "arg2"}.

But if the signature is like below

```
@Cacheable(value="vets")
public Collection<Vet> findVets(String... args) {
}
```

then actual data structure of 'params' is like 
new Object[]{new String[]{"arg1", "arg2"}}.

Becuase of difference between this two data structure, final hashCode
get also different. This pull request contains logic that converting 
data structure like below, and in both case cache key has same value.

```
new Object[]{new String[]{"arg1", "arg2"}}
  => new Object[]{"arg1", "arg2"}
```

Issue: SPR-10870
