### PR TITLE
add testNullSafeToStringWithXSSValue testcase to objectUtilsTests

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -562,7 +562,7 @@ public abstract class ObjectUtils {
 			return NULL_STRING;
 		}
 		if (obj instanceof String) {
-			return (String) obj;
+			return convertXSSValue((String) obj);
 		}
 		if (obj instanceof Object[]) {
 			return nullSafeToString((Object[]) obj);
@@ -594,7 +594,27 @@ public abstract class ObjectUtils {
 		String str = obj.toString();
 		return (str != null ? str : EMPTY_STRING);
 	}
-
+	
+	/**
+	 * Return a String representation of the converted Object for XSS Script value.
+	 * @param value the value to build a String representation for
+	 * @return a String representation of {@code value}
+	 */
+	public static String convertXSSValue(String value){
+		value = value.replaceAll("&", "&amp;");
+	    value = value.replaceAll("<", "&lt;");
+	    value = value.replaceAll(">", "&gt;");
+	    value = value.replaceAll("%00", null);
+	    value = value.replaceAll("\"", "&#34;");
+	    value = value.replaceAll("\'", "&#39;");
+	    value = value.replaceAll("%", "&#37;");
+	    value = value.replaceAll("../", "");
+	    value = value.replaceAll("..\\\\", "");
+	    value = value.replaceAll("./", "");
+	    value = value.replaceAll("%2F", "");
+	    
+	    return value;
+	}
 	/**
 	 * Return a String representation of the contents of the specified array.
 	 * <p>The String representation consists of a list of the array's elements,

--- a/spring-core/src/test/java/org/springframework/util/ObjectUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ObjectUtilsTests.java
@@ -720,6 +720,12 @@ public class ObjectUtilsTests {
 	public void testNullSafeToStringWithStringArrayEqualToNull() {
 		assertEquals("null", ObjectUtils.nullSafeToString((String[]) null));
 	}
+	
+	@Test
+	public void testNullSafeToStringWithXSSValue() {
+		String value = "<script>doBadthings()</script>";
+		assertEquals("&lt;script&gt;doBadthings()&lscript&gt;", ObjectUtils.nullSafeToString(value));
+	}
 
 	@Test
 	public void testContainsConstant() {


### PR DESCRIPTION
In the absence of a message string for the error code, this is the message that gets written as the error.
So ObjectUtils class, nullSafeToString method parameter can contains XSS attack script value.
So I added convertXSSValue method and testCase.

When the vaule contains script then the method converting the value safe.
