### PR TITLE
Clean up spring-jdbc tests warnings

### DIFF
--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
@@ -26,13 +26,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
+
 import javax.sql.DataSource;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 import static org.junit.Assert.*;
@@ -80,10 +80,10 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < 3";
 		given(this.resultSet.next()).willReturn(true, true, false);
 		given(this.resultSet.getObject(1)).willReturn(11, 12);
-		List li = this.template.queryForList(sql);
+		List<Map<String, Object>> li = this.template.queryForList(sql);
 		assertEquals("All rows returned", 2, li.size());
-		assertEquals("First row is Integer", 11, ((Integer)((Map)li.get(0)).get("age")).intValue());
-		assertEquals("Second row is Integer", 12, ((Integer)((Map)li.get(1)).get("age")).intValue());
+		assertEquals("First row is Integer", 11, ((Integer) li.get(0).get("age")).intValue());
+		assertEquals("Second row is Integer", 12, ((Integer) li.get(1).get("age")).intValue());
 		verify(this.resultSet).close();
 		verify(this.statement).close();
 	}
@@ -92,7 +92,7 @@ public class JdbcTemplateQueryTests {
 	public void testQueryForListWithEmptyResult() throws Exception {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < 3";
 		given(this.resultSet.next()).willReturn(false);
-		List li = this.template.queryForList(sql);
+		List<Map<String, Object>> li = this.template.queryForList(sql);
 		assertEquals("All rows returned", 0, li.size());
 		verify(this.resultSet).close();
 		verify(this.statement).close();
@@ -103,9 +103,9 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < 3";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getObject(1)).willReturn(11);
-		List li = this.template.queryForList(sql);
+		List<Map<String, Object>> li = this.template.queryForList(sql);
 		assertEquals("All rows returned", 1, li.size());
-		assertEquals("First row is Integer", 11, ((Integer)((Map)li.get(0)).get("age")).intValue());
+		assertEquals("First row is Integer", 11, ((Integer) li.get(0).get("age")).intValue());
 		verify(this.resultSet).close();
 		verify(this.statement).close();
 	}
@@ -115,9 +115,9 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < 3";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getInt(1)).willReturn(11);
-		List li = this.template.queryForList(sql, Integer.class);
+		List<Integer> li = this.template.queryForList(sql, Integer.class);
 		assertEquals("All rows returned", 1, li.size());
-		assertEquals("Element is Integer", 11, ((Integer) li.get(0)).intValue());
+		assertEquals("Element is Integer", 11, li.get(0).intValue());
 		verify(this.resultSet).close();
 		verify(this.statement).close();
 	}
@@ -127,7 +127,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < 3";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getObject(1)).willReturn(11);
-		Map map = this.template.queryForMap(sql);
+		Map<String, Object> map = this.template.queryForMap(sql);
 		assertEquals("Wow is Integer", 11, ((Integer) map.get("age")).intValue());
 		verify(this.resultSet).close();
 		verify(this.statement).close();
@@ -198,7 +198,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getInt(1)).willReturn(22);
-		assertEquals(new Integer(22), this.template.queryForObject(sql, Integer.class));
+		assertEquals(Integer.valueOf(22), this.template.queryForObject(sql, Integer.class));
 		verify(this.resultSet).close();
 		verify(this.statement).close();
 	}
