### PR TITLE
added database-specific data type condition check

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/StatementCreatorUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/StatementCreatorUtils.java
@@ -36,7 +36,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.core.SpringProperties;
 import org.springframework.jdbc.support.SqlValue;
 
@@ -239,7 +238,7 @@ public abstract class StatementCreatorUtils {
 	 * respecting database-specific peculiarities.
 	 */
 	private static void setNull(PreparedStatement ps, int paramIndex, int sqlType, String typeName) throws SQLException {
-		if (sqlType == SqlTypeValue.TYPE_UNKNOWN) {
+		if (sqlType == SqlTypeValue.TYPE_UNKNOWN || sqlType == Types.OTHER) {
 			boolean useSetObject = false;
 			Integer sqlTypeToUse = null;
 			DatabaseMetaData dbmd = null;
@@ -385,7 +384,7 @@ public abstract class StatementCreatorUtils {
 				ps.setObject(paramIndex, inValue, Types.TIMESTAMP);
 			}
 		}
-		else if (sqlType == SqlTypeValue.TYPE_UNKNOWN) {
+		else if (sqlType == SqlTypeValue.TYPE_UNKNOWN || sqlType == Types.OTHER) {
 			if (isStringValue(inValue.getClass())) {
 				ps.setString(paramIndex, inValue.toString());
 			}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/StatementCreatorUtilsTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/StatementCreatorUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -262,4 +262,15 @@ public class StatementCreatorUtilsTests {
 		verify(preparedStatement).setTimestamp(1, new java.sql.Timestamp(cal.getTime().getTime()), cal);
 	}
 
+	@Test 
+	public void testSetParameterValueWithStringAndVenderSpecificTypeSpr8571() throws SQLException {
+		StatementCreatorUtils.setParameterValue(preparedStatement, 1, Types.OTHER, null, "test");
+		verify(preparedStatement).setString(1, "test");
+	}
+	
+	@Test 
+	public void testSetParameterValueWithNullAndVenderSpecificTypeSpr8571() throws SQLException {
+		StatementCreatorUtils.setParameterValue(preparedStatement, 1, Types.OTHER, null, null);
+		verify(preparedStatement).setNull(1, Types.NULL);
+	}
 }


### PR DESCRIPTION
Before this commit, when using SimpleJdbcInsert for insert into
nvarchar2 it throws java.sql.SQLException(Invalid column type),
because nvarchar2 is oracle-specific data type.

So I added Types.OTHER condition check On setValue and setNull methods.

Issue: SPR-8571
