### PR TITLE
Clean up spring-core warnings

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/comparator/CompoundComparator.java
+++ b/spring-core/src/main/java/org/springframework/util/comparator/CompoundComparator.java
@@ -59,7 +59,7 @@ public class CompoundComparator<T> implements Comparator<T>, Serializable {
 	 * @param comparators the comparators to build into a compound comparator
 	 * @see InvertibleComparator
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings("unchecked")
 	public CompoundComparator(Comparator... comparators) {
 		Assert.notNull(comparators, "Comparators must not be null");
 		this.comparators = new ArrayList<InvertibleComparator>(comparators.length);


### PR DESCRIPTION
Clean up compiler warnings in the spring-core.
This commit removes unnecessary @SupressWarnings.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
