### PR TITLE
[SPR-11126] problem converting empty parameter to List

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToCollectionConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToCollectionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,12 @@ final class StringToCollectionConverter implements ConditionalGenericConverter {
 			return null;
 		}
 		String string = (String) source;
-		String[] fields = StringUtils.commaDelimitedListToStringArray(string);
+		String[] fields = null;
+		if("".equals(string)) {
+			fields = new String[]{""};
+		} else {
+			fields = StringUtils.commaDelimitedListToStringArray(string);
+		}
 		Collection<Object> target = CollectionFactory.createCollection(targetType.getType(), fields.length);
 		if (targetType.getElementTypeDescriptor() == null) {
 			for (String field : fields) {

--- a/spring-core/src/test/java/org/springframework/core/convert/support/StringToCollectionConverterTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/StringToCollectionConverterTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.convert.support;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.core.convert.TypeDescriptor;
+
+import static org.junit.Assert.*;
+
+public class StringToCollectionConverterTests {
+
+	private GenericConversionService conversionService = new GenericConversionService();
+
+	public List<String> strings;
+
+	@SuppressWarnings("unchecked")
+	@Test
+	/**
+	 * See SPR-11126.
+	 */
+	public void emptyStringToList() throws Exception {
+		conversionService.addConverter(new StringToCollectionConverter(conversionService));
+		conversionService.addConverterFactory(new StringToNumberConverterFactory());
+		String source = "";
+		TypeDescriptor sourceType = TypeDescriptor.forObject(source);
+		TypeDescriptor targetType = new TypeDescriptor(getClass().getField("strings"));
+		assertTrue(conversionService.canConvert(sourceType, targetType));
+		Collection<Object> result = (Collection<Object>)conversionService.convert(source, sourceType, targetType);
+		assertEquals(1, result.size());
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
@@ -204,7 +204,7 @@ public class RequestParamMethodArgumentResolver extends AbstractNamedValueMethod
 			if (arg == null) {
 				String[] paramValues = webRequest.getParameterValues(name);
 				if (paramValues != null) {
-					arg = paramValues.length == 1 ? paramValues[0] : paramValues;
+					arg = (paramValues.length == 1 && !List.class.isAssignableFrom(parameter.getParameterType())) ? paramValues[0] : paramValues;
 				}
 			}
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
@@ -138,7 +138,7 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 		for (Entry<String, String> uriVar : uriVariables.entrySet()) {
 			String uriVarValue = uriVar.getValue();
 
-			int equalsIndex = uriVarValue.indexOf('=');
+			int equalsIndex = uriVarValue.lastIndexOf('=');
 			if (equalsIndex == -1) {
 				continue;
 			}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,6 +364,18 @@ public class RequestMappingInfoHandlerMappingTests {
 		assertNull(matrixVariables);
 		assertEquals("cars", uriVariables.get("cars"));
 		assertEquals("", uriVariables.get("params"));
+		
+		// SPR-11897
+		request = new MockHttpServletRequest();
+		testHandleMatch(request, "/{cars}", "/cars=suv;colors=red,blue,green;year=2012");
+
+		matrixVariables = getMatrixVariables(request, "cars");
+		uriVariables = getUriTemplateVariables(request);
+
+		assertNotNull(matrixVariables);
+		assertEquals(Arrays.asList("red", "blue", "green"), matrixVariables.get("colors"));
+		assertEquals("2012", matrixVariables.getFirst("year"));
+		assertEquals("cars=suv", uriVariables.get("cars"));
 	}
 
 	@Test


### PR DESCRIPTION
In connection with "[SPR-11126] problem converting empty parameter to List",
the resolveName(String, MethodParameter, NativeWebRequest) method
in the RequestParamMethodArgumentResolver.java has been slightly chagned.
In case that MethodParameter is related to List type,
String[](with legnth 1) value will be returned itself
without being changed to String.

Thank you.

Issue: SPR-11126
