### PR TITLE
Add merge support to nested collection properties

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,13 +88,17 @@ public class NestedBeansElementAttributeRecursionTests {
 				new ClassPathResource("NestedBeansElementAttributeRecursionTests-merge-nested-path-context.xml", this.getClass()));
 		FooBean foo = bf.getBean("childFoo", FooBean.class);
 
-		// should contain entries added by child
-		assertThat("missing key 'kChild'", foo.getMapBean().getMap().containsKey("kChild"), is(true));
-        assertThat("missing value 'lChild'", foo.getMapBean().getList().contains("lChild"), is(true));
-        
-		// should also contain entries added by parent
+		// should contain entries added by parent
 		assertThat("missing key 'kParent'", foo.getMapBean().getMap().containsKey("kParent"), is(true));
-		assertThat("Missing value 'lParent'", foo.getMapBean().getList().contains("lParent"), is(true));
+		assertThat("missing value 'middleList'", foo.getMapBean().getList().contains("middleList"), is(true));
+		assertThat("too many values in list", foo.getMapBean().getList().size() == 1, is(true));
+		assertThat("missing value 'lParent'", foo.getMapBean().getListBean().getList().contains("lParent"), is(true));
+		
+		// should also contain entries added by child
+		assertThat("missing key 'kChild'", foo.getMapBean().getMap().containsKey("kChild"), is(true));
+        assertThat("missing value 'lChild'", foo.getMapBean().getListBean().getList().contains("lChild"), is(true));
+        assertThat("missing value 'replace'", foo.getMapBean().getListBean().getReplaceList().contains("replace"), is(true));
+        assertThat("too many values in replaceList", foo.getMapBean().getListBean().getReplaceList().size() == 1, is(true));
 	}
 
 	static class FooBean {
@@ -115,6 +119,7 @@ public class NestedBeansElementAttributeRecursionTests {
 
 		private Map map;
 		private List list;
+		private ListBean listBean;
 		
 		public void setMap(Map map) {
 			this.map = map;
@@ -123,7 +128,7 @@ public class NestedBeansElementAttributeRecursionTests {
 		public Map getMap() {
 			return map;
 		}
-		
+
 		public void setList(List list) {
 			this.list = list;
 		}
@@ -131,6 +136,38 @@ public class NestedBeansElementAttributeRecursionTests {
 		public List getList()
 		{
 			return list;
+		}
+
+		public void setListBean(ListBean listBean) {
+			this.listBean = listBean;
+		}
+		
+		public ListBean getListBean() {
+			return listBean;
+		}
+	}
+
+	@SuppressWarnings("rawtypes")
+	static class ListBean {
+		
+		private List list;
+		private List replaceList;
+
+		public void setList(List list) {
+			this.list = list;
+		}
+		
+		public List getList()
+		{
+			return list;
+		}
+		
+		public void setReplaceList(List list) {
+			this.replaceList = list;
+		}
+		
+		public List getReplaceList() {
+			return replaceList;
 		}
 	}
 

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests.java
@@ -21,6 +21,9 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertThat;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -75,6 +78,60 @@ public class NestedBeansElementAttributeRecursionTests {
 		// merges all values
 		assertThat((Iterable<String>)secondLevel.getSomeList(),
 				hasItems("charlie", "delta", "echo", "foxtrot", "golf", "hotel"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void defaultMergeNestedPath() {
+		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+		new XmlBeanDefinitionReader(bf).loadBeanDefinitions(
+				new ClassPathResource("NestedBeansElementAttributeRecursionTests-merge-nested-path-context.xml", this.getClass()));
+		FooBean foo = bf.getBean("childFoo", FooBean.class);
+
+		// should contain entries added by child
+		assertThat("missing key 'kChild'", foo.getMapBean().getMap().containsKey("kChild"), is(true));
+        assertThat("missing value 'lChild'", foo.getMapBean().getList().contains("lChild"), is(true));
+        
+		// should also contain entries added by parent
+		assertThat("missing key 'kParent'", foo.getMapBean().getMap().containsKey("kParent"), is(true));
+		assertThat("Missing value 'lParent'", foo.getMapBean().getList().contains("lParent"), is(true));
+	}
+
+	static class FooBean {
+
+		private MapBean mapBean;
+
+		public MapBean getMapBean() {
+			return mapBean;
+		}
+		
+		public void setMapBean(MapBean mapBean) {
+			this.mapBean = mapBean;
+		}
+	}
+
+	@SuppressWarnings("rawtypes")
+	static class MapBean {
+
+		private Map map;
+		private List list;
+		
+		public void setMap(Map map) {
+			this.map = map;
+		}
+
+		public Map getMap() {
+			return map;
+		}
+		
+		public void setList(List list) {
+			this.list = list;
+		}
+		
+		public List getList()
+		{
+			return list;
+		}
 	}
 
 	@Test

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-merge-nested-path-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-merge-nested-path-context.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+
+	<bean id="parentFoo" class="org.springframework.beans.factory.xml.NestedBeansElementAttributeRecursionTests$FooBean">
+		<property name="mapBean">
+			<bean class="org.springframework.beans.factory.xml.NestedBeansElementAttributeRecursionTests$MapBean">
+				<property name="map">
+					<map>
+						<entry key="kParent" value="vParent"/>
+					</map>
+				</property>
+				<property name="list">
+					<list>
+						<value>lParent</value>
+					</list>
+				</property>
+			</bean>
+		</property>
+	</bean>
+
+	<bean id="childFoo" parent="parentFoo">
+		<property name="mapBean.map">
+			<map merge="true">
+				<entry key="kChild" value="vChild"/>
+			</map>
+		</property>
+		<property name="mapBean.list">
+			<list merge="true">
+				<value>lChild</value>
+			</list>
+		</property>
+	</bean>
+</beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-merge-nested-path-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-merge-nested-path-context.xml
@@ -13,8 +13,22 @@
 				</property>
 				<property name="list">
 					<list>
-						<value>lParent</value>
+						<value>middleList</value>
 					</list>
+				</property>
+				<property name="listBean">
+					<bean class="org.springframework.beans.factory.xml.NestedBeansElementAttributeRecursionTests$ListBean">
+						<property name="list">
+							<list>
+								<value>lParent</value>
+							</list>
+						</property>
+						<property name="replaceList">
+							<list>
+								<value>original</value>
+							</list>
+						</property>
+					</bean>
 				</property>
 			</bean>
 		</property>
@@ -26,9 +40,14 @@
 				<entry key="kChild" value="vChild"/>
 			</map>
 		</property>
-		<property name="mapBean.list">
+		<property name="mapBean.listBean.list">
 			<list merge="true">
 				<value>lChild</value>
+			</list>
+		</property>
+		<property name="mapBean.listBean.replaceList">
+			<list>
+				<value>replace</value>
 			</list>
 		</property>
 	</bean>


### PR DESCRIPTION
Prior to this change, the merge attribute on nested collections was not
handled properly which would result in the typical replacement
behaviour. This is because during the merging of the parent and child
beans the parent bean would have nested BeanDefinition objects while the
child would have a property with the nested name
(beanA.beanB.propertyName). When it came time to look for matching the
property names it would be looking for the nested name which would not
exist in the parent.

The implementation of MutablePropertyValues.addProperty(PropertyValue)
will now try to find a chain of nested BeanDefinition objects that match
the nested property name and walk down the chain of beans and find the
property and then merge if applicable.

A JUnit test has been added to check for the new behaviour.

Issue: SPR-9552

I have signed and agree to the terms of the SpringSource Individual 
Contributor License Agreement.
