### PR TITLE
Fixed [SPR-11897]

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
@@ -151,12 +151,14 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 			String matrixVariables;
 
 			int semicolonIndex = uriVarValue.indexOf(';');
-			if ((semicolonIndex == -1) || (semicolonIndex == 0) || (equalsIndex < semicolonIndex)) {
-				matrixVariables = uriVarValue;
-			}
-			else {
-				matrixVariables = uriVarValue.substring(semicolonIndex + 1);
+			if (semicolonIndex != -1) {
 				uriVariables.put(uriVar.getKey(), uriVarValue.substring(0, semicolonIndex));
+			}
+			
+			if ((semicolonIndex == -1) || (semicolonIndex == 0) || (equalsIndex < semicolonIndex)) {				
+				matrixVariables = uriVarValue;
+			} else {
+				matrixVariables = uriVarValue.substring(semicolonIndex + 1);
 			}
 
 			MultiValueMap<String, String> vars = WebUtils.parseMatrixVariables(matrixVariables);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
@@ -353,7 +353,8 @@ public class RequestMappingInfoHandlerMappingTests {
 		assertEquals(Arrays.asList("red", "blue", "green"), matrixVariables.get("colors"));
 		assertEquals("2012", matrixVariables.getFirst("year"));
 		assertEquals("cars", uriVariables.get("cars"));
-		assertEquals(";colors=red,blue,green;year=2012", uriVariables.get("params"));
+		// SPR-11897
+		assertEquals("", uriVariables.get("params"));
 
 		request = new MockHttpServletRequest();
 		testHandleMatch(request, "/{cars:[^;]+}{params}", "/cars");
@@ -364,6 +365,18 @@ public class RequestMappingInfoHandlerMappingTests {
 		assertNull(matrixVariables);
 		assertEquals("cars", uriVariables.get("cars"));
 		assertEquals("", uriVariables.get("params"));
+
+		// SPR-11897
+		request = new MockHttpServletRequest();
+		testHandleMatch(request, "/{cars}", "/cars=suv;colors=red,blue,green;year=2012");
+
+		matrixVariables = getMatrixVariables(request, "cars");
+		uriVariables = getUriTemplateVariables(request);
+
+		assertNotNull(matrixVariables);
+		assertEquals(Arrays.asList("red", "blue", "green"), matrixVariables.get("colors"));
+		assertEquals("2012", matrixVariables.getFirst("year"));
+		assertEquals("cars=suv", uriVariables.get("cars"));
 	}
 
 	@Test

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/UriTemplateServletAnnotationControllerHandlerMethodTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/UriTemplateServletAnnotationControllerHandlerMethodTests.java
@@ -297,9 +297,50 @@ public class UriTemplateServletAnnotationControllerHandlerMethodTests extends Ab
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		getServlet().service(request, response);
 		assertEquals(200, response.getStatus());
-		assertEquals("test-42-;q=1;q=2-[1, 2]", response.getContentAsString());
+		// SPR-11897
+		assertEquals("test-42--[1, 2]", response.getContentAsString());
 	}
 
+	/*
+	 * See SPR-11897
+	 */
+	@Test
+	public void matrixVariableWithEquals() throws Exception {
+		initServletWithControllers(MatrixParameterController.class);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/42;q=1;q=2");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		getServlet().service(request, response);
+		assertEquals(200, response.getStatus());
+		assertEquals("test-42-[1, 2]", response.getContentAsString());
+		
+		request = new MockHttpServletRequest("GET", "/a=42;q=1;q=2");
+		response = new MockHttpServletResponse();
+		getServlet().service(request, response);
+		assertEquals(200, response.getStatus());
+		assertEquals("test-a=42-[1, 2]", response.getContentAsString());
+	}
+	
+	/*
+	 * See SPR-11897
+	 */
+	@Test
+	public void matrixVariablesGetAll() throws Exception {
+		initServletWithControllers(MatrixAllParametersController.class);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/42;q=1;q=2");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		getServlet().service(request, response);
+		assertEquals(200, response.getStatus());
+		assertEquals("test-42-{q=[1, 2]}", response.getContentAsString());
+		
+		request = new MockHttpServletRequest("GET", "/a=42;q=1;q=2");
+		response = new MockHttpServletResponse();
+		getServlet().service(request, response);
+		assertEquals(200, response.getStatus());
+		assertEquals("test-a=42-{a=[42], q=[1, 2]}", response.getContentAsString());
+	}
+	
 	/*
 	 * See SPR-6640
 	 */
@@ -520,6 +561,27 @@ public class UriTemplateServletAnnotationControllerHandlerMethodTests extends Ab
 
 			assertEquals("Invalid path variable value", 42, root);
 			writer.write("test-" + root + "-" + paramString + "-" + q);
+		}
+	}
+
+	@Controller
+	public static class MatrixParameterController {
+
+		@RequestMapping("/{root}")
+		public void handle(@PathVariable("root") String root,
+				@MatrixVariable List<Integer> q, Writer writer) throws IOException {
+			writer.write("test-" + root + "-" + q);
+		}
+	}
+	
+	@Controller
+	public static class MatrixAllParametersController {
+
+		@RequestMapping("/{root}")
+		public void handle(@PathVariable("root") String root,
+				@MatrixVariable(pathVar="root") Map<String, String> rootMatrixVars, Writer writer) throws IOException {
+
+			writer.write("test-" + root + "-" + rootMatrixVars);
 		}
 	}
 


### PR DESCRIPTION
Please refer to [SPR-11897](https://jira.spring.io/browse/SPR-11897).

The gist of the bug is that in the case of posting "a=a;b=c" as a path variable when shouldRemoveSemicolonContent is false, the matrix parameters are evaluated as [a->a, b->c] and the path variable remains "a=a;b=c" whilst in the case of "aa;b=c" the matrix parameters are evaluated as [b->c] and the path variable is passed as "aa" thus leading to inconsistent and undocumented behavior when a '=' sign is present in the pre-matrix (before the first semicolon) part of the path.
This fix assumes that parsing the pre-matrix part of the path was a desired feature (due to lack of official comment on SPR-11897) but that the returned path variable should omit what spring parsed as matrix variables.

I've added several tests to validate this and fix other tests that expected it (for example: in case of having a path variable that it's first character is a semicolon, the test expected the entire value and not an empty string - I changed it to an empty string as all these values were parsed as matrix variables)

Commit message:
Fixed SPR-11897 in a way that does not harm the feature (?) of parsing key=value in
the pre-matrix part of the path as though it was a matrix variable
- added test to validate that scenario
