### PR TITLE
Add support for jackson mix-in

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBean.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBean.java
@@ -120,6 +120,7 @@ import org.springframework.util.ClassUtils;
  * @author Rossen Stoyanchev
  * @author Brian Clozel
  * @author Juergen Hoeller
+ * @author Tadaya Tsuyukubo
  * @since 3.2
  */
 public class Jackson2ObjectMapperFactoryBean implements FactoryBean<ObjectMapper>, BeanClassLoaderAware, InitializingBean {
@@ -147,6 +148,8 @@ public class Jackson2ObjectMapperFactoryBean implements FactoryBean<ObjectMapper
 	private PropertyNamingStrategy propertyNamingStrategy;
 
 	private ClassLoader beanClassLoader;
+
+	private final Map<Class<?>, Class<?>> mixIns = new HashMap<Class<?>, Class<?>>();
 
 
 	/**
@@ -352,6 +355,15 @@ public class Jackson2ObjectMapperFactoryBean implements FactoryBean<ObjectMapper
 		this.beanClassLoader = beanClassLoader;
 	}
 
+	/**
+	 * Add mixins to {@link ObjectMapper}.
+	 * @since 4.1
+	 */
+	public void setMixIns(Map<Class<?>, Class<?>> mixIns) {
+		if (mixIns != null) {
+			this.mixIns.putAll(mixIns);
+		}
+	}
 
 	@Override
 	public void afterPropertiesSet() {
@@ -407,6 +419,10 @@ public class Jackson2ObjectMapperFactoryBean implements FactoryBean<ObjectMapper
 
 		if (this.propertyNamingStrategy != null) {
 			this.objectMapper.setPropertyNamingStrategy(this.propertyNamingStrategy);
+		}
+
+		for (Map.Entry<Class<?>, Class<?>> entry : this.mixIns.entrySet()) {
+			this.objectMapper.addMixInAnnotations(entry.getKey(), entry.getValue());
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
@@ -276,4 +276,19 @@ public class Jackson2ObjectMapperFactoryBeanTests {
 		assertEquals(XmlMapper.class, this.factory.getObjectType());
 	}
 
+	@Test
+	public void setMixIns() {
+		Class<?> target = String.class;
+		Class<?> mixinSource = Object.class;
+		Map<Class<?>, Class<?>> mixIns = new HashMap<Class<?>, Class<?>>();
+		mixIns.put(target, mixinSource);
+
+		this.factory.setMixIns(mixIns);
+		this.factory.afterPropertiesSet();
+		ObjectMapper objectMapper = this.factory.getObject();
+
+		assertEquals(1, objectMapper.mixInCount());
+		assertSame(mixinSource, objectMapper.findMixInClassFor(target));
+	}
+
 }


### PR DESCRIPTION
In Jackson2ObjectMapperFactoryBean, jackson mix-in classes can be registered via jackson module, but not directly to the factory bean.

This commit adds support for direct jackson mix-in registration in Jackson2ObjectMapperFactoryBean.

Issue: [SPR-12144](https://jira.spring.io/browse/SPR-12144)
CLA submitted
