### PR TITLE
In connection with "[SPR-11126] problem converting empty parameter to

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
@@ -204,7 +204,7 @@ public class RequestParamMethodArgumentResolver extends AbstractNamedValueMethod
 			if (arg == null) {
 				String[] paramValues = webRequest.getParameterValues(name);
 				if (paramValues != null) {
-					arg = paramValues.length == 1 ? paramValues[0] : paramValues;
+					arg = (paramValues.length == 1 && !List.class.isAssignableFrom(parameter.getParameterType())) ? paramValues[0] : paramValues;
 				}
 			}
 		}


### PR DESCRIPTION
In connection with "[SPR-11126] problem converting empty parameter to List", 
the resolveName(String, MethodParameter, NativeWebRequest) method
in the RequestParamMethodArgumentResolver.java has been slightly
chagned.
In case that MethodParameter is related to List type,
String[](with legnth 1) value will be returned itself
without being changed to String.

Issue : SPR-11126