@@ -249,10 +249,10 @@ public class JdbcTemplateQueryTests {
 	private void doTestQueryForListWithArgs(String sql) throws Exception {
 		given(this.resultSet.next()).willReturn(true, true, false);
 		given(this.resultSet.getObject(1)).willReturn(11, 12);
-		List li = this.template.queryForList(sql, new Object[] {new Integer(3)});
+		List<Map<String, Object>> li = this.template.queryForList(sql, new Object[] {3});
 		assertEquals("All rows returned", 2, li.size());
-		assertEquals("First row is Integer", 11, ((Integer)((Map)li.get(0)).get("age")).intValue());
-		assertEquals("Second row is Integer", 12, ((Integer)((Map)li.get(1)).get("age")).intValue());
+		assertEquals("First row is Integer", 11, ((Integer) li.get(0).get("age")).intValue());
+		assertEquals("Second row is Integer", 12, ((Integer) li.get(1).get("age")).intValue());
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();
 		verify(this.preparedStatement).close();
@@ -262,7 +262,7 @@ public class JdbcTemplateQueryTests {
 	public void testQueryForListWithArgsAndEmptyResult() throws Exception {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < ?";
 		given(this.resultSet.next()).willReturn(false);
-		List li = this.template.queryForList(sql, new Object[] {new Integer(3)});
+		List<Map<String, Object>> li = this.template.queryForList(sql, new Object[] {3});
 		assertEquals("All rows returned", 0, li.size());
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();
@@ -274,9 +274,9 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getObject(1)).willReturn(11);
-		List li = this.template.queryForList(sql, new Object[] {new Integer(3)});
+		List<Map<String, Object>> li = this.template.queryForList(sql, new Object[] {3});
 		assertEquals("All rows returned", 1, li.size());
-		assertEquals("First row is Integer", 11, ((Integer)((Map)li.get(0)).get("age")).intValue());
+		assertEquals("First row is Integer", 11, ((Integer) li.get(0).get("age")).intValue());
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();
 		verify(this.preparedStatement).close();
@@ -287,9 +287,9 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getInt(1)).willReturn(11);
-		List li = this.template.queryForList(sql, new Object[] {new Integer(3)}, Integer.class);
+		List<Integer> li = this.template.queryForList(sql, new Object[] {3}, Integer.class);
 		assertEquals("All rows returned", 1, li.size());
-		assertEquals("First row is Integer", 11, ((Integer) li.get(0)).intValue());
+		assertEquals("First row is Integer", 11, li.get(0).intValue());
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();
 		verify(this.preparedStatement).close();
@@ -300,7 +300,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID < ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getObject(1)).willReturn(11);
-		Map map = this.template.queryForMap(sql, new Object[] {new Integer(3)});
+		Map<String, Object> map = this.template.queryForMap(sql, new Object[] {3});
 		assertEquals("Row is Integer", 11, ((Integer) map.get("age")).intValue());
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();
@@ -312,7 +312,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getInt(1)).willReturn(22);
-		Object o = this.template.queryForObject(sql, new Object[] {new Integer(3)}, new RowMapper<Integer>() {
+		Object o = this.template.queryForObject(sql, new Object[] {3}, new RowMapper<Integer>() {
 			@Override
 			public Integer mapRow(ResultSet rs, int rowNum) throws SQLException {
 				return rs.getInt(1);
@@ -329,7 +329,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getInt(1)).willReturn(22);
-		Object o = this.template.queryForObject(sql, new Object[] {new Integer(3)}, Integer.class);
+		Object o = this.template.queryForObject(sql, new Object[] {3}, Integer.class);
 		assertTrue("Correct result type", o instanceof Integer);
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();
@@ -341,7 +341,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getInt(1)).willReturn(22);
-		int i = this.template.queryForInt(sql, new Object[] {new Integer(3)});
+		int i = this.template.queryForInt(sql, new Object[] {3});
 		assertEquals("Return of an int", 22, i);
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();
@@ -353,7 +353,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getLong(1)).willReturn(87L);
-		long l = this.template.queryForLong(sql, new Object[] {new Integer(3)});
+		long l = this.template.queryForLong(sql, new Object[] {3});
 		assertEquals("Return of a long", 87, l);
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
@@ -1289,7 +1289,7 @@ public class JdbcTemplateTests {
 		List<SqlParameter> params = new ArrayList<SqlParameter>();
 		params.add(new SqlOutParameter("a", 12));
 
-		Map out = this.template.call(new CallableStatementCreator() {
+		Map<String, Object> out = this.template.call(new CallableStatementCreator() {
 			@Override
 			public CallableStatement createCallableStatement(Connection conn)
 					throws SQLException {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterQueryTests.java
@@ -91,9 +91,9 @@ public class NamedParameterQueryTests {
 
 		assertEquals("All rows returned", 2, li.size());
 		assertEquals("First row is Integer", 11,
-				((Integer) ((Map) li.get(0)).get("age")).intValue());
+				((Integer) li.get(0).get("age")).intValue());
 		assertEquals("Second row is Integer", 12,
-				((Integer) ((Map) li.get(1)).get("age")).intValue());
+				((Integer) li.get(1).get("age")).intValue());
 
 		verify(connection).prepareStatement("SELECT AGE FROM CUSTMR WHERE ID < ?");
 		verify(preparedStatement).setObject(1, 3);
@@ -126,7 +126,7 @@ public class NamedParameterQueryTests {
 
 		assertEquals("All rows returned", 1, li.size());
 		assertEquals("First row is Integer", 11,
-				((Integer) ((Map) li.get(0)).get("age")).intValue());
+				((Integer) li.get(0).get("age")).intValue());
 		verify(connection).prepareStatement("SELECT AGE FROM CUSTMR WHERE ID < ?");
 		verify(preparedStatement).setObject(1, 3);
 	}
@@ -157,7 +157,7 @@ public class NamedParameterQueryTests {
 
 		MapSqlParameterSource parms = new MapSqlParameterSource();
 		parms.addValue("id", 3);
-		Map map = template.queryForMap("SELECT AGE FROM CUSTMR WHERE ID < :id", parms);
+		Map<String, Object> map = template.queryForMap("SELECT AGE FROM CUSTMR WHERE ID < :id", parms);
 
 		assertEquals("Row is Integer", 11, ((Integer) map.get("age")).intValue());
 		verify(connection).prepareStatement("SELECT AGE FROM CUSTMR WHERE ID < ?");

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/support/LobSupportTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/support/LobSupportTests.java
@@ -65,7 +65,7 @@ public class LobSupportTests {
 			}
 		};
 
-		assertEquals(new Integer(3), psc.doInPreparedStatement(ps));
+		assertEquals(Integer.valueOf(3), psc.doInPreparedStatement(ps));
 		assertTrue(svc.b);
 		verify(creator).close();
 		verify(handler).getLobCreator();
@@ -75,7 +75,7 @@ public class LobSupportTests {
 	@Test
 	public void testAbstractLobStreamingResultSetExtractorNoRows() throws SQLException {
 		ResultSet rset = mock(ResultSet.class);
-		AbstractLobStreamingResultSetExtractor lobRse = getResultSetExtractor(false);
+		AbstractLobStreamingResultSetExtractor<Void> lobRse = getResultSetExtractor(false);
 		thrown.expect(IncorrectResultSizeDataAccessException.class);
 		try {
 			lobRse.extractData(rset);
@@ -89,7 +89,7 @@ public class LobSupportTests {
 	public void testAbstractLobStreamingResultSetExtractorOneRow() throws SQLException {
 		ResultSet rset = mock(ResultSet.class);
 		given(rset.next()).willReturn(true, false);
-		AbstractLobStreamingResultSetExtractor lobRse = getResultSetExtractor(false);
+		AbstractLobStreamingResultSetExtractor<Void> lobRse = getResultSetExtractor(false);
 		lobRse.extractData(rset);
 		verify(rset).clearWarnings();
 	}
@@ -99,7 +99,7 @@ public class LobSupportTests {
 			throws SQLException {
 		ResultSet rset = mock(ResultSet.class);
 		given(rset.next()).willReturn(true, true, false);
-		AbstractLobStreamingResultSetExtractor lobRse = getResultSetExtractor(false);
+		AbstractLobStreamingResultSetExtractor<Void> lobRse = getResultSetExtractor(false);
 		thrown.expect(IncorrectResultSizeDataAccessException.class);
 		try {
 			lobRse.extractData(rset);
@@ -114,13 +114,13 @@ public class LobSupportTests {
 			throws SQLException {
 		ResultSet rset = mock(ResultSet.class);
 		given(rset.next()).willReturn(true);
-		AbstractLobStreamingResultSetExtractor lobRse = getResultSetExtractor(true);
+		AbstractLobStreamingResultSetExtractor<Void> lobRse = getResultSetExtractor(true);
 		thrown.expect(LobRetrievalFailureException.class);
 		lobRse.extractData(rset);
 	}
 
-	private AbstractLobStreamingResultSetExtractor getResultSetExtractor(final boolean ex) {
-		AbstractLobStreamingResultSetExtractor lobRse = new AbstractLobStreamingResultSetExtractor() {
+	private AbstractLobStreamingResultSetExtractor<Void> getResultSetExtractor(final boolean ex) {
+		AbstractLobStreamingResultSetExtractor<Void> lobRse = new AbstractLobStreamingResultSetExtractor<Void>() {
 
 			@Override
 			protected void streamData(ResultSet rs) throws SQLException, IOException {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/JndiDataSourceLookupTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/JndiDataSourceLookupTests.java
@@ -36,10 +36,9 @@ public final class JndiDataSourceLookupTests {
 		final DataSource expectedDataSource = new StubDataSource();
 		JndiDataSourceLookup lookup = new JndiDataSourceLookup() {
 			@Override
-			@SuppressWarnings("unchecked")
-			protected Object lookup(String jndiName, Class requiredType) {
+			protected <T> T lookup(String jndiName, Class<T> requiredType) {
 				assertEquals(DATA_SOURCE_NAME, jndiName);
-				return expectedDataSource;
+				return requiredType.cast(expectedDataSource);
 			}
 		};
 		DataSource dataSource = lookup.getDataSource(DATA_SOURCE_NAME);
@@ -51,8 +50,7 @@ public final class JndiDataSourceLookupTests {
 	public void testNoDataSourceAtJndiLocation() throws Exception {
 		JndiDataSourceLookup lookup = new JndiDataSourceLookup() {
 			@Override
-			@SuppressWarnings("unchecked")
-			protected Object lookup(String jndiName, Class requiredType) throws NamingException {
+			protected <T> T lookup(String jndiName, Class<T> requiredType) throws NamingException {
 				assertEquals(DATA_SOURCE_NAME, jndiName);
 				throw new NamingException();
 			}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/MapDataSourceLookupTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/MapDataSourceLookupTests.java
@@ -37,7 +37,7 @@ public final class MapDataSourceLookupTests {
 	@SuppressWarnings("unchecked")
 	@Test(expected=UnsupportedOperationException.class)
 	public void testGetDataSourcesReturnsUnmodifiableMap() throws Exception {
-		MapDataSourceLookup lookup = new MapDataSourceLookup(new HashMap());
+		MapDataSourceLookup lookup = new MapDataSourceLookup(new HashMap<String, DataSource>());
 		Map dataSources = lookup.getDataSources();
 		dataSources.put("", "");
 	}
@@ -84,7 +84,7 @@ public final class MapDataSourceLookupTests {
 	@SuppressWarnings("unchecked")
 	@Test(expected=ClassCastException.class)
 	public void testGetDataSourceWhereSuppliedMapHasNonDataSourceTypeUnderSpecifiedKey() throws Exception {
-		Map dataSources = new HashMap();
+		Map dataSources = new HashMap<String, DataSource>();
 		dataSources.put(DATA_SOURCE_NAME, new Object());
 		MapDataSourceLookup lookup = new MapDataSourceLookup();
 		lookup.setDataSources(dataSources);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/object/BatchSqlUpdateTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/object/BatchSqlUpdateTests.java
@@ -100,8 +100,8 @@ public class BatchSqlUpdateTests {
 		update.reset();
 		assertEquals(0, update.getRowsAffected().length);
 
-		verify(preparedStatement).setObject(1, new Integer(ids[0]), Types.INTEGER);
-		verify(preparedStatement).setObject(1, new Integer(ids[1]), Types.INTEGER);
+		verify(preparedStatement).setObject(1, ids[0], Types.INTEGER);
+		verify(preparedStatement).setObject(1, ids[1], Types.INTEGER);
 		verify(preparedStatement, times(2)).addBatch();
 		verify(preparedStatement).close();
 	}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/object/GenericSqlQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/object/GenericSqlQueryTests.java
@@ -73,17 +73,17 @@ public class GenericSqlQueryTests  {
 
 	@Test
 	public void testPlaceHoldersCustomerQuery() throws SQLException {
-		SqlQuery query = (SqlQuery) beanFactory.getBean("queryWithPlaceHolders");
+		SqlQuery<?> query = (SqlQuery<?>) beanFactory.getBean("queryWithPlaceHolders");
 		doTestCustomerQuery(query, false);
 	}
 
 	@Test
 	public void testNamedParameterCustomerQuery() throws SQLException {
-		SqlQuery query = (SqlQuery) beanFactory.getBean("queryWithNamedParameters");
+		SqlQuery<?> query = (SqlQuery<?>) beanFactory.getBean("queryWithNamedParameters");
 		doTestCustomerQuery(query, true);
 	}
 
-	private void doTestCustomerQuery(SqlQuery query, boolean namedParameters) throws SQLException {
+	private void doTestCustomerQuery(SqlQuery<?> query, boolean namedParameters) throws SQLException {
 		given(resultSet.next()).willReturn(true);
 		given(resultSet.getInt("id")).willReturn(1);
 		given(resultSet.getString("forename")).willReturn("rod");
@@ -91,15 +91,15 @@ public class GenericSqlQueryTests  {
 		given(preparedStatement.executeQuery()).willReturn(resultSet);
 		given(connection.prepareStatement(SELECT_ID_FORENAME_NAMED_PARAMETERS_PARSED)).willReturn(preparedStatement);
 
-		List queryResults;
+		List<?> queryResults;
 		if (namedParameters) {
 			Map<String, Object> params = new HashMap<String, Object>(2);
-			params.put("id", new Integer(1));
+			params.put("id", 1);
 			params.put("country", "UK");
 			queryResults = query.executeByNamedParam(params);
 		}
 		else {
-			Object[] params = new Object[] {new Integer(1), "UK"};
+			Object[] params = new Object[] {1, "UK"};
 			queryResults = query.execute(params);
 		}
 		assertTrue("Customer was returned correctly", queryResults.size() == 1);
@@ -108,7 +108,7 @@ public class GenericSqlQueryTests  {
 		assertTrue("Customer forename was assigned correctly", cust.getForename().equals("rod"));
 
 		verify(resultSet).close();
-		verify(preparedStatement).setObject(1, new Integer(1), Types.INTEGER);
+		verify(preparedStatement).setObject(1, 1, Types.INTEGER);
 		verify(preparedStatement).setString(2, "UK");
 		verify(preparedStatement).close();
 	}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/object/GenericStoredProcedureTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/object/GenericStoredProcedureTests.java
@@ -24,12 +24,10 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.TestDataSourceWrapper;
 
 import static org.junit.Assert.*;
@@ -39,8 +37,6 @@ import static org.mockito.BDDMockito.*;
  * @author Thomas Risberg
  */
 public class GenericStoredProcedureTests {
-
-	private final boolean debugEnabled = LogFactory.getLog(JdbcTemplate.class).isDebugEnabled();
 
 	@Test
 	public void testAddInvoices() throws Exception {
@@ -56,7 +52,7 @@ public class GenericStoredProcedureTests {
 
 		given(callableStatement.execute()).willReturn(false);
 		given(callableStatement.getUpdateCount()).willReturn(-1);
-		given(callableStatement.getObject(3)).willReturn(new Integer(4));
+		given(callableStatement.getObject(3)).willReturn(4);
 
 		given(connection.prepareCall("{call " + "add_invoice" + "(?, ?, ?)}")).willReturn(callableStatement);
 
@@ -64,12 +60,12 @@ public class GenericStoredProcedureTests {
 		Map<String, Object> in = new HashMap<String, Object>(2);
 		in.put("amount", 1106);
 		in.put("custid", 3);
-		Map out = adder.execute(in);
+		Map<String, Object> out = adder.execute(in);
 		Integer id = (Integer) out.get("newid");
 		assertEquals(4, id.intValue());
 
-		verify(callableStatement).setObject(1, new Integer(1106), Types.INTEGER);
-		verify(callableStatement).setObject(2, new Integer(3), Types.INTEGER);
+		verify(callableStatement).setObject(1, 1106, Types.INTEGER);
+		verify(callableStatement).setObject(2, 3, Types.INTEGER);
 		verify(callableStatement).registerOutParameter(3, Types.INTEGER);
 		verify(callableStatement).close();
 	}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/object/RdbmsOperationTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/object/RdbmsOperationTests.java
@@ -19,8 +19,6 @@ package org.springframework.jdbc.object;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.List;
-import java.util.ArrayList;
 
 import javax.sql.DataSource;
 
@@ -96,7 +94,7 @@ public class RdbmsOperationTests extends TestCase {
 		operation.setSql("select * from mytable");
 		operation.setTypes(new int[] { Types.INTEGER });
 		try {
-			operation.validateNamedParameters((Map) null);
+			operation.validateNamedParameters((Map<String, String>) null);
 			fail("Shouldn't validate without enough parameters");
 		}
 		catch (InvalidDataAccessApiUsageException idaauex) {
@@ -122,7 +120,7 @@ public class RdbmsOperationTests extends TestCase {
 		TestRdbmsOperation operation = new TestRdbmsOperation();
 		operation.setSql("select * from mytable");
 		try {
-			operation.validateParameters(new Object[] {new Integer(1), new Integer(2)});
+			operation.validateParameters(new Object[] {1, 2});
 			fail("Shouldn't validate with too many parameters");
 		}
 		catch (InvalidDataAccessApiUsageException idaauex) {
@@ -134,7 +132,7 @@ public class RdbmsOperationTests extends TestCase {
 		TestRdbmsOperation operation = new TestRdbmsOperation();
 		operation.setSql("select * from mytable");
 		try {
-			Map params = new HashMap();
+			Map<String, String> params = new HashMap<String, String>();
 			params.put("col1", "value");
 			operation.validateNamedParameters(params);
 			fail("Shouldn't validate with unspecified parameters");
@@ -193,15 +191,12 @@ public class RdbmsOperationTests extends TestCase {
 		DataSource ds = new DriverManagerDataSource();
 		operation.setDataSource(ds);
 		operation.setSql("select * from mytable where one = ? and two = ?");
-		List l = new ArrayList();
-		l.add(new SqlParameter("one", Types.NUMERIC));
-		l.add(new SqlParameter("two", Types.VARCHAR));
 		operation.setParameters(new SqlParameter[] {
 				new SqlParameter("one", Types.NUMERIC),
 				new SqlParameter("two", Types.NUMERIC)});
 		operation.afterPropertiesSet();
 		try {
-			operation.validateParameters(new Object[] {new Integer(1), new String("2")});
+			operation.validateParameters(new Object[] {1, "2"});
 			assertEquals(2, operation.getDeclaredParameters().size());
 			// OK
 		}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/object/SqlQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/object/SqlQueryTests.java
@@ -106,7 +106,7 @@ public class SqlQueryTests  {
 
 		SqlQuery<Integer> query = new MappingSqlQueryWithParameters<Integer>() {
 			@Override
-			protected Integer mapRow(ResultSet rs, int rownum, Object[] params, Map context) throws SQLException {
+			protected Integer mapRow(ResultSet rs, int rownum, Object[] params, Map<? ,?> context) throws SQLException {
 				assertTrue("params were null", params == null);
 				assertTrue("context was null", context == null);
 				return rs.getInt(1);
@@ -728,7 +728,7 @@ public class SqlQueryTests  {
 			}
 
 			@Override
-			protected Customer updateRow(ResultSet rs, int rownum, Map context)
+			protected Customer updateRow(ResultSet rs, int rownum, Map<? ,?> context)
 					throws SQLException {
 				rs.updateString(2, "" + context.get(rs.getInt(COLUMN_NAMES[0])));
 				return null;

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/KeyHolderTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/KeyHolderTests.java
@@ -18,12 +18,13 @@ package org.springframework.jdbc.support;
 
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+
+import junit.framework.TestCase;
 
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
-
-import junit.framework.TestCase;
 
 /**
  * Tests for the KeyHolder and GeneratedKeyHolder
@@ -41,17 +42,17 @@ public class KeyHolderTests extends TestCase {
 	}
 
 	public void testSingleKey(){
-		LinkedList l = new LinkedList();
-		HashMap m = new HashMap(1);
-		m.put("key", new Integer(1));
+		List<Map<String, Object>> l = new LinkedList<Map<String, Object>>();
+		Map<String, Object> m = new HashMap<String, Object>(1);
+		m.put("key", 1);
 		l.add(m);
 		kh.getKeyList().addAll(l);
 		assertEquals("single key should be returned", 1, kh.getKey().intValue());
 	}
 
 	public void testSingleKeyNonNumeric(){
-		LinkedList l = new LinkedList();
-		HashMap m = new HashMap(1);
+		List<Map<String, Object>> l = new LinkedList<Map<String, Object>>();
+		Map<String, Object> m = new HashMap<String, Object>(1);
 		m.put("key", "1");
 		l.add(m);
 		kh.getKeyList().addAll(l);
@@ -64,8 +65,8 @@ public class KeyHolderTests extends TestCase {
 	}
 
 	public void testNoKeyReturnedInMap(){
-		LinkedList l = new LinkedList();
-		HashMap m = new HashMap();
+		List<Map<String, Object>> l = new LinkedList<Map<String, Object>>();
+		Map<String, Object> m = new HashMap<String, Object>();
 		l.add(m);
 		kh.getKeyList().addAll(l);
 		try {
@@ -77,13 +78,13 @@ public class KeyHolderTests extends TestCase {
 	}
 
 	public void testMultipleKeys(){
-		LinkedList l = new LinkedList();
-		HashMap m = new HashMap(1);
-		m.put("key", new Integer(1));
-		m.put("seq", new Integer(2));
+		List<Map<String, Object>> l = new LinkedList<Map<String, Object>>();
+		Map<String, Object> m = new HashMap<String, Object>(2);
+		m.put("key", 1);
+		m.put("seq", 2);
 		l.add(m);
 		kh.getKeyList().addAll(l);
-		Map keyMap = kh.getKeys();
+		Map<String, Object> keyMap = kh.getKeys();
 		assertEquals("two keys should be in the map", 2, keyMap.size());
 		try {
 			kh.getKey();
@@ -94,10 +95,10 @@ public class KeyHolderTests extends TestCase {
 	}
 
 	public void testMultipleKeyRows(){
-		LinkedList l = new LinkedList();
-		HashMap m = new HashMap(1);
-		m.put("key", new Integer(1));
-		m.put("seq", new Integer(2));
+		List<Map<String, Object>> l = new LinkedList<Map<String, Object>>();
+		Map<String, Object> m = new HashMap<String, Object>(2);
+		m.put("key", 1);
+		m.put("seq", 2);
 		l.add(m);
 		l.add(m);
 		kh.getKeyList().addAll(l);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/SQLErrorCodeSQLExceptionTranslatorTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/SQLErrorCodeSQLExceptionTranslatorTests.java
@@ -83,7 +83,7 @@ public class SQLErrorCodeSQLExceptionTranslatorTests extends TestCase {
 		assertEquals(sex, bsgex2.getSQLException());
 	}
 
-	private void checkTranslation(SQLExceptionTranslator sext, int errorCode, Class exClass) {
+	private void checkTranslation(SQLExceptionTranslator sext, int errorCode, Class<?> exClass) {
 		SQLException sex = new SQLException("", "", errorCode);
 		DataAccessException ex = sext.translate("", "", sex);
 		assertTrue(exClass.isInstance(ex));

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/rowset/ResultSetWrappingRowSetTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/rowset/ResultSetWrappingRowSetTests.java
@@ -50,21 +50,21 @@ public class ResultSetWrappingRowSetTests {
 	public void testGetBigDecimalInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getBigDecimal", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getBigDecimal", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), BigDecimal.valueOf(1));
+		doTest(rset, rowset, 1, BigDecimal.ONE);
 	}
 
 	@Test
 	public void testGetBigDecimalString() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getBigDecimal", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getBigDecimal", new Class[] {String.class});
-		doTest(rset, rowset, "test", BigDecimal.valueOf(1));
+		doTest(rset, rowset, "test", BigDecimal.ONE);
 	}
 
 	@Test
 	public void testGetStringInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getString", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getString", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), "test");
+		doTest(rset, rowset, 1, "test");
 	}
 
 	@Test
@@ -78,7 +78,7 @@ public class ResultSetWrappingRowSetTests {
 	public void testGetTimestampInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getTimestamp", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getTimestamp", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Timestamp(1234l));
+		doTest(rset, rowset, 1, new Timestamp(1234l));
 	}
 
 	@Test
@@ -92,7 +92,7 @@ public class ResultSetWrappingRowSetTests {
 	public void testGetDateInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getDate", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getDate", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Date(1234l));
+		doTest(rset, rowset, 1, new Date(1234l));
 	}
 
 	@Test
@@ -106,7 +106,7 @@ public class ResultSetWrappingRowSetTests {
 	public void testGetTimeInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getTime", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getTime", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Time(1234l));
+		doTest(rset, rowset, 1, new Time(1234l));
 	}
 
 	@Test
@@ -120,7 +120,7 @@ public class ResultSetWrappingRowSetTests {
 	public void testGetObjectInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getObject", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getObject", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Object());
+		doTest(rset, rowset, 1, new Object());
 	}
 
 	@Test
@@ -134,70 +134,70 @@ public class ResultSetWrappingRowSetTests {
 	public void testGetIntInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getInt", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getInt", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Integer(1));
+		doTest(rset, rowset, 1, 1);
 	}
 
 	@Test
 	public void testGetIntString() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getInt", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getInt", new Class[] {String.class});
-		doTest(rset, rowset, "test", new Integer(1));
+		doTest(rset, rowset, "test", 1);
 	}
 
 	@Test
 	public void testGetFloatInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getFloat", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getFloat", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Float(1));
+		doTest(rset, rowset, 1, 1.0f);
 	}
 
 	@Test
 	public void testGetFloatString() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getFloat", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getFloat", new Class[] {String.class});
-		doTest(rset, rowset, "test", new Float(1));
+		doTest(rset, rowset, "test", 1.0f);
 	}
 
 	@Test
 	public void testGetDoubleInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getDouble", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getDouble", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Double(1));
+		doTest(rset, rowset, 1, 1.0d);
 	}
 
 	@Test
 	public void testGetDoubleString() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getDouble", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getDouble", new Class[] {String.class});
-		doTest(rset, rowset, "test", new Double(1));
+		doTest(rset, rowset, "test", 1.0d);
 	}
 
 	@Test
 	public void testGetLongInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getLong", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getLong", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Long(1));
+		doTest(rset, rowset, 1, 1L);
 	}
 
 	@Test
 	public void testGetLongString() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getLong", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getLong", new Class[] {String.class});
-		doTest(rset, rowset, "test", new Long(1));
+		doTest(rset, rowset, "test", 1L);
 	}
 
 	@Test
 	public void testGetBooleanInt() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getBoolean", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getBoolean", new Class[] {int.class});
-		doTest(rset, rowset, new Integer(1), new Boolean(true));
+		doTest(rset, rowset, 1, true);
 	}
 
 	@Test
 	public void testGetBooleanString() throws Exception {
 		Method rset = ResultSet.class.getDeclaredMethod("getBoolean", new Class[] {int.class});
 		Method rowset = ResultSetWrappingSqlRowSet.class.getDeclaredMethod("getBoolean", new Class[] {String.class});
-		doTest(rset, rowset, "test", new Boolean(true));
+		doTest(rset, rowset, "test", true);
 	}
 
 	private void doTest(Method rsetMethod, Method rowsetMethod, Object arg, Object ret) throws Exception {


### PR DESCRIPTION
Clean up compiler warnings in the tests of spring-jdbc. This commit
adds type parameters to all the types (mostly `List` and `Map`). In
addition it uses Java 5 autoboxing to get rid of all of the following
- new Integer
- new Long
- new Float
- new Double
- new Boolean
- new String

This should be unnoticeably faster since interning can be uses for
Integer and such.

After this commit the only warnings in spring-jdbc left are:
- raw type warning in `MapDataSourceLookupTests`, that code would never
  compile with generics
- deprecation warning for `#queryForInt` and `#queryForLong`

I did sign the CLA
