### PR TITLE
Make ListenableFuture compliant with Java 8 lambda

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncResult.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncResult.java
@@ -18,8 +18,10 @@ package org.springframework.scheduling.annotation;
 
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.util.concurrent.SuccessCallback;
 
 /**
  * A pass-through {@code Future} handle that can be used for method signatures
@@ -74,7 +76,15 @@ public class AsyncResult<V> implements ListenableFuture<V> {
 
 	@Override
 	public void addCallback(ListenableFutureCallback<? super V> callback) {
-		callback.onSuccess(this.value);
+		addCallback(callback, callback);
 	}
 
+	@Override
+	public void addCallback(SuccessCallback<? super V> successCallback, FailureCallback failureCallback) {
+		try {
+			successCallback.onSuccess(this.value);
+		} catch(Throwable t) {
+			failureCallback.onFailure(t);
+		}
+	}
 }

--- a/spring-core/src/main/java/org/springframework/util/concurrent/FailureCallback.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/FailureCallback.java
@@ -17,13 +17,18 @@
 package org.springframework.util.concurrent;
 
 /**
- * Defines the contract for callbacks that accept the result of a
+ * Defines the contract for failure callbacks that accept the result of a
  * {@link ListenableFuture}.
  *
- * @author Arjen Poutsma
  * @author Sebastien Deleuze
- * @since 4.0
+ * @since 4.1
  */
