### PR TITLE
Add tip clarifying that @Transactional is not applicable to @BeforeClass methods

### DIFF
--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -19968,6 +19968,16 @@ __within__ a transaction. In addition, methods annotated with `@BeforeTransactio
 to run within a transaction.
 ====
 
+[TIP]
+====
+
+When using TestNG `@BeforeClass`,`@BeforeSuite` methods can not be used with the 
+`@Transactional` annotation, as they are considered non transactional methods by the 
+the spring text contetxt framework. However, you can inject a `PlatfromTransactionManager`
+or a `TransactionTemplate` and use it within `@BeforeClass` method to perform a 
+transaction.
+===
+
 The following JUnit-based example displays a fictitious integration testing scenario
 highlighting several transaction-related annotations. Consult the
 <<integration-testing-annotations,annotation support>> section for further information


### PR DESCRIPTION
This tip is needed because when using `@BeforeClass` with TestNG tests  unlike JUnit by the time `@BeforeClass` is called the whole application context is setup and and dependency injection is working therefore as a user it easy to assume that @Transactional should be working but it dose not work and then you waste lots of time trying to figure out why, until you make a call to `TransactionSynchronizationManager.isActualTransactionActive()` and discover that `@Transactional` is not supposed to be used with `@BeforeClass` when working with TestNG

For example 

``` java

@ContextConfiguration(locations = { "classpath:test.xml" })  
@Transactional
@TransactionConfiguration(defaultRollback = true)
@ActiveProfiles({ "development", "standalone", "test-db" })
public class TransactionalTest extends AbstractTransactionalTestNGSpringContextTests
{
    @BeforeClass
    @Transactional
     public void setupDB()
     {
          // the following assert fails before there is no TX
          assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isTrue(); 
          // do some stuff that needs a tx
     }
}
```
