### PR TITLE
Make WebSocket fields available after it is closed

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/standard/StandardWebSocketSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/standard/StandardWebSocketSession.java
@@ -54,7 +54,9 @@ public class StandardWebSocketSession extends AbstractWebSocketSession<Session> 
 
 	private final InetSocketAddress remoteAddress;
 
-	private final Principal user;
+	private Principal user;
+
+	private String acceptedProtocol;
 
 	private List<WebSocketExtension> extensions;
 
@@ -136,8 +138,7 @@ public class StandardWebSocketSession extends AbstractWebSocketSession<Session> 
 	@Override
 	public String getAcceptedProtocol() {
 		checkNativeSessionInitialized();
-		String protocol = getNativeSession().getNegotiatedSubprotocol();
-		return StringUtils.isEmpty(protocol)? null : protocol;
+		return this.acceptedProtocol;
 	}
 
 	@Override
@@ -180,6 +181,15 @@ public class StandardWebSocketSession extends AbstractWebSocketSession<Session> 
 	@Override
 	public boolean isOpen() {
 		return (getNativeSession() != null && getNativeSession().isOpen());
+	}
+
+	@Override
+	public void initializeNativeSession(Session session) {
+		super.initializeNativeSession(session);
+		if(this.user == null) {
+			this.user = session.getUserPrincipal();
+		}
+		this.acceptedProtocol = session.getNegotiatedSubprotocol();
 	}
 
 	@Override

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/StompSubProtocolHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/StompSubProtocolHandlerTests.java
@@ -16,12 +16,14 @@
 
 package org.springframework.web.socket.messaging;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import javax.websocket.Session;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +48,7 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.adapter.standard.StandardWebSocketSession;
 import org.springframework.web.socket.handler.TestWebSocketSession;
 import org.springframework.web.socket.sockjs.transport.SockJsSession;
 
@@ -285,6 +288,23 @@ public class StompSubProtocolHandlerTests {
 		assertEquals(1, this.session.getSentMessages().size());
 		TextMessage actual = (TextMessage) this.session.getSentMessages().get(0);
 		assertTrue(actual.getPayload().startsWith("ERROR"));
+	}
+
+	// SPR-11621
+
+	@Test
+	public void availableSessionFieldsAfterSessionEnded() throws IOException {
+		Session nativeSession = Mockito.mock(Session.class);
+		when(nativeSession.getId()).thenReturn("1");
+		when(nativeSession.getUserPrincipal()).thenReturn(new org.springframework.web.socket.handler.TestPrincipal("test"));
+		when(nativeSession.getNegotiatedSubprotocol()).thenReturn("v12.sToMp");
+		StandardWebSocketSession standardWebsocketSession = new StandardWebSocketSession(null, null, null, null);
+		standardWebsocketSession.initializeNativeSession(nativeSession);
+		this.protocolHandler.afterSessionStarted(standardWebsocketSession, this.channel);
+		standardWebsocketSession.close(CloseStatus.NORMAL);
+		this.protocolHandler.afterSessionEnded(standardWebsocketSession, CloseStatus.NORMAL, this.channel);
+		assertEquals("v12.sToMp", standardWebsocketSession.getAcceptedProtocol());
+		assertNotNull(standardWebsocketSession.getPrincipal());
 	}
 
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/SubProtocolWebSocketHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/SubProtocolWebSocketHandlerTests.java
@@ -21,14 +21,19 @@ import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.adapter.standard.StandardWebSocketSession;
 import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator;
+import org.springframework.web.socket.handler.TestPrincipal;
 import org.springframework.web.socket.handler.TestWebSocketSession;
 
+import javax.websocket.Session;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -53,6 +58,9 @@ public class SubProtocolWebSocketHandlerTests {
 
 	@Mock
 	SubscribableChannel outClientChannel;
+
+	@Mock
+	private Session nativeSession;
 
 
 	@Before
@@ -140,6 +148,23 @@ public class SubProtocolWebSocketHandlerTests {
 	public void noSubProtocolNoDefaultHandler() throws Exception {
 		this.webSocketHandler.setProtocolHandlers(Arrays.asList(stompHandler, mqttHandler));
 		this.webSocketHandler.afterConnectionEstablished(session);
+	}
+
+	// SPR-11621
+
+	@Test
+	public void availableSessionFieldsafterConnectionClosed() throws Exception {
+		this.webSocketHandler.setDefaultProtocolHandler(stompHandler);
+		when(nativeSession.getId()).thenReturn("1");
+		when(nativeSession.getUserPrincipal()).thenReturn(new TestPrincipal("test"));
+		when(nativeSession.getNegotiatedSubprotocol()).thenReturn("v12.sToMp");
+		StandardWebSocketSession standardWebsocketSession = new StandardWebSocketSession(null, null, null, null);
+		standardWebsocketSession.initializeNativeSession(this.nativeSession);
+		this.webSocketHandler.afterConnectionEstablished(standardWebsocketSession);
+		standardWebsocketSession.close(CloseStatus.NORMAL);
+		this.webSocketHandler.afterConnectionClosed(standardWebsocketSession, CloseStatus.NORMAL);
+		assertEquals("v12.sToMp", standardWebsocketSession.getAcceptedProtocol());
+		assertNotNull(standardWebsocketSession.getPrincipal());
 	}
 
 }


### PR DESCRIPTION
Update some native WebSocket session getters to return basic
information after it is closed. It is required for example in
SubProtocolWebSocketHandler#afterConnectionEstablished() or
StompSubProtocolHandler#afterSessionStarted().

Issue: SPR-11621
