### PR TITLE
Order of values in @PropertySource annotation depends on name attribute

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/CompositePropertySource.java
+++ b/spring-core/src/main/java/org/springframework/core/env/CompositePropertySource.java
@@ -16,11 +16,11 @@
 
 package org.springframework.core.env;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Composite {@link PropertySource} implementation that iterates over a set of
+ * Composite {@link PropertySource} implementation that iterates over a list of
  * {@link PropertySource} instances. Necessary in cases where multiple property sources
  * share the same name, e.g. when multiple values are supplied to {@code @PropertySource}.
  *
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 public class CompositePropertySource extends PropertySource<Object> {
 
-	private Set<PropertySource<?>> propertySources = new LinkedHashSet<PropertySource<?>>();
+	private List<PropertySource<?>> propertySources = new ArrayList<PropertySource<?>>();
 
 
 	/**
@@ -54,7 +54,7 @@ public class CompositePropertySource extends PropertySource<Object> {
 	}
 
 	public void addPropertySource(PropertySource<?> propertySource) {
-		this.propertySources.add(propertySource);
+		this.propertySources.add(0, propertySource);
 	}
 
 	@Override


### PR DESCRIPTION
ConfigurationClassPostProcessor parses @PropertySource annotation,
then adds each PropertySource into 'envPropertySources'.

```
Stack<PropertySource<?>> parsedPropertySources = parser.getPropertySources();
if (!parsedPropertySources.isEmpty()) {
... some code ...
    MutablePropertySources envPropertySources = 
          ((ConfigurableEnvironment)this.environment).getPropertySources();
    while (!parsedPropertySources.isEmpty()) {
        envPropertySources.addLast(parsedPropertySources.pop());
    }
}
```

ConfigurationClassPostProcessor uses 'Stack' data structure here,
the order works in LIFO. So with below configuration, 'override.properties' file is prior to 'a.properties' file.

```
@PropertySource(value = { "classpath:a.properties",
                          "classpath:override.properties" })
```

But CompositePropertySource uses 'ListHashSet' data structure inside,the order works in FIFO. 
(CompositePropertySource is used when @PropertySource has 'name' attribute.)

To make them work same order, CompositePropertySource needs to manage
each PropertySource as list and work in LIFO. 
Thank you.

Issue: SPR-10820
