### PR TITLE
Clean up spring-jms tests warnings

### DIFF
--- a/spring-jms/src/test/java/org/springframework/jms/annotation/AnnotationDrivenNamespaceTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/annotation/AnnotationDrivenNamespaceTests.java
@@ -82,7 +82,7 @@ public class AnnotationDrivenNamespaceTests extends AbstractJmsAnnotationDrivenT
 
 		private MessageListener messageListener;
 
-		private JmsListenerContainerFactory containerFactory;
+		private JmsListenerContainerFactory<?> containerFactory;
 
 		@Override
 		public void configureJmsListeners(JmsListenerEndpointRegistrar registrar) {
@@ -97,7 +97,7 @@ public class AnnotationDrivenNamespaceTests extends AbstractJmsAnnotationDrivenT
 			this.messageListener = messageListener;
 		}
 
-		public void setContainerFactory(JmsListenerContainerFactory containerFactory) {
+		public void setContainerFactory(JmsListenerContainerFactory<?> containerFactory) {
 			this.containerFactory = containerFactory;
 		}
 	}

--- a/spring-jms/src/test/java/org/springframework/jms/config/JmsListenerContainerFactoryTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/config/JmsListenerContainerFactoryTests.java
@@ -146,7 +146,7 @@ public class JmsListenerContainerFactoryTests {
 		factory.createMessageListenerContainer(endpoint);
 	}
 
