### PR TITLE
Modify getServerName() and getServerPort() to reference "Host" header.

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -544,7 +544,16 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	@Override
 	public String getServerName() {
-		return this.serverName;
+		String host = this.getHeader("Host");
+		if (host == null) {
+			host = this.serverName;
+        } else {
+            if (host.indexOf(':') != -1) {
+                host = host.substring(0, host.indexOf(':'));
+            }
+        }
+		
+		return host;
 	}
 
 	public void setServerPort(int serverPort) {
@@ -553,6 +562,14 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	@Override
 	public int getServerPort() {
+		String host = this.getHeader("Host");
+		if (host != null) {
+			final int colonIndex = host.indexOf(':');
+			if (colonIndex != -1) {
+				return Integer.parseInt(host.substring(colonIndex + 1));
+			}
+		}
+
 		return this.serverPort;
 	}
 

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
@@ -261,5 +261,34 @@ public class MockHttpServletRequestTests {
 			assertEquals("enumeration element #" + ++count, enum1.nextElement(), enum2.nextElement());
 		}
 	}
-
+	
+	/**
+	 * SPR-12088
+	 */
+    @Test
+    public void getServerName() {
+        assertEquals("localhost", request.getServerName());
+        assertEquals(80, request.getServerPort());
+        
+        request.setServerName("127.0.0.1");
+        request.setServerPort(8080);
+        
+        assertEquals("127.0.0.1", request.getServerName());
+        assertEquals(8080, request.getServerPort());        
+    }
+    
+	@Test
+	public void getServerNameWithHeader() {
+		request.addHeader("Host", "12.34.56.78:90");	
+		assertEquals("12.34.56.78", request.getServerName());
+		assertEquals(90, request.getServerPort());
+	}
+		
+    @Test
+    public void getServerNameWithHeaderWithoutPort() {
+        request.addHeader("Host", "23.45.67.89");    
+        assertEquals("23.45.67.89", request.getServerName());
+        assertEquals(80, request.getServerPort());
+    }
+    
 }


### PR DESCRIPTION
This commit modifies getServerName() and getServerPort() in MockHttpServletRequest class to reference "Host" header if header is set.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
