### PR TITLE
Upgrade to Gson 2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ configure(allprojects) { project ->
 	ext.hibVal5Version       = "5.1.2.Final"
 	ext.hsqldbVersion        = "2.3.2"
 	ext.jackson2Version      = "2.4.1"
-	ext.gsonVersion          = "2.2.4"
+	ext.gsonVersion          = "2.3"
 	ext.jasperReportsVersion = "5.6.0"
 	ext.jettyVersion         = "9.2.2.v20140723"
 	ext.jodaVersion          = "2.4"

--- a/spring-web/src/main/java/org/springframework/http/converter/json/GsonHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/GsonHttpMessageConverter.java
@@ -47,7 +47,7 @@ import org.springframework.util.Assert;
  * <p>This converter can be used to bind to typed beans or untyped {@code HashMap}s.
  * By default, it supports {@code application/json} and {@code application/*+json}.
  *
- * <p>Tested against Gson 2.2; compatible with Gson 2.0 and higher.
+ * <p>Tested against Gson 2.3; compatible with Gson 2.0 and higher.
  *
  * @author Roy Clarkson
  * @since 4.1


### PR DESCRIPTION
This release contains the following new features:
- The new @JsonAdapter annotation to specify a Json TypeAdapter for a
  class field
- JsonPath support: JsonParser.getPath() method returns the JsonPath
  expression
- New public methods in JsonArray (similar to the java.util.List):
  contains(JsonElement), remove(JsonElement), remove(int index),
  set(int index, JsonElement element)
- Many other smaller bug fixes

See: https://groups.google.com/forum/#!topic/google-gson/MOqf5RGtIzk
