### PR TITLE
SPR-8696, SPR-11316: custom key generator and cache manager

### DIFF
--- a/spring-aspects/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -118,6 +118,18 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	}
 
 	@Override
+	@Cacheable(value = "default", cacheManager = "customCacheManager")
+	public Object customCacheManager(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", cacheManager = "unknownBeanName")
+	public Object unknownCustomCacheManager(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
 	@CachePut("default")
 	public Object update(Object arg1) {
 		return counter.getAndIncrement();

--- a/spring-aspects/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,18 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	@Override
 	@Cacheable(value = "default", key = "#root.methodName + #root.method.name + #root.targetClass + #root.target")
 	public Object rootVars(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", keyGenerator = "customKyeGenerator")
+	public Object customKeyGenerator(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", keyGenerator = "unknownBeanName")
+	public Object unknownCustomKeyGenerator(Object arg1) {
 		return counter.getAndIncrement();
 	}
 

--- a/spring-aspects/src/test/java/org/springframework/cache/config/CacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/CacheableService.java
@@ -62,6 +62,10 @@ public interface CacheableService<T> {
 
 	T unknownCustomKeyGenerator(Object arg1);
 
+	T customCacheManager(Object arg1);
+
+	T unknownCustomCacheManager(Object arg1);
+
 	T throwChecked(Object arg1) throws Exception;
 
 	T throwUnchecked(Object arg1);

--- a/spring-aspects/src/test/java/org/springframework/cache/config/CacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/CacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,10 @@ public interface CacheableService<T> {
 	Number nullInvocations();
 
 	T rootVars(Object arg1);
+
+	T customKeyGenerator(Object arg1);
+
+	T unknownCustomKeyGenerator(Object arg1);
 
 	T throwChecked(Object arg1) throws Exception;
 

--- a/spring-aspects/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
@@ -122,6 +122,18 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	}
 
 	@Override
+	@Cacheable(value = "default", cacheManager = "customCacheManager")
+	public Long customCacheManager(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", cacheManager = "unknownBeanName")
+	public Long unknownCustomCacheManager(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
 	@CachePut("default")
 	public Long update(Object arg1) {
 		return counter.getAndIncrement();

--- a/spring-aspects/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,18 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	@Override
 	@Cacheable(value = "default", key = "#root.methodName + #root.method.name + #root.targetClass + #root.target")
 	public Long rootVars(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", keyGenerator = "customKeyGenerator")
+	public Long customKeyGenerator(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", keyGenerator = "unknownBeanName")
+	public Long unknownCustomKeyGenerator(Object arg1) {
 		return counter.getAndIncrement();
 	}
 

--- a/spring-aspects/src/test/java/org/springframework/cache/config/SomeCustomKeyGenerator.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/SomeCustomKeyGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.config;
+
+import org.springframework.cache.interceptor.KeyGenerator;
+
+import java.lang.reflect.Method;
+
+/**
+ * A custom {@link KeyGenerator} that exposes the algorithm used to compute the key
+ * for convenience in tests scenario.
+ *
+ * @author Stephane Nicoll
+ */
+final class SomeCustomKeyGenerator implements KeyGenerator {
+
+    @Override
+    public Object generate(Object target, Method method, Object... params) {
+        return generateKey(method.getName(), params);
+    }
+
+    /**
+     * @see #generate(Object, java.lang.reflect.Method, Object...)
+     */
+    static Object generateKey(String methodName, Object... params) {
+        final StringBuilder sb = new StringBuilder(methodName);
+        for (Object param : params) {
+            sb.append(param);
+        }
+        return sb.toString();
+    }
+}

--- a/spring-aspects/src/test/java/org/springframework/cache/config/annotation-cache-aspectj.xml
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/annotation-cache-aspectj.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:aop="http://www.springframework.org/schema/aop"
 	xmlns:cache="http://www.springframework.org/schema/cache"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+	xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
 
 
 	<!--
@@ -44,6 +41,16 @@
 	</bean>
 
 	<bean id="customKeyGenerator" class="org.springframework.cache.config.SomeCustomKeyGenerator" />
+
+	<bean id="customCacheManager" class="org.springframework.cache.support.SimpleCacheManager">
+		<property name="caches">
+			<set>
+				<bean class="org.springframework.cache.concurrent.ConcurrentMapCacheFactoryBean">
+					<property name="name" value="default"/>
+				</bean>
+			</set>
+		</property>
+	</bean>
 
 	<bean id="debugInterceptor" class="org.springframework.aop.interceptor.DebugInterceptor"/>
 

--- a/spring-aspects/src/test/java/org/springframework/cache/config/annotation-cache-aspectj.xml
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/annotation-cache-aspectj.xml
@@ -43,6 +43,8 @@
 		</property>
 	</bean>
 
+	<bean id="customKeyGenerator" class="org.springframework.cache.config.SomeCustomKeyGenerator" />
+
 	<bean id="debugInterceptor" class="org.springframework.aop.interceptor.DebugInterceptor"/>
 
 	<bean id="service" class="org.springframework.cache.config.DefaultCacheableService"/>

--- a/spring-context/src/main/java/org/springframework/cache/annotation/CacheEvict.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/CacheEvict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,9 +45,16 @@ public @interface CacheEvict {
 
 	/**
 	 * Spring Expression Language (SpEL) attribute for computing the key dynamically.
-	 * <p>Default is "", meaning all method parameters are considered as a key.
+	 * <p>Default is "", meaning all method parameters are considered as a key, unless
+	 * a custom {@link #keyGenerator()} has been set.
 	 */
 	String key() default "";
+
+	/**
+	 * The bean name of the custom {@link org.springframework.cache.interceptor.KeyGenerator} to use.
+	 * <p>Mutually exclusive with the {@link #key()} attribute.
+	 */
+	String keyGenerator() default "";
 
 	/**
 	 * Spring Expression Language (SpEL) attribute used for conditioning the method caching.

--- a/spring-context/src/main/java/org/springframework/cache/annotation/CacheEvict.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/CacheEvict.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
  * a cache invalidate operation.
  *
  * @author Costin Leau
+ * @author Stephane Nicoll
  * @since 3.1
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
@@ -55,6 +56,11 @@ public @interface CacheEvict {
 	 * <p>Mutually exclusive with the {@link #key()} attribute.
 	 */
 	String keyGenerator() default "";
+
+	/**
+	 * The bean name of the custom {@link org.springframework.cache.CacheManager} to use.
+	 */
+	String cacheManager() default "";
 
 	/**
 	 * Spring Expression Language (SpEL) attribute used for conditioning the method caching.

--- a/spring-context/src/main/java/org/springframework/cache/annotation/CachePut.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/CachePut.java
@@ -33,6 +33,7 @@ import org.springframework.cache.Cache;
  *
  * @author Costin Leau
  * @author Phillip Webb
+ * @author Stephane Nicoll
  * @since 3.1
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
@@ -60,6 +61,11 @@ public @interface CachePut {
 	 * <p>Mutually exclusive with the {@link #key()} attribute.
 	 */
 	String keyGenerator() default "";
+
+	/**
+	 * The bean name of the custom {@link org.springframework.cache.CacheManager} to use.
+	 */
+	String cacheManager() default "";
 
 	/**
 	 * Spring Expression Language (SpEL) attribute used for conditioning the cache update.

--- a/spring-context/src/main/java/org/springframework/cache/annotation/CachePut.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/CachePut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,9 +50,16 @@ public @interface CachePut {
 
 	/**
 	 * Spring Expression Language (SpEL) attribute for computing the key dynamically.
-	 * <p>Default is "", meaning all method parameters are considered as a key.
+	 * <p>Default is "", meaning all method parameters are considered as a key, unless
+	 * a custom {@link #keyGenerator()} has been set.
 	 */
 	String key() default "";
+
+	/**
+	 * The bean name of the custom {@link org.springframework.cache.interceptor.KeyGenerator} to use.
+	 * <p>Mutually exclusive with the {@link #key()} attribute.
+	 */
+	String keyGenerator() default "";
 
 	/**
 	 * Spring Expression Language (SpEL) attribute used for conditioning the cache update.

--- a/spring-context/src/main/java/org/springframework/cache/annotation/Cacheable.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/Cacheable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,16 @@ public @interface Cacheable {
 
 	/**
 	 * Spring Expression Language (SpEL) attribute for computing the key dynamically.
-	 * <p>Default is "", meaning all method parameters are considered as a key.
+	 * <p>Default is "", meaning all method parameters are considered as a key, unless
+	 * a custom {@link #keyGenerator()} has been set.
 	 */
 	String key() default "";
+
+	/**
+	 * The bean name of the custom {@link org.springframework.cache.interceptor.KeyGenerator} to use.
+	 * <p>Mutually exclusive with the {@link #key()} attribute.
+	 */
+	String keyGenerator() default "";
 
 	/**
 	 * Spring Expression Language (SpEL) attribute used for conditioning the method caching.

--- a/spring-context/src/main/java/org/springframework/cache/annotation/Cacheable.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/Cacheable.java
@@ -31,6 +31,7 @@ import java.lang.annotation.Target;
  *
  * @author Costin Leau
  * @author Phillip Webb
+ * @author Stephane Nicoll
  * @since 3.1
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
@@ -58,6 +59,11 @@ public @interface Cacheable {
 	 * <p>Mutually exclusive with the {@link #key()} attribute.
 	 */
 	String keyGenerator() default "";
+
+	/**
+	 * The bean name of the custom {@link org.springframework.cache.CacheManager} to use.
+	 */
+	String cacheManager() default "";
 
 	/**
 	 * Spring Expression Language (SpEL) attribute used for conditioning the method caching.

--- a/spring-context/src/main/java/org/springframework/cache/annotation/SpringCacheAnnotationParser.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/SpringCacheAnnotationParser.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Juergen Hoeller
  * @author Chris Beams
  * @author Phillip Webb
+ * @author Stephane Nicoll
  * @since 3.1
  */
 @SuppressWarnings("serial")
@@ -88,6 +89,7 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		cuo.setUnless(caching.unless());
 		cuo.setKey(caching.key());
 		cuo.setKeyGenerator(caching.keyGenerator());
+		cuo.setCacheManager(caching.cacheManager());
 		cuo.setName(ae.toString());
 
 		checkKeySourceConsistency(ae, caching.key(), caching.keyGenerator());
@@ -100,6 +102,7 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		ceo.setCondition(caching.condition());
 		ceo.setKey(caching.key());
 		ceo.setKeyGenerator(caching.keyGenerator());
+		ceo.setCacheManager(caching.cacheManager());
 		ceo.setCacheWide(caching.allEntries());
 		ceo.setBeforeInvocation(caching.beforeInvocation());
 		ceo.setName(ae.toString());
@@ -115,6 +118,7 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		cuo.setUnless(caching.unless());
 		cuo.setKey(caching.key());
 		cuo.setKeyGenerator(caching.keyGenerator());
+		cuo.setCacheManager(caching.cacheManager());
 		cuo.setName(ae.toString());
 
 		checkKeySourceConsistency(ae, caching.key(), caching.keyGenerator());

--- a/spring-context/src/main/java/org/springframework/cache/annotation/SpringCacheAnnotationParser.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/SpringCacheAnnotationParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.cache.interceptor.CacheOperation;
 import org.springframework.cache.interceptor.CachePutOperation;
 import org.springframework.cache.interceptor.CacheableOperation;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Strategy implementation for parsing Spring's {@link Caching}, {@link Cacheable},
@@ -86,7 +87,10 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		cuo.setCondition(caching.condition());
 		cuo.setUnless(caching.unless());
 		cuo.setKey(caching.key());
+		cuo.setKeyGenerator(caching.keyGenerator());
 		cuo.setName(ae.toString());
+
+		checkKeySourceConsistency(ae, caching.key(), caching.keyGenerator());
 		return cuo;
 	}
 
@@ -95,9 +99,12 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		ceo.setCacheNames(caching.value());
 		ceo.setCondition(caching.condition());
 		ceo.setKey(caching.key());
+		ceo.setKeyGenerator(caching.keyGenerator());
 		ceo.setCacheWide(caching.allEntries());
 		ceo.setBeforeInvocation(caching.beforeInvocation());
 		ceo.setName(ae.toString());
+
+		checkKeySourceConsistency(ae, caching.key(), caching.keyGenerator());
 		return ceo;
 	}
 
@@ -107,7 +114,10 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		cuo.setCondition(caching.condition());
 		cuo.setUnless(caching.unless());
 		cuo.setKey(caching.key());
+		cuo.setKeyGenerator(caching.keyGenerator());
 		cuo.setName(ae.toString());
+
+		checkKeySourceConsistency(ae, caching.key(), caching.keyGenerator());
 		return cuo;
 	}
 
@@ -157,6 +167,15 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		}
 
 		return (anns.isEmpty() ? null : anns);
+	}
+
+	private void checkKeySourceConsistency(AnnotatedElement ae, String key, String keyGenerator) {
+		if (StringUtils.hasText(key) && StringUtils.hasText(keyGenerator)) {
+			throw new IllegalStateException("Invalid cache annotation configuration on '"
+					+ ae.toString() + "'. Both 'key' and 'keyGenerator' attributes have been set. " +
+					"These attributes are mutually exclusive: either set the SpEL expression used to" +
+					"compute the key at runtime or set the name of the KeyGenerator bean to use.");
+		}
 	}
 
 	@Override

--- a/spring-context/src/main/java/org/springframework/cache/config/CacheAdviceParser.java
+++ b/spring-context/src/main/java/org/springframework/cache/config/CacheAdviceParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 
 	private static String getAttributeValue(Element element, String attributeName, String defaultValue) {
 		String attribute = element.getAttribute(attributeName);
-		if(StringUtils.hasText(attribute)) {
+		if (StringUtils.hasText(attribute)) {
 			return attribute.trim();
 		}
 		return defaultValue;
@@ -184,6 +184,8 @@ class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 
 		private String key;
 
+		private String keyGenerator;
+
 		private String condition;
 
 		private String method;
@@ -194,6 +196,7 @@ class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 		Props(Element root) {
 			String defaultCache = root.getAttribute("cache");
 			key = root.getAttribute("key");
+			keyGenerator = root.getAttribute("key-generator");
 			condition = root.getAttribute("condition");
 			method = root.getAttribute(METHOD_ATTRIBUTE);
 
@@ -218,7 +221,15 @@ class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 			op.setCacheNames(localCaches);
 
 			op.setKey(getAttributeValue(element, "key", this.key));
+			op.setKeyGenerator(getAttributeValue(element, "key-generator", this.keyGenerator));
 			op.setCondition(getAttributeValue(element, "condition", this.condition));
+
+			if (StringUtils.hasText(op.getKey()) && StringUtils.hasText(op.getKeyGenerator())) {
+				throw new IllegalStateException("Invalid cache advice configuration on '"
+						+ element.toString() + "'. Both 'key' and 'keyGenerator' attributes have been set. " +
+						"These attributes are mutually exclusive: either set the SpEL expression used to" +
+						"compute the key at runtime or set the name of the KeyGenerator bean to use.");
+			}
 
 			return op;
 		}

--- a/spring-context/src/main/java/org/springframework/cache/config/CacheAdviceParser.java
+++ b/spring-context/src/main/java/org/springframework/cache/config/CacheAdviceParser.java
@@ -45,6 +45,7 @@ import org.w3c.dom.Element;
  *
  * @author Costin Leau
  * @author Phillip Webb
+ * @author Stephane Nicoll
  */
 class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 
@@ -186,6 +187,8 @@ class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 
 		private String keyGenerator;
 
+		private String cacheManager;
+
 		private String condition;
 
 		private String method;
@@ -197,6 +200,7 @@ class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 			String defaultCache = root.getAttribute("cache");
 			key = root.getAttribute("key");
 			keyGenerator = root.getAttribute("key-generator");
+			cacheManager = root.getAttribute("cache-manager");
 			condition = root.getAttribute("condition");
 			method = root.getAttribute(METHOD_ATTRIBUTE);
 
@@ -222,6 +226,7 @@ class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 
 			op.setKey(getAttributeValue(element, "key", this.key));
 			op.setKeyGenerator(getAttributeValue(element, "key-generator", this.keyGenerator));
+			op.setCacheManager(getAttributeValue(element, "cache-manager", this.cacheManager));
 			op.setCondition(getAttributeValue(element, "condition", this.condition));
 
 			if (StringUtils.hasText(op.getKey()) && StringUtils.hasText(op.getKeyGenerator())) {

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheOperation.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheOperation.java
@@ -26,6 +26,7 @@ import org.springframework.util.Assert;
  * Base class for cache operations.
  *
  * @author Costin Leau
+ * @author Stephane Nicoll
  */
 public abstract class CacheOperation {
 
@@ -36,6 +37,8 @@ public abstract class CacheOperation {
 	private String key = "";
 
 	private String keyGenerator = "";
+
+	private String cacheManager = "";
 
 	private String name = "";
 
@@ -54,6 +57,10 @@ public abstract class CacheOperation {
 
 	public String getKeyGenerator() {
 		return keyGenerator;
+	}
+
+	public String getCacheManager() {
+		return cacheManager;
 	}
 
 	public String getName() {
@@ -86,6 +93,11 @@ public abstract class CacheOperation {
 	public void setKeyGenerator(String keyGenerator) {
 		Assert.notNull(keyGenerator);
 		this.keyGenerator = keyGenerator;
+	}
+
+	public void setCacheManager(String cacheManager) {
+		Assert.notNull(cacheManager);
+		this.cacheManager = cacheManager;
 	}
 
 	public void setName(String name) {
@@ -137,6 +149,8 @@ public abstract class CacheOperation {
 		result.append(this.key);
 		result.append("' | keyGenerator='");
 		result.append(this.keyGenerator);
+		result.append("' | cacheManager='");
+		result.append(this.cacheManager);
 		result.append("' | condition='");
 		result.append(this.condition);
 		result.append("'");

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheOperation.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ public abstract class CacheOperation {
 
 	private String key = "";
 
+	private String keyGenerator = "";
+
 	private String name = "";
 
 
@@ -48,6 +50,10 @@ public abstract class CacheOperation {
 
 	public String getKey() {
 		return key;
+	}
+
+	public String getKeyGenerator() {
+		return keyGenerator;
 	}
 
 	public String getName() {
@@ -75,6 +81,11 @@ public abstract class CacheOperation {
 	public void setKey(String key) {
 		Assert.notNull(key);
 		this.key = key;
+	}
+
+	public void setKeyGenerator(String keyGenerator) {
+		Assert.notNull(keyGenerator);
+		this.keyGenerator = keyGenerator;
 	}
 
 	public void setName(String name) {
@@ -124,6 +135,8 @@ public abstract class CacheOperation {
 		result.append(this.cacheNames);
 		result.append(" | key='");
 		result.append(this.key);
+		result.append("' | keyGenerator='");
+		result.append(this.keyGenerator);
 		result.append("' | condition='");
 		result.append(this.condition);
 		result.append("'");

--- a/spring-context/src/main/resources/org/springframework/cache/config/spring-cache-4.0.xsd
+++ b/spring-context/src/main/resources/org/springframework/cache/config/spring-cache-4.0.xsd
@@ -176,9 +176,15 @@
 		<xsd:attribute name="key" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	The SpEL expression used for computing the cache key.]]></xsd:documentation>
+	The SpEL expression used for computing the cache key, mutually exclusive with the key-generator parameter.]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+        <xsd:attribute name="key-generator" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[
+	The name of the KeyGenerator bean responsible to compute the key, mutually exclusive with the key parameter.]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
 		<xsd:attribute name="condition" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-context/src/main/resources/org/springframework/cache/config/spring-cache-4.0.xsd
+++ b/spring-context/src/main/resources/org/springframework/cache/config/spring-cache-4.0.xsd
@@ -185,6 +185,12 @@
 	The name of the KeyGenerator bean responsible to compute the key, mutually exclusive with the key parameter.]]></xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+		<xsd:attribute name="cache-manager" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The name of the CacheManager bean responsible to manage the operation.]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="condition" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-context/src/test/java/org/springframework/cache/annotation/AnnotationCacheOperationSourceTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/annotation/AnnotationCacheOperationSourceTests.java
@@ -34,6 +34,7 @@ import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Costin Leau
+ * @author Stephane Nicoll
  */
 public class AnnotationCacheOperationSourceTests {
 
@@ -116,6 +117,22 @@ public class AnnotationCacheOperationSourceTests {
 		}
 	}
 
+	@Test
+	public void testCustomCacheManager() {
+		Collection<CacheOperation> ops = getOps("customCacheManager");
+		assertEquals(1, ops.size());
+		CacheOperation cacheOperation = ops.iterator().next();
+		assertEquals("Custom cache manager not set", "custom", cacheOperation.getCacheManager());
+	}
+
+	@Test
+	public void testCustomCacheManagerInherited() {
+		Collection<CacheOperation> ops = getOps("customCacheManagerInherited");
+		assertEquals(1, ops.size());
+		CacheOperation cacheOperation = ops.iterator().next();
+		assertEquals("Custom cache manager not set", "custom", cacheOperation.getCacheManager());
+	}
+
 	private static class AnnotatedClass {
 		@Cacheable("test")
 		public void singular() {
@@ -132,6 +149,10 @@ public class AnnotationCacheOperationSourceTests {
 
 		@Cacheable(value = "test", keyGenerator = "custom")
 		public void customKeyGenerator() {
+		}
+
+		@Cacheable(value = "test", cacheManager = "custom")
+		public void customCacheManager() {
 		}
 
 		@EvictFoo
@@ -155,6 +176,10 @@ public class AnnotationCacheOperationSourceTests {
 		@Cacheable(value = "test", key = "#root.methodName", keyGenerator = "custom")
 		public void invalidKeyAndKeyGeneratorSet() {
 		}
+
+		@CacheableFooCustomCacheManager
+		public void customCacheManagerInherited() {
+		}
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)
@@ -167,6 +192,13 @@ public class AnnotationCacheOperationSourceTests {
 	@Target(ElementType.METHOD)
 	@Cacheable(value = "foo", keyGenerator = "custom")
 	public @interface CacheableFooCustomKeyGenerator {
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	@Cacheable(value = "foo", cacheManager = "custom")
+	public @interface CacheableFooCustomCacheManager {
+
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)

--- a/spring-context/src/test/java/org/springframework/cache/config/AbstractAnnotationTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/AbstractAnnotationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 package org.springframework.cache.config;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.Collection;
@@ -26,6 +25,7 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationContext;
@@ -567,6 +567,28 @@ public abstract class AbstractAnnotationTests {
 	@Test
 	public void testClassRootVars() throws Exception {
 		testRootVars(ccs);
+	}
+
+	@Test
+	public void testCustomKeyGenerator() {
+		Object param = new Object();
+		Object r1 = cs.customKeyGenerator(param);
+		assertSame(r1, cs.customKeyGenerator(param));
+		Cache cache = cm.getCache("default");
+		// Checks that the custom keyGenerator was used
+		Object expectedKey = SomeCustomKeyGenerator.generateKey("customKeyGenerator", param);
+		assertNotNull(cache.get(expectedKey));
+	}
+
+	@Test
+	public void testUnknownCustomKeyGenerator() {
+		try {
+			Object param = new Object();
+			cs.unknownCustomKeyGenerator(param);
+			fail("should have failed with NoSuchBeanDefinitionException");
+		} catch (NoSuchBeanDefinitionException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,18 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	@Override
 	@Cacheable(value = "default", key = "#root.methodName + #root.method.name + #root.targetClass + #root.target")
 	public Object rootVars(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", keyGenerator = "customKyeGenerator")
+	public Object customKeyGenerator(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", keyGenerator = "unknownBeanName")
+	public Object unknownCustomKeyGenerator(Object arg1) {
 		return counter.getAndIncrement();
 	}
 

--- a/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -26,6 +26,7 @@ import org.springframework.cache.annotation.Caching;
 /**
  * @author Costin Leau
  * @author Phillip Webb
+ * @author Stephane Nicoll
  */
 @Cacheable("default")
 public class AnnotatedClassCacheableService implements CacheableService<Object> {
@@ -116,6 +117,18 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	@Override
 	@Cacheable(value = "default", keyGenerator = "unknownBeanName")
 	public Object unknownCustomKeyGenerator(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", cacheManager = "customCacheManager")
+	public Object customCacheManager(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", cacheManager = "unknownBeanName")
+	public Object unknownCustomCacheManager(Object arg1) {
 		return counter.getAndIncrement();
 	}
 

--- a/spring-context/src/test/java/org/springframework/cache/config/CacheAdviceParserTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/CacheAdviceParserTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.config;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.context.support.GenericXmlApplicationContext;
+
+/**
+ * AOP advice specific parsing tests.
+ *
+ * @author Stephane Nicoll
+ */
+public class CacheAdviceParserTests {
+
+	@Test
+	public void keyAndKeyGeneratorCannotBeSetTogether() {
+		try {
+			new GenericXmlApplicationContext("/org/springframework/cache/config/cache-advice-invalid.xml");
+			fail("Should have failed to load context, one advise define both a key and a key generator");
+		} catch (BeanDefinitionStoreException e) { // TODO better exception handling
+		}
+	}
+}

--- a/spring-context/src/test/java/org/springframework/cache/config/CacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/CacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,10 @@ public interface CacheableService<T> {
 	Number nullInvocations();
 
 	T rootVars(Object arg1);
+
+	T customKeyGenerator(Object arg1);
+
+	T unknownCustomKeyGenerator(Object arg1);
 
 	T throwChecked(Object arg1) throws Exception;
 

--- a/spring-context/src/test/java/org/springframework/cache/config/CacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/CacheableService.java
@@ -21,6 +21,7 @@ package org.springframework.cache.config;
  *
  * @author Costin Leau
  * @author Phillip Webb
+ * @author Stephane Nicoll
  */
 public interface CacheableService<T> {
 
@@ -61,6 +62,10 @@ public interface CacheableService<T> {
 	T customKeyGenerator(Object arg1);
 
 	T unknownCustomKeyGenerator(Object arg1);
+
+	T customCacheManager(Object arg1);
+
+	T unknownCustomCacheManager(Object arg1);
 
 	T throwChecked(Object arg1) throws Exception;
 

--- a/spring-context/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
@@ -28,6 +28,7 @@ import org.springframework.cache.annotation.Caching;
  *
  * @author Costin Leau
  * @author Phillip Webb
+ * @author Stephane Nicoll
  */
 public class DefaultCacheableService implements CacheableService<Long> {
 
@@ -118,6 +119,18 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	@Override
 	@Cacheable(value = "default", keyGenerator = "unknownBeanName")
 	public Long unknownCustomKeyGenerator(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", cacheManager = "customCacheManager")
+	public Long customCacheManager(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", cacheManager = "unknownBeanName")
+	public Long unknownCustomCacheManager(Object arg1) {
 		return counter.getAndIncrement();
 	}
 

--- a/spring-context/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,18 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	@Override
 	@Cacheable(value = "default", key = "#root.methodName + #root.method.name + #root.targetClass + #root.target")
 	public Long rootVars(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", keyGenerator = "customKeyGenerator")
+	public Long customKeyGenerator(Object arg1) {
+		return counter.getAndIncrement();
+	}
+
+	@Override
+	@Cacheable(value = "default", keyGenerator = "unknownBeanName")
+	public Long unknownCustomKeyGenerator(Object arg1) {
 		return counter.getAndIncrement();
 	}
 

--- a/spring-context/src/test/java/org/springframework/cache/config/EnableCachingTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/EnableCachingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class EnableCachingTests extends AbstractAnnotationTests {
 	@Test
 	public void testKeyStrategy() throws Exception {
 		CacheInterceptor ci = ctx.getBean(CacheInterceptor.class);
-		assertSame(ctx.getBean(KeyGenerator.class), ci.getKeyGenerator());
+		assertSame(ctx.getBean("keyGenerator", KeyGenerator.class), ci.getKeyGenerator());
 	}
 
 	// --- local tests -------
@@ -139,6 +139,11 @@ public class EnableCachingTests extends AbstractAnnotationTests {
 		@Bean
 		public KeyGenerator keyGenerator() {
 			return new SomeKeyGenerator();
+		}
+
+		@Bean
+		public KeyGenerator customKeyGenerator() {
+			return new SomeCustomKeyGenerator();
 		}
 	}
 

--- a/spring-context/src/test/java/org/springframework/cache/config/EnableCachingTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/EnableCachingTests.java
@@ -40,6 +40,7 @@ import org.springframework.context.annotation.Configuration;
  * Integration tests for @EnableCaching and its related @Configuration classes.
  *
  * @author Chris Beams
+ * @author Stephane Nicoll
  */
 public class EnableCachingTests extends AbstractAnnotationTests {
 
@@ -144,6 +145,13 @@ public class EnableCachingTests extends AbstractAnnotationTests {
 		@Bean
 		public KeyGenerator customKeyGenerator() {
 			return new SomeCustomKeyGenerator();
+		}
+
+		@Bean
+		public CacheManager customCacheManager() {
+			SimpleCacheManager cm = new SimpleCacheManager();
+			cm.setCaches(Arrays.asList(new ConcurrentMapCache("default")));
+			return cm;
 		}
 	}
 

--- a/spring-context/src/test/java/org/springframework/cache/config/SomeCustomKeyGenerator.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/SomeCustomKeyGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.config;
+
+import org.springframework.cache.interceptor.KeyGenerator;
+
+import java.lang.reflect.Method;
+
+/**
+ * A custom {@link KeyGenerator} that exposes the algorithm used to compute the key
+ * for convenience in tests scenario.
+ *
+ * @author Stephane Nicoll
+ */
+final class SomeCustomKeyGenerator implements KeyGenerator {
+
+    @Override
+    public Object generate(Object target, Method method, Object... params) {
+        return generateKey(method.getName(), params);
+    }
+
+    /**
+     * @see #generate(Object, java.lang.reflect.Method, Object...)
+     */
+    static Object generateKey(String methodName, Object... params) {
+        final StringBuilder sb = new StringBuilder(methodName);
+        for (Object param : params) {
+            sb.append(param);
+        }
+        return sb.toString();
+    }
+}

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheConfig.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheConfig.xml
@@ -2,27 +2,27 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<bean id="apc" class="org.springframework.aop.framework.autoproxy.InfrastructureAdvisorAutoProxyCreator"/>
 
 	<bean id="annotationSource" class="org.springframework.cache.annotation.AnnotationCacheOperationSource"/>
-	
+
 	<aop:config>
 		<aop:advisor advice-ref="debugInterceptor" pointcut="execution(* *..CacheableService.*(..))" order="1"/>
 	</aop:config>
-	
+
 	<bean id="cacheInterceptor" class="org.springframework.cache.interceptor.CacheInterceptor">
 		<property name="cacheManager" ref="cacheManager"/>
 		<property name="cacheOperationSources" ref="annotationSource"/>
 	</bean>
-	
+
 	<bean id="advisor" class="org.springframework.cache.interceptor.BeanFactoryCacheOperationSourceAdvisor">
 		<property name="cacheOperationSource" ref="annotationSource"/>
 		<property name="adviceBeanName" value="cacheInterceptor"/>
 	</bean>
-	
+
 
 	<bean id="cacheManager" class="org.springframework.cache.support.SimpleCacheManager">
 		<property name="caches">
@@ -35,13 +35,21 @@
 	</bean>
 
 	<bean id="debugInterceptor" class="org.springframework.aop.interceptor.DebugInterceptor"/>
-	
+
 	<bean id="service" class="org.springframework.cache.config.DefaultCacheableService"/>
-	
+
 	<bean id="classService" class="org.springframework.cache.config.AnnotatedClassCacheableService"/>
-	
+
 	<bean id="keyGenerator" class="org.springframework.cache.config.SomeKeyGenerator"/>
 
 	<bean id="customKeyGenerator" class="org.springframework.cache.config.SomeCustomKeyGenerator"/>
+
+	<bean id="customCacheManager" class="org.springframework.cache.support.SimpleCacheManager">
+		<property name="caches">
+			<set>
+				<bean class="org.springframework.cache.concurrent.ConcurrentMapCacheFactoryBean" p:name="default"/>
+			</set>
+		</property>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheConfig.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheConfig.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:p="http://www.springframework.org/schema/p"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
-       		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-       		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+       		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<bean id="apc" class="org.springframework.aop.framework.autoproxy.InfrastructureAdvisorAutoProxyCreator"/>
 
@@ -43,5 +41,7 @@
 	<bean id="classService" class="org.springframework.cache.config.AnnotatedClassCacheableService"/>
 	
 	<bean id="keyGenerator" class="org.springframework.cache.config.SomeKeyGenerator"/>
+
+	<bean id="customKeyGenerator" class="org.springframework.cache.config.SomeCustomKeyGenerator"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace.xml
@@ -30,5 +30,7 @@
 	<bean id="classService" class="org.springframework.cache.config.AnnotatedClassCacheableService"/>
 
 	<bean id="keyGenerator" class="org.springframework.cache.config.SomeKeyGenerator"/>
-	
+
+	<bean id="customKeyGenerator" class="org.springframework.cache.config.SomeCustomKeyGenerator"/>
+
 </beans>

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace.xml
@@ -3,16 +3,16 @@
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
        		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven proxy-target-class="false" order="0" key-generator="keyGenerator"/>
-		
+
 	<aop:config>
 		<aop:advisor advice-ref="debugInterceptor" pointcut="execution(* *..CacheableService.*(..))" order="1"/>
 	</aop:config>
-	
+
 	<bean id="cacheManager" class="org.springframework.cache.support.SimpleCacheManager">
 		<property name="caches">
 			<set>
@@ -24,13 +24,21 @@
 	</bean>
 
 	<bean id="debugInterceptor" class="org.springframework.aop.interceptor.DebugInterceptor"/>
-	
+
 	<bean id="service" class="org.springframework.cache.config.DefaultCacheableService"/>
-	
+
 	<bean id="classService" class="org.springframework.cache.config.AnnotatedClassCacheableService"/>
 
 	<bean id="keyGenerator" class="org.springframework.cache.config.SomeKeyGenerator"/>
 
 	<bean id="customKeyGenerator" class="org.springframework.cache.config.SomeCustomKeyGenerator"/>
+
+	<bean id="customCacheManager" class="org.springframework.cache.support.SimpleCacheManager">
+		<property name="caches">
+			<set>
+				<bean class="org.springframework.cache.concurrent.ConcurrentMapCacheFactoryBean" p:name="default"/>
+			</set>
+		</property>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice-invalid.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice-invalid.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:cache="http://www.springframework.org/schema/cache"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+
+	<import resource="cache-advice.xml"/>
+
+	<cache:advice id="cacheAdviceInvalid" cache-manager="cacheManager">
+		<cache:caching cache="default">
+			<cache:cacheable method="someFakeMethod" key="#root.methodName" key-generator="unknownBeanName"/>
+		</cache:caching>
+	</cache:advice>
+</beans>

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:cache="http://www.springframework.org/schema/cache"
-       xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns:cache="http://www.springframework.org/schema/cache"
+	   xmlns:p="http://www.springframework.org/schema/p"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
        		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
 
@@ -18,6 +18,8 @@
 			<cache:cacheable method="rootVars" key="#root.methodName + #root.method.name + #root.targetClass + #root.target"/>
 			<cache:cacheable method="customKeyGenerator" key-generator="customKeyGenerator"/>
 			<cache:cacheable method="unknownCustomKeyGenerator" key-generator="unknownBeanName"/>
+			<cache:cacheable method="customCacheManager" cache-manager="customCacheManager"/>
+			<cache:cacheable method="unknownCustomCacheManager" cache-manager="unknownBeanName"/>
 			<cache:cacheable method="nullValue" cache="default"/>
 		</cache:caching>
 		<cache:caching>
@@ -110,6 +112,14 @@
 	<bean id="keyGenerator" class="org.springframework.cache.config.SomeKeyGenerator"/>
 
     <bean id="customKeyGenerator" class="org.springframework.cache.config.SomeCustomKeyGenerator"/>
+
+	<bean id="customCacheManager" class="org.springframework.cache.support.SimpleCacheManager">
+		<property name="caches">
+			<set>
+				<bean class="org.springframework.cache.concurrent.ConcurrentMapCacheFactoryBean" p:name="default"/>
+			</set>
+		</property>
+	</bean>
 
 	<bean id="debugInterceptor" class="org.springframework.aop.interceptor.DebugInterceptor"/>
 

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
@@ -16,6 +16,8 @@
 			<cache:cacheable method="varArgsKey"/>
 			<cache:cacheable method="nam*" key="#root.methodName"/>
 			<cache:cacheable method="rootVars" key="#root.methodName + #root.method.name + #root.targetClass + #root.target"/>
+			<cache:cacheable method="customKeyGenerator" key-generator="customKeyGenerator"/>
+			<cache:cacheable method="unknownCustomKeyGenerator" key-generator="unknownBeanName"/>
 			<cache:cacheable method="nullValue" cache="default"/>
 		</cache:caching>
 		<cache:caching>
@@ -106,6 +108,8 @@
 	</bean>
 
 	<bean id="keyGenerator" class="org.springframework.cache.config.SomeKeyGenerator"/>
+
+    <bean id="customKeyGenerator" class="org.springframework.cache.config.SomeCustomKeyGenerator"/>
 
 	<bean id="debugInterceptor" class="org.springframework.aop.interceptor.DebugInterceptor"/>
 


### PR DESCRIPTION
This change brings more features to the `Cacheable`, `CacheEvict` and `CachePut` annotations.

A custom `CacheManager` and/or `KeyGenerator` can be set _per cache operation_. If the parameter is set, we default as we did before to the global `CacheManager` and `KeyGenerator` respectively.
