### PR TITLE
Move RequestReplyHeaderMapper to core

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/support/AbstractHeaderMapper.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/AbstractHeaderMapper.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.messaging.support;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Abstract base class for {@link RequestReplyHeaderMapper} implementations.
+ *
+ * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @author Stephane Nicoll
+ * @since 4.1
+ */
+public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMapper<T> {
+
+	/**
+	 * A special pattern that only matches standard request headers.
+	 */
+	public static final String STANDARD_REQUEST_HEADER_NAME_PATTERN = "STANDARD_REQUEST_HEADERS";
+
+	/**
+	 * A special pattern that only matches standard reply headers.
+	 */
+	public static final String STANDARD_REPLY_HEADER_NAME_PATTERN = "STANDARD_REPLY_HEADERS";
+
+	/**
+	 * A special pattern that matches any header that is not a standard header (i.e. any
+	 * header that does not start with the configured standard header prefix)
+	 */
+	public static final String NON_STANDARD_HEADER_NAME_PATTERN = "NON_STANDARD_HEADERS";
+
+	private static final Collection<String> TRANSIENT_HEADER_NAMES = Arrays.asList(
+			MessageHeaders.ID, MessageHeaders.TIMESTAMP);
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private final String standardHeaderPrefix;
+
+	private final Collection<String> requestHeaderNames;
+
+	private final Collection<String> replyHeaderNames;
+
+	private volatile HeaderMatcher requestHeaderMatcher;
+
+	private volatile HeaderMatcher replyHeaderMatcher;
+
+	/**
+	 * Create a new instance.
+	 * @param standardHeaderPrefix the header prefix that identifies standard header. Such prefix helps to
+	 * differentiate user-defined headers from standard headers. If set, user-defined headers are also
+	 * mapped by default
+	 * @param requestHeaderNames the header names that should be mapped from a request to {@link MessageHeaders}
+	 * @param replyHeaderNames the header names that should be mapped to a response from {@link MessageHeaders}
+	 */
+	protected AbstractHeaderMapper(String standardHeaderPrefix,
+			Collection<String> requestHeaderNames, Collection<String> replyHeaderNames) {
+
+		this.standardHeaderPrefix = standardHeaderPrefix;
+		this.requestHeaderNames = requestHeaderNames;
+		this.replyHeaderNames = replyHeaderNames;
+		this.requestHeaderMatcher = createDefaultHeaderMatcher(this.standardHeaderPrefix, this.requestHeaderNames);
+		this.replyHeaderMatcher = createDefaultHeaderMatcher(this.standardHeaderPrefix, this.replyHeaderNames);
+	}
+
+	/**
+	 * Provide the header names that should be mapped from a request
+	 * to a {@link MessageHeaders}
+	 * The values can also contain simple wildcard patterns (e.g. "foo*" or "*foo") to be matched.
+	 *
+	 * @param requestHeaderNames The request header names.
+	 */
+	public void setRequestHeaderNames(String... requestHeaderNames) {
+		Assert.notNull(requestHeaderNames, "'requestHeaderNames' must not be null");
+		this.requestHeaderMatcher = createHeaderMatcher(Arrays.asList(requestHeaderNames));
+	}
+
+	/**
+	 * Provide the header names that should be mapped to a response
+	 * from a {@link MessageHeaders}
+	 * The values can also contain simple wildcard patterns (e.g. "foo*" or "*foo") to be matched.
+	 *
+	 * @param replyHeaderNames The reply header names.
+	 */
+	public void setReplyHeaderNames(String... replyHeaderNames) {
+		Assert.notNull(replyHeaderNames, "'replyHeaderNames' must not be null");
+		this.replyHeaderMatcher = createHeaderMatcher(Arrays.asList(replyHeaderNames));
+	}
+
+	/**
+	 * Create the initial {@link HeaderMatcher} based on the specified headers. If a
+	 * {@code standardHeaderPrefix} is set, any non standard headers are mapped as
+	 * well.
+	 */
+	protected HeaderMatcher createDefaultHeaderMatcher(String standardHeaderPrefix, Collection<String> headerNames) {
+		HeaderMatcher headerMatcher = new ContentBasedHeaderMatcher(true, headerNames);
+		if (StringUtils.hasText(standardHeaderPrefix)) {
+			HeaderMatcher nonStandardHeaderMatcher = new PrefixBasedMatcher(false, standardHeaderPrefix);
+			return new CompositeHeaderMatcher(headerMatcher, nonStandardHeaderMatcher);
+		}
+		else {
+			return headerMatcher;
+		}
+	}
+
+	/**
+	 * Create a {@link HeaderMatcher} that match if any of the specified {@code patterns}
+	 * match. The pattern can be a header name, a wildcard pattern such as
+	 * {@code foo*}, {@code *foo}, or {@code within*foo}.
+	 * <p>Special patterns are also recognized: {@link #STANDARD_REQUEST_HEADER_NAME_PATTERN},
+	 * {@link #STANDARD_REQUEST_HEADER_NAME_PATTERN} and {@link #NON_STANDARD_HEADER_NAME_PATTERN}.
+	 * @param patterns the patterns to apply
+	 * @return a header mapper that match if any of the specified patters match
+	 */
+	protected CompositeHeaderMatcher createHeaderMatcher(Collection<String> patterns) {
+		Collection<HeaderMatcher> matchers = new ArrayList<HeaderMatcher>();
+		for (String pattern : patterns) {
+			if (STANDARD_REQUEST_HEADER_NAME_PATTERN.equals(pattern)) {
+				matchers.add(new ContentBasedHeaderMatcher(true, this.requestHeaderNames));
+			}
+			else if (STANDARD_REPLY_HEADER_NAME_PATTERN.equals(pattern)) {
+				matchers.add(new ContentBasedHeaderMatcher(true, this.replyHeaderNames));
+			}
+			else if (NON_STANDARD_HEADER_NAME_PATTERN.equals(pattern)) {
+				matchers.add(new PrefixBasedMatcher(false, this.standardHeaderPrefix));
+			}
+			else {
+				matchers.add(new PatternBasedHeaderMatcher(Collections.singleton(pattern)));
+			}
+		}
+		return new CompositeHeaderMatcher(matchers);
+	}
+
+	@Override
+	public void fromHeadersToRequest(MessageHeaders headers, T target) {
+		fromHeaders(headers, target, this.requestHeaderMatcher);
+	}
+
+	@Override
+	public void fromHeadersToReply(MessageHeaders headers, T target) {
+		fromHeaders(headers, target, this.replyHeaderMatcher);
+	}
+
+	@Override
+	public Map<String, Object> toHeadersFromRequest(T source) {
+		return toHeaders(source, this.requestHeaderMatcher);
+	}
+
+	@Override
+	public Map<String, Object> toHeadersFromReply(T source) {
+		return toHeaders(source, this.replyHeaderMatcher);
+	}
+
+	private void fromHeaders(MessageHeaders headers, T target, HeaderMatcher headerMatcher) {
+		try {
+			Map<String, Object> subset = new HashMap<String, Object>();
+			for (Map.Entry<String, Object> entry : headers.entrySet()) {
+				String headerName = entry.getKey();
+				if (shouldMapHeader(headerName, headerMatcher)) {
+					subset.put(headerName, entry.getValue());
+				}
+			}
+			populateStandardHeaders(subset, target);
+			populateUserDefinedHeaders(subset, target);
+		}
+		catch (Exception e) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("error occurred while mapping from MessageHeaders", e);
+			}
+		}
+	}
+
+	private void populateUserDefinedHeaders(Map<String, Object> headers, T target) {
+		for (String headerName : headers.keySet()) {
+			Object value = headers.get(headerName);
+			if (value != null) {
+				try {
+					if (!headerName.startsWith(this.standardHeaderPrefix)) {
+						String key = createTargetPropertyName(headerName, true);
+						populateUserDefinedHeader(key, value, target);
+					}
+				}
+				catch (Exception e) {
+					if (logger.isWarnEnabled()) {
+						logger.warn("failed to map from Message header '" + headerName + "' to target", e);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Map headers from a source instance to the {@link MessageHeaders} of
+	 * a {@link org.springframework.messaging.Message}.
+	 */
+	private Map<String, Object> toHeaders(T source, HeaderMatcher headerMatcher) {
+		Map<String, Object> headers = new HashMap<String, Object>();
+		Map<String, Object> standardHeaders = extractStandardHeaders(source);
+		copyHeaders(standardHeaders, headers, headerMatcher);
+		Map<String, Object> userDefinedHeaders = extractUserDefinedHeaders(source);
+		copyHeaders(userDefinedHeaders, headers, headerMatcher);
+		return headers;
+	}
+
+	private <V> void copyHeaders(Map<String, Object> source, Map<String, Object> target, HeaderMatcher headerMatcher) {
+		if (!CollectionUtils.isEmpty(source)) {
+			for (Map.Entry<String, Object> entry : source.entrySet()) {
+				try {
+					String headerName = createTargetPropertyName(entry.getKey(), false);
+					if (shouldMapHeader(headerName, headerMatcher)) {
+						target.put(headerName, entry.getValue());
+					}
+				}
+				catch (Exception e) {
+					if (logger.isWarnEnabled()) {
+						logger.warn("error occurred while mapping header '"
+								+ entry.getKey() + "' to Message header", e);
+					}
+				}
+			}
+		}
+	}
+
+	private boolean shouldMapHeader(String headerName, HeaderMatcher headerMatcher) {
+		if (!StringUtils.hasText(headerName)
+				|| getTransientHeaderNames().contains(headerName)) {
+			return false;
+		}
+		return headerMatcher.matchHeader(headerName);
+	}
+
+	@SuppressWarnings("unchecked")
+	protected <V> V getHeaderIfAvailable(Map<String, Object> headers, String name, Class<V> type) {
+		Object value = headers.get(name);
+		if (value == null) {
+			return null;
+		}
+		if (!type.isAssignableFrom(value.getClass())) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("skipping header '" + name + "' since it is not of expected type [" + type + "], it is [" +
+						value.getClass() + "]");
+			}
+			return null;
+		}
+		else {
+			return (V) value;
+		}
+	}
+
+	/**
+	 * Alter the specified {@code propertyName} if necessary. By default, the original
+	 * {@code propertyName} is returned
+	 * @param propertyName the original name of the property
+	 * @param fromMessageHeaders specify if the property originates from a {@link MessageHeaders}
+	 * instance (true) or from the type managed by this mapper (false)
+	 */
+	protected String createTargetPropertyName(String propertyName, boolean fromMessageHeaders) {
+		return propertyName;
+	}
+
+	/**
+	 * Return the transient header names. Transient headers are never mapped.
+	 */
+	protected Collection<String> getTransientHeaderNames() {
+		return TRANSIENT_HEADER_NAMES;
+	}
+
+	/**
+	 * Extract the standard headers from the specified source.
+	 */
+	protected abstract Map<String, Object> extractStandardHeaders(T source);
+
+	/**
+	 * Extract the user-defined headers from the specified source.
+	 */
+	protected abstract Map<String, Object> extractUserDefinedHeaders(T source);
+
+	/**
+	 * Populate the specified standard headers to the specified source.
+	 */
+	protected abstract void populateStandardHeaders(Map<String, Object> headers, T target);
+
+	/**
+	 * Populate the specified user-defined headers to the specified source.
+	 */
+	protected abstract void populateUserDefinedHeader(String headerName, Object headerValue, T target);
+
+	/**
+	 * Strategy interface to determine if a given header name match.
+	 */
+	protected interface HeaderMatcher {
+
+		/**
+		 * Specify if the given {@code headerName} match.
+		 */
+		boolean matchHeader(String headerName);
+
+	}
+
+	/**
+	 * A content-based {@link HeaderMatcher} that match if the specified
+	 * header is contained within a list of candidates. The case of the
+	 * header does not matter.
+	 */
+	protected static class ContentBasedHeaderMatcher implements HeaderMatcher {
+		private static final Log logger = LogFactory.getLog(HeaderMatcher.class);
+
+		private final boolean match;
+
+		private final Collection<String> content;
+
+		public ContentBasedHeaderMatcher(boolean match, Collection<String> content) {
+			this.match = match;
+			Assert.notNull(content, "Content must not be null");
+			this.content = content;
+		}
+
+		@Override
+		public boolean matchHeader(String headerName) {
+			boolean result = (this.match == containsIgnoreCase(headerName));
+			if (result && logger.isDebugEnabled()) {
+				StringBuilder message = new StringBuilder("headerName=[{0}] WILL be mapped, ");
+				if (!this.match) {
+					message.append("not ");
+				}
+				message.append("found in {1}");
+				logger.debug(MessageFormat.format(message.toString(), headerName, this.content));
+			}
+			return result;
+		}
+
+		private boolean containsIgnoreCase(String name) {
+			for (String headerName : this.content) {
+				if (headerName.equalsIgnoreCase(name)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * A pattern-based {@link HeaderMatcher} that match if the specified
+	 * header match one of the specified simple patterns.
+	 * @see org.springframework.util.PatternMatchUtils#simpleMatch(String, String)
+	 */
+	protected static class PatternBasedHeaderMatcher implements HeaderMatcher {
+
+		private static final Log logger = LogFactory.getLog(HeaderMatcher.class);
+
+		private final Collection<String> patterns;
+
+		public PatternBasedHeaderMatcher(Collection<String> patterns) {
+			Assert.notNull(patterns, "Patters must no be null");
+			Assert.notEmpty(patterns, "At least one pattern must be specified");
+			this.patterns = patterns;
+		}
+
+		@Override
+		public boolean matchHeader(String headerName) {
+			String header = headerName.toLowerCase();
+			for (String pattern : this.patterns) {
+				if (PatternMatchUtils.simpleMatch(pattern.toLowerCase(), header)) {
+					if (logger.isDebugEnabled()) {
+						logger.debug(MessageFormat.format(
+								"headerName=[{0}] WILL be mapped, matched pattern={1}", headerName, pattern));
+					}
+					return true;
+				}
+			}
+			return false;
+		}
+
+	}
+
+	/**
+	 * A prefix-based {@link HeaderMatcher} that match if the specified
+	 * header starts with a configurable prefix.
+	 */
+	protected static class PrefixBasedMatcher implements HeaderMatcher {
+		private static final Log logger = LogFactory.getLog(HeaderMatcher.class);
+
+
+		private final boolean match;
+
+		private final String prefix;
+
+		public PrefixBasedMatcher(boolean match, String prefix) {
+			this.match = match;
+			this.prefix = prefix;
+		}
+
+		@Override
+		public boolean matchHeader(String headerName) {
+			boolean result = (this.match == headerName.startsWith(this.prefix));
+			if (result && logger.isDebugEnabled()) {
+				StringBuilder message = new StringBuilder("headerName=[{0}] WILL be mapped, ");
+				if (!this.match) {
+					message.append("does not ");
+				}
+				message.append("start with [{1}]");
+				logger.debug(MessageFormat.format(message.toString(), headerName, this.prefix));
+			}
+			return result;
+		}
+	}
+
+	protected static class CompositeHeaderMatcher implements HeaderMatcher {
+		private final Collection<HeaderMatcher> strategies;
+
+		private static final Log logger = LogFactory.getLog(HeaderMatcher.class);
+
+		CompositeHeaderMatcher(Collection<HeaderMatcher> strategies) {
+			this.strategies = strategies;
+		}
+
+		CompositeHeaderMatcher(HeaderMatcher... strategies) {
+			this(Arrays.asList(strategies));
+		}
+
+		@Override
+		public boolean matchHeader(String headerName) {
+			for (HeaderMatcher strategy : this.strategies) {
+				if (strategy.matchHeader(headerName)) {
+					return true;
+				}
+			}
+			if (logger.isDebugEnabled()) {
+				logger.debug(MessageFormat.format("headerName=[{0}] WILL NOT be mapped", headerName));
+			}
+			return false;
+		}
+	}
+
+}

--- a/spring-messaging/src/main/java/org/springframework/messaging/support/RequestReplyHeaderMapper.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/RequestReplyHeaderMapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.messaging.support;
+
+import java.util.Map;
+
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Request/Reply strategy interface for mapping {@link MessageHeaders} to and from other
+ * types of objects. This would typically be used by adapters where the "other type"
+ * has a concept of headers or properties (HTTP, JMS, AMQP, etc).
+ *
+ * @param <T> the type of the target object holding the headers
+ * @author Oleg Zhurakousky
+ * @author Stephane Nicoll
+ * @since 4.1
+ */
+public interface RequestReplyHeaderMapper<T> {
+
+	/**
+	 * Map from the given {@link MessageHeaders} to the specified request target.
+	 * @param headers the abstracted MessageHeaders
+	 * @param target the native target request
+	 */
+	void fromHeadersToRequest(MessageHeaders headers, T target);
+
+	/**
+	 * Map from the given {@link MessageHeaders} to the specified reply target.
+	 * @param headers the abstracted MessageHeaders
+	 * @param target the native target reply
+	 */
+	void fromHeadersToReply(MessageHeaders headers, T target);
+
+	/**
+	 * Map from the given request object to abstracted {@link MessageHeaders}.
+	 * @param source the native target request
+	 * @return the abstracted MessageHeaders
+	 */
+	Map<String, Object> toHeadersFromRequest(T source);
+
+	/**
+	 * Map from the given reply object to abstracted {@link MessageHeaders}.
+	 * @param source the native target reply
+	 * @return the abstracted MessageHeaders
+	 */
+	Map<String, Object> toHeadersFromReply(T source);
+
+}

--- a/spring-messaging/src/test/java/org/springframework/messaging/support/HeaderMapperTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/support/HeaderMapperTests.java
@@ -1,0 +1,520 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.messaging.support;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.util.StringUtils;
+
+import static org.junit.Assert.*;
+import static org.springframework.messaging.support.AbstractHeaderMapper.*;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class HeaderMapperTests {
+
+	private final GenericTestHeaderMapper mapper = new GenericTestHeaderMapper();
+
+	@Test
+	public void toHeadersFromRequest() {
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromRequest(properties);
+		assertEquals("appId", attributes.get(GenericTestHeaders.APP_ID));
+		assertEquals("request-123", attributes.get(GenericTestHeaders.REQUEST_ONLY));
+		assertFalse(attributes.containsKey(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("bar", attributes.get("foo"));
+		assertEquals("Wrong number of mapped header(s)", 3, attributes.size());
+	}
+
+	@Test
+	public void toHeadersFromRequestWithStar() {
+		this.mapper.setRequestHeaderNames("*");
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromRequest(properties);
+		assertEquals("appId", attributes.get(GenericTestHeaders.APP_ID));
+		assertEquals("request-123", attributes.get(GenericTestHeaders.REQUEST_ONLY));
+		assertEquals("reply-123", attributes.get(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("bar", attributes.get("foo"));
+		assertEquals("Wrong number of mapped header(s)", 4, attributes.size());
+	}
+
+	@Test
+	public void toHeadersFromRequestWithCustomPatterns() {
+		this.mapper.setRequestHeaderNames("foo*", "generic_reply*");
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromRequest(properties);
+		assertEquals(null, attributes.get(GenericTestHeaders.APP_ID));
+		assertEquals(null, attributes.get(GenericTestHeaders.REQUEST_ONLY));
+		assertEquals("reply-123", attributes.get(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("bar", attributes.get("foo"));
+		assertEquals("Wrong number of mapped header(s)", 2, attributes.size());
+	}
+
+	@Test
+	public void toHeadersFromRequestWithStandardRequestPattern() {
+		this.mapper.setRequestHeaderNames("foo*", GenericTestHeaderMapper.STANDARD_REQUEST_HEADER_NAME_PATTERN);
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+		properties.setUserDefinedHeader("foo2", "bar");
+		properties.setUserDefinedHeader("something-else", "bar");
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromRequest(properties);
+		assertEquals("appId", attributes.get(GenericTestHeaders.APP_ID));
+		assertEquals("request-123", attributes.get(GenericTestHeaders.REQUEST_ONLY));
+		assertFalse(attributes.containsKey(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("bar", attributes.get("foo"));
+		assertEquals("bar", attributes.get("foo2"));
+		assertEquals("Wrong number of mapped header(s)", 4, attributes.size());
+	}
+
+	@Test
+	public void toHeadersFromRequestWithOnlyStandardHeaders() {
+		this.mapper.setRequestHeaderNames(GenericTestHeaderMapper.STANDARD_REQUEST_HEADER_NAME_PATTERN);
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+		properties.setUserDefinedHeader("foo2", "bar");
+		properties.setUserDefinedHeader("something-else", "bar");
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromRequest(properties);
+		assertEquals("appId", attributes.get(GenericTestHeaders.APP_ID));
+		assertEquals("request-123", attributes.get(GenericTestHeaders.REQUEST_ONLY));
+		assertFalse(attributes.containsKey(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("Wrong number of mapped header(s)", 2, attributes.size());
+	}
+
+	@Test
+	public void toHeadersFromReply() {
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromReply(properties);
+		assertEquals("appId", attributes.get(GenericTestHeaders.APP_ID));
+		assertFalse(attributes.containsKey(GenericTestHeaders.REQUEST_ONLY));
+		assertEquals("reply-123", attributes.get(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("bar", attributes.get("foo"));
+		assertEquals("Wrong number of mapped header(s)", 3, attributes.size());
+	}
+
+	@Test
+	public void toHeadersFromReplyWithStar() {
+		this.mapper.setReplyHeaderNames("*");
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromReply(properties);
+		assertEquals("appId", attributes.get(GenericTestHeaders.APP_ID));
+		assertEquals("request-123", attributes.get(GenericTestHeaders.REQUEST_ONLY));
+		assertEquals("reply-123", attributes.get(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("bar", attributes.get("foo"));
+		assertEquals("Wrong number of mapped header(s)", 4, attributes.size());
+	}
+
+	@Test
+	public void toHeadersFromReplyWithStandardReplyPattern() {
+		this.mapper.setReplyHeaderNames("foo*", GenericTestHeaderMapper.STANDARD_REPLY_HEADER_NAME_PATTERN);
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+
+		properties.setUserDefinedHeader("foo2", "bar");
+		properties.setUserDefinedHeader("something-else", "bar");
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromReply(properties);
+		assertEquals("appId", attributes.get(GenericTestHeaders.APP_ID));
+		assertFalse(attributes.containsKey(GenericTestHeaders.REQUEST_ONLY));
+		assertEquals("reply-123", attributes.get(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("bar", attributes.get("foo"));
+		assertEquals("bar", attributes.get("foo2"));
+		assertEquals("Wrong number of mapped header(s)", 4, attributes.size());
+	}
+
+	@Test
+	public void toHeadersFromReplyWithOnlyStandardReplyHeaders() {
+		this.mapper.setReplyHeaderNames(GenericTestHeaderMapper.STANDARD_REPLY_HEADER_NAME_PATTERN);
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+
+		properties.setUserDefinedHeader("foo2", "bar");
+		properties.setUserDefinedHeader("something-else", "bar");
+
+		Map<String, Object> attributes = this.mapper.toHeadersFromReply(properties);
+		assertEquals("appId", attributes.get(GenericTestHeaders.APP_ID));
+		assertFalse(attributes.containsKey(GenericTestHeaders.REQUEST_ONLY));
+		assertEquals("reply-123", attributes.get(GenericTestHeaders.REPLY_ONLY));
+		assertEquals("Wrong number of mapped header(s)", 2, attributes.size());
+	}
+
+	@Test
+	public void customTransientHeaderNames() {
+		GenericTestHeaderMapper customMapper = new GenericTestHeaderMapper() {
+			@Override
+			protected Collection<String> getTransientHeaderNames() {
+				return Arrays.asList("foo", GenericTestHeaders.APP_ID);
+			}
+		};
+		GenericTestProperties properties = createSimpleGenericTestProperties();
+		properties.setUserDefinedHeader("foo2", "bar2");
+
+		Map<String, Object> attributes = customMapper.toHeadersFromReply(properties);
+		// foo custom header and app Id not mapped
+		assertFalse(attributes.containsKey(GenericTestHeaders.APP_ID));
+		assertFalse(attributes.containsKey("foo"));
+		assertEquals("bar2", attributes.get("foo2"));
+		assertEquals("Wrong number of mapped header(s)", 2, attributes.size());
+	}
+
+	private GenericTestProperties createSimpleGenericTestProperties() {
+		GenericTestProperties properties = new GenericTestProperties();
+		properties.setAppId("appId");
+		properties.setRequestOnly("request-123");
+		properties.setReplyOnly("reply-123");
+
+		properties.setUserDefinedHeader("foo", "bar");
+		return properties;
+	}
+
+	@Test
+	public void fromHeadersToRequest() {
+		MessageHeaders messageHeaders = createSimpleMessageHeaders();
+		GenericTestProperties properties = new GenericTestProperties();
+		this.mapper.fromHeadersToRequest(messageHeaders, properties);
+		assertEquals("myAppId", properties.getAppId());
+		assertNull(properties.getTransactionSize());
+		assertEquals(true, properties.getRedelivered());
+		assertEquals("request-456", properties.getRequestOnly());
+		assertNull(properties.getReplyOnly());
+		assertEquals("bar", properties.getUserDefinedHeaders().get("foo"));
+		assertEquals(1, properties.getUserDefinedHeaders().size());
+	}
+
+	@Test
+	public void fromHeadersToRequestWithStar() {
+		this.mapper.setRequestHeaderNames("*");
+		MessageHeaders messageHeaders = createSimpleMessageHeaders();
+		GenericTestProperties properties = new GenericTestProperties();
+		this.mapper.fromHeadersToRequest(messageHeaders, properties);
+		assertEquals("myAppId", properties.getAppId());
+		assertNull(properties.getTransactionSize());
+		assertEquals(true, properties.getRedelivered());
+		assertEquals("request-456", properties.getRequestOnly());
+		assertEquals("reply-456", properties.getReplyOnly());
+		assertEquals("bar", properties.getUserDefinedHeaders().get("foo"));
+		assertEquals(1, properties.getUserDefinedHeaders().size());
+	}
+
+	@Test
+	public void fromHeadersToRequestWithStandardRequestPattern() {
+		this.mapper.setRequestHeaderNames("foo", GenericTestHeaderMapper.STANDARD_REQUEST_HEADER_NAME_PATTERN);
+		MessageHeaders messageHeaders = createSimpleMessageHeaders();
+		GenericTestProperties properties = new GenericTestProperties();
+		this.mapper.fromHeadersToRequest(messageHeaders, properties);
+		assertEquals("myAppId", properties.getAppId());
+		assertNull(properties.getTransactionSize());
+		assertEquals(true, properties.getRedelivered());
+		assertEquals("request-456", properties.getRequestOnly());
+		assertNull(properties.getReplyOnly());
+		assertEquals("bar", properties.getUserDefinedHeaders().get("foo"));
+		assertEquals(1, properties.getUserDefinedHeaders().size());
+	}
+
+	@Test
+	public void fromHeadersToReply() {
+		MessageHeaders messageHeaders = createSimpleMessageHeaders();
+		GenericTestProperties properties = new GenericTestProperties();
+		this.mapper.fromHeadersToReply(messageHeaders, properties);
+		assertEquals("myAppId", properties.getAppId());
+		assertNull(properties.getTransactionSize());
+		assertEquals(true, properties.getRedelivered());
+		assertNull(properties.getRequestOnly());
+		assertEquals("reply-456", properties.getReplyOnly());
+		assertEquals("bar", properties.getUserDefinedHeaders().get("foo"));
+		assertEquals(1, properties.getUserDefinedHeaders().size());
+	}
+
+	@Test
+	public void fromHeadersToReplyWithStar() {
+		this.mapper.setReplyHeaderNames("*");
+		MessageHeaders messageHeaders = createSimpleMessageHeaders();
+		GenericTestProperties properties = new GenericTestProperties();
+		this.mapper.fromHeadersToReply(messageHeaders, properties);
+		assertEquals("myAppId", properties.getAppId());
+		assertNull(properties.getTransactionSize());
+		assertEquals(true, properties.getRedelivered());
+		assertEquals("request-456", properties.getRequestOnly());
+		assertEquals("reply-456", properties.getReplyOnly());
+		assertEquals("bar", properties.getUserDefinedHeaders().get("foo"));
+		assertEquals(1, properties.getUserDefinedHeaders().size());
+	}
+
+
+	@Test
+	public void fromHeadersToReplyWithStandardReplyPattern() {
+		this.mapper.setReplyHeaderNames("foo", GenericTestHeaderMapper.STANDARD_REPLY_HEADER_NAME_PATTERN);
+		MessageHeaders messageHeaders = createSimpleMessageHeaders();
+		GenericTestProperties properties = new GenericTestProperties();
+		this.mapper.fromHeadersToReply(messageHeaders, properties);
+		assertEquals("myAppId", properties.getAppId());
+		assertNull(properties.getTransactionSize());
+		assertEquals(true, properties.getRedelivered());
+		assertNull(properties.getRequestOnly());
+		assertEquals("reply-456", properties.getReplyOnly());
+		assertEquals("bar", properties.getUserDefinedHeaders().get("foo"));
+		assertEquals(1, properties.getUserDefinedHeaders().size());
+	}
+
+	public MessageHeaders createSimpleMessageHeaders() {
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put(GenericTestHeaders.APP_ID, "myAppId");
+		headers.put(GenericTestHeaders.REDELIVERED, true);
+		headers.put(GenericTestHeaders.REQUEST_ONLY, "request-456");
+		headers.put(GenericTestHeaders.REPLY_ONLY, "reply-456");
+
+		headers.put("foo", "bar");
+
+		return new MessageHeaders(headers);
+	}
+
+
+	@Test
+	public void prefixHeaderPatternMatching() {
+		PatternBasedHeaderMatcher strategy =
+				new PatternBasedHeaderMatcher(Collections.singleton("foo*"));
+
+		assertMapping(strategy, "foo", true);
+		assertMapping(strategy, "foo123", true);
+		assertMapping(strategy, "FoO", true);
+
+		assertMapping(strategy, "123foo", false);
+		assertMapping(strategy, "_foo", false);
+	}
+
+	@Test
+	public void suffixHeaderPatternMatching() {
+		PatternBasedHeaderMatcher strategy =
+				new PatternBasedHeaderMatcher(Collections.singleton("*foo"));
+
+		assertMapping(strategy, "foo", true);
+		assertMapping(strategy, "123foo", true);
+		assertMapping(strategy, "FoO", true);
+
+		assertMapping(strategy, "foo123", false);
+		assertMapping(strategy, "foo_", false);
+	}
+
+	@Test
+	public void contentHeaderMatching() {
+		ContentBasedHeaderMatcher strategy =
+				new ContentBasedHeaderMatcher(true, Arrays.asList("foo", "bar"));
+
+		assertMapping(strategy, "foo", true);
+		assertMapping(strategy, "bar", true);
+		assertMapping(strategy, "FOO", true);
+		assertMapping(strategy, "somethingElse", false);
+	}
+
+	@Test
+	public void contentHeaderReverseMatching() {
+		ContentBasedHeaderMatcher strategy =
+				new ContentBasedHeaderMatcher(false, Arrays.asList("foo", "bar"));
+
+		assertMapping(strategy, "foo", false);
+		assertMapping(strategy, "bar", false);
+		assertMapping(strategy, "somethingElse", true);
+		assertMapping(strategy, "anything", true);
+	}
+
+	@Test
+	public void prefixHeaderMatching() {
+		PrefixBasedMatcher strategy = new PrefixBasedMatcher(true, "foo_");
+
+		assertMapping(strategy, "foo_", true);
+		assertMapping(strategy, "foo_ANYTHING", true);
+		assertMapping(strategy, "something_foo_", false);
+		assertMapping(strategy, "somethingElse", false);
+	}
+
+	@Test
+	public void prefixHeaderReverseMatching() {
+		PrefixBasedMatcher strategy = new PrefixBasedMatcher(false, "foo_");
+
+		assertMapping(strategy, "foo_", false);
+		assertMapping(strategy, "foo_ANYTHING", false);
+		assertMapping(strategy, "something_foo_", true);
+		assertMapping(strategy, "somethingElse", true);
+	}
+
+
+	protected void assertMapping(HeaderMatcher strategy, String candidate, boolean match) {
+		assertEquals("Wrong mapping result for " + candidate + "", match, strategy.matchHeader(candidate));
+	}
+
+
+	private static abstract class GenericTestHeaders {
+
+		public static final String PREFIX = "generic_";
+
+		public static final String APP_ID = PREFIX + "appId";
+
+		public static final String TRANSACTION_SIZE = PREFIX + "transactionSize";
+
+		public static final String REDELIVERED = PREFIX + "redelivered";
+
+		public static final String REQUEST_ONLY = PREFIX + "requestOnly";
+
+		public static final String REPLY_ONLY = PREFIX + "replyOnly";
+
+	}
+
+	private static class GenericTestHeaderMapper extends AbstractHeaderMapper<GenericTestProperties> {
+
+
+		private GenericTestHeaderMapper() {
+			super(GenericTestHeaders.PREFIX,
+					Arrays.asList(GenericTestHeaders.APP_ID, GenericTestHeaders.TRANSACTION_SIZE,
+							GenericTestHeaders.REDELIVERED, GenericTestHeaders.REQUEST_ONLY),
+					Arrays.asList(GenericTestHeaders.APP_ID, GenericTestHeaders.TRANSACTION_SIZE,
+							GenericTestHeaders.REDELIVERED, GenericTestHeaders.REPLY_ONLY));
+		}
+
+		@Override
+		protected Map<String, Object> extractStandardHeaders(GenericTestProperties source) {
+			Map<String, Object> result = new HashMap<String, Object>();
+			if (StringUtils.hasText(source.getAppId())) {
+				result.put(GenericTestHeaders.APP_ID, source.getAppId());
+			}
+			if (source.getTransactionSize() != null) {
+				result.put(GenericTestHeaders.TRANSACTION_SIZE, source.getTransactionSize());
+			}
+			if (source.getRedelivered() != null) {
+				result.put(GenericTestHeaders.REDELIVERED, source.getRedelivered());
+			}
+			if (StringUtils.hasText(source.getRequestOnly())) {
+				result.put(GenericTestHeaders.REQUEST_ONLY, source.getRequestOnly());
+			}
+			if (StringUtils.hasText(source.getReplyOnly())) {
+				result.put(GenericTestHeaders.REPLY_ONLY, source.getReplyOnly());
+			}
+			return result;
+
+		}
+
+		@Override
+		protected Map<String, Object> extractUserDefinedHeaders(GenericTestProperties source) {
+			return source.getUserDefinedHeaders();
+		}
+
+		@Override
+		protected void populateStandardHeaders(Map<String, Object> headers, GenericTestProperties target) {
+			String appId = getHeaderIfAvailable(headers, GenericTestHeaders.APP_ID, String.class);
+			if (StringUtils.hasText(appId)) {
+				target.setAppId(appId);
+			}
+			Integer transactionSize = getHeaderIfAvailable(headers, GenericTestHeaders.TRANSACTION_SIZE, Integer.class);
+			if (transactionSize != null) {
+				target.setTransactionSize(transactionSize);
+			}
+			Boolean redelivered = getHeaderIfAvailable(headers, GenericTestHeaders.REDELIVERED, Boolean.class);
+			if (redelivered != null) {
+				target.setRedelivered(redelivered);
+			}
+			String requestOnly = getHeaderIfAvailable(headers, GenericTestHeaders.REQUEST_ONLY, String.class);
+			if (StringUtils.hasText(requestOnly)) {
+				target.setRequestOnly(requestOnly);
+			}
+			String replyOnly = getHeaderIfAvailable(headers, GenericTestHeaders.REPLY_ONLY, String.class);
+			if (StringUtils.hasText(replyOnly)) {
+				target.setReplyOnly(replyOnly);
+			}
+
+		}
+
+		@Override
+		protected void populateUserDefinedHeader(String headerName, Object headerValue, GenericTestProperties target) {
+			target.setUserDefinedHeader(headerName, headerValue);
+		}
+	}
+
+	private static class GenericTestProperties {
+
+		private String appId;
+
+		private Integer transactionSize;
+
+		private Boolean redelivered;
+
+		private String requestOnly;
+
+		private String replyOnly;
+
+		private final Map<String, Object> userDefinedHeaders = new HashMap<String, Object>();
+
+		private GenericTestProperties() {
+		}
+
+		public String getAppId() {
+			return appId;
+		}
+
+		public void setAppId(String appId) {
+			this.appId = appId;
+		}
+
+		public Integer getTransactionSize() {
+			return transactionSize;
+		}
+
+		public void setTransactionSize(Integer transactionSize) {
+			this.transactionSize = transactionSize;
+		}
+
+		public Boolean getRedelivered() {
+			return redelivered;
+		}
+
+		public void setRedelivered(boolean redelivered) {
+			this.redelivered = redelivered;
+		}
+
+		public String getRequestOnly() {
+			return requestOnly;
+		}
+
+		public void setRequestOnly(String requestOnly) {
+			this.requestOnly = requestOnly;
+		}
+
+		public String getReplyOnly() {
+			return replyOnly;
+		}
+
+		public void setReplyOnly(String replyOnly) {
+			this.replyOnly = replyOnly;
+		}
+
+		public Map<String, Object> getUserDefinedHeaders() {
+			return userDefinedHeaders;
+		}
+
+		public void setUserDefinedHeader(String name, Object value) {
+			this.userDefinedHeaders.put(name, value);
+		}
+	}
+}


### PR DESCRIPTION
This commit moves the RequestReplyHeaderMapper and related base
implementation from Spring Integration to the core messaging module.

To prepare the migration of AMQP mappers to the spring-amqp module
itself, the priority header value is also now part of the standard
headers.
