### PR TITLE
Make Spring 3.2.x compatible with Java 8 bytecode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,8 @@ project("spring-core") {
 	// avoids including two different copies of asm unnecessarily. If however future cglib
 	// versions drift from the version of asm used by Spring internally, this duplication
 	// will become necessary.
-	def asmVersion = "4.0"
-	def cglibVersion = "3.0"
+	def asmVersion = "5.0"
+	def cglibVersion = "3.1"
 
 	configurations {
 		jarjar

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ project("spring-core") {
 	// avoids including two different copies of asm unnecessarily. If however future cglib
 	// versions drift from the version of asm used by Spring internally, this duplication
 	// will become necessary.
-	def asmVersion = "5.0"
+	def asmVersion = "5.0.1"
 	def cglibVersion = "3.1"
 
 	configurations {

--- a/spring-core/src/main/java/org/springframework/asm/SpringAsmInfo.java
+++ b/spring-core/src/main/java/org/springframework/asm/SpringAsmInfo.java
@@ -33,6 +33,6 @@ public final class SpringAsmInfo {
 	 *
 	 * @see Opcodes#ASM4
 	 */
-	public static final int ASM_VERSION = Opcodes.ASM4;
+	public static final int ASM_VERSION = Opcodes.ASM5;
 
 }


### PR DESCRIPTION
Upgraded ASM from 4.0 to 5.0 and cglib from 3.0 to 3.1

---

Simple example project that uses this build:
https://github.com/mbknor/spring-3.2.x-java-8-test

---

At work, I am not able to start using Java 8 because we're using Camel which needs Spring 3.2.x.
With this fix, we can start using Java 8 while still use Camel and Spring 3.2.x
