### PR TITLE
StringUtils.trimAllWhitespace(String str) is slow.

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -218,9 +218,9 @@ public abstract class StringUtils {
 			StringBuffer sb = new StringBuffer(str.length());
 			int index = 0;
 			while(index < len) {
-				char charAt = str.charAt(index);
-				if (!Character.isWhitespace(charAt)) {
-					sb.append(charAt);
+				char c = str.charAt(index);
+				if (!Character.isWhitespace(c)) {
+					sb.append(c);
 				}
 				index++;
 			}

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -213,20 +213,21 @@ public abstract class StringUtils {
 	 * @see java.lang.Character#isWhitespace
 	 */
 	public static String trimAllWhitespace(String str) {
-		if (!hasLength(str)) {
-			return str;
-		}
-		StringBuilder sb = new StringBuilder(str);
-		int index = 0;
-		while (sb.length() > index) {
-			if (Character.isWhitespace(sb.charAt(index))) {
-				sb.deleteCharAt(index);
-			}
-			else {
+		int len = str.length();
+		if((str != null && len > 0)) {
+			StringBuffer sb = new StringBuffer(str.length());
+			int index = 0;
+			while(index < len) {
+				char charAt = str.charAt(index);
+				if (!Character.isWhitespace(charAt)) {
+					sb.append(charAt);
+				}
 				index++;
 			}
+			return sb.toString();
+		}else {
+			return str;
 		}
-		return sb.toString();
 	}
 
 	/**


### PR DESCRIPTION
StringUtils.trimAllWhitespace(String str) is slow.
Using sb.deleteCharAt(index) is not a good idea, it will call 
System.arraycopy(value, index+1, value, index, count-index-1);

Test:
https://gist.github.com/hengyunabc/a4651e90db24cc5ed29a

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
