### PR TITLE
StaxStreamXMLReader ignores significant whitespace

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/xml/StaxStreamXMLReader.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/StaxStreamXMLReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,11 +217,6 @@ class StaxStreamXMLReader extends AbstractStaxXMLReader {
 	}
 
 	private void handleCharacters() throws SAXException {
-		if (getContentHandler() != null && this.reader.isWhiteSpace()) {
-			getContentHandler().ignorableWhitespace(this.reader.getTextCharacters(),
-					this.reader.getTextStart(), this.reader.getTextLength());
-			return;
-		}
 		if (XMLStreamConstants.CDATA == this.reader.getEventType() && getLexicalHandler() != null) {
 			getLexicalHandler().startCDATA();
 		}

--- a/spring-core/src/test/resources/org/springframework/util/xml/testContentHandler.xml
+++ b/spring-core/src/test/resources/org/springframework/util/xml/testContentHandler.xml
@@ -1,2 +1,2 @@
 <h:hello xmlns:h="http://www.greeting.com/hello/" id="a1" h:person="David"><prefix:goodbye
-		xmlns:prefix="http://www.greeting.com/goodbye/" h:person="Arjen"/></h:hello>
+		xmlns:prefix="http://www.greeting.com/goodbye/" h:person="Arjen"> Some text </prefix:goodbye><h:so-long> </h:so-long></h:hello>


### PR DESCRIPTION
The StaxStreamXMLReader no longer handles all whitespace as ignorable
whitespace.

Issue: SPR-12000
