### PR TITLE
Fixed the broken Javadoc links from http://*/spring/docs/current/api/org to http/*/spring/docs/current/javadoc-api/org

### DIFF
--- a/src/reference/docbook/beans-scopes.xml
+++ b/src/reference/docbook/beans-scopes.xml
@@ -99,7 +99,7 @@
     <para>As of Spring 3.0, a <emphasis>thread scope</emphasis> is available,
       but is not registered by default. For more information, see the
       documentation for <link
-      xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/context/support/SimpleThreadScope.html"
+      xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/support/SimpleThreadScope.html"
       >SimpleThreadScope</link>. For instructions on how to register this or
       any other custom scope, see <xref
       linkend="beans-factory-scopes-custom-using"/>.</para>

--- a/src/reference/docbook/beans.xml
+++ b/src/reference/docbook/beans.xml
@@ -84,9 +84,9 @@ The footnote should x-ref to first section in that chapter but I can't find the 
       <classname>ApplicationContext</classname> interface are supplied
       out-of-the-box with Spring. In standalone applications it is common to
       create an instance of <link
-      xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/context/support/ClassPathXmlApplicationContext.html"
+      xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/support/ClassPathXmlApplicationContext.html"
       ><classname>ClassPathXmlApplicationContext</classname></link> or <link
-      xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/context/support/FileSystemXmlApplicationContext.html"
+      xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/support/FileSystemXmlApplicationContext.html"
       ><classname>FileSystemXmlApplicationContext</classname></link>.
       <!-- MLP: Beverly to review --> While XML has been the traditional format
       for defining configuration metadata you can instruct the container to use
@@ -1178,7 +1178,7 @@ cfg.postProcessBeanFactory(factory);</programlisting>
         a single ApplicationContext as a parent to WebApplicationContexts across
         WAR files. In this case you should look into using the utility class
         <link
-        xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/context/access/ContextSingletonBeanFactoryLocator.html"
+        xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/context/access/ContextSingletonBeanFactoryLocator.html"
         ><classname>ContextSingletonBeanFactoryLocator</classname></link>
         locator that is described in this <link
         xl:href="http://blog.springsource.com/2007/06/11/using-a-shared-parent-application-context-in-a-multi-war-spring-application/"

--- a/src/reference/docbook/oxm.xml
+++ b/src/reference/docbook/oxm.xml
@@ -768,7 +768,7 @@ public class Application {
                   This will make sure that only the registered classes are eligible for unmarshalling.
                 </para>
                 <para>
-                  Additionally, you can register <link xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/oxm/xstream/XStreamMarshaller.html#setConverters(com.thoughtworks.xstream.converters.ConverterMatcher[])">
+                  Additionally, you can register <link xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/oxm/xstream/XStreamMarshaller.html#setConverters(com.thoughtworks.xstream.converters.ConverterMatcher[])">
                   custom converters</link> to make sure that only your supported classes can be unmarshalled.
                   You might want to add a <classname>CatchAllConverter</classname> as the last converter in the list,
                   in addition to converters that explicitly support the domain classes that should be supported.

--- a/src/reference/docbook/remoting.xml
+++ b/src/reference/docbook/remoting.xml
@@ -1005,28 +1005,28 @@ if (HttpStatus.SC_CREATED == post.getStatusCode()) {
               <entry>DELETE</entry>
 
               <entry><link
-              xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/web/client/RestTemplate.html#delete(String,%20Object...)">delete</link></entry>
+              xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html#delete(String,%20Object...)">delete</link></entry>
             </row>
 
             <row>
               <entry>GET</entry>
 
               <entry><link
-              xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/web/client/RestTemplate.html#getForObject(String,%20Class,%20Object...)">getForObject</link></entry>
+              xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html#getForObject(String,%20Class,%20Object...)">getForObject</link></entry>
             </row>
 
             <row>
               <entry></entry>
 
               <entry><link
-              xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/web/client/RestTemplate.html#getForEntity(String,%20Class,%20Object...)">getForEntity</link></entry>
+              xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html#getForEntity(String,%20Class,%20Object...)">getForEntity</link></entry>
             </row>
 
             <row>
               <entry>HEAD</entry>
 
               <entry><link
-              xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/web/client/RestTemplate.html#headForHeaders(String,%20Object...)">headForHeaders(String
+              xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html#headForHeaders(String,%20Object...)">headForHeaders(String
               url, String… urlVariables)</link></entry>
             </row>
 
@@ -1034,7 +1034,7 @@ if (HttpStatus.SC_CREATED == post.getStatusCode()) {
               <entry>OPTIONS</entry>
 
               <entry><link
-              xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/web/client/RestTemplate.html#optionsForAllow(String,%20Object...)">optionsForAllow(String
+              xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html#optionsForAllow(String,%20Object...)">optionsForAllow(String
               url, String… urlVariables)</link></entry>
             </row>
 
@@ -1042,7 +1042,7 @@ if (HttpStatus.SC_CREATED == post.getStatusCode()) {
               <entry>POST</entry>
 
               <entry><link
-              xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/web/client/RestTemplate.html#postForLocation(String,%20Object,%20Object...)">postForLocation(String
+              xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html#postForLocation(String,%20Object,%20Object...)">postForLocation(String
               url, Object request, String… urlVariables)</link></entry>
             </row>
 
@@ -1050,7 +1050,7 @@ if (HttpStatus.SC_CREATED == post.getStatusCode()) {
               <entry></entry>
 
               <entry><link
-              xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/web/client/RestTemplate.html#postForObject(java.lang.String,%20java.lang.Object,%20java.lang.Class,%20java.lang.String...)">postForObject(String
+              xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html#postForObject(java.lang.String,%20java.lang.Object,%20java.lang.Class,%20java.lang.String...)">postForObject(String
                   url, Object request, Class&lt;T&gt; responseType, String…
                   uriVariables)</link></entry>
             </row>
@@ -1059,7 +1059,7 @@ if (HttpStatus.SC_CREATED == post.getStatusCode()) {
               <entry>PUT</entry>
 
               <entry><link
-              xl:href="http://static.springsource.org/spring/docs/current/api/org/springframework/web/client/RestTemplate.html#put(String,%20Object,%20Object...)">put(String
+              xl:href="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html#put(String,%20Object,%20Object...)">put(String
               url, Object request, String…urlVariables)</link></entry>
             </row>
           </tbody>


### PR DESCRIPTION
Some of the links to Javadocs are broken - their paths needed to be changed from /api/\* to /javadoc-api/*
