### PR TITLE
unwrap transaction bound connection proxy pointing to same TransactionAwareDataSourceProxy

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/TransactionAwareDataSourceProxy.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/TransactionAwareDataSourceProxy.java
@@ -229,6 +229,16 @@ public class TransactionAwareDataSourceProxy extends DelegatingDataSource {
 				actualTarget = DataSourceUtils.doGetConnection(this.targetDataSource);
 			}
 
+			if (actualTarget != null && Proxy.isProxyClass(actualTarget.getClass())) {
+				InvocationHandler handler = Proxy.getInvocationHandler(actualTarget);
+				if (handler instanceof TransactionAwareInvocationHandler) {
+					TransactionAwareInvocationHandler taHandler = ((TransactionAwareInvocationHandler) handler);
+					if (taHandler.targetDataSource == this.targetDataSource && taHandler.target != null) {
+						actualTarget = taHandler.target;
+					}
+				}
+			}
+
 			if (method.getName().equals("getTargetConnection")) {
 				// Handle getTargetConnection method: return underlying Connection.
 				return actualTarget;


### PR DESCRIPTION
Possibly related to https://jira.springsource.org/browse/SPR-6949

I've noticed in debugging of Grails apps (which uses TransactionAwareDataSourceProxy + LazyConnectionDataSourceProxy) that the connection gets wrapped twice in a proxy that uses TransactionAwareInvocationHandler as it's handler.

The reason for this is the logic in TransactionAwareInvocationHandler that checks for the transaction bound connection. 

This is the code in https://github.com/lhotari/spring-framework/blob/6a043e3/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/TransactionAwareDataSourceProxy.java#L219

```
            if (this.target == null) {
                if (this.closed) {
                    throw new SQLException("Connection handle already closed");
                }
                if (shouldObtainFixedConnection(this.targetDataSource)) {
                    this.target = DataSourceUtils.doGetConnection(this.targetDataSource);
                }
            }
            Connection actualTarget = this.target;
            if (actualTarget == null) {
                actualTarget = DataSourceUtils.doGetConnection(this.targetDataSource);
            }

            if (method.getName().equals("getTargetConnection")) {
                // Handle getTargetConnection method: return underlying Connection.
                return actualTarget;
            }
```

It looks like this doesn't take into account that target might already be a proxy for the same TransactionAwareDataSourceProxy instance and it should unwrap it to prevent an extra level of calls.
This doesn't cause real problems in applications, but there will always be an extra proxy call for each call to a connection method.

This PR contains logic to unwrap the extra proxy.
