### PR TITLE
Clean up spring-messaging imports

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/MethodArgumentTypeMismatchException.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/MethodArgumentTypeMismatchException.java
@@ -18,7 +18,6 @@ package org.springframework.messaging.handler.annotation.support;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
 
 /**
  * Exception that indicates that a method argument has not the

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/AbstractSubscriptionRegistry.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/AbstractSubscriptionRegistry.java
@@ -22,7 +22,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
-import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.util.MultiValueMap;
 
 /**

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/config/AbstractMessageBrokerConfiguration.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/config/AbstractMessageBrokerConfiguration.java
@@ -17,13 +17,7 @@
 package org.springframework.messaging.simp.config;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationResolver.java
@@ -18,8 +18,6 @@ package org.springframework.messaging.simp.user;
 
 import org.springframework.messaging.Message;
 
-import java.util.Set;
-
 /**
  * A strategy for resolving a "user" destination and translating it to one or more
  * actual destinations unique to the user's active session(s).

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationResult.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationResult.java
@@ -18,7 +18,6 @@ package org.springframework.messaging.simp.user;
 
 import org.springframework.util.Assert;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**

--- a/spring-messaging/src/main/java/org/springframework/messaging/support/ChannelInterceptorChain.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/ChannelInterceptorChain.java
@@ -18,7 +18,6 @@ package org.springframework.messaging.support;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.commons.logging.Log;

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/MessageConverterTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/MessageConverterTests.java
@@ -33,7 +33,6 @@ import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Unit tests for

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/SimpleMessageConverterTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/SimpleMessageConverterTests.java
@@ -23,7 +23,6 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 
 import java.util.Collections;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/SimpMessagingTemplateTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/SimpMessagingTemplateTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.messaging.simp;
 
-import org.apache.activemq.transport.stomp.Stomp;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.messaging.Message;

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandlerTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandlerTests.java
@@ -36,7 +36,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.StringMessageConverter;
-import org.springframework.messaging.core.MessageSendingOperations;
 import org.springframework.messaging.handler.DestinationPatternsMessageCondition;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -50,7 +49,6 @@ import org.springframework.util.MimeType;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 /**

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompHeaderAccessorTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompHeaderAccessorTests.java
@@ -35,7 +35,6 @@ import org.springframework.util.MimeTypeUtils;
 import org.springframework.util.MultiValueMap;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Unit tests for {@link StompHeaderAccessor}.

--- a/spring-messaging/src/test/java/org/springframework/messaging/support/MessageHeaderAccessorTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/support/MessageHeaderAccessorTests.java
@@ -30,7 +30,6 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.IdGenerator;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test fixture for {@link MessageHeaderAccessor}.

--- a/spring-messaging/src/test/java/org/springframework/messaging/support/NativeMessageHeaderAccessorTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/support/NativeMessageHeaderAccessorTests.java
@@ -19,7 +19,6 @@ package org.springframework.messaging.support;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test fixture for {@link NativeMessageHeaderAccessor}.


### PR DESCRIPTION
spring-messaging is full of unused imports. This commit removes all
unused imports from spring-messaging.

I did sing the CLA
