### PR TITLE
Fix MockHttpServletResponse HTTP status update

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -533,13 +533,17 @@ public class MockHttpServletResponse implements HttpServletResponse {
 
 	@Override
 	public void setStatus(int status) {
-		this.status = status;
+		if(!this.isCommitted()) {
+			this.status = status;
+		}
 	}
 
 	@Override
 	public void setStatus(int status, String errorMessage) {
-		this.status = status;
-		this.errorMessage = errorMessage;
+		if(!this.isCommitted()) {
+			this.status = status;
+			this.errorMessage = errorMessage;
+		}
 	}
 
 	@Override

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
@@ -221,4 +221,22 @@ public class MockHttpServletResponseTests {
 		assertEquals(redirectUrl, response.getRedirectedUrl());
 	}
 
+	// SPR-10414
+
+	@Test
+	public void modifyStatusAfterSendError() throws IOException {
+		response.sendError(HttpServletResponse.SC_NOT_FOUND);
+		response.setStatus(HttpServletResponse.SC_OK);
+		assertEquals(response.getStatus(),HttpServletResponse.SC_NOT_FOUND);
+	}
+
+	// SPR-10414
+
+	@Test
+	public void modifyStatusMessageAfterSendError() throws IOException {
+		response.sendError(HttpServletResponse.SC_NOT_FOUND);
+		response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,"Server Error");
+		assertEquals(response.getStatus(),HttpServletResponse.SC_NOT_FOUND);
+	}
+
 }


### PR DESCRIPTION
Prior to this commit, one could call the setStatus method on
this Mock object and update the response's status,
even though the sendError method had already been called.

According to the HttpServletResponse Javadoc, sendError() methods
commit the response; so the response can't be written after that.

This commit fixes MockHttpServletResponse's behavior; setStatus
methods do not update the status once the response has been
committed.

Issue: SPR-10414
