### PR TITLE
[SPR-11317] ServletWebRequest.checkNotModified() methods should treat HEAD identically to GET

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
@@ -47,6 +47,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 
 	private static final String METHOD_GET = "GET";
 
+	private static final String METHOD_HEAD = "HEAD";
 
 	private HttpServletResponse response;
 
@@ -165,6 +166,10 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 	public boolean isSecure() {
 		return getRequest().isSecure();
 	}
+	
+	private boolean isSafeHttpMethod(String method) {
+		return METHOD_GET.equals(method) || METHOD_HEAD.equals(method);
+	}
 
 	@Override
 	public boolean checkNotModified(long lastModifiedTimestamp) {
@@ -173,7 +178,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 			long ifModifiedSince = getRequest().getDateHeader(HEADER_IF_MODIFIED_SINCE);
 			this.notModified = (ifModifiedSince >= (lastModifiedTimestamp / 1000 * 1000));
 			if (this.response != null) {
-				if (this.notModified && METHOD_GET.equals(getRequest().getMethod())) {
+				if (this.notModified && isSafeHttpMethod(getRequest().getMethod())) {
 					this.response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 				}
 				else {
@@ -191,7 +196,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 			String ifNoneMatch = getRequest().getHeader(HEADER_IF_NONE_MATCH);
 			this.notModified = eTag.equals(ifNoneMatch);
 			if (this.response != null) {
-				if (this.notModified && METHOD_GET.equals(getRequest().getMethod())) {
+				if (this.notModified && isSafeHttpMethod(getRequest().getMethod())) {
 					this.response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 				}
 				else {

--- a/spring-web/src/test/java/org/springframework/web/context/request/ServletWebRequestTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/ServletWebRequestTests.java
@@ -116,7 +116,7 @@ public class ServletWebRequestTests {
 	}
 
 	@Test
-	public void checkNotModifiedTimeStamp() {
+	public void checkNotModifiedTimeStampForGET() {
 		long currentTime = new Date().getTime();
 		servletRequest.setMethod("GET");
 		servletRequest.addHeader("If-Modified-Since", currentTime);
@@ -127,7 +127,7 @@ public class ServletWebRequestTests {
 	}
 
 	@Test
-	public void checkModifiedTimeStamp() {
+	public void checkModifiedTimeStampForGET() {
 		long currentTime = new Date().getTime();
 		long oneMinuteAgo  = currentTime - (1000 * 60);
 		servletRequest.setMethod("GET");
@@ -140,7 +140,7 @@ public class ServletWebRequestTests {
 	}
 
 	@Test
-	public void checkNotModifiedETag() {
+	public void checkNotModifiedETagForGET() {
 		String eTag = "\"Foo\"";
 		servletRequest.setMethod("GET");
 		servletRequest.addHeader("If-None-Match", eTag );
@@ -151,10 +151,58 @@ public class ServletWebRequestTests {
 	}
 
 	@Test
-	public void checkModifiedETag() {
+	public void checkModifiedETagForGET() {
 		String currentETag = "\"Foo\"";
 		String oldEtag = "Bar";
 		servletRequest.setMethod("GET");
+		servletRequest.addHeader("If-None-Match", oldEtag);
+
+		request.checkNotModified(currentETag);
+
+		assertEquals(200, servletResponse.getStatus());
+		assertEquals(currentETag, servletResponse.getHeader("ETag"));
+	}
+
+	@Test
+	public void checkNotModifiedTimeStampForHEAD() {
+		long currentTime = new Date().getTime();
+		servletRequest.setMethod("HEAD");
+		servletRequest.addHeader("If-Modified-Since", currentTime);
+
+		request.checkNotModified(currentTime);
+
+		assertEquals(304, servletResponse.getStatus());
+	}
+
+	@Test
+	public void checkModifiedTimeStampForHEAD() {
+		long currentTime = new Date().getTime();
+		long oneMinuteAgo  = currentTime - (1000 * 60);
+		servletRequest.setMethod("HEAD");
+		servletRequest.addHeader("If-Modified-Since", oneMinuteAgo);
+
+		request.checkNotModified(currentTime);
+
+		assertEquals(200, servletResponse.getStatus());
+		assertEquals(""+currentTime, servletResponse.getHeader("Last-Modified"));
+	}
+
+	@Test
+	public void checkNotModifiedETagForHEAD() {
+		String eTag = "\"Foo\"";
+		servletRequest.setMethod("HEAD");
+		servletRequest.addHeader("If-None-Match", eTag );
+
+		request.checkNotModified(eTag);
+
+		assertEquals(304, servletResponse.getStatus());
+	}
+
+	@Test
+	public void checkModifiedETagForHEAD() {
+		String currentETag = "\"Foo\"";
+		String oldEtag = "Bar";
+		servletRequest.setMethod("HEAD");
 		servletRequest.addHeader("If-None-Match", oldEtag);
 
 		request.checkNotModified(currentETag);


### PR DESCRIPTION
[SPR-11317](https://jira.springsource.org/browse/SPR-11317) `ServletWebRequest.checkNotModified()` methods don't treat a `HEAD` request identically to a `GET` request (in fact they don't consider `HEAD` at all).

[HTTP says](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4):

> The HEAD method is identical to GET except that the server MUST NOT
> return a message-body in the response. The metainformation contained
> in the HTTP headers in response to a HEAD request SHOULD be identical
> to the information sent in response to a GET request.

[Spring's reference documentation suggests](http://docs.spring.io/spring/docs/4.0.x/spring-framework-reference/html/mvc.html#mvc-ann-lastmodified) to call `WebRequest.checkNotModified()` to set the status code to 304:

> calling request.checkNotModified(lastModified) and returning null. The
> former sets the response status to 304

As a consequence of the current implementation, applications which follow that recommendation violate against HTTP. In simple words: I had some fun debugging my application for a missing 304 status code while firing HEAD requests with `wget --server-response --spider` on it.

I suggest to respect `HEAD` in the mentioned methods identically to `GET`.
## Test cases

```
@Test
public void checkNotModifiedTimeStampForHEAD() {
    long currentTime = new Date().getTime();
    servletRequest.setMethod("HEAD");
    servletRequest.addHeader("If-Modified-Since", currentTime);

    request.checkNotModified(currentTime);

    assertEquals(304, servletResponse.getStatus());
}

@Test
public void checkNotModifiedETagForHEAD() {
    String eTag = "\"Foo\"";
    servletRequest.setMethod("HEAD");
    servletRequest.addHeader("If-None-Match", eTag );

    request.checkNotModified(eTag);

    assertEquals(304, servletResponse.getStatus());
}
```

> I have signed and agree to the terms of the SpringSource Individual
> Contributor License Agreement.
