### PR TITLE
Add new features on @ControllerAdvice

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/ControllerAdvice.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/ControllerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,21 @@ import org.springframework.stereotype.Component;
  * {@link InitBinder @InitBinder}, and {@link ModelAttribute @ModelAttribute}
  * methods that apply to all {@link RequestMapping @RequestMapping} methods.
  *
+ * <p>One of {@link #annotations()}, {@link #basePackageClasses()},
+ * {@link #basePackages()} or its alias {@link #value()}
+ * may be specified to define specific subsets of Controllers
+ * to assist. When multiple selectors are applied, OR logic is applied -
+ * meaning selected Controllers should match at least one selector.
+ *
+ * <p>The default behavior (i.e. if used without any selector),
+ * the {@code @ControllerAdvice} annotated class will
+ * assist all known Controllers.
+ *
+ * <p>Note that those checks are done at runtime, so adding many attributes and using
+ * multiple strategies may have negative impacts (complexity, performance).
+ *
  * @author Rossen Stoyanchev
+ * @author Brian Clozel
  * @since 3.2
  */
 @Target(ElementType.TYPE)
@@ -43,4 +57,56 @@ import org.springframework.stereotype.Component;
 @Component
 public @interface ControllerAdvice {
 
+	/**
+	 * Alias for the {@link #basePackages()} attribute.
+	 * Allows for more concise annotation declarations e.g.:
+	 * {@code @ControllerAdvice("org.my.pkg")} instead of
+	 * {@code @ControllerAdvice(basePackages="org.my.pkg")}.
+	 * @since 4.0
+	 */
+	String[] value() default {};
+
+	/**
+	 * Array of base packages.
+	 * Controllers that belong to those base packages will be selected
+	 * to be assisted by the annotated class, e.g.:
+	 * {@code @ControllerAdvice(basePackages="org.my.pkg")}
+	 * {@code @ControllerAdvice(basePackages={"org.my.pkg","org.my.other.pkg"})}
+	 *
+	 * <p>{@link #value()} is an alias for this attribute.
+	 * <p>Use {@link #basePackageClasses()} for a type-safe alternative to String-based package names.
+	 * @since 4.0
+	 */
+	String[] basePackages() default {};
+
+	/**
+	 * Array of classes.
+	 * Controllers that are assignable to at least one of the given types
+	 * will be assisted by the {@code @ControllerAdvice} annotated class.
+	 * @since 4.0
+	 */
+	Class<?>[] assignableTypes() default {};
+
+
+	/**
+	 * Array of annotations.
+	 * Controllers that are annotated with this/one of those annotation(s)
+	 * will be assisted by the {@code @ControllerAdvice} annotated class.
+	 *
+	 * <p>Consider creating a special annotation or use a predefined one,
+	 * like {@link RestController @RestController}.
+	 * @since 4.0
+	 */
+	Class<?>[] annotations() default {};
+
+	/**
+	 * Type-safe alternative to {@link #value()} for specifying the packages
+	 * to select Controllers to be assisted by the {@code @ControllerAdvice}
+	 * annotated class.
+	 *
+	 * <p>Consider creating a special no-op marker class or interface in each package
+	 * that serves no purpose other than being referenced by this attribute.
+	 * @since 4.0
+	 */
+	Class<?>[] basePackageClasses() default {};
 }

--- a/spring-web/src/test/java/org/springframework/web/method/ControllerAdviceBeanTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/ControllerAdviceBeanTests.java
@@ -1,0 +1,144 @@
+package org.springframework.web.method;
+
+import org.junit.Test;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Brian Clozel
+ */
+public class ControllerAdviceBeanTests {
+
+	@Test
+	public void shouldMatchAll() {
+		ControllerAdviceBean bean = new ControllerAdviceBean(new SimpleControllerAdvice());
+		assertApplicable("should match all", bean, AnnotatedController.class);
+		assertApplicable("should match all", bean, ImplementationController.class);
+		assertApplicable("should match all", bean, InheritanceController.class);
+		assertApplicable("should match all", bean, String.class);
+	}
+
+	@Test
+	public void basePackageSupport() {
+		ControllerAdviceBean bean = new ControllerAdviceBean(new BasePackageSupport());
+		assertApplicable("base package support", bean, AnnotatedController.class);
+		assertApplicable("base package support", bean, ImplementationController.class);
+		assertApplicable("base package support", bean, InheritanceController.class);
+		assertNotApplicable("bean not in package", bean, String.class);
+	}
+
+	@Test
+	public void basePackageValueSupport() {
+		ControllerAdviceBean bean = new ControllerAdviceBean(new BasePackageValueSupport());
+		assertApplicable("base package support", bean, AnnotatedController.class);
+		assertApplicable("base package support", bean, ImplementationController.class);
+		assertApplicable("base package support", bean, InheritanceController.class);
+		assertNotApplicable("bean not in package", bean, String.class);
+	}
+
+	@Test
+	public void annotationSupport() {
+		ControllerAdviceBean bean = new ControllerAdviceBean(new AnnotationSupport());
+		assertApplicable("annotation support", bean, AnnotatedController.class);
+		assertNotApplicable("this bean is not annotated", bean, InheritanceController.class);
+	}
+
+	@Test
+	public void markerClassSupport() {
+		ControllerAdviceBean bean = new ControllerAdviceBean(new MarkerClassSupport());
+		assertApplicable("base package class support", bean, AnnotatedController.class);
+		assertApplicable("base package class support", bean, ImplementationController.class);
+		assertApplicable("base package class support", bean, InheritanceController.class);
+		assertNotApplicable("bean not in package", bean, String.class);
+	}
+
+	@Test
+	public void shouldNotMatch() {
+		ControllerAdviceBean bean = new ControllerAdviceBean(new ShouldNotMatch());
+		assertNotApplicable("should not match", bean, AnnotatedController.class);
+		assertNotApplicable("should not match", bean, ImplementationController.class);
+		assertNotApplicable("should not match", bean, InheritanceController.class);
+		assertNotApplicable("should not match", bean, String.class);
+	}
+
+	@Test
+	public void assignableTypesSupport() {
+		ControllerAdviceBean bean = new ControllerAdviceBean(new AssignableTypesSupport());
+		assertApplicable("controller implements assignable", bean, ImplementationController.class);
+		assertApplicable("controller inherits assignable", bean, InheritanceController.class);
+		assertNotApplicable("not assignable", bean, AnnotatedController.class);
+		assertNotApplicable("not assignable", bean, String.class);
+	}
+
+	@Test
+	public void multipleMatch() {
+		ControllerAdviceBean bean = new ControllerAdviceBean(new MultipleSelectorsSupport());
+		assertApplicable("controller implements assignable", bean, ImplementationController.class);
+		assertApplicable("controller is annotated", bean, AnnotatedController.class);
+		assertNotApplicable("should not match", bean, InheritanceController.class);
+	}
+
+	private void assertApplicable(String message, ControllerAdviceBean controllerAdvice,
+	                              Class<?> controllerBeanType) {
+		assertNotNull(controllerAdvice);
+		assertTrue(message,controllerAdvice.isApplicableToBeanType(controllerBeanType));
+	}
+
+	private void assertNotApplicable(String message, ControllerAdviceBean controllerAdvice,
+	                              Class<?> controllerBeanType) {
+		assertNotNull(controllerAdvice);
+		assertFalse(message,controllerAdvice.isApplicableToBeanType(controllerBeanType));
+	}
+
+	// ControllerAdvice classes
+
+	@ControllerAdvice
+	static class SimpleControllerAdvice {}
+
+	@ControllerAdvice(annotations = ControllerAnnotation.class)
+	static class AnnotationSupport {}
+
+	@ControllerAdvice(basePackageClasses = MarkerClass.class)
+	static class MarkerClassSupport {}
+
+	@ControllerAdvice(assignableTypes = {ControllerInterface.class,
+			AbstractController.class})
+	static class AssignableTypesSupport {}
+
+	@ControllerAdvice(basePackages = "org.springframework.web.method")
+	static class BasePackageSupport {}
+
+	@ControllerAdvice("org.springframework.web.method")
+	static class BasePackageValueSupport {}
+
+	@ControllerAdvice(annotations = ControllerAnnotation.class,
+			assignableTypes = ControllerInterface.class)
+	static class MultipleSelectorsSupport {}
+
+	@ControllerAdvice(basePackages = "java.util",
+			annotations = RestController.class)
+	static class ShouldNotMatch {}
+
+	// Support classes
+
+	static class MarkerClass {}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface ControllerAnnotation {}
+
+	@ControllerAnnotation
+	public static class AnnotatedController {}
+
+	static interface ControllerInterface {}
+
+	static class ImplementationController implements ControllerInterface {}
+
+	static abstract class AbstractController {}
+
+	static class InheritanceController extends AbstractController {}
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -351,8 +351,8 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 	 * @return a method to handle the exception, or {@code null}
 	 */
 	protected ServletInvocableHandlerMethod getExceptionHandlerMethod(HandlerMethod handlerMethod, Exception exception) {
+		Class<?> handlerType = (handlerMethod != null) ? handlerMethod.getBeanType() : null;
 		if (handlerMethod != null) {
-			Class<?> handlerType = handlerMethod.getBeanType();
 			ExceptionHandlerMethodResolver resolver = this.exceptionHandlerCache.get(handlerType);
 			if (resolver == null) {
 				resolver = new ExceptionHandlerMethodResolver(handlerType);
@@ -364,9 +364,11 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 			}
 		}
 		for (Entry<ControllerAdviceBean, ExceptionHandlerMethodResolver> entry : this.exceptionHandlerAdviceCache.entrySet()) {
-			Method method = entry.getValue().resolveMethod(exception);
-			if (method != null) {
-				return new ServletInvocableHandlerMethod(entry.getKey().resolveBean(), method);
+			if(entry.getKey().isApplicableToBeanType(handlerType)) {
+				Method method = entry.getValue().resolveMethod(exception);
+				if (method != null) {
+					return new ServletInvocableHandlerMethod(entry.getKey().resolveBean(), method);
+				}
 			}
 		}
 		return null;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -776,9 +776,11 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter i
 		List<InvocableHandlerMethod> attrMethods = new ArrayList<InvocableHandlerMethod>();
 		// Global methods first
 		for (Entry<ControllerAdviceBean, Set<Method>> entry : this.modelAttributeAdviceCache.entrySet()) {
-			Object bean = entry.getKey().resolveBean();
-			for (Method method : entry.getValue()) {
-				attrMethods.add(createModelAttributeMethod(binderFactory, bean, method));
+			if(entry.getKey().isApplicableToBeanType(handlerType)) {
+				Object bean = entry.getKey().resolveBean();
+				for (Method method : entry.getValue()) {
+					attrMethods.add(createModelAttributeMethod(binderFactory, bean, method));
+				}
 			}
 		}
 		for (Method method : methods) {
@@ -806,9 +808,11 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter i
 		List<InvocableHandlerMethod> initBinderMethods = new ArrayList<InvocableHandlerMethod>();
 		// Global methods first
 		for (Entry<ControllerAdviceBean, Set<Method>> entry : this.initBinderAdviceCache .entrySet()) {
-			Object bean = entry.getKey().resolveBean();
-			for (Method method : entry.getValue()) {
-				initBinderMethods.add(createInitBinderMethod(bean, method));
+			if(entry.getKey().isApplicableToBeanType(handlerType)) {
+				Object bean = entry.getKey().resolveBean();
+				for (Method method : entry.getValue()) {
+					initBinderMethods.add(createInitBinderMethod(bean, method));
+				}
 			}
 		}
 		for (Method method : methods) {


### PR DESCRIPTION
Prior to this commit, @ControllerAdvice annotated beans would
assist all known Controllers, by applying @ExceptionHandler,
@InitBinder, and @ModelAttribute.

This commit updates the @ControllerAdvice annotation,
which accepts now base package names, assignableTypes,
annotations and basePackageClasses.

If attributes are set, only Controllers that match those
selectors will be assisted by the annotated class.
This commit does not change the default behavior when
no value is set, i.e. @ControllerAdvice().

Issue: SPR-10222
