### PR TITLE
Expose exception as request attribute when calling sendError

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/support/HttpRequestHandlerServlet.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/HttpRequestHandlerServlet.java
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.util.WebUtils;
 
 /**
  * Simple HttpServlet that delegates to an {@link HttpRequestHandler} bean defined
@@ -72,7 +73,7 @@ public class HttpRequestHandlerServlet extends HttpServlet {
 			if (supportedMethods != null) {
 				response.setHeader("Allow", StringUtils.arrayToDelimitedString(supportedMethods, ", "));
 			}
-			response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, ex.getMessage());
+			WebUtils.sendError(request, response, HttpServletResponse.SC_METHOD_NOT_ALLOWED, ex, ex.getMessage());
 		}
 		finally {
 			LocaleContextHolder.resetLocaleContext();

--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -18,6 +18,7 @@ package org.springframework.web.util;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -43,6 +44,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Rod Johnson
  * @author Juergen Hoeller
+ * @author Sebastien Deleuze
  */
 public abstract class WebUtils {
 
@@ -120,6 +122,14 @@ public abstract class WebUtils {
 
 	/** Key for the mutex session attribute */
 	public static final String SESSION_MUTEX_ATTRIBUTE = WebUtils.class.getName() + ".MUTEX";
+
+	/**
+	 * This request attribute is similar to the standard servlet
+	 * {@link WebUtils#ERROR_EXCEPTION_ATTRIBUTE} request attribute, but is more flexible
+	 * since the response won't be automatically handled by the servlet container as an
+	 * {@link org.springframework.http.HttpStatus#INTERNAL_SERVER_ERROR} error page.
+	 */
+	public static final String EXCEPTION_ATTRIBUTE = WebUtils.class.getName() + ".EXCEPTION";
 
 
 	/**
@@ -735,4 +745,46 @@ public abstract class WebUtils {
 		}
 		return result;
 	}
+
+	/**
+	 * Sends an error response to the client using the specified status, and stores the
+	 * exception encountered in the {@link WebUtils#EXCEPTION_ATTRIBUTE} request attribute
+	 * in order to make it available to the view.
+	 *
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @param status the error status code
+	 * @param ex the exception encountered
+	 * @throws IOException if an input or output exception occurs
+	 * @throws IllegalStateException if the response was committed before this method call
+	 *
+	 * @since 4.1
+	 * @see HttpServletResponse#sendError(int)
+	 */
+	public static void sendError(HttpServletRequest request, HttpServletResponse response, int status, Throwable ex) throws IOException {
+		request.setAttribute(EXCEPTION_ATTRIBUTE, ex);
+		response.sendError(status);
+	}
+
+	/**
+	 * Sends an error response to the client using the specified status, stores the
+	 * exception encountered in the {@link WebUtils#EXCEPTION_ATTRIBUTE} request attribute
+	 * in order to make it available to the view, and set the response error message.
+	 *
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @param status the error status code
+	 * @param ex the exception encountered
+	 * @param message the descriptive message of the error
+	 * @throws IOException if an input or output exception occurs
+	 * @throws IllegalStateException if the response was committed before this method call
+	 *
+	 * @since 4.1
+	 * @see HttpServletResponse#sendError(int, String)
+	 */
+	public static void sendError(HttpServletRequest request, HttpServletResponse response, int status, Throwable ex, String message) throws IOException {
+		request.setAttribute(EXCEPTION_ATTRIBUTE, ex);
+		response.sendError(status, message);
+	}
+
 }

--- a/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,24 @@
 
 package org.springframework.web.util;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import org.junit.Test;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.mock.web.test.MockHttpServletRequest;
+import org.springframework.mock.web.test.MockHttpServletResponse;
 import org.springframework.util.MultiValueMap;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Juergen Hoeller
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  */
 public class WebUtilsTests {
 
@@ -95,6 +100,27 @@ public class WebUtilsTests {
 		variables = WebUtils.parseMatrixVariables("colors=red;colors=blue;colors=green");
 		assertEquals(1, variables.size());
 		assertEquals(Arrays.asList("red", "blue", "green"), variables.get("colors"));
+	}
+
+	@Test
+	public void sendError() throws IOException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		HttpMessageNotWritableException ex = new HttpMessageNotWritableException("test message");
+		WebUtils.sendError(request, response, 500, ex);
+		assertNotNull(request.getAttribute(WebUtils.EXCEPTION_ATTRIBUTE));
+		assertEquals(HttpMessageNotWritableException.class, request.getAttribute(WebUtils.EXCEPTION_ATTRIBUTE).getClass());
+	}
+
+	@Test
+	public void sendErrorWithMessage() throws IOException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		HttpMessageNotWritableException ex = new HttpMessageNotWritableException("test message");
+		WebUtils.sendError(request, response, 500, ex, "test message");
+		assertNotNull(request.getAttribute(WebUtils.EXCEPTION_ATTRIBUTE));
+		assertEquals(HttpMessageNotWritableException.class, request.getAttribute(WebUtils.EXCEPTION_ATTRIBUTE).getClass());
+		assertTrue(response.getErrorMessage().contains("test message"));
 	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/annotation/ResponseStatusExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/annotation/ResponseStatusExceptionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.AbstractHandlerExceptionResolver;
+import org.springframework.web.util.WebUtils;
 
 /**
  * Implementation of the {@link org.springframework.web.servlet.HandlerExceptionResolver HandlerExceptionResolver}
@@ -85,10 +86,10 @@ public class ResponseStatusExceptionResolver extends AbstractHandlerExceptionRes
 			reason = this.messageSource.getMessage(reason, null, reason, LocaleContextHolder.getLocale());
 		}
 		if (!StringUtils.hasLength(reason)) {
-			response.sendError(statusCode);
+			WebUtils.sendError(request, response, statusCode, ex);
 		}
 		else {
-			response.sendError(statusCode, reason);
+			WebUtils.sendError(request, response, statusCode, ex, reason);
 		}
 		return new ModelAndView();
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/multiaction/MultiActionController.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/multiaction/MultiActionController.java
@@ -41,6 +41,7 @@ import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
 import org.springframework.web.servlet.mvc.LastModified;
+import org.springframework.web.util.WebUtils;
 
 /**
  * {@link org.springframework.web.servlet.mvc.Controller Controller}
@@ -429,7 +430,7 @@ public class MultiActionController extends AbstractController implements LastMod
 			throws Exception {
 
 		pageNotFoundLogger.warn(ex.getMessage());
-		response.sendError(HttpServletResponse.SC_NOT_FOUND);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_NOT_FOUND, ex);
 		return null;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.handler.AbstractHandlerExceptionResolver;
 import org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException;
+import org.springframework.web.util.WebUtils;
 
 /**
  * Default implementation of the {@link org.springframework.web.servlet.HandlerExceptionResolver
@@ -59,6 +60,7 @@ import org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMeth
  *
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  * @since 3.0
  *
  * @see org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
@@ -175,7 +177,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
 
 		pageNotFoundLogger.warn(ex.getMessage());
-		response.sendError(HttpServletResponse.SC_NOT_FOUND);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_NOT_FOUND, ex);
 		return new ModelAndView();
 	}
 
@@ -200,7 +202,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 		if (supportedMethods != null) {
 			response.setHeader("Allow", StringUtils.arrayToDelimitedString(supportedMethods, ", "));
 		}
-		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, ex.getMessage());
+		WebUtils.sendError(request, response, HttpServletResponse.SC_METHOD_NOT_ALLOWED, ex, ex.getMessage());
 		return new ModelAndView();
 	}
 
@@ -219,7 +221,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	protected ModelAndView handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex,
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
 
-		response.sendError(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE, ex);
 		List<MediaType> mediaTypes = ex.getSupportedMediaTypes();
 		if (!CollectionUtils.isEmpty(mediaTypes)) {
 			response.setHeader("Accept", MediaType.toString(mediaTypes));
@@ -243,7 +245,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	protected ModelAndView handleHttpMediaTypeNotAcceptable(HttpMediaTypeNotAcceptableException ex,
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
 
-		response.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_NOT_ACCEPTABLE, ex);
 		return new ModelAndView();
 	}
 
@@ -262,7 +264,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	protected ModelAndView handleMissingServletRequestParameter(MissingServletRequestParameterException ex,
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
 
-		response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
+		WebUtils.sendError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex, ex.getMessage());
 		return new ModelAndView();
 	}
 
@@ -280,7 +282,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	protected ModelAndView handleServletRequestBindingException(ServletRequestBindingException ex,
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
 
-		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex);
 		return new ModelAndView();
 	}
 
@@ -310,7 +312,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 			HttpServletRequest request, HttpServletResponse response) throws IOException {
 
 		request.setAttribute("javax.servlet.error.exception", ex);
-		response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex);
 	}
 
 	/**
@@ -327,7 +329,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	protected ModelAndView handleTypeMismatch(TypeMismatchException ex,
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
 
-		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex);
 		return new ModelAndView();
 	}
 
@@ -347,7 +349,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	protected ModelAndView handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
 
-		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex);
 		return new ModelAndView();
 	}
 
@@ -383,7 +385,8 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	 */
 	protected ModelAndView handleMethodArgumentNotValidException(MethodArgumentNotValidException ex,
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
- 		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+
+		WebUtils.sendError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex);
 		return new ModelAndView();
 	}
 
