### PR TITLE
Fixed code example in JavaDoc

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/ResultActions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/ResultActions.java
@@ -37,7 +37,7 @@ public interface ResultActions {
 	 * mockMvc.perform(get("/person/1"))
 	 *   .andExpect(status.isOk())
 	 *   .andExpect(content().mimeType(MediaType.APPLICATION_JSON))
-	 *   .andExpect(jsonPath("$.person.name").equalTo("Jason"));
+	 *   .andExpect(jsonPath("$.person.name").value("Jason"));
 	 *
 	 * mockMvc.perform(post("/form"))
 	 *   .andExpect(status.isOk())


### PR DESCRIPTION
equalTo is not a valid method on JsonPathResultMatchers

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
