### PR TITLE
Javadoc: removed support for JBoss AS 5's VFS

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/VfsResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/VfsResource.java
@@ -27,7 +27,7 @@ import org.springframework.util.Assert;
 
 /**
  * VFS based {@link Resource} implementation.
- * Supports the corresponding VFS API versions on JBoss AS 5.x as well as 6.x and 7.x.
+ * Supports the corresponding VFS API versions on JBoss AS 6.x as well as 7.x.
  *
  * @author Ales Justin
  * @author Juergen Hoeller


### PR DESCRIPTION
Since Spring 4.0, the VfsUtils class does not support any more the VFS 2 of JBoss AS 5 and JBoss 5.x EAP.
See commit https://github.com/spring-projects/spring-framework/commit/ca194261a42a0a4f0c8bdc36f447e1029a7d2e3e
