### PR TITLE
SPR-11875: Performance regression for custom autowireBean calls with many properties

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,8 +47,6 @@ import org.springframework.util.Assert;
  */
 @SuppressWarnings("serial")
 public class RootBeanDefinition extends AbstractBeanDefinition {
-
-	boolean allowCaching = true;
 
 	private BeanDefinitionHolder decoratedDefinition;
 
@@ -171,7 +169,6 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 	 */
 	public RootBeanDefinition(RootBeanDefinition original) {
 		super(original);
-		this.allowCaching = original.allowCaching;
 		this.decoratedDefinition = original.decoratedDefinition;
 		this.targetType = original.targetType;
 		this.isFactoryMethodUnique = original.isFactoryMethodUnique;


### PR DESCRIPTION
Please see SPR-11875.

This commit reverts e1d11ec99d40051ecdb60191c49bc587373a031d and uses ConcurrentReferenceHashMap to fix SPR-8956 memory leak instead.

Autowire benchmark https://github.com/trask/spring-autowire-benchmark is back in line with Spring 3.1.4 after this.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
