### PR TITLE
Method for building HEAD requests with MockMvcRequestBuilders

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
@@ -146,6 +146,25 @@ public abstract class MockMvcRequestBuilders {
 		return new MockHttpServletRequestBuilder(HttpMethod.OPTIONS, uri);
 	}
 
+    /**
+     * Create a {@link MockHttpServletRequestBuilder} for a HEAD request.
+     * @param urlTemplate a URL template; the resulting URL will be encoded
+     * @param urlVariables zero or more URL variables
+     * @since 4.0.7
+     */
+    public static MockHttpServletRequestBuilder head(String urlTemplate, Object... urlVariables) {
+        return new MockHttpServletRequestBuilder(HttpMethod.HEAD, urlTemplate, urlVariables);
+    }
+
+    /**
+     * Create a {@link MockHttpServletRequestBuilder} for a HEAD request.
+     * @param uri the URL
+     * @since 4.0.7
+     */
+    public static MockHttpServletRequestBuilder head(URI uri) {
+        return new MockHttpServletRequestBuilder(HttpMethod.HEAD, uri);
+    }
+
 	/**
 	 * Create a {@link MockHttpServletRequestBuilder} for a request with the given HTTP method.
 	 * @param httpMethod the HTTP method


### PR DESCRIPTION
Surprisingly until now the MockMvcRequestBuilders did not head a handy
change adds such method to the  API making it consistent with other
HTTP method types.

Issue: SPR-12055

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
