### PR TITLE
Improve ResolvableType.hashCode() for better performances

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -808,7 +808,11 @@ public final class ResolvableType implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return ObjectUtils.nullSafeHashCode(this.type);
+		int hashCode = ObjectUtils.nullSafeHashCode(this.type);
+		hashCode = 31 * hashCode + ObjectUtils.nullSafeHashCode(getSource());
+		hashCode = 31 * hashCode + variableResolverSourceHashCode();
+		hashCode = 31 * hashCode + ObjectUtils.nullSafeHashCode(this.componentType);
+		return hashCode;
 	}
 
 	/**
@@ -836,6 +840,14 @@ public final class ResolvableType implements Serializable {
 			return false;
 		}
 		return ObjectUtils.nullSafeEquals(this.variableResolver.getSource(), other.getSource());
+	}
+
+	private int variableResolverSourceHashCode() {
+		int hashCode = 0;
+		if (this.variableResolver != null) {
+			hashCode = ObjectUtils.nullSafeHashCode(this.variableResolver.getSource());
+		}
+		return hashCode;
 	}
 
 	private static ResolvableType[] forTypes(Type[] types, VariableResolver owner) {


### PR DESCRIPTION
Prior to this commit, when there was a lot of entries in the ResolvableType.cache HashMap,
getting a simple value could take a lot of time due to a lot of calls to ResolvableType.equals().
ResolvableType.equals() used this.type, getSource(), this.variableResolver.getSource() and
this.componentType, but ResolvableType.hashCode() used only this.type.

With this commit, ResolvableType.hashCode() now uses the same fields than ResolvableType.equals().

Performances on the spring-resolvabletype-benchmark project:
- 8000 us before this commit
- 120 us with this commit

Issue: SPR-12122
