### PR TITLE
Update documentation with MVC config view resolution examples

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/ViewResolversBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/ViewResolversBeanDefinitionParser.java
@@ -122,7 +122,7 @@ public class ViewResolversBeanDefinitionParser implements BeanDefinitionParser {
 			resolvers.add(resolverBeanDef);
 		}
 
-		List<Element> elementList = DomUtils.getChildElementsByTagName(element, new String[] {"content-negotiation"});
+		List<Element> elementList = DomUtils.getChildElementsByTagName(element, new String[] {"content-negotiating"});
 		if (elementList.isEmpty()) {
 			compositeResolverBeanDef.getPropertyValues().add("order", 0);
 			compositeResolverBeanDef.getPropertyValues().add("viewResolvers", resolvers);
@@ -137,7 +137,7 @@ public class ViewResolversBeanDefinitionParser implements BeanDefinitionParser {
 			compositeResolverBeanDef.getPropertyValues().add("viewResolvers", list);
 		}
 		else if (elementList.size() > 1) {
-			throw new IllegalArgumentException("Only one <content-negotiation> element is allowed.");
+			throw new IllegalArgumentException("Only one <content-negotiating> element is allowed.");
 		}
 
 		String beanName = VIEW_RESOLVER_BEAN_NAME;

--- a/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc-4.1.xsd
+++ b/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc-4.1.xsd
@@ -689,7 +689,7 @@
 		</xsd:complexType>
 	</xsd:element>
 
-	<xsd:complexType name="contentNegotiationType">
+	<xsd:complexType name="contentNegotiatingType">
 		<xsd:all>
 			<xsd:element name="default-views" minOccurs="0">
 				<xsd:complexType>
@@ -790,7 +790,7 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:choice minOccurs="1" maxOccurs="unbounded">
-				<xsd:element name="content-negotiation" type="contentNegotiationType">
+				<xsd:element name="content-negotiating" type="contentNegotiatingType">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 	Registers a ContentNegotiatingViewResolver with the list of all other registered

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution-content-negotiation.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution-content-negotiation.xml
@@ -15,11 +15,11 @@
 		  class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean"/>
 
 	<mvc:view-resolvers>
-		<mvc:content-negotiation use-not-acceptable="true">
+		<mvc:content-negotiating use-not-acceptable="true">
 			<mvc:default-views>
 				<bean class="org.springframework.web.servlet.view.json.MappingJackson2JsonView" />
 			</mvc:default-views>
-		</mvc:content-negotiation>
+		</mvc:content-negotiating>
 		<mvc:bean-name />
 		<mvc:jsp />
 		<mvc:tiles />

--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -32402,6 +32402,145 @@ And the same in XML use the `<mvc:view-controller>` element:
 ----
 
 
+[[mvc-config-view-resolution]]
+==== Configuring View Resolution
+This is a shortcut for defining `ViewResolver` beans that can resolve views by name.
+
+The API allows to declare view resolvers with default values, and to customize most
+useful properties. Bean name and JSP view resolvers can be declared like bellow:
+
+[source,java,indent=0]
+[subs="verbatim,quotes"]
+----
+	@Configuration
+	@EnableWebMvc
+	public class WebConfig extends WebMvcConfigurerAdapter {
+
+		@Override
+		public void configureViewResolvers(ViewResolverRegistry registry) {
+			registry.beanName();
+			registry.jsp().prefix("/");
+		}
+
+	}
+----
+
+And the same in XML use the `<mvc:view-resolvers>` child elements:
+
+[source,xml,indent=0]
+[subs="verbatim,quotes"]
+----
+	<mvc:view-resolvers>
+		<mvc:bean-name />
+		<mvc:jsp />
+	</mvc:view-resolvers>
+----
+
+Configuring Tiles, Velocity, FreeMarker and Groovy view resolution requires
+declaring both `ViewResolver` (configured thanks to the `ViewResolverRegistry`)
+and configurer beans:
+
+[source,java,indent=0]
+[subs="verbatim,quotes"]
+----
+	@Configuration
+	@EnableWebMvc
+	public class WebConfig extends WebMvcConfigurerAdapter {
+
+		@Override
+		public void configureViewResolvers(ViewResolverRegistry registry) {
+			registry.tiles();
+			registry.velocity();
+			registry.freeMarker().suffix(".fmt").cache(false);
+			registry.groovy();
+		}
+
+		@Bean
+		public TilesConfigurer tilesConfigurer() {
+			return new TilesConfigurer();
+		}
+
+		@Bean
+		public VelocityConfigurer velocityConfigurer() {
+			return new VelocityConfigurer();
+		}
+
+		@Bean
+		public FreeMarkerConfigurer freeMarkerConfigurer() {
+			return new FreeMarkerConfigurer();
+		}
+
+		@Bean
+		public GroovyMarkupConfigurer groovyMarkupConfigurer() {
+			return new GroovyMarkupConfigurer();
+		}
+
+	}
+----
+
+For XML, in addition to the `<mvc:view-resolvers>` child elements, shortcut alternative
+to declaring configurer beans directly are also provided:
+
+[source,xml,indent=0]
+[subs="verbatim,quotes"]
+----
+	<mvc:view-resolvers>
+		<mvc:tiles />
+		<mvc:velocity />
+		<mvc:freemarker />
+		<mvc:groovy />
+	</mvc:view-resolvers>
+
+	<mvc:tiles-configurer>
+		<mvc:definitions location="/tiles/tiles1.xml" />
+	</mvc:tiles-configurer>
+
+	<mvc:velocity-configurer resource-loader-path="/velocity" />
+
+	<mvc:freemarker-configurer>
+		<mvc:template-loader-path location="/freemarker" />
+	</mvc:freemarker-configurer>
+
+	<mvc:groovy-configurer />
+----
+
+It is also possible to declare a `ContentNegotiatingViewResolver` bean thanks to the
+`ViewResolverRegistry`. The `ContentNegotiationManager` used to determine requested media
+types is configured as described in <<mvc-config-content-negotiation>>.
+All other view resolvers declared are automatically added to the `viewResolvers`
+property of the `ContentNegotiatingViewResolver` bean:
+
+[source,java,indent=0]
+[subs="verbatim,quotes"]
+----
+	@Configuration
+	@EnableWebMvc
+	public class WebConfig extends WebMvcConfigurerAdapter {
+
+		@Override
+		public void configureViewResolvers(ViewResolverRegistry registry) {
+			registry.contentNegotiating(new MappingJackson2JsonView());
+			registry.jsp();
+		}
+
+	}
+----
+
+And the same in XML use the `<mvc:content-negotiation>` element:
+
+[source,xml,indent=0]
+[subs="verbatim,quotes"]
+----
+	<mvc:view-resolvers>
+		<mvc:content-negotiation use-not-acceptable="true">
+			<mvc:default-views>
+				<bean class="org.springframework.web.servlet.view.json.MappingJackson2JsonView" />
+			</mvc:default-views>
+		</mvc:content-negotiation>
+		<mvc:jsp />
+	</mvc:view-resolvers>
+----
+
 
 [[mvc-config-static-resources]]
 ==== Configuring Serving of Resources

--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -32526,17 +32526,17 @@ property of the `ContentNegotiatingViewResolver` bean:
 	}
 ----
 
-And the same in XML use the `<mvc:content-negotiation>` element:
+And the same in XML use the `<mvc:content-negotiating>` element:
 
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<mvc:view-resolvers>
-		<mvc:content-negotiation use-not-acceptable="true">
+		<mvc:content-negotiating use-not-acceptable="true">
 			<mvc:default-views>
 				<bean class="org.springframework.web.servlet.view.json.MappingJackson2JsonView" />
 			</mvc:default-views>
-		</mvc:content-negotiation>
+		</mvc:content-negotiating>
 		<mvc:jsp />
 	</mvc:view-resolvers>
 ----


### PR DESCRIPTION
I have also added a commit to rename mvc:content-negotiation to mvc:content-negotiating, in order to be consistent with JavaConfig.
