### PR TITLE
Clean up spring-tx tests warnings

### DIFF
--- a/spring-tx/src/test/java/org/springframework/dao/support/DataAccessUtilsTests.java
+++ b/spring-tx/src/test/java/org/springframework/dao/support/DataAccessUtilsTests.java
@@ -37,7 +37,7 @@ import org.springframework.dao.TypeMismatchDataAccessException;
 public class DataAccessUtilsTests extends TestCase {
 
 	public void testWithEmptyCollection() {
-		Collection col = new HashSet();
+		Collection<String> col = new HashSet<String>();
 
 		assertNull(DataAccessUtils.uniqueResult(col));
 
@@ -83,7 +83,7 @@ public class DataAccessUtilsTests extends TestCase {
 	}
 
 	public void testWithTooLargeCollection() {
-		Collection col = new HashSet();
+		Collection<String> col = new HashSet<String>(2);
 		col.add("test1");
 		col.add("test2");
 
@@ -139,33 +139,33 @@ public class DataAccessUtilsTests extends TestCase {
 	}
 
 	public void testWithInteger() {
-		Collection col = new HashSet();
-		col.add(new Integer(5));
+		Collection<Integer> col = new HashSet<Integer>(1);
+		col.add(5);
 
-		assertEquals(new Integer(5), DataAccessUtils.uniqueResult(col));
-		assertEquals(new Integer(5), DataAccessUtils.requiredUniqueResult(col));
-		assertEquals(new Integer(5), DataAccessUtils.objectResult(col, Integer.class));
+		assertEquals(Integer.valueOf(5), DataAccessUtils.uniqueResult(col));
+		assertEquals(Integer.valueOf(5), DataAccessUtils.requiredUniqueResult(col));
+		assertEquals(Integer.valueOf(5), DataAccessUtils.objectResult(col, Integer.class));
 		assertEquals("5", DataAccessUtils.objectResult(col, String.class));
 		assertEquals(5, DataAccessUtils.intResult(col));
 		assertEquals(5, DataAccessUtils.longResult(col));
 	}
 
 	public void testWithSameIntegerInstanceTwice() {
-		Integer i = new Integer(5);
-		Collection col = new ArrayList();
+		Integer i = 5;
+		Collection<Integer> col = new ArrayList<Integer>(1);
 		col.add(i);
 		col.add(i);
 
-		assertEquals(new Integer(5), DataAccessUtils.uniqueResult(col));
-		assertEquals(new Integer(5), DataAccessUtils.requiredUniqueResult(col));
-		assertEquals(new Integer(5), DataAccessUtils.objectResult(col, Integer.class));
+		assertEquals(Integer.valueOf(5), DataAccessUtils.uniqueResult(col));
+		assertEquals(Integer.valueOf(5), DataAccessUtils.requiredUniqueResult(col));
+		assertEquals(Integer.valueOf(5), DataAccessUtils.objectResult(col, Integer.class));
 		assertEquals("5", DataAccessUtils.objectResult(col, String.class));
 		assertEquals(5, DataAccessUtils.intResult(col));
 		assertEquals(5, DataAccessUtils.longResult(col));
 	}
 
 	public void testWithEquivalentIntegerInstanceTwice() {
-		Collection col = new ArrayList();
+		Collection<Integer> col = new ArrayList<Integer>(2);
 		col.add(new Integer(5));
 		col.add(new Integer(5));
 
@@ -181,19 +181,19 @@ public class DataAccessUtilsTests extends TestCase {
 	}
 
 	public void testWithLong() {
-		Collection col = new HashSet();
-		col.add(new Long(5));
+		Collection<Long> col = new HashSet<Long>(1);
+		col.add(5L);
 
-		assertEquals(new Long(5), DataAccessUtils.uniqueResult(col));
-		assertEquals(new Long(5), DataAccessUtils.requiredUniqueResult(col));
-		assertEquals(new Long(5), DataAccessUtils.objectResult(col, Long.class));
+		assertEquals(Long.valueOf(5L), DataAccessUtils.uniqueResult(col));
+		assertEquals(Long.valueOf(5L), DataAccessUtils.requiredUniqueResult(col));
+		assertEquals(Long.valueOf(5L), DataAccessUtils.objectResult(col, Long.class));
 		assertEquals("5", DataAccessUtils.objectResult(col, String.class));
 		assertEquals(5, DataAccessUtils.intResult(col));
 		assertEquals(5, DataAccessUtils.longResult(col));
 	}
 
 	public void testWithString() {
-		Collection col = new HashSet();
+		Collection<String> col = new HashSet<String>(1);
 		col.add("test1");
 
 		assertEquals("test1", DataAccessUtils.uniqueResult(col));
@@ -219,7 +219,7 @@ public class DataAccessUtilsTests extends TestCase {
 
 	public void testWithDate() {
 		Date date = new Date();
-		Collection col = new HashSet();
+		Collection<Date> col = new HashSet<Date>(1);
 		col.add(date);
 
 		assertEquals(date, DataAccessUtils.uniqueResult(col));
@@ -262,9 +262,9 @@ public class DataAccessUtilsTests extends TestCase {
 	public static class MapPersistenceExceptionTranslator implements PersistenceExceptionTranslator {
 
 		/**
-		 * Map<RuntimeException,RuntimeException>: in to out
+		 * in to out
 		 */
-		private Map translations = new HashMap();
+		private Map<RuntimeException,RuntimeException> translations = new HashMap<RuntimeException,RuntimeException>();
 
 		public void addTranslation(RuntimeException in, RuntimeException out) {
 			this.translations.put(in, out);

--- a/spring-tx/src/test/java/org/springframework/jca/cci/CciLocalTransactionTests.java
+++ b/spring-tx/src/test/java/org/springframework/jca/cci/CciLocalTransactionTests.java
@@ -107,9 +107,9 @@ public class CciLocalTransactionTests {
 		TransactionTemplate tt = new TransactionTemplate(tm);
 
 		try {
-			tt.execute(new TransactionCallback() {
+			tt.execute(new TransactionCallback<Void>() {
 				@Override
-				public Object doInTransaction(TransactionStatus status) {
+				public Void doInTransaction(TransactionStatus status) {
 					assertTrue("Has thread connection", TransactionSynchronizationManager.hasResource(connectionFactory));
 					CciTemplate ct = new CciTemplate(connectionFactory);
 					ct.execute(interactionSpec, record, record);

--- a/spring-tx/src/test/java/org/springframework/transaction/MockCallbackPreferringTransactionManager.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/MockCallbackPreferringTransactionManager.java
@@ -31,7 +31,7 @@ public class MockCallbackPreferringTransactionManager implements CallbackPreferr
 
 
 	@Override
-	public Object execute(TransactionDefinition definition, TransactionCallback callback) throws TransactionException {
+	public <T> T execute(TransactionDefinition definition, TransactionCallback<T> callback) throws TransactionException {
 		this.definition = definition;
 		this.status = new SimpleTransactionStatus();
 		return callback.doInTransaction(this.status);

--- a/spring-tx/src/test/java/org/springframework/transaction/annotation/AnnotationTransactionNamespaceHandlerTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/annotation/AnnotationTransactionNamespaceHandlerTests.java
@@ -55,7 +55,7 @@ public class AnnotationTransactionNamespaceHandlerTests extends TestCase {
 	public void testIsProxy() throws Exception {
 		TransactionalTestBean bean = getTestBean();
 		assertTrue("testBean is not a proxy", AopUtils.isAopProxy(bean));
-		Map services = this.context.getBeansWithAnnotation(Service.class);
+		Map<String, Object> services = this.context.getBeansWithAnnotation(Service.class);
 		assertTrue("Stereotype annotation not visible", services.containsKey("testBean"));
 	}
 
@@ -110,7 +110,7 @@ public class AnnotationTransactionNamespaceHandlerTests extends TestCase {
 	public static class TransactionalTestBean {
 
 		@Transactional(readOnly = true)
-		public Collection findAllFoos() {
+		public Collection<?> findAllFoos() {
 			return null;
 		}
 

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/BeanFactoryTransactionTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/BeanFactoryTransactionTests.java
@@ -159,7 +159,7 @@ public class BeanFactoryTransactionTests extends TestCase {
 	}
 
 	public void testGetBeansOfTypeWithAbstract() {
-		Map beansOfType = factory.getBeansOfType(ITestBean.class, true, true);
+		Map<String, ITestBean> beansOfType = factory.getBeansOfType(ITestBean.class, true, true);
 		assertNotNull(beansOfType);
 	}
 
@@ -211,7 +211,7 @@ public class BeanFactoryTransactionTests extends TestCase {
 		int counter = 0;
 
 		@Override
-		public boolean matches(Method method, Class clazz) {
+		public boolean matches(Method method, Class<?> clazz) {
 			counter++;
 			return true;
 		}

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/MapTransactionAttributeSource.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/MapTransactionAttributeSource.java
@@ -35,7 +35,7 @@ public class MapTransactionAttributeSource extends AbstractFallbackTransactionAt
 		this.attributeMap.put(method, txAtt);
 	}
 
-	public void register(Class clazz, TransactionAttribute txAtt) {
+	public void register(Class<?> clazz, TransactionAttribute txAtt) {
 		this.attributeMap.put(clazz, txAtt);
 	}
 
@@ -46,7 +46,7 @@ public class MapTransactionAttributeSource extends AbstractFallbackTransactionAt
 	}
 
 	@Override
-	protected TransactionAttribute findTransactionAttribute(Class clazz) {
+	protected TransactionAttribute findTransactionAttribute(Class<?> clazz) {
 		return this.attributeMap.get(clazz);
 	}
 

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
@@ -75,7 +75,7 @@ public class RollbackRuleTests extends TestCase {
 
 	public void testCtorArgMustBeAThrowableClassWithNullThrowableType() {
 		try {
-			new RollbackRuleAttribute((Class) null);
+			new RollbackRuleAttribute((Class<?>) null);
 			fail("Cannot construct a RollbackRuleAttribute with a null-Throwable type");
 		}
 		catch (IllegalArgumentException expected) {

--- a/spring-tx/src/test/java/org/springframework/transaction/jta/MockUOWManager.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/jta/MockUOWManager.java
@@ -43,9 +43,9 @@ public class MockUOWManager implements UOWManager {
 
 	private int status = UOW_STATUS_NONE;
 
-	private final Map resources = new HashMap();
+	private final Map<Object, Object> resources = new HashMap<Object, Object>();
 
-	private final List synchronizations = new LinkedList();
+	private final List<Synchronization> synchronizations = new LinkedList<Synchronization>();
 
 
 	@Override

--- a/spring-tx/src/test/java/org/springframework/transaction/jta/WebSphereUowTransactionManagerTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/jta/WebSphereUowTransactionManagerTests.java
@@ -53,9 +53,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		ptm.afterPropertiesSet();
 
 		DefaultTransactionDefinition definition = new DefaultTransactionDefinition();
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				return "result";
 			}
 		}));
@@ -80,9 +80,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		DefaultTransactionDefinition definition = new DefaultTransactionDefinition();
 		TransactionStatus ts = ptm.getTransaction(definition);
 		ptm.commit(ts);
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				return "result";
 			}
 		}));
@@ -101,9 +101,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		definition.setPropagationBehavior(TransactionDefinition.PROPAGATION_MANDATORY);
 
 		try {
-			ptm.execute(definition, new TransactionCallback() {
+			ptm.execute(definition, new TransactionCallback<String>() {
 				@Override
-				public Object doInTransaction(TransactionStatus status) {
+				public String doInTransaction(TransactionStatus status) {
 					return "result";
 				}
 			});
@@ -171,9 +171,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				if (synchMode == WebSphereUowTransactionManager.SYNCHRONIZATION_ALWAYS) {
 					assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 					assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
@@ -255,9 +255,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				if (synchMode != WebSphereUowTransactionManager.SYNCHRONIZATION_NEVER) {
 					assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 					assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
@@ -293,9 +293,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 				assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 				assertTrue(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
@@ -329,9 +329,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
 		try {
-			ptm.execute(definition, new TransactionCallback() {
+			ptm.execute(definition, new TransactionCallback<String>() {
 				@Override
-				public Object doInTransaction(TransactionStatus status) {
+				public String doInTransaction(TransactionStatus status) {
 					assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 					assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 					assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
@@ -364,9 +364,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
 		try {
-			ptm.execute(definition, new TransactionCallback() {
+			ptm.execute(definition, new TransactionCallback<String>() {
 				@Override
-				public Object doInTransaction(TransactionStatus status) {
+				public String doInTransaction(TransactionStatus status) {
 					assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 					assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 					assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
@@ -398,9 +398,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 				assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 				assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
@@ -429,9 +429,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 				assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 				assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
@@ -457,9 +457,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		definition.setPropagationBehavior(TransactionDefinition.PROPAGATION_NEVER);
 
 		try {
-			ptm.execute(definition, new TransactionCallback() {
+			ptm.execute(definition, new TransactionCallback<String>() {
 				@Override
-				public Object doInTransaction(TransactionStatus status) {
+				public String doInTransaction(TransactionStatus status) {
 					return "result";
 				}
 			});
@@ -478,9 +478,9 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		definition.setPropagationBehavior(TransactionDefinition.PROPAGATION_NESTED);
 
 		try {
-			ptm.execute(definition, new TransactionCallback() {
+			ptm.execute(definition, new TransactionCallback<String>() {
 				@Override
-				public Object doInTransaction(TransactionStatus status) {
+				public String doInTransaction(TransactionStatus status) {
 					return "result";
 				}
 			});
@@ -515,15 +515,15 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 				assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 				assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
-				assertEquals("result2", ptm.execute(definition2, new TransactionCallback() {
+				assertEquals("result2", ptm.execute(definition2, new TransactionCallback<String>() {
 					@Override
-					public Object doInTransaction(TransactionStatus status) {
+					public String doInTransaction(TransactionStatus status) {
 						assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 						assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 						assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
@@ -564,15 +564,15 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 				assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 				assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
-				assertEquals("result2", ptm.execute(definition2, new TransactionCallback() {
+				assertEquals("result2", ptm.execute(definition2, new TransactionCallback<String>() {
 					@Override
-					public Object doInTransaction(TransactionStatus status) {
+					public String doInTransaction(TransactionStatus status) {
 						assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 						assertEquals(propagationBehavior == TransactionDefinition.PROPAGATION_REQUIRES_NEW,
 								TransactionSynchronizationManager.isActualTransactionActive());
@@ -611,15 +611,15 @@ public class WebSphereUowTransactionManagerTests extends TestCase {
 		assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 		assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
 
-		assertEquals("result", ptm.execute(definition, new TransactionCallback() {
+		assertEquals("result", ptm.execute(definition, new TransactionCallback<String>() {
 			@Override
-			public Object doInTransaction(TransactionStatus status) {
+			public String doInTransaction(TransactionStatus status) {
 				assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 				assertTrue(TransactionSynchronizationManager.isActualTransactionActive());
 				assertFalse(TransactionSynchronizationManager.isCurrentTransactionReadOnly());
-				assertEquals("result2", ptm.execute(definition2, new TransactionCallback() {
+				assertEquals("result2", ptm.execute(definition2, new TransactionCallback<String>() {
 					@Override
-					public Object doInTransaction(TransactionStatus status) {
+					public String doInTransaction(TransactionStatus status) {
 						assertTrue(TransactionSynchronizationManager.isSynchronizationActive());
 						assertFalse(TransactionSynchronizationManager.isActualTransactionActive());
 						assertTrue(TransactionSynchronizationManager.isCurrentTransactionReadOnly());


### PR DESCRIPTION
Clean up compiler warnings in the tests of spring-tx. This commit
adds type parameters to all the types (mostly `List` and `Map`). In
addition it uses Java 5 autoboxing to get rid of several `new Integer`
(except in cases where it's needed).

After this commit the only warnings in spring-tx left are in
`TransactionAttributeSourceTests` that code would never compile with
generics.

I did sing the CLA
