### PR TITLE
Fix configuration class overriden/overloaded methods issues (SPR-10992, SPR-10988)

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
@@ -244,8 +244,17 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 			return (candidate instanceof Method ? (Method) candidate : null);
 		}
 	}
-
-
+	
+	/**
+	 * Allow subclasses to set the resolved factory method.
+	 * @param method factory method to use.
+	 */
+	protected void setResolvedFactoryMethod(Method method) {
+		synchronized (this.constructorArgumentLock) {
+			this.resolvedConstructorOrFactoryMethod = method;
+		}
+	}
+	
 	public void registerExternallyManagedConfigMember(Member configMember) {
 		this.externallyManagedConfigMembers.add(configMember);
 	}

--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
@@ -18,6 +18,7 @@ package org.springframework.context.annotation;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -172,6 +173,26 @@ final class ConfigurationClass {
 	public Set<BeanMethod> getBeanMethods() {
 		return this.beanMethods;
 	}
+	
+	/**
+	 * Gets bean methods elegibles for bean definitions
+	 * skipping overriden methods from superclasses.
+	 */
+	public Set<BeanMethod> getBeanMethodsToDefine() {
+		Set<BeanMethod> methods = new LinkedHashSet<BeanMethod>();
+		Set<String> names = new HashSet<String>();
+
+		for (BeanMethod method : beanMethods) {
+			String name = method.getMetadata().getMethodName();
+			if (!names.contains(name)) {
+				methods.add(method);
+				names.add(name);
+			}
+		}
+
+		return methods;
+	}
+
 
 	public void addImportedResource(String importedResource, Class<? extends BeanDefinitionReader> readerClass) {
 		this.importedResources.put(importedResource, readerClass);

--- a/spring-context/src/test/java/org/springframework/context/annotation/BeanMethodPolymorphismTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/BeanMethodPolymorphismTests.java
@@ -79,6 +79,34 @@ public class BeanMethodPolymorphismTests {
 		// SPR-11025
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(SubConfigWithList.class);
 		assertThat(ctx.getBean(String.class), equalTo("overloaded5"));
+
+	}
+	
+	@Test
+	public void beanMethodOverloadingNotGreedyWithInheritance() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(NotGreedySubConfig.class);
+		assertThat(ctx.getBean(String.class), equalTo("overloaded"));
+	}
+	static @Configuration class NotGreedySuperConfig {
+		@Bean Integer anInt() { return 5; }
+		@Bean String aString(Integer dependency) { return "super"; }
+	}
+	static @Configuration class NotGreedySubConfig extends NotGreedySuperConfig {
+		
+		@Bean String aString() { return "overloaded"; }
+	}
+
+	@Test
+	public void beanMethodOverloadingNotBestMathcWithInheritance() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(NotBestMatchSubConfig.class);
+		assertThat(ctx.getBean(String.class), equalTo("overloaded5"));
+	}
+	static @Configuration class NotBestMathcSuperConfig {
+		@Bean String aString(Integer dependency) { return "super"; }
+	}
+	static @Configuration class NotBestMatchSubConfig extends NotBestMathcSuperConfig {
+		@Bean Integer anInt() { return 5; }
+		@Bean String aString(Number dependency) { return "overloaded"+dependency; }
 	}
 
 	/**

--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/ConfigurationClassInheritanceTest.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/ConfigurationClassInheritanceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.type.StandardMethodMetadata;
+
+
+/**
+ * Test for SPR-10992. Check that bean definition is not overridden
+ * by superclass.
+ * 
+ * @author Jose Luis Martin
+ */
+public class ConfigurationClassInheritanceTest {
+
+	@Test
+	public void testBeanDefinitionOverriding() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(Config.class);
+		BeanDefinition bd = ctx.getBeanDefinition("bean");
+		StandardMethodMetadata metadata = (StandardMethodMetadata) bd.getSource();
+		Assert.assertEquals(Config.class, metadata.getIntrospectedMethod().getDeclaringClass());
+		ctx.close();
+	}
+
+	@Configuration
+	public static class ParentConfig {
+
+		@Bean
+		public String bean() {
+			return "parentBean";
+		}
+	}
+
+	@Configuration
+	public static class Config extends ParentConfig {
+
+		@Bean
+		public String bean() {
+			return "overridingBean";
+		}
+
+	}
+
+}
+


### PR DESCRIPTION
When adding bean methods from a configuration class,
overridden methods from superclass are added too and
it's bean definition overrides those declared in the subclass.

The fix add a new method, getBeanMethodsToDefine that filter
overriden methods for use in ConfigurationClassBeanDefinitionReader

When overloading methods from a configuration class, the most
specific subclass bean method is invoked only if
- Argument types has the best match
- Overloaded method in subclass has the same number of arguments.

The fix sets the factory method to use from beanMethod metadata to
RootBeanDefinition.resolvedConstructorOrFactoryMethod in
ConfigurationClassBeanDefinitionReader.loadBeanDefinitionsForBeanMethod()
to avoid looking for appropiate factory method in ConstructorResolver  later.

This pull request already includes changes from https://github.com/spring-projects/spring-framework/pull/390

Issues: SPR-10992, SPR-10988
