### PR TITLE
Add doesNotExist match to HeaderResultMatchers

### DIFF
--- a/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/result/HeaderResultMatchers.java
+++ b/spring-test-mvc/src/main/java/org/springframework/test/web/servlet/result/HeaderResultMatchers.java
@@ -70,6 +70,20 @@ public class HeaderResultMatchers {
 	}
 
 	/**
+	 * Assert that the named response header does not exist.
+	 * @since 4.0
+	 */
+	public ResultMatcher doesNotExist(final String name) {
+		return new ResultMatcher() {
+
+			@Override
+			public void match(MvcResult result) {
+				assertTrue("Response header " + name, !result.getResponse().containsHeader(name));
+			}
+		};
+	}
+
+	/**
 	 * Assert the primary value of the named response header as a {@code long}.
 	 *
 	 * <p>The {@link ResultMatcher} returned by this method throws an {@link AssertionError}

--- a/spring-test-mvc/src/test/java/org/springframework/test/web/servlet/samples/standalone/resultmatchers/HeaderAssertionTests.java
+++ b/spring-test-mvc/src/test/java/org/springframework/test/web/servlet/samples/standalone/resultmatchers/HeaderAssertionTests.java
@@ -110,6 +110,22 @@ public class HeaderAssertionTests {
 		}
 	}
 
+	// SPR-10771
+
+	@Test
+	public void doesNotExist() throws Exception {
+		this.mockMvc.perform(get("/persons/1"))
+				.andExpect(header().doesNotExist("X-Custom-Header"));
+	}
+
+	// SPR-10771
+
+	@Test(expected = AssertionError.class)
+	public void doesNotExistFail() throws Exception {
+		this.mockMvc.perform(get("/persons/1"))
+				.andExpect(header().doesNotExist(LAST_MODIFIED));
+	}
+
 	@Test
 	public void stringWithIncorrectResponseHeaderValue() throws Exception {
 		long unexpected = currentTime + 1;


### PR DESCRIPTION
Prior to this commit, one could not test for the absence of
a specific HTTP header in a response.
Using header("X-Custom-Header", Matchers.nullValue()) would not
work because it tests for an empty value of an existing header.

This commit adds a doesNotExist method on the
HeaderResultMatcher.

Issue: SPR-10771
