### PR TITLE
Workaround for WFLY-3474 NullPointerException

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
@@ -367,10 +367,15 @@ public abstract class AbstractSockJsService implements SockJsService {
 		HttpHeaders requestHeaders = request.getHeaders();
 		HttpHeaders responseHeaders = response.getHeaders();
 
-		// Perhaps a CORS Filter has already added this?
-		if (!CollectionUtils.isEmpty(responseHeaders.get("Access-Control-Allow-Origin"))) {
-			logger.debug("Skip adding CORS headers, response already contains \"Access-Control-Allow-Origin\"");
-			return;
+		try {
+			// Perhaps a CORS Filter has already added this?
+			if (!CollectionUtils.isEmpty(responseHeaders.get("Access-Control-Allow-Origin"))) {
+				logger.debug("Skip adding CORS headers, response already contains \"Access-Control-Allow-Origin\"");
+				return;
+			}
+		}
+		catch (NullPointerException npe) {
+			// See SPR-11919 and https://issues.jboss.org/browse/WFLY-3474
 		}
 
 		String origin = requestHeaders.getFirst("origin");


### PR DESCRIPTION
Prior to this commit, the ServletResponseHttpHeaders.get method
would throw an NPE when used under Wildfly 8.0.0.Final and 8.1.0.Final.
This can be traced to WFLY-3474, which throws an NPE when calling
HttpServletResponse.getHeaders("foo") and that header has not
been defined prior to that.

This commit adds a check for this exception and returns null in that
case.

Issue: SPR-11919
