### PR TITLE
Fix PathVariable encoding if request charset is not set

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
@@ -69,6 +69,46 @@ public class UrlPathHelperTests {
 	}
 
 	@Test
+	public void getPathWithinApplicationDefaultEncoding() throws UnsupportedEncodingException {
+		helper.setAlwaysUseFullPath(true);
+
+		// We should have UTF-8 decoding ideally by default here...
+		testGetPathWithinApplicationEncoding("ISO-8859-1");
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void getPathWithinApplicationIgnoreOtherEncodingIfUriEncodingSet()
+			throws UnsupportedEncodingException {
+		helper.setAlwaysUseFullPath(true);
+		helper.setUriEncoding("UTF-8");
+
+		helper.setDefaultEncoding("ISO-8859-15");
+		request.setCharacterEncoding("ISO-8859-1");
+
+		// Other encoding should not override URL encoding
+		testGetPathWithinApplicationEncoding("UTF-8");
+	}
+
+	@Test
+	public void getPathWithinApplicationCustomEncoding() throws UnsupportedEncodingException {
+		helper.setAlwaysUseFullPath(true);
+		helper.setUriEncoding("UTF-8");
+
+		// We should use a custom encoding, if set
+		testGetPathWithinApplicationEncoding("UTF-8");
+	}
+
+	private void testGetPathWithinApplicationEncoding(String expectedEncoding) throws UnsupportedEncodingException {
+		String escapedUtf8Chars = "%2A%2A%2A%C3%A5";
+		request.setContextPath("/petclinic");
+		request.setRequestURI("/petclinic/pet/" + escapedUtf8Chars);
+
+		String expected = "/pet/" + UriUtils.decode(escapedUtf8Chars, expectedEncoding);
+		assertEquals("Incorrect path returned", expected, helper.getPathWithinApplication(request));
+	}
+
+	@Test
 	public void getPathWithinServlet() {
 		request.setContextPath("/petclinic");
 		request.setServletPath("/main");

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
@@ -51,6 +51,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @see #setDefaultHandler
  * @see #setAlwaysUseFullPath
  * @see #setUrlDecode
+ * @see #setUriEncoding(String)
  * @see org.springframework.util.AntPathMatcher
  * @see #setInterceptors
  * @see org.springframework.web.servlet.HandlerInterceptor
@@ -124,6 +125,17 @@ public abstract class AbstractHandlerMapping extends WebApplicationObjectSupport
 	 */
 	public void setUrlDecode(boolean urlDecode) {
 		this.urlPathHelper.setUrlDecode(urlDecode);
+	}
+
+	/**
+	 * Set the character encoding to use for URL decoding.
+	 * <p>This value <em>must</em> match the encoding used by the servlet
+	 * container so that both servlet decoded and encoded information match
+	 * @param uriEncoding the character encoding to use for URL decoding
+	 * @see UrlPathHelper#setUriEncoding(String)
+	 * */
+	public void setUriEncoding(String uriEncoding) {
+		this.urlPathHelper.setUriEncoding(uriEncoding);
 	}
 
 	/**


### PR DESCRIPTION
This commit simply adds a `@PathVariable` decoding test to reproduce a
scenario exposed in `SPR-11474`

Issue: SPR-11474
