### PR TITLE
Remove duplicate transitive dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,9 +82,13 @@ configure(allprojects) { project ->
 	}
 
 	dependencies {
-		testCompile("junit:junit:${junitVersion}")
+		testCompile("junit:junit:${junitVersion}") {
+			exclude group:'org.hamcrest', module:'hamcrest-core'
+		}
 		testCompile("org.hamcrest:hamcrest-all:1.3")
-		testCompile("org.mockito:mockito-core:1.9.5")
+		testCompile("org.mockito:mockito-core:1.9.5") {
+			exclude group:'org.hamcrest', module:'hamcrest-core'
+		}
 	}
 
 	ext.javadocLinks = [
@@ -454,14 +458,23 @@ project("spring-oxm") {
 	dependencies {
 		compile(project(":spring-beans"))
 		compile(project(":spring-core"))
-		optional("com.thoughtworks.xstream:xstream:${xstreamVersion}")
+		optional("com.thoughtworks.xstream:xstream:${xstreamVersion}") {
+			exclude group: 'xpp3', module: 'xpp3_min'
+			exclude group: 'xmlpull', module: 'xmlpull'
+		}
 		optional("org.jibx:jibx-run:1.2.5")
-		optional("org.apache.xmlbeans:xmlbeans:2.6.0")
-		optional("org.codehaus.castor:castor-xml:1.3.2")
+		optional("org.apache.xmlbeans:xmlbeans:2.6.0") {
+			exclude group: 'stax', module: 'stax-api'
+		}
+		optional("org.codehaus.castor:castor-xml:1.3.2")  {
+			exclude group: 'stax', module: 'stax-api'
+		}
 		testCompile(project(":spring-context"))
-		testCompile("org.codehaus.jettison:jettison:1.0.1")
+		testCompile("org.codehaus.jettison:jettison:1.0.1") {
+			exclude group: 'stax', module: 'stax-api'
+		}
 		testCompile("xmlunit:xmlunit:1.5")
-		testCompile("xmlpull:xmlpull:1.1.3.4a")
+		testCompile("xpp3:xpp3:1.1.3.4.O")
 		testCompile(files(genCastor.classesDir).builtBy(genCastor))
 		testCompile(files(genJaxb.classesDir).builtBy(genJaxb))
 		testCompile(files(genXmlbeans.classesDir).builtBy(genXmlbeans))
@@ -601,6 +614,7 @@ project("spring-websocket") {
 		optional("org.eclipse.jetty.websocket:websocket-client:${jettyVersion}")
 		optional("io.undertow:undertow-core:1.0.0.Final")
 		optional("io.undertow:undertow-servlet:1.0.0.Final") {
+			exclude group: "org.jboss.spec.javax.annotation", module: "jboss-annotations-api_1.2_spec"
 			exclude group: "org.jboss.spec.javax.servlet", module: "jboss-servlet-api_3.1_spec"
 		}
 		optional("io.undertow:undertow-websockets-jsr:1.0.0.Final") {
@@ -631,11 +645,25 @@ project("spring-orm") {
 		optional("aopalliance:aopalliance:1.0")
 		optional("org.eclipse.persistence:javax.persistence:2.0.0")
 		optional("org.eclipse.persistence:org.eclipse.persistence.core:2.4.0")
-		optional("org.eclipse.persistence:org.eclipse.persistence.jpa:2.4.0")
-		optional("org.hibernate:hibernate-core:${hibernate3Version}")
-		optional("org.hibernate:hibernate-entitymanager:${hibernate3Version}")
-		optional("org.apache.openjpa:openjpa:2.2.1")
-		optional("javax.jdo:jdo-api:3.0")
+		optional("org.eclipse.persistence:org.eclipse.persistence.jpa:2.4.0") {
+			exclude group: 'org.eclipse.persistence', module: 'javax.persistence'
+		}
+		optional("org.hibernate:hibernate-core:${hibernate3Version}") {
+			exclude group: 'org.hibernate.javax.persistence', module: 'hibernate-jpa-2.0-api'
+			exclude group: 'javax.transaction', module: 'jta'
+		}
+		optional("org.hibernate:hibernate-entitymanager:${hibernate3Version}") {
+			exclude group: 'org.hibernate.javax.persistence', module: 'hibernate-jpa-2.0-api'
+		}
+		optional("org.apache.openjpa:openjpa:2.2.1") {
+			exclude group: 'junit', module: 'junit'
+			exclude group: 'org.apache.geronimo.specs', module: 'geronimo-jpa_2.0_spec'
+			exclude group: 'org.apache.geronimo.specs', module: 'geronimo-jms_1.1_spec'
+			exclude group: 'org.apache.geronimo.specs', module: 'geronimo-jta_1.1_spec'
+		}
+		optional("javax.jdo:jdo-api:3.0") {
+			exclude group: 'javax.transaction', module: 'transaction-api'
+		}
 		optional("javax.servlet:javax.servlet-api:3.0.1")
 		testCompile("commons-dbcp:commons-dbcp:1.4")
 		testCompile("org.hsqldb:hsqldb:${hsqldbVersion}")
@@ -700,6 +728,7 @@ project("spring-webmvc") {
 		optional("org.apache.tiles:tiles-extras:${tiles2Version}") {
 			exclude group: "org.slf4j", module: "jcl-over-slf4j"
 			exclude group: "org.springframework", module: "spring-web"
+			exclude group: "org.apache.velocity", module: "velocity-tools"
 		}
 		testCompile(project(":spring-aop"))
 		testCompile("rhino:js:1.7R1")
@@ -812,7 +841,9 @@ project("spring-test") {
 		testCompile(project(":spring-webmvc-tiles3"))
 		testCompile("javax.mail:mail:1.4.7")
 		testCompile("javax.ejb:ejb-api:3.0")
-		testCompile("org.hibernate:hibernate-core:${hibernate3Version}")
+		testCompile("org.hibernate:hibernate-core:${hibernate3Version}") {
+			exclude group: 'org.hibernate.javax.persistence', module: 'hibernate-jpa-2.0-api'
+		}
 		testCompile("org.hibernate:hibernate-entitymanager:${hibernate3Version}")
 		testCompile("org.hibernate:hibernate-validator:${hibValVersion}")
 		testCompile("com.thoughtworks.xstream:xstream:${xstreamVersion}")


### PR DESCRIPTION
This PR adds a number of transitive dependency exclusions so that, where possible, each project only has a single source for each class on its classpath. Please see the commit message for further details.
