### PR TITLE
Created a builder to create HttpHeaders

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeadersBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeadersBuilder.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http;
+
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Builder for simple creation of a {@link HttpHeaders} instance.
+ *
+ * <p>Similar to {@link HttpHeaders}, this class offers the following convenience methods:
+ * <ul>
+ * <li>{@link #add(String, String)} adds a header value to the list of values for a header name</li>
+ * <li>{@link #set(String, String)} sets the header value to a single string value</li>
+ * </ul>
+ *
+ * @author Mattias Severson
+ * @since 4.1
+ */
+public class HttpHeadersBuilder {
+
+	private final HttpHeaders httpHeaders;
+
+
+	/**
+	 * Constructs a new, empty instance of the {@code HttpHeadersBuilder} object.
+	 */
+	public HttpHeadersBuilder() {
+		this.httpHeaders = new HttpHeaders();
+	}
+
+
+	/**
+	 * Set the list of acceptable {@linkplain MediaType media types}, as specified by the
+	 * {@code Accept} header.
+	 * @param acceptableMediaTypes the acceptable media types
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setAccept(List<MediaType> acceptableMediaTypes) {
+		this.httpHeaders.setAccept(acceptableMediaTypes);
+		return this;
+	}
+
+	/**
+	 * Set the list of acceptable {@linkplain java.nio.charset.Charset charsets}, as
+	 * specified by the {@code Accept-Charset} header.
+	 * @param acceptableCharsets the acceptable charsets
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setAcceptCharset(List<Charset> acceptableCharsets) {
+		this.httpHeaders.setAcceptCharset(acceptableCharsets);
+		return this;
+	}
+
+	/**
+	 * Set the set of allowed {@link HttpMethod HTTP methods}, as specified by the
+	 * {@code Allow} header.
+	 * @param allowedMethods the allowed methods
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setAllow(Set<HttpMethod> allowedMethods) {
+		this.httpHeaders.setAllow(allowedMethods);
+		return this;
+	}
+
+	/**
+	 * Set the (new) value of the {@code Cache-Control} header.
+	 * @param cacheControl the value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setCacheControl(String cacheControl) {
+		this.httpHeaders.setCacheControl(cacheControl);
+		return this;
+	}
+
+	/**
+	 * Set the (new) value of the {@code Connection} header.
+	 * @param connection the value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setConnection(String connection) {
+		this.httpHeaders.setConnection(connection);
+		return this;
+	}
+
+	/**
+	 * Set the (new) value of the {@code Connection} header.
+	 * @param connection the value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setConnection(List<String> connection) {
+		this.httpHeaders.setConnection(connection);
+		return this;
+	}
+
+	/**
+	 * Set the (new) value of the {@code Content-Disposition} header for {@code form-data}.
+	 * @param name the control name
+	 * @param filename the filename, may be {@code null}
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setContentDispositionFormData(String name, String filename) {
+		this.httpHeaders.setContentDispositionFormData(name, filename);
+		return this;
+	}
+
+	/**
+	 * Set the length of the body in bytes, as specified by the {@code Content-Length} header.
+	 * @param contentLength the content length
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setContentLength(long contentLength) {
+		this.httpHeaders.setContentLength(contentLength);
+		return this;
+	}
+
+	/**
+	 * Set the {@linkplain MediaType media type} of the body, as specified by the
+	 * {@code Content-Type} header.
+	 * @param mediaType the media type
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setContentType(MediaType mediaType) {
+		this.httpHeaders.setContentType(mediaType);
+		return this;
+	}
+
+	/**
+	 * Set the date and time at which the message was created, as specified by the
+	 * {@code Date} header.
+	 * <p>The date should be specified as the number of milliseconds since January 1, 1970 GMT.
+	 * @param date the date
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setDate(long date) {
+		this.httpHeaders.setDate(date);
+		return this;
+	}
+
+	/**
+	 * Set the (new) entity tag of the body, as specified by the {@code ETag} header.
+	 * @param eTag the new entity tag
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setETag(String eTag) {
+		this.httpHeaders.setETag(eTag);
+		return this;
+	}
+
+	/**
+	 * Set the date and time at which the message is no longer valid, as specified by the
+	 * {@code Expires} header.
+	 * <p>The date should be specified as the number of milliseconds since January 1, 1970 GMT.
+	 * @param expires the new expires header value
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setExpires(long expires) {
+		this.httpHeaders.setExpires(expires);
+		return this;
+	}
+
+	/**
+	 * Set the (new) value of the {@code If-Modified-Since} header.
+	 * <p>The date should be specified as the number of milliseconds since January 1, 1970 GMT.
+	 * @param ifModifiedSince the new value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setIfModifiedSince(long ifModifiedSince) {
+		this.httpHeaders.setIfModifiedSince(ifModifiedSince);
+		return this;
+	}
+
+	/**
+	 * Set the (new) value of the {@code If-None-Match} header.
+	 * @param ifNoneMatch the new value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setIfNoneMatch(String ifNoneMatch) {
+		this.httpHeaders.setIfNoneMatch(ifNoneMatch);
+		return this;
+	}
+
+	/**
+	 * Set the (new) values of the {@code If-None-Match} header.
+	 * @param ifNoneMatchList the new value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setIfNoneMatch(List<String> ifNoneMatchList) {
+		this.httpHeaders.setIfNoneMatch(ifNoneMatchList);
+		return this;
+	}
+
+	/**
+	 * Set the time the resource was last changed, as specified by the
+	 * {@code Last-Modified} header.
+	 * <p>The date should be specified as the number of milliseconds since January 1, 1970 GMT.
+	 * @param lastModified the last modified date
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setLastModified(long lastModified) {
+		this.httpHeaders.setLastModified(lastModified);
+		return this;
+	}
+
+	/**
+	 * Set the (new) location of a resource, as specified by the {@code Location} header.
+	 * @param location the location
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setLocation(URI location) {
+		this.httpHeaders.setLocation(location);
+		return this;
+	}
+
+	/**
+	 * Sets the (new) value of the {@code Origin} header.
+	 * @param origin the value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setOrigin(String origin) {
+		this.httpHeaders.setOrigin(origin);
+		return this;
+	}
+
+	/**
+	 * Set the (new) value of the {@code Pragma} header.
+	 * @param pragma the value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setPragma(String pragma) {
+		this.httpHeaders.setPragma(pragma);
+		return this;
+	}
+
+	/**
+	 * Set the (new) value of the {@code Upgrade} header.
+	 * @param upgrade the value of the header
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setUpgrade(String upgrade) {
+		this.httpHeaders.setUpgrade(upgrade);
+		return this;
+	}
+
+	/**
+	 * Set the given date under the given header name after formatting it as a string
+	 * using the pattern {@code "EEE, dd MMM yyyy HH:mm:ss zzz"}.
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setDate(String headerName, long date) {
+		this.httpHeaders.setDate(headerName, date);
+		return this;
+	}
+
+	/**
+	 * Add the given, single header value under the given name.
+	 * @param headerName  the header name
+	 * @param headerValue the header value
+	 * @see #put(String, java.util.List)
+	 * @see #set(String, String)
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder add(String headerName, String headerValue) {
+		this.httpHeaders.add(headerName, headerValue);
+		return this;
+	}
+
+	/**
+	 * Set the given, single header value under the given name.
+	 * @param headerName  the header name
+	 * @param headerValue the header value
+	 * @see #put(String, java.util.List)
+	 * @see #add(String, String)
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder set(String headerName, String headerValue) {
+		this.httpHeaders.set(headerName, headerValue);
+		return this;
+	}
+
+	/**
+	 * Set the given map keys as header values under the given map keys.
+	 * @param values the header values
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder setAll(Map<String, String> values) {
+		this.httpHeaders.setAll(values);
+		return this;
+	}
+
+	/**
+	 * Set the given list as header value under the given name.
+	 * @param headerName the header name
+	 * @param headerValues the header values
+	 * @return this builder
+	 */
+	public HttpHeadersBuilder put(String headerName, List<String> headerValues) {
+		this.httpHeaders.put(headerName, headerValues);
+		return this;
+	}
+
+	/**
+	 * Return the {@code HttpHeaders} from this builder.
+	 * @return the {@code HttpHeaders} instance
+	 */
+	public HttpHeaders build() {
+		return httpHeaders;
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersBuilderTests.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.EnumSet;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.TimeZone;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Mattias Severson
+ */
+public class HttpHeadersBuilderTests {
+
+	private HttpHeadersBuilder builder;
+
+
+	@Before
+	public void setUp() {
+		builder = new HttpHeadersBuilder();
+	}
+
+	@Test
+	public void accept() {
+		MediaType mediaType = new MediaType("text", "plain");
+		List<MediaType> mediaTypes = Arrays.asList(mediaType);
+		builder.setAccept(mediaTypes);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Accept header", mediaTypes, httpHeaders.getAccept());
+	}
+
+	@Test
+	public void acceptCharsets() {
+		Charset charset = Charset.forName("UTF-8");
+		List<Charset> charsets = Arrays.asList(charset);
+		builder.setAcceptCharset(charsets);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Accept Charset header", charsets, httpHeaders.getAcceptCharset());
+	}
+
+	@Test
+	public void allow() {
+		EnumSet<HttpMethod> methods = EnumSet.of(HttpMethod.GET, HttpMethod.POST);
+		builder.setAllow(methods);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Allow header", methods, httpHeaders.getAllow());
+	}
+
+	@Test
+	public void contentLength() {
+		long length = 42L;
+		builder.setContentLength(length);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Content-Length header", length, httpHeaders.getContentLength());
+	}
+
+	@Test
+	public void contentType() {
+		MediaType contentType = new MediaType("text", "html", Charset.forName("UTF-8"));
+		builder.setContentType(contentType);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Content-Type header", contentType, httpHeaders.getContentType());
+	}
+
+	@Test
+	public void location() throws URISyntaxException {
+		URI location = new URI("http://www.example.com/hotels");
+		builder.setLocation(location);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Location header", location, httpHeaders.getLocation());
+	}
+
+	@Test
+	public void eTag() {
+		String eTag = "\"v2.6\"";
+		builder.setETag(eTag);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid ETag header", eTag, httpHeaders.getETag());
+	}
+
+	@Test
+	public void ifNoneMatch() {
+		String ifNoneMatch = "\"v2.6\"";
+		builder.setIfNoneMatch(ifNoneMatch);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid If-None-Match header", ifNoneMatch, httpHeaders.getIfNoneMatch().get(0));
+	}
+
+	@Test
+	public void ifNoneMatchList() {
+		String ifNoneMatch1 = "\"v2.6\"";
+		String ifNoneMatch2 = "\"v2.7\"";
+		List<String> ifNoneMatchList = new ArrayList<String>(2);
+		ifNoneMatchList.add(ifNoneMatch1);
+		ifNoneMatchList.add(ifNoneMatch2);
+		builder.setIfNoneMatch(ifNoneMatchList);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid If-None-Match header", ifNoneMatchList, httpHeaders.getIfNoneMatch());
+	}
+
+	@Test
+	public void date() {
+		Calendar calendar = new GregorianCalendar(2008, 11, 18, 11, 20);
+		calendar.setTimeZone(TimeZone.getTimeZone("CET"));
+		long date = calendar.getTimeInMillis();
+		builder.setDate(date);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Date header", date, httpHeaders.getDate());
+
+		builder.setDate("Date", date);
+		httpHeaders = builder.build();
+		assertEquals("Invalid Date header", date, httpHeaders.getDate());
+	}
+
+	@Test
+	public void lastModified() {
+		Calendar calendar = new GregorianCalendar(2008, 11, 18, 11, 20);
+		calendar.setTimeZone(TimeZone.getTimeZone("CET"));
+		long date = calendar.getTimeInMillis();
+		builder.setLastModified(date);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Last-Modified header", date, httpHeaders.getLastModified());
+	}
+
+	@Test
+	public void expires() {
+		Calendar calendar = new GregorianCalendar(2008, 11, 18, 11, 20);
+		calendar.setTimeZone(TimeZone.getTimeZone("CET"));
+		long date = calendar.getTimeInMillis();
+		builder.setExpires(date);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Expires header", date, httpHeaders.getExpires());
+	}
+
+	@Test
+	public void ifModifiedSince() {
+		Calendar calendar = new GregorianCalendar(2008, 11, 18, 11, 20);
+		calendar.setTimeZone(TimeZone.getTimeZone("CET"));
+		long date = calendar.getTimeInMillis();
+		builder.setIfModifiedSince(date);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid If-Modified-Since header", date, httpHeaders.getIfModifiedSince());
+	}
+
+	@Test
+	public void pragma() {
+		String pragma = "no-cache";
+		builder.setPragma(pragma);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Pragma header", pragma, httpHeaders.getPragma());
+	}
+
+	@Test
+	public void cacheControl() {
+		String cacheControl = "no-cache";
+		builder.setCacheControl(cacheControl);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Cache-Control header", cacheControl, httpHeaders.getCacheControl());
+	}
+
+	@Test
+	public void contentDisposition() {
+		builder.setContentDispositionFormData("name", null);
+		HttpHeaders httpHeaders = builder.build();
+		assertEquals("Invalid Content-Disposition header", "form-data; name=\"name\"",
+				httpHeaders.getFirst("Content-Disposition"));
+
+		builder.setContentDispositionFormData("name", "filename");
+		assertEquals("Invalid Content-Disposition header", "form-data; name=\"name\"; filename=\"filename\"",
+				httpHeaders.getFirst("Content-Disposition"));
+	}
+
+}


### PR DESCRIPTION
Implemented a simple builder that creates a HttpHeaders instance by
wrapping calls to an internal HttpHeaders object. The builder pattern
allows both creation of simple objects as well as chaining calls to more
complex constructs.

The major disadvantage with this implementation compared to the
proposed solution in the issue is that it is more verbose when only a
single header is desired. On the other hand, the fluent API will make
the creation of a HttpHeaders object concise if more parameters are
added. Additionally, the builder pattern enables methods like
setContentType(MediaType mediaType) to be implemented in a type-safe
way.

Example usages:

HttpHeaders etagHeader = new HttpHeadersBuilder.setETag(etagValue).build();

HttpHeaders httpHeader = new HttpHeadersBuilder
    .setETag(etagValue)
    .setContentType(MediaType.APPLICATION_JSON)
    .setContentLength(42L)
    // more setters
    .build();

Issue: SPR-11597
