### PR TITLE
Change validate() overloaded methods check (SPR-11025)

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/Spr11025Test.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/Spr11025Test.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * Test Configuration class overloaded methods by inheritance
+ * 
+ * @author Jose Luis Martin
+ */
+public class Spr11025Test {
+
+	@Test
+	public void testBeanMethodOverloading() {
+		try {
+			AnnotationConfigApplicationContext ctx = 
+					new AnnotationConfigApplicationContext(OverloadingConfig.class);
+			ctx.close();
+			Assert.fail("Accepted invalid overloaded configuration");
+			
+		}
+		catch(BeanDefinitionParsingException bdpe) {
+			// pass
+		}
+	}
+	
+	@Test
+	public void testBeanMethodOverriding() {
+		
+		AnnotationConfigApplicationContext ctx = 
+				new AnnotationConfigApplicationContext(OverridingConfig.class);
+		ctx.close();
+	}
+
+	@Configuration
+	public static class ParentConfig {
+
+		@Bean
+		public String bean() {
+			return "parentBean";
+		}
+
+	}
+
+	@Configuration
+	public static class OverridingConfig extends ParentConfig {
+
+
+		@Bean
+		public String bean() {
+			return "overriden";
+		}
+
+	}
+	
+	@Configuration
+	public static class OverloadingConfig extends ParentConfig {
+
+
+		@Bean
+		public String bean(String arg) {
+			return "overriden";
+		}
+
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/MethodMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/MethodMetadata.java
@@ -56,5 +56,12 @@ public interface MethodMetadata extends AnnotatedTypeMetadata {
 	 * i.e. not marked as static, final or private.
 	 */
 	boolean isOverridable();
+	
+	/** 
+	 * Returns an array of strings that represent the formal parameter types
+	 * in declaration order. 
+	 */
+	String[] getParameterTypes();
+
 
 }

--- a/spring-core/src/main/java/org/springframework/core/type/StandardMethodMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/StandardMethodMetadata.java
@@ -126,4 +126,16 @@ public class StandardMethodMetadata implements MethodMetadata {
 				annotationType, classValuesAsString, this.nestedAnnotationsAsMap);
 	}
 
+	@Override
+	public String[] getParameterTypes() {
+		Class<?>[] parameterTypes = getIntrospectedMethod().getParameterTypes();
+		String[] values = new String[parameterTypes.length];
+		
+		for (int i = 0; i < parameterTypes.length; i++) {
+			values[i] = parameterTypes[i].getName();
+		}
+		
+		return values;
+	}
+
 }

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/AnnotationMetadataReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/AnnotationMetadataReadingVisitor.java
@@ -64,7 +64,8 @@ public class AnnotationMetadataReadingVisitor extends ClassMetadataReadingVisito
 
 	@Override
 	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-		return new MethodMetadataReadingVisitor(name, access, this.getClassName(), this.classLoader, this.methodMetadataMap);
+		return new MethodMetadataReadingVisitor(name, access, desc, this.getClassName(), this.classLoader, 
+				this.methodMetadataMap);
 	}
 
 	@Override

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/MethodMetadataReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/MethodMetadataReadingVisitor.java
@@ -54,10 +54,12 @@ public class MethodMetadataReadingVisitor extends MethodVisitor implements Metho
 	protected final MultiValueMap<String, MethodMetadata> methodMetadataMap;
 
 	protected final MultiValueMap<String, AnnotationAttributes> attributeMap = new LinkedMultiValueMap<String, AnnotationAttributes>(2);
+	
+	protected final String[] parameterTypes;
 
 
-	public MethodMetadataReadingVisitor(String name, int access, String declaringClassName, ClassLoader classLoader,
-			MultiValueMap<String, MethodMetadata> methodMetadataMap) {
+	public MethodMetadataReadingVisitor(String name, int access, String desc, String declaringClassName,
+			ClassLoader classLoader, MultiValueMap<String, MethodMetadata> methodMetadataMap) {
 
 		super(SpringAsmInfo.ASM_VERSION);
 		this.name = name;
@@ -65,9 +67,20 @@ public class MethodMetadataReadingVisitor extends MethodVisitor implements Metho
 		this.declaringClassName = declaringClassName;
 		this.classLoader = classLoader;
 		this.methodMetadataMap = methodMetadataMap;
+		this.parameterTypes = convertParameters(desc);
 	}
 
-
+	private String[] convertParameters(String desc) {
+		Type[] types = Type.getArgumentTypes(desc);
+		String[] values = new String[types.length];
+		
+		for (int i = 0; i < types.length; i++) {
+			values[i] = types[i].getClassName();
+		}
+		
+		return values;
+	}
+	
 	@Override
 	public AnnotationVisitor visitAnnotation(final String desc, boolean visible) {
 		String className = Type.getType(desc).getClassName();
@@ -137,6 +150,12 @@ public class MethodMetadataReadingVisitor extends MethodVisitor implements Metho
 	@Override
 	public String getDeclaringClassName() {
 		return this.declaringClassName;
+	}
+
+
+	@Override
+	public String[] getParameterTypes() {
+		return parameterTypes;
 	}
 
 }


### PR DESCRIPTION
When checking for overloaded methods, ConfigurationClass.validate()
don't take in account overloaded methods from superclasses.

The check was updated with the following steps
- Add getParamerTypes to MethodMetadata interface
- Split beanMethods Set into Lists by method name
- For each bean method list, test that all have the same parameters
- add Spr11025Test

Issue: SPR-11025
