### PR TITLE
Clean Up Deprecated Method Call

### DIFF
--- a/spring-jdbc/src/test/java/org/springframework/jdbc/config/InitializeDatabaseIntegrationTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/config/InitializeDatabaseIntegrationTests.java
@@ -108,7 +108,7 @@ public class InitializeDatabaseIntegrationTests {
 
 	private void assertCorrectSetup(DataSource dataSource) {
 		JdbcTemplate t = new JdbcTemplate(dataSource);
-		assertEquals(1, t.queryForInt("select count(*) from T_TEST"));
+		assertEquals(1, t.queryForObject("select count(*) from T_TEST", Integer.class).intValue());
 	}
 
 	public static class CacheData implements InitializingBean {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
@@ -220,7 +220,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getInt(1)).willReturn(22);
-		int i = this.template.queryForInt(sql);
+		int i = this.template.queryForObject(sql,Integer.class).intValue();
 		assertEquals("Return of an int", 22, i);
 		verify(this.resultSet).close();
 		verify(this.statement).close();
@@ -231,7 +231,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getLong(1)).willReturn(87L);
-		long l = this.template.queryForLong(sql);
+		long l = this.template.queryForObject(sql, Long.class).longValue();
 		assertEquals("Return of a long", 87, l);
 		verify(this.resultSet).close();
 		verify(this.statement).close();
@@ -342,7 +342,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getInt(1)).willReturn(22);
-		int i = this.template.queryForInt(sql, new Object[] {3});
+		int i = this.template.queryForObject(sql, new Object[] {3}, Integer.class).intValue();
 		assertEquals("Return of an int", 22, i);
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();
@@ -354,7 +354,7 @@ public class JdbcTemplateQueryTests {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = ?";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getLong(1)).willReturn(87L);
-		long l = this.template.queryForLong(sql, new Object[] {3});
+		long l = this.template.queryForObject(sql, new Object[] {3}, Long.class).longValue();
 		assertEquals("Return of a long", 87, l);
 		verify(this.preparedStatement).setObject(1, 3);
 		verify(this.resultSet).close();

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterQueryTests.java
@@ -262,7 +262,7 @@ public class NamedParameterQueryTests {
 
 		MapSqlParameterSource parms = new MapSqlParameterSource();
 		parms.addValue("id", 3);
-		int i = template.queryForInt("SELECT AGE FROM CUSTMR WHERE ID = :id", parms);
+		int i = template.queryForObject("SELECT AGE FROM CUSTMR WHERE ID = :id", parms, Integer.class).intValue();
 
 		assertEquals("Return of an int", 22, i);
 		verify(connection).prepareStatement("SELECT AGE FROM CUSTMR WHERE ID = ?");
@@ -278,7 +278,7 @@ public class NamedParameterQueryTests {
 		BeanPropertySqlParameterSource parms = new BeanPropertySqlParameterSource(
 				new ParameterBean(3));
 
-		long l = template.queryForLong("SELECT AGE FROM CUSTMR WHERE ID = :id", parms);
+		long l = template.queryForObject("SELECT AGE FROM CUSTMR WHERE ID = :id", parms, Long.class).longValue();
 
 		assertEquals("Return of a long", 87, l);
 		verify(connection).prepareStatement("SELECT AGE FROM CUSTMR WHERE ID = ?");


### PR DESCRIPTION
change all testcases in spring-jdbc those use queryForInt and
queryForLong methods to queryForObject
