### PR TITLE
Add date formatting to MockHttpServletRequest and MockHttpServletResponse .

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/FastHttpDateFormat.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/FastHttpDateFormat.java
@@ -1,0 +1,219 @@
+/* Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.mock.web;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.TimeZone;
+
+
+/**
+ * Utility class to generate HTTP dates.
+ * <p>
+ * This class is based on code in Apache Tomcat.
+ *
+ * @author Remy Maucherat
+ * @author Andrey Grebnev
+ */
+public class FastHttpDateFormat {
+    //~ Static fields/initializers =====================================================================================
+
+    /** HTTP date format. */
+    protected static final SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+
+    /** The set of SimpleDateFormat formats to use in <code>getDateHeader()</code>. */
+    protected static final SimpleDateFormat[] formats = {
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US),
+            new SimpleDateFormat("EEEEEE, dd-MMM-yy HH:mm:ss zzz", Locale.US),
+            new SimpleDateFormat("EEE MMMM d HH:mm:ss yyyy", Locale.US)
+        };
+
+    /** GMT time zone - all HTTP dates are on GMT */
+    protected static final TimeZone gmtZone = TimeZone.getTimeZone("GMT");
+
+    static {
+        format.setTimeZone(gmtZone);
+
+        formats[0].setTimeZone(gmtZone);
+        formats[1].setTimeZone(gmtZone);
+        formats[2].setTimeZone(gmtZone);
+    }
+
+    /** Instant on which the currentDate object was generated. */
+    protected static long currentDateGenerated = 0L;
+
+    /** Current formatted date. */
+    protected static String currentDate = null;
+
+    /** Formatter cache. */
+    protected static final HashMap<Long,String> formatCache = new HashMap<Long,String>();
+
+    /** Parser cache. */
+    protected static final HashMap<String,Long> parseCache = new HashMap<String,Long>();
+
+    //~ Methods ========================================================================================================
+
+    /**
+     * Formats a specified date to HTTP format. If local format is not <code>null</code>, it's used instead.
+     *
+     * @param value Date value to format
+     * @param threadLocalformat The format to use (or <code>null</code> -- then HTTP format will be used)
+     *
+     * @return Formatted date
+     */
+    public static String formatDate(long value, DateFormat threadLocalformat) {
+        String cachedDate = null;
+        Long longValue = Long.valueOf(value);
+
+        try {
+            cachedDate = formatCache.get(longValue);
+        } catch (Exception ignored) {}
+
+        if (cachedDate != null) {
+            return cachedDate;
+        }
+
+        String newDate;
+        Date dateValue = new Date(value);
+
+        if (threadLocalformat != null) {
+            newDate = threadLocalformat.format(dateValue);
+
+            synchronized (formatCache) {
+                updateCache(formatCache, longValue, newDate);
+            }
+        } else {
+            synchronized (formatCache) {
+                newDate = format.format(dateValue);
+                updateCache(formatCache, longValue, newDate);
+            }
+        }
+
+        return newDate;
+    }
+
+    /**
+     * Gets the current date in HTTP format.
+     *
+     * @return Current date in HTTP format
+     */
+    public static String getCurrentDate() {
+        long now = System.currentTimeMillis();
+
+        if ((now - currentDateGenerated) > 1000) {
+            synchronized (format) {
+                if ((now - currentDateGenerated) > 1000) {
+                    currentDateGenerated = now;
+                    currentDate = format.format(new Date(now));
+                }
+            }
+        }
+
+        return currentDate;
+    }
+
+    /**
+     * Parses date with given formatters.
+     *
+     * @param value The string to parse
+     * @param formats Array of formats to use
+     *
+     * @return Parsed date (or <code>null</code> if no formatter mached)
+     */
+    private static Long internalParseDate(String value, DateFormat[] formats) {
+        Date date = null;
+
+        for (int i = 0; (date == null) && (i < formats.length); i++) {
+            try {
+                date = formats[i].parse(value);
+            } catch (ParseException ignored) {
+            }
+        }
+
+        if (date == null) {
+            return null;
+        }
+
+        return new Long(date.getTime());
+    }
+
+    /**
+     * Tries to parse the given date as an HTTP date. If local format list is not <code>null</code>, it's used
+     * instead.
+     *
+     * @param value The string to parse
+     * @param threadLocalformats Array of formats to use for parsing. If <code>null</code>, HTTP formats are used.
+     *
+     * @return Parsed date (or -1 if error occurred)
+     */
+    public static long parseDate(String value, DateFormat[] threadLocalformats) {
+        Long cachedDate = null;
+
+        try {
+            cachedDate = (Long) parseCache.get(value);
+        } catch (Exception ignored) {}
+
+        if (cachedDate != null) {
+            return cachedDate.longValue();
+        }
+
+        Long date;
+
+        if (threadLocalformats != null) {
+            date = internalParseDate(value, threadLocalformats);
+
+            synchronized (parseCache) {
+                updateCache(parseCache, value, date);
+            }
+        } else {
+            synchronized (parseCache) {
+                date = internalParseDate(value, formats);
+                updateCache(parseCache, value, date);
+            }
+        }
+
+        if (date == null) {
+            return (-1L);
+        } else {
+            return date.longValue();
+        }
+    }
+
+    /**
+     * Updates cache.
+     *
+     * @param cache Cache to be updated
+     * @param key Key to be updated
+     * @param value New value
+     */
+    @SuppressWarnings("unchecked")
+    private static void updateCache(HashMap cache, Object key, Object value) {
+        if (value == null) {
+            return;
+        }
+
+        if (cache.size() > 1000) {
+            cache.clear();
+        }
+
+        cache.put(key, value);
+    }
+}

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.DispatcherType;
@@ -197,7 +199,8 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	private boolean requestedSessionIdFromURL = false;
 
 	private final Map<String, Part> parts = new LinkedHashMap<String, Part>();
