### PR TITLE
Compact ignore of all build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,7 @@ argfile*
 pom.xml
 activemq-data/
 
-/build
-buildSrc/build
-/spring-*/build
-/src/asciidoc/build
+build/
 target/
 
 # Eclipse artifacts, including WTP generated manifests


### PR DESCRIPTION
This patch replaces multiple ignore patterns for build directories with
one which matches all.
