### PR TITLE
Fix typos throughout project

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/support/DelegatePerTargetObjectIntroductionInterceptor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/DelegatePerTargetObjectIntroductionInterceptor.java
@@ -67,7 +67,7 @@ public class DelegatePerTargetObjectIntroductionInterceptor extends Introduction
 	public DelegatePerTargetObjectIntroductionInterceptor(Class defaultImplType, Class interfaceType) {
 		this.defaultImplType = defaultImplType;
 		this.interfaceType = interfaceType;
-		// cCeate a new delegate now (but don't store it in the map).
+		// Create a new delegate now (but don't store it in the map).
 		// We do this for two reasons:
 		// 1) to fail early if there is a problem instantiating delegates
 		// 2) to populate the interface map once and once only

--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/NamespaceHandler.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/NamespaceHandler.java
@@ -36,7 +36,7 @@ import org.springframework.beans.factory.config.BeanDefinitionHolder;
  * it encounters a custom tag directly under a {@code &lt;bean&gt;} tag.
  *
  * <p>Developers writing their own custom element extensions typically will
- * not implement this interface drectly, but rather make use of the provided
+ * not implement this interface directly, but rather make use of the provided
  * {@link NamespaceHandlerSupport} class.
  *
  * @author Rob Harrop

--- a/spring-core/src/main/java/org/springframework/asm/Frame.java
+++ b/spring-core/src/main/java/org/springframework/asm/Frame.java
@@ -585,7 +585,7 @@ final class Frame {
         }
         // pushes the type on the output stack
         outputStack[outputStackTop++] = type;
-        // updates the maximun height reached by the output stack, if needed
+        // updates the maximum height reached by the output stack, if needed
         int top = owner.inputStackTop + outputStackTop;
         if (top > owner.outputStackMax) {
             owner.outputStackMax = top;

--- a/spring-core/src/main/java/org/springframework/util/AutoPopulatingList.java
+++ b/spring-core/src/main/java/org/springframework/util/AutoPopulatingList.java
@@ -276,7 +276,7 @@ public class AutoPopulatingList<E> implements List<E>, Serializable {
 		private final Class<? extends E> elementClass;
 
 		public ReflectiveElementFactory(Class<? extends E> elementClass) {
-			Assert.notNull(elementClass, "Element clas must not be null");
+			Assert.notNull(elementClass, "Element class must not be null");
 			Assert.isTrue(!elementClass.isInterface(), "Element class must not be an interface type");
 			Assert.isTrue(!Modifier.isAbstract(elementClass.getModifiers()), "Element class cannot be an abstract class");
 			this.elementClass = elementClass;

--- a/spring-core/src/main/java/org/springframework/util/CompositeIterator.java
+++ b/spring-core/src/main/java/org/springframework/util/CompositeIterator.java
@@ -68,7 +68,7 @@ public class CompositeIterator<E> implements Iterator<E> {
 				return iterator.next();
 			}
 		}
-		throw new NoSuchElementException("Exhaused all iterators");
+		throw new NoSuchElementException("Exhausted all iterators");
 	}
 
 	@Override

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -208,7 +208,7 @@ public abstract class StringUtils {
 
 	/**
 	 * Trim <i>all</i> whitespace from the given String:
-	 * leading, trailing, and inbetween characters.
+	 * leading, trailing, and in between characters.
 	 * @param str the String to check
 	 * @return the trimmed String
 	 * @see java.lang.Character#isWhitespace
@@ -265,7 +265,7 @@ public abstract class StringUtils {
 	}
 
 	/**
-	 * Trim all occurences of the supplied leading character from the given String.
+	 * Trim all occurrences of the supplied leading character from the given String.
 	 * @param str the String to check
 	 * @param leadingCharacter the leading character to be trimmed
 	 * @return the trimmed String
@@ -282,7 +282,7 @@ public abstract class StringUtils {
 	}
 
 	/**
-	 * Trim all occurences of the supplied trailing character from the given String.
+	 * Trim all occurrences of the supplied trailing character from the given String.
 	 * @param str the String to check
 	 * @param trailingCharacter the trailing character to be trimmed
 	 * @return the trimmed String
@@ -381,7 +381,7 @@ public abstract class StringUtils {
 	}
 
 	/**
-	 * Replace all occurences of a substring within a string with
+	 * Replace all occurrences of a substring within a string with
 	 * another string.
 	 * @param inString String to examine
 	 * @param oldPattern String to replace

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProvider.java
@@ -41,7 +41,7 @@ public interface CallMetaDataProvider {
 
 	/**
 	 * Initialize the database specific management of procedure column meta data.
-	 * This is only called for databases that are supported. This initalization
+	 * This is only called for databases that are supported. This initialization
 	 * can be turned off by specifying that column meta data should not be used.
 	 * @param databaseMetaData used to retrieve database specific information
 	 * @param catalogName name of catalog to use or null

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProviderFactory.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProviderFactory.java
@@ -61,9 +61,9 @@ public class CallMetaDataProviderFactory {
 		);
 
 	/**
-	 * Create a CallMetaDataProvider based on the database metedata
-	 * @param dataSource used to retrieve metedata
-	 * @param context the class that holds configuration and metedata
+	 * Create a CallMetaDataProvider based on the database metadata
+	 * @param dataSource used to retrieve metadata
+	 * @param context the class that holds configuration and metadata
 	 * @return instance of the CallMetaDataProvider implementation to be used
 	 */
 	static public CallMetaDataProvider createMetaDataProvider(DataSource dataSource, final CallMetaDataContext context) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericTableMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericTableMetaDataProvider.java
@@ -340,7 +340,7 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 				try {
 					tables.close();
 				} catch (SQLException e) {
-					logger.warn("Error while closing table meta data reults" + e.getMessage());
+					logger.warn("Error while closing table meta data results" + e.getMessage());
 				}
 			}
 		}
@@ -379,7 +379,7 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 	}
 
 	/**
-	 * Method supporting the metedata processing for a table's columns
+	 * Method supporting the metadata processing for a table's columns
 	 */
 	private void processTableColumns(DatabaseMetaData databaseMetaData, TableMetaData tmd) {
 		ResultSet tableColumns = null;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/ParsedSql.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/ParsedSql.java
@@ -70,7 +70,7 @@ public class ParsedSql {
 
 	/**
 	 * Return all of the parameters (bind variables) in the parsed SQL statement.
-	 * Repeated occurences of the same parameter name are included here.
+	 * Repeated occurrences of the same parameter name are included here.
 	 */
 	List<String> getParameterNames() {
 		return this.parameterNames;
@@ -89,7 +89,7 @@ public class ParsedSql {
 
 	/**
 	 * Set the count of named parameters in the SQL statement.
-	 * Each parameter name counts once; repeated occurences do not count here.
+	 * Each parameter name counts once; repeated occurrences do not count here.
 	 */
 	void setNamedParameterCount(int namedParameterCount) {
 		this.namedParameterCount = namedParameterCount;
@@ -97,7 +97,7 @@ public class ParsedSql {
 
 	/**
 	 * Return the count of named parameters in the SQL statement.
-	 * Each parameter name counts once; repeated occurences do not count here.
+	 * Each parameter name counts once; repeated occurrences do not count here.
 	 */
 	int getNamedParameterCount() {
 		return this.namedParameterCount;
@@ -119,7 +119,7 @@ public class ParsedSql {
 
 	/**
 	 * Set the total count of all of the parameters in the SQL statement.
-	 * Repeated occurences of the same parameter name do count here.
+	 * Repeated occurrences of the same parameter name do count here.
 	 */
 	void setTotalParameterCount(int totalParameterCount) {
 		this.totalParameterCount = totalParameterCount;
@@ -127,7 +127,7 @@ public class ParsedSql {
 
 	/**
 	 * Return the total count of all of the parameters in the SQL statement.
-	 * Repeated occurences of the same parameter name do count here.
+	 * Repeated occurrences of the same parameter name do count here.
 	 */
 	int getTotalParameterCount() {
 		return this.totalParameterCount;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
@@ -311,7 +311,7 @@ public abstract class AbstractJdbcInsert {
 	}
 
 	/**
-	 * Method to check whether we are allowd to make any configuration changes at this time.
+	 * Method to check whether we are allowed to make any configuration changes at this time.
 	 * If the class has been compiled, then no further changes to the configuration are allowed.
 	 */
 	protected void checkIfConfigurationModificationIsAllowed() {
@@ -450,12 +450,12 @@ public abstract class AbstractJdbcInsert {
 						"The getGeneratedKeys feature is not supported by this database");
 			}
 			if (getGeneratedKeyNames().length < 1) {
-				throw new InvalidDataAccessApiUsageException("Generated Key Name(s) not specificed. " +
+				throw new InvalidDataAccessApiUsageException("Generated Key Name(s) not specified. " +
 						"Using the generated keys features requires specifying the name(s) of the generated column(s)");
 			}
 			if (getGeneratedKeyNames().length > 1) {
 				throw new InvalidDataAccessApiUsageException(
-						"Current database only supports retreiving the key for a single column. There are " +
+						"Current database only supports retrieving the key for a single column. There are " +
 						getGeneratedKeyNames().length  + " columns specified: " + Arrays.asList(getGeneratedKeyNames()));
 			}
 			// This is a hack to be able to get the generated key from a database that doesn't support
@@ -615,9 +615,9 @@ public abstract class AbstractJdbcInsert {
 	}
 
 	/**
-	 * Match the provided in parameter values with regitered parameters and parameters defined
+	 * Match the provided in parameter values with registered parameters and parameters defined
 	 * via metadata processing.
-	 * @param parameterSource the parameter vakues provided as a {@link SqlParameterSource}
+	 * @param parameterSource the parameter values provided as a {@link SqlParameterSource}
 	 * @return Map with parameter names and values
 	 */
 	protected List<Object> matchInParameterValuesWithInsertColumns(SqlParameterSource parameterSource) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsertOperations.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsertOperations.java
@@ -40,7 +40,7 @@ public interface SimpleJdbcInsertOperations {
 	SimpleJdbcInsertOperations withTableName(String tableName);
 
 	/**
-	 * Specify the shema name, if any, to be used for the insert.
+	 * Specify the schema name, if any, to be used for the insert.
 	 * @param schemaName the name of the schema
 	 * @return the instance of this SimpleJdbcInsert
 	 */

--- a/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
@@ -42,7 +42,7 @@ import org.springframework.transaction.support.TransactionSynchronizationUtils;
  *
  * <p>This listener container variant is built for repeated polling attempts,
  * each invoking the {@link #receiveAndExecute} method. The MessageConsumer used
- * may be reobtained fo reach attempt or cached inbetween attempts; this is up
+ * may be reobtained fo reach attempt or cached in between attempts; this is up
  * to the concrete implementation. The receive timeout for each attempt can be
  * configured through the {@link #setReceiveTimeout "receiveTimeout"} property.
  *

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/handler/SimpleBrokerMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/handler/SimpleBrokerMessageHandler.java
@@ -83,7 +83,7 @@ public class SimpleBrokerMessageHandler extends AbstractBrokerMessageHandler {
 
 		if (!checkDestinationPrefix(destination)) {
 			if (logger.isTraceEnabled()) {
-				logger.trace("Ingoring message to destination=" + destination);
+				logger.trace("Ignoring message to destination=" + destination);
 			}
 			return;
 		}

--- a/spring-oxm/src/main/java/org/springframework/oxm/xstream/XStreamMarshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/xstream/XStreamMarshaller.java
@@ -780,7 +780,7 @@ public class XStreamMarshaller extends AbstractMarshaller implements Initializin
      * {@code org.springframework.oxm} hierarchy.
      * <p>A boolean flag is used to indicate whether this exception occurs during marshalling or
      * unmarshalling, since XStream itself does not make this distinction in its exception hierarchy.
-     * @param ex XStream exception that occured
+     * @param ex XStream exception that occurred
      * @param marshalling indicates whether the exception occurs during marshalling ({@code true}),
      * or unmarshalling ({@code false})
      * @return the corresponding {@code XmlMappingException}

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptor.java
@@ -55,7 +55,7 @@ public interface CallableProcessingInterceptor {
 	 * <p>
 	 * This is useful for capturing the state of the current thread just prior to
 	 * invoking the {@link Callable}. Once the state is captured, it can then be
-	 * transfered to the new {@link Thread} in
+	 * transferred to the new {@link Thread} in
 	 * {@link #preProcess(NativeWebRequest, Callable)}. Capturing the state of
 	 * Spring Security's SecurityContextHolder and migrating it to the new Thread
 	 * is a concrete example of where this is useful.

--- a/spring-web/src/main/java/org/springframework/web/context/support/ServletContextAwareProcessor.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/ServletContextAwareProcessor.java
@@ -48,7 +48,7 @@ public class ServletContextAwareProcessor implements BeanPostProcessor {
 	/**
 	 * Create a new ServletContextAwareProcessor without an initial context or config.
 	 * When this constructor is used the {@link #getServletContext()} and/or
-	 * {@link #getServletConfig()} methods should be overriden.
+	 * {@link #getServletConfig()} methods should be overridden.
 	 */
 	protected ServletContextAwareProcessor() {
 	}

--- a/spring-web/src/main/java/org/springframework/web/filter/OncePerRequestFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/OncePerRequestFilter.java
@@ -41,7 +41,7 @@ import org.springframework.web.util.WebUtils;
  * should be involved in async dispatches. However, in some cases servlet
  * containers assume different default configuration. Therefore sub-classes can
  * override the method {@link #shouldNotFilterAsyncDispatch()} to declare
- * statically if they shouuld indeed be invoked, <em>once</em>, during both types
+ * statically if they should indeed be invoked, <em>once</em>, during both types
  * of dispatches in order to provide thread initialization, logging, security,
  * and so on. This mechanism complements and does not replace the need to
  * configure a filter in {@code web.xml} with dispatcher types.

--- a/spring-web/src/main/java/org/springframework/web/jsf/DecoratingNavigationHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/jsf/DecoratingNavigationHandler.java
@@ -115,7 +115,7 @@ public abstract class DecoratingNavigationHandler extends NavigationHandler {
 	 * <p>If no decorated NavigationHandler specified as constructor argument,
 	 * this instance is the last element in the chain. Hence, this method will
 	 * call the original NavigationHandler as passed into this method. If no
-	 * original NavigantionHandler has been passed in (for example if this
+	 * original NavigationHandler has been passed in (for example if this
 	 * instance is the last element in a chain with standard NavigationHandlers
 	 * as earlier elements), this method corresponds to a no-op.
 	 * @param facesContext the current JSF context

--- a/spring-web/src/main/java/org/springframework/web/util/WebAppRootListener.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebAppRootListener.java
@@ -25,7 +25,7 @@ import javax.servlet.ServletContextListener;
  * parameter at the servlet context level (i.e. context-param in web.xml),
  * the default key is "webapp.root".
  *
- * <p>Can be used for toolkits that support substition with system properties
+ * <p>Can be used for toolkits that support substitution with system properties
  * (i.e. System.getProperty values), like log4j's "${key}" syntax within log
  * file locations.
  *

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/ResourceServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/ResourceServlet.java
@@ -295,7 +295,7 @@ public class ResourceServlet extends HttpServletBean {
 	 * to allow for message resolution etc that influences JSP contents,
 	 * assuming that those background resources might have changed on restart.
 	 * <p>Returns the startup time of this servlet if the file that corresponds
-	 * to the target resource URL coudln't be resolved (for example, because
+	 * to the target resource URL couldn't be resolved (for example, because
 	 * the WAR is not expanded).
 	 * @see #determineResourceUrl
 	 * @see #getFileTimestamp

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerExceptionResolver.java
@@ -189,7 +189,7 @@ public abstract class AbstractHandlerExceptionResolver implements HandlerExcepti
 	}
 
 	/**
-	 * Build a log message for the given exception, occured during processing the given request.
+	 * Build a log message for the given exception, occurred during processing the given request.
 	 * @param ex the exception that got thrown during handler execution
 	 * @param request current HTTP request (useful for obtaining metadata)
 	 * @return the log message to use

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/annotation/AnnotationMethodHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/annotation/AnnotationMethodHandlerAdapter.java
@@ -512,7 +512,7 @@ public class AnnotationMethodHandlerAdapter extends WebContentGenerator
 	}
 
 	/**
-	 * Template method for creating a new HttpOuputMessage instance.
+	 * Template method for creating a new HttpOutputMessage instance.
 	 * <p>The default implementation creates a standard {@link ServletServerHttpResponse}.
 	 * This can be overridden for custom {@code HttpOutputMessage} implementations
 	 * @param servletResponse current HTTP response
@@ -1196,7 +1196,7 @@ public class AnnotationMethodHandlerAdapter extends WebContentGenerator
 	 * sorting a list with this comparator will result in:
 	 * <ul>
 	 * <li>RHIs with {@linkplain AnnotationMethodHandlerAdapter.RequestSpecificMappingInfo#matchedPatterns better matched paths}
-	 * take prescedence over those with a weaker match (as expressed by the {@linkplain PathMatcher#getPatternComparator(String)
+	 * take precedence over those with a weaker match (as expressed by the {@linkplain PathMatcher#getPatternComparator(String)
 	 * path pattern comparator}.) Typically, this means that patterns without wild cards and uri templates
 	 * will be ordered before those without.</li>
 	 * <li>RHIs with one single {@linkplain RequestMappingInfo#methods request method} will be

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/ServletUriComponentsBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/ServletUriComponentsBuilder.java
@@ -82,7 +82,7 @@ public class ServletUriComponentsBuilder extends UriComponentsBuilder {
 
 	/**
 	 * Prepare a builder from the host, port, scheme, and path of
-	 * an HttpSevletRequest.
+	 * an HttpServletRequest.
 	 */
 	public static ServletUriComponentsBuilder fromRequestUri(HttpServletRequest request) {
 		ServletUriComponentsBuilder builder = fromRequest(request);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/WebContentGenerator.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/WebContentGenerator.java
@@ -211,7 +211,7 @@ public abstract class WebContentGenerator extends WebApplicationObjectSupport {
 	}
 
 	/**
-	 * Return whether 'must-revaliate' is added to every Cache-Control header.
+	 * Return whether 'must-revalidate' is added to every Cache-Control header.
 	 */
 	public boolean isAlwaysMustRevalidate() {
 		return alwaysMustRevalidate;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/BeanNameViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/BeanNameViewResolver.java
@@ -38,7 +38,7 @@ import org.springframework.web.servlet.ViewResolver;
  * application beans - such a separation will make this clear.
  *
  * <p>This ViewResolver does not support internationalization.
- * Conside ResourceBundleViewResolver if you need to apply different
+ * Consider ResourceBundleViewResolver if you need to apply different
  * view resources per locale.
  *
  * <p>Note: This ViewResolver implements the Ordered interface to allow for

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/ContentNegotiatingViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/ContentNegotiatingViewResolver.java
@@ -70,7 +70,7 @@ import org.springframework.web.servlet.ViewResolver;
  * with the view's {@linkplain View#getContentType() content type}). The most compatible view is returned.
  *
  * <p>Additionally, this view resolver exposes the {@link #setDefaultViews(List) defaultViews} property, allowing you to
- * override the views provided by the view resolvers. Note that these default views are offered as candicates, and
+ * override the views provided by the view resolvers. Note that these default views are offered as candidates, and
  * still need have the content type requested (via file extension, parameter, or {@code Accept} header, described above).
  * You can also set the {@linkplain #setDefaultContentType(MediaType) default content type} directly, which will be
  * returned when the other mechanisms ({@code Accept} header, file extension or parameter) do not result in a match.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/document/AbstractPdfStamperView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/document/AbstractPdfStamperView.java
@@ -103,7 +103,7 @@ public abstract class AbstractPdfStamperView extends AbstractUrlBasedView {
 	 * e.g. setting the "formFlattening" property.
 	 * @param request in case we need locale etc. Shouldn't look at attributes.
 	 * @param response in case we need to set cookies. Shouldn't write to it.
-	 * @throws Exception any exception that occured during document building
+	 * @throws Exception any exception that occurred during document building
      */
 	protected abstract void mergePdfDocument(Map<String, Object> model, PdfStamper stamper,
 			HttpServletRequest request, HttpServletResponse response) throws Exception;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/document/AbstractPdfView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/document/AbstractPdfView.java
@@ -172,7 +172,7 @@ public abstract class AbstractPdfView extends AbstractView {
 	 * @param writer the PdfWriter to use
 	 * @param request in case we need locale etc. Shouldn't look at attributes.
 	 * @param response in case we need to set cookies. Shouldn't write to it.
-	 * @throws Exception any exception that occured during document building
+	 * @throws Exception any exception that occurred during document building
 	 * @see com.lowagie.text.Document#open()
 	 * @see com.lowagie.text.Document#close()
 	 */

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/feed/AbstractAtomFeedView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/feed/AbstractAtomFeedView.java
@@ -96,7 +96,7 @@ public abstract class AbstractAtomFeedView extends AbstractFeedView<Feed> {
 	 * @param request in case we need locale etc. Shouldn't look at attributes.
 	 * @param response in case we need to set cookies. Shouldn't write to it.
 	 * @return the feed entries to be added to the feed
-	 * @throws Exception any exception that occured during document building
+	 * @throws Exception any exception that occurred during document building
 	 * @see Entry
 	 */
 	protected abstract List<Entry> buildFeedEntries(

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/feed/AbstractFeedView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/feed/AbstractFeedView.java
@@ -91,7 +91,7 @@ public abstract class AbstractFeedView<T extends WireFeed> extends AbstractView 
 	 * @param feed the feed to add entries to
 	 * @param request in case we need locale etc. Shouldn't look at attributes.
 	 * @param response in case we need to set cookies. Shouldn't write to it.
-	 * @throws Exception any exception that occured during building
+	 * @throws Exception any exception that occurred during building
 	 */
 	protected abstract void buildFeedEntries(Map<String, Object> model, T feed,
 			HttpServletRequest request, HttpServletResponse response) throws Exception;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/feed/AbstractRssFeedView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/feed/AbstractRssFeedView.java
@@ -79,7 +79,7 @@ public abstract class AbstractRssFeedView extends AbstractFeedView<Channel> {
 	 * @param request  in case we need locale etc. Shouldn't look at attributes.
 	 * @param response in case we need to set cookies. Shouldn't write to it.
 	 * @return the feed items to be added to the feed
-	 * @throws Exception any exception that occured during document building
+	 * @throws Exception any exception that occurred during document building
 	 * @see Item
 	 */
 	protected abstract List<Item> buildFeedItems(

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/jasperreports/AbstractJasperReportsView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/jasperreports/AbstractJasperReportsView.java
@@ -217,7 +217,7 @@ public abstract class AbstractJasperReportsView extends AbstractUrlBasedView {
 	 * <p>The name specified in the list should correspond to an attribute in the
 	 * model Map, and to a sub-report data source parameter in your report file.
 	 * If you pass in {@code JRDataSource} objects as model attributes,
-	 * specifing this list of keys is not required.
+	 * specifying this list of keys is not required.
 	 * <p>If you specify a list of sub-report data keys, it is required to also
 	 * specify a {@code reportDataKey} for the main report, to avoid confusion
 	 * between the data source objects for the various reports involved.
@@ -536,7 +536,7 @@ public abstract class AbstractJasperReportsView extends AbstractUrlBasedView {
 	 * {@link #renderReport} method that should be implemented by the subclass.
 	 * @param model the model map, as passed in for view rendering. Must contain
 	 * a report data value that can be converted to a {@code JRDataSource},
-	 * acccording to the rules of the {@link #fillReport} method.
+	 * according to the rules of the {@link #fillReport} method.
 	 */
 	@Override
 	protected void renderMergedOutputModel(
@@ -820,12 +820,12 @@ public abstract class AbstractJasperReportsView extends AbstractUrlBasedView {
 
 	/**
 	 * Subclasses should implement this method to perform the actual rendering process.
-	 * <p>Note that the content type has not been set yet: Implementors should build
+	 * <p>Note that the content type has not been set yet: Implementers should build
 	 * a content type String and set it via {@code response.setContentType}.
 	 * If necessary, this can include a charset clause for a specific encoding.
 	 * The latter will only be necessary for textual output onto a Writer, and only
 	 * in case of the encoding being specified in the JasperReports exporter parameters.
-	 * <p><b>WARNING:</b> Implementors should not use {@code response.setCharacterEncoding}
+	 * <p><b>WARNING:</b> Implementers should not use {@code response.setCharacterEncoding}
 	 * unless they are willing to depend on Servlet API 2.4 or higher. Prefer a
 	 * concatenated content type String with a charset clause instead.
 	 * @param populatedReport the populated {@code JasperPrint} to render

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/velocity/VelocityToolboxView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/velocity/VelocityToolboxView.java
@@ -73,7 +73,7 @@ public class VelocityToolboxView extends VelocityView {
 	 * to automatically load a Velocity Tools toolbox definition file and expose
 	 * all defined tools in the specified scopes. If no config location is
 	 * specified, no toolbox will be loaded and exposed.
-	 * <p>The specfied location string needs to refer to a ServletContext
+	 * <p>The specified location string needs to refer to a ServletContext
 	 * resource, as expected by ServletToolboxManager which is part of
 	 * the view package of Velocity Tools.
 	 * @see org.apache.velocity.tools.view.servlet.ServletToolboxManager#getInstance

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/velocity/VelocityViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/velocity/VelocityViewResolver.java
@@ -88,7 +88,7 @@ public class VelocityViewResolver extends AbstractTemplateViewResolver {
 	 * to automatically load a Velocity Tools toolbox definition file and expose
 	 * all defined tools in the specified scopes. If no config location is
 	 * specified, no toolbox will be loaded and exposed.
-	 * <p>The specfied location string needs to refer to a ServletContext
+	 * <p>The specified location string needs to refer to a ServletContext
 	 * resource, as expected by ServletToolboxManager which is part of
 	 * the view package of Velocity Tools.
 	 * <p><b>Note:</b> Specifying a toolbox config location will lead to

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xslt/XsltView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xslt/XsltView.java
@@ -264,7 +264,7 @@ public class XsltView extends AbstractUrlBasedView {
 	 * an object of {@link #getSourceTypes() supported type}.
 	 * @param model the merged model Map
 	 * @return the XSLT Source object (or {@code null} if none found)
-	 * @throws Exception if an error occured during locating the source
+	 * @throws Exception if an error occurred during locating the source
 	 * @see #setSourceKey
 	 * @see #convertSource
 	 */

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/endpoint/ServerEndpointRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/endpoint/ServerEndpointRegistration.java
@@ -90,7 +90,7 @@ public class ServerEndpointRegistration extends ServerEndpointConfig.Configurato
 
 	/**
 	 * Create a new {@link ServerEndpointRegistration} instance from an
-	 * {@code javax.webscoket.Endpoint} instance.
+	 * {@code javax.websocket.Endpoint} instance.
 	 * @param path the endpoint path
 	 * @param endpoint the endpoint instance
 	 */


### PR DESCRIPTION
This fixes a variety of typos throughout the project, primarily in
comments (javadoc or otherwise) but also in a handful of log messages
and a couple exception messages. I noticed a few typos and then 
searched for more to fix.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
