### PR TITLE
Provide meta-annotation support in the TCF

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
@@ -285,9 +285,8 @@ public abstract class AnnotationUtils {
 	 * <p>The standard {@link Class} API does not provide a mechanism for determining which class
 	 * in an inheritance hierarchy actually declares an {@link Annotation}, so we need to handle
 	 * this explicitly.
-	 * @param annotationType the Class object corresponding to the annotation type
-	 * @param clazz the Class object corresponding to the class on which to check for the annotation,
-	 * or {@code null}
+	 * @param annotationType the annotation class to look for, both locally and as a meta-annotation
+	 * @param clazz the class on which to check for the annotation, or {@code null}
 	 * @return the first {@link Class} in the inheritance hierarchy of the specified {@code clazz}
 	 * which declares an annotation for the specified {@code annotationType}, or {@code null}
 	 * if not found
@@ -314,14 +313,6 @@ public abstract class AnnotationUtils {
 				if (declaringClass != null) {
 					return declaringClass;
 				}
-			}
-		}
-
-		// Declared on an interface?
-		for (Class<?> ifc : clazz.getInterfaces()) {
-			Class<?> declaringClass = findAnnotationDeclaringClass(annotationType, ifc);
-			if (declaringClass != null) {
-				return declaringClass;
 			}
 		}
 

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
@@ -301,8 +301,32 @@ public abstract class AnnotationUtils {
 		if (clazz == null || clazz.equals(Object.class)) {
 			return null;
 		}
-		return (isAnnotationDeclaredLocally(annotationType, clazz)) ? clazz : findAnnotationDeclaringClass(
-			annotationType, clazz.getSuperclass());
+
+		// Declared locally?
+		if (isAnnotationDeclaredLocally(annotationType, clazz)) {
+			return clazz;
+		}
+
+		// Declared on a stereotype annotation (i.e., as a meta-annotation)?
+		if (!Annotation.class.isAssignableFrom(clazz)) {
+			for (Annotation stereotype : clazz.getAnnotations()) {
+				Class<?> declaringClass = findAnnotationDeclaringClass(annotationType, stereotype.annotationType());
+				if (declaringClass != null) {
+					return declaringClass;
+				}
+			}
+		}
+
+		// Declared on an interface?
+		for (Class<?> ifc : clazz.getInterfaces()) {
+			Class<?> declaringClass = findAnnotationDeclaringClass(annotationType, ifc);
+			if (declaringClass != null) {
+				return declaringClass;
+			}
+		}
+
+		// Declared on a superclass?
+		return findAnnotationDeclaringClass(annotationType, clazz.getSuperclass());
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
@@ -117,7 +117,8 @@ public class AnnotationUtilsTests {
 		// inherited class-level annotation; note: @Transactional is inherited
 		assertEquals(InheritedAnnotationInterface.class,
 			findAnnotationDeclaringClass(Transactional.class, InheritedAnnotationInterface.class));
-		assertNull(findAnnotationDeclaringClass(Transactional.class, SubInheritedAnnotationInterface.class));
+		assertEquals(InheritedAnnotationInterface.class,
+			findAnnotationDeclaringClass(Transactional.class, SubInheritedAnnotationInterface.class));
 		assertEquals(InheritedAnnotationClass.class,
 			findAnnotationDeclaringClass(Transactional.class, InheritedAnnotationClass.class));
 		assertEquals(InheritedAnnotationClass.class,
@@ -127,7 +128,8 @@ public class AnnotationUtilsTests {
 		// but findAnnotationDeclaringClass() should still find it on classes.
 		assertEquals(NonInheritedAnnotationInterface.class,
 			findAnnotationDeclaringClass(Order.class, NonInheritedAnnotationInterface.class));
-		assertNull(findAnnotationDeclaringClass(Order.class, SubNonInheritedAnnotationInterface.class));
+		assertEquals(NonInheritedAnnotationInterface.class,
+			findAnnotationDeclaringClass(Order.class, SubNonInheritedAnnotationInterface.class));
 		assertEquals(NonInheritedAnnotationClass.class,
 			findAnnotationDeclaringClass(Order.class, NonInheritedAnnotationClass.class));
 		assertEquals(NonInheritedAnnotationClass.class,

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
@@ -117,8 +117,7 @@ public class AnnotationUtilsTests {
 		// inherited class-level annotation; note: @Transactional is inherited
 		assertEquals(InheritedAnnotationInterface.class,
 			findAnnotationDeclaringClass(Transactional.class, InheritedAnnotationInterface.class));
-		assertEquals(InheritedAnnotationInterface.class,
-			findAnnotationDeclaringClass(Transactional.class, SubInheritedAnnotationInterface.class));
+		assertNull(findAnnotationDeclaringClass(Transactional.class, SubInheritedAnnotationInterface.class));
 		assertEquals(InheritedAnnotationClass.class,
 			findAnnotationDeclaringClass(Transactional.class, InheritedAnnotationClass.class));
 		assertEquals(InheritedAnnotationClass.class,
@@ -128,8 +127,7 @@ public class AnnotationUtilsTests {
 		// but findAnnotationDeclaringClass() should still find it on classes.
 		assertEquals(NonInheritedAnnotationInterface.class,
 			findAnnotationDeclaringClass(Order.class, NonInheritedAnnotationInterface.class));
-		assertEquals(NonInheritedAnnotationInterface.class,
-			findAnnotationDeclaringClass(Order.class, SubNonInheritedAnnotationInterface.class));
+		assertNull(findAnnotationDeclaringClass(Order.class, SubNonInheritedAnnotationInterface.class));
 		assertEquals(NonInheritedAnnotationClass.class,
 			findAnnotationDeclaringClass(Order.class, NonInheritedAnnotationClass.class));
 		assertEquals(NonInheritedAnnotationClass.class,

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
@@ -97,6 +97,18 @@ public class AnnotationUtilsTests {
 	// }
 
 	@Test
+	public void findAnnotationPrefersInteracesOverLocalMetaAnnotations() {
+		Component component = AnnotationUtils.findAnnotation(
+			ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class, Component.class);
+
+		// By inspecting ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface, one
+		// might expect that "meta2" should be found; however, with the current
+		// implementation "meta1" will be found.
+		assertNotNull(component);
+		assertEquals("meta1", component.value());
+	}
+
+	@Test
 	public void testFindAnnotationDeclaringClass() throws Exception {
 		// no class-level annotation
 		assertNull(findAnnotationDeclaringClass(Transactional.class, NonAnnotatedInterface.class));
@@ -133,7 +145,7 @@ public class AnnotationUtilsTests {
 		assertEquals(InheritedAnnotationInterface.class,
 			findAnnotationDeclaringClassForTypes(transactionalCandidateList, InheritedAnnotationInterface.class));
 		assertNull(findAnnotationDeclaringClassForTypes(transactionalCandidateList,
-			SubInheritedAnnotationInterface.class));
+				SubInheritedAnnotationInterface.class));
 		assertEquals(InheritedAnnotationClass.class,
 			findAnnotationDeclaringClassForTypes(transactionalCandidateList, InheritedAnnotationClass.class));
 		assertEquals(InheritedAnnotationClass.class,
@@ -288,19 +300,23 @@ public class AnnotationUtilsTests {
 
 
 	@Component(value = "meta1")
+	@Order
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface Meta1 {
 	}
 
 	@Component(value = "meta2")
+	@Transactional
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface Meta2 {
 	}
 
 	@Meta1
-	@Component(value = "local")
+	static interface InterfaceWithMetaAnnotation {
+	}
+
 	@Meta2
-	static class HasLocalAndMetaComponentAnnotation {
+	static class ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface implements InterfaceWithMetaAnnotation {
 	}
 
 	public static interface AnnotatedInterface {

--- a/spring-test/src/main/java/org/springframework/test/annotation/ProfileValueUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/annotation/ProfileValueUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+
+import static org.springframework.core.annotation.AnnotationUtils.*;
 
 /**
  * General utility methods for working with <em>profile values</em>.
@@ -114,7 +116,7 @@ public abstract class ProfileValueUtils {
 	 * environment
 	 */
 	public static boolean isTestEnabledInThisEnvironment(Class<?> testClass) {
-		IfProfileValue ifProfileValue = testClass.getAnnotation(IfProfileValue.class);
+		IfProfileValue ifProfileValue = findAnnotation(testClass, IfProfileValue.class);
 		return isTestEnabledInThisEnvironment(retrieveProfileValueSource(testClass), ifProfileValue);
 	}
 
@@ -157,11 +159,11 @@ public abstract class ProfileValueUtils {
 	public static boolean isTestEnabledInThisEnvironment(ProfileValueSource profileValueSource, Method testMethod,
 			Class<?> testClass) {
 
-		IfProfileValue ifProfileValue = testClass.getAnnotation(IfProfileValue.class);
+		IfProfileValue ifProfileValue = findAnnotation(testClass, IfProfileValue.class);
 		boolean classLevelEnabled = isTestEnabledInThisEnvironment(profileValueSource, ifProfileValue);
 
 		if (classLevelEnabled) {
-			ifProfileValue = testMethod.getAnnotation(IfProfileValue.class);
+			ifProfileValue = findAnnotation(testMethod, IfProfileValue.class);
 			return isTestEnabledInThisEnvironment(profileValueSource, ifProfileValue);
 		}
 

--- a/spring-test/src/main/java/org/springframework/test/annotation/ProfileValueUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/annotation/ProfileValueUtils.java
@@ -65,7 +65,7 @@ public abstract class ProfileValueUtils {
 		Assert.notNull(testClass, "testClass must not be null");
 
 		Class<ProfileValueSourceConfiguration> annotationType = ProfileValueSourceConfiguration.class;
-		ProfileValueSourceConfiguration config = testClass.getAnnotation(annotationType);
+		ProfileValueSourceConfiguration config = findAnnotation(testClass, annotationType);
 		if (logger.isDebugEnabled()) {
 			logger.debug("Retrieved @ProfileValueSourceConfiguration [" + config + "] for test class ["
 					+ testClass.getName() + "]");

--- a/spring-test/src/main/java/org/springframework/test/annotation/Repeat.java
+++ b/spring-test/src/main/java/org/springframework/test/annotation/Repeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,25 +17,27 @@
 package org.springframework.test.annotation;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
 
 /**
  * Test annotation to indicate that a test method should be invoked repeatedly.
- * <p />
- * Note that the scope of execution to be repeated includes execution of the
+ *
+ * <p>Note that the scope of execution to be repeated includes execution of the
  * test method itself as well as any <em>set up</em> or <em>tear down</em> of
  * the test fixture.
  *
  * @author Rod Johnson
  * @author Sam Brannen
  * @since 2.0
+ * @see Timed
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Target({ METHOD, ANNOTATION_TYPE })
 public @interface Repeat {
 
 	int value() default 1;

--- a/spring-test/src/main/java/org/springframework/test/annotation/Timed.java
+++ b/spring-test/src/main/java/org/springframework/test/annotation/Timed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,25 +17,22 @@
 package org.springframework.test.annotation;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
 /**
- * <p>
  * Test-specific annotation to indicate that a test method has to finish
  * execution in a {@link #millis() specified time period}.
- * </p>
- * <p>
- * If the text execution takes longer than the specified time period, then the
- * test is to be considered failed.
- * </p>
- * <p>
- * Note that the time period includes execution of the test method itself, any
- * {@link Repeat repetitions} of the test, and any <em>set up</em> or
+ *
+ * <p>If the text execution takes longer than the specified time period, then
+ * the test is to be considered failed.
+ *
+ * <p>Note that the time period includes execution of the test method itself,
+ * any {@link Repeat repetitions} of the test, and any <em>set up</em> or
  * <em>tear down</em> of the test fixture.
- * </p>
  *
  * @author Rod Johnson
  * @author Sam Brannen
@@ -43,8 +40,8 @@ import java.lang.annotation.Target;
  * @see Repeat
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Target({ METHOD, ANNOTATION_TYPE })
 public @interface Timed {
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
@@ -599,9 +599,18 @@ abstract class ContextLoaderUtils {
 	 * @see #buildContextHierarchyMap(Class)
 	 * @see #buildMergedContextConfiguration(Class, List, String, MergedContextConfiguration, CacheAwareContextLoaderDelegate)
 	 */
-	@SuppressWarnings("javadoc")
+	@SuppressWarnings({ "javadoc", "unchecked" })
 	static MergedContextConfiguration buildMergedContextConfiguration(Class<?> testClass,
 			String defaultContextLoaderClassName, CacheAwareContextLoaderDelegate cacheAwareContextLoaderDelegate) {
+
+		if (findAnnotationDescriptorForTypes(testClass, ContextConfiguration.class, ContextHierarchy.class) == null) {
+			if (logger.isInfoEnabled()) {
+				logger.info(String.format(
+					"Neither @ContextConfiguration nor @ContextHierarchy found for test class [%s]",
+					testClass.getName()));
+			}
+			return new MergedContextConfiguration(testClass, null, null, null, null);
+		}
 
 		if (findAnnotation(testClass, ContextHierarchy.class) != null) {
 			Map<String, List<ContextConfigurationAttributes>> hierarchyMap = buildContextHierarchyMap(testClass);

--- a/spring-test/src/main/java/org/springframework/test/context/DefaultTestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/DefaultTestContext.java
@@ -106,6 +106,7 @@ class DefaultTestContext extends AttributeAccessorSupport implements TestContext
 		final Class<ContextHierarchy> contextHierarchyType = ContextHierarchy.class;
 		final List<Class<? extends Annotation>> annotationTypes = Arrays.asList(contextConfigType, contextHierarchyType);
 
+		// TODO Switch to MetaAnnotationUtils for proper meta-annotation support
 		if (findAnnotationDeclaringClassForTypes(annotationTypes, testClass) != null) {
 			mergedContextConfiguration = ContextLoaderUtils.buildMergedContextConfiguration(testClass,
 				defaultContextLoaderClassName, cacheAwareContextLoaderDelegate);

--- a/spring-test/src/main/java/org/springframework/test/context/DefaultTestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/DefaultTestContext.java
@@ -16,16 +16,20 @@
 
 package org.springframework.test.context;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.AttributeAccessorSupport;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
 import org.springframework.util.Assert;
+
+import static org.springframework.core.annotation.AnnotationUtils.*;
 
 /**
  * Default implementation of the {@link TestContext} interface.
@@ -98,8 +102,11 @@ class DefaultTestContext extends AttributeAccessorSupport implements TestContext
 
 		MergedContextConfiguration mergedContextConfiguration;
 
-		if (testClass.isAnnotationPresent(ContextConfiguration.class)
-				|| testClass.isAnnotationPresent(ContextHierarchy.class)) {
+		final Class<ContextConfiguration> contextConfigType = ContextConfiguration.class;
+		final Class<ContextHierarchy> contextHierarchyType = ContextHierarchy.class;
+		final List<Class<? extends Annotation>> annotationTypes = Arrays.asList(contextConfigType, contextHierarchyType);
+
+		if (findAnnotationDeclaringClassForTypes(annotationTypes, testClass) != null) {
 			mergedContextConfiguration = ContextLoaderUtils.buildMergedContextConfiguration(testClass,
 				defaultContextLoaderClassName, cacheAwareContextLoaderDelegate);
 		}

--- a/spring-test/src/main/java/org/springframework/test/context/DefaultTestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/DefaultTestContext.java
@@ -16,20 +16,13 @@
 
 package org.springframework.test.context;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.AttributeAccessorSupport;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
 import org.springframework.util.Assert;
-
-import static org.springframework.core.annotation.AnnotationUtils.*;
 
 /**
  * Default implementation of the {@link TestContext} interface.
@@ -46,8 +39,6 @@ import static org.springframework.core.annotation.AnnotationUtils.*;
 class DefaultTestContext extends AttributeAccessorSupport implements TestContext {
 
 	private static final long serialVersionUID = -5827157174866681233L;
-
-	private static final Log logger = LogFactory.getLog(DefaultTestContext.class);
 
 	private final ContextCache contextCache;
 
@@ -99,28 +90,8 @@ class DefaultTestContext extends AttributeAccessorSupport implements TestContext
 		this.testClass = testClass;
 		this.contextCache = contextCache;
 		this.cacheAwareContextLoaderDelegate = new CacheAwareContextLoaderDelegate(contextCache);
-
-		MergedContextConfiguration mergedContextConfiguration;
-
-		final Class<ContextConfiguration> contextConfigType = ContextConfiguration.class;
-		final Class<ContextHierarchy> contextHierarchyType = ContextHierarchy.class;
-		final List<Class<? extends Annotation>> annotationTypes = Arrays.asList(contextConfigType, contextHierarchyType);
-
-		// TODO Switch to MetaAnnotationUtils for proper meta-annotation support
-		if (findAnnotationDeclaringClassForTypes(annotationTypes, testClass) != null) {
-			mergedContextConfiguration = ContextLoaderUtils.buildMergedContextConfiguration(testClass,
-				defaultContextLoaderClassName, cacheAwareContextLoaderDelegate);
-		}
-		else {
-			if (logger.isInfoEnabled()) {
-				logger.info(String.format(
-					"Neither @ContextConfiguration nor @ContextHierarchy found for test class [%s]",
-					testClass.getName()));
-			}
-			mergedContextConfiguration = new MergedContextConfiguration(testClass, null, null, null, null);
-		}
-
-		this.mergedContextConfiguration = mergedContextConfiguration;
+		this.mergedContextConfiguration = ContextLoaderUtils.buildMergedContextConfiguration(testClass,
+			defaultContextLoaderClassName, cacheAwareContextLoaderDelegate);
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/MetaAnnotationUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/MetaAnnotationUtils.java
@@ -40,8 +40,10 @@ abstract class MetaAnnotationUtils {
 	 * TODO Document findAnnotationDescriptor().
 	 *
 	 * @param clazz the class to look for annotations on
-	 * @param annotationType the annotation class to look for
-	 * @return the annotation found, or {@code null} if none found
+	 * @param annotationType the annotation class to look for, both locally and
+	 * as a meta-annotation
+	 * @return the corresponding annotation descriptor if the annotation was found;
+	 * otherwise {@code null}
 	 */
 	public static <T extends Annotation> AnnotationDescriptor<T> findAnnotationDescriptor(Class<?> clazz,
 			Class<T> annotationType) {
@@ -67,14 +69,6 @@ abstract class MetaAnnotationUtils {
 			}
 		}
 
-		// Declared on an interface?
-		for (Class<?> ifc : clazz.getInterfaces()) {
-			AnnotationDescriptor<T> descriptor = findAnnotationDescriptor(ifc, annotationType);
-			if (descriptor != null) {
-				return descriptor;
-			}
-		}
-
 		// Declared on a superclass?
 		return findAnnotationDescriptor(clazz.getSuperclass(), annotationType);
 	}
@@ -83,8 +77,10 @@ abstract class MetaAnnotationUtils {
 	 * TODO Document findAnnotationDescriptorForTypes().
 	 *
 	 * @param clazz the class to look for annotations on
-	 * @param annotationTypes the types of annotations to look for
-	 * @return the annotation found, or {@code null} if none found
+	 * @param annotationTypes the types of annotations to look for, both locally
+	 * and as meta-annotations
+	 * @return the corresponding annotation descriptor if one of the annotations
+	 * was found; otherwise {@code null}
 	 */
 	@SuppressWarnings("unchecked")
 	public static UntypedAnnotationDescriptor findAnnotationDescriptorForTypes(Class<?> clazz,
@@ -112,14 +108,6 @@ abstract class MetaAnnotationUtils {
 						return new UntypedAnnotationDescriptor(clazz, stereotype, annotation);
 					}
 				}
-			}
-		}
-
-		// Declared on an interface?
-		for (Class<?> ifc : clazz.getInterfaces()) {
-			UntypedAnnotationDescriptor descriptor = findAnnotationDescriptorForTypes(ifc, annotationTypes);
-			if (descriptor != null) {
-				return descriptor;
 			}
 		}
 

--- a/spring-test/src/main/java/org/springframework/test/context/MetaAnnotationUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/MetaAnnotationUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.util.Assert;
+
+import static org.springframework.core.annotation.AnnotationUtils.*;
+
+/**
+ * TODO Document MetaAnnotationUtils.
+ * 
+ * @author Sam Brannen
+ * @since 4.0
+ */
+abstract class MetaAnnotationUtils {
+
+	private MetaAnnotationUtils() {
+		/* no-op */
+	}
+
+	// TODO Rename and document findAnnotationDescriptor().
+	// Note: does not traverse interface hierarchies.
+	public static <T extends Annotation> AnnotationDescriptor<T> findAnnotationDescriptor(Class<T> annotationType,
+			Class<?> clazz) {
+
+		Assert.notNull(annotationType, "Annotation type must not be null");
+		if (clazz == null || clazz.equals(Object.class)) {
+			return null;
+		}
+
+		// Declared locally?
+		if (isAnnotationDeclaredLocally(annotationType, clazz)) {
+			return new AnnotationDescriptor<T>(clazz.getAnnotation(annotationType), clazz);
+		}
+
+		// Declared on an annotation (i.e., as a meta-annotation)?
+		if (!Annotation.class.isAssignableFrom(clazz)) {
+			for (Annotation ann : clazz.getAnnotations()) {
+				T annotation = ann.annotationType().getAnnotation(annotationType);
+				if (annotation != null) {
+					return new AnnotationDescriptor<T>(annotation, clazz, ann.annotationType());
+				}
+			}
+		}
+
+		// Declared on a superclass?
+		return findAnnotationDescriptor(annotationType, clazz.getSuperclass());
+	}
+
+
+	/**
+	 * Descriptor for an {@link Annotation}, including the
+	 * {@linkplain #getAnnotatedClass() class} on which the annotation is declared as well
+	 * as the {@linkplain #getAnnotation() annotation} itself.
+	 * 
+	 * <p>
+	 * If the annotation is used as a meta-annotation, the descriptor also includes the
+	 * {@linkplain #getMetaAnnotatedClass() meta-annotated class} (i.e., an annotation
+	 * that is present on the {@linkplain #getAnnotatedClass() annotated class} and is
+	 * itself annotated with the {@linkplain #getAnnotation() annotation} that this object
+	 * describes).
+	 * 
+	 * @author Sam Brannen
+	 * @since 4.0
+	 */
+	public static class AnnotationDescriptor<T extends Annotation> {
+
+		private final T annotation;
+
+		private final Class<?> annotatedClass;
+
+		private final Class<?> metaAnnotatedClass;
+
+
+		public AnnotationDescriptor(T annotation, Class<?> annotatedClass) {
+			this(annotation, annotatedClass, null);
+		}
+
+		public AnnotationDescriptor(T annotation, Class<?> annotatedClass, Class<?> metaAnnotatedClass) {
+			Assert.notNull(annotation, "annotation must not be null");
+			Assert.notNull(annotatedClass, "annotatedClass must not be null");
+			this.annotation = annotation;
+			this.annotatedClass = annotatedClass;
+			this.metaAnnotatedClass = metaAnnotatedClass;
+		}
+
+		public T getAnnotation() {
+			return this.annotation;
+		}
+
+		public Class<? extends Annotation> getAnnotationType() {
+			return this.annotation.annotationType();
+		}
+
+		public Class<?> getAnnotatedClass() {
+			return this.annotatedClass;
+		}
+
+		public Class<?> getMetaAnnotatedClass() {
+			return this.metaAnnotatedClass;
+		}
+
+		/**
+		 * Provide a String representation of this {@code AnnotationDescriptor}.
+		 */
+		@Override
+		public String toString() {
+			return new ToStringCreator(this)//
+			.append("annotation", annotation)//
+			.append("annotatedClass", annotatedClass)//
+			.append("metaAnnotatedClass", metaAnnotatedClass)//
+			.toString();
+		}
+	}
+
+}

--- a/spring-test/src/main/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunner.java
+++ b/spring-test/src/main/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunner.java
@@ -34,6 +34,7 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.annotation.ProfileValueUtils;
 import org.springframework.test.annotation.Repeat;
 import org.springframework.test.annotation.Timed;
@@ -410,7 +411,7 @@ public class SpringJUnit4ClassRunner extends BlockJUnit4ClassRunner {
 	 * @return the timeout, or {@code 0} if none was specified.
 	 */
 	protected long getSpringTimeout(FrameworkMethod frameworkMethod) {
-		Timed timedAnnotation = frameworkMethod.getAnnotation(Timed.class);
+		Timed timedAnnotation = AnnotationUtils.getAnnotation(frameworkMethod.getMethod(), Timed.class);
 		return (timedAnnotation != null && timedAnnotation.millis() > 0 ? timedAnnotation.millis() : 0);
 	}
 
@@ -449,7 +450,7 @@ public class SpringJUnit4ClassRunner extends BlockJUnit4ClassRunner {
 	 * @see SpringRepeat
 	 */
 	protected Statement withPotentialRepeat(FrameworkMethod frameworkMethod, Object testInstance, Statement next) {
-		Repeat repeatAnnotation = frameworkMethod.getAnnotation(Repeat.class);
+		Repeat repeatAnnotation = AnnotationUtils.getAnnotation(frameworkMethod.getMethod(), Repeat.class);
 		int repeat = (repeatAnnotation != null ? repeatAnnotation.value() : 1);
 		return new SpringRepeat(next, frameworkMethod.getMethod(), repeat);
 	}

--- a/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
@@ -20,13 +20,14 @@ import java.lang.reflect.Method;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
 import org.springframework.test.context.TestContext;
 import org.springframework.util.Assert;
+
+import static org.springframework.core.annotation.AnnotationUtils.*;
 
 /**
  * {@code TestExecutionListener} which provides support for marking the
@@ -82,9 +83,11 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 
 		final Class<DirtiesContext> annotationType = DirtiesContext.class;
 
-		boolean methodDirtiesContext = testMethod.isAnnotationPresent(annotationType);
-		boolean classDirtiesContext = testClass.isAnnotationPresent(annotationType);
-		DirtiesContext classDirtiesContextAnnotation = testClass.getAnnotation(annotationType);
+		DirtiesContext methodDirtiesContextAnnotation = findAnnotation(testMethod, annotationType);
+		boolean methodDirtiesContext = methodDirtiesContextAnnotation != null;
+
+		DirtiesContext classDirtiesContextAnnotation = findAnnotation(testClass, annotationType);
+		boolean classDirtiesContext = classDirtiesContextAnnotation != null;
 		ClassMode classMode = classDirtiesContext ? classDirtiesContextAnnotation.classMode() : null;
 
 		if (logger.isDebugEnabled()) {
@@ -93,8 +96,8 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 					+ methodDirtiesContext + "].");
 		}
 
-		if (methodDirtiesContext || (classDirtiesContext && classMode == ClassMode.AFTER_EACH_TEST_METHOD)) {
-			HierarchyMode hierarchyMode = methodDirtiesContext ? testMethod.getAnnotation(annotationType).hierarchyMode()
+		if (methodDirtiesContext || (classMode == ClassMode.AFTER_EACH_TEST_METHOD)) {
+			HierarchyMode hierarchyMode = methodDirtiesContext ? methodDirtiesContextAnnotation.hierarchyMode()
 					: classDirtiesContextAnnotation.hierarchyMode();
 			dirtyContext(testContext, hierarchyMode);
 		}
@@ -117,12 +120,13 @@ public class DirtiesContextTestExecutionListener extends AbstractTestExecutionLi
 
 		final Class<DirtiesContext> annotationType = DirtiesContext.class;
 
-		boolean dirtiesContext = testClass.isAnnotationPresent(annotationType);
+		DirtiesContext dirtiesContextAnnotation = findAnnotation(testClass, annotationType);
+		boolean dirtiesContext = dirtiesContextAnnotation != null;
 		if (logger.isDebugEnabled()) {
 			logger.debug("After test class: context [" + testContext + "], dirtiesContext [" + dirtiesContext + "].");
 		}
 		if (dirtiesContext) {
-			HierarchyMode hierarchyMode = testClass.getAnnotation(annotationType).hierarchyMode();
+			HierarchyMode hierarchyMode = dirtiesContextAnnotation.hierarchyMode();
 			dirtyContext(testContext, hierarchyMode);
 		}
 	}

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/AfterTransaction.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/AfterTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,11 @@
 package org.springframework.test.context.transaction;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
 
 /**
  * <p>
@@ -37,9 +38,10 @@ import java.lang.annotation.Target;
  * @author Sam Brannen
  * @since 2.5
  * @see org.springframework.transaction.annotation.Transactional
+ * @see BeforeTransaction
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Target({ METHOD, ANNOTATION_TYPE })
 public @interface AfterTransaction {
 }

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/BeforeTransaction.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/BeforeTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,11 @@
 package org.springframework.test.context.transaction;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
 
 /**
  * <p>
@@ -37,9 +38,10 @@ import java.lang.annotation.Target;
  * @author Sam Brannen
  * @since 2.5
  * @see org.springframework.transaction.annotation.Transactional
+ * @see AfterTransaction
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Target({ METHOD, ANNOTATION_TYPE })
 public @interface BeforeTransaction {
 }

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListenerTests.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListenerTests.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.transaction;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.context.TestContext;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link TransactionalTestExecutionListener}.
+ *
+ * @author Sam Brannen
+ * @since 4.0
+ */
+public class TransactionalTestExecutionListenerTests {
+
+	private final PlatformTransactionManager tm = mock(PlatformTransactionManager.class);
+
+	private final TransactionalTestExecutionListener listener = new TransactionalTestExecutionListener() {
+
+		protected PlatformTransactionManager getTransactionManager(TestContext testContext, String qualifier) {
+			return tm;
+		}
+	};
+
+	private final TestContext testContext = mock(TestContext.class);
+
+
+	private void assertBeforeTestMethod(Class<? extends Invocable> clazz) throws Exception {
+		assertBeforeTestMethodWithTransactionalTestMethod(clazz);
+		assertBeforeTestMethodWithNonTransactionalTestMethod(clazz);
+	}
+
+	private void assertBeforeTestMethodWithTransactionalTestMethod(Class<? extends Invocable> clazz) throws Exception {
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		Invocable instance = clazz.newInstance();
+		when(testContext.getTestInstance()).thenReturn(instance);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("transactionalTest"));
+
+		assertFalse(instance.invoked);
+		listener.beforeTestMethod(testContext);
+		assertTrue(instance.invoked);
+	}
+
+	private void assertBeforeTestMethodWithNonTransactionalTestMethod(Class<? extends Invocable> clazz)
+			throws Exception {
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		Invocable instance = clazz.newInstance();
+		when(testContext.getTestInstance()).thenReturn(instance);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("nonTransactionalTest"));
+
+		assertFalse(instance.invoked);
+		listener.beforeTestMethod(testContext);
+		assertFalse(instance.invoked);
+	}
+
+	private void assertAfterTestMethod(Class<? extends Invocable> clazz) throws Exception {
+		assertAfterTestMethodWithTransactionalTestMethod(clazz);
+		assertAfterTestMethodWithNonTransactionalTestMethod(clazz);
+	}
+
+	private void assertAfterTestMethodWithTransactionalTestMethod(Class<? extends Invocable> clazz) throws Exception {
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		Invocable instance = clazz.newInstance();
+		when(testContext.getTestInstance()).thenReturn(instance);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("transactionalTest"));
+
+		when(tm.getTransaction(Mockito.any(TransactionDefinition.class))).thenReturn(new SimpleTransactionStatus());
+
+		assertFalse(instance.invoked);
+		listener.beforeTestMethod(testContext);
+		listener.afterTestMethod(testContext);
+		assertTrue(instance.invoked);
+	}
+
+	private void assertAfterTestMethodWithNonTransactionalTestMethod(Class<? extends Invocable> clazz) throws Exception {
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		Invocable instance = clazz.newInstance();
+		when(testContext.getTestInstance()).thenReturn(instance);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("nonTransactionalTest"));
+
+		assertFalse(instance.invoked);
+		listener.beforeTestMethod(testContext);
+		listener.afterTestMethod(testContext);
+		assertFalse(instance.invoked);
+	}
+
+	@Test
+	public void beforeTestMethodWithTransactionalDeclaredOnClassLocally() throws Exception {
+		assertBeforeTestMethodWithTransactionalTestMethod(TransactionalDeclaredOnClassLocallyTestCase.class);
+	}
+
+	@Test
+	public void beforeTestMethodWithTransactionalDeclaredOnClassViaMetaAnnotation() throws Exception {
+		assertBeforeTestMethodWithTransactionalTestMethod(TransactionalDeclaredOnClassViaMetaAnnotationTestCase.class);
+	}
+
+	@Test
+	public void beforeTestMethodWithTransactionalDeclaredOnMethodLocally() throws Exception {
+		assertBeforeTestMethod(TransactionalDeclaredOnMethodLocallyTestCase.class);
+	}
+
+	@Test
+	public void beforeTestMethodWithTransactionalDeclaredOnMethodViaMetaAnnotation() throws Exception {
+		assertBeforeTestMethod(TransactionalDeclaredOnMethodViaMetaAnnotationTestCase.class);
+	}
+
+	@Test
+	public void beforeTestMethodWithBeforeTransactionDeclaredLocally() throws Exception {
+		assertBeforeTestMethod(BeforeTransactionDeclaredLocallyTestCase.class);
+	}
+
+	@Test
+	public void beforeTestMethodWithBeforeTransactionDeclaredViaMetaAnnotation() throws Exception {
+		assertBeforeTestMethod(BeforeTransactionDeclaredViaMetaAnnotationTestCase.class);
+	}
+
+	@Test
+	public void afterTestMethodWithAfterTransactionDeclaredLocally() throws Exception {
+		assertAfterTestMethod(AfterTransactionDeclaredLocallyTestCase.class);
+	}
+
+	@Test
+	public void afterTestMethodWithAfterTransactionDeclaredViaMetaAnnotation() throws Exception {
+		assertAfterTestMethod(AfterTransactionDeclaredViaMetaAnnotationTestCase.class);
+	}
+
+
+	// -------------------------------------------------------------------------
+
+	@Transactional
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaTransactional {
+	}
+
+	@BeforeTransaction
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaBeforeTransaction {
+	}
+
+	@AfterTransaction
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaAfterTransaction {
+	}
+
+	private static abstract class Invocable {
+
+		boolean invoked = false;
+	}
+
+	@Transactional
+	static class TransactionalDeclaredOnClassLocallyTestCase extends Invocable {
+
+		@BeforeTransaction
+		public void beforeTransaction() {
+			invoked = true;
+		}
+
+		public void transactionalTest() {
+			/* no-op */
+		}
+	}
+
+	static class TransactionalDeclaredOnMethodLocallyTestCase extends Invocable {
+
+		@BeforeTransaction
+		public void beforeTransaction() {
+			invoked = true;
+		}
+
+		@Transactional
+		public void transactionalTest() {
+			/* no-op */
+		}
+
+		public void nonTransactionalTest() {
+			/* no-op */
+		}
+	}
+
+	@MetaTransactional
+	static class TransactionalDeclaredOnClassViaMetaAnnotationTestCase extends Invocable {
+
+		@BeforeTransaction
+		public void beforeTransaction() {
+			invoked = true;
+		}
+
+		public void transactionalTest() {
+			/* no-op */
+		}
+
+		public void nonTransactionalTest() {
+			/* no-op */
+		}
+	}
+
+	static class TransactionalDeclaredOnMethodViaMetaAnnotationTestCase extends Invocable {
+
+		@BeforeTransaction
+		public void beforeTransaction() {
+			invoked = true;
+		}
+
+		@MetaTransactional
+		public void transactionalTest() {
+			/* no-op */
+		}
+
+		public void nonTransactionalTest() {
+			/* no-op */
+		}
+	}
+
+	static class BeforeTransactionDeclaredLocallyTestCase extends Invocable {
+
+		@BeforeTransaction
+		public void beforeTransaction() {
+			invoked = true;
+		}
+
+		@Transactional
+		public void transactionalTest() {
+			/* no-op */
+		}
+
+		public void nonTransactionalTest() {
+			/* no-op */
+		}
+	}
+
+	static class BeforeTransactionDeclaredViaMetaAnnotationTestCase extends Invocable {
+
+		@MetaBeforeTransaction
+		public void beforeTransaction() {
+			invoked = true;
+		}
+
+		@Transactional
+		public void transactionalTest() {
+			/* no-op */
+		}
+
+		public void nonTransactionalTest() {
+			/* no-op */
+		}
+	}
+
+	static class AfterTransactionDeclaredLocallyTestCase extends Invocable {
+
+		@AfterTransaction
+		public void afterTransaction() {
+			invoked = true;
+		}
+
+		@Transactional
+		public void transactionalTest() {
+			/* no-op */
+		}
+
+		public void nonTransactionalTest() {
+			/* no-op */
+		}
+	}
+
+	static class AfterTransactionDeclaredViaMetaAnnotationTestCase extends Invocable {
+
+		@MetaAfterTransaction
+		public void afterTransaction() {
+			invoked = true;
+		}
+
+		@Transactional
+		public void transactionalTest() {
+			/* no-op */
+		}
+
+		public void nonTransactionalTest() {
+			/* no-op */
+		}
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/annotation/ProfileValueUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/annotation/ProfileValueUtilsTests.java
@@ -90,9 +90,11 @@ public class ProfileValueUtilsTests {
 		assertClassIsEnabled(EnabledAnnotatedSingleValue.class);
 		assertClassIsEnabled(EnabledAnnotatedMultiValue.class);
 		assertClassIsEnabled(MetaEnabledClass.class);
+		assertClassIsEnabled(MetaEnabledWithCustomProfileValueSourceClass.class);
 		assertClassIsDisabled(DisabledAnnotatedSingleValue.class);
 		assertClassIsDisabled(DisabledAnnotatedMultiValue.class);
 		assertClassIsDisabled(MetaDisabledClass.class);
+		assertClassIsDisabled(MetaDisabledWithCustomProfileValueSourceClass.class);
 	}
 
 	@Test
@@ -270,6 +272,34 @@ public class ProfileValueUtilsTests {
 		@MetaDisabled
 		public void disabledAnnotatedMethod() {
 		}
+	}
+
+	public static class HardCodedProfileValueSource implements ProfileValueSource {
+
+		@Override
+		public String get(final String key) {
+			return (key.equals(NAME) ? "42" : null);
+		}
+	}
+
+	@ProfileValueSourceConfiguration(HardCodedProfileValueSource.class)
+	@IfProfileValue(name = NAME, value = "42")
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaEnabledWithCustomProfileValueSource {
+	}
+
+	@ProfileValueSourceConfiguration(HardCodedProfileValueSource.class)
+	@IfProfileValue(name = NAME, value = "13")
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaDisabledWithCustomProfileValueSource {
+	}
+
+	@MetaEnabledWithCustomProfileValueSource
+	private static class MetaEnabledWithCustomProfileValueSourceClass {
+	}
+
+	@MetaDisabledWithCustomProfileValueSource
+	private static class MetaDisabledWithCustomProfileValueSourceClass {
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/annotation/ProfileValueUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/annotation/ProfileValueUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package org.springframework.test.annotation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link ProfileValueUtils}.
@@ -88,8 +89,10 @@ public class ProfileValueUtilsTests {
 		assertClassIsEnabled(NonAnnotated.class);
 		assertClassIsEnabled(EnabledAnnotatedSingleValue.class);
 		assertClassIsEnabled(EnabledAnnotatedMultiValue.class);
+		assertClassIsEnabled(MetaEnabledClass.class);
 		assertClassIsDisabled(DisabledAnnotatedSingleValue.class);
 		assertClassIsDisabled(DisabledAnnotatedMultiValue.class);
+		assertClassIsDisabled(MetaDisabledClass.class);
 	}
 
 	@Test
@@ -100,6 +103,10 @@ public class ProfileValueUtilsTests {
 		assertMethodIsEnabled(ENABLED_ANNOTATED_METHOD, EnabledAnnotatedSingleValue.class);
 		assertMethodIsDisabled(DISABLED_ANNOTATED_METHOD, EnabledAnnotatedSingleValue.class);
 
+		assertMethodIsEnabled(NON_ANNOTATED_METHOD, MetaEnabledAnnotatedSingleValue.class);
+		assertMethodIsEnabled(ENABLED_ANNOTATED_METHOD, MetaEnabledAnnotatedSingleValue.class);
+		assertMethodIsDisabled(DISABLED_ANNOTATED_METHOD, MetaEnabledAnnotatedSingleValue.class);
+
 		assertMethodIsEnabled(NON_ANNOTATED_METHOD, EnabledAnnotatedMultiValue.class);
 		assertMethodIsEnabled(ENABLED_ANNOTATED_METHOD, EnabledAnnotatedMultiValue.class);
 		assertMethodIsDisabled(DISABLED_ANNOTATED_METHOD, EnabledAnnotatedMultiValue.class);
@@ -107,6 +114,10 @@ public class ProfileValueUtilsTests {
 		assertMethodIsDisabled(NON_ANNOTATED_METHOD, DisabledAnnotatedSingleValue.class);
 		assertMethodIsDisabled(ENABLED_ANNOTATED_METHOD, DisabledAnnotatedSingleValue.class);
 		assertMethodIsDisabled(DISABLED_ANNOTATED_METHOD, DisabledAnnotatedSingleValue.class);
+
+		assertMethodIsDisabled(NON_ANNOTATED_METHOD, MetaDisabledAnnotatedSingleValue.class);
+		assertMethodIsDisabled(ENABLED_ANNOTATED_METHOD, MetaDisabledAnnotatedSingleValue.class);
+		assertMethodIsDisabled(DISABLED_ANNOTATED_METHOD, MetaDisabledAnnotatedSingleValue.class);
 
 		assertMethodIsDisabled(NON_ANNOTATED_METHOD, DisabledAnnotatedMultiValue.class);
 		assertMethodIsDisabled(ENABLED_ANNOTATED_METHOD, DisabledAnnotatedMultiValue.class);
@@ -207,6 +218,56 @@ public class ProfileValueUtilsTests {
 		}
 
 		@IfProfileValue(name = NAME, value = VALUE + "X")
+		public void disabledAnnotatedMethod() {
+		}
+	}
+
+	@IfProfileValue(name = NAME, value = VALUE)
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaEnabled {
+	}
+
+	@IfProfileValue(name = NAME, value = VALUE + "X")
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaDisabled {
+	}
+
+	@MetaEnabled
+	private static class MetaEnabledClass {
+	}
+
+	@MetaDisabled
+	private static class MetaDisabledClass {
+	}
+
+	@SuppressWarnings("unused")
+	@MetaEnabled
+	private static class MetaEnabledAnnotatedSingleValue {
+
+		public void nonAnnotatedMethod() {
+		}
+
+		@MetaEnabled
+		public void enabledAnnotatedMethod() {
+		}
+
+		@MetaDisabled
+		public void disabledAnnotatedMethod() {
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@MetaDisabled
+	private static class MetaDisabledAnnotatedSingleValue {
+
+		public void nonAnnotatedMethod() {
+		}
+
+		@MetaEnabled
+		public void enabledAnnotatedMethod() {
+		}
+
+		@MetaDisabled
 		public void disabledAnnotatedMethod() {
 		}
 	}

--- a/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
@@ -75,7 +75,13 @@ abstract class AbstractContextLoaderUtilsTests {
 		assertNotNull(mergedConfig.getClasses());
 		assertArrayEquals(expectedClasses, mergedConfig.getClasses());
 		assertNotNull(mergedConfig.getActiveProfiles());
-		assertEquals(expectedContextLoaderClass, mergedConfig.getContextLoader().getClass());
+		System.err.println(expectedContextLoaderClass);
+		if (expectedContextLoaderClass == null) {
+			assertNull(mergedConfig.getContextLoader());
+		}
+		else {
+			assertEquals(expectedContextLoaderClass, mergedConfig.getContextLoader().getClass());
+		}
 		assertNotNull(mergedConfig.getContextInitializerClasses());
 		assertEquals(expectedInitializerClasses, mergedConfig.getContextInitializerClasses());
 	}

--- a/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
@@ -30,6 +30,8 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import static org.junit.Assert.*;
 
+import static org.junit.Assert.*;
+
 /**
  * Abstract base class for tests involving {@link ContextLoaderUtils}.
  *
@@ -43,6 +45,16 @@ abstract class AbstractContextLoaderUtilsTests {
 	static final Set<Class<? extends ApplicationContextInitializer<? extends ConfigurableApplicationContext>>> EMPTY_INITIALIZER_CLASSES = //
 	Collections.<Class<? extends ApplicationContextInitializer<? extends ConfigurableApplicationContext>>> emptySet();
 
+
+	void assertAttributes(ContextConfigurationAttributes attributes, Class<?> expectedDeclaringClass,
+			String[] expectedLocations, Class<?>[] expectedClasses,
+			Class<? extends ContextLoader> expectedContextLoaderClass, boolean expectedInheritLocations) {
+		assertEquals(expectedDeclaringClass, attributes.getDeclaringClass());
+		assertArrayEquals(expectedLocations, attributes.getLocations());
+		assertArrayEquals(expectedClasses, attributes.getClasses());
+		assertEquals(expectedInheritLocations, attributes.isInheritLocations());
+		assertEquals(expectedContextLoaderClass, attributes.getContextLoaderClass());
+	}
 
 	void assertMergedConfig(MergedContextConfiguration mergedConfig, Class<?> expectedTestClass,
 			String[] expectedLocations, Class<?>[] expectedClasses,
@@ -91,11 +103,22 @@ abstract class AbstractContextLoaderUtilsTests {
 	@ActiveProfiles(profiles = "foo")
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
-	public static @interface MetaLocationsFooTest {
+	public static @interface MetaLocationsFooConfig {
 	}
 
-	@MetaLocationsFooTest
+	@ContextConfiguration("/bar.xml")
+	@ActiveProfiles(profiles = "bar")
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	public static @interface MetaLocationsBarConfig {
+	}
+
+	@MetaLocationsFooConfig
 	static class MetaLocationsFoo {
+	}
+
+	@MetaLocationsBarConfig
+	static class MetaLocationsBar extends MetaLocationsFoo {
 	}
 
 	@ContextConfiguration(locations = "/foo.xml", inheritLocations = false)

--- a/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.test.context;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Collections;
 import java.util.Set;
 
@@ -81,6 +85,17 @@ abstract class AbstractContextLoaderUtilsTests {
 
 	@Configuration
 	static class BarConfig {
+	}
+
+	@ContextConfiguration("/foo.xml")
+	@ActiveProfiles(profiles = "foo")
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	public static @interface MetaLocationsFooTest {
+	}
+
+	@MetaLocationsFooTest
+	static class MetaLocationsFoo {
 	}
 
 	@ContextConfiguration(locations = "/foo.xml", inheritLocations = false)

--- a/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
@@ -30,8 +30,6 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import static org.junit.Assert.*;
 
-import static org.junit.Assert.*;
-
 /**
  * Abstract base class for tests involving {@link ContextLoaderUtils}.
  *

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsActiveProfilesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsActiveProfilesTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.test.context;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Arrays;
 import java.util.List;
 
@@ -72,13 +76,6 @@ public class ContextLoaderUtilsActiveProfilesTests extends AbstractContextLoader
 	}
 
 	@Test
-	public void resolveActiveProfilesWithMetaAnnotation() {
-		String[] profiles = resolveActiveProfiles(MetaLocationsFoo.class);
-		assertNotNull(profiles);
-		assertArrayEquals(new String[] { "foo" }, profiles);
-	}
-
-	@Test
 	public void resolveActiveProfilesWithInheritedAnnotationAndLocations() {
 		String[] profiles = resolveActiveProfiles(InheritedLocationsFoo.class);
 		assertNotNull(profiles);
@@ -106,6 +103,44 @@ public class ContextLoaderUtilsActiveProfilesTests extends AbstractContextLoader
 	@Test
 	public void resolveActiveProfilesWithOverriddenAnnotation() {
 		String[] profiles = resolveActiveProfiles(Animals.class);
+		assertNotNull(profiles);
+		assertEquals(2, profiles.length);
+
+		List<String> list = Arrays.asList(profiles);
+		assertTrue(list.contains("dog"));
+		assertTrue(list.contains("cat"));
+	}
+
+	/**
+	 * @since 4.0
+	 */
+	@Test
+	public void resolveActiveProfilesWithMetaAnnotation() {
+		String[] profiles = resolveActiveProfiles(MetaLocationsFoo.class);
+		assertNotNull(profiles);
+		assertArrayEquals(new String[] { "foo" }, profiles);
+	}
+
+	/**
+	 * @since 4.0
+	 */
+	@Test
+	public void resolveActiveProfilesWithLocalAndInheritedMetaAnnotations() {
+		String[] profiles = resolveActiveProfiles(MetaLocationsBar.class);
+		assertNotNull(profiles);
+		assertEquals(2, profiles.length);
+
+		List<String> list = Arrays.asList(profiles);
+		assertTrue(list.contains("foo"));
+		assertTrue(list.contains("bar"));
+	}
+
+	/**
+	 * @since 4.0
+	 */
+	@Test
+	public void resolveActiveProfilesWithOverriddenMetaAnnotation() {
+		String[] profiles = resolveActiveProfiles(MetaAnimals.class);
 		assertNotNull(profiles);
 		assertEquals(2, profiles.length);
 
@@ -213,6 +248,16 @@ public class ContextLoaderUtilsActiveProfilesTests extends AbstractContextLoader
 
 	@ActiveProfiles(profiles = { "dog", "cat" }, inheritProfiles = false)
 	private static class Animals extends LocationsBar {
+	}
+
+	@ActiveProfiles(profiles = { "dog", "cat" }, inheritProfiles = false)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	private static @interface MetaAnimalsConfig {
+	}
+
+	@MetaAnimalsConfig
+	private static class MetaAnimals extends MetaLocationsBar {
 	}
 
 	private static class InheritedLocationsFoo extends LocationsFoo {

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsActiveProfilesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsActiveProfilesTests.java
@@ -72,6 +72,13 @@ public class ContextLoaderUtilsActiveProfilesTests extends AbstractContextLoader
 	}
 
 	@Test
+	public void resolveActiveProfilesWithMetaAnnotation() {
+		String[] profiles = resolveActiveProfiles(MetaLocationsFoo.class);
+		assertNotNull(profiles);
+		assertArrayEquals(new String[] { "foo" }, profiles);
+	}
+
+	@Test
 	public void resolveActiveProfilesWithInheritedAnnotationAndLocations() {
 		String[] profiles = resolveActiveProfiles(InheritedLocationsFoo.class);
 		assertNotNull(profiles);

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsConfigurationAttributesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsConfigurationAttributesTests.java
@@ -32,16 +32,6 @@ import static org.springframework.test.context.ContextLoaderUtils.*;
  */
 public class ContextLoaderUtilsConfigurationAttributesTests extends AbstractContextLoaderUtilsTests {
 
-	private void assertAttributes(ContextConfigurationAttributes attributes, Class<?> expectedDeclaringClass,
-			String[] expectedLocations, Class<?>[] expectedClasses,
-			Class<? extends ContextLoader> expectedContextLoaderClass, boolean expectedInheritLocations) {
-		assertEquals(expectedDeclaringClass, attributes.getDeclaringClass());
-		assertArrayEquals(expectedLocations, attributes.getLocations());
-		assertArrayEquals(expectedClasses, attributes.getClasses());
-		assertEquals(expectedInheritLocations, attributes.isInheritLocations());
-		assertEquals(expectedContextLoaderClass, attributes.getContextLoaderClass());
-	}
-
 	private void assertLocationsFooAttributes(ContextConfigurationAttributes attributes) {
 		assertAttributes(attributes, LocationsFoo.class, new String[] { "/foo.xml" }, EMPTY_CLASS_ARRAY,
 			ContextLoader.class, false);
@@ -89,7 +79,18 @@ public class ContextLoaderUtilsConfigurationAttributesTests extends AbstractCont
 		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(MetaLocationsFoo.class);
 		assertNotNull(attributesList);
 		assertEquals(1, attributesList.size());
-		assertAttributes(attributesList.get(0), MetaLocationsFooTest.class, new String[] { "/foo.xml" },
+		assertAttributes(attributesList.get(0), MetaLocationsFooConfig.class, new String[] { "/foo.xml" },
+			EMPTY_CLASS_ARRAY, ContextLoader.class, true);
+	}
+
+	@Test
+	public void resolveConfigAttributesWithMetaAnnotationAndLocationsInClassHierarchy() {
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(MetaLocationsBar.class);
+		assertNotNull(attributesList);
+		assertEquals(2, attributesList.size());
+		assertAttributes(attributesList.get(0), MetaLocationsBarConfig.class, new String[] { "/bar.xml" },
+			EMPTY_CLASS_ARRAY, ContextLoader.class, true);
+		assertAttributes(attributesList.get(1), MetaLocationsFooConfig.class, new String[] { "/foo.xml" },
 			EMPTY_CLASS_ARRAY, ContextLoader.class, true);
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsConfigurationAttributesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsConfigurationAttributesTests.java
@@ -85,6 +85,15 @@ public class ContextLoaderUtilsConfigurationAttributesTests extends AbstractCont
 	}
 
 	@Test
+	public void resolveConfigAttributesWithMetaAnnotationAndLocations() {
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(MetaLocationsFoo.class);
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertAttributes(attributesList.get(0), MetaLocationsFooTest.class, new String[] { "/foo.xml" },
+			EMPTY_CLASS_ARRAY, ContextLoader.class, true);
+	}
+
+	@Test
 	public void resolveConfigAttributesWithLocalAnnotationAndClasses() {
 		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(ClassesFoo.class);
 		assertNotNull(attributesList);

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsContextHierarchyTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsContextHierarchyTests.java
@@ -69,6 +69,7 @@ public class ContextLoaderUtilsContextHierarchyTests extends AbstractContextLoad
 		debugConfigAttributes(configAttributesList);
 	}
 
+	@Ignore("[SPR-7827] Work in Progress")
 	@Test
 	public void resolveContextHierarchyAttributesForSingleTestClassWithSingleLevelContextHierarchyFromMetaAnnotation() {
 		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(SingleTestClassWithSingleLevelContextHierarchyFromMetaAnnotation.class);
@@ -109,7 +110,7 @@ public class ContextLoaderUtilsContextHierarchyTests extends AbstractContextLoad
 		assertThat(configAttributesListClassLevel3.get(0).getLocations()[0], equalTo("three.xml"));
 	}
 
-	@Ignore("Work in Progress")
+	@Ignore("[SPR-7827] Work in Progress")
 	@Test
 	public void resolveContextHierarchyAttributesForTestClassHierarchyWithSingleLevelContextHierarchiesAndMetaAnnotations() {
 		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(TestClass3WithSingleLevelContextHierarchyFromMetaAnnotation.class);

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsMergedConfigTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsMergedConfigTests.java
@@ -58,6 +58,15 @@ public class ContextLoaderUtilsMergedConfigTests extends AbstractContextLoaderUt
 	}
 
 	@Test
+	public void buildMergedConfigWithMetaAnnotationAndLocations() {
+		Class<?> testClass = MetaLocationsFoo.class;
+		MergedContextConfiguration mergedConfig = buildMergedContextConfiguration(testClass, null, null);
+
+		assertMergedConfig(mergedConfig, testClass, new String[] { "classpath:/foo.xml" }, EMPTY_CLASS_ARRAY,
+			DelegatingSmartContextLoader.class);
+	}
+
+	@Test
 	public void buildMergedConfigWithLocalAnnotationAndClasses() {
 		Class<?> testClass = ClassesFoo.class;
 		MergedContextConfiguration mergedConfig = buildMergedContextConfiguration(testClass, null, null);

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsMergedConfigTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsMergedConfigTests.java
@@ -31,9 +31,12 @@ import static org.springframework.test.context.ContextLoaderUtils.*;
  */
 public class ContextLoaderUtilsMergedConfigTests extends AbstractContextLoaderUtilsTests {
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void buildMergedConfigWithoutAnnotation() {
-		buildMergedContextConfiguration(Enigma.class, null, null);
+		Class<Enigma> testClass = Enigma.class;
+		MergedContextConfiguration mergedConfig = buildMergedContextConfiguration(testClass, null, null);
+
+		assertMergedConfig(mergedConfig, testClass, EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY, null);
 	}
 
 	@Test

--- a/spring-test/src/test/java/org/springframework/test/context/MetaAnnotationUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/MetaAnnotationUtilsTests.java
@@ -71,16 +71,8 @@ public class MetaAnnotationUtilsTests {
 	}
 
 	@Test
-	public void findAnnotationDescriptorWithInheritedClassLevelAnnotation() throws Exception {
+	public void findAnnotationDescriptorWithInheritedAnnotationOnClass() throws Exception {
 		// Note: @Transactional is inherited
-
-		assertEquals(InheritedAnnotationInterface.class,
-			findAnnotationDescriptor(InheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
-		assertEquals(InheritedAnnotationInterface.class,
-			findAnnotationDescriptor(SubInheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
-		assertEquals(InheritedAnnotationInterface.class,
-			findAnnotationDescriptor(SubSubInheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
-
 		assertEquals(InheritedAnnotationClass.class,
 			findAnnotationDescriptor(InheritedAnnotationClass.class, Transactional.class).getDeclaringClass());
 		assertEquals(InheritedAnnotationClass.class,
@@ -88,19 +80,29 @@ public class MetaAnnotationUtilsTests {
 	}
 
 	@Test
-	public void findAnnotationDescriptorWithNonInheritedClassLevelAnnotation() throws Exception {
-		// Note: @Order is not inherited, but findAnnotationDescriptor() should still find
-		// it.
+	public void findAnnotationDescriptorWithInheritedAnnotationOnInterface() throws Exception {
+		// Note: @Transactional is inherited
+		assertEquals(InheritedAnnotationInterface.class,
+			findAnnotationDescriptor(InheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
+		assertNull(findAnnotationDescriptor(SubInheritedAnnotationInterface.class, Transactional.class));
+		assertNull(findAnnotationDescriptor(SubSubInheritedAnnotationInterface.class, Transactional.class));
+	}
 
-		assertEquals(NonInheritedAnnotationInterface.class,
-			findAnnotationDescriptor(NonInheritedAnnotationInterface.class, Order.class).getDeclaringClass());
-		assertEquals(NonInheritedAnnotationInterface.class,
-			findAnnotationDescriptor(SubNonInheritedAnnotationInterface.class, Order.class).getDeclaringClass());
-
+	@Test
+	public void findAnnotationDescriptorForNonInheritedAnnotationOnClass() throws Exception {
+		// Note: @Order is not inherited.
 		assertEquals(NonInheritedAnnotationClass.class,
 			findAnnotationDescriptor(NonInheritedAnnotationClass.class, Order.class).getDeclaringClass());
 		assertEquals(NonInheritedAnnotationClass.class,
 			findAnnotationDescriptor(SubNonInheritedAnnotationClass.class, Order.class).getDeclaringClass());
+	}
+
+	@Test
+	public void findAnnotationDescriptorForNonInheritedAnnotationOnInterface() throws Exception {
+		// Note: @Order is not inherited.
+		assertEquals(NonInheritedAnnotationInterface.class,
+			findAnnotationDescriptor(NonInheritedAnnotationInterface.class, Order.class).getDeclaringClass());
+		assertNull(findAnnotationDescriptor(SubNonInheritedAnnotationInterface.class, Order.class));
 	}
 
 	@Test
@@ -128,8 +130,7 @@ public class MetaAnnotationUtilsTests {
 
 	@Test
 	public void findAnnotationDescriptorForClassWithMetaAnnotatedInterface() {
-		assertComponentOnStereotype(ClassWithMetaAnnotatedInterface.class, InterfaceWithMetaAnnotation.class, "meta1",
-			Meta1.class);
+		assertNull(findAnnotationDescriptor(ClassWithMetaAnnotatedInterface.class, Component.class));
 	}
 
 	@Test
@@ -155,19 +156,8 @@ public class MetaAnnotationUtilsTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void findAnnotationDescriptorForTypesWithInheritedClassLevelAnnotation() throws Exception {
+	public void findAnnotationDescriptorForTypesWithInheritedAnnotationOnClass() throws Exception {
 		// Note: @Transactional is inherited
-
-		assertEquals(
-			InheritedAnnotationInterface.class,
-			findAnnotationDescriptorForTypes(InheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
-		assertEquals(
-			InheritedAnnotationInterface.class,
-			findAnnotationDescriptorForTypes(SubInheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
-		assertEquals(
-			InheritedAnnotationInterface.class,
-			findAnnotationDescriptorForTypes(SubSubInheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
-
 		assertEquals(InheritedAnnotationClass.class,
 			findAnnotationDescriptorForTypes(InheritedAnnotationClass.class, Transactional.class).getDeclaringClass());
 		assertEquals(
@@ -177,19 +167,32 @@ public class MetaAnnotationUtilsTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void findAnnotationDescriptorForTypesWithNonInheritedClassLevelAnnotation() throws Exception {
-		// Note: @Order is not inherited, but findAnnotationDescriptor() should still find
-		// it.
+	public void findAnnotationDescriptorForTypesWithInheritedAnnotationOnInterface() throws Exception {
+		// Note: @Transactional is inherited
+		assertEquals(
+			InheritedAnnotationInterface.class,
+			findAnnotationDescriptorForTypes(InheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
+		assertNull(findAnnotationDescriptorForTypes(SubInheritedAnnotationInterface.class, Transactional.class));
+		assertNull(findAnnotationDescriptorForTypes(SubSubInheritedAnnotationInterface.class, Transactional.class));
+	}
 
-		assertEquals(NonInheritedAnnotationInterface.class,
-			findAnnotationDescriptorForTypes(NonInheritedAnnotationInterface.class, Order.class).getDeclaringClass());
-		assertEquals(NonInheritedAnnotationInterface.class,
-			findAnnotationDescriptorForTypes(SubNonInheritedAnnotationInterface.class, Order.class).getDeclaringClass());
-
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesForNonInheritedAnnotationOnClass() throws Exception {
+		// Note: @Order is not inherited.
 		assertEquals(NonInheritedAnnotationClass.class,
 			findAnnotationDescriptorForTypes(NonInheritedAnnotationClass.class, Order.class).getDeclaringClass());
 		assertEquals(NonInheritedAnnotationClass.class,
 			findAnnotationDescriptorForTypes(SubNonInheritedAnnotationClass.class, Order.class).getDeclaringClass());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesForNonInheritedAnnotationOnInterface() throws Exception {
+		// Note: @Order is not inherited.
+		assertEquals(NonInheritedAnnotationInterface.class,
+			findAnnotationDescriptorForTypes(NonInheritedAnnotationInterface.class, Order.class).getDeclaringClass());
+		assertNull(findAnnotationDescriptorForTypes(SubNonInheritedAnnotationInterface.class, Order.class));
 	}
 
 	@Test
@@ -217,9 +220,10 @@ public class MetaAnnotationUtilsTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void findAnnotationDescriptorForTypesForClassWithMetaAnnotatedInterface() {
-		assertComponentOnStereotypeForMultipleCandidateTypes(ClassWithMetaAnnotatedInterface.class,
-			InterfaceWithMetaAnnotation.class, "meta1", Meta1.class);
+		assertNull(findAnnotationDescriptorForTypes(ClassWithMetaAnnotatedInterface.class, Service.class,
+			Component.class, Order.class, Transactional.class));
 	}
 
 	@Test

--- a/spring-test/src/test/java/org/springframework/test/context/MetaAnnotationUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/MetaAnnotationUtilsTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.Test;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.MetaAnnotationUtils.AnnotationDescriptor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.Assert.*;
+import static org.springframework.test.context.MetaAnnotationUtils.*;
+
+/**
+ * Unit tests for {@link MetaAnnotationUtils}.
+ * 
+ * @author Sam Brannen
+ * @since 4.0
+ */
+public class MetaAnnotationUtilsTests {
+
+	@Test
+	public void testFindAnnotationDescriptor() throws Exception {
+		// no annotation
+		assertNull(findAnnotationDescriptor(Transactional.class, NonAnnotatedInterface.class));
+		assertNull(findAnnotationDescriptor(Transactional.class, NonAnnotatedClass.class));
+
+		// inherited class-level annotation; note: @Transactional is inherited
+		assertEquals(InheritedAnnotationInterface.class,
+			findAnnotationDescriptor(Transactional.class, InheritedAnnotationInterface.class).getAnnotatedClass());
+		assertNull(findAnnotationDescriptor(Transactional.class, SubInheritedAnnotationInterface.class));
+		assertEquals(InheritedAnnotationClass.class,
+			findAnnotationDescriptor(Transactional.class, InheritedAnnotationClass.class).getAnnotatedClass());
+		assertEquals(InheritedAnnotationClass.class,
+			findAnnotationDescriptor(Transactional.class, SubInheritedAnnotationClass.class).getAnnotatedClass());
+
+		// non-inherited class-level annotation; note: @Order is not inherited,
+		// but findAnnotationDescriptor() should still find it.
+		assertEquals(NonInheritedAnnotationInterface.class,
+			findAnnotationDescriptor(Order.class, NonInheritedAnnotationInterface.class).getAnnotatedClass());
+		assertNull(findAnnotationDescriptor(Order.class, SubNonInheritedAnnotationInterface.class));
+		assertEquals(NonInheritedAnnotationClass.class,
+			findAnnotationDescriptor(Order.class, NonInheritedAnnotationClass.class).getAnnotatedClass());
+		assertEquals(NonInheritedAnnotationClass.class,
+			findAnnotationDescriptor(Order.class, SubNonInheritedAnnotationClass.class).getAnnotatedClass());
+
+		// Meta-annotations:
+		AnnotationDescriptor<Component> descriptor = findAnnotationDescriptor(Component.class,
+			HasMetaComponentAnnotation.class);
+		assertEquals(HasMetaComponentAnnotation.class, descriptor.getAnnotatedClass());
+		assertEquals(Meta1.class, descriptor.getMetaAnnotatedClass());
+		descriptor = findAnnotationDescriptor(Component.class, HasLocalAndMetaComponentAnnotation.class);
+		assertEquals(HasLocalAndMetaComponentAnnotation.class, descriptor.getAnnotatedClass());
+		assertNull(descriptor.getMetaAnnotatedClass());
+	}
+
+
+	// -------------------------------------------------------------------------
+
+	@Component(value = "meta1")
+	@Order
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface Meta1 {
+	}
+
+	@Component(value = "meta2")
+	@Transactional
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface Meta2 {
+	}
+
+	@Meta1
+	static class HasMetaComponentAnnotation {
+	}
+
+	@Meta1
+	@Component(value = "local")
+	@Meta2
+	static class HasLocalAndMetaComponentAnnotation {
+	}
+
+	@Meta1
+	static interface InterfaceWithMetaAnnotation {
+	}
+
+	static class ClassWithMetaAnnotatedInterface implements InterfaceWithMetaAnnotation {
+	}
+
+	@Meta2
+	static class ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface implements InterfaceWithMetaAnnotation {
+	}
+
+	// -------------------------------------------------------------------------
+
+	@Transactional
+	public static interface InheritedAnnotationInterface {
+	}
+
+	public static interface SubInheritedAnnotationInterface extends InheritedAnnotationInterface {
+	}
+
+	@Order
+	public static interface NonInheritedAnnotationInterface {
+	}
+
+	public static interface SubNonInheritedAnnotationInterface extends NonInheritedAnnotationInterface {
+	}
+
+	public static class NonAnnotatedClass {
+	}
+
+	public static interface NonAnnotatedInterface {
+	}
+
+	@Transactional
+	public static class InheritedAnnotationClass {
+	}
+
+	public static class SubInheritedAnnotationClass extends InheritedAnnotationClass {
+	}
+
+	@Order
+	public static class NonInheritedAnnotationClass {
+	}
+
+	public static class SubNonInheritedAnnotationClass extends NonInheritedAnnotationClass {
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/TestExecutionListenersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/TestExecutionListenersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@
 package org.springframework.test.context;
 
 import static org.junit.Assert.assertEquals;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 import org.junit.Test;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -42,7 +45,7 @@ public class TestExecutionListenersTests {
 	@Test
 	public void verifyNumDefaultListenersRegistered() throws Exception {
 		TestContextManager testContextManager = new TestContextManager(DefaultListenersExampleTestCase.class);
-		assertEquals("Verifying the number of registered TestExecutionListeners for DefaultListenersExampleTest.", 4,
+		assertEquals("Num registered TELs for DefaultListenersExampleTestCase.", 4,
 			testContextManager.getTestExecutionListeners().size());
 	}
 
@@ -50,47 +53,64 @@ public class TestExecutionListenersTests {
 	public void verifyNumNonInheritedDefaultListenersRegistered() throws Exception {
 		TestContextManager testContextManager = new TestContextManager(
 			NonInheritedDefaultListenersExampleTestCase.class);
-		assertEquals(
-			"Verifying the number of registered TestExecutionListeners for NonInheritedDefaultListenersExampleTest.",
-			1, testContextManager.getTestExecutionListeners().size());
+		assertEquals("Num registered TELs for NonInheritedDefaultListenersExampleTestCase.", 1,
+			testContextManager.getTestExecutionListeners().size());
 	}
 
 	@Test
 	public void verifyNumInheritedDefaultListenersRegistered() throws Exception {
 		TestContextManager testContextManager = new TestContextManager(InheritedDefaultListenersExampleTestCase.class);
-		assertEquals(
-			"Verifying the number of registered TestExecutionListeners for InheritedDefaultListenersExampleTest.", 1,
+		assertEquals("Num registered TELs for InheritedDefaultListenersExampleTestCase.", 1,
 			testContextManager.getTestExecutionListeners().size());
 
 		testContextManager = new TestContextManager(SubInheritedDefaultListenersExampleTestCase.class);
-		assertEquals(
-			"Verifying the number of registered TestExecutionListeners for SubInheritedDefaultListenersExampleTest.",
-			1, testContextManager.getTestExecutionListeners().size());
+		assertEquals("Num registered TELs for SubInheritedDefaultListenersExampleTestCase.", 1,
+			testContextManager.getTestExecutionListeners().size());
 
 		testContextManager = new TestContextManager(SubSubInheritedDefaultListenersExampleTestCase.class);
-		assertEquals(
-			"Verifying the number of registered TestExecutionListeners for SubSubInheritedDefaultListenersExampleTest.",
-			2, testContextManager.getTestExecutionListeners().size());
+		assertEquals("Num registered TELs for SubSubInheritedDefaultListenersExampleTestCase.", 2,
+			testContextManager.getTestExecutionListeners().size());
 	}
 
 	@Test
 	public void verifyNumListenersRegistered() throws Exception {
 		TestContextManager testContextManager = new TestContextManager(ExampleTestCase.class);
-		assertEquals("Verifying the number of registered TestExecutionListeners for ExampleTest.", 3,
+		assertEquals("Num registered TELs for ExampleTestCase.", 3,
 			testContextManager.getTestExecutionListeners().size());
 	}
 
 	@Test
 	public void verifyNumNonInheritedListenersRegistered() throws Exception {
 		TestContextManager testContextManager = new TestContextManager(NonInheritedListenersExampleTestCase.class);
-		assertEquals("Verifying the number of registered TestExecutionListeners for NonInheritedListenersExampleTest.",
-			1, testContextManager.getTestExecutionListeners().size());
+		assertEquals("Num registered TELs for NonInheritedListenersExampleTestCase.", 1,
+			testContextManager.getTestExecutionListeners().size());
 	}
 
 	@Test
 	public void verifyNumInheritedListenersRegistered() throws Exception {
 		TestContextManager testContextManager = new TestContextManager(InheritedListenersExampleTestCase.class);
-		assertEquals("Verifying the number of registered TestExecutionListeners for InheritedListenersExampleTest.", 4,
+		assertEquals("Num registered TELs for InheritedListenersExampleTestCase.", 4,
+			testContextManager.getTestExecutionListeners().size());
+	}
+
+	@Test
+	public void verifyNumListenersRegisteredViaMetaAnnotation() throws Exception {
+		TestContextManager testContextManager = new TestContextManager(MetaExampleTestCase.class);
+		assertEquals("Num registered TELs for MetaExampleTestCase.", 3,
+			testContextManager.getTestExecutionListeners().size());
+	}
+
+	@Test
+	public void verifyNumNonInheritedListenersRegisteredViaMetaAnnotation() throws Exception {
+		TestContextManager testContextManager = new TestContextManager(MetaNonInheritedListenersExampleTestCase.class);
+		assertEquals("Num registered TELs for MetaNonInheritedListenersExampleTestCase.", 1,
+			testContextManager.getTestExecutionListeners().size());
+	}
+
+	@Test
+	public void verifyNumInheritedListenersRegisteredViaMetaAnnotation() throws Exception {
+		TestContextManager testContextManager = new TestContextManager(MetaInheritedListenersExampleTestCase.class);
+		assertEquals("Num registered TELs for MetaInheritedListenersExampleTestCase.", 4,
 			testContextManager.getTestExecutionListeners().size());
 	}
 
@@ -118,7 +138,7 @@ public class TestExecutionListenersTests {
 	static class NonInheritedDefaultListenersExampleTestCase extends InheritedDefaultListenersExampleTestCase {
 	}
 
-	@TestExecutionListeners( { FooTestExecutionListener.class, BarTestExecutionListener.class,
+	@TestExecutionListeners({ FooTestExecutionListener.class, BarTestExecutionListener.class,
 		BazTestExecutionListener.class })
 	static class ExampleTestCase {
 	}
@@ -133,6 +153,37 @@ public class TestExecutionListenersTests {
 
 	@TestExecutionListeners(listeners = FooTestExecutionListener.class, value = BarTestExecutionListener.class)
 	static class DuplicateListenersConfigExampleTestCase {
+	}
+
+	@TestExecutionListeners({//
+	FooTestExecutionListener.class,//
+		BarTestExecutionListener.class,//
+		BazTestExecutionListener.class //
+	})
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaListeners {
+	}
+
+	@TestExecutionListeners(QuuxTestExecutionListener.class)
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaInheritedListeners {
+	}
+
+	@TestExecutionListeners(listeners = QuuxTestExecutionListener.class, inheritListeners = false)
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaNonInheritedListeners {
+	}
+
+	@MetaListeners
+	static class MetaExampleTestCase {
+	}
+
+	@MetaInheritedListeners
+	static class MetaInheritedListenersExampleTestCase extends MetaExampleTestCase {
+	}
+
+	@MetaNonInheritedListeners
+	static class MetaNonInheritedListenersExampleTestCase extends MetaInheritedListenersExampleTestCase {
 	}
 
 	static class FooTestExecutionListener extends AbstractTestExecutionListener {

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/RepeatedSpringRunnerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/RepeatedSpringRunnerTests.java
@@ -19,6 +19,8 @@ package org.springframework.test.context.junit4;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -77,6 +79,7 @@ public class RepeatedSpringRunnerTests {
 			{ DefaultRepeatValueRepeatedTestCase.class, 0, 1, 1, 1 },//
 			{ NegativeRepeatValueRepeatedTestCase.class, 0, 1, 1, 1 },//
 			{ RepeatedFiveTimesRepeatedTestCase.class, 0, 1, 1, 5 },//
+			{ RepeatedFiveTimesViaMetaAnnotationRepeatedTestCase.class, 0, 1, 1, 5 },//
 			{ TimedRepeatedTestCase.class, 3, 4, 4, (5 + 1 + 4 + 10) } //
 		});
 	}
@@ -142,6 +145,20 @@ public class RepeatedSpringRunnerTests {
 
 		@Test
 		@Repeat(5)
+		public void repeatedFiveTimes() throws Exception {
+			incrementInvocationCount();
+		}
+	}
+
+	@Repeat(5)
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface RepeatedFiveTimes {
+	}
+
+	public static final class RepeatedFiveTimesViaMetaAnnotationRepeatedTestCase extends AbstractRepeatedTestCase {
+
+		@Test
+		@RepeatedFiveTimes
 		public void repeatedFiveTimes() throws Exception {
 			incrementInvocationCount();
 		}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/TimedSpringRunnerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/TimedSpringRunnerTests.java
@@ -18,6 +18,9 @@ package org.springframework.test.context.junit4;
 
 import static org.junit.Assert.*;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,11 +54,11 @@ public class TimedSpringRunnerTests {
 		notifier.addListener(listener);
 
 		new SpringJUnit4ClassRunner(testClass).run(notifier);
-		assertEquals("Verifying number of failures for test class [" + testClass + "].", 3,
-			listener.getTestFailureCount());
-		assertEquals("Verifying number of tests started for test class [" + testClass + "].", 5,
+		assertEquals("Verifying number of tests started for test class [" + testClass + "].", 6,
 			listener.getTestStartedCount());
-		assertEquals("Verifying number of tests finished for test class [" + testClass + "].", 5,
+		assertEquals("Verifying number of failures for test class [" + testClass + "].", 4,
+			listener.getTestFailureCount());
+		assertEquals("Verifying number of tests finished for test class [" + testClass + "].", 6,
 			listener.getTestFinishedCount());
 	}
 
@@ -91,12 +94,24 @@ public class TimedSpringRunnerTests {
 			Thread.sleep(20);
 		}
 
+		// Should Fail due to timeout.
+		@Test
+		@MetaTimed
+		public void springTimeoutWithSleepAndMetaAnnotation() throws Exception {
+			Thread.sleep(20);
+		}
+
 		// Should Fail due to duplicate configuration.
 		@Test(timeout = 200)
 		@Timed(millis = 200)
 		public void springAndJUnitTimeouts() {
 			/* no-op */
 		}
+	}
+
+	@Timed(millis = 10)
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaTimed {
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/context/support/DirtiesContextTestExecutionListenerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/DirtiesContextTestExecutionListenerTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.support;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
+import org.springframework.test.context.TestContext;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.annotation.DirtiesContext.HierarchyMode.*;
+
+/**
+ * Unit tests for {@link DirtiesContextTestExecutionListener}.
+ *
+ * @author Sam Brannen
+ * @since 4.0
+ */
+public class DirtiesContextTestExecutionListenerTests {
+
+	private final DirtiesContextTestExecutionListener listener = new DirtiesContextTestExecutionListener();
+	private final TestContext testContext = mock(TestContext.class);
+
+
+	@Test
+	public void afterTestMethodForDirtiesContextDeclaredLocallyOnMethod() throws Exception {
+		Class<?> clazz = getClass();
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("dirtiesContextDeclaredLocally"));
+		listener.afterTestMethod(testContext);
+		verify(testContext, times(1)).markApplicationContextDirty(EXHAUSTIVE);
+	}
+
+	@Test
+	public void afterTestMethodForDirtiesContextDeclaredOnMethodViaMetaAnnotation() throws Exception {
+		Class<?> clazz = getClass();
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("dirtiesContextDeclaredViaMetaAnnotation"));
+		listener.afterTestMethod(testContext);
+		verify(testContext, times(1)).markApplicationContextDirty(EXHAUSTIVE);
+	}
+
+	@Test
+	public void afterTestMethodForDirtiesContextDeclaredLocallyOnClassAfterEachTestMethod() throws Exception {
+		Class<?> clazz = DirtiesContextDeclaredLocallyAfterEachTestMethod.class;
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("clean"));
+		listener.afterTestMethod(testContext);
+		verify(testContext, times(1)).markApplicationContextDirty(EXHAUSTIVE);
+	}
+
+	@Test
+	public void afterTestMethodForDirtiesContextDeclaredViaMetaAnnotationOnClassAfterEachTestMethod() throws Exception {
+		Class<?> clazz = DirtiesContextDeclaredViaMetaAnnotationAfterEachTestMethod.class;
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("clean"));
+		listener.afterTestMethod(testContext);
+		verify(testContext, times(1)).markApplicationContextDirty(EXHAUSTIVE);
+	}
+
+	@Test
+	public void afterTestMethodForDirtiesContextDeclaredLocallyOnClassAfterClass() throws Exception {
+		Class<?> clazz = DirtiesContextDeclaredLocallyAfterClass.class;
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("clean"));
+		listener.afterTestMethod(testContext);
+		verify(testContext, times(0)).markApplicationContextDirty(any(HierarchyMode.class));
+	}
+
+	@Test
+	public void afterTestMethodForDirtiesContextDeclaredViaMetaAnnotationOnClassAfterClass() throws Exception {
+		Class<?> clazz = DirtiesContextDeclaredViaMetaAnnotationAfterClass.class;
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		when(testContext.getTestMethod()).thenReturn(clazz.getDeclaredMethod("clean"));
+		listener.afterTestMethod(testContext);
+		verify(testContext, times(0)).markApplicationContextDirty(any(HierarchyMode.class));
+	}
+
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void afterTestClassForDirtiesContextDeclaredLocallyOnMethod() throws Exception {
+		Class<?> clazz = getClass();
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		listener.afterTestClass(testContext);
+		verify(testContext, times(0)).markApplicationContextDirty(any(HierarchyMode.class));
+	}
+
+	@Test
+	public void afterTestClassForDirtiesContextDeclaredLocallyOnClassAfterEachTestMethod() throws Exception {
+		Class<?> clazz = DirtiesContextDeclaredLocallyAfterEachTestMethod.class;
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		listener.afterTestClass(testContext);
+		verify(testContext, times(1)).markApplicationContextDirty(EXHAUSTIVE);
+	}
+
+	@Test
+	public void afterTestClassForDirtiesContextDeclaredViaMetaAnnotationOnClassAfterEachTestMethod() throws Exception {
+		Class<?> clazz = DirtiesContextDeclaredViaMetaAnnotationAfterEachTestMethod.class;
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		listener.afterTestClass(testContext);
+		verify(testContext, times(1)).markApplicationContextDirty(EXHAUSTIVE);
+	}
+
+	@Test
+	public void afterTestClassForDirtiesContextDeclaredLocallyOnClassAfterClass() throws Exception {
+		Class<?> clazz = DirtiesContextDeclaredLocallyAfterClass.class;
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		listener.afterTestClass(testContext);
+		verify(testContext, times(1)).markApplicationContextDirty(any(HierarchyMode.class));
+	}
+
+	@Test
+	public void afterTestClassForDirtiesContextDeclaredViaMetaAnnotationOnClassAfterClass() throws Exception {
+		Class<?> clazz = DirtiesContextDeclaredViaMetaAnnotationAfterClass.class;
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+		listener.afterTestClass(testContext);
+		verify(testContext, times(1)).markApplicationContextDirty(any(HierarchyMode.class));
+	}
+
+	// -------------------------------------------------------------------------
+
+	@DirtiesContext
+	void dirtiesContextDeclaredLocally() {
+		/* no-op */
+	}
+
+	@MetaDirty
+	void dirtiesContextDeclaredViaMetaAnnotation() {
+		/* no-op */
+	}
+
+
+	@DirtiesContext
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaDirty {
+	}
+
+	@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaDirtyAfterEachTestMethod {
+	}
+
+	@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaDirtyAfterClass {
+	}
+
+	@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+	static class DirtiesContextDeclaredLocallyAfterEachTestMethod {
+
+		void clean() {
+			/* no-op */
+		}
+	}
+
+	@MetaDirtyAfterEachTestMethod
+	static class DirtiesContextDeclaredViaMetaAnnotationAfterEachTestMethod {
+
+		void clean() {
+			/* no-op */
+		}
+	}
+
+	@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+	static class DirtiesContextDeclaredLocallyAfterClass {
+
+		void clean() {
+			/* no-op */
+		}
+	}
+
+	@MetaDirtyAfterClass
+	static class DirtiesContextDeclaredViaMetaAnnotationAfterClass {
+
+		void clean() {
+			/* no-op */
+		}
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/web/MetaAnnotationConfigWacTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/web/MetaAnnotationConfigWacTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.web;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration test that verifies meta-annotation support for {@link WebAppConfiguration}
+ * and {@link org.springframework.test.context.ContextConfiguration ContextConfiguration}.
+ *
+ * @author Sam Brannen
+ * @since 4.0
+ * @see WebTests
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebTests
+public class MetaAnnotationConfigWacTests {
+
+	@Autowired
+	protected WebApplicationContext wac;
+
+	@Autowired
+	protected MockServletContext mockServletContext;
+
+	@Autowired
+	protected String foo;
+
+
+	@Test
+	public void fooEnigmaAutowired() {
+		assertEquals("enigma", foo);
+	}
+
+	@Test
+	public void basicWacFeatures() throws Exception {
+		assertNotNull("ServletContext should be set in the WAC.", wac.getServletContext());
+
+		assertNotNull("ServletContext should have been autowired from the WAC.", mockServletContext);
+
+		Object rootWac = mockServletContext.getAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE);
+		assertNotNull("Root WAC must be stored in the ServletContext as: "
+				+ WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, rootWac);
+		assertSame("test WAC and Root WAC in ServletContext must be the same object.", wac, rootWac);
+		assertSame("ServletContext instances must be the same object.", mockServletContext, wac.getServletContext());
+
+		assertEquals("Getting real path for ServletContext resource.",
+			new File("src/main/webapp/index.jsp").getCanonicalPath(), mockServletContext.getRealPath("index.jsp"));
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/web/WebTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/web/WebTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.web;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Custom stereotype combining {@link WebAppConfiguration} and
+ * {@link ContextConfiguration} as meta-annotations.
+ *
+ * @author Sam Brannen
+ * @since 4.0
+ */
+@WebAppConfiguration
+@ContextConfiguration
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WebTests {
+
+	@Configuration
+	static class Config {
+
+		@Bean
+		public String foo() {
+			return "enigma";
+		}
+	}
+}


### PR DESCRIPTION
Spring 3.0 already allows component stereotypes to be used in a
meta-annotation fashion, for example by creating a custom
@TransactionalService stereotype annotation which combines
@Transactional and @Service in a single, reusable, application-specific
annotation. However, the Spring TestContext Framework (TCF) currently
does not provide any support for test-related annotations to be used as
meta-annotations.

This commit overhauls the TCF with regard to how annotations are
retrieved and adds explicit support for the following annotations to be
used as meta-annotations in conjunction with the TCF.
- @ContextConfiguration
- @ContextHierarchy
- @ActiveProfiles
- @DirtiesContext
- @IfProfileValue
- @ProfileValueSourceConfiguration
- @BeforeTransaction
- @AfterTransaction
- @TransactionConfiguration
- @Rollback
- @TestExecutionListeners
- @Repeat
- @Timed
- @WebAppConfiguration

Note that meta-annotation support for @Transactional was already
available prior to this commit.

Issue: SPR-7827
