### PR TITLE
Fix custom config with older HttpClient

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequest.java
@@ -70,6 +70,9 @@ final class HttpComponentsClientHttpRequest extends AbstractBufferingClientHttpR
 		return this.httpRequest.getURI();
 	}
 
+	HttpContext getHttpContext() {
+		return httpContext;
+	}
 
 	@Override
 	protected ClientHttpResponse executeInternal(HttpHeaders headers, byte[] bufferedOutput) throws IOException {

--- a/spring-web/src/test/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,16 @@
 
 package org.springframework.http.client;
 
+import static org.junit.Assert.*;
+
+import java.net.URI;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.params.CoreConnectionPNames;
 import org.junit.Test;
 import org.springframework.http.HttpMethod;
 
@@ -32,4 +42,36 @@ public class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpReq
 		assertHttpMethod("patch", HttpMethod.PATCH);
 	}
 
+	@SuppressWarnings("deprecation")
+	@Test
+	public void assertLegacyCustomConfig() {
+		HttpClient httpClient = new DefaultHttpClient(); // Does not support RequestConfig
+		HttpComponentsClientHttpRequestFactory hrf = new HttpComponentsClientHttpRequestFactory(httpClient);
+		hrf.setConnectTimeout(1234);
+		assertEquals(1234, httpClient.getParams().getIntParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, 0));
+
+		hrf.setReadTimeout(4567);
+		assertEquals(4567, httpClient.getParams().getIntParameter(CoreConnectionPNames.SO_TIMEOUT, 0));
+	}
+
+	@Test
+	public void assertCustomConfig() throws Exception {
+		HttpClient httpClient = HttpClientBuilder.create().build();
+		HttpComponentsClientHttpRequestFactory hrf = new HttpComponentsClientHttpRequestFactory(httpClient);
+		hrf.setConnectTimeout(1234);
+		hrf.setReadTimeout(4567);
+
+		URI uri = new URI(baseUrl + "/status/ok");
+		HttpComponentsClientHttpRequest request = (HttpComponentsClientHttpRequest)
+				hrf.createRequest(uri, HttpMethod.GET);
+
+		Object config = request.getHttpContext().getAttribute(HttpClientContext.REQUEST_CONFIG);
+		assertNotNull("Request config should be set", config);
+		assertTrue("Wrong request config type" + config.getClass().getName(),
+				RequestConfig.class.isInstance(config));
+		RequestConfig requestConfig = (RequestConfig) config;
+		assertEquals("Wrong custom connection timeout", 1234, requestConfig.getConnectTimeout());
+		assertEquals("Wrong custom socket timeout", 4567, requestConfig.getSocketTimeout());
+
+	}
 }


### PR DESCRIPTION
Since HttpClient 4.3, custom configuration such as the connection timeout and the socket timeout are set in a `RequestConfig` object stored in the `HttpContext`.

Unfortunately, older HttpClients are not supporting this infrastructure and new clients throw an exception when the deprecated API is used.

This commit detects if the client is an "old" implementation and set the configuration through the deprecated means to restore full backward compatibility with these features.

_Note that because of the -WError flag, no import on deprecated classes are allowed which is the reason why I used FQNs_
