### PR TITLE
Add overloads in HtmlUtils to allow for encoding aware behavior.

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityReferences.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityReferences.java
@@ -106,19 +106,44 @@ class HtmlCharacterEntityReferences {
 	/**
 	 * Return true if the given character is mapped to a supported entity reference.
 	 */
-	public boolean isMappedToReference(char character) {
+	public boolean isMappedToReference(char character, String encoding) {
 		return (convertToReference(character) != null);
 	}
 
 	/**
 	 * Return the reference mapped to the given character or {@code null}.
 	 */
-	public String convertToReference(char character) {
-		if (character < 1000 || (character >= 8000 && character < 10000)) {
-			int index = (character < 1000 ? character : character - 7000);
-			String entityReference = this.characterToEntityReferenceMap[index];
-			if (entityReference != null) {
-				return entityReference;
+	public String convertToReference(char character, String encoding) {
+		if(encoding.startsWith("UTF-")){
+			// There are only 5 characters to handle, so just do it inline
+			switch(character){
+			case '<':
+				return "&lt;";
+				break;
+			case '>:
+				return "&gt;";
+				break;
+			case '"':
+				return "&quot;";
+				break;
+			case '&':
+				return "&amp;";
+				break;
+			case '\'':
+				// XML defines the &apos;, but HTML 4 does not.
+				// To ensure backwards compatibility use &#39; instead
+				// as recommended by the XHTML specification, see
+				// http://www.w3.org/TR/2002/REC-xhtml1-20020801/#C_16
+				return "&#39;";
+				break;
+			}
+		}else{
+			if (character < 1000 || (character >= 8000 && character < 10000)) {
+				int index = (character < 1000 ? character : character - 7000);
+				String entityReference = this.characterToEntityReferenceMap[index];
+				if (entityReference != null) {
+					return entityReference;
+				}
 			}
 		}
 		return null;

--- a/spring-web/src/main/java/org/springframework/web/util/HtmlUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlUtils.java
@@ -37,11 +37,14 @@ package org.springframework.web.util;
  */
 public abstract class HtmlUtils {
 
+	private final static String DEFAULT_ENCODING = "ISO-8859-1";
+
 	/**
 	 * Shared instance of pre-parsed HTML character entity references.
 	 */
 	private static final HtmlCharacterEntityReferences characterEntityReferences =
 			new HtmlCharacterEntityReferences();
+
 
 
 	/**
@@ -57,13 +60,35 @@ public abstract class HtmlUtils {
 	 * @return the escaped string
 	 */
 	public static String htmlEscape(String input) {
+		return htmlEscape(input, DEFAULT_ENCODING);
+	}
+
+	/**
+	 * Turn special characters into HTML character references.
+	 * Handles complete character set defined in HTML 4.01 recommendation.
+	 * <p>Escapes all special characters to their corresponding
+	 * entity reference (e.g. {@code &lt;}) at least as required by the
+	 * specified encoding. In other words, if a special character does
+	 * not have to be escaped for the given encoding, it may not be.
+	 * <p>Reference:
+	 * <a href="http://www.w3.org/TR/html4/sgml/entities.html">
+	 * http://www.w3.org/TR/html4/sgml/entities.html
+	 * </a>
+	 * @param input the (unescaped) input string
+	 * @param encoding The name of a supported {@link java.nio.charset.Charset charset}
+	 * @return the escaped string
+	 */
+	public static String htmlEscape(String input, String encoding) {
+		if (encoding == null) {
+			throw new IllegalArgumentException("encoding is required");
+		}
 		if (input == null) {
 			return null;
 		}
 		StringBuilder escaped = new StringBuilder(input.length() * 2);
 		for (int i = 0; i < input.length(); i++) {
 			char character = input.charAt(i);
-			String reference = characterEntityReferences.convertToReference(character);
+			String reference = characterEntityReferences.convertToReference(character, encoding);
 			if (reference != null) {
 				escaped.append(reference);
 			}
@@ -87,13 +112,34 @@ public abstract class HtmlUtils {
 	 * @return the escaped string
 	 */
 	public static String htmlEscapeDecimal(String input) {
+		return htmlEscapeDecimal(input, DEFAULT_ENCODING);
+	}
+
+	/**
+	 * Turn special characters into HTML character references.
+	 * Handles complete character set defined in HTML 4.01 recommendation.
+	 * <p>Escapes all special characters to their corresponding numeric
+	 * reference in decimal format (&#<i>Decimal</i>;) at least as required by the
+	 * specified encoding. In other words, if a special character does
+	 * not have to be escaped for the given encoding, it may not be.
+	 * <p>Reference:
+	 * <a href="http://www.w3.org/TR/html4/sgml/entities.html">
+	 * http://www.w3.org/TR/html4/sgml/entities.html
+	 * </a>
+	 * @param input the (unescaped) input string
+	 * @return the escaped string
+	 */
+	public static String htmlEscapeDecimal(String input, String encoding) {
+		if (encoding == null) {
+			throw new IllegalArgumentException("encoding is required");
+		}
 		if (input == null) {
 			return null;
 		}
 		StringBuilder escaped = new StringBuilder(input.length() * 2);
 		for (int i = 0; i < input.length(); i++) {
 			char character = input.charAt(i);
-			if (characterEntityReferences.isMappedToReference(character)) {
+			if (characterEntityReferences.isMappedToReference(character, encoding)) {
 				escaped.append(HtmlCharacterEntityReferences.DECIMAL_REFERENCE_START);
 				escaped.append((int) character);
 				escaped.append(HtmlCharacterEntityReferences.REFERENCE_END);
@@ -118,13 +164,34 @@ public abstract class HtmlUtils {
 	 * @return the escaped string
 	 */
 	public static String htmlEscapeHex(String input) {
+		return htmlEscapeHex(input, DEFAULT_ENCODING);
+	}
+
+	/**
+	 * Turn special characters into HTML character references.
+	 * Handles complete character set defined in HTML 4.01 recommendation.
+	 * <p>Escapes all special characters to their corresponding numeric
+	 * reference in hex format (&#x<i>Hex</i>;) at least as required by the
+	 * specified encoding. In other words, if a special character does
+	 * not have to be escaped for the given encoding, it may not be.
+	 * <p>Reference:
+	 * <a href="http://www.w3.org/TR/html4/sgml/entities.html">
+	 * http://www.w3.org/TR/html4/sgml/entities.html
+	 * </a>
+	 * @param input the (unescaped) input string
+	 * @return the escaped string
+	 */
+	public static String htmlEscapeHex(String input, String encoding) {
+		if (encoding == null) {
+			throw new IllegalArgumentException("encoding is required")
+		}
 		if (input == null) {
 			return null;
 		}
 		StringBuilder escaped = new StringBuilder(input.length() * 2);
 		for (int i = 0; i < input.length(); i++) {
 			char character = input.charAt(i);
-			if (characterEntityReferences.isMappedToReference(character)) {
+			if (characterEntityReferences.isMappedToReference(character, encoding)) {
 				escaped.append(HtmlCharacterEntityReferences.HEX_REFERENCE_START);
 				escaped.append(Integer.toString(character, 16));
 				escaped.append(HtmlCharacterEntityReferences.REFERENCE_END);


### PR DESCRIPTION
Based on the encoding, in many cases, many characters do not need to be transformed into entities.
For instance, when the encoding is UTF-8, there are only 5 characters that needs to become entities
and shouldn't appear in their literal forms.

See SPR-9293
