### PR TITLE
Added 406 Not Acceptable response support for @ExceptionHandler methods

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/HandlerExceptionResolverComposite.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/HandlerExceptionResolverComposite.java
@@ -71,14 +71,29 @@ public class HandlerExceptionResolverComposite implements HandlerExceptionResolv
 										 Object handler,
 										 Exception ex) {
 		if (resolvers != null) {
-			for (HandlerExceptionResolver handlerExceptionResolver : resolvers) {
-				ModelAndView mav = handlerExceptionResolver.resolveException(request, response, handler, ex);
-				if (mav != null) {
-					return mav;
-				}
+			try {
+				return handleException(request, response, handler, ex);
+			}
+			catch (WrappedException wrapped) {
+				return handleException(request, response, handler, (Exception) wrapped.getCause());
+			}
+			catch (RuntimeException e) {
+				return handleException(request, response, handler, e);
 			}
 		}
 		return null;
 	}
 
+	private ModelAndView handleException(HttpServletRequest request,
+			HttpServletResponse response,
+			Object handler,
+			Exception ex) {
+		for (HandlerExceptionResolver handlerExceptionResolver : resolvers) {
+			ModelAndView mav = handlerExceptionResolver.resolveException(request, response, handler, ex);
+			if (mav != null) {
+				return mav;
+			}
+		}
+		return null;
+	}
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/WrappedException.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/WrappedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.handler;
+
+/**
+ * Exception used to indicate when an {@link Exception} has been wrapped so should be unwrapped to find the actual
+ * cause.
+ *
+ * It can be used to propagate checked exceptions up to the {@link HandlerExceptionResolverComposite#resolveException}
+ * method from within a method that can't throw checked exceptions.
+ *
+ * @author Karl Bennett
+ * @since 4.1.1
+ */
+@SuppressWarnings("serial")
+public class WrappedException extends RuntimeException {
+
+	public WrappedException(Exception cause) {
+		super(cause);
+	}
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/HandlerExceptionResolverCompositeTest.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/HandlerExceptionResolverCompositeTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.handler;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test fixture with {@link HandlerExceptionResolverComposite}.
+ *
+ * @author Karl Bennett
+ * @since 4.1.1
+ */
+public class HandlerExceptionResolverCompositeTest {
+
+	private HttpServletRequest request;
+	private HttpServletResponse response;
+	private Object handler;
+	private Exception exception;
+	private RuntimeException thrown;
+	private HandlerExceptionResolver exceptionResolver;
+
+    private HandlerExceptionResolverComposite resolver;
+
+    @Before
+    public void setUp() {
+		request = mock(HttpServletRequest.class);
+		response = mock(HttpServletResponse.class);
+		handler = mock(Object.class);
+		exception = mock(Exception.class);
+		thrown = new FirstException("This exception should be caught and handled.");
+
+		exceptionResolver = mock(HandlerExceptionResolver.class);
+
+
+        resolver = new HandlerExceptionResolverComposite();
+    }
+
+    @Test
+    public void testResolveExceptionThatThrowsResolvedException() {
+
+        final ModelAndView expectedMav = mock(ModelAndView.class);
+
+		when(exceptionResolver.resolveException(request, response, handler, exception)).thenThrow(thrown);
+        when(exceptionResolver.resolveException(request, response, handler, thrown)).thenReturn(expectedMav);
+
+		assertThrownExceptionResolved(expectedMav);
+    }
+
+	@Test
+    public void testResolveExceptionThatThrowsResolvedWrappedException() {
+
+        final ModelAndView expectedMav = mock(ModelAndView.class);
+
+		when(exceptionResolver.resolveException(request, response, handler, exception))
+				.thenThrow(new WrappedException(thrown));
+        when(exceptionResolver.resolveException(request, response, handler, thrown)).thenReturn(expectedMav);
+
+		assertThrownExceptionResolved(expectedMav);
+    }
+
+	private void assertThrownExceptionResolved(ModelAndView expected) {
+
+		final ModelAndView mav = resolveException();
+
+		assertEquals("An attempt should be made to handle any exceptions thrown by a handler.", expected, mav);
+	}
+
+	@Test(expected = SecondException.class)
+    public void testResolveExceptionThatThrowsAnUnresolvedException() {
+
+        final RuntimeException thrownSecond = new SecondException("This exception should be thrown out.");
+
+		when(exceptionResolver.resolveException(request, response, handler, exception)).thenThrow(thrown);
+        when(exceptionResolver.resolveException(request, response, handler, thrown)).thenThrow(thrownSecond);
+
+		resolveException();
+    }
+
+	@Test(expected = WrappedException.class)
+    public void testResolveExceptionThatThrowsAnUnresolvedWrappedException() {
+
+        final RuntimeException thrownSecond = new SecondException("This exception should be thrown out.");
+
+		when(exceptionResolver.resolveException(request, response, handler, exception)).thenThrow(thrown);
+        when(exceptionResolver.resolveException(request, response, handler, thrown))
+				.thenThrow(new WrappedException(thrownSecond));
+
+		resolveException();
+    }
+
+	@Test(expected = SecondException.class)
+    public void testPossibleInfiniteExceptionLoop() {
+
+        final RuntimeException thrownSecond = new SecondException("This exception should be thrown out.");
+
+		when(exceptionResolver.resolveException(request, response, handler, exception)).thenThrow(thrown);
+        when(exceptionResolver.resolveException(request, response, handler, thrown)).thenThrow(thrownSecond);
+		// This third resolve call would cause an infinite loop if executed. It should never be called.
+        when(exceptionResolver.resolveException(request, response, handler, thrownSecond)).thenThrow(thrown);
+
+		resolveException();
+    }
+
+	private ModelAndView resolveException() {
+
+		resolver.setExceptionResolvers(singletonList(exceptionResolver));
+
+		return resolver.resolveException(request, response, handler, exception);
+	}
+
+	@SuppressWarnings("serial")
+	private static class FirstException extends RuntimeException {
+		private FirstException(String message) {
+			super(message);
+		}
+	}
+	@SuppressWarnings("serial")
+	private static class SecondException extends RuntimeException {
+		private SecondException(String message) {
+			super(message);
+		}
+	}
+}


### PR DESCRIPTION
I found this while writing a file server when testing not found errors. When I attempted to handle my
not found exception for the file `Text.txt` I got a 500 instead of a 404. This is because I don't have a
message converter for `text/plain` so when the my hander method returns, the error cannot be
marshelled and an `HttpMediaTypeNotAcceptableException` is thrown by the resolver. This I would
expect to produce a 406 not a 500. The 500 happens because the
`HttpMediaTypeNotAcceptableException` is just logged and null returned, this indicates to the framework
that my not found exception wasn't actually resolved so it is then thrown up out into the web server.

I have updated the `ExceptionHandlerExceptionResolver` to propagate exceptions thrown from
`@ExceptionHandler` methods up to the `HandlerExceptionResolverComposite`. The
`HandlerExceptionResolverComposite` now catches the propagated exception and passes
that through the exception resolvers to see if it too can be handled. This prevents
the current behaviour of `HttpMediaTypeNotAcceptableException`s produced by
`@ExceptionHandler` methods causing HTTP 500s. They now produce HTTP 406 responses as
expected. It also allows the use of the defaul Spring MVC exceptions from within exception
`@ExceptionHandler` methods.

Issue: SPR-12188
