### PR TITLE
Fix return zero size array with empty String parameter in StringUtils.delimiitedListToStringArray

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -1045,6 +1045,9 @@ public abstract class StringUtils {
 		if (str == null) {
 			return new String[0];
 		}
+		else if ("".equals(str)) {
+			return new String[] {""};
+		}
 		if (delimiter == null) {
 			return new String[] {str};
 		}

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -434,8 +434,8 @@ public class StringUtilsTests extends TestCase {
 
 	public void testCommaDelimitedListToStringArrayWithEmptyStringProducesEmptyArray() {
 		String[] sa = StringUtils.commaDelimitedListToStringArray("");
-		assertTrue("String array isn't null with null input", sa != null);
-		assertTrue("String array length == 0 with null input", sa.length == 0);
+		assertEquals(1, sa.length);
+		assertTrue("component is correct", sa[0].equals(""));
 	}
 
 	private void testStringArrayReverseTransformationMatches(String[] sa) {

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -426,16 +426,16 @@ public class StringUtilsTests extends TestCase {
 				sa[0].equals("a") && sa[1].equals("b ") && sa[2].equals("c"));
 	}
 
-	public void testCommaDelimitedListToStringArrayWithNullProducesEmptyArray() {
-		String[] sa = StringUtils.commaDelimitedListToStringArray(null);
-		assertTrue("String array isn't null with null input", sa != null);
-		assertTrue("String array length == 0 with null input", sa.length == 0);
-	}
-
 	public void testCommaDelimitedListToStringArrayWithEmptyStringProducesEmptyArray() {
 		String[] sa = StringUtils.commaDelimitedListToStringArray("");
 		assertEquals(1, sa.length);
 		assertTrue("component is correct", sa[0].equals(""));
+	}
+
+	public void testCommaDelimitedListToStringArrayWithNullProducesEmptyArray() {
+		String[] sa = StringUtils.commaDelimitedListToStringArray(null);
+		assertTrue("String array isn't null with null input", sa != null);
+		assertTrue("String array length == 0 with null input", sa.length == 0);
 	}
 
 	private void testStringArrayReverseTransformationMatches(String[] sa) {


### PR DESCRIPTION
Prior to this commit, zero size String array returns if StringUtils.delimitedListToStringArray is called with parameter empty String ("")

I think, after call StringUtils.delimitedListToStringArray("", ",", null);

it should return one size String array -> [""]

but it returns zero size String array.

StringUtils.delimitedListToStringArray(null, ",", null) & StringUtils.delimitedListToStringArray("", ",", null)

should returns differently. However there are same results.

There's no logic for empty String(""), but just is for null parameter.

I added if statement for "" parameter. The result will be one size String array.

And also in SPR-11126, the issue will be fine.

Issue: SPR-11126
