### PR TITLE
Update support for using "." as path separator

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SimpAnnotationMethodMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SimpAnnotationMethodMessageHandler.java
@@ -95,8 +95,6 @@ public class SimpAnnotationMethodMessageHandler extends AbstractMethodMessageHan
 
 	private PathMatcher pathMatcher = new AntPathMatcher();
 
-	private boolean slashPathSeparator = true;
-
 	private Validator validator;
 
 	private MessageHeaderInitializer headerInitializer;
@@ -205,7 +203,6 @@ public class SimpAnnotationMethodMessageHandler extends AbstractMethodMessageHan
 	public void setPathMatcher(PathMatcher pathMatcher) {
 		Assert.notNull(pathMatcher, "PathMatcher must not be null");
 		this.pathMatcher = pathMatcher;
-		this.slashPathSeparator = this.pathMatcher.combine("a", "a").equals("a/a");
 	}
 
 	/**
@@ -403,12 +400,7 @@ public class SimpAnnotationMethodMessageHandler extends AbstractMethodMessageHan
 		}
 		for (String prefix : getDestinationPrefixes()) {
 			if (destination.startsWith(prefix)) {
-				if (this.slashPathSeparator) {
-					return destination.substring(prefix.length() - 1);
-				}
-				else {
-					return destination.substring(prefix.length());
-				}
+				return destination.substring(prefix.length() - 1);
 			}
 		}
 		return null;

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/DestinationPatternsMessageConditionTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/DestinationPatternsMessageConditionTests.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.util.AntPathMatcher;
 
 import static org.junit.Assert.*;
 
@@ -30,21 +29,6 @@ import static org.junit.Assert.*;
  * @author Rossen Stoyanchev
  */
 public class DestinationPatternsMessageConditionTests {
-
-	@Test
-	public void prependSlash() {
-		DestinationPatternsMessageCondition c = condition("foo");
-		assertEquals("/foo", c.getPatterns().iterator().next());
-	}
-
-	@Test
-	public void prependSlashWithCustomPathSeparator() {
-		DestinationPatternsMessageCondition c =
-				new DestinationPatternsMessageCondition(new String[] {"foo"}, new AntPathMatcher("."));
-
-		assertEquals("Pre-pending should be disabled when not using '/' as path separator",
-				"foo", c.getPatterns().iterator().next());
-	}
 
 	// SPR-8255
 
@@ -87,6 +71,14 @@ public class DestinationPatternsMessageConditionTests {
 	@Test
 	public void matchDirectPath() {
 		DestinationPatternsMessageCondition condition = condition("/foo");
+		DestinationPatternsMessageCondition match = condition.getMatchingCondition(messageTo("/foo"));
+
+		assertNotNull(match);
+	}
+
+	@Test
+	public void matchDirectPathWithoutLeadingSlash() {
+		DestinationPatternsMessageCondition condition = condition("foo");
 		DestinationPatternsMessageCondition match = condition.getMatchingCondition(messageTo("/foo"));
 
 		assertNotNull(match);


### PR DESCRIPTION
Leading slash is now managed in a generic way, regardless of
the AntPathMatcher path separator.

Issue: SPR-11660
