### PR TITLE
While registering an excludePathPattern an includePathPattern is also required

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/InterceptorRegistration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/InterceptorRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public class InterceptorRegistration {
 	 * {@link MappedInterceptor}; otherwise {@link HandlerInterceptor}.
 	 */
 	protected Object getInterceptor() {
-		if (this.includePatterns.isEmpty()) {
+		if (this.includePatterns.isEmpty() && this.excludePatterns.isEmpty()) {
 			return this.interceptor;
 		}
 		MappedInterceptor mappedInterceptor = new MappedInterceptor(

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/InterceptorRegistryTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/InterceptorRegistryTests.java
@@ -138,6 +138,20 @@ public class InterceptorRegistryTests {
 		verifyAdaptedInterceptor(interceptors.get(0), webRequestInterceptor2);
 	}
 
+	/**
+	 * Test for SPR-11130
+	 */
+	@Test
+	public void addInterceptorWithExcludePathPatternOnly() {
+		registry.addInterceptor(interceptor1).excludePathPatterns("/path1/secret");
+		registry.addInterceptor(interceptor2).addPathPatterns("/path2");
+
+		assertEquals(Arrays.asList(interceptor1), getInterceptorsForPath("/path1"));
+		assertEquals(Arrays.asList(interceptor1, interceptor2), getInterceptorsForPath("/path2"));
+		assertEquals(Collections.emptyList(), getInterceptorsForPath("/path1/secret"));
+	}
+
+
 	private List<HandlerInterceptor> getInterceptorsForPath(String lookupPath) {
 		PathMatcher pathMatcher = new AntPathMatcher();
 		List<HandlerInterceptor> result = new ArrayList<HandlerInterceptor>();
@@ -147,11 +161,9 @@ public class InterceptorRegistryTests {
 				if (mappedInterceptor.matches(lookupPath, pathMatcher)) {
 					result.add(mappedInterceptor.getInterceptor());
 				}
-			}
-			else if (i instanceof HandlerInterceptor){
+			} else if (i instanceof HandlerInterceptor) {
 				result.add((HandlerInterceptor) i);
-			}
-			else {
+			} else {
 				fail("Unexpected interceptor type: " + i.getClass().getName());
 			}
 		}


### PR DESCRIPTION
Added a check for emtpyness of `excludePatterns` next to the `includePatterns`

Issue: SPR-11130

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
