### PR TITLE
Add JSONP support to MappingJackson2JsonView

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/json/MappingJackson2JsonViewTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/json/MappingJackson2JsonViewTests.java
@@ -17,11 +17,7 @@
 package org.springframework.web.servlet.view.json;
 
 import java.io.IOException;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import org.junit.Before;
@@ -54,6 +50,7 @@ import static org.mockito.Mockito.*;
  * @author Jeremy Grelle
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  */
 public class MappingJackson2JsonViewTests {
 
@@ -290,7 +287,48 @@ public class MappingJackson2JsonViewTests {
 		assertTrue(content.length() > 0);
 		assertEquals(content.length(), response.getContentLength());
 		assertTrue(content.contains("foo"));
-		assertFalse(content.contains("42"));
+		assertFalse(content.contains("boo"));
+		assertFalse(content.contains(JsonView.class.getName()));
+	}
+
+	@Test
+	public void renderWithJsonpDefaultParameterName() throws Exception {
+		Map<String, Object> model = new HashMap<String, Object>();
+		model.put("foo", "bar");
+		request.addParameter("otherparam", "value");
+		request.addParameter("jsonp", "jsonpCallback");
+
+		view.render(model, request, response);
+
+		String content = response.getContentAsString();
+		assertEquals("jsonpCallback({\"foo\":\"bar\"});", content);
+	}
+
+	@Test
+	public void renderWithCallbackDefaultParameterName() throws Exception {
+		Map<String, Object> model = new HashMap<String, Object>();
+		model.put("foo", "bar");
+		request.addParameter("otherparam", "value");
+		request.addParameter("callback", "jsonpCallback");
+
+		view.render(model, request, response);
+
+		String content = response.getContentAsString();
+		assertEquals("jsonpCallback({\"foo\":\"bar\"});", content);
+	}
+
+	@Test
+	 public void renderWithCustomJsonpParameterName() throws Exception {
+		Map<String, Object> model = new HashMap<String, Object>();
+		model.put("foo", "bar");
+		request.addParameter("otherparam", "value");
+		request.addParameter("custom", "jsonpCallback");
+		view.setJsonpParameterNames(Arrays.asList("jsonp", "callback", "custom"));
+
+		view.render(model, request, response);
+
+		String content = response.getContentAsString();
+		assertEquals("jsonpCallback({\"foo\":\"bar\"});", content);
 	}
 
 	private void validateResult() throws Exception {
@@ -307,25 +345,25 @@ public class MappingJackson2JsonViewTests {
 	public static class TestBeanSimple {
 
 		@JsonView(MyJacksonView1.class)
-		private String value = "foo";
+		private String property1 = "foo";
 
 		private boolean test = false;
 
 		@JsonView(MyJacksonView2.class)
-		private long number = 42;
+		private String property2 = "boo";
 
 		private TestChildBean child = new TestChildBean();
 
-		public String getValue() {
-			return value;
+		public String getProperty1() {
+			return property1;
 		}
 
 		public boolean getTest() {
 			return test;
 		}
 
-		public long getNumber() {
-			return number;
+		public String getProperty2() {
+			return property2;
 		}
 
 		public Date getNow() {


### PR DESCRIPTION
Enable JSONP support by wrapping the JSON output into
a callback when a JSONP query parameter specifying the
function name to use as callback is detected.

Default query parameter names recognized as JSONP ones
are "jsonp" and "callback". This list can be customized if
needed.

This commit also fixes JSONView support by removing
the view name specified in the model from the output.

Issue: SPR-8346
