### PR TITLE
Removed extraneous character from the online documentation

### DIFF
--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -43734,7 +43734,7 @@ If you prefer XML configuration use the `<task:annotation-driven>` element.
 ----
 	<task:annotation-driven executor="myExecutor" scheduler="myScheduler"/>
 	<task:executor id="myExecutor" pool-size="5"/>
-	<task:scheduler id="myScheduler" pool-size="10"/>}
+	<task:scheduler id="myScheduler" pool-size="10"/>
 ----
 
 Notice with the above XML that an executor reference is provided for handling those


### PR DESCRIPTION
The curly brace after the XML snippet in section 27.4.1 -> http://docs.spring.io/spring/docs/current/spring-framework-reference/html/scheduling.html#scheduling-enable-annotation-support 

---

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
