### PR TITLE
Add "ignoreResourceNotFound" attribute to the @PropertySource

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/PropertySource.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/PropertySource.java
@@ -165,5 +165,12 @@ public @interface PropertySource {
 	 * property source, and in the order declared.
 	 */
 	String[] value();
+	
+	/**
+	 * Indicate the failure to find the property resource should be ignored.
+	 * <p>"true" is appropriate if the properties file is completely optional.
+	 * Default is "false".
+	 */
+	boolean ignoreResourceNotFound() default false;
 
 }


### PR DESCRIPTION
Currently, a file is required to exist if it is added to the @PropertySource annotation. If the application already 
has the properties it needs, it should be possible to launch it without the associated file being present:

```
@PropertySource(value = "classpath:/notexists.properties", ignoreResourceNotFound = true)
```

Adding new attribute 'ignoreResourceNotFound' to @PropertySource,
user can decide to ignore the not-existing resource.
- default is false
- The ignoreResourceNotFound is supported for XML-based application
  context by context:property-placeholder

ConfigurationClassParser is changed to load properties regarding option 'ignoreResourceNotFound', 
and PropertySource is changed to have new member 'boolean ignoreResourceNotFound'. 
Thank you.

issue: SPR-10932
