### PR TITLE
Converting Number to Models in Spring MVC

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/NumberToObjectConversionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/NumberToObjectConversionTests.java
@@ -21,6 +21,7 @@ import java.util.EnumSet;
 
 import org.junit.Test;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 
 public class NumberToObjectConversionTests {
@@ -155,5 +156,35 @@ public class NumberToObjectConversionTests {
 		converter.setConversionService(service);
 
 		converter.convertIfNecessary(1, TestEnum.class);
+	}
+
+	@Test
+	public void multipleEnumConvertersNumber() {
+		DefaultConversionService service = new DefaultConversionService();
+		service.addConverter(new TestConverter<Integer>());
+
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.TWO, converter.convertIfNecessary("2", TestEnum.class));
+	}
+
+	/**
+	 * A precondition to the fallback test is that enum name can't be equal to the value 
+	 * being compared against.
+	 * 
+	 * examples 
+	 * - ONE(1) is valid for this test
+	 * - ONE("ONE") is not valid for this test because the fallback would not be executed.
+	 */
+	@Test
+	public void multipleEnumConvertersFallback() {
+		DefaultConversionService service = new DefaultConversionService();
+		service.addConverter(new TestConverter<Integer>());
+
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.TWO, converter.convertIfNecessary("TWO", TestEnum.class));
 	}
 }

