### PR TITLE
SPR-12068 Added exception tracking to JamonPerformanceMonitorInterceptor

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/interceptor/JamonPerformanceMonitorInterceptor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/interceptor/JamonPerformanceMonitorInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.aop.interceptor;
 
+import com.jamonapi.MonKeyImp;
+import com.jamonapi.utils.Misc;
 import com.jamonapi.Monitor;
 import com.jamonapi.MonitorFactory;
 import org.aopalliance.intercept.MethodInvocation;
@@ -24,7 +26,9 @@ import org.apache.commons.logging.Log;
 /**
  * Performance monitor interceptor that uses <b>JAMon</b> library
  * to perform the performance measurement on the intercepted method
- * and output the stats.
+ * and output the stats. In addition it can track/count exceptions
+ * thrown by the intercepted method. The stacktraces can be viewed in
+ * the JAMon web application.
  *
  * <p>This code is inspired by Thierry Templier's blog.
  *
@@ -37,82 +41,135 @@ import org.apache.commons.logging.Log;
  */
 @SuppressWarnings("serial")
 public class JamonPerformanceMonitorInterceptor extends AbstractMonitoringInterceptor {
+    private static final String EXCEPTION = "Exception";
+    private boolean trackAllInvocations = false;
+    private boolean trackExceptions = false;
 
-	private boolean trackAllInvocations = false;
+    /**
+     * Create a new JamonPerformanceMonitorInterceptor with a static logger.
+     */
+    public JamonPerformanceMonitorInterceptor() {
+    }
+
+    /**
+     * Create a new JamonPerformanceMonitorInterceptor with a dynamic or static logger,
+     * according to the given flag.
+     * @param useDynamicLogger whether to use a dynamic logger or a static logger
+     * @see #setUseDynamicLogger(boolean)
+     */
+    public JamonPerformanceMonitorInterceptor(boolean useDynamicLogger) {
+        setUseDynamicLogger(useDynamicLogger);
+    }
+
+    /**
+     * Create a new JamonPerformanceMonitorInterceptor with a dynamic or static logger,
+     * according to the given flag.
+     * @param useDynamicLogger whether to use a dynamic logger or a static logger
+     * @param trackAllInvocations whether to track all invocations that go through
+     * this interceptor, or just invocations with trace logging enabled
+     * @see #setUseDynamicLogger(boolean)
+     * @see #setTrackAllInvocations(boolean)
+     */
+    public JamonPerformanceMonitorInterceptor(boolean useDynamicLogger, boolean trackAllInvocations) {
+        this(useDynamicLogger, trackAllInvocations, false);
+    }
+
+    /**
+     * Create a new JamonPerformanceMonitorInterceptor with a dynamic or static logger,
+     * according to the given flags.
+     * @param useDynamicLogger whether to use a dynamic logger or a static logger
+     * @param trackAllInvocations whether to track all invocations that go through
+     * this interceptor, or just invocations with trace logging enabled
+     * @param trackExceptions whether to track/count exceptions that are thrown
+     * @see #setUseDynamicLogger(boolean)
+     * @see #setTrackAllInvocations(boolean)
+     * @see #setTrackExceptions(boolean)
+     * @since 4.1
+     */
+    public JamonPerformanceMonitorInterceptor(boolean useDynamicLogger, boolean trackAllInvocations, boolean trackExceptions) {
+        setUseDynamicLogger(useDynamicLogger);
+        setTrackAllInvocations(trackAllInvocations);
+        setTrackExceptions(trackExceptions);
+    }
+
+    /**
+     * Set whether to track all invocations that go through this interceptor,
+     * or just invocations with trace logging enabled.
+     * <p>Default is "false": Only invocations with trace logging enabled will
+     * be monitored. Specify "true" to let JAMon track all invocations,
+     * gathering statistics even when trace logging is disabled.
+     */
+    public void setTrackAllInvocations(boolean trackAllInvocations) {
+        this.trackAllInvocations = trackAllInvocations;
+    }
+
+    /**
+     * Set whether to track/count exceptions thrown by invocations that go through this interceptor.
+     * In addition stack traces will be able available to be viewed with the JAMon web application.
+     * <p>For backwards compatibility the default is "false", however it is recommended that
+     * it is enabled.</p>
+     * @since  4.1
+     */
+    public void setTrackExceptions(boolean trackExceptions) {
+        this.trackExceptions = trackExceptions;
+    }
 
 
-	/**
-	 * Create a new JamonPerformanceMonitorInterceptor with a static logger.
-	 */
-	public JamonPerformanceMonitorInterceptor() {
-	}
+    /**
+     * Always applies the interceptor if the "trackAllInvocations" flag has been set;
+     * else just kicks in if the log is enabled.
+     * @see #setTrackAllInvocations
+     * @see #isLogEnabled
+     */
+    @Override
+    protected boolean isInterceptorEnabled(MethodInvocation invocation, Log logger) {
+        return (this.trackAllInvocations || isLogEnabled(logger));
+    }
 
-	/**
-	 * Create a new JamonPerformanceMonitorInterceptor with a dynamic or static logger,
-	 * according to the given flag.
-	 * @param useDynamicLogger whether to use a dynamic logger or a static logger
-	 * @see #setUseDynamicLogger
-	 */
-	public JamonPerformanceMonitorInterceptor(boolean useDynamicLogger) {
-		setUseDynamicLogger(useDynamicLogger);
-	}
-
-	/**
-	 * Create a new JamonPerformanceMonitorInterceptor with a dynamic or static logger,
-	 * according to the given flag.
-	 * @param useDynamicLogger whether to use a dynamic logger or a static logger
-	 * @param trackAllInvocations whether to track all invocations that go through
-	 * this interceptor, or just invocations with trace logging enabled
-	 * @see #setUseDynamicLogger
-	 */
-	public JamonPerformanceMonitorInterceptor(boolean useDynamicLogger, boolean trackAllInvocations) {
-		setUseDynamicLogger(useDynamicLogger);
-		setTrackAllInvocations(trackAllInvocations);
-	}
-
-
-	/**
-	 * Set whether to track all invocations that go through this interceptor,
-	 * or just invocations with trace logging enabled.
-	 * <p>Default is "false": Only invocations with trace logging enabled will
-	 * be monitored. Specify "true" to let JAMon track all invocations,
-	 * gathering statistics even when trace logging is disabled.
-	 */
-	public void setTrackAllInvocations(boolean trackAllInvocations) {
-		this.trackAllInvocations = trackAllInvocations;
-	}
+    /**
+     * Wraps the invocation with a JAMon Monitor and writes the current
+     * performance statistics to the log (if enabled).
+     * @see com.jamonapi.MonitorFactory#start
+     * @see com.jamonapi.Monitor#stop
+     */
+    @Override
+    protected Object invokeUnderTrace(MethodInvocation invocation, Log logger) throws Throwable {
+        String name = createInvocationTraceName(invocation);
+        MonKeyImp key = new MonKeyImp(name, name, "ms.");
+        Monitor monitor = MonitorFactory.start(key);
+        try {
+            return invocation.proceed();
+        } catch (Throwable t) {
+            if (this.trackExceptions) {
+                trackException(key, t);
+            }
+            throw t;
+        } finally {
+            monitor.stop();
+            if (!this.trackAllInvocations || isLogEnabled(logger)) {
+                logger.trace("JAMon performance statistics for method [" + name + "]:\n" + monitor);
+            }
+        }
+    }
 
 
-	/**
-	 * Always applies the interceptor if the "trackAllInvocations" flag has been set;
-	 * else just kicks in if the log is enabled.
-	 * @see #setTrackAllInvocations
-	 * @see #isLogEnabled
-	 */
-	@Override
-	protected boolean isInterceptorEnabled(MethodInvocation invocation, Log logger) {
-		return (this.trackAllInvocations || isLogEnabled(logger));
-	}
+    /**
+     * Count the thrown exception and also put the stack trace in the details portion of the key.
+     * This will allow the stack trace to be viewed in the JAMon web application.
+     * @since 4.1
+     */
+    private void trackException(MonKeyImp key, Throwable exception) {
+        String stackTrace = new StringBuilder()
+                .append("stackTrace=")
+                .append(Misc.getExceptionTrace(exception))
+                .toString();
 
-	/**
-	 * Wraps the invocation with a JAMon Monitor and writes the current
-	 * performance statistics to the log (if enabled).
-	 * @see com.jamonapi.MonitorFactory#start
-	 * @see com.jamonapi.Monitor#stop
-	 */
-	@Override
-	protected Object invokeUnderTrace(MethodInvocation invocation, Log logger) throws Throwable {
-		String name = createInvocationTraceName(invocation);
-		Monitor monitor = MonitorFactory.start(name);
-		try {
-			return invocation.proceed();
-		}
-		finally {
-			monitor.stop();
-			if (!this.trackAllInvocations || isLogEnabled(logger)) {
-				logger.trace("JAMon performance statistics for method [" + name + "]:\n" + monitor);
-			}
-		}
-	}
+        key.setDetails(stackTrace);
+        // Specific exception counter. Example: java.lang.RuntimeException
+        MonitorFactory.add(new MonKeyImp(exception.getClass().getName(), stackTrace, EXCEPTION), 1);
+        // General exception counter which is a total for all exceptions thrown
+        MonitorFactory.add(new MonKeyImp(MonitorFactory.EXCEPTIONS_LABEL, stackTrace, EXCEPTION), 1);
+    }
 
 }
