### PR TITLE
Decode target parameter names prior to saving a FlashMap

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractFlashMapManager.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractFlashMapManager.java
@@ -219,7 +219,7 @@ public abstract class AbstractFlashMapManager implements FlashMapManager {
 	private void decodeParameters(MultiValueMap<String, String> params, HttpServletRequest request) {
 		for (String name : new ArrayList<String>(params.keySet())) {
 			for (String value : new ArrayList<String>(params.remove(name))) {
-				params.add(name, this.urlPathHelper.decodeRequestString(request, value));
+				params.add(this.urlPathHelper.decodeRequestString(request, name), this.urlPathHelper.decodeRequestString(request, value));
 			}
 		}
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/support/FlashMapManagerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/support/FlashMapManagerTests.java
@@ -271,10 +271,13 @@ public class FlashMapManagerTests {
 		flashMap.addTargetRequestParam("key", "%D0%90%D0%90");
 		flashMap.addTargetRequestParam("key", "%D0%91%D0%91");
 		flashMap.addTargetRequestParam("key", "%D0%92%D0%92");
+		flashMap.addTargetRequestParam("%3A%2F%3F%23%5B%5D%40", "value");
 		this.flashMapManager.saveOutputFlashMap(flashMap, this.request, this.response);
 
 		assertEquals(Arrays.asList("\u0410\u0410", "\u0411\u0411", "\u0412\u0412"),
 				flashMap.getTargetRequestParams().get("key"));
+		assertEquals(Arrays.asList("value"),
+				flashMap.getTargetRequestParams().get(":/?#[]@"));
 	}
 
 


### PR DESCRIPTION
In addition to the target parameter values (SPR-9657), the target
parameter names must also be decoded to be able to match
them to the parameter names of incoming requests.

Issue: SPR-11504
