### PR TITLE
DefaultContentTypeResolver String-based contentType

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/converter/DefaultContentTypeResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/converter/DefaultContentTypeResolver.java
@@ -49,11 +49,22 @@ public class DefaultContentTypeResolver implements ContentTypeResolver {
 
 	@Override
 	public MimeType resolve(MessageHeaders headers) {
-		MimeType mimeType = null;
+		Object mimeType = null;
 		if (headers != null) {
-			mimeType = headers.get(MessageHeaders.CONTENT_TYPE, MimeType.class);
+			mimeType = headers.get(MessageHeaders.CONTENT_TYPE);
+			if(mimeType == null) {
+				return this.defaultMimeType;
+			}
+			if(String.class.isAssignableFrom(mimeType.getClass())) {
+				mimeType = MimeType.valueOf((String)mimeType);
+			}
+			if (!MimeType.class.isAssignableFrom(mimeType.getClass())) {
+				throw new IllegalArgumentException("Incorrect type for mime type header. Expected " +
+						"[class org.springframework.util.MimeType] or [class java.lang.String] " +
+						"but actual type is [" + mimeType.getClass() + "]");
+			}
 		}
-		return (mimeType != null) ? mimeType : this.defaultMimeType;
+		return (MimeType)mimeType;
 	}
 
 	@Override

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/DefaultContentTypeResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/DefaultContentTypeResolverTests.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.DefaultContentTypeResolver;
+import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.util.MimeTypeUtils;
 
 import static org.junit.Assert.*;
@@ -50,6 +51,31 @@ public class DefaultContentTypeResolverTests {
 		MessageHeaders headers = new MessageHeaders(map);
 
 		assertEquals(MimeTypeUtils.APPLICATION_JSON, this.resolver.resolve(headers));
+	}
+
+	@Test
+	public void resolveStringBasedContentType() {
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON_VALUE);
+		MessageHeaders headers = new MessageHeaders(map);
+
+		assertEquals(MimeTypeUtils.APPLICATION_JSON, this.resolver.resolve(headers));
+	}
+
+	@Test(expected = InvalidMimeTypeException.class)
+	public void invalidStringBasedContentType() {
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(MessageHeaders.CONTENT_TYPE, "invalidContentType");
+		MessageHeaders headers = new MessageHeaders(map);
+		this.resolver.resolve(headers);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void invalidContentType() {
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(MessageHeaders.CONTENT_TYPE, new Integer(1));
+		MessageHeaders headers = new MessageHeaders(map);
+		this.resolver.resolve(headers);
 	}
 
 	@Test


### PR DESCRIPTION
DefaultContentTypeResolver now also supports String-based
"contentType" header values.

SPR-11461
