### PR TITLE
Improve description of switching off commons-logging

### DIFF
--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -567,9 +567,16 @@ as a new project it would use a different logging dependency. The first choice w
 probably be the Simple Logging Facade for Java ( http://www.slf4j.org[SLF4J]), which is
 also used by a lot of other tools that people use with Spring inside their applications.
 
-Switching off `commons-logging` is easy: just make sure it isn't on the classpath at
-runtime. In Maven terms you exclude the dependency, and because of the way that the
-Spring dependencies are declared, you only have to do that once.
+There are basically two ways to switch off `commons-logging`:
+
+. Exclude the dependency from the spring modules you are explicitly relying upon
+. Depend on a special `commons-logging` dependency that replaces the library with
+  an empty jar (more details can be found in the
+  http://slf4j.org/faq.html#excludingJCL[SLF4J FAQ])
+
+To exclude commons-logging, add the following to your `dependencies` or better
+`dependencyManagement` section for *all* the spring modules you are relying upon
+explicitly (here `spring-core` and `spring-context`):
 
 [source,xml,indent=0]
 [subs="verbatim,quotes,attributes"]
@@ -579,7 +586,16 @@ Spring dependencies are declared, you only have to do that once.
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 			<version>{spring-version}</version>
-			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>{spring-version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>

--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -569,14 +569,13 @@ also used by a lot of other tools that people use with Spring inside their appli
 
 There are basically two ways to switch off `commons-logging`:
 
-. Exclude the dependency from the spring modules you are explicitly relying upon
+. Exclude the dependency from the `spring-core` module as it is the only module that has
+  an explicit dependency on it
 . Depend on a special `commons-logging` dependency that replaces the library with
   an empty jar (more details can be found in the
   http://slf4j.org/faq.html#excludingJCL[SLF4J FAQ])
 
-To exclude commons-logging, add the following to your `dependencies` or better
-`dependencyManagement` section for *all* the spring modules you are relying upon
-explicitly (here `spring-core` and `spring-context`):
+To exclude commons-logging, add the following to your `dependencyManagement` section:
 
 [source,xml,indent=0]
 [subs="verbatim,quotes,attributes"]
@@ -585,16 +584,6 @@ explicitly (here `spring-core` and `spring-context`):
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
-			<version>{spring-version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
 			<version>{spring-version}</version>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
Prior this commit, it was not clear that all Spring modules on which
the project relies upon explicitly must exclude the commons-logging
dependency. Besides, another alternative exists which is nicely
explained in the SLF4J FAQ. This commit adds a reference to that.
