### PR TITLE
Fixed URLs in import-into-eclipse scripts

### DIFF
--- a/import-into-eclipse.bat
+++ b/import-into-eclipse.bat
@@ -17,7 +17,7 @@ echo been tested against STS %STS_TEST_VERSION%), but at the minimum you will
 echo need Eclipse + AJDT.
 echo.
 echo If you need to download and install STS, please do that now by
-echo visiting http://springsource.org/downloads/sts
+echo visiting http://spring.io/tools/sts/all 
 echo.
 echo Otherwise, press enter and we'll begin.
 

--- a/import-into-eclipse.sh
+++ b/import-into-eclipse.sh
@@ -14,7 +14,7 @@ been tested against STS $STS_TEST_VERSION), but at the minimum you will
 need Eclipse + AJDT.
 
 If you need to download and install STS, please do that now by
-visiting http://springsource.org/downloads/sts
+visiting http://spring.io/tools/sts/all 
 
 Otherwise, press enter and we'll begin.
 EOM


### PR DESCRIPTION
URLs in the import scripts were to 404s.  Updated them to current locations.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
