### PR TITLE
Fix standard multipart binding + Polish

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderIntegrationTests.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletException;
-import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -38,7 +37,6 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.mock.web.test.MockMultipartFile;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.SocketUtils;
@@ -109,7 +107,7 @@ public class WebRequestDataBinderIntegrationTests {
 		partsServlet.setBean(bean);
 
 		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<String, Object>();
-		MockMultipartFile firstPart = new MockMultipartFile("fileName", "aValue".getBytes());
+		Resource firstPart = new ClassPathResource("/org/springframework/http/converter/logo.jpg");
 		parts.add("firstPart", firstPart);
 		parts.add("secondPart", "secondValue");
 
@@ -134,7 +132,7 @@ public class WebRequestDataBinderIntegrationTests {
 		template.postForLocation(baseUrl + "/partlist", parts);
 
 		assertNotNull(bean.getPartList());
-		assertEquals(parts.size(), bean.getPartList().size());
+		assertEquals(parts.get("partList").size(), bean.getPartList().size());
 	}
 
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestPartIntegrationTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestPartIntegrationTests.java
@@ -56,6 +56,8 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
+import javax.servlet.MultipartConfigElement;
+
 import static org.junit.Assert.*;
 
 /**
@@ -91,9 +93,8 @@ public class RequestPartIntegrationTests {
 		ServletHolder standardResolverServlet = new ServletHolder(DispatcherServlet.class);
 		standardResolverServlet.setInitParameter("contextConfigLocation", config.getName());
 		standardResolverServlet.setInitParameter("contextClass", AnnotationConfigWebApplicationContext.class.getName());
+		standardResolverServlet.getRegistration().setMultipartConfig(new MultipartConfigElement(""));
 		handler.addServlet(standardResolverServlet, "/standard-resolver/*");
-
-		// TODO: add Servlet 3.0 test case without MultipartResolver
 
 		server.setHandler(handler);
 		server.start();
@@ -123,7 +124,6 @@ public class RequestPartIntegrationTests {
 	}
 
 	@Test
-	@Ignore("jetty 6.1.9 doesn't support Servlet 3.0")
 	public void standardMultipartResolver() throws Exception {
 		testCreate(baseUrl + "/standard-resolver/test");
 	}


### PR DESCRIPTION
Fixing standard multipart binding when multiple parts share
the same name.
Uncomment previously @Ignored tests now that Jetty supports
Servlet 3.0 spec.

Follow up for
Issue: SPR-10591