-	private void setDefaultJmsConfig(AbstractJmsListenerContainerFactory factory) {
+	private void setDefaultJmsConfig(AbstractJmsListenerContainerFactory<?> factory) {
 		factory.setConnectionFactory(connectionFactory);
 		factory.setDestinationResolver(destinationResolver);
 		factory.setMessageConverter(messageConverter);

--- a/spring-jms/src/test/java/org/springframework/jms/config/JmsNamespaceHandlerTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/config/JmsNamespaceHandlerTests.java
@@ -78,7 +78,7 @@ public class JmsNamespaceHandlerTests {
 
 	@Test
 	public void testBeansCreated() {
-		Map containers = context.getBeansOfType(DefaultMessageListenerContainer.class);
+		Map<String, ?> containers = context.getBeansOfType(DefaultMessageListenerContainer.class);
 		assertEquals("Context should contain 3 JMS listener containers", 3, containers.size());
 
 		containers = context.getBeansOfType(GenericMessageEndpointManager.class);
@@ -272,9 +272,9 @@ public class JmsNamespaceHandlerTests {
 
 	@Test
 	public void testSourceExtraction() {
-		Iterator iterator = context.getRegisteredComponents();
+		Iterator<ComponentDefinition> iterator = context.getRegisteredComponents();
 		while (iterator.hasNext()) {
-			ComponentDefinition compDef = (ComponentDefinition) iterator.next();
+			ComponentDefinition compDef = iterator.next();
 			assertNotNull("CompositeComponentDefinition '" + compDef.getName() + "' has no source attachment", compDef.getSource());
 			validateComponentDefinition(compDef);
 		}
@@ -339,7 +339,7 @@ public class JmsNamespaceHandlerTests {
 
 		private Set<ComponentDefinition> registeredComponents;
 
-		public ToolingTestApplicationContext(String path, Class clazz) {
+		public ToolingTestApplicationContext(String path, Class<?> clazz) {
 			super(path, clazz);
 		}
 

--- a/spring-jms/src/test/java/org/springframework/jms/connection/JmsTransactionManagerTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/connection/JmsTransactionManagerTests.java
@@ -67,9 +67,9 @@ public class JmsTransactionManagerTests {
 		JmsTransactionManager tm = new JmsTransactionManager(cf);
 		TransactionStatus ts = tm.getTransaction(new DefaultTransactionDefinition());
 		JmsTemplate jt = new JmsTemplate(cf);
-		jt.execute(new SessionCallback() {
+		jt.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session sess) {
+			public Void doInJms(Session sess) {
 				assertTrue(sess == session);
 				return null;
 			}
@@ -93,9 +93,9 @@ public class JmsTransactionManagerTests {
 		JmsTransactionManager tm = new JmsTransactionManager(cf);
 		TransactionStatus ts = tm.getTransaction(new DefaultTransactionDefinition());
 		JmsTemplate jt = new JmsTemplate(cf);
-		jt.execute(new SessionCallback() {
+		jt.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session sess) {
+			public Void doInJms(Session sess) {
 				assertTrue(sess == session);
 				return null;
 			}
@@ -119,9 +119,9 @@ public class JmsTransactionManagerTests {
 		JmsTransactionManager tm = new JmsTransactionManager(cf);
 		TransactionStatus ts = tm.getTransaction(new DefaultTransactionDefinition());
 		final JmsTemplate jt = new JmsTemplate(cf);
-		jt.execute(new SessionCallback() {
+		jt.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session sess) {
+			public Void doInJms(Session sess) {
 				assertTrue(sess == session);
 				return null;
 			}
@@ -130,9 +130,9 @@ public class JmsTransactionManagerTests {
 		tt.execute(new TransactionCallbackWithoutResult() {
 			@Override
 			protected void doInTransactionWithoutResult(TransactionStatus status) {
-				jt.execute(new SessionCallback() {
+				jt.execute(new SessionCallback<Void>() {
 					@Override
-					public Object doInJms(Session sess) {
+					public Void doInJms(Session sess) {
 						assertTrue(sess == session);
 						return null;
 					}
@@ -158,9 +158,9 @@ public class JmsTransactionManagerTests {
 		JmsTransactionManager tm = new JmsTransactionManager(cf);
 		TransactionStatus ts = tm.getTransaction(new DefaultTransactionDefinition());
 		final JmsTemplate jt = new JmsTemplate(cf);
-		jt.execute(new SessionCallback() {
+		jt.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session sess) {
+			public Void doInJms(Session sess) {
 				assertTrue(sess == session);
 				return null;
 			}
@@ -169,9 +169,9 @@ public class JmsTransactionManagerTests {
 		tt.execute(new TransactionCallbackWithoutResult() {
 			@Override
 			protected void doInTransactionWithoutResult(TransactionStatus status) {
-				jt.execute(new SessionCallback() {
+				jt.execute(new SessionCallback<Void>() {
 					@Override
-					public Object doInJms(Session sess) {
+					public Void doInJms(Session sess) {
 						assertTrue(sess == session);
 						return null;
 					}
@@ -206,9 +206,9 @@ public class JmsTransactionManagerTests {
 		JmsTransactionManager tm = new JmsTransactionManager(cf);
 		TransactionStatus ts = tm.getTransaction(new DefaultTransactionDefinition());
 		final JmsTemplate jt = new JmsTemplate(cf);
-		jt.execute(new SessionCallback() {
+		jt.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session sess) {
+			public Void doInJms(Session sess) {
 				assertTrue(sess == session);
 				return null;
 			}
@@ -218,18 +218,18 @@ public class JmsTransactionManagerTests {
 		tt.execute(new TransactionCallbackWithoutResult() {
 			@Override
 			protected void doInTransactionWithoutResult(TransactionStatus status) {
-				jt.execute(new SessionCallback() {
+				jt.execute(new SessionCallback<Void>() {
 					@Override
-					public Object doInJms(Session sess) {
+					public Void doInJms(Session sess) {
 						assertTrue(sess != session);
 						return null;
 					}
 				});
 			}
 		});
-		jt.execute(new SessionCallback() {
+		jt.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session sess) {
+			public Void doInJms(Session sess) {
 				assertTrue(sess == session);
 				return null;
 			}
@@ -255,9 +255,9 @@ public class JmsTransactionManagerTests {
 		JmsTransactionManager tm = new JmsTransactionManager(cf);
 		TransactionStatus ts = tm.getTransaction(new DefaultTransactionDefinition());
 		final JmsTemplate jt = new JmsTemplate(cf);
-		jt.execute(new SessionCallback() {
+		jt.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session sess) {
+			public Void doInJms(Session sess) {
 				assertTrue(sess == session);
 				return null;
 			}
@@ -267,18 +267,18 @@ public class JmsTransactionManagerTests {
 		tt.execute(new TransactionCallbackWithoutResult() {
 			@Override
 			protected void doInTransactionWithoutResult(TransactionStatus status) {
-				jt.execute(new SessionCallback() {
+				jt.execute(new SessionCallback<Void>() {
 					@Override
-					public Object doInJms(Session sess) {
+					public Void doInJms(Session sess) {
 						assertTrue(sess != session);
 						return null;
 					}
 				});
 			}
 		});
-		jt.execute(new SessionCallback() {
+		jt.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session sess) {
+			public Void doInJms(Session sess) {
 				assertTrue(sess == session);
 				return null;
 			}

--- a/spring-jms/src/test/java/org/springframework/jms/core/JmsTemplateTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/core/JmsTemplateTests.java
@@ -143,9 +143,9 @@ public class JmsTemplateTests {
 		given(session.createProducer(null)).willReturn(messageProducer);
 		given(messageProducer.getPriority()).willReturn(4);
 
-		template.execute(new ProducerCallback() {
+		template.execute(new ProducerCallback<Void>() {
 			@Override
-			public Object doInJms(Session session, MessageProducer producer) throws JMSException {
+			public Void doInJms(Session session, MessageProducer producer) throws JMSException {
 				session.getTransacted();
 				producer.getPriority();
 				return null;
@@ -168,9 +168,9 @@ public class JmsTemplateTests {
 		given(session.createProducer(null)).willReturn(messageProducer);
 		given(messageProducer.getPriority()).willReturn(4);
 
-		template.execute(new ProducerCallback() {
+		template.execute(new ProducerCallback<Void>() {
 			@Override
-			public Object doInJms(Session session, MessageProducer producer) throws JMSException {
+			public Void doInJms(Session session, MessageProducer producer) throws JMSException {
 				session.getTransacted();
 				producer.getPriority();
 				return null;
@@ -192,9 +192,9 @@ public class JmsTemplateTests {
 		JmsTemplate template = createTemplate();
 		template.setConnectionFactory(connectionFactory);
 
-		template.execute(new SessionCallback() {
+		template.execute(new SessionCallback<Void>() {
 			@Override
-			public Object doInJms(Session session) throws JMSException {
+			public Void doInJms(Session session) throws JMSException {
 				session.getTransacted();
 				return null;
 			}
@@ -212,16 +212,16 @@ public class JmsTemplateTests {
 
 		TransactionSynchronizationManager.initSynchronization();
 		try {
-			template.execute(new SessionCallback() {
+			template.execute(new SessionCallback<Void>() {
 				@Override
-				public Object doInJms(Session session) throws JMSException {
+				public Void doInJms(Session session) throws JMSException {
 					session.getTransacted();
 					return null;
 				}
 			});
-			template.execute(new SessionCallback() {
+			template.execute(new SessionCallback<Void>() {
 				@Override
-				public Object doInJms(Session session) throws JMSException {
+				public Void doInJms(Session session) throws JMSException {
 					session.getTransacted();
 					return null;
 				}
@@ -237,9 +237,9 @@ public class JmsTemplateTests {
 			tas.close();
 			tac.close();
 
-			List synchs = TransactionSynchronizationManager.getSynchronizations();
+			List<TransactionSynchronization> synchs = TransactionSynchronizationManager.getSynchronizations();
 			assertEquals(1, synchs.size());
-			TransactionSynchronization synch = (TransactionSynchronization) synchs.get(0);
+			TransactionSynchronization synch = synchs.get(0);
 			synch.beforeCommit(false);
 			synch.beforeCompletion();
 			synch.afterCommit();
@@ -695,7 +695,7 @@ public class JmsTemplateTests {
 		doTestJmsException(new javax.jms.JMSException(""), UncategorizedJmsException.class);
 	}
 
-	protected void doTestJmsException(JMSException original, Class thrownExceptionClass) throws Exception {
+	protected void doTestJmsException(JMSException original, Class<? extends JmsException> thrownExceptionClass) throws Exception {
 		JmsTemplate template = createTemplate();
 		template.setConnectionFactory(connectionFactory);
 		template.setMessageConverter(new SimpleMessageConverter());

--- a/spring-jms/src/test/java/org/springframework/jms/core/support/JmsGatewaySupportTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/core/support/JmsGatewaySupportTests.java
@@ -35,7 +35,7 @@ public class JmsGatewaySupportTests {
 	@Test
 	public void testJmsGatewaySupportWithConnectionFactory() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
-		final List test = new ArrayList();
+		final List<String> test = new ArrayList<String>(1);
 		JmsGatewaySupport gateway = new JmsGatewaySupport() {
 			@Override
 			protected void initGateway() {
@@ -52,7 +52,7 @@ public class JmsGatewaySupportTests {
 	@Test
 	public void testJmsGatewaySupportWithJmsTemplate() throws Exception {
 		JmsTemplate template = new JmsTemplate();
-		final List test = new ArrayList();
+		final List<String> test = new ArrayList<String>(1);
 		JmsGatewaySupport gateway = new JmsGatewaySupport() {
 			@Override
 			protected void initGateway() {

--- a/spring-jms/src/test/java/org/springframework/jms/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/listener/SimpleMessageListenerContainerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.jms.listener;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -169,11 +170,11 @@ public class SimpleMessageListenerContainerTests extends AbstractMessageListener
 		final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		given(connectionFactory.createConnection()).willReturn(connection);
 
-		final HashSet failure = new HashSet();
+		final Set<String> failure = new HashSet<String>(1);
 
 		this.container.setConnectionFactory(connectionFactory);
 		this.container.setDestinationName(DESTINATION_NAME);
-		this.container.setMessageListener(new SessionAwareMessageListener() {
+		this.container.setMessageListener(new SessionAwareMessageListener<Message>() {
 			@Override
 			public void onMessage(Message message, Session sess) {
 				try {
@@ -269,7 +270,7 @@ public class SimpleMessageListenerContainerTests extends AbstractMessageListener
 
 		this.container.setConnectionFactory(connectionFactory);
 		this.container.setDestinationName(DESTINATION_NAME);
-		this.container.setMessageListener(new SessionAwareMessageListener() {
+		this.container.setMessageListener(new SessionAwareMessageListener<Message>() {
 			@Override
 			public void onMessage(Message message, Session session) throws JMSException {
 				throw theException;
@@ -319,7 +320,7 @@ public class SimpleMessageListenerContainerTests extends AbstractMessageListener
 
 		this.container.setConnectionFactory(connectionFactory);
 		this.container.setDestinationName(DESTINATION_NAME);
-		this.container.setMessageListener(new SessionAwareMessageListener() {
+		this.container.setMessageListener(new SessionAwareMessageListener<Message>() {
 			@Override
 			public void onMessage(Message message, Session session) throws JMSException {
 				throw theException;

--- a/spring-jms/src/test/java/org/springframework/jms/listener/adapter/MessageContentsDelegate.java
+++ b/spring-jms/src/test/java/org/springframework/jms/listener/adapter/MessageContentsDelegate.java
@@ -28,7 +28,7 @@ public interface MessageContentsDelegate {
 
 	void handleMessage(CharSequence message);
 
-	void handleMessage(Map message);
+	void handleMessage(Map<String, Object>  message);
 
 	void handleMessage(byte[] message);
 

--- a/spring-jms/src/test/java/org/springframework/jms/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -18,8 +18,6 @@ package org.springframework.jms.listener.adapter;
 
 import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
 

--- a/spring-jms/src/test/java/org/springframework/jms/listener/adapter/ResponsiveMessageDelegate.java
+++ b/spring-jms/src/test/java/org/springframework/jms/listener/adapter/ResponsiveMessageDelegate.java
@@ -33,7 +33,7 @@ public interface ResponsiveMessageDelegate {
 
 	String handleMessage(TextMessage message);
 
-	Map handleMessage(MapMessage message);
+	Map<String, Object> handleMessage(MapMessage message);
 
 	byte[] handleMessage(BytesMessage message);
 

--- a/spring-jms/src/test/java/org/springframework/jms/support/SimpleMessageConverterTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/support/SimpleMessageConverterTests.java
@@ -92,7 +92,7 @@ public final class SimpleMessageConverterTests {
 		Session session = mock(Session.class);
 		MapMessage message = mock(MapMessage.class);
 
-		Map content = new HashMap();
+		Map<String, String> content = new HashMap<String, String>(2);
 		content.put("key1", "value1");
 		content.put("key2", "value2");
 
@@ -162,8 +162,8 @@ public final class SimpleMessageConverterTests {
 		final Session session = mock(Session.class);
 		given(session.createMapMessage()).willReturn(message);
 
-		final Map content = new HashMap();
-		content.put(new Integer(1), "value1");
+		final Map<Integer, String> content = new HashMap<Integer, String>(1);
+		content.put(1, "value1");
 
 		final SimpleMessageConverter converter = new SimpleMessageConverter();
 		try {
@@ -179,7 +179,7 @@ public final class SimpleMessageConverterTests {
 		final Session session = mock(Session.class);
 		given(session.createMapMessage()).willReturn(message);
 
-		final Map content = new HashMap();
+		final Map<Object, String> content = new HashMap<Object, String>(1);
 		content.put(null, "value1");
 
 		final SimpleMessageConverter converter = new SimpleMessageConverter();

--- a/spring-jms/src/test/java/org/springframework/jms/support/destination/JndiDestinationResolverTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/support/destination/JndiDestinationResolverTests.java
@@ -77,7 +77,7 @@ public class JndiDestinationResolverTests {
 
 		JndiDestinationResolver resolver = new JndiDestinationResolver() {
 			@Override
-			protected Object lookup(String jndiName, Class requiredClass) throws NamingException {
+			protected <T> T lookup(String jndiName, Class<T> requiredClass) throws NamingException {
 				throw new NamingException();
 			}
 		};
@@ -96,7 +96,7 @@ public class JndiDestinationResolverTests {
 
 		final JndiDestinationResolver resolver = new JndiDestinationResolver() {
 			@Override
-			protected Object lookup(String jndiName, Class requiredClass) throws NamingException {
+			protected <T> T lookup(String jndiName, Class<T> requiredClass) throws NamingException {
 				throw new NamingException();
 			}
 		};
@@ -117,13 +117,13 @@ public class JndiDestinationResolverTests {
 		private boolean called;
 
 		@Override
-		protected Object lookup(String jndiName, Class requiredType) throws NamingException {
+		protected <T> T lookup(String jndiName, Class<T> requiredType) throws NamingException {
 			if (called) {
 				fail("Must not be delegating to lookup(..), must be resolving from cache.");
 			}
 			assertEquals(DESTINATION_NAME, jndiName);
 			called = true;
-			return DESTINATION;
+			return requiredType.cast(DESTINATION);
 		}
 	}
 
@@ -136,9 +136,9 @@ public class JndiDestinationResolverTests {
 		}
 
 		@Override
-		protected Object lookup(String jndiName, Class requiredType) throws NamingException {
+		protected <T> T lookup(String jndiName, Class<T> requiredType) throws NamingException {
 			++this.callCount;
-			return DESTINATION;
+			return requiredType.cast(DESTINATION);
 		}
 	}
 }


### PR DESCRIPTION
Clean up compiler warnings in the tests of spring-jms. This commit
adds type parameters to all the types (mostly `List` and `Map`).

I am not too sure about the `Map` type parameters in
`MessageContentsDelegate` and `ResponsiveMessageDelegate` however the
respective methods seem unused.

I did sing the CLA
