### PR TITLE
Minor doc fix to sample for @ConstructorProperties

### DIFF
--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -1867,7 +1867,7 @@ You can also use the constructor parameter name for value disambiguation:
 ----
 	<bean id="exampleBean" class="examples.ExampleBean">
 		<constructor-arg name="years" value="7500000"/>
-		<constructor-arg name="ultimateanswer" value="42"/>
+		<constructor-arg name="ultimateAnswer" value="42"/>
 	</bean>
 ----
 


### PR DESCRIPTION
Very minor doc fix for a sample on `@ConstructorProperties` - http://stackoverflow.com/questions/23073226/constructorproperties-annotation-does-not-work/23073551
