### PR TITLE
Introduce RequestEntity and builder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestOperations.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestOperations.java
@@ -24,6 +24,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 
 /**
@@ -460,6 +461,46 @@ public interface RestOperations {
 	 */
 	<T> ResponseEntity<T> exchange(URI url, HttpMethod method, HttpEntity<?> requestEntity,
 			ParameterizedTypeReference<T> responseType) throws RestClientException;
+
+	/**
+	 * Execute the HTTP method and URL of the {@link RequestEntity}, writing it to the
+	 * request, and returns the response as {@link ResponseEntity}. Typically used in
+	 * combination with the static builder methods on {@code RequestEntity}, for instance:
+	 *
+	 * <pre class="code">
+	 * MyRequest body = ...
+	 * RequestEntity request = RequestEntity.post(&quot;http://example.com/{foo}&quot;, &quot;bar&quot;).accept(MediaType.APPLICATION_JSON).body(body);
+	 * ResponseEntity&lt;MyResponse&gt; response = template.exchange(request, MyResponse.class);
+	 * </pre>
+	 *
+	 * @param requestEntity the entity to write to the request
+	 * @param responseType the type of the return value
+	 * @return the response as entity
+	 * @since 4.1
+	 */
+	<T> ResponseEntity<T> exchange(RequestEntity<?> requestEntity,
+			Class<T> responseType) throws RestClientException;
+
+	/**
+	 * Execute the HTTP method and URL of the {@link RequestEntity}, writing it to the
+	 * request, and returns the response as {@link ResponseEntity}.
+	 * The given {@link ParameterizedTypeReference} is used to pass generic type information:
+	 *
+	 * <pre class="code">
+	 * MyRequest body = ...
+	 * RequestEntity request = RequestEntity.post(&quot;http://example.com/{foo}&quot;, &quot;bar&quot;).accept(MediaType.APPLICATION_JSON).body(body);
+	 * ParameterizedTypeReference&lt;List&lt;MyResponse&gt;&gt; myBean = new ParameterizedTypeReference&lt;List&lt;MyResponse&gt;&gt;() {};
+	 * ResponseEntity&lt;List&lt;MyResponse&gt;&gt; response = template.exchange(request, myBean);
+	 * </pre>
+	 *
+	 * @param requestEntity the entity to write to the request
+	 * @param responseType the type of the return value
+	 * @return the response as entity
+	 * @since 4.1
+	 */
+	<T> ResponseEntity<T> exchange(RequestEntity<?> requestEntity,
+			ParameterizedTypeReference<T> responseType) throws RestClientException;
+
 
 	// general execution
 

--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -31,6 +31,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -492,6 +493,28 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 		ResponseExtractor<ResponseEntity<T>> responseExtractor = responseEntityExtractor(type);
 		return execute(url, method, requestCallback, responseExtractor);
 	}
+
+	@Override
+	public <T> ResponseEntity<T> exchange(RequestEntity<?> requestEntity,
+			Class<T> responseType) throws RestClientException {
+		Assert.notNull(requestEntity, "'requestEntity' must not be null");
+
+		RequestCallback requestCallback = httpEntityCallback(requestEntity, responseType);
+		ResponseExtractor<ResponseEntity<T>> responseExtractor = responseEntityExtractor(responseType);
+		return execute(requestEntity.getUrl(), requestEntity.getMethod(), requestCallback, responseExtractor);
+	}
+
+	@Override
+	public <T> ResponseEntity<T> exchange(RequestEntity<?> requestEntity,
+			ParameterizedTypeReference<T> responseType) throws RestClientException {
+		Assert.notNull(requestEntity, "'requestEntity' must not be null");
+
+		Type type = responseType.getType();
+		RequestCallback requestCallback = httpEntityCallback(requestEntity, type);
+		ResponseExtractor<ResponseEntity<T>> responseExtractor = responseEntityExtractor(type);
+		return execute(requestEntity.getUrl(), requestEntity.getMethod(), requestCallback, responseExtractor);
+	}
+
 
 	// general execution
 

