### PR TITLE
Failing test for SPR-11736 Method signature isn't used for computing the cache key

### DIFF
--- a/spring-context/src/test/java/org/springframework/cache/config/AbstractAnnotationTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/AbstractAnnotationTests.java
@@ -73,6 +73,17 @@ public abstract class AbstractAnnotationTests {
 		assertSame(r1, r3);
 	}
 
+	public void testMethodSignatureInCacheKey(CacheableService<?> service) throws Exception {
+		Object o1 = new Object();
+
+		Object r1 = service.cache(o1);
+		Object r2 = service.cacheAnother(o1);
+		Object r3 = service.cache(o1);
+
+		assertNotSame(r1, r2);
+		assertSame(r1, r3);
+	}
+	
 	public void testEvict(CacheableService<?> service) throws Exception {
 		Object o1 = new Object();
 
@@ -439,6 +450,11 @@ public abstract class AbstractAnnotationTests {
 	@Test
 	public void testCacheable() throws Exception {
 		testCacheable(cs);
+	}
+	
+	@Test
+	public void testMethodSignatureInCacheKey() throws Exception {
+		testMethodSignatureInCacheKey(cs);
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -31,12 +31,18 @@ import org.springframework.cache.annotation.Caching;
 public class AnnotatedClassCacheableService implements CacheableService<Object> {
 
 	private final AtomicLong counter = new AtomicLong();
+	private final AtomicLong counter2 = new AtomicLong(100000);
 
 	public static final AtomicLong nullInvocations = new AtomicLong();
 
 	@Override
 	public Object cache(Object arg1) {
 		return counter.getAndIncrement();
+	}
+
+	@Override
+	public Object cacheAnother(Object arg1) {
+		return counter2.getAndIncrement();
 	}
 
 	@Override

--- a/spring-context/src/test/java/org/springframework/cache/config/CacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/CacheableService.java
@@ -25,6 +25,8 @@ package org.springframework.cache.config;
 public interface CacheableService<T> {
 
 	T cache(Object arg1);
+	
+	T cacheAnother(Object arg1);
 
 	void invalidate(Object arg1);
 

--- a/spring-context/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
@@ -32,6 +32,7 @@ import org.springframework.cache.annotation.Caching;
 public class DefaultCacheableService implements CacheableService<Long> {
 
 	private final AtomicLong counter = new AtomicLong();
+	private final AtomicLong counter2 = new AtomicLong(100000);
 	private final AtomicLong nullInvocations = new AtomicLong();
 
 	@Override
@@ -40,6 +41,12 @@ public class DefaultCacheableService implements CacheableService<Long> {
 		return counter.getAndIncrement();
 	}
 
+	@Override
+	@Cacheable("default")
+	public Long cacheAnother(Object arg1) {
+		return counter2.getAndIncrement();
+	}
+	
 	@Override
 	@CacheEvict("default")
 	public void invalidate(Object arg1) {


### PR DESCRIPTION
This is a failing test for https://jira.spring.io/browse/SPR-11736
Method signature isn't used for computing the cache key in SimpleKeyGenerator
