### PR TITLE
Generate bracketless tag id in Velocity forms

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/velocity/spring.vm
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/velocity/spring.vm
@@ -112,7 +112,7 @@
  *#
 #macro( springFormInput $path $attributes )
     #springBind($path)
-    <input type="text" id="${status.expression}" name="${status.expression}" value="$!status.value" ${attributes}#springCloseTag()
+    <input type="text" id="#xmlId(${status.expression})" name="${status.expression}" value="$!status.value" ${attributes}#springCloseTag()
 #end
 
 #**
@@ -129,7 +129,7 @@
  *#
 #macro( springFormPasswordInput $path $attributes )
     #springBind($path)
-    <input type="password" id="${status.expression}" name="${status.expression}" value="" ${attributes}#springCloseTag()
+    <input type="password" id="#xmlId(${status.expression})" name="${status.expression}" value="" ${attributes}#springCloseTag()
 #end
 
 #**
@@ -145,7 +145,7 @@
  *#
 #macro( springFormHiddenInput $path $attributes )
     #springBind($path)
-    <input type="hidden" id="${status.expression}" name="${status.expression}" value="$!status.value" ${attributes}#springCloseTag()
+    <input type="hidden" id="#xmlId(${status.expression})" name="${status.expression}" value="$!status.value" ${attributes}#springCloseTag()
 #end
 
 #**
@@ -161,7 +161,7 @@
  *#
 #macro( springFormTextarea $path $attributes )
     #springBind($path)
-    <textarea id="${status.expression}" name="${status.expression}" ${attributes}>$!status.value</textarea>
+    <textarea id="#xmlId(${status.expression})" name="${status.expression}" ${attributes}>$!status.value</textarea>
 #end
 
 #**
@@ -182,7 +182,7 @@
 *#
 #macro( springFormSingleSelect $path $options $attributes )
     #springBind($path)
-    <select id="${status.expression}" name="${status.expression}" ${attributes}>
+    <select id="#xmlId(${status.expression})" name="${status.expression}" ${attributes}>
         #foreach($option in $options.keySet())
             <option value="${option}"
             #if ("$!status.value" == "$option") selected="selected" #end>
@@ -204,7 +204,7 @@
 *#
 #macro( springFormMultiSelect $path $options $attributes )
     #springBind($path)
-    <select multiple="multiple" id="${status.expression}" name="${status.expression}" ${attributes}>
+    <select multiple="multiple" id="#xmlId(${status.expression})" name="${status.expression}" ${attributes}>
         #foreach($option in $options.keySet())
             <option value="${option}"
             #foreach($item in $status.actualValue)
@@ -274,8 +274,8 @@
 *#
 #macro( springFormCheckbox $path $attributes )
     #springBind($path)
-    <input type="hidden" name="_${status.expression}" value="on"/>
-    <input type="checkbox" id="${status.expression}" name="${status.expression}"#if ("$!{status.value}"=="true") checked="checked"#end ${attributes}/>
+    <input type="hidden" name="_#xmlId(${status.expression})" value="on"/>
+    <input type="checkbox" id="#xmlId(${status.expression})" name="${status.expression}"#if ("$!{status.value}"=="true") checked="checked"#end ${attributes}/>
 #end
 
 #**
@@ -316,7 +316,7 @@
  *#
 #macro( springCloseTag )#if ($springXhtmlCompliant)/>#else>#end #end
 
-
+#macro( xmlId $id)#if($id)$id.replaceAll("\[","").replaceAll("\]","")#else$id#end#end
 
 
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/velocity/test-spr5172.vm
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/velocity/test-spr5172.vm
@@ -1,0 +1,30 @@
+##
+## test template for Velocity macro test class
+##
+
+FORM1
+#springFormInput("command.spouses[0].name" "")
+
+FORM2
+#springFormTextarea("command.spouses[0].name" "")
+
+FORM3
+#springFormSingleSelect("command.spouses[0].name" $nameOptionMap "")
+
+FORM4
+#springFormMultiSelect("command.spouses" $nameOptionMap "")
+
+FORM5
+#springFormRadioButtons("command.spouses[0].name" $nameOptionMap " " "")
+
+FORM6
+#springFormPasswordInput("command.spouses[0].name" "")
+
+FORM7
+#springFormHiddenInput("command.spouses[0].name" "")
+
+FORM8
+#springFormCheckbox("command.spouses[0].name" "")
+
+FORM9
+#springFormCheckbox("command.spouses[0].jedi" "")


### PR DESCRIPTION
Before this change if Velocity Spring form macro was bound to a path
which contains square brackets, those brackets would also appear in id
of generated tag, making the id invalid.

As of this fix all Velocity Spring form macros generate tag with id
that does not contain square brackets.

Issue: SPR-5172
