### PR TITLE
Fix of unexpected override order for @Configuration based property sources

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
@@ -93,6 +93,7 @@ import org.springframework.util.StringUtils;
  * @author Chris Beams
  * @author Juergen Hoeller
  * @author Phillip Webb
+ * @author Martin Becker
  * @since 3.0
  * @see ConfigurationClassBeanDefinitionReader
  */
@@ -374,8 +375,7 @@ class ConfigurationClassParser {
 				propertySources.addLast(propertySource);
 			}
 			else {
-				String firstProcessed = this.propertySourceNames.iterator().next();
-				propertySources.addBefore(firstProcessed, propertySource);
+				propertySources.addFirst(propertySource);
 			}
 		}
 		this.propertySourceNames.add(name);

--- a/spring-context/src/test/java/org/springframework/context/annotation/PropertySourceAnnotationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/PropertySourceAnnotationTests.java
@@ -18,12 +18,12 @@ package org.springframework.context.annotation;
 
 import java.io.FileNotFoundException;
 import java.util.Iterator;
+
 import javax.inject.Inject;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.core.env.Environment;
@@ -38,6 +38,7 @@ import static org.junit.Assert.*;
  *
  * @author Chris Beams
  * @author Phillip Webb
+ * @author Martin Becker
  * @since 3.1
  */
 public class PropertySourceAnnotationTests {
@@ -169,6 +170,13 @@ public class PropertySourceAnnotationTests {
 		AnnotationConfigApplicationContext ctxWithoutName = new AnnotationConfigApplicationContext(ConfigWithMultipleResourceLocations.class);
 		assertThat(ctxWithoutName.getEnvironment().getProperty("testbean.name"), equalTo("p2TestBean"));
 		assertThat(ctxWithName.getEnvironment().getProperty("testbean.name"), equalTo("p2TestBean"));
+	}
+	
+	@Test
+	public void orderingWithAndWithoutNameAndThreeResourceLocations() {
+		// p2 should 'win' as it was registered last
+		AnnotationConfigApplicationContext ctxWithoutName = new AnnotationConfigApplicationContext(ConfigWithThreeResourceLocations.class);
+		assertThat(ctxWithoutName.getEnvironment().getProperty("testbean.name"), equalTo("p3TestBean"));
 	}
 
 	@Test
@@ -354,7 +362,16 @@ public class PropertySourceAnnotationTests {
 			})
 	static class ConfigWithMultipleResourceLocations {
 	}
