### PR TITLE
Added support for nested path traversing in DirectFieldAccessor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,6 +322,7 @@ project("spring-beans") {
 	dependencies {
 		compile(project(":spring-core"))
 		compile(files(project(":spring-core").cglibRepackJar))
+		compile(files(project(":spring-core").objenesisRepackJar))
 		optional("javax.inject:javax.inject:1")
 		optional("javax.el:javax.el-api:2.2.5")
 		optional("org.yaml:snakeyaml:${snakeYamlVersion}")

--- a/spring-beans/src/test/java/org/springframework/beans/DirectFieldAccessorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/DirectFieldAccessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,131 @@
 
 package org.springframework.beans;
 
-import static org.junit.Assert.assertEquals;
-
-import javax.swing.JPanel;
-import javax.swing.JTextField;
-
+import org.junit.Before;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * Unit tests for {@link DirectFieldAccessor}
  *
  * @author Jose Luis Martin
  * @author Chris Beams
+ * @author Maciej Walkowiak
  */
 public class DirectFieldAccessorTests {
 
-	@Test
-	public void withShadowedField() throws Exception {
-		@SuppressWarnings("serial")
-		JPanel p = new JPanel() {
-			@SuppressWarnings("unused")
-			JTextField name = new JTextField();
-		};
+	private Person person;
+	private DirectFieldAccessor accessor;
 
-		DirectFieldAccessor dfa = new DirectFieldAccessor(p);
-		assertEquals(JTextField.class, dfa.getPropertyType("name"));
+	@Before
+	public void setup() {
+		person = new Person();
+		accessor = new DirectFieldAccessor(person);
+	}
+
+	@Test
+	public void testGettingSimpleProperty(){
+		person.name = "John";
+
+		assertThat(accessor.getPropertyValue("name"), is("John"));
+	}
+
+	@Test
+	public void testGettingNestedProperty() {
+		person.name = "John";
+		person.address = new Address();
+		person.address.city = "London";
+
+		assertThat(accessor.getPropertyValue("address.city"), is("London"));
+	}
+
+	@Test(expected = NotReadablePropertyException.class)
+	public void testGettingNonExistingField() {
+		accessor.getPropertyValue("foo");
+	}
+
+	@Test
+	public void testSettingSimpleProperty() {
+		accessor.setPropertyValue("name", "John");
+
+		assertThat(person.name, is("John"));
+	}
+
+	@Test
+	public void testSettingNestedProperty() {
+		accessor.setPropertyValue("address.city", "London");
+
+		assertThat(person.address.city, is("London"));
+	}
+
+	@Test(expected = NotWritablePropertyException.class)
+	public void testSettingNonExistingField() {
+		accessor.setPropertyValue("foo", "bar");
+	}
+
+	@Test
+	public void testSettingNestedPropertyWhenDefaultConstructorNotDefined() {
+		accessor.setPropertyValue("address.country.name", "United Kingdom");
+
+		assertThat(person.address.country.name, is("United Kingdom"));
+	}
+
+	@Test
+	public void testSettingNestedPropertyAsObject() {
+		accessor.setPropertyValue("address.country", new Country("United Kingdom"));
+
+		assertThat(person.address.country.name, is("United Kingdom"));
+	}
+
+	@Test
+	public void testNonReadableProperty() {
+		assertThat(accessor.isReadableProperty("foo"), is(false));
+	}
+
+	@Test
+	public void testNonwritableProperty() {
+		assertThat(accessor.isWritableProperty("foo"), is(false));
+	}
+
+	@Test
+	public void testReadableProperty() {
+		assertThat(accessor.isReadableProperty("name"), is(true));
+	}
+
+	@Test
+	public void testWritableProperty() {
+		assertThat(accessor.isWritableProperty("name"), is(true));
+	}
+
+	@Test
+	public void returnsNullPropertyDescriptorWhenFieldNotFound() {
+		assertThat(accessor.getPropertyTypeDescriptor("foo"), is(nullValue()));
+	}
+
+	@Test
+	public void returnsPropertyDescriptorForExistingField() {
+		assertThat(accessor.getPropertyTypeDescriptor("address.city"), is(notNullValue()));
+	}
+
+	public static class Person {
+		private String name;
+		private Address address;
+	}
+
+	public static class Address {
+		private String city;
+		private Country country;
+	}
+
+	public static class Country {
+		private String name;
+
+		public Country(String name) {
+			this.name = name;
+		}
 	}
 }

--- a/spring-context/src/main/java/org/springframework/validation/DirectFieldBindingResult.java
+++ b/spring-context/src/main/java/org/springframework/validation/DirectFieldBindingResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,7 @@ import org.springframework.util.Assert;
  * supporting registration and evaluation of binding errors on value objects.
  * Performs direct field access instead of going through JavaBean getters.
  *
- * <p>This implementation just supports fields in the actual target object.
- * It is not able to traverse nested fields.
+ * <p>Since 4.1 this implementation is able to traverse nested fields.
  *
  * @author Juergen Hoeller
  * @since 2.0


### PR DESCRIPTION
Major change in `DirectFieldAccessor` - added support for nested path traversing.

As an example, piece of code:

```
Person person = new Person();
person.name = "John";
person.address = new Address();
person.address.city = "London";

assertThat(new DirectFieldAccessor(person).getPropertyValue("address.city"), is("London"));
```

works after improvements made in this pull request.

As a small explanation - mapping creating algorithm has slightly changed: instead of creating `fieldMap` in `DirectFieldAccessor`'s constructor, field is added to map when it is being read or written for the first time. Thanks to that there is no chance to fall into infinite loop or poor performance for complex objects - we map only what has to be mapped.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.

Issue: SPR-9705, SPR-10623, SPR-8692
