### PR TITLE
Add reply mode singleSession to @SendToUser

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/SendToUser.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/SendToUser.java
@@ -48,4 +48,11 @@ public @interface SendToUser {
 	 */
 	String[] value() default {};
 
+	/**
+     * A flag indicating whether the message is to be sent to a particular user session.
+     *
+     */
+    boolean singleSession() default false;
+
+
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandler.java
@@ -136,7 +136,10 @@ public class SendToMethodReturnValueHandler implements HandlerMethodReturnValueH
 			}
 			String[] destinations = getTargetDestinations(sendToUser, inputHeaders, this.defaultUserDestinationPrefix);
 			for (String destination : destinations) {
-				this.messagingTemplate.convertAndSendToUser(userName, destination, returnValue, postProcessor);
+				if (sendToUser.singleSession())
+					this.messagingTemplate.convertAndSendToUser(userName, destination, returnValue,postProcessor);
+				else 
+					this.messagingTemplate.convertAndSendToUser(userName, destination, returnValue);
 			}
 			return;
 		}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
@@ -156,7 +156,12 @@ public class DefaultUserDestinationResolver implements UserDestinationResolver {
 			subscribeDestination = this.destinationPrefix.substring(0, startIndex-1) + destinationWithoutPrefix;
 			user = destination.substring(startIndex, endIndex);
 			user = StringUtils.replace(user, "%2F", "/");
-			sessionIds = this.userSessionRegistry.getSessionIds(user);
+			if (headers.getSessionId() == null){
+				sessionIds = this.userSessionRegistry.getSessionIds(user);				
+			} else {
+				sessionIds = Collections.singleton(headers.getSessionId());
+			}
+
 		}
 		else {
 			if (logger.isTraceEnabled()) {

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandlerTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandlerTests.java
@@ -68,7 +68,9 @@ public class SendToMethodReturnValueHandlerTests {
 	private MethodParameter sendToReturnType;
 	private MethodParameter sendToDefaultDestReturnType;
 	private MethodParameter sendToUserReturnType;
+	private MethodParameter sendToUserSingleSessionReturnType;
 	private MethodParameter sendToUserDefaultDestReturnType;
+	private MethodParameter sendToUserSingleSessionDefaultDestReturnType;
 
 
 	@Before
@@ -97,9 +99,15 @@ public class SendToMethodReturnValueHandlerTests {
 
 		method = this.getClass().getDeclaredMethod("handleAndSendToUser");
 		this.sendToUserReturnType = new MethodParameter(method, -1);
+		
+		method = this.getClass().getDeclaredMethod("handleAndSendToUserSingleSession");
+		this.sendToUserSingleSessionReturnType = new MethodParameter(method, -1);
 
 		method = this.getClass().getDeclaredMethod("handleAndSendToUserDefaultDestination");
 		this.sendToUserDefaultDestReturnType = new MethodParameter(method, -1);
+		
+		method = this.getClass().getDeclaredMethod("handleAndSendToUserSingleSessionDefaultDestination");
+		this.sendToUserSingleSessionDefaultDestReturnType = new MethodParameter(method, -1);
 	}
 
 
@@ -184,6 +192,31 @@ public class SendToMethodReturnValueHandlerTests {
 
 		Message<?> message = this.messageCaptor.getAllValues().get(0);
 		SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(message);
+		assertNull(headers.getSessionId());
+		assertNull(headers.getSubscriptionId());
+		assertEquals("/user/" + user.getName() + "/dest1", headers.getDestination());
+
+		message = this.messageCaptor.getAllValues().get(1);
+		headers = SimpMessageHeaderAccessor.wrap(message);
+		assertNull(headers.getSessionId());
+		assertNull(headers.getSubscriptionId());
+		assertEquals("/user/" + user.getName() + "/dest2", headers.getDestination());
+	}
+	
+	@Test
+	public void sendToUserSingleSession() throws Exception {
+
+		when(this.messageChannel.send(any(Message.class))).thenReturn(true);
+
+		String sessionId = "sess1";
+		TestUser user = new TestUser();
+		Message<?> inputMessage = createInputMessage(sessionId, "sub1", null, user);
+		this.handler.handleReturnValue(payloadContent, this.sendToUserSingleSessionReturnType, inputMessage);
+
+		verify(this.messageChannel, times(2)).send(this.messageCaptor.capture());
+
+		Message<?> message = this.messageCaptor.getAllValues().get(0);
+		SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(message);
 		assertEquals(sessionId, headers.getSessionId());
 		assertNull(headers.getSubscriptionId());
 		assertEquals("/user/" + user.getName() + "/dest1", headers.getDestination());
@@ -223,6 +256,25 @@ public class SendToMethodReturnValueHandlerTests {
 		TestUser user = new TestUser();
 		Message<?> inputMessage = createInputMessage(sessionId, "sub1", "/dest", user);
 		this.handler.handleReturnValue(payloadContent, this.sendToUserDefaultDestReturnType, inputMessage);
+
+		verify(this.messageChannel, times(1)).send(this.messageCaptor.capture());
+
+		Message<?> message = this.messageCaptor.getAllValues().get(0);
+		SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(message);
+		assertNull(headers.getSessionId());
+		assertNull(headers.getSubscriptionId());
+		assertEquals("/user/" + user.getName() + "/queue/dest", headers.getDestination());
+	}
+	
+	@Test
+	public void sendToUserDefaultDestinationSingleSession() throws Exception {
+
+		when(this.messageChannel.send(any(Message.class))).thenReturn(true);
+
+		String sessionId = "sess1";
+		TestUser user = new TestUser();
+		Message<?> inputMessage = createInputMessage(sessionId, "sub1", "/dest", user);
+		this.handler.handleReturnValue(payloadContent, this.sendToUserSingleSessionDefaultDestReturnType, inputMessage);
 
 		verify(this.messageChannel, times(1)).send(this.messageCaptor.capture());
 
@@ -284,9 +336,19 @@ public class SendToMethodReturnValueHandlerTests {
 	public String handleAndSendToUserDefaultDestination() {
 		return payloadContent;
 	}
+	
+	@SendToUser(singleSession=true)
+	public String handleAndSendToUserSingleSessionDefaultDestination() {
+		return payloadContent;
+	}
 
 	@SendToUser({"/dest1", "/dest2"})
 	public String handleAndSendToUser() {
+		return payloadContent;
+	}
+	
+	@SendToUser(value={"/dest1", "/dest2"}, singleSession=true)
+	public String handleAndSendToUserSingleSession() {
 		return payloadContent;
 	}
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolverTests.java
@@ -109,7 +109,7 @@ public class DefaultUserDestinationResolverTests {
 		String userName = "http://joe.openid.example.org/";
 		this.registry.registerSessionId(userName, "openid123");
 		String destination = "/user/" + StringUtils.replace(userName, "/", "%2F") + "/queue/foo";
-		Message<?> message = createMessage(SimpMessageType.MESSAGE, this.user, SESSION_ID, destination);
+		Message<?> message = createMessage(SimpMessageType.MESSAGE, this.user, null, destination);
 		UserDestinationResult actual = this.resolver.resolveDestination(message);
 
 		assertEquals(1, actual.getTargetDestinations().size());


### PR DESCRIPTION
Added the ability to target a particular user session when a message
passes through the broker. Given a user has two tabs open and the client
sends a message to the server from tab 1, it is now possible to reply only to tab 1
instead of the default reply to all semantics.

Issue: SPR-11506
