### PR TITLE
SPR-11505: Use deepEquals/deepHashCode for keys

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
@@ -50,12 +50,12 @@ public final class SimpleKey implements Serializable {
 
 	@Override
 	public boolean equals(Object obj) {
-		return (this == obj || (obj instanceof SimpleKey && Arrays.equals(this.params, ((SimpleKey) obj).params)));
+		return (this == obj || (obj instanceof SimpleKey && Arrays.deepEquals(this.params, ((SimpleKey) obj).params)));
 	}
 
 	@Override
 	public int hashCode() {
-		return Arrays.hashCode(this.params);
+		return Arrays.deepHashCode(this.params);
 	}
 
 	@Override


### PR DESCRIPTION
Using deepEquals and deepHashCode allows for cache keys that work with methods that have arguments that are array types.
