### PR TITLE
Clean up spring-web tests warnings

### DIFF
--- a/spring-web/src/test/java/org/springframework/http/client/AbstractJettyServerTestCase.java
+++ b/spring-web/src/test/java/org/springframework/http/client/AbstractJettyServerTestCase.java
@@ -149,10 +149,10 @@ public class AbstractJettyServerTestCase {
 
 		private void echo(HttpServletRequest request, HttpServletResponse response) throws IOException {
 			response.setStatus(HttpServletResponse.SC_OK);
-			for (Enumeration e1 = request.getHeaderNames(); e1.hasMoreElements();) {
-				String headerName = (String) e1.nextElement();
-				for (Enumeration e2 = request.getHeaders(headerName); e2.hasMoreElements();) {
-					String headerValue = (String) e2.nextElement();
+			for (Enumeration<String> e1 = request.getHeaderNames(); e1.hasMoreElements();) {
+				String headerName = e1.nextElement();
+				for (Enumeration<String> e2 = request.getHeaders(headerName); e2.hasMoreElements();) {
+					String headerValue = e2.nextElement();
 					response.addHeader(headerName, headerValue);
 				}
 			}

--- a/spring-web/src/test/java/org/springframework/http/converter/FormHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/FormHttpMessageConverterTests.java
@@ -131,31 +131,31 @@ public class FormHttpMessageConverterTests {
 		// see if Commons FileUpload can read what we wrote
 		FileItemFactory fileItemFactory = new DiskFileItemFactory();
 		FileUpload fileUpload = new FileUpload(fileItemFactory);
-		List items = fileUpload.parseRequest(new MockHttpOutputMessageRequestContext(outputMessage));
+		List<FileItem> items = fileUpload.parseRequest(new MockHttpOutputMessageRequestContext(outputMessage));
 		assertEquals(5, items.size());
-		FileItem item = (FileItem) items.get(0);
+		FileItem item = items.get(0);
 		assertTrue(item.isFormField());
 		assertEquals("name 1", item.getFieldName());
 		assertEquals("value 1", item.getString());
 
-		item = (FileItem) items.get(1);
+		item = items.get(1);
 		assertTrue(item.isFormField());
 		assertEquals("name 2", item.getFieldName());
 		assertEquals("value 2+1", item.getString());
 
-		item = (FileItem) items.get(2);
+		item = items.get(2);
 		assertTrue(item.isFormField());
 		assertEquals("name 2", item.getFieldName());
 		assertEquals("value 2+2", item.getString());
 
-		item = (FileItem) items.get(3);
+		item = items.get(3);
 		assertFalse(item.isFormField());
 		assertEquals("logo", item.getFieldName());
 		assertEquals("logo.jpg", item.getName());
 		assertEquals("image/jpeg", item.getContentType());
 		assertEquals(logo.getFile().length(), item.getSize());
 
-		item = (FileItem) items.get(4);
+		item = items.get(4);
 		assertEquals("xml", item.getFieldName());
 		assertEquals("text/xml", item.getContentType());
 		verify(outputMessage.getBody(), never()).close();
@@ -182,6 +182,7 @@ public class FormHttpMessageConverterTests {
 		}
 
 		@Override
+		@Deprecated
 		public int getContentLength() {
 			return outputMessage.getBodyAsBytes().length;
 		}

--- a/spring-web/src/test/java/org/springframework/http/converter/HttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/HttpMessageConverterTests.java
@@ -77,7 +77,7 @@ public class HttpMessageConverterTests {
 		}
 
 		@Override
-		protected T readInternal(Class clazz, HttpInputMessage inputMessage)
+		protected T readInternal(Class<? extends T> clazz, HttpInputMessage inputMessage)
 				throws IOException, HttpMessageNotReadableException {
 			fail("Not expected");
 			return null;

--- a/spring-web/src/test/java/org/springframework/http/converter/feed/AtomFeedHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/feed/AtomFeedHttpMessageConverterTests.java
@@ -70,7 +70,7 @@ public class AtomFeedHttpMessageConverterTests {
 		Feed result = converter.read(Feed.class, inputMessage);
 		assertEquals("title", result.getTitle());
 		assertEquals("subtitle", result.getSubtitle().getValue());
-		List entries = result.getEntries();
+		List<?> entries = result.getEntries();
 		assertEquals(2, entries.size());
 
 		Entry entry1 = (Entry) entries.get(0);
@@ -95,7 +95,7 @@ public class AtomFeedHttpMessageConverterTests {
 		entry2.setId("id2");
 		entry2.setTitle("title2");
 
-		List entries = new ArrayList(2);
+		List<Entry> entries = new ArrayList<Entry>(2);
 		entries.add(entry1);
 		entries.add(entry2);
 		feed.setEntries(entries);

--- a/spring-web/src/test/java/org/springframework/http/converter/feed/RssChannelHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/feed/RssChannelHttpMessageConverterTests.java
@@ -72,7 +72,7 @@ public class RssChannelHttpMessageConverterTests {
 		assertEquals("http://example.com", result.getLink());
 		assertEquals("description", result.getDescription());
 
-		List items = result.getItems();
+		List<?> items = result.getItems();
 		assertEquals(2, items.size());
 
 		Item item1 = (Item) items.get(0);
@@ -95,7 +95,7 @@ public class RssChannelHttpMessageConverterTests {
 		Item item2 = new Item();
 		item2.setTitle("title2");
 
-		List items = new ArrayList(2);
+		List<Item> items = new ArrayList<Item>(2);
 		items.add(item1);
 		items.add(item2);
 		channel.setItems(items);

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.beans.FatalBeanException;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -211,8 +210,8 @@ public class Jackson2ObjectMapperFactoryBeanTests {
 
 		factory.setObjectMapper(objectMapper);
 
-		JsonSerializer serializer1 = new ClassSerializer();
-		JsonSerializer serializer2 = new NumberSerializer();
+		JsonSerializer<Class<?>> serializer1 = new ClassSerializer();
+		JsonSerializer<Number> serializer2 = new NumberSerializer();
 
 		factory.setSerializers(serializer1);
 		factory.setSerializersByType(Collections.<Class<?>, JsonSerializer<?>> singletonMap(Boolean.class, serializer2));

--- a/spring-web/src/test/java/org/springframework/http/server/ServletServerHttpResponseTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/ServletServerHttpResponseTests.java
@@ -64,7 +64,7 @@ public class ServletServerHttpResponseTests {
 
 		response.close();
 		assertTrue("Header not set", mockResponse.getHeaderNames().contains(headerName));
-		List headerValues = mockResponse.getHeaders(headerName);
+		List<String> headerValues = mockResponse.getHeaders(headerName);
 		assertTrue("Header not set", headerValues.contains(headerValue1));
 		assertTrue("Header not set", headerValues.contains(headerValue2));
 		assertEquals("Invalid Content-Type", "text/plain;charset=UTF-8", mockResponse.getHeader("Content-Type"));

--- a/spring-web/src/test/java/org/springframework/web/context/request/ServletWebRequestTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/ServletWebRequestTests.java
@@ -19,6 +19,7 @@ package org.springframework.web.context.request;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
+
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
@@ -28,7 +29,6 @@ import javax.servlet.http.HttpServletResponseWrapper;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.mock.web.test.MockHttpServletResponse;
 import org.springframework.web.multipart.MultipartRequest;
@@ -69,13 +69,13 @@ public class ServletWebRequestTests {
 		assertEquals("value2", request.getParameterValues("param2")[0]);
 		assertEquals("value2a", request.getParameterValues("param2")[1]);
 
-		Map paramMap = request.getParameterMap();
+		Map<String, String[]> paramMap = request.getParameterMap();
 		assertEquals(2, paramMap.size());
-		assertEquals(1, ((String[]) paramMap.get("param1")).length);
-		assertEquals("value1", ((String[]) paramMap.get("param1"))[0]);
-		assertEquals(2, ((String[]) paramMap.get("param2")).length);
-		assertEquals("value2", ((String[]) paramMap.get("param2"))[0]);
-		assertEquals("value2a", ((String[]) paramMap.get("param2"))[1]);
+		assertEquals(1, paramMap.get("param1").length);
+		assertEquals("value1", paramMap.get("param1")[0]);
+		assertEquals(2, paramMap.get("param2").length);
+		assertEquals("value2", paramMap.get("param2")[0]);
+		assertEquals("value2a", paramMap.get("param2")[1]);
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/web/jsf/MockFacesContext.java
+++ b/spring-web/src/test/java/org/springframework/web/jsf/MockFacesContext.java
@@ -54,7 +54,7 @@ public class MockFacesContext extends FacesContext {
 	}
 
 	@Override
-	public Iterator getClientIdsWithMessages() {
+	public Iterator<String> getClientIdsWithMessages() {
 		return null;
 	}
 
@@ -73,12 +73,12 @@ public class MockFacesContext extends FacesContext {
 	}
 
 	@Override
-	public Iterator getMessages() {
+	public Iterator<FacesMessage> getMessages() {
 		return null;
 	}
 
 	@Override
-	public Iterator getMessages(String arg0) {
+	public Iterator<FacesMessage> getMessages(String clientId) {
 		return null;
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/multipart/commons/CommonsMultipartResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/multipart/commons/CommonsMultipartResolverTests.java
@@ -117,16 +117,16 @@ public class CommonsMultipartResolverTests {
 
 	private void doTestParameters(MultipartHttpServletRequest request) {
 		Set<String> parameterNames = new HashSet<String>();
-		Enumeration parameterEnum = request.getParameterNames();
+		Enumeration<String> parameterEnum = request.getParameterNames();
 		while (parameterEnum.hasMoreElements()) {
-			parameterNames.add((String) parameterEnum.nextElement());
+			parameterNames.add(parameterEnum.nextElement());
 		}
 		assertEquals(3, parameterNames.size());
 		assertTrue(parameterNames.contains("field3"));
 		assertTrue(parameterNames.contains("field4"));
 		assertTrue(parameterNames.contains("getField"));
 		assertEquals("value3", request.getParameter("field3"));
-		List parameterValues = Arrays.asList(request.getParameterValues("field3"));
+		List<String> parameterValues = Arrays.asList(request.getParameterValues("field3"));
 		assertEquals(1, parameterValues.size());
 		assertTrue(parameterValues.contains("value3"));
 		assertEquals("value4", request.getParameter("field4"));
@@ -166,9 +166,9 @@ public class CommonsMultipartResolverTests {
 
 	private void doTestFiles(MultipartHttpServletRequest request) throws IOException {
 		Set<String> fileNames = new HashSet<String>();
-		Iterator fileIter = request.getFileNames();
+		Iterator<String> fileIter = request.getFileNames();
 		while (fileIter.hasNext()) {
-			fileNames.add((String) fileIter.next());
+			fileNames.add(fileIter.next());
 		}
 		assertEquals(3, fileNames.size());
 		assertTrue(fileNames.contains("field1"));
@@ -373,7 +373,7 @@ public class CommonsMultipartResolverTests {
 		protected FileUpload newFileUpload(FileItemFactory fileItemFactory) {
 			return new ServletFileUpload() {
 				@Override
-				public List parseRequest(HttpServletRequest request) {
+				public List<FileItem> parseRequest(HttpServletRequest request) {
 					if (request instanceof MultipartHttpServletRequest) {
 						throw new IllegalStateException("Already a multipart request");
 					}

--- a/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityReferencesTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityReferencesTests.java
@@ -39,10 +39,10 @@ public class HtmlCharacterEntityReferencesTests {
 	@Test
 	public void testSupportsAllCharacterEntityReferencesDefinedByHtml() {
 		HtmlCharacterEntityReferences entityReferences = new HtmlCharacterEntityReferences();
-		Map referenceCharactersMap = getReferenceCharacterMap();
+		Map<Integer, String> referenceCharactersMap = getReferenceCharacterMap();
 
 		for (int character = 0; character < 10000; character++) {
-			String referenceName = (String) referenceCharactersMap.get(new Integer(character));
+			String referenceName = referenceCharactersMap.get(character);
 			if (referenceName != null) {
 				String fullReference =
 						HtmlCharacterEntityReferences.REFERENCE_START +
@@ -76,7 +76,7 @@ public class HtmlCharacterEntityReferencesTests {
 				(char) -1, entityReferences.convertToCharacter("invalid"));
 	}
 
-	private Map getReferenceCharacterMap() {
+	private Map<Integer, String> getReferenceCharacterMap() {
 		CharacterEntityResourceIterator entityIterator = new CharacterEntityResourceIterator();
 		Map<Integer, String> referencedCharactersMap = new HashMap<Integer, String>();
 		while (entityIterator.hasNext()) {

--- a/spring-web/src/test/java/org/springframework/web/util/MockLog4jAppender.java
+++ b/spring-web/src/test/java/org/springframework/web/util/MockLog4jAppender.java
@@ -27,7 +27,7 @@ import org.apache.log4j.spi.LoggingEvent;
  */
 public class MockLog4jAppender extends AppenderSkeleton {
 
-	public static final List loggingStrings = new ArrayList();
+	public static final List<Object> loggingStrings = new ArrayList<Object>();
 
 	public static boolean closeCalled = false;
 


### PR DESCRIPTION
Clean up compiler warnings in the tests of spring-web. This commit
adds type parameters to all the types (mostly `List` and `Map`).

After this commit the only warnings in spring-web left are in
- `MockExpressionEvaluator` this can't be fixed until JSP-EL is fixed
- `Jackson2ObjectMapperFactoryBeanTests#testSetModules` that code
  would never compile with generics.

I did sing the CLA
