### PR TITLE
Added HTML close policy tag to control tag close style

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -108,6 +108,24 @@ public abstract class WebUtils {
 	public static final String HTML_ESCAPE_CONTEXT_PARAM = "defaultHtmlEscape";
 
 	/**
+	 * HTML tag close policy parameter at the servlet context level
+	 * (i.e., a context-param in {@code web.xml}): "defaultHtmlClosePolicy".
+	 * @see #HTML_CLOSE_POLICY_ATTRIBUTE
+	 */
+	public static final String HTML_CLOSE_POLICY_PARAM = "defaultHtmlClosePolicy";
+
+	/**
+	 * HTML tag close policy page context attribute. All code generating HTML
+	 * tags should first check this page context attribute to determine whether
+	 * HTML tags not requiring a closing tag should be closed using XML
+	 * (<code>/&gt;</code>, {@literal true}) or HTML (<code>&gt;</code>,
+	 * {@literal false}) style. If this attribute is not set, the code should then
+	 * check the servlet context parameter. If the parameter is also not set, the
+	 * code should use XML style tag closing.
+	 */
+	public static final String HTML_CLOSE_POLICY_ATTRIBUTE = "org.springframework.web.tag.htmlClosePolicy.xml";
+
+	/**
 	 * Web app root key parameter at the servlet context level
 	 * (i.e. a context-param in {@code web.xml}): "webAppRootKey".
 	 */
@@ -202,6 +220,27 @@ public abstract class WebUtils {
 		Assert.notNull(servletContext, "ServletContext must not be null");
 		String param = servletContext.getInitParameter(HTML_ESCAPE_CONTEXT_PARAM);
 		return (StringUtils.hasText(param)? Boolean.valueOf(param) : null);
+	}
+
+	/**
+	 * Returns the default HTML tag close policy from the servlet context. All
+	 * code generating HTML tags should first check the page context attribute
+	 * ({@link #HTML_CLOSE_POLICY_ATTRIBUTE}) to determine whether HTML tags not
+	 * requiring a closing tag should be closed using XML (<code>/&gt;</code>,
+	 * {@literal true}) or HTML (<code>&gt;</code>, {@literal false}) style. If
+	 * this attribute is not set, the code should then check the servlet context
+	 * parameter using this method. If the parameter is also not set, the code
+	 * should use XML style tag closing.
+	 *
+	 * @param servletContext the servlet context of the web application
+	 * @return the default HTML tag close policy from the servlet context provided
+	 */
+	public static Boolean isDefaultHtmlClosePolicyXml(ServletContext servletContext) {
+		if (servletContext == null) {
+			return true;
+		}
+		String param = servletContext.getInitParameter(HTML_CLOSE_POLICY_PARAM);
+		return StringUtils.hasText(param) ? Boolean.valueOf(param) : null;
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/HtmlClosePolicyTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/HtmlClosePolicyTag.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.tags;
+
+import org.springframework.web.util.WebUtils;
+
+/**
+ * Sets the HTML close policy for the current page. This determines whether
+ * HTML tags that don't require closing tags are ended in XML style
+ * (<code>/&gt;</code>) or traditional HTML style (<code>&gt;</code>),
+ * allowing the user to control the syntax and better pass W3C validators.
+ * This overrides the {@code defaultHtmlClosePolicy} property set in
+ * {@code web.xml}, if any.
+ *
+ * @author Nick Williams
+ * @since 4.0
+ */
+public class HtmlClosePolicyTag extends RequestContextAwareTag {
+
+	private boolean xml;
+
+	/**
+	 * Set the HTML close policy for the current page.
+	 *
+	 * @param xml The HTML close policy
+	 */
+	public void setXml(boolean xml) {
+		this.xml = xml;
+	}
+
+	@Override
+	protected int doStartTagInternal() {
+		this.pageContext.setAttribute(WebUtils.HTML_CLOSE_POLICY_ATTRIBUTE, this.xml);
+		return EVAL_BODY_INCLUDE;
+	}
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractFormTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractFormTag.java
@@ -21,6 +21,7 @@ import javax.servlet.jsp.JspException;
 
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.servlet.tags.HtmlEscapingAwareTag;
+import org.springframework.web.util.WebUtils;
 
 /**
  * Base class for all JSP form tags. Provides utility methods for
@@ -71,7 +72,17 @@ public abstract class AbstractFormTag extends HtmlEscapingAwareTag {
 	 * change the {@link java.io.Writer} to which output is actually written.
 	 */
 	protected TagWriter createTagWriter() {
-		return new TagWriter(this.pageContext);
+		TagWriter tagWriter = new TagWriter(this.pageContext);
+		Object attribute = this.pageContext.getAttribute(WebUtils.HTML_CLOSE_POLICY_ATTRIBUTE);
+		if (attribute != null) {
+			tagWriter.setUseXmlCloseStyle((Boolean) attribute);
+		} else {
+			Boolean param = WebUtils.isDefaultHtmlClosePolicyXml(this.pageContext.getServletContext());
+			if (param != null) {
+				tagWriter.setUseXmlCloseStyle(param);
+			}
+		}
+		return tagWriter;
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/FormTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/FormTag.java
@@ -495,8 +495,12 @@ public class FormTag extends AbstractHtmlElementTag {
 		if (hiddenFields != null) {
 			for (String name : hiddenFields.keySet()) {
 				this.tagWriter.appendValue("<input type=\"hidden\" ");
-				this.tagWriter.appendValue("name=\"" + name + "\" value=\"" + hiddenFields.get(name) + "\" ");
-				this.tagWriter.appendValue("/>\n");
+				this.tagWriter.appendValue("name=\"" + name + "\" value=\"" + hiddenFields.get(name) + "\"");
+				if (this.tagWriter.isUseXmlCloseStyle()) {
+					this.tagWriter.appendValue(" />\n");
+				} else {
+					this.tagWriter.appendValue(">\n");
+				}
 			}
 		}
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/TagWriter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/TagWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,11 @@ public class TagWriter {
 	 */
 	private final Stack tagState = new Stack();
 
+	/**
+	 * Indicates whether tags should be ended XML style or HTML style.
+	 */
+	private boolean useXmlCloseStyle = true;
+
 
 	/**
 	 * Create a new instance of the {@link TagWriter} class that writes to
@@ -68,6 +73,26 @@ public class TagWriter {
 		this.writer = new SafeWriter(writer);
 	}
 
+
+	/**
+	 * Indicates whether tags should be ended XML style or HTML style.
+	 *
+	 * @param useXmlCloseStyle {@code true} to use XML style (<code>/&gt;</code>),
+	 *                         {@code false} to use HTML style (<code>&gt;</code>).
+	 */
+	public void setUseXmlCloseStyle(boolean useXmlCloseStyle) {
+		this.useXmlCloseStyle = useXmlCloseStyle;
+	}
+
+	/**
+	 * Indicates whether tags should be ended XML style or HTML style.
+	 *
+	 * @return {@code true} to use XML style (<code>/&gt;</code>),
+	 *         {@code false} to use HTML style (<code>&gt;</code>).
+	 */
+	public boolean isUseXmlCloseStyle() {
+		return this.useXmlCloseStyle;
+	}
 
 	/**
 	 * Start a new tag with the supplied name. Leaves the tag open so
@@ -161,7 +186,11 @@ public class TagWriter {
 				this.writer.append(">");
 			}
 			else {
-				this.writer.append("/>");
+				if (this.isUseXmlCloseStyle()) {
+					this.writer.append(" />");
+				} else {
+					this.writer.append(">");
+				}
 				renderClosingTag = false;
 			}
 		}

--- a/spring-webmvc/src/main/resources/META-INF/spring.tld
+++ b/spring-webmvc/src/main/resources/META-INF/spring.tld
@@ -472,4 +472,25 @@
 		</attribute>
 	</tag>
 
+	<tag>
+		<description>
+			Sets the HTML close policy for the current page. This determines whether
+			HTML tags that don't require closing tags are ended in XML style (/&gt;)
+			or traditional HTML style (&gt;), allowing the user to control the syntax
+			and better pass W3C validators. This overrides the defaultHtmlClosePolicy
+			property set in web.xml, if any.
+		</description>
+		<name>htmlClosePolicy</name>
+		<tag-class>org.springframework.web.servlet.tags.HtmlClosePolicyTag</tag-class>
+		<body-content>empty</body-content>
+		<attribute>
+			<description>Set the policy for closing HTML tags in the current page,
+			    overriding the property specified in web.xml, if any.</description>
+			<name>xml</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+	</tag>
+
 </taglib>

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/HtmlClosePolicyTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/HtmlClosePolicyTagTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.tags;
+
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.Tag;
+
+import org.springframework.web.util.WebUtils;
+
+/**
+ * @author Nick Williams
+ */
+public class HtmlClosePolicyTagTests extends AbstractTagTests {
+
+	public void testHtmlClosePolicyTag() {
+		PageContext pageContext = createPageContext();
+
+		HtmlClosePolicyTag tag = new HtmlClosePolicyTag();
+		tag.setPageContext(pageContext);
+		tag.setXml(true);
+
+		assertEquals("The return value is not correct.", Tag.EVAL_BODY_INCLUDE, tag.doStartTagInternal());
+		assertEquals("The attribute is not correct.", true,
+				pageContext.getAttribute(WebUtils.HTML_CLOSE_POLICY_ATTRIBUTE));
+
+		pageContext = createPageContext();
+		tag = new HtmlClosePolicyTag();
+		tag.setPageContext(pageContext);
+		tag.setXml(false);
+
+		assertEquals("The return value is not correct.", Tag.EVAL_BODY_INCLUDE, tag.doStartTagInternal());
+		assertEquals("The attribute is not correct.", false,
+				pageContext.getAttribute(WebUtils.HTML_CLOSE_POLICY_ATTRIBUTE));
+	}
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/TagWriterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/TagWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,19 +38,53 @@ public class TagWriterTests extends TestCase {
 	}
 
 
-	public void testSimpleTag() throws Exception {
+	public void testSimpleTagDefaultClose() throws Exception {
 		this.writer.startTag("br");
 		this.writer.endTag();
 
-		assertEquals("<br/>", this.data.toString());
+		assertEquals("<br />", this.data.toString());
 	}
 
-	public void testEmptyTag() throws Exception {
+	public void testSimpleTagCloseStyleXml() throws Exception {
+		this.writer.setUseXmlCloseStyle(true);
+		this.writer.startTag("br");
+		this.writer.endTag();
+
+		assertEquals("<br />", this.data.toString());
+	}
+
+	public void testSimpleTagCloseStyleHtml() throws Exception {
+		this.writer.setUseXmlCloseStyle(false);
+		this.writer.startTag("br");
+		this.writer.endTag();
+
+		assertEquals("<br>", this.data.toString());
+	}
+
+	public void testEmptyTagDefaultClose() throws Exception {
 		this.writer.startTag("input");
 		this.writer.writeAttribute("type", "text");
 		this.writer.endTag();
 
-		assertEquals("<input type=\"text\"/>", this.data.toString());
+		assertEquals("<input type=\"text\" />", this.data.toString());
+	}
+
+	public void testEmptyTagCloseStyleXml() throws Exception {
+		this.writer.setUseXmlCloseStyle(true);
+		this.writer.startTag("input");
+		this.writer.writeAttribute("type", "text");
+		this.writer.endTag();
+
+		assertEquals("<input type=\"text\" />", this.data.toString());
+	}
+
+	public void testEmptyTagCloseStyleHtml() throws Exception {
+		this.writer.setUseXmlCloseStyle(false);
+		this.writer.startTag("input");
+		this.writer.writeAttribute("type", "text");
+		this.writer.endTag();
+
+		assertEquals("<input type=\"text\">", this.data.toString());
 	}
 
 	public void testSimpleBlockTag() throws Exception {


### PR DESCRIPTION
This commit adds a new `<spring:htmlClosePolicy>` tag that can be used to specify how generated HTML tags are closed—XML style (`/>`) or HTML style (`>`). This is necessary to properly generate W3C validator-compliant HTML code.

Issue: SPR-10916