-public interface ListenableFutureCallback<T> extends SuccessCallback<T>, FailureCallback {
+public interface FailureCallback {
+
+	/**
+	 * Called when the {@link ListenableFuture} fails to complete.
+	 * @param t the exception that triggered the failure
+	 */
+	void onFailure(Throwable t);
 
 }

--- a/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFuture.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.concurrent.Future;
  * <p>Inspired by {@code com.google.common.util.concurrent.ListenableFuture}.
 
  * @author Arjen Poutsma
+ * @author Sebastien Deleuze
  * @since 4.0
  */
 public interface ListenableFuture<T> extends Future<T> {
@@ -36,5 +37,16 @@ public interface ListenableFuture<T> extends Future<T> {
 	 * @param callback the callback to register
 	 */
 	void addCallback(ListenableFutureCallback<? super T> callback);
+
+	/**
+	 * Registers the given success and failure callbacks to this {@code ListenableFuture}.
+	 * The callback will be triggered when this {@code Future} is complete or, if it is
+	 * already complete immediately. This is a Java 8 lambdas compliant alternative to
+	 * {@link #addCallback(ListenableFutureCallback)}.
+	 * @param successCallback the success callback to register
+	 * @param failureCallback the failure callback to register
+	 * @since 4.1
+	 */
+	void addCallback(SuccessCallback<? super T> successCallback, FailureCallback failureCallback);
 
 }

--- a/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFutureAdapter.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFutureAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,12 +44,18 @@ public abstract class ListenableFutureAdapter<T, S> extends FutureAdapter<T, S>
 
 	@Override
 	public void addCallback(final ListenableFutureCallback<? super T> callback) {
+		addCallback(callback, callback);
+	}
+
+	@Override
+	public void addCallback(final SuccessCallback<? super T> successCallback,
+							final FailureCallback failureCallback) {
 		ListenableFuture<S> listenableAdaptee = (ListenableFuture<S>) getAdaptee();
 		listenableAdaptee.addCallback(new ListenableFutureCallback<S>() {
 			@Override
 			public void onSuccess(S result) {
 				try {
-					callback.onSuccess(adaptInternal(result));
+					successCallback.onSuccess(adaptInternal(result));
 				}
 				catch (ExecutionException ex) {
 					Throwable cause = ex.getCause();
@@ -62,8 +68,9 @@ public abstract class ListenableFutureAdapter<T, S> extends FutureAdapter<T, S>
 
 			@Override
 			public void onFailure(Throwable t) {
-				callback.onFailure(t);
+				failureCallback.onFailure(t);
 			}
 		});
 	}
+
 }

--- a/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFutureTask.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFutureTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,12 @@ public class ListenableFutureTask<T> extends FutureTask<T> implements Listenable
 	@Override
 	public void addCallback(ListenableFutureCallback<? super T> callback) {
 		this.callbacks.addCallback(callback);
+	}
+
+	@Override
+	public void addCallback(SuccessCallback<? super T> successCallback, FailureCallback failureCallback) {
+		this.callbacks.addSuccessCallback(successCallback);
+		this.callbacks.addFailureCallback(failureCallback);
 	}
 
 	@Override

--- a/spring-core/src/main/java/org/springframework/util/concurrent/SettableListenableFuture.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/SettableListenableFuture.java
@@ -85,6 +85,11 @@ public class SettableListenableFuture<T> implements ListenableFuture<T> {
 	}
 
 	@Override
+	public void addCallback(SuccessCallback<? super T> successCallback, FailureCallback failureCallback) {
+		this.listenableFuture.addCallback(successCallback, failureCallback);
+	}
+
+	@Override
 	public boolean cancel(boolean mayInterruptIfRunning) {
 		this.settableTask.setCancelled();
 		boolean cancelled = this.listenableFuture.cancel(mayInterruptIfRunning);

--- a/spring-core/src/main/java/org/springframework/util/concurrent/SuccessCallback.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/SuccessCallback.java
@@ -17,13 +17,18 @@
 package org.springframework.util.concurrent;
 
 /**
- * Defines the contract for callbacks that accept the result of a
+ * Defines the contract for success callbacks that accept the result of a
  * {@link ListenableFuture}.
  *
- * @author Arjen Poutsma
  * @author Sebastien Deleuze
- * @since 4.0
+ * @since 4.1
  */
-public interface ListenableFutureCallback<T> extends SuccessCallback<T>, FailureCallback {
+public interface SuccessCallback<T> {
+
+	/**
+	 * Called when the {@link ListenableFuture} successfully completes.
+	 * @param result the result
+	 */
+	void onSuccess(T result);
 
 }

--- a/spring-core/src/test/java/org/springframework/util/concurrent/ListenableFutureTaskTests.java
+++ b/spring-core/src/test/java/org/springframework/util/concurrent/ListenableFutureTaskTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import org.junit.Test;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
 /**
  * @author Arjen Poutsma
+ * @author Sebastien Deleuze
  */
 public class ListenableFutureTaskTests {
 
@@ -77,6 +82,33 @@ public class ListenableFutureTaskTests {
 		task.run();
 	}
 
+	@Test
+	public void successWithLambdas() throws ExecutionException, InterruptedException {
+		final String s = "Hello World";
+		Callable<String> callable = () -> s;
+		SuccessCallback<String> successCallback = mock(SuccessCallback.class);
+		FailureCallback failureCallback = mock(FailureCallback.class);
+		ListenableFutureTask<String> task = new ListenableFutureTask<>(callable);
+		task.addCallback(successCallback, failureCallback);
+		task.run();
+		verify(successCallback).onSuccess(s);
+		verifyZeroInteractions(failureCallback);
+	}
 
+	@Test
+	public void failureWithLambdas() throws ExecutionException, InterruptedException {
+		final String s = "Hello World";
+		IOException ex = new IOException(s);
+		Callable<String> callable = () -> {
+			throw ex;
+		};
+		SuccessCallback<String> successCallback = mock(SuccessCallback.class);
+		FailureCallback failureCallback = mock(FailureCallback.class);
+		ListenableFutureTask<String> task = new ListenableFutureTask<>(callable);
+		task.addCallback(successCallback, failureCallback);
+		task.run();
+		verify(failureCallback).onFailure(ex);
+		verifyZeroInteractions(successCallback);
+	}
 
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/tcp/reactor/AbstractPromiseToListenableFutureAdapter.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/tcp/reactor/AbstractPromiseToListenableFutureAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.springframework.util.Assert;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.ListenableFutureCallbackRegistry;
+import org.springframework.util.concurrent.SuccessCallback;
 
 import reactor.core.composable.Promise;
 import reactor.function.Consumer;
@@ -106,4 +108,9 @@ abstract class AbstractPromiseToListenableFutureAdapter<S, T> implements Listena
 		this.registry.addCallback(callback);
 	}
 
+	@Override
+	public void addCallback(SuccessCallback<? super T> successCallback, FailureCallback failureCallback) {
+		this.registry.addSuccessCallback(successCallback);
+		this.registry.addFailureCallback(failureCallback);
+	}
 }

--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpRequest.java
@@ -29,12 +29,15 @@ import org.apache.http.nio.client.HttpAsyncClient;
 import org.apache.http.nio.entity.NByteArrayEntity;
 import org.apache.http.protocol.HttpContext;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.FutureAdapter;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.ListenableFutureCallbackRegistry;
+import org.springframework.util.concurrent.SuccessCallback;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
 
 /**
  * {@link ClientHttpRequest} implementation that uses Apache HttpComponents HttpClient to
@@ -101,6 +104,14 @@ final class HttpComponentsAsyncClientHttpRequest extends AbstractBufferingAsyncC
 			this.callbacks.addCallback(callback);
 		}
 
+		public void addSuccessCallback(SuccessCallback<? super ClientHttpResponse> callback) {
+			this.callbacks.addSuccessCallback(callback);
+		}
+
+		public void addFailureCallback(FailureCallback callback) {
+			this.callbacks.addFailureCallback(callback);
+		}
+
 		@Override
 		public void completed(HttpResponse result) {
 			this.callbacks.success(new HttpComponentsAsyncClientHttpResponse(result));
@@ -135,6 +146,12 @@ final class HttpComponentsAsyncClientHttpRequest extends AbstractBufferingAsyncC
 		@Override
 		public void addCallback(ListenableFutureCallback<? super ClientHttpResponse> callback) {
 			this.callback.addCallback(callback);
+		}
+
+		@Override
+		public void addCallback(SuccessCallback<? super ClientHttpResponse> successCallback, FailureCallback failureCallback) {
+			this.callback.addSuccessCallback(successCallback);
+			this.callback.addFailureCallback(failureCallback);
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/client/AsyncRestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/AsyncRestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,9 +44,11 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.client.support.AsyncHttpAccessor;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.util.Assert;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureAdapter;
 import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.util.concurrent.SuccessCallback;
 import org.springframework.web.util.UriTemplate;
 
 /**
@@ -254,15 +256,21 @@ public class AsyncRestTemplate extends AsyncHttpAccessor implements AsyncRestOpe
 
 			@Override
 			public void addCallback(final ListenableFutureCallback<? super URI> callback) {
+				addCallback(callback, callback);
+			}
+
+			@Override
+			public void addCallback(final SuccessCallback<? super URI> successCallback,
+									final FailureCallback failureCallback) {
 				headersFuture.addCallback(new ListenableFutureCallback<HttpHeaders>() {
 					@Override
 					public void onSuccess(HttpHeaders result) {
-						callback.onSuccess(result.getLocation());
+						successCallback.onSuccess(result.getLocation());
 					}
 
 					@Override
 					public void onFailure(Throwable t) {
-						callback.onFailure(t);
+						failureCallback.onFailure(t);
 					}
 				});
 			}
@@ -391,17 +399,21 @@ public class AsyncRestTemplate extends AsyncHttpAccessor implements AsyncRestOpe
 		return new ListenableFuture<Set<HttpMethod>>() {
 
 			@Override
-			public void addCallback(
-					final ListenableFutureCallback<? super Set<HttpMethod>> callback) {
+			public void addCallback(final ListenableFutureCallback<? super Set<HttpMethod>> callback) {
+				addCallback(callback, callback);
+			}
+
+			@Override
+			public void addCallback(final SuccessCallback<? super Set<HttpMethod>> successCallback, final FailureCallback failureCallback) {
 				headersFuture.addCallback(new ListenableFutureCallback<HttpHeaders>() {
 					@Override
 					public void onSuccess(HttpHeaders result) {
-						callback.onSuccess(result.getAllow());
+						successCallback.onSuccess(result.getAllow());
 					}
 
 					@Override
 					public void onFailure(Throwable t) {
-						callback.onFailure(t);
+						failureCallback.onFailure(t);
 					}
 				});
 			}


### PR DESCRIPTION
Make it possible to use a ListenableFuture with Java 8
lambda expressions, using a syntax like
listenableFuture.onSuccess(() -> ...).onFailure(() -> ...);

Issue: SPR-11820
