### PR TITLE
Adding support for shared consumers in message listener containers

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/listener/AbstractMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/AbstractMessageListenerContainer.java
@@ -135,6 +135,10 @@ public abstract class AbstractMessageListenerContainer
 	private boolean subscriptionDurable = false;
 
 	private String durableSubscriptionName;
+	
+	private boolean sharedSubscription = false;
+	
+	private String sharedSubscriptionName;
 
 	private ExceptionListener exceptionListener;
 
@@ -334,6 +338,46 @@ public abstract class AbstractMessageListenerContainer
 	 */
 	public String getDurableSubscriptionName() {
 		return this.durableSubscriptionName;
+	}
+
+
+	/**
+	 * @return whether or not this is a shared subscription
+	 */
+	public boolean isSharedSubscription() {
+		return sharedSubscription;
+	}
+
+	
+	/**
+	 * Set the name of the shared subscription
+	 * <p>Note: JMS 2.0 must be enabled to set this flag to true.
+	 * 
+	 * @param sharedSubscription true if shared, else false
+	 */
+	public void setSharedSubscription(boolean sharedSubscription) {
+		this.sharedSubscription = sharedSubscription;
+	}
+
+	
+	/**
+	 * Returns the shared subscription name, if any.
+	 * 
+	 * @return the sharedSubscriptionName
+	 */
+	public String getSharedSubscriptionName() {
+		return sharedSubscriptionName;
+	}
+
+	
+	/**
+	 * Sets the name of the shared subscription.
+	 * <p>Note: JMS 2.0 must be enabled for this property to apply.
+	 * 
+	 * @param sharedSubscriptionName the sharedSubscriptionName to set
+	 */
+	public void setSharedSubscriptionName(String sharedSubscriptionName) {
+		this.sharedSubscriptionName = sharedSubscriptionName;
 	}
 
 	/**

--- a/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
@@ -28,6 +28,7 @@ import org.springframework.jms.connection.ConnectionFactoryUtils;
 import org.springframework.jms.connection.JmsResourceHolder;
 import org.springframework.jms.connection.SingleConnectionFactory;
 import org.springframework.jms.support.JmsUtils;
+import org.springframework.jms.util.Jms2Utils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -492,7 +493,10 @@ public abstract class AbstractPollingMessageListenerContainer extends AbstractMe
 		// Some JMS providers, such as WebSphere MQ 6.0, throw IllegalStateException
 		// in case of the NoLocal flag being specified for a Queue.
 		if (isPubSubDomain()) {
-			if (isSubscriptionDurable() && destination instanceof Topic) {
+			if (isSharedSubscription() && destination instanceof Topic) {
+				return Jms2Utils.createSharedConsumer(session, (Topic)destination, getSharedSubscriptionName(), 
+						getMessageSelector(), isSubscriptionDurable());
+			} else if (isSubscriptionDurable() && destination instanceof Topic) {
 				return session.createDurableSubscriber(
 						(Topic) destination, getDurableSubscriptionName(), getMessageSelector(), isPubSubNoLocal());
 			}

--- a/spring-jms/src/main/java/org/springframework/jms/listener/SimpleMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/SimpleMessageListenerContainer.java
@@ -19,6 +19,7 @@ package org.springframework.jms.listener;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executor;
+
 import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.ExceptionListener;
@@ -30,6 +31,7 @@ import javax.jms.Session;
 import javax.jms.Topic;
 
 import org.springframework.jms.support.JmsUtils;
+import org.springframework.jms.util.Jms2Utils;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 
@@ -387,7 +389,10 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		// Some JMS providers, such as WebSphere MQ 6.0, throw IllegalStateException
 		// in case of the NoLocal flag being specified for a Queue.
 		if (isPubSubDomain()) {
-			if (isSubscriptionDurable() && destination instanceof Topic) {
+			if (isSharedSubscription() && destination instanceof Topic) {
+				return Jms2Utils.createSharedConsumer(session, (Topic)destination, getSharedSubscriptionName(), 
+						getMessageSelector(), isSubscriptionDurable());
+			}else if (isSubscriptionDurable() && destination instanceof Topic) {
 				return session.createDurableSubscriber(
 						(Topic) destination, getDurableSubscriptionName(), getMessageSelector(), isPubSubNoLocal());
 			}

--- a/spring-jms/src/main/java/org/springframework/jms/util/Jms2Utils.java
+++ b/spring-jms/src/main/java/org/springframework/jms/util/Jms2Utils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jms.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+
+/**
+ * The is a utility class to help invoke JMS 2.0 api methods using reflection.  
+ * This class requires that the JMS 2.0 jar be on the classpath to work properly.
+ * 
+ * @author Juergen Hoeller
+ * @author Chris Shannon
+ * @since 4.1
+ */
+public class Jms2Utils {
+
+	private static final Method createSharedConsumerMethod = ClassUtils.getMethodIfAvailable(
+			Session.class, "createSharedConsumer", Topic.class, String.class, String.class);
+
+	private static final Method createSharedDurableConsumerMethod = ClassUtils.getMethodIfAvailable(
+			Session.class, "createSharedDurableConsumer", Topic.class, String.class, String.class);
+	
+	/**
+	 * Utility method to create a shared consumer using the JMS 2.0 api
+	 * 
+	 * @param session the JMS Session to create a MessageConsumer for
+	 * @param topic the JMS Topic to create a MessageConsumer for
+	 * @param sharedSubscriptionName the shared subscription name
+	 * @param messageSelector the JMS message selector expression (or {@code null} if none)
+	 * @param durable whether the subscription is durable or not
+	 * @return a new shared MessageConsumer
+	 * @throws JMSException
+	 */
+	public static MessageConsumer createSharedConsumer(Session session, Topic topic, 
+			String sharedSubscriptionName, String messageSelector, boolean durable) throws JMSException {
+		
+		Method method = (durable ? createSharedDurableConsumerMethod : createSharedConsumerMethod);
+		MessageConsumer consumer = null;
+		try {
+			consumer = (MessageConsumer) method.invoke(session, topic, 
+					sharedSubscriptionName, messageSelector);
+		}
+		catch (InvocationTargetException ex) {
+			if (ex.getTargetException() instanceof JMSException) {
+				throw (JMSException) ex.getTargetException();
+			}
+			ReflectionUtils.handleInvocationTargetException(ex);
+		}
+		catch (IllegalAccessException ex) {
+			throw new IllegalStateException("Could not access JMS 2.0 API method: " + ex.getMessage());
+		}
+		return consumer;
+	}
+}


### PR DESCRIPTION
JMS 2.0 adds the ability to support shared consumers (durable and
no durable)  This commit adds in the ability to create shared consumers
in different message listener containers just like in
CachingConnectionFactory.  Note that there are no unit tests for
this because spring-jms is currently building against JMS 1.1.  Once
there is a JMS 2.0 test project this can be tested.

Issue: SPR-11969

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
