### PR TITLE
Fix <websocket:interceptors> default configuration

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParser.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParser.java
@@ -176,9 +176,10 @@ class MessageBrokerBeanDefinitionParser implements BeanDefinitionParser {
 			ParserContext parserCxt, Object source) {
 
 		RootBeanDefinition executorDef = null;
+		Element executor = null;
 
 		if (channelElement != null) {
-			Element executor = DomUtils.getChildElementByTagName(channelElement, "executor");
+			executor = DomUtils.getChildElementByTagName(channelElement, "executor");
 			if (executor != null) {
 				executorDef = new RootBeanDefinition(ThreadPoolTaskExecutor.class);
 				String attrValue = executor.getAttribute("core-pool-size");
@@ -199,7 +200,7 @@ class MessageBrokerBeanDefinitionParser implements BeanDefinitionParser {
 				}
 			}
 		}
-		else if (!channelName.equals("brokerChannel")) {
+		if ((channelElement == null && !channelName.equals("brokerChannel")) || (channelElement != null && executor == null)) {
 			executorDef = new RootBeanDefinition(ThreadPoolTaskExecutor.class);
 			executorDef.getPropertyValues().add("corePoolSize", Runtime.getRuntime().availableProcessors() * 2);
 			executorDef.getPropertyValues().add("maxPoolSize", Integer.MAX_VALUE);

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParserTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParserTests.java
@@ -293,6 +293,15 @@ public class MessageBrokerBeanDefinitionParserTests {
 		testExecutor("brokerChannel", 102, 202, 602);
 	}
 
+	// SPR-11623
+
+	@Test
+	public void customChannelsWithDefaultExecutor() {
+		loadBeanDefinitions("websocket-config-broker-customchannels-default-executor.xml");
+		List<Class<? extends MessageHandler>> subscriberTypes = Arrays.<Class<? extends MessageHandler>>asList(SubProtocolWebSocketHandler.class);
+		testExecutor("clientOutboundChannel", Runtime.getRuntime().availableProcessors() * 2, Integer.MAX_VALUE, 60);
+	}
+
 	@Test
 	public void messageConverters() {
 		loadBeanDefinitions("websocket-config-broker-converters.xml");

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-customchannels-default-executor.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-customchannels-default-executor.xml
@@ -1,0 +1,30 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:websocket="http://www.springframework.org/schema/websocket"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket-4.0.xsd">
+
+    <websocket:message-broker>
+        <websocket:stomp-endpoint path="/foo,/bar">
+            <websocket:handshake-handler ref="myHandler"/>
+        </websocket:stomp-endpoint>
+        <websocket:simple-broker prefix="/topic"/>
+        <websocket:client-inbound-channel>
+            <websocket:executor core-pool-size="100" max-pool-size="200" keep-alive-seconds="600"/>
+            <websocket:interceptors>
+                <ref bean="myInterceptor"/>
+            </websocket:interceptors>
+        </websocket:client-inbound-channel>
+        <websocket:client-outbound-channel>
+            <websocket:interceptors>
+                <ref bean="myInterceptor"/>
+                <bean class="org.springframework.web.socket.config.TestChannelInterceptor"/>
+            </websocket:interceptors>
+        </websocket:client-outbound-channel>
+    </websocket:message-broker>
+
+    <bean id="myHandler" class="org.springframework.web.socket.config.TestHandshakeHandler"/>
+
+    <bean id="myInterceptor" class="org.springframework.web.socket.config.TestChannelInterceptor"/>
+
+</beans>


### PR DESCRIPTION
Adding a ChannelInterceptor does not suppress default executor
settings anymore in the XML namespace.

Issue: SPR-11623
