### PR TITLE
SPR-11103: Thread count doesn't need locking, instead should use an AtomicInteger

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/CustomizableThreadCreator.java
+++ b/spring-core/src/main/java/org/springframework/util/CustomizableThreadCreator.java
@@ -17,6 +17,7 @@
 package org.springframework.util;
 
 import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Simple customizable helper class for creating threads. Provides various
@@ -40,9 +41,7 @@ public class CustomizableThreadCreator implements Serializable {
 
 	private ThreadGroup threadGroup;
 
-	private int threadCount = 0;
-
-	private final Object threadCountMonitor = new SerializableMonitor();
+	private final AtomicInteger threadCount = new AtomicInteger();
 
 
 	/**
@@ -161,12 +160,7 @@ public class CustomizableThreadCreator implements Serializable {
 	 * @see #getThreadNamePrefix()
 	 */
 	protected String nextThreadName() {
-		int threadNumber = 0;
-		synchronized (this.threadCountMonitor) {
-			this.threadCount++;
-			threadNumber = this.threadCount;
-		}
-		return getThreadNamePrefix() + threadNumber;
+		return getThreadNamePrefix() + threadCount.incrementAndGet();
 	}
 
 	/**
@@ -175,13 +169,6 @@ public class CustomizableThreadCreator implements Serializable {
 	 */
 	protected String getDefaultThreadNamePrefix() {
 		return ClassUtils.getShortName(getClass()) + "-";
-	}
-
-
-	/**
-	 * Empty class used for a serializable monitor object.
-	 */
-	private static class SerializableMonitor implements Serializable {
 	}
 
 }


### PR DESCRIPTION
Thread count doesn't need locking, instead should use an AtomicInteger.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
