### PR TITLE
MockHttpServletRequest does not handle rfc formatted dates.

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -24,18 +24,9 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.DispatcherType;
@@ -112,6 +103,17 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	private static final ServletInputStream EMPTY_SERVLET_INPUT_STREAM =
 			new DelegatingServletInputStream(new ByteArrayInputStream(new byte[0]));
 
+    /**
+     * The dates formats as described in:
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
+     */
+    private static final String[] DATE_FORMATS = new String[] {
+            "EEE, dd MMM yyyy HH:mm:ss zzz",
+            "EEE, dd-MMM-yy HH:mm:ss zzz",
+            "EEE MMM dd HH:mm:ss yyyy"
+    };
+
+    private static TimeZone GMT = TimeZone.getTimeZone("GMT");
 
 	private boolean active = true;
 
@@ -854,6 +856,10 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		else if (value instanceof Number) {
 			return ((Number) value).longValue();
 		}
+        else if (value instanceof String) {
+
+            return parseDateHeader(name, (String) value);
+        }
 		else if (value != null) {
 			throw new IllegalArgumentException(
 					"Value for header '" + name + "' is neither a Date nor a Number: " + value);
@@ -863,7 +869,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		}
 	}
 
-	@Override
+    @Override
 	public String getHeader(String name) {
 		HeaderValueHolder header = HeaderValueHolder.getByName(this.headers, name);
 		return (header != null ? header.getStringValue() : null);
@@ -1115,4 +1121,27 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		return this.parts.values();
 	}
 
+
+    /**
+     * Parses the date header value, by trying to match it with one of the expected date formats.
+     *
+     * @param name  the header name
+     * @param value the header value
+     * @return the parsed date
+     * @throws java.lang.IllegalArgumentException if the date hasn't been correctly formatted
+     */
+    private long parseDateHeader(String name, String value) {
+        for (String dateFormat : DATE_FORMATS) {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dateFormat, Locale.US);
+            simpleDateFormat.setTimeZone(GMT);
+            try {
+                return simpleDateFormat.parse(value).getTime();
+            }
+            catch (ParseException e) {
+                // ignore
+            }
+        }
+        throw new IllegalArgumentException("Cannot parse date value \"" + value +
+                "\" for \"" + name + "\" header");
+    }
 }

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
@@ -18,14 +18,8 @@ package org.springframework.mock.web;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 import org.junit.Test;
 import org.springframework.util.StreamUtils;
@@ -121,8 +115,40 @@ public class MockHttpServletRequestTests {
 		request.addHeader(headerName, "value1");
 		Enumeration<String> requestHeaders = request.getHeaderNames();
 		assertNotNull(requestHeaders);
-		assertEquals("HTTP header casing not being preserved", headerName, requestHeaders.nextElement());
+		assertEquals("HTTP header casing not being preserved",
+                headerName, requestHeaders.nextElement());
 	}
+
+    @Test
+    public void httpHeaderDate() throws Exception {
+        String headerName = "if-modified-since";
+        Date date = Calendar.getInstance().getTime();
+        request.addHeader(headerName, date);
+        assertEquals("The HTTP header didn't contain valid value.",
+                date.getTime(), request.getDateHeader(headerName));
+    }
+
+    @Test
+    public void httpHeaderTimestamp() throws Exception {
+        String headerName = "if-modified-since";
+        long timestamp = Calendar.getInstance().getTime().getTime();
+        request.addHeader(headerName, timestamp);
+        assertEquals("The HTTP header didn't contain valid value.", timestamp,
+                request.getDateHeader(headerName));
+    }
+
+    @Test
+    public void httpHeaderRfcFormatedDate() throws Exception {
+        String headerName = "if-modified-since";
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.MILLISECOND, 0);
+        Date date = calendar.getTime();
+        SimpleDateFormat rfcFormat = new SimpleDateFormat(
+                "EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+        request.addHeader(headerName, rfcFormat.format(date));
+        assertEquals("The HTTP header didn't contain valid value.",
+                date.getTime(), request.getDateHeader(headerName));
+    }
 
 	@Test
 	public void nullParameterName() {


### PR DESCRIPTION
This change within MockHttpServletRequest implementation allows to
use a formatted date headers. This opens the possibility to prepare
the tests that are as close as possible to the behaviour of real
client/server communication.

Issue: SPR-12056

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
