### PR TITLE
Move exposeContextBeans to UrlBasedViewResolver

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/InternalResourceView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/InternalResourceView.java
@@ -16,17 +16,13 @@
 
 package org.springframework.web.servlet.view;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.util.StringUtils;
-import org.springframework.web.context.support.ContextExposingHttpServletRequest;
 import org.springframework.web.util.WebUtils;
 
 /**
@@ -67,10 +63,6 @@ import org.springframework.web.util.WebUtils;
 public class InternalResourceView extends AbstractUrlBasedView {
 
 	private boolean alwaysInclude = false;
-
-	private boolean exposeContextBeansAsAttributes = false;
-
-	private Set<String> exposedContextBeanNames;
 
 	private boolean preventDispatchLoop = false;
 
@@ -115,36 +107,7 @@ public class InternalResourceView extends AbstractUrlBasedView {
 		this.alwaysInclude = alwaysInclude;
 	}
 
-	/**
-	 * Set whether to make all Spring beans in the application context accessible
-	 * as request attributes, through lazy checking once an attribute gets accessed.
-	 * <p>This will make all such beans accessible in plain {@code ${...}}
-	 * expressions in a JSP 2.0 page, as well as in JSTL's {@code c:out}
-	 * value expressions.
-	 * <p>Default is "false". Switch this flag on to transparently expose all
-	 * Spring beans in the request attribute namespace.
-	 * <p><b>NOTE:</b> Context beans will override any custom request or session
-	 * attributes of the same name that have been manually added. However, model
-	 * attributes (as explicitly exposed to this view) of the same name will
-	 * always override context beans.
-	 * @see #getRequestToExpose
-	 */
-	public void setExposeContextBeansAsAttributes(boolean exposeContextBeansAsAttributes) {
-		this.exposeContextBeansAsAttributes = exposeContextBeansAsAttributes;
-	}
-
-	/**
-	 * Specify the names of beans in the context which are supposed to be exposed.
-	 * If this is non-null, only the specified beans are eligible for exposure as
-	 * attributes.
-	 * <p>If you'd like to expose all Spring beans in the application context, switch
-	 * the {@link #setExposeContextBeansAsAttributes "exposeContextBeansAsAttributes"}
-	 * flag on but do not list specific bean names for this property.
-	 */
-	public void setExposedContextBeanNames(String[] exposedContextBeanNames) {
-		this.exposedContextBeanNames = new HashSet<String>(Arrays.asList(exposedContextBeanNames));
-	}
-
+	
 	/**
 	 * Set whether to explicitly prevent dispatching back to the
 	 * current handler path.
@@ -173,32 +136,29 @@ public class InternalResourceView extends AbstractUrlBasedView {
 	protected void renderMergedOutputModel(
 			Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-		// Determine which request handle to expose to the RequestDispatcher.
-		HttpServletRequest requestToExpose = getRequestToExpose(request);
-
 		// Expose the model object as request attributes.
-		exposeModelAsRequestAttributes(model, requestToExpose);
+		exposeModelAsRequestAttributes(model, request);
 
 		// Expose helpers as request attributes, if any.
-		exposeHelpers(requestToExpose);
+		exposeHelpers(request);
 
 		// Determine the path for the request dispatcher.
-		String dispatcherPath = prepareForRendering(requestToExpose, response);
+		String dispatcherPath = prepareForRendering(request, response);
 
 		// Obtain a RequestDispatcher for the target resource (typically a JSP).
-		RequestDispatcher rd = getRequestDispatcher(requestToExpose, dispatcherPath);
+		RequestDispatcher rd = getRequestDispatcher(request, dispatcherPath);
 		if (rd == null) {
 			throw new ServletException("Could not get RequestDispatcher for [" + getUrl() +
 					"]: Check that the corresponding file exists within your web application archive!");
 		}
 
 		// If already included or response already committed, perform include, else forward.
-		if (useInclude(requestToExpose, response)) {
+		if (useInclude(request, response)) {
 			response.setContentType(getContentType());
 			if (logger.isDebugEnabled()) {
 				logger.debug("Including resource [" + getUrl() + "] in InternalResourceView '" + getBeanName() + "'");
 			}
-			rd.include(requestToExpose, response);
+			rd.include(request, response);
 		}
 
 		else {
@@ -206,25 +166,8 @@ public class InternalResourceView extends AbstractUrlBasedView {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Forwarding to resource [" + getUrl() + "] in InternalResourceView '" + getBeanName() + "'");
 			}
-			rd.forward(requestToExpose, response);
+			rd.forward(request, response);
 		}
-	}
-
-	/**
-	 * Get the request handle to expose to the RequestDispatcher, i.e. to the view.
-	 * <p>The default implementation wraps the original request for exposure of
-	 * Spring beans as request attributes (if demanded).
-	 * @param originalRequest the original servlet request as provided by the engine
-	 * @return the wrapped request, or the original request if no wrapping is necessary
-	 * @see #setExposeContextBeansAsAttributes
-	 * @see org.springframework.web.context.support.ContextExposingHttpServletRequest
-	 */
-	protected HttpServletRequest getRequestToExpose(HttpServletRequest originalRequest) {
-		if (this.exposeContextBeansAsAttributes || this.exposedContextBeanNames != null) {
-			return new ContextExposingHttpServletRequest(
-					originalRequest, getWebApplicationContext(), this.exposedContextBeanNames);
-		}
-		return originalRequest;
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/InternalResourceViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/InternalResourceViewResolver.java
@@ -52,11 +52,6 @@ public class InternalResourceViewResolver extends UrlBasedViewResolver {
 
 	private Boolean alwaysInclude;
 
-	private Boolean exposeContextBeansAsAttributes;
-
-	private String[] exposedContextBeanNames;
-
-
 	/**
 	 * Sets the default {@link #setViewClass view class} to {@link #requiredViewClass}:
 	 * by default {@link InternalResourceView}, or {@link JstlView} if the JSTL API
@@ -88,42 +83,13 @@ public class InternalResourceViewResolver extends UrlBasedViewResolver {
 	public void setAlwaysInclude(boolean alwaysInclude) {
 		this.alwaysInclude = Boolean.valueOf(alwaysInclude);
 	}
-
-	/**
-	 * Set whether to make all Spring beans in the application context accessible
-	 * as request attributes, through lazy checking once an attribute gets accessed.
-	 * <p>This will make all such beans accessible in plain {@code ${...}}
-	 * expressions in a JSP 2.0 page, as well as in JSTL's {@code c:out}
-	 * value expressions.
-	 * <p>Default is "false".
-	 * @see InternalResourceView#setExposeContextBeansAsAttributes
-	 */
-	public void setExposeContextBeansAsAttributes(boolean exposeContextBeansAsAttributes) {
-		this.exposeContextBeansAsAttributes = exposeContextBeansAsAttributes;
-	}
-
-	/**
-	 * Specify the names of beans in the context which are supposed to be exposed.
-	 * If this is non-null, only the specified beans are eligible for exposure as
-	 * attributes.
-	 * @see InternalResourceView#setExposedContextBeanNames
-	 */
-	public void setExposedContextBeanNames(String[] exposedContextBeanNames) {
-		this.exposedContextBeanNames = exposedContextBeanNames;
-	}
-
+	
 
 	@Override
 	protected AbstractUrlBasedView buildView(String viewName) throws Exception {
 		InternalResourceView view = (InternalResourceView) super.buildView(viewName);
 		if (this.alwaysInclude != null) {
 			view.setAlwaysInclude(this.alwaysInclude);
-		}
-		if (this.exposeContextBeansAsAttributes != null) {
-			view.setExposeContextBeansAsAttributes(this.exposeContextBeansAsAttributes);
-		}
-		if (this.exposedContextBeanNames != null) {
-			view.setExposedContextBeanNames(this.exposedContextBeanNames);
 		}
 		view.setPreventDispatchLoop(true);
 		return view;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/UrlBasedViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/UrlBasedViewResolver.java
@@ -122,6 +122,11 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 	private final Map<String, Object> staticAttributes = new HashMap<String, Object>();
 
 	private Boolean exposePathVariables;
+	
+	private Boolean exposeContextBeansAsAttributes;
+
+	private String[] exposedContextBeanNames;
+	
 
 	/**
 	 * Set the view class that should be used to create views.
@@ -354,6 +359,31 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 	public void setExposePathVariables(Boolean exposePathVariables) {
 		this.exposePathVariables = exposePathVariables;
 	}
+	
+	/**
+	 * Set whether to make all Spring beans in the application context accessible
+	 * as request attributes, through lazy checking once an attribute gets accessed.
+	 * <p>This will make all such beans accessible in plain {@code ${...}}
+	 * expressions in a JSP 2.0 page, as well as in JSTL's {@code c:out}
+	 * value expressions.
+	 * <p>Default is "false".
+	 * @see InternalResourceView#setExposeContextBeansAsAttributes
+	 */
+	public void setExposeContextBeansAsAttributes(boolean exposeContextBeansAsAttributes) {
+		this.exposeContextBeansAsAttributes = exposeContextBeansAsAttributes;
+	}
+
+	/**
+	 * Specify the names of beans in the context which are supposed to be exposed.
+	 * If this is non-null, only the specified beans are eligible for exposure as
+	 * attributes.
+	 * @see InternalResourceView#setExposedContextBeanNames
+	 */
+	public void setExposedContextBeanNames(String[] exposedContextBeanNames) {
+		this.exposedContextBeanNames = exposedContextBeanNames;
+	}
+
+	
 
 	@Override
 	protected void initApplicationContext() {
@@ -469,6 +499,12 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 		if (this.exposePathVariables != null) {
 			view.setExposePathVariables(exposePathVariables);
 		}
+		if (this.exposeContextBeansAsAttributes != null) {
+			view.setExposeContextBeansAsAttributes(this.exposeContextBeansAsAttributes);
+		}
+		if (this.exposedContextBeanNames != null) {
+			view.setExposedContextBeanNames(this.exposedContextBeanNames);
+		}		
 		return view;
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -32,7 +33,6 @@ import javax.servlet.jsp.jstl.core.Config;
 import javax.servlet.jsp.jstl.fmt.LocalizationContext;
 
 import org.junit.Test;
-
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.PropertyValue;
 import org.springframework.tests.sample.beans.TestBean;
@@ -231,14 +231,14 @@ public class ViewResolverTests {
 	}
 
 	@Test
-	public void testInternalResourceViewResolverWithContextBeans() throws Exception {
+	public void testUrlBasedViewResolverWithContextBeans() throws Exception {
 		MockServletContext sc = new MockServletContext();
 		final StaticWebApplicationContext wac = new StaticWebApplicationContext();
 		wac.registerSingleton("myBean", TestBean.class);
 		wac.registerSingleton("myBean2", TestBean.class);
 		wac.setServletContext(sc);
 		wac.refresh();
-		InternalResourceViewResolver vr = new InternalResourceViewResolver();
+		UrlBasedViewResolver vr = new UrlBasedViewResolver();
 		Properties props = new Properties();
 		props.setProperty("key1", "value1");
 		vr.setAttributes(props);
@@ -246,6 +246,7 @@ public class ViewResolverTests {
 		map.put("key2", new Integer(2));
 		vr.setAttributesMap(map);
 		vr.setExposeContextBeansAsAttributes(true);
+		vr.setViewClass(TestView.class);
 		vr.setApplicationContext(wac);
 
 		MockHttpServletRequest request = new MockHttpServletRequest(sc) {
@@ -271,14 +272,14 @@ public class ViewResolverTests {
 	}
 
 	@Test
-	public void testInternalResourceViewResolverWithSpecificContextBeans() throws Exception {
+	public void testUrlBasedViewResolverWithSpecificContextBeans() throws Exception {
 		MockServletContext sc = new MockServletContext();
 		final StaticWebApplicationContext wac = new StaticWebApplicationContext();
 		wac.registerSingleton("myBean", TestBean.class);
 		wac.registerSingleton("myBean2", TestBean.class);
 		wac.setServletContext(sc);
 		wac.refresh();
-		InternalResourceViewResolver vr = new InternalResourceViewResolver();
+		UrlBasedViewResolver vr = new UrlBasedViewResolver();
 		Properties props = new Properties();
 		props.setProperty("key1", "value1");
 		vr.setAttributes(props);
@@ -286,6 +287,7 @@ public class ViewResolverTests {
 		map.put("key2", new Integer(2));
 		vr.setAttributesMap(map);
 		vr.setExposedContextBeanNames(new String[] {"myBean2"});
+		vr.setViewClass(TestView.class);
 		vr.setApplicationContext(wac);
 
 		MockHttpServletRequest request = new MockHttpServletRequest(sc) {


### PR DESCRIPTION
Prior to this commit, the ability to expose all (or a named subset)
of context beans lived on InternalResourceView and
InternalResourceViewResolver.  This changes moves this functionality
up the hierarchy to AbstractView/UrlBasedViewResolver.

Issue: SPR-8064

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
