### PR TITLE
SPR-10548

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,8 @@ project("spring-beans") {
 		provided("javax.el:javax.el-api:2.2.4")
 		provided("javax.inject:javax.inject:1")
 		testCompile("log4j:log4j:1.2.17")
-	}
+		testCompile("org.apache.tomcat.embed:tomcat-embed-core:8.0.0-RC10")
+    }
 }
 
 project('spring-beans-groovy') {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -1042,11 +1042,11 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 				if (primaryBeanName != null) {
 					boolean candidateLocal = containsBeanDefinition(candidateBeanName);
 					boolean primaryLocal = containsBeanDefinition(primaryBeanName);
-					if (candidateLocal == primaryLocal) {
+					if (candidateLocal && primaryLocal) {
 						throw new NoUniqueBeanDefinitionException(descriptor.getDependencyType(), candidateBeans.size(),
 								"more than one 'primary' bean found among candidates: " + candidateBeans.keySet());
 					}
-					else if (candidateLocal && !primaryLocal) {
+					else if (candidateLocal) {
 						primaryBeanName = candidateBeanName;
 					}
 				}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -1512,6 +1512,41 @@ public class DefaultListableBeanFactoryTests {
 	}
 
 	@Test
+	public void testAutowireBeanByTypeWithTwoMatchesAndOnePrimary() {
+		DefaultListableBeanFactory lbf = new DefaultListableBeanFactory();
+		RootBeanDefinition bd = new RootBeanDefinition(TestBean.class);
+		bd.setPrimary(true);
+		RootBeanDefinition bd2 = new RootBeanDefinition(TestBean.class);
+		lbf.registerBeanDefinition("test", bd);
+		lbf.registerBeanDefinition("spouse", bd2);
+
+		DependenciesBean bean = (DependenciesBean)
+				lbf.autowire(DependenciesBean.class, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, true);
+		assertThat(bean.getSpouse(), equalTo(lbf.getBean("test")));
+	}
+
+	@Test
+	public void testAutowireBeanByTypeWithTwoPrimaryCandidates() {
+		DefaultListableBeanFactory lbf = new DefaultListableBeanFactory();
+		RootBeanDefinition bd = new RootBeanDefinition(TestBean.class);
+		bd.setPrimary(true);
+		RootBeanDefinition bd2 = new RootBeanDefinition(TestBean.class);
+		bd2.setPrimary(true);
+		lbf.registerBeanDefinition("test", bd);
+		lbf.registerBeanDefinition("spouse", bd2);
+
+		try {
+			lbf.autowire(DependenciesBean.class, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, true);
+			fail("Should have thrown UnsatisfiedDependencyException");
+		}
+		catch (UnsatisfiedDependencyException ex) {
+			// expected
+			assertNotNull("Exception should have cause", ex.getCause());
+			assertEquals("Wrong cause type", NoUniqueBeanDefinitionException.class, ex.getCause().getClass());
+		}
+	}
+
+	@Test
 	public void testAutowireExistingBeanByName() {
 		DefaultListableBeanFactory lbf = new DefaultListableBeanFactory();
 		RootBeanDefinition bd = new RootBeanDefinition(TestBean.class);


### PR DESCRIPTION
This adds support for `javax.annotation.Priority` to filter multiple candidates for autowiring. When multiple candidates are available for a given bean, the bean annotated with `@Primary` is used. If none exists, the one with the higher  value for the `@Priority` annotation is used. If two beans have the same priority a `NoUniqueBeanDefinitionException` is thrown, just as if two beans are annotated with `@Primary`.

The underlying code for `getBean` and `resolveDependency` has been merged as this feature is available for both dependency injection and bean lookup by type.

This PR also improves the test coverage of `determinePrimaryCandidate`

There is still a problem to be discussed concerning some fallback code that was initially present in `determinePrimaryCandidate` and that has been moved to `determineAutowireCandidate` as it is not obvious which use case it covers.
