### PR TITLE
In case that reqeust url includes "=" char in front of first semicolon,

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
@@ -143,7 +143,7 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 		for (Entry<String, String> uriVar : uriVariables.entrySet()) {
 			String uriVarValue = uriVar.getValue();
 
-			int equalsIndex = uriVarValue.indexOf('=');
+			int equalsIndex = uriVarValue.lastIndexOf('=');
 			if (equalsIndex == -1) {
 				continue;
 			}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,6 +364,18 @@ public class RequestMappingInfoHandlerMappingTests {
 		assertNull(matrixVariables);
 		assertEquals("cars", uriVariables.get("cars"));
 		assertEquals("", uriVariables.get("params"));
+		
+		// SPR-11897
+		request = new MockHttpServletRequest();
+		testHandleMatch(request, "/{cars}", "/cars=suv;colors=red,blue,green;year=2012");
+
+		matrixVariables = getMatrixVariables(request, "cars");
+		uriVariables = getUriTemplateVariables(request);
+
+		assertNotNull(matrixVariables);
+		assertEquals(Arrays.asList("red", "blue", "green"), matrixVariables.get("colors"));
+		assertEquals("2012", matrixVariables.getFirst("year"));
+		assertEquals("cars=suv", uriVariables.get("cars"));
 	}
 
 	@Test


### PR DESCRIPTION
In case that reqeust url includes "=" char in front of first semicolon,
PathVariable do not work properly.
Problem is that @PathVariable value includes matrixVariable String.

For example, if Spring MVC Controller method has @RequestMapping(value =
/bar/{foo}", method = RequestMethod.GET) and request url is
http://localhost:8080/context/bar/abc;key=xyz, we expect @PathVariable
foo == "abc" and @MatrixVariable key == "xyz". Actually this works well.
But when request url is
http://localhost:8080/context/bar/name=abc;key=xyz,
despite expectations that @PathVariable foo == "name=abc" and
@MatrixVariable key == "xyz", @PathVariable foo == "name=abc;key=xyz".

I modified so that @PathVariable foo may have "name=abc".

Issue : SPR-11897
