### PR TITLE
Add AbstractMessageConverter#contentTypeResolutionRequired

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/converter/AbstractMessageConverter.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/converter/AbstractMessageConverter.java
@@ -49,6 +49,7 @@ public abstract class AbstractMessageConverter implements MessageConverter {
 
 	private ContentTypeResolver contentTypeResolver;
 
+	private boolean contentTypeResolutionRequired = false;
 
 	/**
 	 * Construct an {@code AbstractMessageConverter} with one supported MIME type.
@@ -108,6 +109,21 @@ public abstract class AbstractMessageConverter implements MessageConverter {
 	 */
 	public Class<?> getSerializedPayloadClass() {
 		return this.serializedPayloadClass;
+	}
+
+	/**
+	 * When set to true, #supportsMimeType(MessageHeaders) will return false if the
+	 * contentTypeResolver is not defined or if no content-type header is present.
+	 */
+	public void setContentTypeResolutionRequired(boolean contentTypeResolutionRequired) {
+		this.contentTypeResolutionRequired = contentTypeResolutionRequired;
+	}
+
+	/**
+	 * Return the content type resolution required status.
+	 */
+	public boolean isContentTypeResolutionRequired() {
+		return contentTypeResolutionRequired;
 	}
 
 	/**
@@ -179,7 +195,7 @@ public abstract class AbstractMessageConverter implements MessageConverter {
 	protected boolean supportsMimeType(MessageHeaders headers) {
 		MimeType mimeType = getMimeType(headers);
 		if (mimeType == null) {
-			return true;
+			return !contentTypeResolutionRequired;
 		}
 		if (getSupportedMimeTypes().isEmpty()) {
 			return true;

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/AbstractMessageConverterTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/AbstractMessageConverterTests.java
@@ -30,6 +30,7 @@ import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test fixture for {@link org.springframework.messaging.converter.AbstractMessageConverter}.
@@ -103,6 +104,23 @@ public class AbstractMessageConverterTests {
 	public void toMessageContentTypeHeader() {
 		Message<?> message = this.converter.toMessage("ABC", null);
 		assertEquals(MimeTypeUtils.TEXT_PLAIN, message.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+	}
+
+	@Test
+	public void noContentTypeResolverWhenTypeResolutionRequired() {
+		Message<String> message = MessageBuilder.withPayload("ABC").build();
+		this.converter = new TestMessageConverter();
+		this.converter.setContentTypeResolutionRequired(true);
+		assertNull(this.converter.fromMessage(message, String.class));
+	}
+
+	@Test
+	public void noMimeTypeDefinedWhenTypeResolutionRequired() {
+		Message<String> message = MessageBuilder.withPayload("ABC").build();
+		this.converter = new TestMessageConverter(Collections.<MimeType>emptyList());
+		this.converter.setContentTypeResolver(new DefaultContentTypeResolver());
+		this.converter.setContentTypeResolutionRequired(true);
+		assertNull(this.converter.fromMessage(message, String.class));
 	}
 
 


### PR DESCRIPTION
In order to facilitate more restrictive matching strategies,
AbstractMessageConverter has now a contentTypeResolutionRequired
boolean property.

When set to true, supportsMimeType(MessageHeaders) will return
false if the contentTypeResolver is not defined or if no
content-type header is present.

Issue: SPR-11463
