### PR TITLE
Modify isSecure() to reference scheme.

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -110,6 +110,8 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	private static final String HOST_HEADER = "Host";
 
 	private static final String CHARSET_PREFIX = "charset=";
+	
+	private static final String HTTPS = "https";
 
 	private static final ServletInputStream EMPTY_SERVLET_INPUT_STREAM =
 			new DelegatingServletInputStream(new ByteArrayInputStream(new byte[0]));
@@ -707,7 +709,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	@Override
 	public boolean isSecure() {
-		return this.secure;
+		return this.secure || this.getScheme().equalsIgnoreCase(HTTPS);
 	}
 
 	@Override

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
@@ -333,6 +333,33 @@ public class MockHttpServletRequestTests {
 		StringBuffer requestURL = request.getRequestURL();
 		assertEquals("http://localhost", requestURL.toString());
 	}
+	
+	@Test
+	public void isSecure() {
+		request.setSecure(true);
+		assertTrue(request.isSecure());
+	}
+	
+	@Test
+	public void isSecureWithScheme() {
+		assertFalse(request.isSecure());		
+		request.setScheme("https");
+		assertTrue(request.isSecure());
+	}
+	
+	@Test
+	public void isSecureWithSecureAndScheme() {
+		request.setSecure(true);
+		request.setScheme("http");
+		assertTrue(request.isSecure());
+	}
+	
+	@Test
+	public void isSecureWithSchemeAndSecure() {
+		request.setSecure(false);
+		request.setScheme("https");
+		assertTrue(request.isSecure());
+	}	
 
 	private void assertEqualEnumerations(Enumeration<?> enum1, Enumeration<?> enum2) {
 		assertNotNull(enum1);


### PR DESCRIPTION
This commit modifies isSecure() in MockHttpServletRequest to reference scheme.
Whether secure is true or scheme is "https" return true.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
