### PR TITLE
Change GenericConversionService to match interfaces before enums

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -759,6 +759,21 @@ public class GenericConversionServiceTests {
 	}
 
 	@Test
+	public void testStringToEnumWithInterfaceConversion() {
+		conversionService.addConverterFactory(new StringToEnumConverterFactory());
+		conversionService.addConverterFactory(new StringToMyEnumInterfaceConverterFactory());
+		assertEquals(MyEnum.A, conversionService.convert("1", MyEnum.class));
+	}
+	
+	@Test
+	public void testStringToEnumWithBaseInterfaceConversion() {
+		conversionService.addConverterFactory(new StringToEnumConverterFactory());
+		conversionService.addConverterFactory(new StringToMyEnumBaseInterfaceConverterFactory());
+		assertEquals(MyEnum.A, conversionService.convert("base1", MyEnum.class));
+	}
+	
+	
+	@Test
 	public void convertNullAnnotatedStringToString() throws Exception {
 		DefaultConversionService.addDefaultConverters(conversionService);
 		String source = null;
@@ -930,20 +945,35 @@ public class GenericConversionServiceTests {
 		}
 	}
 
-
-	interface MyEnumInterface {
-
+	interface MyEnumBaseInterface {
+		String getBaseCode();
+	}
+	
+	interface MyEnumInterface extends MyEnumBaseInterface {
 		String getCode();
 	}
 
 	public static enum MyEnum implements MyEnumInterface {
 
-		A {
-			@Override
-			public String getCode() {
-				return "1";
-			}
-		}
+	    A("1"),
+	    B("2"),
+	    C("3");
+
+	    private String code;
+
+	    MyEnum(String code) {
+	        this.code = code;
+	    }
+
+	    @Override
+	    public String getCode() {
+	        return code;
+	    }
+	    
+	    @Override
+	    public String getBaseCode() {
+	    	return "base" + code;
+	    }
 	}
 
 
@@ -970,6 +1000,59 @@ public class GenericConversionServiceTests {
 			return source.getCode();
 		}
 	}
+	
+	private static class StringToMyEnumInterfaceConverterFactory implements ConverterFactory<String, MyEnumInterface> {
+
+	    @SuppressWarnings("unchecked")
+	    public <T extends MyEnumInterface> Converter<String, T> getConverter(Class<T> targetType) {
+	        return new StringToMyEnumInterfaceConverter(targetType);
+	    }
+
+	    private static class StringToMyEnumInterfaceConverter<T extends Enum<?> & MyEnumInterface> implements Converter<String, T> {
+	        private final Class<T> enumType;
+
+	        public StringToMyEnumInterfaceConverter(Class<T> enumType) {
+	            this.enumType = enumType;
+	        }
+
+	        public T convert(String source) {
+	            for (T value : enumType.getEnumConstants()) {
+	                if (value.getCode().equals(source)) {
+	                    return value;
+	                }
+	            }
+	            return null;
+	        }
+	    }
+
+	}
+	
+	private static class StringToMyEnumBaseInterfaceConverterFactory implements ConverterFactory<String, MyEnumBaseInterface> {
+
+	    @SuppressWarnings("unchecked")
+	    public <T extends MyEnumBaseInterface> Converter<String, T> getConverter(Class<T> targetType) {
+	        return new StringToMyEnumBaseInterfaceConverter(targetType);
+	    }
+
+	    private static class StringToMyEnumBaseInterfaceConverter<T extends Enum<?> & MyEnumBaseInterface> implements Converter<String, T> {
+	        private final Class<T> enumType;
+
+	        public StringToMyEnumBaseInterfaceConverter(Class<T> enumType) {
+	            this.enumType = enumType;
+	        }
+
+	        public T convert(String source) {
+	            for (T value : enumType.getEnumConstants()) {
+	                if (value.getBaseCode().equals(source)) {
+	                    return value;
+	                }
+	            }
+	            return null;
+	        }
+	    }
+
+	}	
+	
 
 	public static class MyStringToStringCollectionConverter implements Converter<String, Collection<String>> {
 


### PR DESCRIPTION
Prior to this commit, given an enum which implements some interface,
GenericConversionService would select the String -> Enum converter even
if a converter for String -> SomeInterface was registered.  This also
affected converters that were registered for String ->
SomeBaseInterface, when SomeInterface extended SomeBaseInterface.

This change modifies the behavior of the private method
getClassHierarchy() by placing interfaces first in the class hierarchy
that is returned.  To ensure that any implementing interfaces also had
their super-interfaces explored and added to the hierarchy before the
superclass, the logic for traversing the class hierarchy was changed to
use a stack of candidate types to add the hierarchy.

Previously the hiearchy was built up in an ArrayList, with an auxillary
set used to make sure duplicates were not added (presumably for
performance?). I have changed the hierarchy to be built up in a
LinkedHashSet, which preserves these semantics, although the method now
returns Iterable instead of List.

Issue: SPR-12050

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
