### PR TITLE
Fix enum detection in GenericConversionService

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
@@ -568,14 +568,14 @@ public class GenericConversionService implements ConfigurableConversionService {
 				Class<?> candidate = hierarchy.get(i);
 				candidate = (array ? candidate.getComponentType() : ClassUtils.resolvePrimitiveIfNecessary(candidate));
 				Class<?> superclass = candidate.getSuperclass();
-				if (candidate.getSuperclass() != null && superclass != Object.class && superclass != Enum.class) {
+				if (superclass != null && superclass != Object.class && superclass != Enum.class) {
 					addToClassHierarchy(i + 1, candidate.getSuperclass(), array, hierarchy, visited);
 				}
 				addInterfacesToClassHierarchy(candidate, array, hierarchy, visited);
 				i++;
 			}
 
-			if (type.isEnum()) {
+			if (Enum.class.isAssignableFrom(type)) {
 				addToClassHierarchy(hierarchy.size(), Enum.class, array, hierarchy, visited);
 				addToClassHierarchy(hierarchy.size(), Enum.class, false, hierarchy, visited);
 				addInterfacesToClassHierarchy(Enum.class, array, hierarchy, visited);

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -750,6 +750,22 @@ public class GenericConversionServiceTests {
 		assertEquals("A", result);
 	}
 
+	enum EnumWithSubclass {
+		FIRST {
+			@Override
+			public String toString() {
+				return "1st";
+			}
+		}
+	}
+
+	@Test
+	public void testSubclassOfEnumToString() throws Exception {
+		conversionService.addConverter(new EnumToStringConverter(conversionService));
+		String result = conversionService.convert(EnumWithSubclass.FIRST, String.class);
+		assertEquals("FIRST", result);
+	}
+
 	@Test
 	public void testEnumWithInterfaceToStringConversion() {
 		// SPR-9692


### PR DESCRIPTION
Use Enum.class.isAssignableFrom(type) in preference to type.isEnum(), since the latter returns false for enum subclasses. This was causing EnumToStringConverter not to be matched and resulted in the enum's toString() being used instead of name().

Issue: SPR-12181

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
