### PR TITLE
Enable the possibility to automatically copy selected headers from input message

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/SendToUser.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/SendToUser.java
@@ -59,4 +59,13 @@ public @interface SendToUser {
      */
     boolean broadcast() default true;
 
+	/**
+	 * One or more native headers to copy from the input message. Since call and reply using
+   * messages is completely asynchronous, this is useful to implement an RPC pattern where
+   * the message containing the RPC call carry an identifier that is copied on the reply
+   * and that enables the client to associate each reply with a former request he made
+   * <p>By default no header is copied</p>
+	 */
+	String[] copyHeaders() default {};
+
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandler.java
@@ -140,8 +140,9 @@ public class SendToMethodReturnValueHandler implements HandlerMethodReturnValueH
 		}
 		MessageHeaders headers = message.getHeaders();
 		String sessionId = SimpMessageHeaderAccessor.getSessionId(headers);
-
 		SendToUser sendToUser = returnType.getMethodAnnotation(SendToUser.class);
+    SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(message);
+    
 		if (sendToUser != null) {
 			boolean broadcast = sendToUser.broadcast();
 			String user = getUserName(message, headers);
@@ -155,10 +156,10 @@ public class SendToMethodReturnValueHandler implements HandlerMethodReturnValueH
 			String[] destinations = getTargetDestinations(sendToUser, message, this.defaultUserDestinationPrefix);
 			for (String destination : destinations) {
 				if (broadcast) {
-					this.messagingTemplate.convertAndSendToUser(user, destination, returnValue);
+					this.messagingTemplate.convertAndSendToUser(user, destination, returnValue, createHeaders(null, accessor, sendToUser.copyHeaders()));
 				}
 				else {
-					this.messagingTemplate.convertAndSendToUser(user, destination, returnValue, createHeaders(sessionId));
+					this.messagingTemplate.convertAndSendToUser(user, destination, returnValue, createHeaders(sessionId, accessor, sendToUser.copyHeaders()));
 				}
 			}
 		}
@@ -166,7 +167,7 @@ public class SendToMethodReturnValueHandler implements HandlerMethodReturnValueH
 			SendTo sendTo = returnType.getMethodAnnotation(SendTo.class);
 			String[] destinations = getTargetDestinations(sendTo, message, this.defaultDestinationPrefix);
 			for (String destination : destinations) {
-				this.messagingTemplate.convertAndSend(destination, returnValue, createHeaders(sessionId));
+				this.messagingTemplate.convertAndSend(destination, returnValue, createHeaders(sessionId, null, null));
 			}
 		}
 	}
@@ -195,13 +196,21 @@ public class SendToMethodReturnValueHandler implements HandlerMethodReturnValueH
 				new String[] {defaultPrefix + destination} : new String[] {defaultPrefix + "/" + destination});
 	}
 
-	private MessageHeaders createHeaders(String sessionId) {
+	private MessageHeaders createHeaders(String sessionId, SimpMessageHeaderAccessor inputHeaderAccessor, String[] headersToCopy) {
 		SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
 		if (getHeaderInitializer() != null) {
 			getHeaderInitializer().initHeaders(headerAccessor);
 		}
-		headerAccessor.setSessionId(sessionId);
+    if (sessionId != null)
+      headerAccessor.setSessionId(sessionId);
 		headerAccessor.setLeaveMutable(true);
+
+    if (inputHeaderAccessor != null)
+      for (String h : headersToCopy) {
+        String v = inputHeaderAccessor.getFirstNativeHeader(h);
+        if (v != null)
+          headerAccessor.addNativeHeader(h, v);
+      }
 		return headerAccessor.getMessageHeaders();
 	}
 


### PR DESCRIPTION
Extension to @SendToUser annotation to allow the possibility to automatically copy selected headers from input message to output message.
Useful to implement RPC pattern and track the association between request and reply.

This is a proposal to solve https://jira.spring.io/browse/SPR-12048
