### PR TITLE
SPR-11505: Use deepHashCode for keys

### DIFF
--- a/org.springframework.context/src/main/java/org/springframework/cache/interceptor/DefaultKeyGenerator.java
+++ b/org.springframework.context/src/main/java/org/springframework/cache/interceptor/DefaultKeyGenerator.java
@@ -44,9 +44,7 @@ public class DefaultKeyGenerator implements KeyGenerator {
 			return NO_PARAM_KEY;
 		}
 		int hashCode = 17;
-		for (Object object : params) {
-			hashCode = 31 * hashCode + (object == null ? NULL_PARAM_KEY : object.hashCode());
-		}
+		hashCode *= Arrays.deepHashCode(params);
 		return Integer.valueOf(hashCode);
 	}
 


### PR DESCRIPTION
Using deepHashCode allows for cache keys that work with methods that have arguments that are array types.
