### PR TITLE
Fix method comment for getRequiredProperty(key)

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/PropertyResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/env/PropertyResolver.java
@@ -82,8 +82,7 @@ public interface PropertyResolver {
 	<T> Class<T> getPropertyAsClass(String key, Class<T> targetType);
 
 	/**
-	 * Return the property value associated with the given key, converted to the given
-	 * targetType (never {@code null}).
+	 * Return the property value associated with the given key (never {@code null}).
 	 * @throws IllegalStateException if the key cannot be resolved
 	 * @see #getRequiredProperty(String, Class)
 	 */


### PR DESCRIPTION
Method comment apparently copy-pasted from `getRequiredProperty(key, targetType)`, affected online docs: [link](http://docs.spring.io/spring/docs/4.0.x/javadoc-api/org/springframework/core/env/PropertyResolver.html#getRequiredProperty-java.lang.String-)

---

I've signed the CLA
