### PR TITLE
Add marshalling hooks in Jaxb2RootElementHttpMessageConverter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/xml/Jaxb2RootElementHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/xml/Jaxb2RootElementHttpMessageConverter.java
@@ -28,7 +28,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
-import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamSource;
 
@@ -39,7 +38,6 @@ import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.xml.StaxUtils;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -53,6 +51,7 @@ import org.xml.sax.helpers.XMLReaderFactory;
  * annotated with with {@link XmlRootElement}, or subclasses thereof.
  *
  * @author Arjen Poutsma
+ * @author Sebastien Deleuze
  * @since 3.0
  */
 public class Jaxb2RootElementHttpMessageConverter extends AbstractJaxb2HttpMessageConverter<Object> {
@@ -90,6 +89,7 @@ public class Jaxb2RootElementHttpMessageConverter extends AbstractJaxb2HttpMessa
 		try {
 			source = processSource(source);
 			Unmarshaller unmarshaller = createUnmarshaller(clazz);
+			this.customizeUnmarshaller(unmarshaller);
 			if (clazz.isAnnotationPresent(XmlRootElement.class)) {
 				return unmarshaller.unmarshal(source);
 			}
@@ -132,6 +132,7 @@ public class Jaxb2RootElementHttpMessageConverter extends AbstractJaxb2HttpMessa
 		try {
 			Class<?> clazz = ClassUtils.getUserClass(o);
 			Marshaller marshaller = createMarshaller(clazz);
+			this.customizeMarshaller(marshaller);
 			setCharset(headers.getContentType(), marshaller);
 			marshaller.marshal(o, result);
 		}
@@ -147,6 +148,28 @@ public class Jaxb2RootElementHttpMessageConverter extends AbstractJaxb2HttpMessa
 		if (contentType != null && contentType.getCharSet() != null) {
 			marshaller.setProperty(Marshaller.JAXB_ENCODING, contentType.getCharSet().name());
 		}
+	}
+
+	/**
+	 * Customize the {@link Marshaller} created by this
+	 * message converter before using it to write the object to the output.
+	 * @param marshaller the marshaller to customize
+	 * @see #createMarshaller(Class)
+	 * @since 4.0.3
+	 */
+	protected void customizeMarshaller(Marshaller marshaller) {
+
+	}
+
+	/**
+	 * Customize the {@link Unmarshaller} created by this
+	 * message converter before using it to read the object from the input.
+	 * @param unmarshaller the unmarshaller to customize
+	 * @see #createUnmarshaller(Class)
+	 * @since 4.0.3
+	 */
+	protected void customizeUnmarshaller(Unmarshaller unmarshaller) {
+
 	}
 
 }


### PR DESCRIPTION
Allow Jaxb2RootElementHttpMessageConverter subclasses to customize
the {@link Marshaller} and the {@link Unmarshaller} created by the
message converter.

Issue: SPR-11488
