### PR TITLE
SPR-11129: Handling of HttpHeaders as controller return type

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/annotation/AnnotationMethodHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/annotation/AnnotationMethodHandlerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,6 +133,7 @@ import org.springframework.web.util.WebUtils;
  *
  * @author Juergen Hoeller
  * @author Arjen Poutsma
+ * @author Stephane Nicoll
  * @since 2.5
  * @see #setPathMatcher
  * @see #setMethodNameResolver
@@ -943,7 +944,10 @@ public class AnnotationMethodHandlerAdapter extends WebContentGenerator
 				}
 			}
 
-			if (returnValue instanceof HttpEntity) {
+			if (returnValue instanceof HttpHeaders) {
+				handleHttpHeaders ((HttpHeaders) returnValue, webRequest);
+				return null;
+			} else if (returnValue instanceof HttpEntity) {
 				handleHttpEntityResponse((HttpEntity<?>) returnValue, webRequest);
 				return null;
 			}
@@ -990,6 +994,14 @@ public class AnnotationMethodHandlerAdapter extends WebContentGenerator
 			else {
 				throw new IllegalArgumentException("Invalid handler method return value: " + returnValue);
 			}
+		}
+
+		private void handleHttpHeaders(HttpHeaders headers, ServletWebRequest webRequest) throws Exception {
+			HttpOutputMessage outputMessage = createHttpOutputMessage(webRequest);
+			if (!headers.isEmpty()) {
+				outputMessage.getHeaders().putAll(headers);
+			}
+			outputMessage.getBody(); // flush headers
 		}
 
 		private void handleResponseBody(Object returnValue, ServletWebRequest webRequest)

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/HttpHeadersReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/HttpHeadersReturnValueHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.mvc.method.annotation;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.util.Assert;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * Handles {@link HttpHeaders} return values.
+ *
+ * @author Stephane Nicoll
+ * @since 4.0.1
+ */
+public class HttpHeadersReturnValueHandler implements HandlerMethodReturnValueHandler {
+
+	@Override
+	public boolean supportsReturnType(MethodParameter returnType) {
+		return HttpHeaders.class.isAssignableFrom(returnType.getParameterType());
+	}
+
+	@Override
+	public void handleReturnValue(Object returnValue, MethodParameter returnType,
+								  ModelAndViewContainer mavContainer, NativeWebRequest webRequest) throws Exception {
+		mavContainer.setRequestHandled(true);
+
+		Assert.isInstanceOf(HttpHeaders.class, returnValue);
+		HttpHeaders headers = (HttpHeaders) returnValue;
+
+		HttpServletResponse response = webRequest.getNativeResponse(HttpServletResponse.class);
+		ServletServerHttpResponse outputMessage = new ServletServerHttpResponse(response);
+		if (!headers.isEmpty()) {
+			outputMessage.getHeaders().putAll(headers);
+		}
+		outputMessage.getBody(); // flush headers
+	}
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -585,6 +585,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter i
 		handlers.add(new ModelMethodProcessor());
 		handlers.add(new ViewMethodReturnValueHandler());
 		handlers.add(new HttpEntityMethodProcessor(getMessageConverters(), this.contentNegotiationManager));
+		handlers.add(new HttpHeadersReturnValueHandler());
 		handlers.add(new CallableMethodReturnValueHandler());
 		handlers.add(new DeferredResultMethodReturnValueHandler());
 		handlers.add(new AsyncTaskMethodReturnValueHandler(this.beanFactory));


### PR DESCRIPTION
This commit permits to produce a response with only custom headers by
returning a `HttpHeaders` instance. Previously, one has to wrap that
`HttpHeaders` instance in a `ResponseEntity<Void>`

Simply returning the `HttpHeaders` instance directly as the same effect now.
