### PR TITLE
remove allocation from NamedParameterUtils

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,7 +255,7 @@ public abstract class NamedParameterUtils {
 			int[] indexes = parsedSql.getParameterIndexes(i);
 			int startIndex = indexes[0];
 			int endIndex = indexes[1];
-			actualSql.append(originalSql.substring(lastIndex, startIndex));
+			actualSql.append(originalSql, lastIndex, startIndex);
 			if (paramSource != null && paramSource.hasValue(paramName)) {
 				Object value = paramSource.getValue(paramName);
 				if (value instanceof SqlParameterValue) {
@@ -295,7 +295,7 @@ public abstract class NamedParameterUtils {
 			}
 			lastIndex = endIndex;
 		}
-		actualSql.append(originalSql.substring(lastIndex, originalSql.length()));
+		actualSql.append(originalSql, lastIndex, originalSql.length());
 		return actualSql.toString();
 	}
 


### PR DESCRIPTION
NamedParameterUtils first creates a substring before appending to a
Appendable. This is unnecessary and creates a new `char[]` in later
HotSpot versions.
- use `Appendable#append` directly instead of creating substring first

I did sign the Contributor License Agreement.

Issue: SPR-11042