@@ -399,7 +402,8 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	 */
 	protected ModelAndView handleMissingServletRequestPartException(MissingServletRequestPartException ex,
 			HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
-		response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
+
+		WebUtils.sendError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex, ex.getMessage());
 		return new ModelAndView();
 	}
 
@@ -416,7 +420,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	 */
 	protected ModelAndView handleBindException(BindException ex, HttpServletRequest request,
 			HttpServletResponse response, Object handler) throws IOException {
-		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		WebUtils.sendError(request, response, HttpServletResponse.SC_BAD_REQUEST, ex);
 		return new ModelAndView();
 	}
 
@@ -436,7 +440,8 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	 */
 	protected ModelAndView handleNoHandlerFoundException(NoHandlerFoundException ex, HttpServletRequest request,
 	                                           HttpServletResponse response, Object handler) throws IOException {
-		response.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+		WebUtils.sendError(request, response, HttpServletResponse.SC_NOT_FOUND, ex);
 		return new ModelAndView();
 	}
 


### PR DESCRIPTION
When sending an error response, expose the encountered exception
as a "org.springframework.web.util.WebUtils.EXCEPTION" request
attribute.

This request attribute is similar to the standard servlet
"javax.servlet.error.exception" request attribute, but is more
flexible since the response won't be automatically handled
by the servlet container as an INTERNAL_SERVER_ERROR error page.

Issue: SPR-11686