-
+	
+	@Configuration
+	@PropertySource(
+			value = {
+					"classpath:org/springframework/context/annotation/p1.properties",
+					"classpath:org/springframework/context/annotation/p2.properties",
+					"classpath:org/springframework/context/annotation/p3.properties"
+			})
+	static class ConfigWithThreeResourceLocations {
+	}
 
 	@Configuration
 	@PropertySources({

--- a/spring-context/src/test/java/org/springframework/context/annotation/PropertySourceAnnotationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/PropertySourceAnnotationTests.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.*;
  *
  * @author Chris Beams
  * @author Phillip Webb
- * @author Martin Becker
  * @since 3.1
  */
 public class PropertySourceAnnotationTests {
@@ -173,10 +172,10 @@ public class PropertySourceAnnotationTests {
 	}
 	
 	@Test
-	public void orderingWithAndWithoutNameAndThreeResourceLocations() {
+	public void orderingWithAndWithoutNameAndFourResourceLocations() {
 		// p2 should 'win' as it was registered last
-		AnnotationConfigApplicationContext ctxWithoutName = new AnnotationConfigApplicationContext(ConfigWithThreeResourceLocations.class);
-		assertThat(ctxWithoutName.getEnvironment().getProperty("testbean.name"), equalTo("p3TestBean"));
+		AnnotationConfigApplicationContext ctxWithoutName = new AnnotationConfigApplicationContext(ConfigWithFourResourceLocations.class);
+		assertThat(ctxWithoutName.getEnvironment().getProperty("testbean.name"), equalTo("p4TestBean"));
 	}
 
 	@Test
@@ -368,9 +367,10 @@ public class PropertySourceAnnotationTests {
 			value = {
 					"classpath:org/springframework/context/annotation/p1.properties",
 					"classpath:org/springframework/context/annotation/p2.properties",
-					"classpath:org/springframework/context/annotation/p3.properties"
+					"classpath:org/springframework/context/annotation/p3.properties",
+					"classpath:org/springframework/context/annotation/p4.properties"
 			})
-	static class ConfigWithThreeResourceLocations {
+	static class ConfigWithFourResourceLocations {
 	}
 
 	@Configuration

--- a/spring-context/src/test/java/org/springframework/context/annotation/PropertySourceAnnotationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/PropertySourceAnnotationTests.java
@@ -18,12 +18,12 @@ package org.springframework.context.annotation;
 
 import java.io.FileNotFoundException;
 import java.util.Iterator;
-
 import javax.inject.Inject;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.core.env.Environment;
@@ -169,13 +169,6 @@ public class PropertySourceAnnotationTests {
 		AnnotationConfigApplicationContext ctxWithoutName = new AnnotationConfigApplicationContext(ConfigWithMultipleResourceLocations.class);
 		assertThat(ctxWithoutName.getEnvironment().getProperty("testbean.name"), equalTo("p2TestBean"));
 		assertThat(ctxWithName.getEnvironment().getProperty("testbean.name"), equalTo("p2TestBean"));
-	}
-	
-	@Test
-	public void orderingWithAndWithoutNameAndFourResourceLocations() {
-		// p2 should 'win' as it was registered last
-		AnnotationConfigApplicationContext ctxWithoutName = new AnnotationConfigApplicationContext(ConfigWithFourResourceLocations.class);
-		assertThat(ctxWithoutName.getEnvironment().getProperty("testbean.name"), equalTo("p4TestBean"));
 	}
 
 	@Test
@@ -361,17 +354,7 @@ public class PropertySourceAnnotationTests {
 			})
 	static class ConfigWithMultipleResourceLocations {
 	}
-	
-	@Configuration
-	@PropertySource(
-			value = {
-					"classpath:org/springframework/context/annotation/p1.properties",
-					"classpath:org/springframework/context/annotation/p2.properties",
-					"classpath:org/springframework/context/annotation/p3.properties",
-					"classpath:org/springframework/context/annotation/p4.properties"
-			})
-	static class ConfigWithFourResourceLocations {
-	}
+
 
 	@Configuration
 	@PropertySources({

--- a/spring-context/src/test/java/org/springframework/context/annotation/Spr12198Tests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/Spr12198Tests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+
+/**
+ * Unit tests for issue SPR-12198, in which the order of adding 
+ * {@link PropertySource}s is fixed. When adding in the order
+ * A then B then C then D, properties from D should override the ones from
+ * C, properties from C should override properties from B and so on:
+ * D > C > B > A. Before SPR-12198 was addressed the order was B > C > D > A.
+ * 
+ * @author Martin Becker
+ */
+public class Spr12198Tests {
+	
+	@Test
+	public void orderingWithAndWithoutNameAndFourResourceLocations() {
+		// p4 should 'win' as it was registered last
+		AnnotationConfigApplicationContext ctxWithoutName = new AnnotationConfigApplicationContext(ConfigWithFourResourceLocations.class);
+		assertThat(ctxWithoutName.getEnvironment().getProperty("testbean.name"), equalTo("p4TestBean"));
+	}
+	
+	@Configuration
+	@PropertySource(
+			value = {
+					"classpath:org/springframework/context/annotation/p1.properties",
+					"classpath:org/springframework/context/annotation/p2.properties",
+					"classpath:org/springframework/context/annotation/p3.properties",
+					"classpath:org/springframework/context/annotation/p4.properties"
+			})
+	static class ConfigWithFourResourceLocations {
+	}
+	
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/p3.properties
+++ b/spring-context/src/test/java/org/springframework/context/annotation/p3.properties
@@ -1,0 +1,1 @@
+testbean.name=p3TestBean

--- a/spring-context/src/test/java/org/springframework/context/annotation/p4.properties
+++ b/spring-context/src/test/java/org/springframework/context/annotation/p4.properties
@@ -1,0 +1,1 @@
+testbean.name=p4TestBean


### PR DESCRIPTION
This change fixes the override order for @Configuration based property source registration via the @PropertySource and @PropertySources
annotations.

Issue: SPR-12198
