### PR TITLE
Support meta-annotation attr overrides in the TCF

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
@@ -214,6 +214,25 @@ abstract class ContextLoaderUtils {
 	}
 
 	/**
+	 * Convenience method for creating a {@link ContextConfigurationAttributes}
+	 * instance from the supplied {@link ContextConfiguration} attributes and
+	 * declaring class and then adding the attributes to the supplied list.
+	 */
+	private static void convertContextConfigToConfigAttributesAndAddToList(AnnotationAttributes annAttrs,
+			Class<?> declaringClass, final List<ContextConfigurationAttributes> attributesList) {
+		if (logger.isTraceEnabled()) {
+			logger.trace(String.format("Retrieved @ContextConfiguration attributes [%s] for declaring class [%s].",
+				annAttrs, declaringClass.getName()));
+		}
+
+		ContextConfigurationAttributes attributes = new ContextConfigurationAttributes(declaringClass, annAttrs);
+		if (logger.isTraceEnabled()) {
+			logger.trace("Resolved context configuration attributes: " + attributes);
+		}
+		attributesList.add(attributes);
+	}
+
+	/**
 	 * Resolve the list of lists of {@linkplain ContextConfigurationAttributes context
 	 * configuration attributes} for the supplied {@linkplain Class test class} and its
 	 * superclasses, taking into account context hierarchies declared via
@@ -411,8 +430,10 @@ abstract class ContextLoaderUtils {
 			Class<?> declaringClass = (descriptor.getStereotype() != null) ? descriptor.getStereotypeType()
 					: rootDeclaringClass;
 
-			convertContextConfigToConfigAttributesAndAddToList(descriptor.getAnnotation(), declaringClass,
-				attributesList);
+			AnnotationAttributes annAttrs = AnnotatedElementUtils.getAnnotationAttributes(rootDeclaringClass,
+				annotationType.getName());
+
+			convertContextConfigToConfigAttributesAndAddToList(annAttrs, declaringClass, attributesList);
 			descriptor = findAnnotationDescriptor(rootDeclaringClass.getSuperclass(), annotationType);
 		}
 

--- a/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
@@ -288,17 +288,16 @@ abstract class ContextLoaderUtils {
 			contextConfigType.getName(), contextHierarchyType.getName(), testClass.getName()));
 
 		while (descriptor != null) {
-			Class<?> rootDeclaringClass = descriptor.getDeclaringClass();
-			Class<?> declaringClass = (descriptor.getStereotype() != null) ? descriptor.getStereotypeType()
-					: rootDeclaringClass;
+			Class<?> rootDeclaringClass = descriptor.getRootDeclaringClass();
+			Class<?> declaringClass = descriptor.getDeclaringClass();
 
 			boolean contextConfigDeclaredLocally = isAnnotationDeclaredLocally(contextConfigType, declaringClass);
 			boolean contextHierarchyDeclaredLocally = isAnnotationDeclaredLocally(contextHierarchyType, declaringClass);
 
 			if (contextConfigDeclaredLocally && contextHierarchyDeclaredLocally) {
-				String msg = String.format("Test class [%s] has been configured with both @ContextConfiguration "
+				String msg = String.format("Class [%s] has been configured with both @ContextConfiguration "
 						+ "and @ContextHierarchy. Only one of these annotations may be declared on a test class "
-						+ "or custom stereotype annotation.", rootDeclaringClass.getName());
+						+ "or custom stereotype annotation.", declaringClass.getName());
 				logger.error(msg);
 				throw new IllegalStateException(msg);
 			}
@@ -429,13 +428,9 @@ abstract class ContextLoaderUtils {
 			annotationType.getName(), testClass.getName()));
 
 		while (descriptor != null) {
-			Class<?> rootDeclaringClass = descriptor.getDeclaringClass();
-			Class<?> declaringClass = (descriptor.getStereotype() != null) ? descriptor.getStereotypeType()
-					: rootDeclaringClass;
-
 			convertAnnotationAttributesToConfigAttributesAndAddToList(descriptor.getAnnotationAttributes(),
-				declaringClass, attributesList);
-			descriptor = findAnnotationDescriptor(rootDeclaringClass.getSuperclass(), annotationType);
+				descriptor.getDeclaringClass(), attributesList);
+			descriptor = findAnnotationDescriptor(descriptor.getRootDeclaringClass().getSuperclass(), annotationType);
 		}
 
 		return attributesList;
@@ -513,9 +508,7 @@ abstract class ContextLoaderUtils {
 		final Set<String> activeProfiles = new HashSet<String>();
 
 		while (descriptor != null) {
-			Class<?> rootDeclaringClass = descriptor.getDeclaringClass();
-			Class<?> declaringClass = (descriptor.getStereotype() != null) ? descriptor.getStereotypeType()
-					: rootDeclaringClass;
+			Class<?> declaringClass = descriptor.getDeclaringClass();
 
 			AnnotationAttributes annAttrs = descriptor.getAnnotationAttributes();
 			if (logger.isTraceEnabled()) {
@@ -563,7 +556,7 @@ abstract class ContextLoaderUtils {
 			}
 
 			descriptor = annAttrs.getBoolean("inheritProfiles") ? findAnnotationDescriptor(
-				rootDeclaringClass.getSuperclass(), annotationType) : null;
+				descriptor.getRootDeclaringClass().getSuperclass(), annotationType) : null;
 		}
 
 		return StringUtils.toStringArray(activeProfiles);

--- a/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextLoaderUtils.java
@@ -31,7 +31,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.context.MetaAnnotationUtils.AnnotationDescriptor;
@@ -307,10 +306,8 @@ abstract class ContextLoaderUtils {
 			final List<ContextConfigurationAttributes> configAttributesList = new ArrayList<ContextConfigurationAttributes>();
 
 			if (contextConfigDeclaredLocally) {
-				AnnotationAttributes annAttrs = AnnotatedElementUtils.getAnnotationAttributes(rootDeclaringClass,
-					contextConfigType.getName());
-				convertAnnotationAttributesToConfigAttributesAndAddToList(annAttrs, declaringClass,
-					configAttributesList);
+				convertAnnotationAttributesToConfigAttributesAndAddToList(descriptor.getAnnotationAttributes(),
+					declaringClass, configAttributesList);
 			}
 			else if (contextHierarchyDeclaredLocally) {
 				ContextHierarchy contextHierarchy = getAnnotation(declaringClass, contextHierarchyType);
@@ -436,9 +433,8 @@ abstract class ContextLoaderUtils {
 			Class<?> declaringClass = (descriptor.getStereotype() != null) ? descriptor.getStereotypeType()
 					: rootDeclaringClass;
 
-			AnnotationAttributes annAttrs = AnnotatedElementUtils.getAnnotationAttributes(rootDeclaringClass,
-				annotationType.getName());
-			convertAnnotationAttributesToConfigAttributesAndAddToList(annAttrs, declaringClass, attributesList);
+			convertAnnotationAttributesToConfigAttributesAndAddToList(descriptor.getAnnotationAttributes(),
+				declaringClass, attributesList);
 			descriptor = findAnnotationDescriptor(rootDeclaringClass.getSuperclass(), annotationType);
 		}
 
@@ -521,8 +517,7 @@ abstract class ContextLoaderUtils {
 			Class<?> declaringClass = (descriptor.getStereotype() != null) ? descriptor.getStereotypeType()
 					: rootDeclaringClass;
 
-			AnnotationAttributes annAttrs = AnnotatedElementUtils.getAnnotationAttributes(rootDeclaringClass,
-				annotationType.getName());
+			AnnotationAttributes annAttrs = descriptor.getAnnotationAttributes();
 			if (logger.isTraceEnabled()) {
 				logger.trace(String.format("Retrieved @ActiveProfiles attributes [%s] for declaring class [%s].",
 					annAttrs, declaringClass.getName()));

--- a/spring-test/src/main/java/org/springframework/test/context/MetaAnnotationUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/MetaAnnotationUtils.java
@@ -126,7 +126,7 @@ abstract class MetaAnnotationUtils {
 	 * <p>
 	 * If the annotation is used as a meta-annotation, the descriptor also includes
 	 * the {@linkplain #getStereotype() stereotype} on which the annotation is
-	 * present. In such cases, the <em>declaring class</em> is not directly
+	 * present. In such cases, the <em>root declaring class</em> is not directly
 	 * annotated with the annotation but rather indirectly via the stereotype.
 	 *
 	 * <p>
@@ -135,6 +135,7 @@ abstract class MetaAnnotationUtils {
 	 * properties of the {@code AnnotationDescriptor} would be as follows.
 	 *
 	 * <ul>
+	 * <li>rootDeclaringClass: {@code TransactionalTests} class object</li>
 	 * <li>declaringClass: {@code TransactionalTests} class object</li>
 	 * <li>stereotype: {@code null}</li>
 	 * <li>annotation: instance of the {@code Transactional} annotation</li>
@@ -152,7 +153,8 @@ abstract class MetaAnnotationUtils {
 	 * properties of the {@code AnnotationDescriptor} would be as follows.
 	 *
 	 * <ul>
-	 * <li>declaringClass: {@code UserRepositoryTests} class object</li>
+	 * <li>rootDeclaringClass: {@code UserRepositoryTests} class object</li>
+	 * <li>declaringClass: {@code RepositoryTests} class object</li>
 	 * <li>stereotype: instance of the {@code RepositoryTests} annotation</li>
 	 * <li>annotation: instance of the {@code Transactional} annotation</li>
 	 * </ul>
@@ -172,25 +174,31 @@ abstract class MetaAnnotationUtils {
 	 */
 	public static class AnnotationDescriptor<T extends Annotation> {
 
+		private final Class<?> rootDeclaringClass;
 		private final Class<?> declaringClass;
 		private final Annotation stereotype;
 		private final T annotation;
 		private final AnnotationAttributes annotationAttributes;
 
 
-		public AnnotationDescriptor(Class<?> declaringClass, T annotation) {
-			this(declaringClass, null, annotation);
+		public AnnotationDescriptor(Class<?> rootDeclaringClass, T annotation) {
+			this(rootDeclaringClass, null, annotation);
 		}
 
-		public AnnotationDescriptor(Class<?> declaringClass, Annotation stereotype, T annotation) {
-			Assert.notNull(declaringClass, "declaringClass must not be null");
+		public AnnotationDescriptor(Class<?> rootDeclaringClass, Annotation stereotype, T annotation) {
+			Assert.notNull(rootDeclaringClass, "rootDeclaringClass must not be null");
 			Assert.notNull(annotation, "annotation must not be null");
 
-			this.declaringClass = declaringClass;
+			this.rootDeclaringClass = rootDeclaringClass;
+			this.declaringClass = (stereotype != null) ? stereotype.annotationType() : rootDeclaringClass;
 			this.stereotype = stereotype;
 			this.annotation = annotation;
-			this.annotationAttributes = AnnotatedElementUtils.getAnnotationAttributes(declaringClass,
+			this.annotationAttributes = AnnotatedElementUtils.getAnnotationAttributes(rootDeclaringClass,
 				annotation.annotationType().getName());
+		}
+
+		public Class<?> getRootDeclaringClass() {
+			return this.rootDeclaringClass;
 		}
 
 		public Class<?> getDeclaringClass() {
@@ -223,6 +231,7 @@ abstract class MetaAnnotationUtils {
 		@Override
 		public String toString() {
 			return new ToStringCreator(this)//
+			.append("rootDeclaringClass", rootDeclaringClass)//
 			.append("declaringClass", declaringClass)//
 			.append("stereotype", stereotype)//
 			.append("annotation", annotation)//

--- a/spring-test/src/main/java/org/springframework/test/context/MetaAnnotationUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/MetaAnnotationUtils.java
@@ -18,6 +18,8 @@ package org.springframework.test.context;
 
 import java.lang.annotation.Annotation;
 
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -173,6 +175,7 @@ abstract class MetaAnnotationUtils {
 		private final Class<?> declaringClass;
 		private final Annotation stereotype;
 		private final T annotation;
+		private final AnnotationAttributes annotationAttributes;
 
 
 		public AnnotationDescriptor(Class<?> declaringClass, T annotation) {
@@ -186,6 +189,8 @@ abstract class MetaAnnotationUtils {
 			this.declaringClass = declaringClass;
 			this.stereotype = stereotype;
 			this.annotation = annotation;
+			this.annotationAttributes = AnnotatedElementUtils.getAnnotationAttributes(declaringClass,
+				annotation.annotationType().getName());
 		}
 
 		public Class<?> getDeclaringClass() {
@@ -198,6 +203,10 @@ abstract class MetaAnnotationUtils {
 
 		public Class<? extends Annotation> getAnnotationType() {
 			return this.annotation.annotationType();
+		}
+
+		public AnnotationAttributes getAnnotationAttributes() {
+			return this.annotationAttributes;
 		}
 
 		public Annotation getStereotype() {

--- a/spring-test/src/main/java/org/springframework/test/context/TestContextManager.java
+++ b/spring-test/src/main/java/org/springframework/test/context/TestContextManager.java
@@ -28,7 +28,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeanUtils;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.test.context.MetaAnnotationUtils.AnnotationDescriptor;
 import org.springframework.util.Assert;
@@ -181,7 +180,6 @@ public class TestContextManager {
 		List<Class<? extends TestExecutionListener>> classesList = new ArrayList<Class<? extends TestExecutionListener>>();
 
 		AnnotationDescriptor<TestExecutionListeners> descriptor = findAnnotationDescriptor(clazz, annotationType);
-
 		boolean defaultListeners = false;
 
 		// Use defaults?
@@ -195,13 +193,9 @@ public class TestContextManager {
 		else {
 			// Traverse the class hierarchy...
 			while (descriptor != null) {
-				Class<?> rootDeclaringClass = descriptor.getDeclaringClass();
-				Class<?> declaringClass = (descriptor.getStereotype() != null) ? descriptor.getStereotypeType()
-						: rootDeclaringClass;
+				Class<?> declaringClass = descriptor.getDeclaringClass();
 
-				AnnotationAttributes annAttrs = AnnotatedElementUtils.getAnnotationAttributes(rootDeclaringClass,
-					TestExecutionListeners.class.getName());
-
+				AnnotationAttributes annAttrs = descriptor.getAnnotationAttributes();
 				if (logger.isTraceEnabled()) {
 					logger.trace(String.format(
 						"Retrieved @TestExecutionListeners attributes [%s] for declaring class [%s].", annAttrs,
@@ -212,7 +206,7 @@ public class TestContextManager {
 				Class<? extends TestExecutionListener>[] listenerClasses = (Class<? extends TestExecutionListener>[]) annAttrs.getClassArray("listeners");
 				if (!ObjectUtils.isEmpty(valueListenerClasses) && !ObjectUtils.isEmpty(listenerClasses)) {
 					String msg = String.format(
-						"Test class [%s] has been configured with @TestExecutionListeners' 'value' [%s] "
+						"Class [%s] has been configured with @TestExecutionListeners' 'value' [%s] "
 								+ "and 'listeners' [%s] attributes. Use one or the other, but not both.",
 						declaringClass, ObjectUtils.nullSafeToString(valueListenerClasses),
 						ObjectUtils.nullSafeToString(listenerClasses));
@@ -228,7 +222,7 @@ public class TestContextManager {
 				}
 
 				descriptor = (annAttrs.getBoolean("inheritListeners") ? findAnnotationDescriptor(
-					rootDeclaringClass.getSuperclass(), annotationType) : null);
+					descriptor.getRootDeclaringClass().getSuperclass(), annotationType) : null);
 			}
 		}
 

--- a/spring-test/src/main/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunner.java
+++ b/spring-test/src/main/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunner.java
@@ -34,6 +34,8 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.annotation.ProfileValueUtils;
 import org.springframework.test.annotation.Repeat;
@@ -411,8 +413,9 @@ public class SpringJUnit4ClassRunner extends BlockJUnit4ClassRunner {
 	 * @return the timeout, or {@code 0} if none was specified.
 	 */
 	protected long getSpringTimeout(FrameworkMethod frameworkMethod) {
-		Timed timedAnnotation = AnnotationUtils.getAnnotation(frameworkMethod.getMethod(), Timed.class);
-		return (timedAnnotation != null && timedAnnotation.millis() > 0 ? timedAnnotation.millis() : 0);
+		AnnotationAttributes ann = AnnotatedElementUtils.getAnnotationAttributes(frameworkMethod.getMethod(),
+			Timed.class.getName());
+		return (ann != null && ann.getNumber("millis").intValue() > 0 ? ann.getNumber("millis").intValue() : 0);
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunner.java
+++ b/spring-test/src/main/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunner.java
@@ -413,9 +413,15 @@ public class SpringJUnit4ClassRunner extends BlockJUnit4ClassRunner {
 	 * @return the timeout, or {@code 0} if none was specified.
 	 */
 	protected long getSpringTimeout(FrameworkMethod frameworkMethod) {
-		AnnotationAttributes ann = AnnotatedElementUtils.getAnnotationAttributes(frameworkMethod.getMethod(),
+		AnnotationAttributes annAttrs = AnnotatedElementUtils.getAnnotationAttributes(frameworkMethod.getMethod(),
 			Timed.class.getName());
-		return (ann != null && ann.getNumber("millis").intValue() > 0 ? ann.getNumber("millis").intValue() : 0);
+		if (annAttrs == null) {
+			return 0;
+		}
+		else {
+			long millis = annAttrs.<Long> getNumber("millis").longValue();
+			return millis > 0 ? millis : 0;
+		}
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
@@ -416,15 +416,18 @@ public class TransactionalTestExecutionListener extends AbstractTestExecutionLis
 		if (rollbackAnnotation != null) {
 			boolean rollbackOverride = rollbackAnnotation.value();
 			if (logger.isDebugEnabled()) {
-				logger.debug("Method-level @Rollback(" + rollbackOverride + ") overrides default rollback [" + rollback
-						+ "] for test context " + testContext);
+				logger.debug(String.format(
+					"Method-level @Rollback(%s) overrides default rollback [%s] for test context %s.",
+					rollbackOverride,
+					rollback, testContext));
 			}
 			rollback = rollbackOverride;
 		}
 		else {
 			if (logger.isDebugEnabled()) {
-				logger.debug("No method-level @Rollback override: using default rollback [" + rollback
-						+ "] for test context " + testContext);
+				logger.debug(String.format(
+					"No method-level @Rollback override: using default rollback [%s] for test context %s.", rollback,
+					testContext));
 			}
 		}
 		return rollback;

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
@@ -418,8 +418,7 @@ public class TransactionalTestExecutionListener extends AbstractTestExecutionLis
 			if (logger.isDebugEnabled()) {
 				logger.debug(String.format(
 					"Method-level @Rollback(%s) overrides default rollback [%s] for test context %s.",
-					rollbackOverride,
-					rollback, testContext));
+					rollbackOverride, rollback, testContext));
 			}
 			rollback = rollbackOverride;
 		}
@@ -536,18 +535,18 @@ public class TransactionalTestExecutionListener extends AbstractTestExecutionLis
 		if (this.configurationAttributes == null) {
 			Class<?> clazz = testContext.getTestClass();
 
-			AnnotationAttributes ann = AnnotatedElementUtils.getAnnotationAttributes(clazz,
+			AnnotationAttributes annAttrs = AnnotatedElementUtils.getAnnotationAttributes(clazz,
 				TransactionConfiguration.class.getName());
 			if (logger.isDebugEnabled()) {
-				logger.debug("Retrieved @TransactionConfiguration attributes [" + ann + "] for test class [" + clazz
-						+ "]");
+				logger.debug(String.format("Retrieved @TransactionConfiguration attributes [%s] for test class [%s].",
+					annAttrs, clazz));
 			}
 
 			String transactionManagerName;
 			boolean defaultRollback;
-			if (ann != null) {
-				transactionManagerName = ann.getString("transactionManager");
-				defaultRollback = ann.getBoolean("defaultRollback");
+			if (annAttrs != null) {
+				transactionManagerName = annAttrs.getString("transactionManager");
+				defaultRollback = annAttrs.getBoolean("defaultRollback");
 			}
 			else {
 				transactionManagerName = DEFAULT_TRANSACTION_MANAGER_NAME;
@@ -557,8 +556,8 @@ public class TransactionalTestExecutionListener extends AbstractTestExecutionLis
 			TransactionConfigurationAttributes configAttributes = new TransactionConfigurationAttributes(
 				transactionManagerName, defaultRollback);
 			if (logger.isDebugEnabled()) {
-				logger.debug("Retrieved TransactionConfigurationAttributes " + configAttributes + " for class ["
-						+ clazz + "]");
+				logger.debug(String.format("Retrieved TransactionConfigurationAttributes %s for class [%s].",
+					configAttributes, clazz));
 			}
 			this.configurationAttributes = configAttributes;
 		}

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
@@ -33,6 +33,8 @@ import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -524,21 +526,25 @@ public class TransactionalTestExecutionListener extends AbstractTestExecutionLis
 	 * {@code @TransactionConfiguration} will be used instead.
 	 * @param testContext the test context for which the configuration
 	 * attributes should be retrieved
-	 * @return a new TransactionConfigurationAttributes instance
+	 * @return the TransactionConfigurationAttributes instance for this listener,
+	 * potentially cached
 	 */
-	private TransactionConfigurationAttributes retrieveConfigurationAttributes(TestContext testContext) {
+	TransactionConfigurationAttributes retrieveConfigurationAttributes(TestContext testContext) {
 		if (this.configurationAttributes == null) {
 			Class<?> clazz = testContext.getTestClass();
-			TransactionConfiguration config = findAnnotation(clazz, TransactionConfiguration.class);
+
+			AnnotationAttributes ann = AnnotatedElementUtils.getAnnotationAttributes(clazz,
+				TransactionConfiguration.class.getName());
 			if (logger.isDebugEnabled()) {
-				logger.debug("Retrieved @TransactionConfiguration [" + config + "] for test class [" + clazz + "]");
+				logger.debug("Retrieved @TransactionConfiguration attributes [" + ann + "] for test class [" + clazz
+						+ "]");
 			}
 
 			String transactionManagerName;
 			boolean defaultRollback;
-			if (config != null) {
-				transactionManagerName = config.transactionManager();
-				defaultRollback = config.defaultRollback();
+			if (ann != null) {
+				transactionManagerName = ann.getString("transactionManager");
+				defaultRollback = ann.getBoolean("defaultRollback");
 			}
 			else {
 				transactionManagerName = DEFAULT_TRANSACTION_MANAGER_NAME;

--- a/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/AbstractContextLoaderUtilsTests.java
@@ -110,6 +110,17 @@ abstract class AbstractContextLoaderUtilsTests {
 	public static @interface MetaLocationsFooConfig {
 	}
 
+	@ContextConfiguration
+	@ActiveProfiles
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	public static @interface MetaLocationsFooConfigWithOverrides {
+
+		String[] locations() default "/foo.xml";
+
+		String[] profiles() default "foo";
+	}
+
 	@ContextConfiguration("/bar.xml")
 	@ActiveProfiles(profiles = "bar")
 	@Retention(RetentionPolicy.RUNTIME)
@@ -123,6 +134,14 @@ abstract class AbstractContextLoaderUtilsTests {
 
 	@MetaLocationsBarConfig
 	static class MetaLocationsBar extends MetaLocationsFoo {
+	}
+
+	@MetaLocationsFooConfigWithOverrides
+	static class MetaLocationsFooWithOverrides {
+	}
+
+	@MetaLocationsFooConfigWithOverrides(locations = { "foo1.xml", "foo2.xml" }, profiles = { "foo1", "foo2" })
+	static class MetaLocationsFooWithOverriddenAttributes {
 	}
 
 	@ContextConfiguration(locations = "/foo.xml", inheritLocations = false)

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsActiveProfilesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsActiveProfilesTests.java
@@ -125,6 +125,26 @@ public class ContextLoaderUtilsActiveProfilesTests extends AbstractContextLoader
 	 * @since 4.0
 	 */
 	@Test
+	public void resolveActiveProfilesWithMetaAnnotationAndOverrides() {
+		String[] profiles = resolveActiveProfiles(MetaLocationsFooWithOverrides.class);
+		assertNotNull(profiles);
+		assertArrayEquals(new String[] { "foo" }, profiles);
+	}
+
+	/**
+	 * @since 4.0
+	 */
+	@Test
+	public void resolveActiveProfilesWithMetaAnnotationAndOverriddenAttributes() {
+		String[] profiles = resolveActiveProfiles(MetaLocationsFooWithOverriddenAttributes.class);
+		assertNotNull(profiles);
+		assertArrayEquals(new String[] { "foo1", "foo2" }, profiles);
+	}
+
+	/**
+	 * @since 4.0
+	 */
+	@Test
 	public void resolveActiveProfilesWithLocalAndInheritedMetaAnnotations() {
 		String[] profiles = resolveActiveProfiles(MetaLocationsBar.class);
 		assertNotNull(profiles);
@@ -254,6 +274,18 @@ public class ContextLoaderUtilsActiveProfilesTests extends AbstractContextLoader
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
 	private static @interface MetaAnimalsConfig {
+	}
+
+	@ActiveProfiles
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	private static @interface MetaProfilesWithOverrides {
+
+		String[] profiles() default { "dog", "cat" };
+
+		Class<? extends ActiveProfilesResolver> resolver() default ActiveProfilesResolver.class;
+
+		boolean inheritProfiles() default false;
 	}
 
 	@MetaAnimalsConfig

--- a/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsConfigurationAttributesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/ContextLoaderUtilsConfigurationAttributesTests.java
@@ -84,6 +84,24 @@ public class ContextLoaderUtilsConfigurationAttributesTests extends AbstractCont
 	}
 
 	@Test
+	public void resolveConfigAttributesWithMetaAnnotationAndLocationsAndOverrides() {
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(MetaLocationsFooWithOverrides.class);
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertAttributes(attributesList.get(0), MetaLocationsFooConfigWithOverrides.class, new String[] { "/foo.xml" },
+			EMPTY_CLASS_ARRAY, ContextLoader.class, true);
+	}
+
+	@Test
+	public void resolveConfigAttributesWithMetaAnnotationAndLocationsAndOverriddenAttributes() {
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(MetaLocationsFooWithOverriddenAttributes.class);
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertAttributes(attributesList.get(0), MetaLocationsFooConfigWithOverrides.class, new String[] { "foo1.xml",
+			"foo2.xml" }, EMPTY_CLASS_ARRAY, ContextLoader.class, true);
+	}
+
+	@Test
 	public void resolveConfigAttributesWithMetaAnnotationAndLocationsInClassHierarchy() {
 		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(MetaLocationsBar.class);
 		assertNotNull(attributesList);

--- a/spring-test/src/test/java/org/springframework/test/context/MetaAnnotationUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/MetaAnnotationUtilsTests.java
@@ -43,7 +43,7 @@ public class MetaAnnotationUtilsTests {
 			Class<? extends Annotation> stereotypeType) {
 		AnnotationDescriptor<Component> descriptor = findAnnotationDescriptor(startClass, Component.class);
 		assertNotNull(descriptor);
-		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(declaringClass, descriptor.getRootDeclaringClass());
 		assertEquals(Component.class, descriptor.getAnnotationType());
 		assertEquals(name, descriptor.getAnnotation().value());
 		assertNotNull(descriptor.getStereotype());
@@ -57,7 +57,7 @@ public class MetaAnnotationUtilsTests {
 		UntypedAnnotationDescriptor descriptor = findAnnotationDescriptorForTypes(startClass, Service.class,
 			annotationType, Order.class, Transactional.class);
 		assertNotNull(descriptor);
-		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(declaringClass, descriptor.getRootDeclaringClass());
 		assertEquals(annotationType, descriptor.getAnnotationType());
 		assertEquals(name, ((Component) descriptor.getAnnotation()).value());
 		assertNotNull(descriptor.getStereotype());
@@ -74,16 +74,16 @@ public class MetaAnnotationUtilsTests {
 	public void findAnnotationDescriptorWithInheritedAnnotationOnClass() throws Exception {
 		// Note: @Transactional is inherited
 		assertEquals(InheritedAnnotationClass.class,
-			findAnnotationDescriptor(InheritedAnnotationClass.class, Transactional.class).getDeclaringClass());
+			findAnnotationDescriptor(InheritedAnnotationClass.class, Transactional.class).getRootDeclaringClass());
 		assertEquals(InheritedAnnotationClass.class,
-			findAnnotationDescriptor(SubInheritedAnnotationClass.class, Transactional.class).getDeclaringClass());
+			findAnnotationDescriptor(SubInheritedAnnotationClass.class, Transactional.class).getRootDeclaringClass());
 	}
 
 	@Test
 	public void findAnnotationDescriptorWithInheritedAnnotationOnInterface() throws Exception {
 		// Note: @Transactional is inherited
 		assertEquals(InheritedAnnotationInterface.class,
-			findAnnotationDescriptor(InheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
+			findAnnotationDescriptor(InheritedAnnotationInterface.class, Transactional.class).getRootDeclaringClass());
 		assertNull(findAnnotationDescriptor(SubInheritedAnnotationInterface.class, Transactional.class));
 		assertNull(findAnnotationDescriptor(SubSubInheritedAnnotationInterface.class, Transactional.class));
 	}
@@ -92,16 +92,16 @@ public class MetaAnnotationUtilsTests {
 	public void findAnnotationDescriptorForNonInheritedAnnotationOnClass() throws Exception {
 		// Note: @Order is not inherited.
 		assertEquals(NonInheritedAnnotationClass.class,
-			findAnnotationDescriptor(NonInheritedAnnotationClass.class, Order.class).getDeclaringClass());
+			findAnnotationDescriptor(NonInheritedAnnotationClass.class, Order.class).getRootDeclaringClass());
 		assertEquals(NonInheritedAnnotationClass.class,
-			findAnnotationDescriptor(SubNonInheritedAnnotationClass.class, Order.class).getDeclaringClass());
+			findAnnotationDescriptor(SubNonInheritedAnnotationClass.class, Order.class).getRootDeclaringClass());
 	}
 
 	@Test
 	public void findAnnotationDescriptorForNonInheritedAnnotationOnInterface() throws Exception {
 		// Note: @Order is not inherited.
 		assertEquals(NonInheritedAnnotationInterface.class,
-			findAnnotationDescriptor(NonInheritedAnnotationInterface.class, Order.class).getDeclaringClass());
+			findAnnotationDescriptor(NonInheritedAnnotationInterface.class, Order.class).getRootDeclaringClass());
 		assertNull(findAnnotationDescriptor(SubNonInheritedAnnotationInterface.class, Order.class));
 	}
 
@@ -116,7 +116,7 @@ public class MetaAnnotationUtilsTests {
 		Class<Component> annotationType = Component.class;
 		AnnotationDescriptor<Component> descriptor = findAnnotationDescriptor(HasLocalAndMetaComponentAnnotation.class,
 			annotationType);
-		assertEquals(HasLocalAndMetaComponentAnnotation.class, descriptor.getDeclaringClass());
+		assertEquals(HasLocalAndMetaComponentAnnotation.class, descriptor.getRootDeclaringClass());
 		assertEquals(annotationType, descriptor.getAnnotationType());
 		assertNull(descriptor.getStereotype());
 		assertNull(descriptor.getStereotypeType());
@@ -159,10 +159,10 @@ public class MetaAnnotationUtilsTests {
 	public void findAnnotationDescriptorForTypesWithInheritedAnnotationOnClass() throws Exception {
 		// Note: @Transactional is inherited
 		assertEquals(InheritedAnnotationClass.class,
-			findAnnotationDescriptorForTypes(InheritedAnnotationClass.class, Transactional.class).getDeclaringClass());
+			findAnnotationDescriptorForTypes(InheritedAnnotationClass.class, Transactional.class).getRootDeclaringClass());
 		assertEquals(
 			InheritedAnnotationClass.class,
-			findAnnotationDescriptorForTypes(SubInheritedAnnotationClass.class, Transactional.class).getDeclaringClass());
+			findAnnotationDescriptorForTypes(SubInheritedAnnotationClass.class, Transactional.class).getRootDeclaringClass());
 	}
 
 	@Test
@@ -171,7 +171,7 @@ public class MetaAnnotationUtilsTests {
 		// Note: @Transactional is inherited
 		assertEquals(
 			InheritedAnnotationInterface.class,
-			findAnnotationDescriptorForTypes(InheritedAnnotationInterface.class, Transactional.class).getDeclaringClass());
+			findAnnotationDescriptorForTypes(InheritedAnnotationInterface.class, Transactional.class).getRootDeclaringClass());
 		assertNull(findAnnotationDescriptorForTypes(SubInheritedAnnotationInterface.class, Transactional.class));
 		assertNull(findAnnotationDescriptorForTypes(SubSubInheritedAnnotationInterface.class, Transactional.class));
 	}
@@ -181,9 +181,9 @@ public class MetaAnnotationUtilsTests {
 	public void findAnnotationDescriptorForTypesForNonInheritedAnnotationOnClass() throws Exception {
 		// Note: @Order is not inherited.
 		assertEquals(NonInheritedAnnotationClass.class,
-			findAnnotationDescriptorForTypes(NonInheritedAnnotationClass.class, Order.class).getDeclaringClass());
+			findAnnotationDescriptorForTypes(NonInheritedAnnotationClass.class, Order.class).getRootDeclaringClass());
 		assertEquals(NonInheritedAnnotationClass.class,
-			findAnnotationDescriptorForTypes(SubNonInheritedAnnotationClass.class, Order.class).getDeclaringClass());
+			findAnnotationDescriptorForTypes(SubNonInheritedAnnotationClass.class, Order.class).getRootDeclaringClass());
 	}
 
 	@Test
@@ -191,7 +191,7 @@ public class MetaAnnotationUtilsTests {
 	public void findAnnotationDescriptorForTypesForNonInheritedAnnotationOnInterface() throws Exception {
 		// Note: @Order is not inherited.
 		assertEquals(NonInheritedAnnotationInterface.class,
-			findAnnotationDescriptorForTypes(NonInheritedAnnotationInterface.class, Order.class).getDeclaringClass());
+			findAnnotationDescriptorForTypes(NonInheritedAnnotationInterface.class, Order.class).getRootDeclaringClass());
 		assertNull(findAnnotationDescriptorForTypes(SubNonInheritedAnnotationInterface.class, Order.class));
 	}
 
@@ -201,7 +201,7 @@ public class MetaAnnotationUtilsTests {
 		Class<Component> annotationType = Component.class;
 		UntypedAnnotationDescriptor descriptor = findAnnotationDescriptorForTypes(
 			HasLocalAndMetaComponentAnnotation.class, Transactional.class, annotationType, Order.class);
-		assertEquals(HasLocalAndMetaComponentAnnotation.class, descriptor.getDeclaringClass());
+		assertEquals(HasLocalAndMetaComponentAnnotation.class, descriptor.getRootDeclaringClass());
 		assertEquals(annotationType, descriptor.getAnnotationType());
 		assertNull(descriptor.getStereotype());
 		assertNull(descriptor.getStereotypeType());
@@ -223,7 +223,7 @@ public class MetaAnnotationUtilsTests {
 			ContextConfiguration.class, Order.class, Transactional.class);
 
 		assertNotNull(descriptor);
-		assertEquals(startClass, descriptor.getDeclaringClass());
+		assertEquals(startClass, descriptor.getRootDeclaringClass());
 		assertEquals(annotationType, descriptor.getAnnotationType());
 		assertArrayEquals(new Class[] {}, ((ContextConfiguration) descriptor.getAnnotation()).value());
 		assertArrayEquals(new Class[] { MetaConfig.DevConfig.class, MetaConfig.ProductionConfig.class },
@@ -242,7 +242,7 @@ public class MetaAnnotationUtilsTests {
 			ContextConfiguration.class, Order.class, Transactional.class);
 
 		assertNotNull(descriptor);
-		assertEquals(startClass, descriptor.getDeclaringClass());
+		assertEquals(startClass, descriptor.getRootDeclaringClass());
 		assertEquals(annotationType, descriptor.getAnnotationType());
 		assertArrayEquals(new Class[] {}, ((ContextConfiguration) descriptor.getAnnotation()).value());
 		assertArrayEquals(new Class[] { MetaAnnotationUtilsTests.class },

--- a/spring-test/src/test/java/org/springframework/test/context/MetaAnnotationUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/MetaAnnotationUtilsTests.java
@@ -214,6 +214,44 @@ public class MetaAnnotationUtilsTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesWithMetaAnnotationWithDefaultAttributes() throws Exception {
+		Class<?> startClass = MetaConfigWithDefaultAttributesTestCase.class;
+		Class<ContextConfiguration> annotationType = ContextConfiguration.class;
+
+		UntypedAnnotationDescriptor descriptor = findAnnotationDescriptorForTypes(startClass, Service.class,
+			ContextConfiguration.class, Order.class, Transactional.class);
+
+		assertNotNull(descriptor);
+		assertEquals(startClass, descriptor.getDeclaringClass());
+		assertEquals(annotationType, descriptor.getAnnotationType());
+		assertArrayEquals(new Class[] {}, ((ContextConfiguration) descriptor.getAnnotation()).value());
+		assertArrayEquals(new Class[] { MetaConfig.DevConfig.class, MetaConfig.ProductionConfig.class },
+			descriptor.getAnnotationAttributes().getClassArray("classes"));
+		assertNotNull(descriptor.getStereotype());
+		assertEquals(MetaConfig.class, descriptor.getStereotypeType());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesWithMetaAnnotationWithOverriddenAttributes() throws Exception {
+		Class<?> startClass = MetaConfigWithOverriddenAttributesTestCase.class;
+		Class<ContextConfiguration> annotationType = ContextConfiguration.class;
+
+		UntypedAnnotationDescriptor descriptor = findAnnotationDescriptorForTypes(startClass, Service.class,
+			ContextConfiguration.class, Order.class, Transactional.class);
+
+		assertNotNull(descriptor);
+		assertEquals(startClass, descriptor.getDeclaringClass());
+		assertEquals(annotationType, descriptor.getAnnotationType());
+		assertArrayEquals(new Class[] {}, ((ContextConfiguration) descriptor.getAnnotation()).value());
+		assertArrayEquals(new Class[] { MetaAnnotationUtilsTests.class },
+			descriptor.getAnnotationAttributes().getClassArray("classes"));
+		assertNotNull(descriptor.getStereotype());
+		assertEquals(MetaConfig.class, descriptor.getStereotypeType());
+	}
+
+	@Test
 	public void findAnnotationDescriptorForTypesForInterfaceWithMetaAnnotation() {
 		Class<InterfaceWithMetaAnnotation> startClass = InterfaceWithMetaAnnotation.class;
 		assertComponentOnStereotypeForMultipleCandidateTypes(startClass, startClass, "meta1", Meta1.class);
@@ -277,6 +315,28 @@ public class MetaAnnotationUtilsTests {
 
 	static class SubClassWithLocalMetaAnnotationAndMetaAnnotatedInterface extends
 			ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface {
+	}
+
+	@ContextConfiguration
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaConfig {
+
+		static class DevConfig {
+		}
+
+		static class ProductionConfig {
+		}
+
+
+		Class<?>[] classes() default { DevConfig.class, ProductionConfig.class };
+	}
+
+	@MetaConfig
+	public class MetaConfigWithDefaultAttributesTestCase {
+	}
+
+	@MetaConfig(classes = MetaAnnotationUtilsTests.class)
+	public class MetaConfigWithOverriddenAttributesTestCase {
 	}
 
 	// -------------------------------------------------------------------------

--- a/spring-test/src/test/java/org/springframework/test/context/OverriddenMetaAnnotationAttributesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/OverriddenMetaAnnotationAttributesTests.java
@@ -43,7 +43,7 @@ public class OverriddenMetaAnnotationAttributesTests {
 		AnnotationDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(declaringClass,
 			ContextConfiguration.class);
 		assertNotNull(descriptor);
-		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(declaringClass, descriptor.getRootDeclaringClass());
 		assertEquals(MetaValueConfig.class, descriptor.getStereotypeType());
 		assertEquals(ContextConfiguration.class, descriptor.getAnnotationType());
 		assertNotNull(descriptor.getStereotype());
@@ -59,7 +59,7 @@ public class OverriddenMetaAnnotationAttributesTests {
 		AnnotationDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(declaringClass,
 			ContextConfiguration.class);
 		assertNotNull(descriptor);
-		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(declaringClass, descriptor.getRootDeclaringClass());
 		assertEquals(MetaValueConfig.class, descriptor.getStereotypeType());
 		assertEquals(ContextConfiguration.class, descriptor.getAnnotationType());
 		assertNotNull(descriptor.getStereotype());
@@ -84,7 +84,7 @@ public class OverriddenMetaAnnotationAttributesTests {
 		AnnotationDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(declaringClass,
 			ContextConfiguration.class);
 		assertNotNull(descriptor);
-		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(declaringClass, descriptor.getRootDeclaringClass());
 		assertEquals(MetaLocationsConfig.class, descriptor.getStereotypeType());
 		assertEquals(ContextConfiguration.class, descriptor.getAnnotationType());
 		assertNotNull(descriptor.getStereotype());
@@ -101,7 +101,7 @@ public class OverriddenMetaAnnotationAttributesTests {
 		AnnotationDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(declaringClass,
 			ContextConfiguration.class);
 		assertNotNull(descriptor);
-		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(declaringClass, descriptor.getRootDeclaringClass());
 		assertEquals(MetaLocationsConfig.class, descriptor.getStereotypeType());
 		assertEquals(ContextConfiguration.class, descriptor.getAnnotationType());
 		assertNotNull(descriptor.getStereotype());

--- a/spring-test/src/test/java/org/springframework/test/context/OverriddenMetaAnnotationAttributesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/OverriddenMetaAnnotationAttributesTests.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.Test;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.test.context.MetaAnnotationUtils.AnnotationDescriptor;
+
+import static org.junit.Assert.*;
+import static org.springframework.test.context.MetaAnnotationUtils.*;
+
+/**
+ * Unit tests for {@link MetaAnnotationUtils} that verify support for overridden
+ * meta-annotation attributes.
+ *
+ * <p>See <a href="https://jira.springsource.org/browse/SPR-10181">SPR-10181</a>.
+ *
+ * @author Sam Brannen
+ * @since 4.0
+ */
+public class OverriddenMetaAnnotationAttributesTests {
+
+	@Test
+	public void contextConfigurationValue() throws Exception {
+		Class<MetaValueConfigTest> declaringClass = MetaValueConfigTest.class;
+		AnnotationDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(declaringClass,
+			ContextConfiguration.class);
+		assertNotNull(descriptor);
+		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(MetaValueConfig.class, descriptor.getStereotypeType());
+		assertEquals(ContextConfiguration.class, descriptor.getAnnotationType());
+		assertNotNull(descriptor.getStereotype());
+		assertEquals(MetaValueConfig.class, descriptor.getStereotypeType());
+
+		// direct access to annotation value:
+		assertArrayEquals(new String[] { "foo.xml" }, descriptor.getAnnotation().value());
+	}
+
+	@Test
+	public void overriddenContextConfigurationValue() throws Exception {
+		Class<?> declaringClass = OverriddenMetaValueConfigTest.class;
+		AnnotationDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(declaringClass,
+			ContextConfiguration.class);
+		assertNotNull(descriptor);
+		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(MetaValueConfig.class, descriptor.getStereotypeType());
+		assertEquals(ContextConfiguration.class, descriptor.getAnnotationType());
+		assertNotNull(descriptor.getStereotype());
+		assertEquals(MetaValueConfig.class, descriptor.getStereotypeType());
+
+		// direct access to annotation value:
+		assertArrayEquals(new String[] { "foo.xml" }, descriptor.getAnnotation().value());
+
+		// overridden attribute:
+		AnnotationAttributes attributes = descriptor.getAnnotationAttributes();
+
+		// NOTE: we would like to be able to override the 'value' attribute; however,
+		// Spring currently does not allow overrides for the 'value' attribute.
+		// TODO Determine if Spring should allow overrides for the 'value' attribute in
+		// custom annotations.
+		assertArrayEquals(new String[] { "foo.xml" }, attributes.getStringArray("value"));
+	}
+
+	@Test
+	public void contextConfigurationLocationsAndInheritLocations() throws Exception {
+		Class<MetaLocationsConfigTest> declaringClass = MetaLocationsConfigTest.class;
+		AnnotationDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(declaringClass,
+			ContextConfiguration.class);
+		assertNotNull(descriptor);
+		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(MetaLocationsConfig.class, descriptor.getStereotypeType());
+		assertEquals(ContextConfiguration.class, descriptor.getAnnotationType());
+		assertNotNull(descriptor.getStereotype());
+		assertEquals(MetaLocationsConfig.class, descriptor.getStereotypeType());
+
+		// direct access to annotation attributes:
+		assertArrayEquals(new String[] { "foo.xml" }, descriptor.getAnnotation().locations());
+		assertFalse(descriptor.getAnnotation().inheritLocations());
+	}
+
+	@Test
+	public void overriddenContextConfigurationLocationsAndInheritLocations() throws Exception {
+		Class<?> declaringClass = OverriddenMetaLocationsConfigTest.class;
+		AnnotationDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(declaringClass,
+			ContextConfiguration.class);
+		assertNotNull(descriptor);
+		assertEquals(declaringClass, descriptor.getDeclaringClass());
+		assertEquals(MetaLocationsConfig.class, descriptor.getStereotypeType());
+		assertEquals(ContextConfiguration.class, descriptor.getAnnotationType());
+		assertNotNull(descriptor.getStereotype());
+		assertEquals(MetaLocationsConfig.class, descriptor.getStereotypeType());
+
+		// direct access to annotation attributes:
+		assertArrayEquals(new String[] { "foo.xml" }, descriptor.getAnnotation().locations());
+		assertFalse(descriptor.getAnnotation().inheritLocations());
+
+		// overridden attributes:
+		AnnotationAttributes attributes = descriptor.getAnnotationAttributes();
+		assertArrayEquals(new String[] { "bar.xml" }, attributes.getStringArray("locations"));
+		assertTrue(attributes.getBoolean("inheritLocations"));
+	}
+
+
+	// -------------------------------------------------------------------------
+
+	@ContextConfiguration("foo.xml")
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaValueConfig {
+
+		String[] value() default {};
+	}
+
+	@MetaValueConfig
+	public static class MetaValueConfigTest {
+	}
+
+	@MetaValueConfig("bar.xml")
+	public static class OverriddenMetaValueConfigTest {
+	}
+
+	@ContextConfiguration(locations = "foo.xml", inheritLocations = false)
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaLocationsConfig {
+
+		String[] locations() default {};
+
+		boolean inheritLocations();
+	}
+
+	@MetaLocationsConfig(inheritLocations = true)
+	static class MetaLocationsConfigTest {
+	}
+
+	@MetaLocationsConfig(locations = "bar.xml", inheritLocations = true)
+	static class OverriddenMetaLocationsConfigTest {
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/TestExecutionListenersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/TestExecutionListenersTests.java
@@ -16,13 +16,13 @@
 
 package org.springframework.test.context;
 
-import static org.junit.Assert.assertEquals;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import org.junit.Test;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import static org.junit.Assert.*;
 
 /**
  * <p>
@@ -114,6 +114,29 @@ public class TestExecutionListenersTests {
 			testContextManager.getTestExecutionListeners().size());
 	}
 
+	@Test
+	public void verifyNumListenersRegisteredViaMetaAnnotationWithOverrides() throws Exception {
+		TestContextManager testContextManager = new TestContextManager(MetaWithOverridesExampleTestCase.class);
+		assertEquals("Num registered TELs for MetaWithOverridesExampleTestCase.", 3,
+			testContextManager.getTestExecutionListeners().size());
+	}
+
+	@Test
+	public void verifyNumListenersRegisteredViaMetaAnnotationWithInheritedListenersWithOverrides() throws Exception {
+		TestContextManager testContextManager = new TestContextManager(
+			MetaInheritedListenersWithOverridesExampleTestCase.class);
+		assertEquals("Num registered TELs for MetaInheritedListenersWithOverridesExampleTestCase.", 5,
+			testContextManager.getTestExecutionListeners().size());
+	}
+
+	@Test
+	public void verifyNumListenersRegisteredViaMetaAnnotationWithNonInheritedListenersWithOverrides() throws Exception {
+		TestContextManager testContextManager = new TestContextManager(
+			MetaNonInheritedListenersWithOverridesExampleTestCase.class);
+		assertEquals("Num registered TELs for MetaNonInheritedListenersWithOverridesExampleTestCase.", 8,
+			testContextManager.getTestExecutionListeners().size());
+	}
+
 	@Test(expected = IllegalStateException.class)
 	public void verifyDuplicateListenersConfigThrowsException() throws Exception {
 		new TestContextManager(DuplicateListenersConfigExampleTestCase.class);
@@ -174,6 +197,32 @@ public class TestExecutionListenersTests {
 	static @interface MetaNonInheritedListeners {
 	}
 
+	@TestExecutionListeners
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaListenersWithOverrides {
+
+		Class<? extends TestExecutionListener>[] listeners() default { FooTestExecutionListener.class,
+			BarTestExecutionListener.class };
+	}
+
+	@TestExecutionListeners
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaInheritedListenersWithOverrides {
+
+		Class<? extends TestExecutionListener>[] listeners() default QuuxTestExecutionListener.class;
+
+		boolean inheritListeners() default true;
+	}
+
+	@TestExecutionListeners
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface MetaNonInheritedListenersWithOverrides {
+
+		Class<? extends TestExecutionListener>[] listeners() default QuuxTestExecutionListener.class;
+
+		boolean inheritListeners() default false;
+	}
+
 	@MetaListeners
 	static class MetaExampleTestCase {
 	}
@@ -184,6 +233,28 @@ public class TestExecutionListenersTests {
 
 	@MetaNonInheritedListeners
 	static class MetaNonInheritedListenersExampleTestCase extends MetaInheritedListenersExampleTestCase {
+	}
+
+	@MetaListenersWithOverrides(listeners = {//
+	FooTestExecutionListener.class,//
+		BarTestExecutionListener.class,//
+		BazTestExecutionListener.class //
+	})
+	static class MetaWithOverridesExampleTestCase {
+	}
+
+	@MetaInheritedListenersWithOverrides(listeners = { FooTestExecutionListener.class, BarTestExecutionListener.class })
+	static class MetaInheritedListenersWithOverridesExampleTestCase extends MetaWithOverridesExampleTestCase {
+	}
+
+	@MetaNonInheritedListenersWithOverrides(listeners = {//
+	FooTestExecutionListener.class,//
+		BarTestExecutionListener.class,//
+		BazTestExecutionListener.class //
+	},//
+	inheritListeners = true)
+	static class MetaNonInheritedListenersWithOverridesExampleTestCase extends
+			MetaInheritedListenersWithOverridesExampleTestCase {
 	}
 
 	static class FooTestExecutionListener extends AbstractTestExecutionListener {

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/TimedSpringRunnerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/TimedSpringRunnerTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.test.context.junit4;
 
-import static org.junit.Assert.*;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -28,8 +26,8 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.JUnit4;
 import org.springframework.test.annotation.Timed;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.tests.Assume;
-import org.springframework.tests.TestGroup;
+
+import static org.junit.Assert.*;
 
 /**
  * Verifies proper handling of the following in conjunction with the
@@ -47,18 +45,18 @@ public class TimedSpringRunnerTests {
 
 	@Test
 	public void timedTests() throws Exception {
-		Assume.group(TestGroup.PERFORMANCE);
+		// Assume.group(TestGroup.PERFORMANCE);
 		Class<TimedSpringRunnerTestCase> testClass = TimedSpringRunnerTestCase.class;
 		TrackingRunListener listener = new TrackingRunListener();
 		RunNotifier notifier = new RunNotifier();
 		notifier.addListener(listener);
 
 		new SpringJUnit4ClassRunner(testClass).run(notifier);
-		assertEquals("Verifying number of tests started for test class [" + testClass + "].", 6,
+		assertEquals("Verifying number of tests started for test class [" + testClass + "].", 7,
 			listener.getTestStartedCount());
-		assertEquals("Verifying number of failures for test class [" + testClass + "].", 4,
+		assertEquals("Verifying number of failures for test class [" + testClass + "].", 5,
 			listener.getTestFailureCount());
-		assertEquals("Verifying number of tests finished for test class [" + testClass + "].", 6,
+		assertEquals("Verifying number of tests finished for test class [" + testClass + "].", 7,
 			listener.getTestFinishedCount());
 	}
 
@@ -101,6 +99,13 @@ public class TimedSpringRunnerTests {
 			Thread.sleep(20);
 		}
 
+		// Should Fail due to timeout.
+		@Test
+		@MetaTimedWithOverride(millis = 10)
+		public void springTimeoutWithSleepAndMetaAnnotationAndOverride() throws Exception {
+			Thread.sleep(20);
+		}
+
 		// Should Fail due to duplicate configuration.
 		@Test(timeout = 200)
 		@Timed(millis = 200)
@@ -112,6 +117,13 @@ public class TimedSpringRunnerTests {
 	@Timed(millis = 10)
 	@Retention(RetentionPolicy.RUNTIME)
 	private static @interface MetaTimed {
+	}
+
+	@Timed(millis = 1000)
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaTimedWithOverride {
+
+		long millis() default 1000;
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/annotation/meta/MetaConfig.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/annotation/meta/MetaConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4.annotation.meta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Custom configuration annotation with meta-annotation attribute overrides for
+ * {@link ContextConfiguration#classes} and {@link ActiveProfiles#profiles}.
+ *
+ * @author Sam Brannen
+ * @since 4.0
+ */
+@ContextConfiguration
+@ActiveProfiles
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MetaConfig {
+
+	@Configuration
+	@Profile("dev")
+	static class DevConfig {
+
+		@Bean
+		public String foo() {
+			return "Dev Foo";
+		}
+	}
+
+	@Configuration
+	@Profile("prod")
+	static class ProductionConfig {
+
+		@Bean
+		public String foo() {
+			return "Production Foo";
+		}
+	}
+
+
+	Class<?>[] classes() default { DevConfig.class, ProductionConfig.class };
+
+	String[] profiles() default "dev";
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/annotation/meta/MetaConfigDefaultsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/annotation/meta/MetaConfigDefaultsTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4.annotation.meta;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for meta-annotation attribute override support, relying on
+ * default attribute values defined in {@link MetaConfig}.
+ *
+ * @author Sam Brannen
+ * @since 4.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@MetaConfig
+public class MetaConfigDefaultsTests {
+
+	@Autowired
+	private String foo;
+
+
+	@Test
+	public void foo() {
+		assertEquals("Dev Foo", foo);
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/annotation/meta/MetaConfigOverrideTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/annotation/meta/MetaConfigOverrideTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4.annotation.meta;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.annotation.PojoAndStringConfig;
+import org.springframework.tests.sample.beans.Employee;
+import org.springframework.tests.sample.beans.Pet;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for meta-annotation attribute override support, overriding
+ * default attribute values defined in {@link MetaConfig}.
+ *
+ * @author Sam Brannen
+ * @since 4.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@MetaConfig(classes = { PojoAndStringConfig.class, MetaConfig.ProductionConfig.class }, profiles = "prod")
+public class MetaConfigOverrideTests {
+
+	@Autowired
+	private String foo;
+
+	@Autowired
+	private Pet pet;
+
+	@Autowired
+	protected Employee employee;
+
+
+	@Test
+	public void verifyEmployee() {
+		assertNotNull("The employee should have been autowired.", this.employee);
+		assertEquals("John Smith", this.employee.getName());
+	}
+
+	@Test
+	public void verifyPet() {
+		assertNotNull("The pet should have been autowired.", this.pet);
+		assertEquals("Fido", this.pet.getName());
+	}
+
+	@Test
+	public void verifyFoo() {
+		assertEquals("Production Foo", this.foo);
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/transaction/TransactionalTestExecutionListenerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/transaction/TransactionalTestExecutionListenerTests.java
@@ -24,11 +24,13 @@ import org.mockito.Mockito;
 import org.springframework.test.context.TestContext;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.transaction.annotation.Propagation.*;
 
 /**
  * Unit tests for {@link TransactionalTestExecutionListener}.
@@ -56,6 +58,11 @@ public class TransactionalTestExecutionListenerTests {
 	}
 
 	private void assertBeforeTestMethodWithTransactionalTestMethod(Class<? extends Invocable> clazz) throws Exception {
+		assertBeforeTestMethodWithTransactionalTestMethod(clazz, true);
+	}
+
+	private void assertBeforeTestMethodWithTransactionalTestMethod(Class<? extends Invocable> clazz, boolean invokedInTx)
+			throws Exception {
 		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
 		Invocable instance = clazz.newInstance();
 		when(testContext.getTestInstance()).thenReturn(instance);
@@ -63,7 +70,7 @@ public class TransactionalTestExecutionListenerTests {
 
 		assertFalse(instance.invoked);
 		listener.beforeTestMethod(testContext);
-		assertTrue(instance.invoked);
+		assertEquals(invokedInTx, instance.invoked);
 	}
 
 	private void assertBeforeTestMethodWithNonTransactionalTestMethod(Class<? extends Invocable> clazz)
@@ -109,6 +116,16 @@ public class TransactionalTestExecutionListenerTests {
 		assertFalse(instance.invoked);
 	}
 
+	private void assertTransactionConfigurationAttributes(Class<?> clazz, String transactionManagerName,
+			boolean defaultRollback) {
+		Mockito.<Class<?>> when(testContext.getTestClass()).thenReturn(clazz);
+
+		TransactionConfigurationAttributes attributes = listener.retrieveConfigurationAttributes(testContext);
+		assertNotNull(attributes);
+		assertEquals(transactionManagerName, attributes.getTransactionManagerName());
+		assertEquals(defaultRollback, attributes.isDefaultRollback());
+	}
+
 	@Test
 	public void beforeTestMethodWithTransactionalDeclaredOnClassLocally() throws Exception {
 		assertBeforeTestMethodWithTransactionalTestMethod(TransactionalDeclaredOnClassLocallyTestCase.class);
@@ -117,6 +134,23 @@ public class TransactionalTestExecutionListenerTests {
 	@Test
 	public void beforeTestMethodWithTransactionalDeclaredOnClassViaMetaAnnotation() throws Exception {
 		assertBeforeTestMethodWithTransactionalTestMethod(TransactionalDeclaredOnClassViaMetaAnnotationTestCase.class);
+	}
+
+	@Test
+	public void beforeTestMethodWithTransactionalDeclaredOnClassViaMetaAnnotationWithOverride() throws Exception {
+		// Note: not actually invoked within a transaction since the test class is
+		// annotated with @MetaTxWithOverride(propagation = NOT_SUPPORTED)
+		assertBeforeTestMethodWithTransactionalTestMethod(
+			TransactionalDeclaredOnClassViaMetaAnnotationWithOverrideTestCase.class, false);
+	}
+
+	@Test
+	public void beforeTestMethodWithTransactionalDeclaredOnMethodViaMetaAnnotationWithOverride() throws Exception {
+		// Note: not actually invoked within a transaction since the method is
+		// annotated with @MetaTxWithOverride(propagation = NOT_SUPPORTED)
+		assertBeforeTestMethodWithTransactionalTestMethod(
+			TransactionalDeclaredOnMethodViaMetaAnnotationWithOverrideTestCase.class, false);
+		assertBeforeTestMethodWithNonTransactionalTestMethod(TransactionalDeclaredOnMethodViaMetaAnnotationWithOverrideTestCase.class);
 	}
 
 	@Test
@@ -149,12 +183,48 @@ public class TransactionalTestExecutionListenerTests {
 		assertAfterTestMethod(AfterTransactionDeclaredViaMetaAnnotationTestCase.class);
 	}
 
+	@Test
+	public void retrieveConfigurationAttributesWithMissingTransactionConfiguration() throws Exception {
+		assertTransactionConfigurationAttributes(MissingTransactionConfigurationTestCase.class, "transactionManager",
+			true);
+	}
+
+	@Test
+	public void retrieveConfigurationAttributesWithEmptyTransactionConfiguration() throws Exception {
+		assertTransactionConfigurationAttributes(EmptyTransactionConfigurationTestCase.class, "transactionManager",
+			true);
+	}
+
+	@Test
+	public void retrieveConfigurationAttributesWithExplicitValues() throws Exception {
+		assertTransactionConfigurationAttributes(TransactionConfigurationWithExplicitValuesTestCase.class, "tm", false);
+	}
+
+	@Test
+	public void retrieveConfigurationAttributesViaMetaAnnotation() throws Exception {
+		assertTransactionConfigurationAttributes(TransactionConfigurationViaMetaAnnotationTestCase.class, "metaTxMgr",
+			true);
+	}
+
+	@Test
+	public void retrieveConfigurationAttributesViaMetaAnnotationWithOverride() throws Exception {
+		assertTransactionConfigurationAttributes(TransactionConfigurationViaMetaAnnotationWithOverrideTestCase.class,
+			"overriddenTxMgr", true);
+	}
+
 
 	// -------------------------------------------------------------------------
 
 	@Transactional
 	@Retention(RetentionPolicy.RUNTIME)
 	private static @interface MetaTransactional {
+	}
+
+	@Transactional
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaTxWithOverride {
+
+		Propagation propagation() default REQUIRED;
 	}
 
 	@BeforeTransaction
@@ -165,6 +235,13 @@ public class TransactionalTestExecutionListenerTests {
 	@AfterTransaction
 	@Retention(RetentionPolicy.RUNTIME)
 	private static @interface MetaAfterTransaction {
+	}
+
+	@TransactionConfiguration
+	@Retention(RetentionPolicy.RUNTIME)
+	private static @interface MetaTxConfig {
+
+		String transactionManager() default "metaTxMgr";
 	}
 
 	private static abstract class Invocable {
@@ -213,10 +290,6 @@ public class TransactionalTestExecutionListenerTests {
 		public void transactionalTest() {
 			/* no-op */
 		}
-
-		public void nonTransactionalTest() {
-			/* no-op */
-		}
 	}
 
 	static class TransactionalDeclaredOnMethodViaMetaAnnotationTestCase extends Invocable {
@@ -227,6 +300,36 @@ public class TransactionalTestExecutionListenerTests {
 		}
 
 		@MetaTransactional
+		public void transactionalTest() {
+			/* no-op */
+		}
+
+		public void nonTransactionalTest() {
+			/* no-op */
+		}
+	}
+
+	@MetaTxWithOverride(propagation = NOT_SUPPORTED)
+	static class TransactionalDeclaredOnClassViaMetaAnnotationWithOverrideTestCase extends Invocable {
+
+		@BeforeTransaction
+		public void beforeTransaction() {
+			invoked = true;
+		}
+
+		public void transactionalTest() {
+			/* no-op */
+		}
+	}
+
+	static class TransactionalDeclaredOnMethodViaMetaAnnotationWithOverrideTestCase extends Invocable {
+
+		@BeforeTransaction
+		public void beforeTransaction() {
+			invoked = true;
+		}
+
+		@MetaTxWithOverride(propagation = NOT_SUPPORTED)
 		public void transactionalTest() {
 			/* no-op */
 		}
@@ -302,6 +405,25 @@ public class TransactionalTestExecutionListenerTests {
 		public void nonTransactionalTest() {
 			/* no-op */
 		}
+	}
+
+	static class MissingTransactionConfigurationTestCase {
+	}
+
+	@TransactionConfiguration
+	static class EmptyTransactionConfigurationTestCase {
+	}
+
+	@TransactionConfiguration(transactionManager = "tm", defaultRollback = false)
+	static class TransactionConfigurationWithExplicitValuesTestCase {
+	}
+
+	@MetaTxConfig
+	static class TransactionConfigurationViaMetaAnnotationTestCase {
+	}
+
+	@MetaTxConfig(transactionManager = "overriddenTxMgr")
+	static class TransactionConfigurationViaMetaAnnotationWithOverrideTestCase {
 	}
 
 }


### PR DESCRIPTION
Prior to this commit, the Spring TestContext Framework (TCF) supported
the use of test-related annotations as meta-annotations for composing
custom test stereotype annotations; however, attributes in custom
stereotypes could not be used to override meta-annotation attributes.

This commit addresses this by allowing attributes from the following
annotations (when used as meta-annotations) to be overridden in custom
stereotypes.
- @ContextConfiguration
- @ActiveProfiles
- @DirtiesContext
- @TransactionConfiguration
- @Timed
- @TestExecutionListeners

This support depends on functionality provided by
AnnotatedElementUtils. See the 'Notes' below for further details and
ramifications.

Notes:
- AnnotatedElementUtils does not support overrides for the 'value'
  attribute of an annotation. It is therefore not possible or not
  feasible to support meta-annotation attribute overrides for some
  test-related annotations.
- @ContextHierarchy, @WebAppConfiguration, @Rollback, @Repeat, and
  @ProfileValueSourceConfiguration define single 'value' attributes
  which cannot be overridden via Spring's meta-annotation attribute
  support.
- Although @IfProfileValue has 'values' and 'name' attributes, the
  typical usage scenario involves the 'value' attribute which is not
  supported for meta-annotation attribute overrides. Furthermore,
  'name' and 'values' are so generic that it is deemed unfeasible to
  provide meta-annotation attribute override support for these.
- @BeforeTransaction and @AfterTransaction do not define any attributes
  that can be overridden.
- Support for meta-annotation attribute overrides for @Transactional is
  provided indirectly via SpringTransactionAnnotationParser.

Implementation Details:
- MetaAnnotationUtils.AnnotationDescriptor now provides access to the
  AnnotationAttributes for the described annotation.
- MetaAnnotationUtils.AnnotationDescriptor now provides access to the
  root declaring class as well as the declaring class.
- ContextLoaderUtils now retrieves AnnotationAttributes from
  AnnotationDescriptor to look up annotation attributes for
  @ContextConfiguration and @ActiveProfiles.
- ContextConfigurationAttributes now provides a constructor to have its
  attributes sourced from an instance of AnnotationAttributes.
- ContextLoaderUtils.resolveContextHierarchyAttributes() now throws an
  IllegalStateException if no class in the class hierarchy declares
  @ContextHierarchy.
- TransactionalTestExecutionListener now uses AnnotatedElementUtils to
  look up annotation attributes for @TransactionConfiguration.
- Implemented missing unit tests for @Rollback resolution in
  TransactionalTestExecutionListener.
- SpringJUnit4ClassRunner now uses AnnotatedElementUtils to look up
  annotation attributes for @Timed.
- TestContextManager now retrieves AnnotationAttributes from
  AnnotationDescriptor to look up annotation attributes for
  @TestExecutionListeners.
- DirtiesContextTestExecutionListener now uses AnnotatedElementUtils to
  look up annotation attributes for @DirtiesContext.

Issue: SPR-11038
