### PR TITLE
Add status controllers

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/MvcNamespaceHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/MvcNamespaceHandler.java
@@ -35,6 +35,7 @@ public class MvcNamespaceHandler extends NamespaceHandlerSupport {
 		registerBeanDefinitionParser("interceptors", new InterceptorsBeanDefinitionParser());
 		registerBeanDefinitionParser("resources", new ResourcesBeanDefinitionParser());
 		registerBeanDefinitionParser("view-controller", new ViewControllerBeanDefinitionParser());
+		registerBeanDefinitionParser("status-controller", new StatusControllerBeanDefinitionParser());
 		registerBeanDefinitionParser("view-resolvers", new ViewResolversBeanDefinitionParser());
 		registerBeanDefinitionParser("tiles", new TilesBeanDefinitionParser());
 		registerBeanDefinitionParser("freemarker", new FreeMarkerBeanDefinitionParser());

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/StatusControllerBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/StatusControllerBeanDefinitionParser.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.config;
+
+import java.util.Map;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
+import org.springframework.beans.factory.support.ManagedMap;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.beans.factory.xml.BeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.servlet.mvc.StatusController;
+
+/**
+ * {@link BeanDefinitionParser} that parses a
+ * {@code status-controller} element to register a {@link StatusController}.
+ * Will also register a {@link SimpleUrlHandlerMapping} for status controllers.
+ *
+ * @author Sebastien Deleuze
+ * @since 4.1
+ */
+class StatusControllerBeanDefinitionParser implements BeanDefinitionParser {
+
+	private static final String HANDLER_MAPPING_BEAN_NAME =
+		"org.springframework.web.servlet.config.statusControllerHandlerMapping";
+
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public BeanDefinition parse(Element element, ParserContext parserContext) {
+		Object source = parserContext.extractSource(element);
+
+		// Register SimpleUrlHandlerMapping for status controllers
+		BeanDefinition handlerMappingDef = registerHandlerMapping(parserContext, source);
+
+		// Ensure BeanNameUrlHandlerMapping (SPR-8289) and default HandlerAdapters are not "turned off"
+		MvcNamespaceUtils.registerDefaultComponents(parserContext, source);
+
+		// Create status controller bean definition
+		RootBeanDefinition statusControllerDef = new RootBeanDefinition(StatusController.class);
+		statusControllerDef.setSource(source);
+		HttpStatus statusCode = HttpStatus.valueOf(Integer.valueOf(element.getAttribute("status-code")));
+		statusControllerDef.getConstructorArgumentValues().addIndexedArgumentValue(0, statusCode);
+		if (element.hasAttribute("view-name")) {
+			statusControllerDef.getPropertyValues().add("viewName", element.getAttribute("view-name"));
+		}
+		if (element.hasAttribute("redirect-path")) {
+			statusControllerDef.getPropertyValues().add("redirectPath", element.getAttribute("redirect-path"));
+		}
+		if (element.hasAttribute("use-query-string")) {
+			statusControllerDef.getPropertyValues().add("useQueryString", element.getAttribute("use-query-string"));
+		}
+		if (element.hasAttribute("reason")) {
+			statusControllerDef.getPropertyValues().add("reason", element.getAttribute("reason"));
+		}
+
+		Map<String, BeanDefinition> urlMap;
+		if (handlerMappingDef.getPropertyValues().contains("urlMap")) {
+			urlMap = (Map<String, BeanDefinition>) handlerMappingDef.getPropertyValues().getPropertyValue("urlMap").getValue();
+		}
+		else {
+			urlMap = new ManagedMap<String, BeanDefinition>();
+			handlerMappingDef.getPropertyValues().add("urlMap", urlMap);
+		}
+		urlMap.put(element.getAttribute("path"), statusControllerDef);
+
+		return null;
+	}
+
+	private BeanDefinition registerHandlerMapping(ParserContext parserContext, Object source) {
+		if (!parserContext.getRegistry().containsBeanDefinition(HANDLER_MAPPING_BEAN_NAME)) {
+			RuntimeBeanReference pathMatcherRef = MvcNamespaceUtils.registerPathMatcher(null, parserContext, source);
+			RuntimeBeanReference pathHelperRef = MvcNamespaceUtils.registerUrlPathHelper(null, parserContext, source);
+
+			RootBeanDefinition handlerMappingDef = new RootBeanDefinition(SimpleUrlHandlerMapping.class);
+			handlerMappingDef.setSource(source);
+			handlerMappingDef.getPropertyValues().add("order", "-1");
+			handlerMappingDef.getPropertyValues().add("pathMatcher", pathMatcherRef).add("urlPathHelper", pathHelperRef);
+			handlerMappingDef.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+			parserContext.getRegistry().registerBeanDefinition(HANDLER_MAPPING_BEAN_NAME, handlerMappingDef);
+			parserContext.registerComponent(new BeanComponentDefinition(handlerMappingDef, HANDLER_MAPPING_BEAN_NAME));
+			return handlerMappingDef;
+		}
+		else {
+			return parserContext.getRegistry().getBeanDefinition(HANDLER_MAPPING_BEAN_NAME);
+		}
+
+	}
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/AbstractStatusControllerRegistration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/AbstractStatusControllerRegistration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.config.annotation;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Base class for information required to create a status controller.
+ *
+ * @author Sebastien Deleuze
+ * @since 4.1
+ */
+public abstract class AbstractStatusControllerRegistration {
+
+	protected final String urlPath;
+
+	protected final HttpStatus statusCode;
+
+
+	/**
+	 * Creates a {@link AbstractStatusControllerRegistration} with the given URL path and status code.
+	 * When a request matches to the given URL path, this status controller will process it.
+	 */
+	public AbstractStatusControllerRegistration(String urlPath, HttpStatus statusCode) {
+		this.urlPath = urlPath;
+		this.statusCode = statusCode;
+	}
+
+
+	/**
+	 * Returns the URL path for the status controller.
+	 */
+	protected String getUrlPath() {
+		return urlPath;
+	}
+
+	/**
+	 * Returns the status code for the status controller.
+	 */
+	protected HttpStatus getStatusCode() {
+		return statusCode;
+	}
+
+	protected abstract Object getStatusController();
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfiguration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfiguration.java
@@ -76,6 +76,11 @@ public class DelegatingWebMvcConfiguration extends WebMvcConfigurationSupport {
 	}
 
 	@Override
+	protected void addStatusControllers(StatusControllerRegistry registry) {
+		this.configurers.addStatusControllers(registry);
+	}
+	
+	@Override
 	protected void configureViewResolvers(ViewResolverRegistry registry) {
 		this.configurers.configureViewResolvers(registry);
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/RedirectStatusControllerRegistration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/RedirectStatusControllerRegistration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.config.annotation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.mvc.StatusController;
+
+/**
+ * Encapsulates information required to create a status controller for 3xx redirect requests.
+ *
+ * @author Sebastien Deleuze
+ * @since 4.1
+ */
+public class RedirectStatusControllerRegistration extends AbstractStatusControllerRegistration {
+
+	private final String redirectPath;
+
+	private boolean useQueryString = false;
+
+
+	/**
+	 * Creates a {@link RedirectStatusControllerRegistration} with the given URL path and status code.
+	 * When a request matches to the given URL path, this status controller will process it and
+	 * redirect the request to the specified redirect path.
+	 */
+	public RedirectStatusControllerRegistration(String urlPath, HttpStatus statusCode, String redirectPath) {
+		super(urlPath, statusCode);
+		this.redirectPath = redirectPath;
+	}
+
+
+	/**
+	 * The initial request query string will be appended to the redirect path.
+	 */
+	public RedirectStatusControllerRegistration useQueryString() {
+		this.useQueryString = true;
+		return this;
+	}
+
+	protected String getRedirectPath() {
+		return redirectPath;
+	}
+
+	protected boolean isUseQueryString() {
+		return useQueryString;
+	}
+
+	@Override
+	protected Object getStatusController() {
+		StatusController controller = new StatusController(this.statusCode);
+		controller.setRedirectPath(this.redirectPath);
+		controller.setUseQueryString(this.useQueryString);
+		return controller;
+	}
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/StatusControllerRegistration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/StatusControllerRegistration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.config.annotation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.mvc.StatusController;
+
+/**
+ * Encapsulates information required to create a status controller.
+ *
+ * @author Sebastien Deleuze
+ * @since 4.1
+ */
+public class StatusControllerRegistration extends AbstractStatusControllerRegistration {
+
+	private String viewName;
+
+	private String reason;
+
+
+	/**
+	 * Creates a {@link StatusControllerRegistration} with the given URL path and status code.
+	 * When a request matches to the given URL path, this status controller will process it.
+	 */
+	public StatusControllerRegistration(String urlPath, HttpStatus statusCode) {
+		super(urlPath, statusCode);
+	}
+
+
+	/**
+	 * Sets the view name to use for this view controller.
+	 * It is not possible to set both viewName and reason, you must use either one or the other.
+	 */
+	public void setViewName(String viewName) {
+		this.viewName = viewName;
+	}
+
+	/**
+	 * Sets the reason to display.
+	 * It is not possible to set both viewName and reason, you must use either one or the other.
+	 */
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+
+	protected Object getStatusController() {
+		StatusController controller = new StatusController(this.statusCode);
+		controller.setViewName(this.viewName);
+		controller.setReason(this.reason);
+		return controller;
+	}
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/StatusControllerRegistry.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/StatusControllerRegistry.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.config.annotation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.handler.AbstractHandlerMapping;
+import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helps with configuring a list of status controllers.
+ *
+ * @author Sebastien Deleuze
+ * @since 4.1
+ */
+public class StatusControllerRegistry {
+
+	private final List<AbstractStatusControllerRegistration> registrations = new ArrayList<AbstractStatusControllerRegistration>();
+
+	private int order = -1;
+
+	/**
+	 * Add a new status controller for status code other than 3xx.
+	 */
+	public StatusControllerRegistration addStatusController(String urlPath, HttpStatus statusCode) {
+		Assert.isTrue(!statusCode.is3xxRedirection(), "Status code can not be a 3xx redirection");
+		StatusControllerRegistration registration = new StatusControllerRegistration(urlPath, statusCode);
+		registrations.add(registration);
+		return registration;
+	}
+
+	/**
+	 * Add a new status controller for 3xx status code (redirects).
+	 */
+	public RedirectStatusControllerRegistration addStatusController(String urlPath,
+			HttpStatus statusCode, String redirectPath) {
+		Assert.isTrue(statusCode.is3xxRedirection(), "Status code must be a 3xx redirection");
+		RedirectStatusControllerRegistration registration = new RedirectStatusControllerRegistration(urlPath, statusCode, redirectPath);
+		registrations.add(registration);
+		return registration;
+	}
+
+	/**
+	 * Specify the order to use for StatusControllers mappings relative to other {@link HandlerMapping}s
+	 * configured in the Spring MVC application context. The default value for status controllers is -1,
+	 * which is 1 lower than the value used for annotated controllers.
+	 */
+	public void setOrder(int order) {
+		this.order = order;
+	}
+
+	/**
+	 * Returns a handler mapping with the mapped StatusControllers; or {@code null} in case of no registrations.
+	 */
+	protected AbstractHandlerMapping getHandlerMapping() {
+		if (registrations.isEmpty()) {
+			return null;
+		}
+
+		Map<String, Object> urlMap = new LinkedHashMap<String, Object>();
+		for (AbstractStatusControllerRegistration registration : registrations) {
+			urlMap.put(registration.getUrlPath(), registration.getStatusController());
+		}
+
+		SimpleUrlHandlerMapping handlerMapping = new SimpleUrlHandlerMapping();
+		handlerMapping.setOrder(order);
+		handlerMapping.setUrlMap(urlMap);
+		return handlerMapping;
+	}
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -354,6 +354,30 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	}
 
 	/**
+	 * Return a handler mapping ordered at -1 to map URL paths to
+	 * status controllers. To configure status controllers, override
+	 * {@link #addStatusControllers}.
+	 */
+	@Bean
+	public HandlerMapping statusControllerHandlerMapping() {
+		StatusControllerRegistry registry = new StatusControllerRegistry();
+		addStatusControllers(registry);
+
+		AbstractHandlerMapping handlerMapping = registry.getHandlerMapping();
+		handlerMapping = handlerMapping != null ? handlerMapping : new EmptyHandlerMapping();
+		handlerMapping.setPathMatcher(mvcPathMatcher());
+		handlerMapping.setUrlPathHelper(mvcUrlPathHelper());
+		return handlerMapping;
+	}
+
+	/**
+	 * Override this method to add status controllers.
+	 * @see StatusControllerRegistry
+	 */
+	protected void addStatusControllers(StatusControllerRegistry registry) {
+	}
+
+	/**
 	 * Return a {@link BeanNameUrlHandlerMapping} ordered at 2 to map URL
 	 * paths to controller bean names.
 	 */

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurer.java
@@ -139,6 +139,12 @@ public interface WebMvcConfigurer {
 	void addViewControllers(ViewControllerRegistry registry);
 
 	/**
+	 * Add status controllers to create a mapping between a URL path and
+	 * status code + eventually a redirect.
+	 */
+	void addStatusControllers(StatusControllerRegistry registry);
+
+	/**
 	 * Configure view resolvers to translate String-based view names returned from
 	 * controllers into concrete {@link org.springframework.web.servlet.View}
 	 * implementations to perform rendering with.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurerAdapter.java
@@ -138,6 +138,14 @@ public abstract class WebMvcConfigurerAdapter implements WebMvcConfigurer {
 	 * <p>This implementation is empty.
 	 */
 	@Override
+	public void addStatusControllers(StatusControllerRegistry registry) {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>This implementation is empty.
+	 */
+	@Override
 	public void configureViewResolvers(ViewResolverRegistry registry) {
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurerComposite.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurerComposite.java
@@ -114,6 +114,13 @@ class WebMvcConfigurerComposite implements WebMvcConfigurer {
 	}
 
 	@Override
+	public void addStatusControllers(StatusControllerRegistry registry) {
+		for (WebMvcConfigurer delegate : this.delegates) {
+			delegate.addStatusControllers(registry);
+		}
+	}
+
+	@Override
 	public void configureViewResolvers(ViewResolverRegistry registry) {
 		for (WebMvcConfigurer delegate : this.delegates) {
 			delegate.configureViewResolvers(registry);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/StatusController.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/StatusController.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.mvc;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.View;
+
+/**
+ * Controller that returns a specified status code and optionally redirect the request.
+ *
+ * @author Sebastien Deleuze
+ * @since 4.1
+ */
+public class StatusController extends ParameterizableViewController {
+
+	private final HttpStatus statusCode;
+
+	private String reason;
+
+	private String redirectPath;
+
+	private boolean useQueryString = false;
+
+	/**
+	 * Create a new StatusController with the provided status code.
+	 * @param statusCode the http response status code
+	 */
+	public StatusController(HttpStatus statusCode) {
+		this.statusCode = statusCode;
+	}
+
+	/**
+	 * Set the error message to display. It is not possible to set both viewName and reason,
+	 * you must use either one or the other.
+	 */
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+
+	/**
+	 * Set the path where the request should be redirected for 3xx requests.
+	 */
+	public void setRedirectPath(String redirectPath) {
+		this.redirectPath = redirectPath;
+	}
+
+	/**
+	 * Set whether the initial request query string should be appended to the redirect path or not.
+	 */
+	public void setUseQueryString(boolean useQueryString) {
+		this.useQueryString = useQueryString;
+	}
+
+	@Override
+	protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
+			throws Exception {
+
+		Assert.state(!(this.reason !=null && this.getViewName() != null),
+				"Can't set both viewName and reason, you must use either one or the other.");
+		Assert.state(!(this.redirectPath != null && !this.statusCode.is3xxRedirection()),
+				"Status code should be 3xx when redirect path is set.");
+
+		if(statusCode.is3xxRedirection()) {
+			if(this.useQueryString && request.getQueryString() != null) {
+				response.addHeader(HttpHeaders.LOCATION, this.redirectPath + "?" + request.getQueryString());
+			}
+			else {
+				response.addHeader(HttpHeaders.LOCATION, this.redirectPath);
+			}
+		}
+
+		if(this.getViewName() == null) {
+			if (!StringUtils.hasText(reason)) {
+				response.setStatus(statusCode.value());
+			}
+			else {
+				response.sendError(statusCode.value(), reason);
+			}
+			return null;
+		}
+		response.setStatus(statusCode.value());
+		// to be picked up by the RedirectView
+		request.setAttribute(View.RESPONSE_STATUS_ATTRIBUTE, statusCode.value());
+		return super.handleRequestInternal(request, response);
+	}
+
+}

--- a/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc-4.1.xsd
+++ b/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc-4.1.xsd
@@ -572,31 +572,79 @@
 		</xsd:complexType>
 	</xsd:element>
 
-	<xsd:element name="view-controller">
+	<xsd:complexType name="parameterizable-view-controllers">
+		<xsd:attribute name="path" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The URL path the view is mapped to.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="view-name" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The name of the view to render. Optional.
+	If not specified, the view name will be determined from the current HttpServletRequest
+	by the DispatcherServlet's RequestToViewNameTranslator.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="view-controller" type="parameterizable-view-controllers">
 		<xsd:annotation>
 			<xsd:documentation
 				source="java:org.springframework.web.servlet.mvc.ParameterizableViewController"><![CDATA[
 	Defines a simple Controller that selects a view to render the response.
 			]]></xsd:documentation>
 		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:attribute name="path" type="xsd:string" use="required">
-				<xsd:annotation>
-					<xsd:documentation><![CDATA[
-	The URL path the view is mapped to.
-					]]></xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="view-name" type="xsd:string">
-				<xsd:annotation>
-					<xsd:documentation><![CDATA[
-	The name of the view to render. Optional.
-	If not specified, the view name will be determined from the current HttpServletRequest
-	by the DispatcherServlet's RequestToViewNameTranslator.
-					]]></xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="status-controllers">
+		<xsd:complexContent>
+			<xsd:extension base="parameterizable-view-controllers">
+				<xsd:attribute name="status-code" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+	The HTTP status code of the response.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="redirect-path" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+	The path where the request should be redirected for 3xx requests.
+	Only for redirect status controllers.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="use-query-string" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+	Define whether the query string of the original request should be added to the redirect path.
+	Only for redirect status controllers, optional.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="reason" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+	Define the error message.
+	Only for non-redirect status controllers, optional.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="status-controller" type="status-controllers">
+		<xsd:annotation>
+			<xsd:documentation source="java:org.springframework.web.servlet.mvc.StatusController"><![CDATA[
+	Defines a status Controller that returns a specified status code and optionally redirect
+	the request.
+			]]></xsd:documentation>
+		</xsd:annotation>
 	</xsd:element>
 
 	<xsd:complexType name="contentNegotiationType">

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/StatusControllerRegistryTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/StatusControllerRegistryTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.config.annotation;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.servlet.mvc.StatusController;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test fixture with a {@link StatusControllerRegistry}.
+ * @author Sebastien Deleuze
+ * @since 4.1
+ */
+public class StatusControllerRegistryTests {
+
+	private StatusControllerRegistry registry;
+
+
+	@Before
+	public void setUp() {
+		this.registry = new StatusControllerRegistry();
+	}
+
+	@Test
+	public void status() throws Exception {
+		registry.addStatusController("/notfound", HttpStatus.NOT_FOUND);
+		Map<String, ?> urlMap = getHandlerMapping().getUrlMap();
+		StatusController controller = (StatusController)urlMap.get("/notfound");
+		assertNotNull(controller);
+		assertEquals(StatusController.class, controller.getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(controller);
+		assertEquals(HttpStatus.NOT_FOUND, accessor.getPropertyValue("statusCode"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void statusWithWrongStatusCode() throws Exception {
+		registry.addStatusController("/notfound", HttpStatus.TEMPORARY_REDIRECT);
+		fail();
+	}
+
+	@Test
+	public void redirect() throws Exception {
+		registry.addStatusController("/source", HttpStatus.TEMPORARY_REDIRECT,
+				"/destination");
+		Map<String, ?> urlMap = getHandlerMapping().getUrlMap();
+		StatusController controller = (StatusController)urlMap.get("/source");
+		assertNotNull(controller);
+		assertEquals(StatusController.class, controller.getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(controller);
+		assertEquals(HttpStatus.TEMPORARY_REDIRECT, accessor.getPropertyValue("statusCode"));
+		assertEquals("/destination", accessor.getPropertyValue("redirectPath"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void redirectWithWrongStatusCode() throws Exception {
+		registry.addStatusController("/source", HttpStatus.NOT_FOUND, "/destination");
+		fail();
+	}
+
+	private SimpleUrlHandlerMapping getHandlerMapping() {
+		return (SimpleUrlHandlerMapping) registry.getHandlerMapping();
+	}
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupportExtensionTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupportExtensionTests.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.http.HttpStatus;
 import org.springframework.core.Ordered;
 import org.springframework.tests.sample.beans.TestBean;
 import org.springframework.core.convert.converter.Converter;
@@ -348,6 +349,11 @@ public class WebMvcConfigurationSupportExtensionTests {
 		@Override
 		public void addViewControllers(ViewControllerRegistry registry) {
 			registry.addViewController("/path");
+		}
+
+		@Override
+		public void addStatusControllers(StatusControllerRegistry registry) {
+			registry.addStatusController("/notfound", HttpStatus.NOT_FOUND);
 		}
 
 		@Override

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/StatusControllerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/StatusControllerTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.handler;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.test.MockHttpServletRequest;
+import org.springframework.mock.web.test.MockHttpServletResponse;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.StatusController;
+
+/**
+ * Test fixture for {@link StatusControllerTests} tests.
+ *
+ * @author Sebastien Deleuze
+ * @since 4.1
+ */
+public class StatusControllerTests {
+
+	@Test
+	public void status() throws Exception {
+		StatusController controller = new StatusController(HttpStatus.NOT_ACCEPTABLE);
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		ModelAndView mav = controller.handleRequest(request, response);
+		assertEquals(HttpStatus.NOT_ACCEPTABLE.value(), response.getStatus());
+		assertNull(mav);
+	}
+
+	@Test
+	public void statusAndView() throws Exception {
+		StatusController controller = new StatusController(HttpStatus.NOT_ACCEPTABLE);
+		controller.setViewName("view1");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		ModelAndView mav = controller.handleRequest(request, response);
+		assertEquals(HttpStatus.NOT_ACCEPTABLE.value(), response.getStatus());
+		assertNotNull(mav);
+	}
+
+	@Test
+	public void statusAndReason() throws Exception {
+		StatusController controller = new StatusController(HttpStatus.NOT_ACCEPTABLE);
+		controller.setReason("Foo");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		ModelAndView mav = controller.handleRequest(request, response);
+		assertEquals(HttpStatus.NOT_ACCEPTABLE.value(), response.getStatus());
+		assertNull(mav);
+		assertEquals("Foo", response.getErrorMessage());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void viewAndReason() throws Exception {
+		StatusController controller = new StatusController(HttpStatus.NOT_ACCEPTABLE);
+		controller.setViewName("view1");
+		controller.setReason("Foo");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		controller.handleRequest(request, response);
+		fail();
+	}
+
+	@Test
+	public void redirect() throws Exception {
+		StatusController controller = new StatusController(HttpStatus.TEMPORARY_REDIRECT);
+		controller.setRedirectPath("/destination");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/source");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		ModelAndView mav = controller.handleRequest(request, response);
+		assertEquals(HttpStatus.TEMPORARY_REDIRECT.value(), response.getStatus());
+		assertNull(mav);
+		assertEquals("/destination", response.getHeader(HttpHeaders.LOCATION));
+	}
+
+	@Test
+	public void redirectWithoutQueryString() throws Exception {
+		StatusController controller = new StatusController(HttpStatus.TEMPORARY_REDIRECT);
+		controller.setRedirectPath("/destination");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/source");
+		request.setQueryString("foo=bar");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		ModelAndView mav = controller.handleRequest(request, response);
+		assertEquals(HttpStatus.TEMPORARY_REDIRECT.value(), response.getStatus());
+		assertNull(mav);
+		assertEquals("/destination", response.getHeader(HttpHeaders.LOCATION));
+	}
+
+	@Test
+	public void redirectWithQueryString() throws Exception {
+		StatusController controller = new StatusController(HttpStatus.TEMPORARY_REDIRECT);
+		controller.setRedirectPath("/destination");
+		controller.setUseQueryString(true);
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/source?foo=bar");
+		request.setQueryString("foo=bar");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		ModelAndView mav = controller.handleRequest(request, response);
+		assertEquals(HttpStatus.TEMPORARY_REDIRECT.value(), response.getStatus());
+		assertNull(mav);
+		assertEquals("/destination?foo=bar", response.getHeader(HttpHeaders.LOCATION));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void redirectWithWrongStatusCode() throws Exception {
+		StatusController controller = new StatusController(HttpStatus.NOT_ACCEPTABLE);
+		controller.setRedirectPath("/destination");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/source?foo=bar");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		controller.handleRequest(request, response);
+		fail();
+	}
+
+
+}

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-status-controllers.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-status-controllers.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+
+	<mvc:annotation-driven/>
+
+	<mvc:status-controller path="/foo" status-code="400" view-name="view1" />
+
+	<mvc:status-controller path="/bar" status-code="400" reason="Bar" />
+
+	<mvc:status-controller path="/source" status-code="307" redirect-path="/destination" use-query-string="true" />
+
+</beans>


### PR DESCRIPTION
Status controllers allow easily to define some URL that
should send a response with a specified status code.

For non redirect status controllers, it is possible to
specify a reason or a view to display. For redirect status
controllers, a redirect path is specified and a flag allows
to control if the query string of the original request should
be added to the redirect one.

For configuration, both XML MVC namespace and JavaConfig are
provided.

Issue: SPR-11543
