### PR TITLE
Outdated code example correction in section 10.3.6

### DIFF
--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -20618,7 +20618,7 @@ requests and provide "stub" responses:
 	RestTemplate restTemplate = new RestTemplate();
 
 	MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
-	mockServer.expect(requestTo("/greeting")).andRespond(withSuccess("Hello world", "text/plain"));
+	mockServer.expect(requestTo("/greeting")).andRespond(withSuccess("Hello world", MediaType.TEXT_PLAIN));
 
 	// use RestTemplate ...
 


### PR DESCRIPTION
`withSuccess("Hello world", "text/plain")` replaced with `withSuccess("Hello world", MediaType.TEXT_PLAIN)`
