### PR TITLE
With relation to [SPR-11126] problem converting empty parameter to List,

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToCollectionConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToCollectionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,12 @@ final class StringToCollectionConverter implements ConditionalGenericConverter {
 			return null;
 		}
 		String string = (String) source;
-		String[] fields = StringUtils.commaDelimitedListToStringArray(string);
+		String[] fields = null;
+		if("".equals(string)) {
+			fields = new String[]{""};
+		} else {
+			fields = StringUtils.commaDelimitedListToStringArray(string);
+		}
 		Collection<Object> target = CollectionFactory.createCollection(targetType.getType(), fields.length);
 		if (targetType.getElementTypeDescriptor() == null) {
 			for (String field : fields) {

--- a/spring-core/src/test/java/org/springframework/core/convert/support/StringToCollectionConverterTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/StringToCollectionConverterTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.convert.support;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.core.convert.TypeDescriptor;
+
+import static org.junit.Assert.*;
+
+public class StringToCollectionConverterTests {
+
+	private GenericConversionService conversionService = new GenericConversionService();
+
+	public List<String> strings;
+
+	@SuppressWarnings("unchecked")
+	@Test
+	/**
+	 * See SPR-11126.
+	 */
+	public void emptyStringToList() throws Exception {
+		conversionService.addConverter(new StringToCollectionConverter(conversionService));
+		conversionService.addConverterFactory(new StringToNumberConverterFactory());
+		String source = "";
+		TypeDescriptor sourceType = TypeDescriptor.forObject(source);
+		TypeDescriptor targetType = new TypeDescriptor(getClass().getField("strings"));
+		assertTrue(conversionService.canConvert(sourceType, targetType));
+		Collection<Object> result = (Collection<Object>)conversionService.convert(source, sourceType, targetType);
+		assertEquals(1, result.size());
+	}
+
+}


### PR DESCRIPTION
We want to get a request parameter with the type of List<String> in the Spring-mvc Controller class like below

``` java
SampleController.java
@RequestMapping(value = "/urlpath")
public void create(@RequestParam(value = "param") List<String> paramList) {
 ...
}
```

When invoking ".../urlpath?param=", We expect `List<String>` has size 1 with empty String value, but actually the size of `List<String>` is 0.

Actually `StringUtils.commaDelimitedListToStringArray(String)` method is a real worker, but the purpose of that method is to return the empty array in case of empty input(by java doc).
So, I slightly chnaged `convert(Object source, TypeDescriptor sourceType,
TypeDescriptor targetType)` method in the `StringToCollectionConverter`
class.

reated Issue: 
