### PR TITLE
Clean up spring-expression tests warnings

### DIFF
--- a/spring-expression/src/test/java/org/springframework/expression/spel/ExpressionWithConversionTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/ExpressionWithConversionTests.java
@@ -75,14 +75,14 @@ public class ExpressionWithConversionTests extends AbstractExpressionTests {
 		// ArrayList containing List<Integer> to List<String>
 		Class<?> clazz = typeDescriptorForListOfString.getElementTypeDescriptor().getType();
 		assertEquals(String.class,clazz);
-		List l = (List) tcs.convertValue(listOfInteger, TypeDescriptor.forObject(listOfInteger), typeDescriptorForListOfString);
+		List<?> l = (List<?>) tcs.convertValue(listOfInteger, TypeDescriptor.forObject(listOfInteger), typeDescriptorForListOfString);
 		assertNotNull(l);
 
 		// ArrayList containing List<String> to List<Integer>
 		clazz = typeDescriptorForListOfInteger.getElementTypeDescriptor().getType();
 		assertEquals(Integer.class,clazz);
 
-		l = (List) tcs.convertValue(listOfString, TypeDescriptor.forObject(listOfString), typeDescriptorForListOfString);
+		l = (List<?>) tcs.convertValue(listOfString, TypeDescriptor.forObject(listOfString), typeDescriptorForListOfString);
 		assertNotNull(l);
 	}
 
@@ -95,7 +95,7 @@ public class ExpressionWithConversionTests extends AbstractExpressionTests {
 		// Assign a List<String> to the List<Integer> field - the component elements should be converted
 		parser.parseExpression("listOfInteger").setValue(context,listOfString);
 		assertEquals(3,e.getValue(context,Integer.class).intValue()); // size now 3
-		Class clazz = parser.parseExpression("listOfInteger[1].getClass()").getValue(context,Class.class); // element type correctly Integer
+		Class<?> clazz = parser.parseExpression("listOfInteger[1].getClass()").getValue(context, Class.class); // element type correctly Integer
 		assertEquals(Integer.class,clazz);
 	}
 

