### PR TITLE
Clean up spring-webmvc-portlet tests warnings

### DIFF
--- a/spring-webmvc-portlet/src/test/java/org/springframework/context/BeanThatListens.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/context/BeanThatListens.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * @author Thomas Risberg
  * @author Juergen Hoeller
  */
-public class BeanThatListens implements ApplicationListener {
+public class BeanThatListens implements ApplicationListener<ApplicationEvent> {
 
 	private BeanThatBroadcasts beanThatBroadcasts;
 
@@ -36,7 +36,7 @@ public class BeanThatListens implements ApplicationListener {
 
 	public BeanThatListens(BeanThatBroadcasts beanThatBroadcasts) {
 		this.beanThatBroadcasts = beanThatBroadcasts;
-		Map beans = beanThatBroadcasts.applicationContext.getBeansOfType(BeanThatListens.class);
+		Map<String, BeanThatListens> beans = beanThatBroadcasts.applicationContext.getBeansOfType(BeanThatListens.class);
 		if (!beans.isEmpty()) {
 			throw new IllegalStateException("Shouldn't have found any BeanThatListens instances");
 		}

--- a/spring-webmvc-portlet/src/test/java/org/springframework/context/TestListener.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/context/TestListener.java
@@ -9,7 +9,7 @@ import org.springframework.context.ApplicationListener;
  * @author Rod Johnson
  * @since January 21, 2001
  */
-public class TestListener implements ApplicationListener {
+public class TestListener implements ApplicationListener<ApplicationEvent> {
 
 	private int eventCount;
 

--- a/spring-webmvc-portlet/src/test/java/org/springframework/mock/web/portlet/MockPortletRequest.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/mock/web/portlet/MockPortletRequest.java
@@ -271,8 +271,8 @@ public class MockPortletRequest implements PortletRequest {
 	@Override
 	public String getProperty(String key) {
 		Assert.notNull(key, "Property key must not be null");
-		List list = this.properties.get(key);
-		return (list != null && list.size() > 0 ? (String) list.get(0) : null);
+		List<String> list = this.properties.get(key);
+		return (list != null && list.size() > 0 ? list.get(0) : null);
 	}
 
 	@Override

--- a/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/ComplexPortletApplicationContext.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/ComplexPortletApplicationContext.java
@@ -39,6 +39,7 @@ import javax.portlet.ResourceResponse;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.config.BeanReference;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.ManagedList;
@@ -118,14 +119,14 @@ public class ComplexPortletApplicationContext extends StaticPortletApplicationCo
 		ParameterMappingInterceptor parameterMappingInterceptor = new ParameterMappingInterceptor();
 		parameterMappingInterceptor.setParameterName("interceptingParam");
 
-		List interceptors = new ArrayList();
+		List<HandlerInterceptor> interceptors = new ArrayList<HandlerInterceptor>(4);
 		interceptors.add(parameterMappingInterceptor);
 		interceptors.add(userRoleInterceptor);
 		interceptors.add(new MyHandlerInterceptor1());
 		interceptors.add(new MyHandlerInterceptor2());
 
 		MutablePropertyValues pvs = new MutablePropertyValues();
-		Map portletModeMap = new ManagedMap();
+		Map<String, BeanReference> portletModeMap = new ManagedMap<String, BeanReference>();
 		portletModeMap.put("view", new RuntimeBeanReference("viewController"));
 		portletModeMap.put("edit", new RuntimeBeanReference("editController"));
 		pvs.add("portletModeMap", portletModeMap);
@@ -133,7 +134,7 @@ public class ComplexPortletApplicationContext extends StaticPortletApplicationCo
 		registerSingleton("handlerMapping3", PortletModeHandlerMapping.class, pvs);
 
 		pvs = new MutablePropertyValues();
-		Map parameterMap = new ManagedMap();
+		Map<String, BeanReference> parameterMap = new ManagedMap<String, BeanReference>();
 		parameterMap.put("test1", new RuntimeBeanReference("testController1"));
 		parameterMap.put("test2", new RuntimeBeanReference("testController2"));
 		parameterMap.put("requestLocaleChecker", new RuntimeBeanReference("requestLocaleCheckingController"));
@@ -148,10 +149,10 @@ public class ComplexPortletApplicationContext extends StaticPortletApplicationCo
 		registerSingleton("handlerMapping2", ParameterHandlerMapping.class, pvs);
 
 		pvs = new MutablePropertyValues();
-		Map innerMap = new ManagedMap();
+		Map<String, Object> innerMap = new ManagedMap<String, Object>();
 		innerMap.put("help1", new RuntimeBeanReference("helpController1"));
 		innerMap.put("help2", new RuntimeBeanReference("helpController2"));
-		Map outerMap = new ManagedMap();
+		Map<String, Object> outerMap = new ManagedMap<String, Object>();
 		outerMap.put("help", innerMap);
 		pvs.add("portletModeParameterMap", outerMap);
 		pvs.add("order", "1");
@@ -171,7 +172,7 @@ public class ComplexPortletApplicationContext extends StaticPortletApplicationCo
 		pvs.add("exceptionMappings",
 				"java.lang.Exception=failed-exception\n" +
 				"java.lang.RuntimeException=failed-runtime");
-		List mappedHandlers = new ManagedList();
+		List<BeanReference> mappedHandlers = new ManagedList<BeanReference>();
 		mappedHandlers.add(new RuntimeBeanReference("exceptionThrowingHandler1"));
 		pvs.add("mappedHandlers", mappedHandlers);
 		pvs.add("defaultErrorView", "failed-default-0");
@@ -533,7 +534,7 @@ public class ComplexPortletApplicationContext extends StaticPortletApplicationCo
 	}
 
 
-	public static class TestApplicationListener implements ApplicationListener {
+	public static class TestApplicationListener implements ApplicationListener<ApplicationEvent> {
 
 		public int counter = 0;
 

--- a/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/DispatcherPortletTests.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/DispatcherPortletTests.java
@@ -125,7 +125,7 @@ public class DispatcherPortletTests extends TestCase {
 		request.setPortletMode(PortletMode.HELP);
 		request.setParameter("action", "help3");
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		assertTrue(model.get("exception").getClass().equals(NoHandlerFoundException.class));
 		InternalResourceView view = (InternalResourceView) request.getAttribute(ViewRendererServlet.VIEW_ATTRIBUTE);
 		assertEquals("failed-unavailable", view.getBeanName());
@@ -164,7 +164,7 @@ public class DispatcherPortletTests extends TestCase {
 		request.setParameter("action", "not mapped");
 		request.setParameter("myParam", "not mapped");
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		assertEquals("view was here", model.get("result"));
 		InternalResourceView view = (InternalResourceView) request.getAttribute(ViewRendererServlet.VIEW_ATTRIBUTE);
 		assertEquals("someViewName", view.getBeanName());
@@ -178,7 +178,7 @@ public class DispatcherPortletTests extends TestCase {
 		request.setParameter("action", "not mapped");
 		request.setParameter("myParam", "not mapped");
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		Exception exception = (Exception) model.get("exception");
 		assertNotNull(exception);
 		assertTrue(exception.getClass().equals(PortletSecurityException.class));
@@ -222,7 +222,7 @@ public class DispatcherPortletTests extends TestCase {
 		MockRenderResponse response = new MockRenderResponse();
 		request.setParameter("myParam", "unknown");
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		Exception exception = (Exception)model.get("exception");
 		assertTrue(exception.getClass().equals(PortletException.class));
 		assertTrue(exception.getMessage().indexOf("No adapter for handler") != -1);
@@ -255,7 +255,7 @@ public class DispatcherPortletTests extends TestCase {
 		MockRenderResponse response = new MockRenderResponse();
 		request.setParameter("myParam", "test1");
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		Exception exception = (Exception) model.get("exception");
 		assertTrue(exception.getClass().equals(NoHandlerFoundException.class));
 		InternalResourceView view = (InternalResourceView) request.getAttribute(ViewRendererServlet.VIEW_ATTRIBUTE);
@@ -333,7 +333,7 @@ public class DispatcherPortletTests extends TestCase {
 		request.setParameter("myParam", "requestLocaleChecker");
 		request.addPreferredLocale(Locale.ENGLISH);
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		Exception exception = (Exception) model.get("exception");
 		assertTrue(exception.getClass().equals(PortletException.class));
 		assertEquals("Incorrect Locale in RenderRequest", exception.getMessage());
@@ -356,7 +356,7 @@ public class DispatcherPortletTests extends TestCase {
 		request.setParameter("myParam", "contextLocaleChecker");
 		request.addPreferredLocale(Locale.ENGLISH);
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		Exception exception = (Exception) model.get("exception");
 		assertTrue(exception.getClass().equals(PortletException.class));
 		assertEquals("Incorrect Locale in LocaleContextHolder", exception.getMessage());
@@ -401,7 +401,7 @@ public class DispatcherPortletTests extends TestCase {
 		request.addUserRole("role1");
 		request.addParameter("noView", "false");
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		assertEquals("view was here", model.get("result"));
 		InternalResourceView view = (InternalResourceView) request.getAttribute(ViewRendererServlet.VIEW_ATTRIBUTE);
 		assertEquals("someViewName", view.getBeanName());
@@ -414,7 +414,7 @@ public class DispatcherPortletTests extends TestCase {
 		request.addUserRole("role1");
 		request.addParameter("noView", "true");
 		complexDispatcherPortlet.doDispatch(request, response);
-		Map model = (Map) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
+		Map<?, ?> model = (Map<?, ?>) request.getAttribute(ViewRendererServlet.MODEL_ATTRIBUTE);
 		assertNull(model);
 		InternalResourceView view = (InternalResourceView) request.getAttribute(ViewRendererServlet.VIEW_ATTRIBUTE);
 		assertNull(view);

--- a/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/bind/PortletRequestDataBinderTests.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/bind/PortletRequestDataBinderTests.java
@@ -166,7 +166,7 @@ public class PortletRequestDataBinderTests extends TestCase {
 
 	public void testBindingSet() {
 		TestBean bean = new TestBean();
-		Set set = new LinkedHashSet<>(2);
+		Set<TestBean> set = new LinkedHashSet<TestBean>(2);
 		set.add(new TestBean("test1"));
 		set.add(new TestBean("test2"));
 		bean.setSomeSet(set);
@@ -181,7 +181,7 @@ public class PortletRequestDataBinderTests extends TestCase {
 		assertNotNull(bean.getSomeSet());
 		assertEquals(2, bean.getSomeSet().size());
 
-		Iterator iter = bean.getSomeSet().iterator();
+		Iterator<?> iter = bean.getSomeSet().iterator();
 
 		TestBean bean1 = (TestBean) iter.next();
 		assertEquals("test1", bean1.getName());

--- a/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/context/PortletWebRequestTests.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/context/PortletWebRequestTests.java
@@ -56,13 +56,13 @@ public class PortletWebRequestTests {
 		assertEquals("value2", request.getParameterValues("param2")[0]);
 		assertEquals("value2a", request.getParameterValues("param2")[1]);
 
-		Map paramMap = request.getParameterMap();
+		Map<String, String[]> paramMap = request.getParameterMap();
 		assertEquals(2, paramMap.size());
-		assertEquals(1, ((String[]) paramMap.get("param1")).length);
-		assertEquals("value1", ((String[]) paramMap.get("param1"))[0]);
-		assertEquals(2, ((String[]) paramMap.get("param2")).length);
-		assertEquals("value2", ((String[]) paramMap.get("param2"))[0]);
-		assertEquals("value2a", ((String[]) paramMap.get("param2"))[1]);
+		assertEquals(1, paramMap.get("param1").length);
+		assertEquals("value1", paramMap.get("param1")[0]);
+		assertEquals(2, paramMap.get("param2").length);
+		assertEquals("value2", paramMap.get("param2")[0]);
+		assertEquals("value2a", paramMap.get("param2")[1]);
 	}
 
 	@Test

--- a/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/mvc/annotation/Portlet20AnnotationControllerTests.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/mvc/annotation/Portlet20AnnotationControllerTests.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.EventResponse;
@@ -39,7 +40,6 @@ import javax.portlet.WindowState;
 import javax.servlet.http.Cookie;
 
 import org.junit.Test;
-
 import org.springframework.beans.BeansException;
 import org.springframework.tests.sample.beans.DerivedTestBean;
 import org.springframework.tests.sample.beans.ITestBean;
@@ -173,7 +173,7 @@ public class Portlet20AnnotationControllerTests {
 		doTestAdaptedHandleMethods(MyAdaptedController4.class);
 	}
 
-	private void doTestAdaptedHandleMethods(final Class controllerClass) throws Exception {
+	private void doTestAdaptedHandleMethods(final Class<?> controllerClass) throws Exception {
 		DispatcherPortlet portlet = new DispatcherPortlet() {
 			@Override
 			protected ApplicationContext createPortletApplicationContext(ApplicationContext parent) throws BeansException {
@@ -1233,7 +1233,7 @@ public class Portlet20AnnotationControllerTests {
 
 	private static class TestView {
 
-		public void render(String viewName, Map model, PortletRequest request, MimeResponse response) throws Exception {
+		public void render(String viewName, Map<String, Object> model, PortletRequest request, MimeResponse response) throws Exception {
 			TestBean tb = (TestBean) model.get("testBean");
 			if (tb == null) {
 				tb = (TestBean) model.get("myCommand");
@@ -1248,9 +1248,9 @@ public class Portlet20AnnotationControllerTests {
 			if (errors.hasFieldErrors("date")) {
 				throw new IllegalStateException();
 			}
-			List<TestBean> testBeans = (List<TestBean>) model.get("testBeanList");
+			List<?> testBeans = (List<?>) model.get("testBeanList");
 			response.getWriter().write(viewName + "-" + tb.getName() + "-" + errors.getFieldError("age").getCode() +
-					"-" + testBeans.get(0).getName() + "-" + model.get("myKey"));
+					"-" + ((TestBean) testBeans.get(0)).getName() + "-" + model.get("myKey"));
 		}
 	}
 

--- a/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/mvc/annotation/PortletAnnotationControllerTests.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/mvc/annotation/PortletAnnotationControllerTests.java
@@ -114,7 +114,7 @@ public class PortletAnnotationControllerTests extends TestCase {
 		doTestAdaptedHandleMethods(MyAdaptedController3.class);
 	}
 
-	public void doTestAdaptedHandleMethods(final Class controllerClass) throws Exception {
+	public void doTestAdaptedHandleMethods(final Class<?> controllerClass) throws Exception {
 		DispatcherPortlet portlet = new DispatcherPortlet() {
 			@Override
 			protected ApplicationContext createPortletApplicationContext(ApplicationContext parent) throws BeansException {
@@ -796,7 +796,7 @@ public class PortletAnnotationControllerTests extends TestCase {
 
 	private static class TestView {
 
-		public void render(String viewName, Map model, PortletRequest request, MimeResponse response) throws Exception {
+		public void render(String viewName, Map<String, Object> model, PortletRequest request, MimeResponse response) throws Exception {
 			TestBean tb = (TestBean) model.get("testBean");
 			if (tb == null) {
 				tb = (TestBean) model.get("myCommand");
@@ -811,9 +811,9 @@ public class PortletAnnotationControllerTests extends TestCase {
 			if (errors.hasFieldErrors("date")) {
 				throw new IllegalStateException();
 			}
-			List<TestBean> testBeans = (List<TestBean>) model.get("testBeanList");
+			List<?> testBeans = (List<?>) model.get("testBeanList");
 			response.getWriter().write(viewName + "-" + tb.getName() + "-" + errors.getFieldError("age").getCode() +
-					"-" + testBeans.get(0).getName() + "-" + model.get("myKey"));
+					"-" + ((TestBean) testBeans.get(0)).getName() + "-" + model.get("myKey"));
 		}
 	}
 
@@ -830,7 +830,7 @@ public class PortletAnnotationControllerTests extends TestCase {
 
 		@Override
 		public org.springframework.web.servlet.ModelAndView resolveModelAndView(Method handlerMethod,
-				Class handlerType,
+				Class<?> handlerType,
 				Object returnValue,
 				ExtendedModelMap implicitModel,
 				NativeWebRequest webRequest) {

--- a/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/util/PortletUtilsTests.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/util/PortletUtilsTests.java
@@ -245,8 +245,7 @@ public final class PortletUtilsTests {
 	public void testClearAllRenderParametersDoesNotPropagateExceptionIfRedirectAlreadySentAtTimeOfCall() throws Exception {
 		MockActionResponse response = new MockActionResponse() {
 			@Override
-			@SuppressWarnings("unchecked")
-			public void setRenderParameters(Map parameters) {
+			public void setRenderParameters(Map<String, String[]> parameters) {
 				throw new IllegalStateException();
 			}
 		};
@@ -302,7 +301,6 @@ public final class PortletUtilsTests {
 		PortletUtils.exposeRequestAttributes(new MockPortletRequest(), null);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testExposeRequestAttributesSunnyDay() throws Exception {
 		MockPortletRequest request = new MockPortletRequest();
@@ -314,7 +312,6 @@ public final class PortletUtilsTests {
 		assertEquals("Roy Fokker", request.getAttribute("mentor"));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testExposeRequestAttributesWithEmptyAttributesMapIsAnIdempotentOperation() throws Exception {
 		MockPortletRequest request = new MockPortletRequest();


### PR DESCRIPTION
Clean up compiler warnings in the tests of spring-webmvc-portlet. This
commit adds type parameters to all the types (mostly `List` and `Map`).

After this commit the only warnings in spring-web left are the
subclasses of `MyCommandProvidingFormController`.

I did sing the CLA
