### PR TITLE
Update MvcUriComponentsBuilder.java

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilder.java
@@ -118,7 +118,7 @@ public class MvcUriComponentsBuilder extends UriComponentsBuilder {
 
 		Method match = null;
 		for (Method method : controllerType.getDeclaredMethods()) {
-			if ((method.getParameterCount() == argumentValues.length) && method.getName().equals(methodName)) {
+			if ((method.getParameterTypes().length == argumentValues.length) && method.getName().equals(methodName)) {
 				if (match != null) {
 					throw new IllegalStateException("Found two methods named '" + methodName
 							+ "' having " + argumentValues + " arguments, controller "


### PR DESCRIPTION
Method with following signature "public static UriComponentsBuilder fromMethodName(Class<?> controllerType,String methodName, Object... argumentValues)" makes use of the getParameterCount() method found in the java.lang.reflect.Method class. This is specific to Java 8 and will cause projects using prior versions of Java to throw an exception (java.lang.NoSuchMethodError: java.lang.reflect.Method.getParameterCount()). My proposed modification is to change it to getParameterTypes().length to get the total number of parameters.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