--- a/spring-beans/src/test/java/org/springframework/beans/NumberToObjectConversionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/NumberToObjectConversionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-beans/src/test/java/org/springframework/beans/NumberToObjectConversionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/NumberToObjectConversionTests.java
@@ -26,67 +26,48 @@ import org.springframework.core.convert.support.GenericConversionService;
 public class NumberToObjectConversionTests {
 
 	private enum TestEnum {
-		  ONE((byte)1, (short)1, 1, (long)1, (float)1, (double)1) 
-		, TWO((byte)2, (short)2, 2, (long)2, (float)2, (double)2) 
-		// MAX_INT represents the largest possible integer value.  Since it's not 
-		// possible to represent this as a byte or short, just set it as null
-		, MAX_INT(null, null, Integer.MAX_VALUE, (long)Integer.MAX_VALUE, (float)Integer.MAX_VALUE, (double)Integer.MAX_VALUE)
-		;
+		ONE("1"), TWO("2"), MAX_INT(String.valueOf(Integer.MAX_VALUE));
 
-		private Byte byteValue;
-		private Short shortValue;
-		private Integer intValue;
-		private Long longValue;
-		private Float floatValue;
-		private Double doubleValue;
+		private String value;
 
-		private TestEnum(Byte byteValue, Short shortValue, Integer integerValue, Long longValue, Float floatValue, Double doubleValue) {
-			this.byteValue = byteValue;
-			this.shortValue = shortValue;
-			this.intValue = integerValue;
-			this.longValue = longValue;
-			this.floatValue = floatValue;
-			this.doubleValue = doubleValue;
+		private TestEnum(String value) {
+			this.value = value;
 		}
 
-		public Byte getByteValue() { 
-			return byteValue;
-		}
-
-		public Short getShortValue() { 
-			return shortValue;
-		}
-
-		public Integer getIntegerValue() { 
-			return intValue;
-		}
-
-		public Long getLongValue() { 
-			return longValue;
-		}
-
-		public Float getFloatValue() { 
-			return floatValue;
-		}
-
-		public Double getDoubleValue() { 
-			return doubleValue;
+		public Number getValue(Class<? extends Number> _class) { 
+			if (Byte.class.equals(_class)) {
+				return new Byte(value);
+			} else if (Short.class.equals(_class)) {
+				return new Short(value);
+			} else if (Integer.class.equals(_class)) {
+				return new Integer(value);
+			} else if (Long.class.equals(_class)) {
+				return new Long(value);
+			} else if (Float.class.equals(_class)) {
+				return new Float(value);
+			} else if (Double.class.equals(_class)) {
+				return new Double(value);
+			}
+			throw new IllegalArgumentException("unsupported input class: " + _class.getName());
 		}
 	}
+
+	private class TestConverter<T extends Number>  implements Converter<T, TestEnum> {
+		public TestEnum convert(T source) {
+			for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+				if (testEnum.getValue(source.getClass()).equals(source)) {
+					return testEnum;
+				}
+			}
+			return null;
+		}
+	};
 
 	@Test
 	public void byteToObjectTest() {
 		GenericConversionService service = new GenericConversionService();
-		service.addConverter(new Converter<Byte, TestEnum>() {
-			public TestEnum convert(Byte source) {
-				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
-					if (testEnum.getByteValue().equals(source)) {
-						return testEnum;
-					}
-				}
-				return null;
-			}
-		});
+		service.addConverter(new TestConverter<Byte>());
+
 		SimpleTypeConverter converter = new SimpleTypeConverter();
 		converter.setConversionService(service);
 
@@ -96,16 +77,8 @@ public class NumberToObjectConversionTests {
 	@Test
 	public void shortToObjectTest() {
 		GenericConversionService service = new GenericConversionService();
-		service.addConverter(new Converter<Short, TestEnum>() {
-			public TestEnum convert(Short source) {
-				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
-					if (testEnum.getShortValue().equals(source)) {
-						return testEnum;
-					}
-				}
-				return null;
-			}
-		});
+		service.addConverter(new TestConverter<Short>());
+
 		SimpleTypeConverter converter = new SimpleTypeConverter();
 		converter.setConversionService(service);
 
@@ -115,16 +88,8 @@ public class NumberToObjectConversionTests {
 	@Test
 	public void integerToObjectTest() {
 		GenericConversionService service = new GenericConversionService();
-		service.addConverter(new Converter<Integer, TestEnum>() {
-			public TestEnum convert(Integer source) {
-				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
-					if (testEnum.getIntegerValue().equals(source)) {
-						return testEnum;
-					}
-				}
-				return null;
-			}
-		});
+		service.addConverter(new TestConverter<Integer>());
+
 		SimpleTypeConverter converter = new SimpleTypeConverter();
 		converter.setConversionService(service);
 
@@ -135,16 +100,8 @@ public class NumberToObjectConversionTests {
 	@Test
 	public void longToObjectTest() {
 		GenericConversionService service = new GenericConversionService();
-		service.addConverter(new Converter<Long, TestEnum>() {
-			public TestEnum convert(Long source) {
-				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
-					if (testEnum.getLongValue().equals(source)) {
-						return testEnum;
-					}
-				}
-				return null;
-			}
-		});
+		service.addConverter(new TestConverter<Long>());
+
 		SimpleTypeConverter converter = new SimpleTypeConverter();
 		converter.setConversionService(service);
 
@@ -154,16 +111,8 @@ public class NumberToObjectConversionTests {
 	@Test
 	public void floatToObjectTest() {
 		GenericConversionService service = new GenericConversionService();
-		service.addConverter(new Converter<Float, TestEnum>() {
-			public TestEnum convert(Float source) {
-				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
-					if (testEnum.getFloatValue().equals(source)) {
-						return testEnum;
-					}
-				}
-				return null;
-			}
-		});
+		service.addConverter(new TestConverter<Float>());
+
 		SimpleTypeConverter converter = new SimpleTypeConverter();
 		converter.setConversionService(service);
 
@@ -173,16 +122,8 @@ public class NumberToObjectConversionTests {
 	@Test
 	public void doubleToObjectTest() {
 		GenericConversionService service = new GenericConversionService();
-		service.addConverter(new Converter<Double, TestEnum>() {
-			public TestEnum convert(Double source) {
-				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
-					if (testEnum.getDoubleValue().equals(source)) {
-						return testEnum;
-					}
-				}
-				return null;
-			}
-		});
+		service.addConverter(new TestConverter<Double>());
+
 		SimpleTypeConverter converter = new SimpleTypeConverter();
 		converter.setConversionService(service);
 
@@ -193,6 +134,7 @@ public class NumberToObjectConversionTests {
 	public void noConverterForString() {
 		GenericConversionService service = new GenericConversionService();
 		SimpleTypeConverter converter = new SimpleTypeConverter();
+
 		converter.setConversionService(service);
 
 		converter.convertIfNecessary("1", TestEnum.class);
@@ -202,6 +144,7 @@ public class NumberToObjectConversionTests {
 	public void noConverterForNumber() {
 		GenericConversionService service = new GenericConversionService();
 		SimpleTypeConverter converter = new SimpleTypeConverter();
+
 		converter.setConversionService(service);
 
 		converter.convertIfNecessary(1, TestEnum.class);
@@ -213,26 +156,9 @@ public class NumberToObjectConversionTests {
 	@Test
 	public void integerToObjectTestMultipleConverters() {
 		GenericConversionService service = new GenericConversionService();
-		service.addConverter(new Converter<Byte, TestEnum>() {
-			public TestEnum convert(Byte source) {
-				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
-					if (testEnum.getByteValue().equals(source)) {
-						return testEnum;
-					}
-				}
-				return null;
-			}
-		});
-		service.addConverter(new Converter<Integer, TestEnum>() {
-			public TestEnum convert(Integer source) {
-				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
-					if (testEnum.getIntegerValue().equals(source)) {
-						return testEnum;
-					}
-				}
-				return null;
-			}
-		});
+		service.addConverter(new TestConverter<Byte>());
+		service.addConverter(new TestConverter<Integer>());
+
 		SimpleTypeConverter converter = new SimpleTypeConverter();
 		converter.setConversionService(service);
 

--- a/spring-beans/src/test/java/org/springframework/beans/NumberToObjectConversionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/NumberToObjectConversionTests.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.beans;
+
+import java.util.EnumSet;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.support.GenericConversionService;
+
+public class NumberToObjectConversionTests {
+
+	private enum TestEnum {
+		  ONE((byte)1, (short)1, 1, (long)1, (float)1, (double)1) 
+		, TWO((byte)2, (short)2, 2, (long)2, (float)2, (double)2) 
+		// MAX_INT represents the largest possible integer value.  Since it's not 
+		// possible to represent this as a byte or short, just set it as null
+		, MAX_INT(null, null, Integer.MAX_VALUE, (long)Integer.MAX_VALUE, (float)Integer.MAX_VALUE, (double)Integer.MAX_VALUE)
+		;
+
+		private Byte byteValue;
+		private Short shortValue;
+		private Integer intValue;
+		private Long longValue;
+		private Float floatValue;
+		private Double doubleValue;
+
+		private TestEnum(Byte byteValue, Short shortValue, Integer integerValue, Long longValue, Float floatValue, Double doubleValue) {
+			this.byteValue = byteValue;
+			this.shortValue = shortValue;
+			this.intValue = integerValue;
+			this.longValue = longValue;
+			this.floatValue = floatValue;
+			this.doubleValue = doubleValue;
+		}
+
+		public Byte getByteValue() { 
+			return byteValue;
+		}
+
+		public Short getShortValue() { 
+			return shortValue;
+		}
+
+		public Integer getIntegerValue() { 
+			return intValue;
+		}
+
+		public Long getLongValue() { 
+			return longValue;
+		}
+
+		public Float getFloatValue() { 
+			return floatValue;
+		}
+
+		public Double getDoubleValue() { 
+			return doubleValue;
+		}
+	}
+
+	@Test
+	public void byteToObjectTest() {
+		GenericConversionService service = new GenericConversionService();
+		service.addConverter(new Converter<Byte, TestEnum>() {
+			public TestEnum convert(Byte source) {
+				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+					if (testEnum.getByteValue().equals(source)) {
+						return testEnum;
+					}
+				}
+				return null;
+			}
+		});
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.ONE, converter.convertIfNecessary("1", TestEnum.class));
+	}
+
+	@Test
+	public void shortToObjectTest() {
+		GenericConversionService service = new GenericConversionService();
+		service.addConverter(new Converter<Short, TestEnum>() {
+			public TestEnum convert(Short source) {
+				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+					if (testEnum.getShortValue().equals(source)) {
+						return testEnum;
+					}
+				}
+				return null;
+			}
+		});
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.ONE, converter.convertIfNecessary("1", TestEnum.class));
+	}
+
+	@Test
+	public void integerToObjectTest() {
+		GenericConversionService service = new GenericConversionService();
+		service.addConverter(new Converter<Integer, TestEnum>() {
+			public TestEnum convert(Integer source) {
+				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+					if (testEnum.getIntegerValue().equals(source)) {
+						return testEnum;
+					}
+				}
+				return null;
+			}
+		});
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.ONE, converter.convertIfNecessary("1", TestEnum.class));
+	}
+
+
+	@Test
+	public void longToObjectTest() {
+		GenericConversionService service = new GenericConversionService();
+		service.addConverter(new Converter<Long, TestEnum>() {
+			public TestEnum convert(Long source) {
+				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+					if (testEnum.getLongValue().equals(source)) {
+						return testEnum;
+					}
+				}
+				return null;
+			}
+		});
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.ONE, converter.convertIfNecessary("1", TestEnum.class));
+	}
+
+	@Test
+	public void floatToObjectTest() {
+		GenericConversionService service = new GenericConversionService();
+		service.addConverter(new Converter<Float, TestEnum>() {
+			public TestEnum convert(Float source) {
+				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+					if (testEnum.getFloatValue().equals(source)) {
+						return testEnum;
+					}
+				}
+				return null;
+			}
+		});
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.ONE, converter.convertIfNecessary("1", TestEnum.class));
+	}
+
+	@Test
+	public void doubleToObjectTest() {
+		GenericConversionService service = new GenericConversionService();
+		service.addConverter(new Converter<Double, TestEnum>() {
+			public TestEnum convert(Double source) {
+				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+					if (testEnum.getDoubleValue().equals(source)) {
+						return testEnum;
+					}
+				}
+				return null;
+			}
+		});
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.ONE, converter.convertIfNecessary("1", TestEnum.class));
+	}
+
+	@Test(expected = ConversionNotSupportedException.class)
+	public void noConverterForString() {
+		GenericConversionService service = new GenericConversionService();
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		converter.convertIfNecessary("1", TestEnum.class);
+	}
+
+	@Test(expected = ConversionNotSupportedException.class)
+	public void noConverterForNumber() {
+		GenericConversionService service = new GenericConversionService();
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		converter.convertIfNecessary(1, TestEnum.class);
+	}
+
+	/* Test for multiple converters.  Use a byte + long converters, and use a value can 
+	 * be parsed as a long but not a byte.
+	 */
+	@Test
+	public void integerToObjectTestMultipleConverters() {
+		GenericConversionService service = new GenericConversionService();
+		service.addConverter(new Converter<Byte, TestEnum>() {
+			public TestEnum convert(Byte source) {
+				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+					if (testEnum.getByteValue().equals(source)) {
+						return testEnum;
+					}
+				}
+				return null;
+			}
+		});
+		service.addConverter(new Converter<Integer, TestEnum>() {
+			public TestEnum convert(Integer source) {
+				for (TestEnum testEnum : EnumSet.allOf(TestEnum.class)) {
+					if (testEnum.getIntegerValue().equals(source)) {
+						return testEnum;
+					}
+				}
+				return null;
+			}
+		});
+		SimpleTypeConverter converter = new SimpleTypeConverter();
+		converter.setConversionService(service);
+
+		assertEquals(TestEnum.MAX_INT, converter.convertIfNecessary(String.valueOf(Integer.MAX_VALUE), TestEnum.class));
+	}
+
+}


### PR DESCRIPTION
I had a Converter<Integer, Object> class I wanted to use to build a model off a @RequestMapping.  The conversion mechanism only worked with Converter<String, Object> instances.  I expected the request parameter my situtation to be an Integer, so I wanted to use the framework to validate parameters as opposed to adapting my existing class into a Converter<String, Object>.

The documentation has not been updated to reflect this feature.  I am waiting for approval of this enhancement before doing so.

Issue: SPR-11060

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
