### PR TITLE
Add support for WebSocket Protocol Extensions

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/websocket/SubProtocolHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/websocket/SubProtocolHandler.java
@@ -69,7 +69,7 @@ public interface SubProtocolHandler {
 	/**
 	 * Resolve the session id from the given message or return {@code null}.
 	 *
-	 * @param the message to resolve the session id from
+	 * @param message the message to resolve the session id from
 	 */
 	String resolveSessionId(Message<?> message);
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketExtension.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketExtension.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.socket;
+
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.LinkedCaseInsensitiveMap;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * WebSocket Protocol extension.
+ * Adds new protocol features to the WebSocket protocol; the extensions used
+ * within a session are negotiated during the handshake phase:
+ * <ul>
+ * <li>the client may ask for specific extensions in the HTTP request</li>
+ * <li>the server declares the final list of supported extensions for the current session in the HTTP response</li>
+ * </ul>
+ *
+ * <p>WebSocket Extension HTTP headers may include parameters and follow
+ * <a href="https://tools.ietf.org/html/rfc2616#section-4.2">RFC 2616 Section 4.2</a>
+ * specifications.</p>
+ *
+ * <p>Note that the order of extensions in HTTP headers defines their order of execution,
+ * e.g. extensions "foo, bar" will be executed as "bar(foo(message))".</p>
+ *
+ * @author Brian Clozel
+ * @since 4.0
+ * @see <a href="https://tools.ietf.org/html/rfc6455#section-9">
+ *     WebSocket Protocol Extensions, RFC 6455 - Section 9</a>
+ */
+public class WebSocketExtension {
+
+	private final String name;
+
+	private final Map<String, String> parameters;
+
+	public WebSocketExtension(String name) {
+		this(name,null);
+	}
+
+	public WebSocketExtension(String name, Map<String, String> parameters) {
+		Assert.hasLength(name, "extension name must not be empty");
+		this.name = name;
+		if (!CollectionUtils.isEmpty(parameters)) {
+			Map<String, String> m = new LinkedCaseInsensitiveMap<String>(parameters.size(), Locale.ENGLISH);
+			m.putAll(parameters);
+			this.parameters = Collections.unmodifiableMap(m);
+		}
+		else {
+			this.parameters = Collections.emptyMap();
+		}
+	}
+
+	/**
+	 * @return the name of the extension
+	 */
+	public String getName() {
+		return this.name;
+	}
+
+	/**
+	 * @return the parameters of the extension
+	 */
+	public Map<String, String> getParameters() {
+		return this.parameters;
+	}
+
+	/**
+	 * Parse a list of raw WebSocket extension headers
+	 */
+	public static List<WebSocketExtension> parseHeaders(List<String> headers) {
+		if (headers == null || headers.isEmpty()) {
+			return Collections.emptyList();
+		}
+		else {
+			List<WebSocketExtension> result = new ArrayList<WebSocketExtension>(headers.size());
+			for (String header : headers) {
+				result.addAll(parseHeader(header));
+			}
+			return result;
+		}
+	}
+
+	/**
+	 * Parse a raw WebSocket extension header
+	 */
+	public static List<WebSocketExtension> parseHeader(String header) {
+		if (header == null || !StringUtils.hasText(header)) {
+			return Collections.emptyList();
+		}
+		else {
+			List<WebSocketExtension> result = new ArrayList<WebSocketExtension>();
+			for(String token : header.split(",")) {
+				result.add(parse(token));
+			}
+			return result;
+		}
+	}
+
+	private static WebSocketExtension parse(String extension) {
+		Assert.doesNotContain(extension,",","this string contains multiple extension declarations");
+		String[] parts = StringUtils.tokenizeToStringArray(extension, ";");
+		String name = parts[0].trim();
+
+		Map<String, String> parameters = null;
+		if (parts.length > 1) {
+			parameters = new LinkedHashMap<String, String>(parts.length - 1);
+			for (int i = 1; i < parts.length; i++) {
+				String parameter = parts[i];
+				int eqIndex = parameter.indexOf('=');
+				if (eqIndex != -1) {
+					String attribute = parameter.substring(0, eqIndex);
+					String value = parameter.substring(eqIndex + 1, parameter.length());
+					parameters.put(attribute, value);
+				}
+			}
+		}
+
+		return new WebSocketExtension(name,parameters);
+	}
+
+	/**
+	 * Convert a list of WebSocketExtensions to a list of String,
+	 * which is convenient for native HTTP headers.
+	 */
+	public static List<String> toStringList(List<WebSocketExtension> extensions) {
+		List<String> result = new ArrayList<String>(extensions.size());
+		for(WebSocketExtension extension : extensions) {
+			result.add(extension.toString());
+		}
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder str = new StringBuilder();
+		str.append(this.name);
+		for (String param : parameters.keySet()) {
+			str.append(';');
+			str.append(param);
+			str.append('=');
+			str.append(this.parameters.get(param));
+		}
+		return str.toString();
+	}
+}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketSession.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
@@ -78,6 +79,12 @@ public interface WebSocketSession {
 	 * negotiated successfully.
 	 */
 	String getAcceptedProtocol();
+
+	/**
+	 * Return the negotiated extensions or {@code null} if none was specified or
+	 * negotiated successfully.
+	 */
+	List<WebSocketExtension> getExtensions();
 
 	/**
 	 * Return whether the connection is still open.

--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/JettyWebSocketSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/JettyWebSocketSession.java
@@ -20,8 +20,11 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.socket.BinaryMessage;
@@ -29,6 +32,7 @@ import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.PingMessage;
 import org.springframework.web.socket.PongMessage;
 import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.WebSocketSession;
 
 /**
@@ -41,6 +45,8 @@ import org.springframework.web.socket.WebSocketSession;
 public class JettyWebSocketSession extends AbstractWebSocketSesssion<org.eclipse.jetty.websocket.api.Session> {
 
 	private HttpHeaders headers;
+
+	private List<WebSocketExtension> extensions;
 
 	private final Principal principal;
 
@@ -102,6 +108,18 @@ public class JettyWebSocketSession extends AbstractWebSocketSesssion<org.eclipse
 	public String getAcceptedProtocol() {
 		checkNativeSessionInitialized();
 		return getNativeSession().getUpgradeResponse().getAcceptedSubProtocol();
+	}
+
+	@Override
+	public List<WebSocketExtension> getExtensions() {
+		checkNativeSessionInitialized();
+		if(this.extensions == null) {
+			this.extensions = new ArrayList<WebSocketExtension>();
+			for(ExtensionConfig ext : getNativeSession().getUpgradeResponse().getExtensions()) {
+				this.extensions.add(new WebSocketExtension(ext.getName(),ext.getParameters()));
+			}
+		}
+		return this.extensions;
 	}
 
 	@Override

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/RequestUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/RequestUpgradeStrategy.java
@@ -16,10 +16,12 @@
 
 package org.springframework.web.socket.server;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.WebSocketHandler;
 
 /**
@@ -35,6 +37,12 @@ public interface RequestUpgradeStrategy {
 	 * Return the supported WebSocket protocol versions.
 	 */
 	String[] getSupportedVersions();
+
+	/**
+	 * @return the list of available WebSocket protocol extensions,
+	 * implemented by the underlying WebSocket server.
+	 */
+	List<WebSocketExtension> getAvailableExtensions(ServerHttpRequest request);
 
 	/**
 	 * Perform runtime specific steps to complete the upgrade. Invoked after successful

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/config/WebSocketConfigurer.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/config/WebSocketConfigurer.java
@@ -16,8 +16,7 @@
 
 package org.springframework.web.socket.server.config;
 
-import org.eclipse.jetty.websocket.server.WebSocketHandler;
-
+import org.springframework.web.socket.WebSocketHandler;
 
 
 /**

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/AbstractStandardUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/AbstractStandardUpgradeStrategy.java
@@ -17,15 +17,18 @@
 package org.springframework.web.socket.server.support;
 
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.websocket.Endpoint;
+import javax.websocket.Extension;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.adapter.StandardWebSocketHandlerAdapter;
 import org.springframework.web.socket.adapter.StandardWebSocketSession;
@@ -61,5 +64,13 @@ public abstract class AbstractStandardUpgradeStrategy implements RequestUpgradeS
 
 	protected abstract void upgradeInternal(ServerHttpRequest request, ServerHttpResponse response,
 			String selectedProtocol, Endpoint endpoint) throws HandshakeFailureException;
+
+	protected WebSocketExtension parseStandardExtension(Extension extension) {
+		Map<String, String> params = new HashMap<String,String>(extension.getParameters().size());
+		for(Extension.Parameter param : extension.getParameters()) {
+			params.put(param.getName(),param.getValue());
+		}
+		return new WebSocketExtension(extension.getName(),params);
+	}
 
 }

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/JettyRequestUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/JettyRequestUpgradeStrategy.java
@@ -17,6 +17,8 @@
 package org.springframework.web.socket.server.support;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,6 +36,7 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.util.Assert;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.adapter.JettyWebSocketHandlerAdapter;
 import org.springframework.web.socket.adapter.JettyWebSocketSession;
@@ -53,6 +56,8 @@ public class JettyRequestUpgradeStrategy implements RequestUpgradeStrategy {
 	private static final String WS_HANDLER_ATTR_NAME = JettyRequestUpgradeStrategy.class.getName() + ".WS_LISTENER";
 
 	private WebSocketServerFactory factory;
+
+	private List<WebSocketExtension> availableExtensions;
 
 
 	/**
@@ -90,6 +95,17 @@ public class JettyRequestUpgradeStrategy implements RequestUpgradeStrategy {
 	@Override
 	public String[] getSupportedVersions() {
 		return new String[] { String.valueOf(HandshakeRFC6455.VERSION) };
+	}
+
+	@Override
+	public List<WebSocketExtension> getAvailableExtensions(ServerHttpRequest request) {
+		if(this.availableExtensions == null) {
+			this.availableExtensions = new ArrayList<WebSocketExtension>();
+			for(String extensionName : this.factory.getExtensionFactory().getExtensionNames()) {
+				this.availableExtensions.add(new WebSocketExtension(extensionName));
+			}
+		}
+		return this.availableExtensions;
 	}
 
 	@Override

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/TomcatRequestUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/TomcatRequestUpgradeStrategy.java
@@ -17,8 +17,10 @@
 package org.springframework.web.socket.server.support;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.ServletContext;
@@ -26,6 +28,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.websocket.Endpoint;
+import javax.websocket.Extension;
 
 import org.apache.tomcat.websocket.server.WsServerContainer;
 import org.springframework.http.server.ServerHttpRequest;
@@ -33,6 +36,7 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.util.Assert;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.server.HandshakeFailureException;
 import org.springframework.web.socket.server.endpoint.ServerEndpointRegistration;
 import org.springframework.web.socket.server.endpoint.ServletServerContainerFactoryBean;
@@ -50,10 +54,24 @@ import org.springframework.web.socket.server.endpoint.ServletServerContainerFact
  */
 public class TomcatRequestUpgradeStrategy extends AbstractStandardUpgradeStrategy {
 
+	private List<WebSocketExtension> availableExtensions;
 
 	@Override
 	public String[] getSupportedVersions() {
 		return new String[] { "13" };
+	}
+
+	@Override
+	public List<WebSocketExtension> getAvailableExtensions(ServerHttpRequest request) {
+
+		if(this.availableExtensions == null) {
+			this.availableExtensions = new ArrayList<WebSocketExtension>();
+			HttpServletRequest servletRequest = ((ServletServerHttpRequest) request).getServletRequest();
+			for(Extension extension : getContainer(servletRequest).getInstalledExtensions()) {
+				this.availableExtensions.add(parseStandardExtension(extension));
+			}
+		}
+		return this.availableExtensions;
 	}
 
 	@Override

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/AbstractHttpSockJsSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/AbstractHttpSockJsSession.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -30,6 +31,7 @@ import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.util.Assert;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.sockjs.SockJsException;
 import org.springframework.web.socket.sockjs.SockJsTransportFailureException;
@@ -66,6 +68,7 @@ public abstract class AbstractHttpSockJsSession extends AbstractSockJsSession {
 
 	private String acceptedProtocol;
 
+	private List<WebSocketExtension> extensions;
 
 	public AbstractHttpSockJsSession(String id, SockJsServiceConfig config,
 			WebSocketHandler wsHandler, Map<String, Object> handshakeAttributes) {
@@ -116,6 +119,9 @@ public abstract class AbstractHttpSockJsSession extends AbstractSockJsSession {
 		this.remoteAddress = remoteAddress;
 	}
 
+	@Override
+	public List<WebSocketExtension> getExtensions() { return this.extensions; }
+
 	/**
 	 * Unlike WebSocket where sub-protocol negotiation is part of the
 	 * initial handshake, in HTTP transports the same negotiation must
@@ -152,6 +158,7 @@ public abstract class AbstractHttpSockJsSession extends AbstractSockJsSession {
 		this.principal = request.getPrincipal();
 		this.localAddress = request.getLocalAddress();
 		this.remoteAddress = request.getRemoteAddress();
+		this.extensions = WebSocketExtension.parseHeaders(response.getHeaders().getSecWebSocketExtensions());
 
 		try {
 			delegateConnectionEstablished();

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/WebSocketServerSockJsSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/WebSocketServerSockJsSession.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
@@ -27,6 +28,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.adapter.NativeWebSocketSession;
@@ -87,6 +89,12 @@ public class WebSocketServerSockJsSession extends AbstractSockJsSession
 	public String getAcceptedProtocol() {
 		checkDelegateSessionInitialized();
 		return this.wsSession.getAcceptedProtocol();
+	}
+
+	@Override
+	public List<WebSocketExtension> getExtensions() {
+		checkDelegateSessionInitialized();
+		return this.wsSession.getExtensions();
 	}
 
 	private void checkDelegateSessionInitialized() {

--- a/spring-websocket/src/test/java/org/springframework/web/socket/WebSocketExtensionTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/WebSocketExtensionTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test fixture for {@link WebSocketExtension}
+ * @author Brian Clozel
+ */
+public class WebSocketExtensionTests {
+
+	@Test
+	public void parseHeaderSingle() {
+		List<WebSocketExtension> extensions = WebSocketExtension.parseHeader("x-test-extension ; foo=bar");
+		assertThat(extensions, Matchers.hasSize(1));
+		WebSocketExtension extension = extensions.get(0);
+		assertEquals("x-test-extension", extension.getName());
+		assertEquals(1, extension.getParameters().size());
+		assertEquals("bar", extension.getParameters().get("foo"));
+	}
+
+	@Test
+	public void parseHeaderMultiple() {
+		List<WebSocketExtension> extensions = WebSocketExtension.parseHeader("x-foo-extension, x-bar-extension");
+		assertThat(extensions, Matchers.hasSize(2));
+		assertEquals("x-foo-extension", extensions.get(0).getName());
+		assertEquals("x-bar-extension", extensions.get(1).getName());
+	}
+
+	@Test
+	public void parseHeaders() {
+		List<String> extensions = new ArrayList<String>();
+		extensions.add("x-foo-extension, x-bar-extension");
+		extensions.add("x-test-extension");
+		List<WebSocketExtension> parsedExtensions = WebSocketExtension.parseHeaders(extensions);
+		assertThat(parsedExtensions, Matchers.hasSize(3));
+	}
+
+}

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/session/TestSockJsSession.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/session/TestSockJsSession.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.sockjs.support.frame.SockJsFrame;
 
@@ -57,6 +58,8 @@ public class TestSockJsSession extends AbstractSockJsSession {
 	private boolean cancelledHeartbeat;
 
 	private String subProtocol;
+
+	private List<WebSocketExtension> extensions = new ArrayList<WebSocketExtension>();
 
 
 	public TestSockJsSession(String sessionId, SockJsServiceConfig config,
@@ -118,7 +121,7 @@ public class TestSockJsSession extends AbstractSockJsSession {
 	}
 
 	/**
-	 * @param remoteAddress the remoteAddress to set
+	 * @param localAddress the remoteAddress to set
 	 */
 	public void setLocalAddress(InetSocketAddress localAddress) {
 		this.localAddress = localAddress;
@@ -147,6 +150,18 @@ public class TestSockJsSession extends AbstractSockJsSession {
 	public void setAcceptedProtocol(String protocol) {
 		this.subProtocol = protocol;
 	}
+
+	/**
+	 * @return the extensions
+	 */
+	@Override
+	public List<WebSocketExtension> getExtensions() { return this.extensions; }
+
+	/**
+	 *
+	 * @param extensions the extensions to set
+	 */
+	public void setExtensions(List<WebSocketExtension> extensions) { this.extensions = extensions; }
 
 	public CloseStatus getCloseStatus() {
 		return this.closeStatus;

--- a/spring-websocket/src/test/java/org/springframework/web/socket/support/TestWebSocketSession.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/support/TestWebSocketSession.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketExtension;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -50,6 +51,8 @@ public class TestWebSocketSession implements WebSocketSession {
 	private InetSocketAddress remoteAddress;
 
 	private String protocol;
+
+	private List<WebSocketExtension> extensions = new ArrayList<WebSocketExtension>();
 
 	private boolean open;
 
@@ -149,7 +152,7 @@ public class TestWebSocketSession implements WebSocketSession {
 	}
 
 	/**
-	 * @param remoteAddress the remoteAddress to set
+	 * @param localAddress the remoteAddress to set
 	 */
 	public void setLocalAddress(InetSocketAddress localAddress) {
 		this.localAddress = localAddress;
@@ -183,6 +186,18 @@ public class TestWebSocketSession implements WebSocketSession {
 	public void setAcceptedProtocol(String protocol) {
 		this.protocol = protocol;
 	}
+
+	/**
+	 * @return the extensions
+	 */
+	@Override
+	public List<WebSocketExtension> getExtensions() { return this.extensions; }
+
+	/**
+	 *
+	 * @param extensions the extensions to set
+	 */
+	public void setExtensions(List<WebSocketExtension> extensions) { this.extensions = extensions; }
 
 	/**
 	 * @return the open


### PR DESCRIPTION
This commits adds simple, overridable WebSocket Extension
filtering during the handshake phase and adds that
information in the WebSocket session.

The actual WebSocket Extension negotiation happens
within the server implementation (Glassfish, Jetty, Tomcat...),
so one can only remove requested extensions from
the list provided by the WebSocket client.

See RFC6455 Section 9.

Issue: SPR-10843
