### PR TITLE
SPR-11415 Call free() on Blob and Clob

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/lob/DefaultLobHandler.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/lob/DefaultLobHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,7 +144,11 @@ public class DefaultLobHandler extends AbstractLobHandler {
 		logger.debug("Returning BLOB as bytes");
 		if (this.wrapAsLob) {
 			Blob blob = rs.getBlob(columnIndex);
-			return blob.getBytes(1, (int) blob.length());
+			try {
+				return blob.getBytes(1, (int) blob.length());
+			} finally {
+				blob.free();
+			}
 		}
 		else {
 			return rs.getBytes(columnIndex);
@@ -168,7 +172,11 @@ public class DefaultLobHandler extends AbstractLobHandler {
 		logger.debug("Returning CLOB as string");
 		if (this.wrapAsLob) {
 			Clob clob = rs.getClob(columnIndex);
-			return clob.getSubString(1, (int) clob.length());
+			try {
+				return clob.getSubString(1, (int) clob.length());
+			} finally {
+				clob.free();
+			}
 		}
 		else {
 			return rs.getString(columnIndex);


### PR DESCRIPTION
Since Java 1.6/JDBC 4 `ava.sql.Blob` and `java.sql.Clob` have
a `#free()` method to release the resources that they hold. They should
be called as early as possible because otherwise the objects remain
valid for at least the duration of the transaction in which they are
created. `DefaultLobHandler` currently creates `Blob`s and `Clob`s and
throws them away without calling `#free()`.
- change `#getBlobAsBytes()` and `#getClobAsString()` in
  `DefaultLobHandler` to call `#free()`

There are more methods in `DefaultLobHandler` where `Blob`s and `Clob`s
are used without calling free. However they return a stream so we
probably shouldn’t call `#free()` before being done reading. This is a
bit of an issues because the `Blob` and `Clob` are out of scope for
calling code. `OracleLobHandler` also uses `Blobs` and `Clob`s are used
without calling `#free()` but since the class is deprecated I did not
update it.

I did sign the Contributor License Agreement.

Issue: SPR-11415
https://jira.springsource.org/browse/SPR-11415
