### PR TITLE
Update DefaultKeyGenerator.java

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/DefaultKeyGenerator.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/DefaultKeyGenerator.java
@@ -44,7 +44,7 @@ public class DefaultKeyGenerator implements KeyGenerator {
 
 	public static final int NO_PARAM_KEY = 0;
 
-	public static final int NULL_PARAM_KEY = 53;
+	public static final int NULL_PARAM_KEY = Integer.MIN_VALUE + 1 ;
 
 
 	@Override


### PR DESCRIPTION
problem: If I have a method with a single parameter and this equal a 53L. 
Consequently, I can recuper this object in passing a null.
