### PR TITLE
SPR-10953 fix LiteralExpression.getValue with ctx

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/common/LiteralExpression.java
+++ b/spring-expression/src/main/java/org/springframework/expression/common/LiteralExpression.java
@@ -27,7 +27,7 @@ import org.springframework.expression.TypedValue;
  * string literal. It is used with CompositeStringExpression when representing a template
  * expression which is made up of pieces - some being real expressions to be handled by an
  * EL implementation like Spel, and some being just textual elements.
- * 
+ *
  * @author Andy Clement
  * @since 3.0
  */
@@ -118,7 +118,7 @@ public class LiteralExpression implements Expression {
 	@Override
 	public <T> T getValue(EvaluationContext context, Object rootObject, Class<T> desiredResultType) throws EvaluationException {
 		Object value = getValue(context, rootObject);
-		return ExpressionUtils.convertTypedValue(null, new TypedValue(value), desiredResultType);
+		return ExpressionUtils.convertTypedValue(context, new TypedValue(value), desiredResultType);
 	}
 
 	@Override

--- a/spring-expression/src/test/java/org/springframework/expression/spel/LiteralExpressionTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/LiteralExpressionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,11 +42,14 @@ public class LiteralExpressionTests {
 		checkString("somevalue", lEx.getValue(new Rooty()));
 		checkString("somevalue", lEx.getValue(new Rooty(), String.class));
 		checkString("somevalue", lEx.getValue(ctx, new Rooty()));
-		checkString("somevalue", lEx.getValue(ctx, new Rooty(),String.class));
+		checkString("somevalue", lEx.getValue(ctx, new Rooty(), String.class));
 		assertEquals("somevalue", lEx.getExpressionString());
 		assertFalse(lEx.isWritable(new StandardEvaluationContext()));
 		assertFalse(lEx.isWritable(new Rooty()));
 		assertFalse(lEx.isWritable(new StandardEvaluationContext(), new Rooty()));
+
+		lEx = new LiteralExpression("1");
+		assertEquals(new Integer(1), lEx.getValue(ctx, new Rooty(), Integer.class));
 	}
 
 	static class Rooty {}


### PR DESCRIPTION
Propagate `EvaluationContext` to the the conversion function
in the `LiteralExpression.getValue(EvaluationContext, Object , Class<T>)` method

JIRA: https://jira.springsource.org/browse/SPR-10953