-
+	
+	private SimpleDateFormat[] formats;
 
 	// ---------------------------------------------------------------------
 	// Constructors
@@ -253,8 +256,15 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		this.method = method;
 		this.requestURI = requestURI;
 		this.locales.add(Locale.ENGLISH);
+		
+		this.formats = new SimpleDateFormat[3];
+		this.formats[0] = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", this.getLocale()); 
+		this.formats[1] = new SimpleDateFormat("EEEEEE, dd-MMM-yy HH:mm:ss zzz", this.getLocale());
+        this.formats[2] = new SimpleDateFormat("EEE MMMM d HH:mm:ss yyyy", this.getLocale());
+        this.formats[0].setTimeZone(TimeZone.getTimeZone("GMT"));
+        this.formats[1].setTimeZone(TimeZone.getTimeZone("GMT"));
+        this.formats[2].setTimeZone(TimeZone.getTimeZone("GMT"));
 	}
-
 
 	// ---------------------------------------------------------------------
 	// Lifecycle methods
@@ -819,6 +829,9 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		}
 		else if (value instanceof Number) {
 			return ((Number) value).longValue();
+		}
+		else if (value instanceof String) {
+			return FastHttpDateFormat.parseDate((String)value, this.formats); 
 		}
 		else if (value != null) {
 			throw new IllegalArgumentException(

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -23,12 +23,16 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
+
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
@@ -460,9 +464,16 @@ public class MockHttpServletResponse implements HttpServletResponse {
 		return getHeader(LOCATION_HEADER);
 	}
 
+	private DateFormat format = null;
+	
 	@Override
 	public void setDateHeader(String name, long value) {
-		setHeaderValue(name, value);
+		if (this.format == null) {
+			this.format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", this.locale);
+			this.format.setTimeZone(TimeZone.getTimeZone("GMT"));
+		}
+		
+		setHeaderValue(name, FastHttpDateFormat.formatDate(value, this.format));
 	}
 
 	@Override

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
@@ -16,14 +16,18 @@
 
 package org.springframework.mock.web;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.junit.Test;
 
@@ -231,6 +235,20 @@ public class MockHttpServletRequestTests {
 		request.setServerPort(-99);
 		StringBuffer requestURL = request.getRequestURL();
 		assertEquals("http://localhost", requestURL.toString());
+	}
+	
+	/**
+	 * SPR-11912
+	 */
+	@Test
+	public void getDateHeaderWithString() {
+		DateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", request.getLocale());
+		format.setTimeZone(TimeZone.getTimeZone("GMT"));		
+		long currentTime = System.currentTimeMillis();
+		String formatStr = format.format(new Date(currentTime));
+		request.addHeader("testDate", formatStr);
+		assertEquals(Long.toString(currentTime).substring(0, 10), 
+				Long.toString(request.getDateHeader("testDate")).subSequence(0, 10));
 	}
 
 	private void assertEqualEnumerations(Enumeration<?> enum1, Enumeration<?> enum2) {

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
@@ -17,13 +17,16 @@
 package org.springframework.mock.web;
 
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
+import java.util.TimeZone;
 
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Test;
-
 import org.springframework.web.util.WebUtils;
 
 import static org.junit.Assert.*;
@@ -243,4 +246,15 @@ public class MockHttpServletResponseTests {
 		assertEquals(response.getStatus(),HttpServletResponse.SC_NOT_FOUND);
 	}
 
+	/**
+	 * SPR-11912
+	 */
+	@Test
+	public void getDateHeader() {
+		DateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", response.getLocale());
+		format.setTimeZone(TimeZone.getTimeZone("GMT"));		
+		long currentTime = System.currentTimeMillis();
+		response.setDateHeader("testTime", currentTime);		
+		assertEquals(format.format(new Date(currentTime)), response.getHeader("testTime"));
+	}
 }


### PR DESCRIPTION
I improved MockHttpServletRequest.java and MockHttpServletResponse.java by adding date formatting.

The FastHttpDateFormat.java class added in org.springframework.mock.web package is a utility class to generate Http dates, and this class is based on code in Apache Tomcat.

Well, I found this class is already included in spring-security-web project as org.springframework.security.web.savedrequest.FastHttpDateFormat.java.

But because of project dependency problem, I can't use FastHttpDateFormat.java in spring-security-web and add same class in different package.

So spring team may have to think about how to solve FastHttpDateFormat class duplication.

Thanks.