--- a/spring-web/src/test/java/org/springframework/http/RequestEntityTests.java
+++ b/spring-web/src/test/java/org/springframework/http/RequestEntityTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class RequestEntityTests {
+
+	@Test
+	public void normal() throws URISyntaxException {
+		String headerName = "My-Custom-Header";
+		String headerValue = "HeaderValue";
+		URI url = new URI("http://example.com");
+		Integer entity = 42;
+
+		RequestEntity<Object> requestEntity =
+				RequestEntity.method(HttpMethod.GET, url)
+						.header(headerName, headerValue).body(entity);
+
+		assertNotNull(requestEntity);
+		assertEquals(HttpMethod.GET, requestEntity.getMethod());
+		assertTrue(requestEntity.getHeaders().containsKey(headerName));
+		assertEquals(headerValue, requestEntity.getHeaders().getFirst(headerName));
+		assertEquals(entity, requestEntity.getBody());
+	}
+
+	@Test
+	public void uriVariablesExpansion() throws URISyntaxException {
+		RequestEntity.get("http://example.com/{foo}", "bar").accept(MediaType.TEXT_PLAIN).build();
+
+		String url = "http://www.{host}.com/{path}";
+		String host = "example";
+		String path = "foo/bar";
+
+		URI expected = new URI("http://www.example.com/foo/bar");
+
+		RequestEntity<?> entity = RequestEntity.method(HttpMethod.GET, url, host, path).build();
+		assertEquals(expected, entity.getUrl());
+
+		Map<String, String> uriVariables = new HashMap<String, String>(2);
+		uriVariables.put("host", host);
+		uriVariables.put("path", path);
+
+		entity = RequestEntity.method(HttpMethod.GET, url, uriVariables).build();
+		assertEquals(expected, entity.getUrl());
+	}
+
+	@Test
+	public void get() {
+		RequestEntity<Void> requestEntity = RequestEntity.get(URI.create("http://example.com")).accept(
+				MediaType.IMAGE_GIF, MediaType.IMAGE_JPEG, MediaType.IMAGE_PNG).build();
+
+		assertNotNull(requestEntity);
+		assertEquals(HttpMethod.GET, requestEntity.getMethod());
+		assertTrue(requestEntity.getHeaders().containsKey("Accept"));
+		assertEquals("image/gif, image/jpeg, image/png", requestEntity.getHeaders().getFirst("Accept"));
+		assertNull(requestEntity.getBody());
+	}
+
+	@Test
+	public void headers() throws URISyntaxException {
+		MediaType accept = MediaType.TEXT_PLAIN;
+		Charset charset = Charset.forName("UTF-8");
+		long ifModifiedSince = 12345L;
+		String ifNoneMatch = "\"foo\"";
+		long contentLength = 67890;
+		MediaType contentType = MediaType.TEXT_PLAIN;
+
+		RequestEntity<Void> responseEntity = RequestEntity.post("http://example.com").
+				accept(accept).
+				acceptCharset(charset).
+				ifModifiedSince(ifModifiedSince).
+				ifNoneMatch(ifNoneMatch).
+				contentLength(contentLength).
+				contentType(contentType).
+				build();
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpMethod.POST, responseEntity.getMethod());
+		assertEquals(new URI("http://example.com"), responseEntity.getUrl());
+		HttpHeaders responseHeaders = responseEntity.getHeaders();
+
+		assertEquals("text/plain", responseHeaders.getFirst("Accept"));
+		assertEquals("utf-8", responseHeaders.getFirst("Accept-Charset"));
+		assertEquals("Thu, 01 Jan 1970 00:00:12 GMT",
+				responseHeaders.getFirst("If-Modified-Since"));
+		assertEquals(ifNoneMatch, responseHeaders.getFirst("If-None-Match"));
+		assertEquals(String.valueOf(contentLength), responseHeaders.getFirst("Content-Length"));
+		assertEquals(contentType.toString(), responseHeaders.getFirst("Content-Type"));
+
+		assertNull(responseEntity.getBody());
+	}
+
+	@Test
+	public void methods() throws URISyntaxException {
+		URI url = new URI("http://example.com");
+
+		RequestEntity<?> entity = RequestEntity.get(url).build();
+		assertEquals(HttpMethod.GET, entity.getMethod());
+
+		entity = RequestEntity.post(url).build();
+		assertEquals(HttpMethod.POST, entity.getMethod());
+
+		entity = RequestEntity.head(url).build();
+		assertEquals(HttpMethod.HEAD, entity.getMethod());
+
+		entity = RequestEntity.options(url).build();
+		assertEquals(HttpMethod.OPTIONS, entity.getMethod());
+
+		entity = RequestEntity.put(url).build();
+		assertEquals(HttpMethod.PUT, entity.getMethod());
+
+		entity = RequestEntity.patch(url).build();
+		assertEquals(HttpMethod.PATCH, entity.getMethod());
+
+		entity = RequestEntity.delete(url).build();
+		assertEquals(HttpMethod.DELETE, entity.getMethod());
+
+	}
+
+
+
+
+}


### PR DESCRIPTION
This commit introduces the RequestEntity, a class similar to
ResponseEntity, but meant for HTTP requests rather than responses. The
RequestEntity can be used both in RestTemplate as well as @MVC
scenarios.

The class also comes with a builder, similar to the one found in
ResponseEntity, which allows for building of a RequestEntity through a
fluent API.

Issue: SPR-11752
