### PR TITLE
Fix method signature mismatch in Quartz

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SchedulerAccessor.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SchedulerAccessor.java
@@ -481,10 +481,21 @@ public abstract class SchedulerAccessor implements ResourceLoaderAware {
 				}
 			}
 			if (this.globalJobListeners != null) {
-				Method addJobListener = target.getClass().getMethod(
-						(quartz2 ? "addJobListener" : "addGlobalJobListener"), JobListener.class);
+				final Method addJobListener;
+				if (quartz2) {
+					addJobListener = target.getClass().getMethod(
+							"addJobListener", JobListener.class, List.class);
+				} else {
+					addJobListener = target.getClass().getMethod(
+							"addGlobalJobListener", JobListener.class);
+				}
 				for (JobListener listener : this.globalJobListeners) {
-					ReflectionUtils.invokeMethod(addJobListener, target, listener);
+					if (quartz2) {
+						final List<?> matchers = new ArrayList<Object>();
+						ReflectionUtils.invokeMethod(addJobListener, target, listener, matchers);
+					} else {
+						ReflectionUtils.invokeMethod(addJobListener, target, listener);
+					}
 				}
 			}
 			if (this.jobListeners != null) {
@@ -497,10 +508,21 @@ public abstract class SchedulerAccessor implements ResourceLoaderAware {
 				}
 			}
 			if (this.globalTriggerListeners != null) {
-				Method addTriggerListener = target.getClass().getMethod(
-						(quartz2 ? "addTriggerListener" : "addGlobalTriggerListener"), TriggerListener.class);
+				final Method addTriggerListener;
+				if (quartz2) {
+					addTriggerListener = target.getClass().getMethod(
+							"addTriggerListener", TriggerListener.class, List.class);
+				} else {
+					addTriggerListener = target.getClass().getMethod(
+							"addGlobalTriggerListener", TriggerListener.class);
+				}
 				for (TriggerListener listener : this.globalTriggerListeners) {
-					ReflectionUtils.invokeMethod(addTriggerListener, target, listener);
+					if (quartz2) {
+						final List<?> matchers = new ArrayList<Object>();
+						ReflectionUtils.invokeMethod(addTriggerListener, target, listener, matchers);
+					} else {
+						ReflectionUtils.invokeMethod(addTriggerListener, target, listener);
+					}
 				}
 			}
 			if (this.triggerListeners != null) {


### PR DESCRIPTION
Quartz 2.2 provides methods to register `JobListener` and `TriggerListener` that the previous 2.0.x generations do not define. However, a method taking an extra list of `KeyMatcher` instances exists since 2.0.0

This commit uses this method instead of the one that was introduced as from 2.2.0 to ensure compatibility with previous 2.0.x releases.

It is hard to test such a change in the current infrastructure so a separate project was used to validate that the scheduler is properly created when those listeners are present. This has been tested against `1.8.6`, `2.0.0`, `2.1.0` and `2.2.0`.

Issue: SPR-11362
