### PR TITLE
upgrade to Jetty 9.1.0 .RC0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -388,8 +388,10 @@ project("spring-messaging") {
 		optional("com.fasterxml.jackson.core:jackson-databind:2.2.0")
 		optional("org.projectreactor:reactor-core:1.0.0.BUILD-SNAPSHOT")
 		optional("org.projectreactor:reactor-tcp:1.0.0.BUILD-SNAPSHOT")
-		optional("org.eclipse.jetty.websocket:websocket-server:9.0.5.v20130815")
-		optional("org.eclipse.jetty.websocket:websocket-client:9.0.5.v20130815")
+		optional("org.eclipse.jetty.websocket:websocket-server:9.1.0.RC0") {
+			exclude group: "javax.servlet", module: "javax.servlet-api"
+		}
+		optional("org.eclipse.jetty.websocket:websocket-client:9.1.0.RC0")
 		testCompile(project(":spring-test"))
 		testCompile("com.thoughtworks.xstream:xstream:1.4.4")
 		testCompile("commons-dbcp:commons-dbcp:1.2.2")
@@ -401,8 +403,8 @@ project("spring-messaging") {
 			exclude group: "org.springframework", module: "spring-context"
 		}
 		testCompile("org.apache.activemq:activemq-stomp:5.8.0")
-		testCompile("org.eclipse.jetty:jetty-webapp:9.0.5.v20130815") {
-			exclude group: "org.eclipse.jetty.orbit", module: "javax.servlet"
+		testCompile("org.eclipse.jetty:jetty-webapp:9.1.0.RC0") {
+			exclude group: "javax.servlet", module: "javax.servlet-api"
 		}
 		testCompile("org.apache.tomcat.embed:tomcat-embed-core:8.0.0-RC3")
 		testCompile("org.apache.tomcat.embed:tomcat-embed-logging-juli:8.0.0-RC3")
@@ -558,11 +560,11 @@ project("spring-web") {
 		optional("org.codehaus.jackson:jackson-mapper-asl:1.9.12")
 		optional("com.fasterxml.jackson.core:jackson-databind:2.2.0")
 		optional("taglibs:standard:1.1.2")
-		optional("org.eclipse.jetty:jetty-servlet:9.0.5.v20130815") {
-			exclude group: "org.eclipse.jetty.orbit", module: "javax.servlet"
+		optional("org.eclipse.jetty:jetty-servlet:9.1.0.RC0") {
+			exclude group: "javax.servlet", module: "javax.servlet-api"
 		}
-		optional("org.eclipse.jetty:jetty-server:9.0.5.v20130815") {
-			exclude group: "org.eclipse.jetty.orbit", module: "javax.servlet"
+		optional("org.eclipse.jetty:jetty-server:9.1.0.RC0") {
+			exclude group: "javax.servlet", module: "javax.servlet-api"
 		}
 		optional("log4j:log4j:1.2.17")
 		testCompile(project(":spring-context-support"))  // for JafMediaTypeFactory
@@ -591,11 +593,13 @@ project("spring-websocket") {
 		}
 		optional("org.glassfish.tyrus:tyrus-websocket-core:1.2.1")
 		optional("org.glassfish.tyrus:tyrus-container-servlet:1.2.1")
-		optional("org.eclipse.jetty:jetty-webapp:9.0.5.v20130815") {
-			exclude group: "org.eclipse.jetty.orbit", module: "javax.servlet"
+		optional("org.eclipse.jetty:jetty-webapp:9.1.0.RC0") {
+			exclude group: "javax.servlet", module: "javax.servlet"
 		}
-		optional("org.eclipse.jetty.websocket:websocket-server:9.0.5.v20130815")
-		optional("org.eclipse.jetty.websocket:websocket-client:9.0.5.v20130815")
+		optional("org.eclipse.jetty.websocket:websocket-server:9.1.0.RC0") {
+			exclude group: "javax.servlet", module: "javax.servlet"
+		}
+		optional("org.eclipse.jetty.websocket:websocket-client:9.1.0.RC0")
 		optional("com.fasterxml.jackson.core:jackson-databind:2.2.0")
 		optional("org.codehaus.jackson:jackson-mapper-asl:1.9.12")
 		testCompile("org.apache.tomcat.embed:tomcat-embed-core:8.0.0-RC3")
@@ -687,11 +691,11 @@ project("spring-webmvc") {
 			exclude group: "xom", module: "xom"
 			exclude group: "xerces", module: "xercesImpl"
 		}
-		testCompile("org.eclipse.jetty:jetty-servlet:8.1.5.v20120716") {
-			exclude group: "org.eclipse.jetty.orbit", module: "javax.servlet"
+		testCompile("org.eclipse.jetty:jetty-servlet:9.1.0.RC0") {
+			exclude group: "javax.servlet", module: "javax.servlet"
 		}
-		testCompile("org.eclipse.jetty:jetty-server:8.1.5.v20120716") {
-			exclude group: "org.eclipse.jetty.orbit", module: "javax.servlet"
+		testCompile("org.eclipse.jetty:jetty-server:9.1.0.RC0") {
+			exclude group: "javax.servlet", module: "javax.servlet"
 		}
 		testCompile("javax.validation:validation-api:1.0.0.GA")
 		testCompile("commons-fileupload:commons-fileupload:1.2")

--- a/spring-web/src/test/java/org/springframework/http/client/AbstractJettyServerTestCase.java
+++ b/spring-web/src/test/java/org/springframework/http/client/AbstractJettyServerTestCase.java
@@ -54,7 +54,6 @@ public class AbstractJettyServerTestCase {
 		handler.setContextPath("/");
 
 		handler.addServlet(new ServletHolder(new EchoServlet()), "/echo");
-		handler.addServlet(new ServletHolder(new EchoServlet()), "/echo");
 		handler.addServlet(new ServletHolder(new StatusServlet(200)), "/status/ok");
 		handler.addServlet(new ServletHolder(new StatusServlet(404)), "/status/notfound");
 		handler.addServlet(new ServletHolder(new MethodServlet("DELETE")), "/methods/delete");

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/JettyRequestUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/JettyRequestUpgradeStrategy.java
@@ -30,6 +30,8 @@ import org.eclipse.jetty.websocket.api.WebSocketPolicy;
 import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
 import org.eclipse.jetty.websocket.server.HandshakeRFC6455;
 import org.eclipse.jetty.websocket.server.WebSocketServerFactory;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.springframework.core.NamedThreadLocal;
 import org.springframework.http.server.ServerHttpRequest;
@@ -81,7 +83,12 @@ public class JettyRequestUpgradeStrategy implements RequestUpgradeStrategy {
 		Assert.notNull(factory, "WebSocketServerFactory is required");
 		this.factory = factory;
 		this.factory.setCreator(new WebSocketCreator() {
-			@Override
+			// Jetty 9.1
+			public Object createWebSocket(ServletUpgradeRequest request, ServletUpgradeResponse response) {
+				return createWebSocket((UpgradeRequest)request,(UpgradeResponse)response);
+			}
+
+			// Jetty < 9.1
 			public Object createWebSocket(UpgradeRequest request, UpgradeResponse response) {
 
 				WebSocketHandlerContainer container = wsContainerHolder.get();

--- a/spring-websocket/src/test/java/org/springframework/web/socket/client/jetty/JettyWebSocketClientTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/client/jetty/JettyWebSocketClientTests.java
@@ -21,14 +21,13 @@ import java.util.Arrays;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.websocket.api.UpgradeRequest;
-import org.eclipse.jetty.websocket.api.UpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.SocketUtils;
 import org.springframework.web.socket.WebSocketHandler;
@@ -108,7 +107,7 @@ public class JettyWebSocketClientTests {
 				public void configure(WebSocketServletFactory factory) {
 					factory.setCreator(new WebSocketCreator() {
 						@Override
-						public Object createWebSocket(UpgradeRequest req, UpgradeResponse resp) {
+						public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp) {
 							if (!CollectionUtils.isEmpty(req.getSubProtocols())) {
 								resp.setAcceptedSubProtocol(req.getSubProtocols().get(0));
 							}


### PR DESCRIPTION
This commit upgrades Jetty to its latest version,
which is JSP-356 compliant and allows WebSocket
extensions negotiation by the application.
