### PR TITLE
Fixed example in JavaDoc.

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/ResultActions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/ResultActions.java
@@ -36,7 +36,7 @@ public interface ResultActions {
 	 *
 	 * mockMvc.perform(get("/person/1"))
 	 *   .andExpect(status.isOk())
-	 *   .andExpect(content().mimeType(MediaType.APPLICATION_JSON))
+	 *   .andExpect(content().contentType(MediaType.APPLICATION_JSON))
 	 *   .andExpect(jsonPath("$.person.name").value("Jason"));
 	 *
 	 * mockMvc.perform(post("/form"))


### PR DESCRIPTION
mimeType is not a valid method on ContentResultMatche.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
