### PR TITLE
 Should not close response output stream

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xml/MarshallingView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xml/MarshallingView.java
@@ -107,9 +107,9 @@ public class MarshallingView extends AbstractView {
 		marshaller.marshal(toBeMarshalled, new StreamResult(bos));
 
 		setResponseContentType(request, response);
-		response.setContentLength(bos.size());
-
-		FileCopyUtils.copy(bos.toByteArray(), response.getOutputStream());
+		ServletOutputStream os = response.getOutputStream();
+		os.write(bos.toByteArray());
+		os.flush();
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xml/MarshallingView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xml/MarshallingView.java
@@ -28,6 +28,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.oxm.Marshaller;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.view.AbstractView;
 
@@ -108,8 +109,7 @@ public class MarshallingView extends AbstractView {
 
 		setResponseContentType(request, response);
 		ServletOutputStream os = response.getOutputStream();
-		os.write(bos.toByteArray());
-		os.flush();
+		StreamUtils.copy(bos.toByteArray(),os);
 	}
 
 	/**


### PR DESCRIPTION
The method renderMergedOutputModel should not close the HttpServletResponse output stream. 
The called utility method 
FileCopyUtils.copy(bos.toByteArray(), response.getOutputStream());
closes the stream avoiding other output filters adding more informations. 
For example, if the view is invoked by a url under security, the session id cookie isn't sent back to the clinent.
