### PR TITLE
SPR-11299: Add PATCH support to MockMvcRequestBuilders

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
@@ -33,6 +33,7 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
+ * @author Greg Turnquist
  * @since 3.2
  */
 public abstract class MockMvcRequestBuilders {
@@ -68,6 +69,16 @@ public abstract class MockMvcRequestBuilders {
 	 */
 	public static MockHttpServletRequestBuilder put(String urlTemplate, Object... urlVariables) {
 		return new MockHttpServletRequestBuilder(HttpMethod.PUT, urlTemplate, urlVariables);
+	}
+
+	/**
+	 * Create a {@link MockHttpServletRequestBuilder} for a PATCH request.
+	 *
+	 * @param urlTemplate a URL template; the resulting URL will be encoded
+	 * @param urlVariables zero or more URL variables
+	 */
+	public static MockHttpServletRequestBuilder patch(String urlTemplate, Object... urlVariables) {
+		return new MockHttpServletRequestBuilder(HttpMethod.PATCH, urlTemplate, urlVariables);
 	}
 
 	/**


### PR DESCRIPTION
This is shortcut to avoid having to use MockMvcRequestBuilders.request()
and instead have a simple patch(url, params...)