+

--- a/spring-aop/src/test/java/org/springframework/aop/interceptor/JamonPerformanceMonitorInterceptorTest.java
+++ b/spring-aop/src/test/java/org/springframework/aop/interceptor/JamonPerformanceMonitorInterceptorTest.java
@@ -1,0 +1,88 @@
+
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.interceptor;
+
+import com.jamonapi.MonitorFactory;
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.commons.logging.Log;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.*;
+
+public class JamonPerformanceMonitorInterceptorTest {
+    private JamonPerformanceMonitorInterceptor interceptor = new JamonPerformanceMonitorInterceptor();
+    private MethodInvocation mi = mock(MethodInvocation.class);
+    private Log log = mock(Log.class);
+
+    @Before
+    public void setUp() {
+       MonitorFactory.reset();
+    }
+
+    @After
+    public void tearDown() {
+        MonitorFactory.reset();
+    }
+
+    @Test
+    public void testInvokeUnderTraceWithNormalProcessing() throws Throwable {
+        given(mi.getMethod()).willReturn(String.class.getMethod("toString", new Class[0]));
+
+        interceptor.invokeUnderTrace(mi, log);
+
+        assertEquals("jamon must track the method being invoked", 1, MonitorFactory.getNumRows());
+        assertTrue("The jamon report must contain the toString method that was invoked", MonitorFactory.getReport().contains("toString"));
+    }
+
+
+    @Test
+    public void testInvokeUnderTraceWithException() throws Throwable {
+        given(mi.getMethod()).willReturn(String.class.getMethod("toString", new Class[0]));
+        given(mi.proceed()).willThrow(new IllegalArgumentException());
+
+        try {
+            interceptor.invokeUnderTrace(mi, log);
+            fail("Must have propagated the IllegalArgumentException.");
+        } catch (IllegalArgumentException expected) {
+        }
+
+        assertEquals("A monitor must exist for the method being invoked", 1, MonitorFactory.getNumRows());
+        assertTrue("The jamon report must contain the toString method that was invoked",  MonitorFactory.getReport().contains("toString"));
+    }
+
+    @Test
+    public void testInvokeUnderTraceWithExceptionTracking() throws Throwable {
+        interceptor.setTrackExceptions(true);
+        given(mi.getMethod()).willReturn(String.class.getMethod("toString", new Class[0]));
+        given(mi.proceed()).willThrow(new IllegalArgumentException());
+
+        try {
+            interceptor.invokeUnderTrace(mi, log);
+            fail("Must have propagated the IllegalArgumentException.");
+        } catch (IllegalArgumentException expected) {
+        }
+
+        assertEquals("Monitors must exist for the method invocation and 2 exceptions", 3, MonitorFactory.getNumRows());
+        assertTrue("The jamon report must contain the toString method that was invoked", MonitorFactory.getReport().contains("toString"));
+        assertTrue("The jamon report must contain the generic exception: "+MonitorFactory.EXCEPTIONS_LABEL,  MonitorFactory.getReport().contains(MonitorFactory.EXCEPTIONS_LABEL));
+        assertTrue("The jamon report must contain the specific exception: IllegalArgumentException'",  MonitorFactory.getReport().contains("IllegalArgumentException"));
+    }
+}


### PR DESCRIPTION
Ok, I made the changes, and added tests for the following:
https://jira.spring.io/browse/SPR-12068

Let me know if anything else needs to be done.

A couple notes.  
- I was unable to compile spring, so I made the changes in my own project and copied the files over when done.  
- I was able to run my unit tests successfully and also tested it in Spring by adding it to my applicationContext.xml and it worked.  
- However, because I couldn't get Spring to compile/test the code I didn't run the Spring test suite.
- One thing I wasn't sure of is if the jamon jar is available as a jar in your test suite.  It would need to be.  
- Although not required jamon 2.78 is the latest version so if it has to be added to your build file that should be used (it is in maven).

Here is what the applicationContext entry would look like.  Note I disabled exception tracking by default so as not to change the current users behaviour (although I think having it enabled is a better default).  The property below 'trackExceptions' controls this behaviour.

```
<bean id="jamonMonitoringAspectInterceptor" class="org.springframework.aop.interceptor.JamonPerformanceMonitorInterceptor">
    <property name="trackAllInvocations" value="true"></property>
    <property name="trackExceptions" value="true"></property>
</bean>
```