--- a/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
@@ -64,12 +64,12 @@ public class IndexingTests {
 
 		@Override
 		public boolean canRead(EvaluationContext context, Object target, String name) throws AccessException {
-			return (((Map) target).containsKey(name));
+			return (((Map<?, ?>) target).containsKey(name));
 		}
 
 		@Override
 		public TypedValue read(EvaluationContext context, Object target, String name) throws AccessException {
-			return new TypedValue(((Map) target).get(name));
+			return new TypedValue(((Map<?, ?>) target).get(name));
 		}
 
 		@Override
@@ -298,7 +298,7 @@ public class IndexingTests {
 
 	@Test
 	public void resolveCollectionElementType() {
-		listNotGeneric = new ArrayList();
+		listNotGeneric = new ArrayList(2);
 		listNotGeneric.add(5);
 		listNotGeneric.add(6);
 		SpelExpressionParser parser = new SpelExpressionParser();
@@ -338,7 +338,7 @@ public class IndexingTests {
 
 	@Test
 	public void testListOfScalar() {
-		listOfScalarNotGeneric = new ArrayList();
+		listOfScalarNotGeneric = new ArrayList(1);
 		listOfScalarNotGeneric.add("5");
 		SpelExpressionParser parser = new SpelExpressionParser();
 		Expression expression = parser.parseExpression("listOfScalarNotGeneric[0]");

--- a/spring-expression/src/test/java/org/springframework/expression/spel/MapAccessTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/MapAccessTests.java
@@ -182,12 +182,12 @@ public class MapAccessTests extends AbstractExpressionTests {
 
 		@Override
 		public boolean canRead(EvaluationContext context, Object target, String name) throws AccessException {
-			return (((Map) target).containsKey(name));
+			return (((Map<?, ?>) target).containsKey(name));
 		}
 
 		@Override
 		public TypedValue read(EvaluationContext context, Object target, String name) throws AccessException {
-			return new TypedValue(((Map) target).get(name));
+			return new TypedValue(((Map<? ,?>) target).get(name));
 		}
 
 		@Override

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SelectionAndProjectionTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SelectionAndProjectionTests.java
@@ -46,7 +46,7 @@ public class SelectionAndProjectionTests {
 		EvaluationContext context = new StandardEvaluationContext(new ListTestBean());
 		Object value = expression.getValue(context);
 		assertTrue(value instanceof List);
-		List list = (List) value;
+		List<?> list = (List<?>) value;
 		assertEquals(5, list.size());
 		assertEquals(0, list.get(0));
 		assertEquals(1, list.get(1));
@@ -79,7 +79,7 @@ public class SelectionAndProjectionTests {
 		EvaluationContext context = new StandardEvaluationContext(new SetTestBean());
 		Object value = expression.getValue(context);
 		assertTrue(value instanceof List);
-		List list = (List) value;
+		List<?> list = (List<?>) value;
 		assertEquals(5, list.size());
 		assertEquals(0, list.get(0));
 		assertEquals(1, list.get(1));
@@ -221,7 +221,7 @@ public class SelectionAndProjectionTests {
 		context.setVariable("testList", IntegerTestBean.createList());
 		Object value = expression.getValue(context);
 		assertTrue(value instanceof List);
-		List list = (List) value;
+		List<?> list = (List<?>) value;
 		assertEquals(3, list.size());
 		assertEquals(5, list.get(0));
 		assertEquals(6, list.get(1));
@@ -235,7 +235,7 @@ public class SelectionAndProjectionTests {
 		context.setVariable("testList", IntegerTestBean.createSet());
 		Object value = expression.getValue(context);
 		assertTrue(value instanceof List);
-		List list = (List) value;
+		List<?> list = (List<?>) value;
 		assertEquals(3, list.size());
 		assertEquals(5, list.get(0));
 		assertEquals(6, list.get(1));

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SetValueTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SetValueTests.java
@@ -166,15 +166,15 @@ public class SetValueTests extends AbstractExpressionTests {
 		e.setValue(eContext, "true");
 
 		// All keys should be strings
-		Set ks = parse("mapOfStringToBoolean.keySet()").getValue(eContext,Set.class);
+		Set<?> ks = parse("mapOfStringToBoolean.keySet()").getValue(eContext, Set.class);
 		for (Object o: ks) {
 			assertEquals(String.class,o.getClass());
 		}
 
 		// All values should be booleans
-		Collection vs = parse("mapOfStringToBoolean.values()").getValue(eContext,Collection.class);
+		Collection<?> vs = parse("mapOfStringToBoolean.values()").getValue(eContext, Collection.class);
 		for (Object o: vs) {
-			assertEquals(Boolean.class,o.getClass());
+			assertEquals(Boolean.class, o.getClass());
 		}
 
 		// One final test check coercion on the key for a map lookup

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
@@ -383,8 +383,8 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 
 	@Test
 	public void testTypes() throws Exception {
-		Class dateClass = parser.parseExpression("T(java.util.Date)").getValue(Class.class);
-		assertEquals(Date.class,dateClass);
+		Class<?> dateClass = parser.parseExpression("T(java.util.Date)").getValue(Class.class);
+		assertEquals(Date.class, dateClass);
 		boolean trueValue = parser.parseExpression("T(java.math.RoundingMode).CEILING < T(java.math.RoundingMode).FLOOR").getValue(Boolean.class);
 		assertTrue(trueValue);
 	}

--- a/spring-expression/src/test/java/org/springframework/expression/spel/support/ReflectionHelperTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/support/ReflectionHelperTests.java
@@ -481,7 +481,7 @@ public class ReflectionHelperTests extends AbstractExpressionTests {
 	/**
 	 * Used to validate the match returned from a compareArguments call.
 	 */
-	private void checkMatch(Class[] inputTypes, Class[] expectedTypes, StandardTypeConverter typeConverter, ArgumentsMatchKind expectedMatchKind) {
+	private void checkMatch(Class<?>[] inputTypes, Class<?>[] expectedTypes, StandardTypeConverter typeConverter, ArgumentsMatchKind expectedMatchKind) {
 		ReflectionHelper.ArgumentsMatchInfo matchInfo = ReflectionHelper.compareArguments(getTypeDescriptors(expectedTypes), getTypeDescriptors(inputTypes), typeConverter);
 		if (expectedMatchKind == null) {
 			assertNull("Did not expect them to match in any way", matchInfo);
@@ -504,7 +504,7 @@ public class ReflectionHelperTests extends AbstractExpressionTests {
 	/**
 	 * Used to validate the match returned from a compareArguments call.
 	 */
-	private void checkMatch2(Class[] inputTypes, Class[] expectedTypes, StandardTypeConverter typeConverter, ArgumentsMatchKind expectedMatchKind) {
+	private void checkMatch2(Class<?>[] inputTypes, Class<?>[] expectedTypes, StandardTypeConverter typeConverter, ArgumentsMatchKind expectedMatchKind) {
 		ReflectionHelper.ArgumentsMatchInfo matchInfo = ReflectionHelper.compareArgumentsVarargs(getTypeDescriptors(expectedTypes), getTypeDescriptors(inputTypes), typeConverter);
 		if (expectedMatchKind == null) {
 			assertNull("Did not expect them to match in any way: " + matchInfo, matchInfo);
@@ -535,9 +535,9 @@ public class ReflectionHelperTests extends AbstractExpressionTests {
 		assertEquals(expected,actual);
 	}
 
-	private List<TypeDescriptor> getTypeDescriptors(Class... types) {
+	private List<TypeDescriptor> getTypeDescriptors(Class<?>... types) {
 		List<TypeDescriptor> typeDescriptors = new ArrayList<TypeDescriptor>(types.length);
-		for (Class type : types) {
+		for (Class<?> type : types) {
 			typeDescriptors.add(TypeDescriptor.valueOf(type));
 		}
 		return typeDescriptors;


### PR DESCRIPTION
Clean up compiler warnings in the tests of spring-expression. This
commit adds type parameters to some of the types (mostly `List` and
`Map`). Some of them can't be cleaned up, some tests are even
specifically for raw types.

I did sing the CLA
