### PR TITLE
Improve handling of send failures

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.simp.handler.AbstractBrokerMessageHandler;
@@ -205,34 +206,29 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 			return;
 		}
 
-		try {
-			if (SimpMessageType.CONNECT.equals(messageType)) {
-				message = MessageBuilder.withPayloadAndHeaders(message.getPayload(), headers).build();
-				StompRelaySession session = new StompRelaySession(sessionId);
-				this.relaySessions.put(sessionId, session);
-				session.connect(message);
-			}
-			else if (SimpMessageType.DISCONNECT.equals(messageType)) {
-				StompRelaySession session = this.relaySessions.remove(sessionId);
-				if (session == null) {
-					if (logger.isTraceEnabled()) {
-						logger.trace("Session already removed, sessionId=" + sessionId);
-					}
-					return;
-				}
-				session.forward(message);
-			}
-			else {
-				StompRelaySession session = this.relaySessions.get(sessionId);
-				if (session == null) {
-					logger.warn("Session id=" + sessionId + " not found. Ignoring message: " + message);
-					return;
-				}
-				session.forward(message);
-			}
+		if (SimpMessageType.CONNECT.equals(messageType)) {
+			message = MessageBuilder.withPayloadAndHeaders(message.getPayload(), headers).build();
+			StompRelaySession session = new StompRelaySession(sessionId);
+			this.relaySessions.put(sessionId, session);
+			session.connect(message);
 		}
-		catch (Throwable t) {
-			logger.error("Failed to handle message " + message, t);
+		else if (SimpMessageType.DISCONNECT.equals(messageType)) {
+			StompRelaySession session = this.relaySessions.remove(sessionId);
+			if (session == null) {
+				if (logger.isTraceEnabled()) {
+					logger.trace("Session already removed, sessionId=" + sessionId);
+				}
+				return;
+			}
+			session.forward(message);
+		}
+		else {
+			StompRelaySession session = this.relaySessions.get(sessionId);
+			if (session == null) {
+				logger.warn("Session id=" + sessionId + " not found. Ignoring message: " + message);
+				return;
+			}
+			session.forward(message);
 		}
 	}
 
@@ -323,7 +319,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 			publishBrokerAvailableEvent();
 		}
 
-		private void handleTcpClientFailure(String message, Throwable ex) {
+		protected void handleTcpClientFailure(String message, Throwable ex) {
 			if (logger.isErrorEnabled()) {
 				logger.error(message + ", sessionId=" + this.sessionId, ex);
 			}
@@ -348,13 +344,21 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 			messageChannel.send(message);
 		}
 
-		public void forward(Message<?> message) {
+		protected void handleForwardFailure(Message<?> message) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("Failed to forward message to the broker. message=" + message);
+			}
+		}
+
+		private void forward(Message<?> message) {
 			TcpConnection<Message<byte[]>, Message<byte[]>> tcpConnection = this.stompConnection.getReadyConnection();
 			if (tcpConnection == null) {
-				logger.warn("Connection to STOMP broker is not active, discarding message: " + message);
-				return;
+				logger.warn("Connection to STOMP broker is not active");
+				handleForwardFailure(message);
 			}
-			forwardInternal(tcpConnection, message);
+			else if (!forwardInternal(tcpConnection, message)) {
+				handleForwardFailure(message);
+			}
 		}
 
 		private boolean forwardInternal(
@@ -501,7 +505,12 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 					public void run() {
 						TcpConnection<Message<byte[]>, Message<byte[]>> connection = stompConnection.connection;
 						if (connection != null) {
-							connection.send(MessageBuilder.withPayload(heartbeatPayload).build());
+							connection.send(MessageBuilder.withPayload(heartbeatPayload).build(), new Consumer<Boolean>() {
+								@Override
+								public void accept(Boolean t) {
+									handleTcpClientFailure("Failed to send heartbeat to the broker", null);
+								}
+							});
 						}
 					}
 
@@ -536,6 +545,12 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 			else {
 				// Ignore
 			}
+		}
+
+		@Override
+		protected void handleForwardFailure(Message<?> message) {
+			super.handleForwardFailure(message);
+			throw new MessageDeliveryException(message);
 		}
 	}
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandlerIntegrationTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandlerIntegrationTests.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.BrokerAvailabilityEvent;
@@ -141,6 +142,12 @@ public class StompBrokerRelayMessageHandlerIntegrationTests {
 
 		this.relay.handleMessage(connect.message);
 		this.responseHandler.awaitAndAssert();
+	}
+
+	@Test(expected=MessageDeliveryException.class)
+	public void messageDeliverExceptionIfSystemSessionForwardFails() throws Exception {
+		StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.MESSAGE);
+		this.relay.handleMessage(MessageBuilder.withPayloadAndHeaders("test", headers).build());
 	}
 
 	@Test


### PR DESCRIPTION
Improve StompBrokerRelayMessageHandler's handling of send failures, for both heartbeats and 'normal' messages
