### PR TITLE
add asserBufferedRequestBodyFalseConfig in HttpComponentsClientHttpRequestFactoryTests

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -562,7 +562,14 @@ public abstract class ObjectUtils {
 			return NULL_STRING;
 		}
 		if (obj instanceof String) {
-			return (String) obj;
+			// added by SPR-10729
+			// obj converting space string if obj contains sneaky values
+			String value = (String) obj;
+			if(value.contains("<") || value.contains(">")){
+				value = value.replaceAll("<", "&lt;");
+				value = value.replaceAll(">", "&gt;");
+			}
+			return value;
 		}
 		if (obj instanceof Object[]) {
 			return nullSafeToString((Object[]) obj);

--- a/spring-core/src/test/java/org/springframework/util/ObjectUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ObjectUtilsTests.java
@@ -720,6 +720,12 @@ public class ObjectUtilsTests {
 	public void testNullSafeToStringWithStringArrayEqualToNull() {
 		assertEquals("null", ObjectUtils.nullSafeToString((String[]) null));
 	}
+	
+	@Test
+	public void testNullSafeToStringWithXSSValue() {
+		String value = "<script>doBadthings()</script>";
+		assertEquals("&lt;script&gt;doBadthings()&lt;/script&gt;", ObjectUtils.nullSafeToString(value));
+	}
 
 	@Test
 	public void testContainsConstant() {

--- a/spring-web/src/test/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactoryTests.java
@@ -16,8 +16,7 @@
 
 package org.springframework.http.client;
 
-import static org.junit.Assert.*;
-
+import java.io.OutputStream;
 import java.net.URI;
 
 import org.apache.http.client.HttpClient;
@@ -28,6 +27,8 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.params.CoreConnectionPNames;
 import org.junit.Test;
 import org.springframework.http.HttpMethod;
+
+import static org.junit.Assert.*;
 
 public class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpRequestFactoryTestCase {
 
@@ -73,5 +74,25 @@ public class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpReq
 		assertEquals("Wrong custom connection timeout", 1234, requestConfig.getConnectTimeout());
 		assertEquals("Wrong custom socket timeout", 4567, requestConfig.getSocketTimeout());
 
+	}
+	
+	/**
+	 * HttpComponentsClientHttpRequestFactory can not use getBody() method if bufferRequestBody set false.
+	 * So recommend use SimpleClientHttpRequestFactory instead of HttpComponentsClientHttpRequestFactory if bufferRequestBody set false.
+	 * (SPR-11981)
+	 * @throws Exception
+	 */
+	@Test
+	(expected=UnsupportedOperationException.class)
+	public void assertBufferedRequestBodyFalseConfig() throws Exception {
+		HttpClient httpClient = HttpClientBuilder.create().build();
+		HttpComponentsClientHttpRequestFactory hrf = new HttpComponentsClientHttpRequestFactory(httpClient);
+		hrf.setBufferRequestBody(false);
+		
+		URI uri = new URI(baseUrl + "/status/ok");
+		HttpComponentsStreamingClientHttpRequest request = (HttpComponentsStreamingClientHttpRequest)hrf.createRequest(uri, HttpMethod.GET);
+		
+		OutputStream os = request.getBody();
+		assertNotNull(os);
 	}
 }


### PR DESCRIPTION
The HttpComponentsClientHttpRequestFactory throw UnsupportedOperationException when bufferRequestBody is set false. So I added testcase HttpComponentsClientHttpRequestFactoryTests to recommend about use SimpleClientHttpRequestFactory if bufferRequestBody is set false.
Because no buffer can not use OutputStream result.
Testcase is useful of knowing the fact. And I added comment at that testcase.

Issue: SPR-11981
