### PR TITLE
Issue: SPR-10919

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/JDK8BeanAnnotationOnDefaultMethodSupportTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/JDK8BeanAnnotationOnDefaultMethodSupportTests.java
@@ -1,0 +1,42 @@
+package org.springframework.context.annotation.configuration;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ *
+ * Unit tests for SPR-10919, in which a bean definition is defined by a Java 8 default method annotated with @Bean.
+ *
+ * Author: Thomas Darimont
+ *
+ * @see https://jira.springsource.org/browse/SPR-10919
+ */
+public class JDK8BeanAnnotationOnDefaultMethodSupportTests {
+
+    static class Dependency{}
+
+    interface SubConfig {
+        @Bean
+        default Dependency dependency() {
+            return new Dependency();
+        }
+    }
+
+    @Configuration
+    static class Config implements SubConfig{
+    }
+
+    @Test
+    public void beanDefinitionOnDefaultMethodShouldBeRegisteredInBeanFactory(){
+
+        AnnotationConfigApplicationContext ctxt = new AnnotationConfigApplicationContext(Config.class);
+        assertThat(ctxt.containsBean("dependency"), is(true));
+        assertThat(ctxt.getBean(Dependency.class), is(notNullValue()));
+    }
+}


### PR DESCRIPTION
Added support to ConfigurationClassParser to deal with @Bean annotated Java 8 default Methods. Introduced getInterfaces() Method to SourceClass to be able to consider @Bean annotated Bean factory methods on interfaces. Added additional processing step to doProcessConfigurationClass(…) to process information in interfaces. Introduced getRawCandidateMethods(…) to ConstructorResolver that is able to consider default Methods in addition to the previous raw candidates if executed on Java 8 or later. Added test case for feature.

All existing and new tests pass.
