### PR TITLE
Add support to reference external HandlerMethodArgumentResolver beans 

### DIFF
--- a/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc-4.1.xsd
+++ b/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc-4.1.xsd
@@ -127,15 +127,28 @@
 						]]></xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
-						<xsd:sequence>
-							<xsd:element ref="beans:bean" minOccurs="1" maxOccurs="unbounded">
+						<xsd:choice minOccurs="1" maxOccurs="unbounded">
+							<xsd:element ref="beans:bean" minOccurs="0" maxOccurs="unbounded">
 								<xsd:annotation>
 									<xsd:documentation><![CDATA[
 	The HandlerMethodArgumentResolver (or WebArgumentResolver for backwards compatibility) bean definition.
 									]]></xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
-						</xsd:sequence>
+                            <xsd:element ref="beans:ref" minOccurs="0" maxOccurs="unbounded">
+                                <xsd:annotation>
+                                    <xsd:documentation><![CDATA[
+	A reference to a HandlerMethodArgumentResolver bean definition. Expects a HandlerMethodArgumentResolver instance,
+	 WebArgumentResolver instances has to be wrapped with a ServletWebArgumentResolverAdapter
+									]]></xsd:documentation>
+                                        <xsd:appinfo>
+                                            <tool:annotation kind="ref">
+                                                <tool:expected-type type="java:org.springframework.web.method.support.HandlerMethodArgumentResolver" />
+                                            </tool:annotation>
+                                        </xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+						</xsd:choice>
 					</xsd:complexType>
 				</xsd:element>
 				<xsd:element name="return-value-handlers" minOccurs="0">

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParserTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParserTests.java
@@ -38,9 +38,9 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.servlet.handler.BeanNameUrlHandlerMapping;
+import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
 import org.springframework.web.servlet.mvc.method.annotation.JsonViewResponseBodyAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
-import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ServletWebArgumentResolverAdapter;
@@ -52,6 +52,7 @@ import static org.junit.Assert.*;
  * Test fixture for the configuration in mvc-config-annotation-driven.xml.
  * @author Rossen Stoyanchev
  * @author Brian Clozel
+ * @author Agim Emruli
  */
 public class AnnotationDrivenBeanDefinitionParserTests {
 
@@ -120,6 +121,21 @@ public class AnnotationDrivenBeanDefinitionParserTests {
 		assertTrue(resolvers.get(0) instanceof ServletWebArgumentResolverAdapter);
 		assertTrue(resolvers.get(1) instanceof TestHandlerMethodArgumentResolver);
 	}
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testArgumentResolversWithReference() {
+        loadBeanDefinitions("mvc-config-argument-resolvers-references.xml");
+        RequestMappingHandlerAdapter adapter = appContext.getBean(RequestMappingHandlerAdapter.class);
+        assertNotNull(adapter);
+        Object value = new DirectFieldAccessor(adapter).getPropertyValue("customArgumentResolvers");
+        assertNotNull(value);
+        assertTrue(value instanceof List);
+        List<HandlerMethodArgumentResolver> resolvers = (List<HandlerMethodArgumentResolver>) value;
+        assertEquals(2, resolvers.size());
+        assertTrue(resolvers.get(0) instanceof ServletWebArgumentResolverAdapter);
+        assertTrue(resolvers.get(1) instanceof TestHandlerMethodArgumentResolver);
+    }
 
 	@SuppressWarnings("unchecked")
 	@Test

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-argument-resolvers-references.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-argument-resolvers-references.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+
+	<mvc:annotation-driven>
+		<mvc:argument-resolvers>
+			<bean class="org.springframework.web.servlet.config.TestWebArgumentResolver"/>
+            <ref bean="customArgumentResolver" />
+		</mvc:argument-resolvers>
+	</mvc:annotation-driven>
+
+    <bean id="customArgumentResolver" class="org.springframework.web.servlet.config.TestHandlerMethodArgumentResolver"/>
+
+</beans>


### PR DESCRIPTION
Users can now mix and match between "inner bean" argument resolver and "external bean" argument resolvers. This commit only focuses only on argument-resolver, while the support could be extended to return value handlers as well.

 Issue: SPR-11927
