### PR TITLE
Add javax.servlet.http.Part support for databinding

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderIntegrationTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.bind.support;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.mock.web.test.MockMultipartFile;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.SocketUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Brian Clozel
+ */
+public class WebRequestDataBinderIntegrationTests {
+
+	protected static String baseUrl;
+
+	protected static MediaType contentType;
+
+	private static Server jettyServer;
+
+	private RestTemplate template;
+
+	private static PartsServlet partsServlet;
+
+	private static PartListServlet partListServlet;
+
+	@Before
+	public void createTemplate() {
+		template = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+	}
+
+	@BeforeClass
+	public static void startJettyServer() throws Exception {
+		int port = SocketUtils.findAvailableTcpPort();
+		jettyServer = new Server(port);
+		baseUrl = "http://localhost:" + port;
+		ServletContextHandler handler = new ServletContextHandler();
+
+		partsServlet = new PartsServlet();
+		partListServlet = new PartListServlet();
+
+		handler.addServlet(new ServletHolder(partsServlet), "/parts");
+		handler.addServlet(new ServletHolder(partListServlet), "/partlist");
+		jettyServer.setHandler(handler);
+		jettyServer.start();
+	}
+
+	@AfterClass
+	public static void stopJettyServer() throws Exception {
+		if (jettyServer != null) {
+			jettyServer.stop();
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private abstract static class AbstractStandardMultipartServlet<T> extends HttpServlet {
+
+		private T bean;
+
+		@Override
+		public void service(HttpServletRequest request, HttpServletResponse response) throws
+				ServletException, IOException {
+
+			WebRequestDataBinder binder = new WebRequestDataBinder(bean);
+			ServletWebRequest webRequest = new ServletWebRequest(request, response);
+
+			binder.bind(webRequest);
+
+			response.setStatus(HttpServletResponse.SC_OK);
+		}
+
+		public void setBean(T bean) {
+			this.bean = bean;
+		}
+	}
+
+	private static class PartsBean {
+
+		public Part firstPart;
+
+		public Part secondPart;
+
+		public Part getFirstPart() {
+			return firstPart;
+		}
+
+		public void setFirstPart(Part firstPart) {
+			this.firstPart = firstPart;
+		}
+
+		public Part getSecondPart() {
+			return secondPart;
+		}
+
+		public void setSecondPart(Part secondPart) {
+			this.secondPart = secondPart;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static class PartsServlet extends AbstractStandardMultipartServlet<PartsBean> {
+
+	}
+
+	private static class PartListBean {
+
+		public List<Part> partList;
+
+		public List<Part> getPartList() {
+			return partList;
+		}
+
+		public void setPartList(List<Part> partList) {
+			this.partList = partList;
+		}
+	}
+
+	@SuppressWarnings("serial")
+	private static class PartListServlet extends AbstractStandardMultipartServlet<PartListBean> {
+
+	}
+
+	@Test
+	public void testPartsBinding() {
+
+		PartsBean bean = new PartsBean();
+		partsServlet.setBean(bean);
+
+		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<String, Object>();
+		MockMultipartFile firstPart = new MockMultipartFile("fileName", "aValue".getBytes());
+		parts.add("firstPart", firstPart);
+		parts.add("secondPart", "secondValue");
+
+		template.postForLocation(baseUrl + "/parts", parts);
+
+		assertNotNull(bean.getFirstPart());
+		assertNotNull(bean.getSecondPart());
+	}
+
+	@Test
+	public void testPartListBinding() {
+
+		PartListBean bean = new PartListBean();
+		partListServlet.setBean(bean);
+
+		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<String, Object>();
+		parts.add("partList", "first value");
+		parts.add("partList", "second value");
+		Resource logo = new ClassPathResource("/org/springframework/http/converter/logo.jpg");
+		parts.add("partList", logo);
+
+		template.postForLocation(baseUrl + "/partlist", parts);
+
+		assertNotNull(bean.getPartList());
+		assertEquals(parts.size(), bean.getPartList().size());
+	}
+}


### PR DESCRIPTION
This PR covers both "scenario 7" listed in [SPR-10591](https://jira.springsource.org/browse/SPR-10591).
All other scenarii have been implemented by @rstoyanchev

Prior to this commit, Multipart databinding would only support
MultiPartFile databinding using commons-multipart.

Now the WebRequestDataBinder supports Part and List<Part>
databinding for Servlet 3.0 compliant containers.

Issue: SPR-10591
