### PR TITLE
Removing problematic creation of unnecessary RequestConfig

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactory.java
@@ -84,7 +84,7 @@ public class HttpComponentsClientHttpRequestFactory implements ClientHttpRequest
 	public HttpComponentsClientHttpRequestFactory(HttpClient httpClient) {
 		Assert.notNull(httpClient, "'httpClient' must not be null");
 		Assert.isInstanceOf(CloseableHttpClient.class, httpClient, "'httpClient' is not of type CloseableHttpClient");
-        this.httpClient = (CloseableHttpClient) httpClient;
+        	this.httpClient = (CloseableHttpClient) httpClient;
 	}
 
 
@@ -185,32 +185,12 @@ public class HttpComponentsClientHttpRequestFactory implements ClientHttpRequest
         if (context == null) {
             context = HttpClientContext.create();
         }
-        // Request configuration not set in the context
-        if (context.getAttribute(HttpClientContext.REQUEST_CONFIG) == null) {
-            // Use request configuration given by the user, when available
-            RequestConfig config = null;
-            if (httpRequest instanceof Configurable) {
-                config = ((Configurable) httpRequest).getConfig();
-            }
-            if (config == null) {
-                if (this.socketTimeout > 0 || this.connectTimeout > 0) {
-                    config = RequestConfig.custom()
-                            .setConnectTimeout(this.connectTimeout)
-                            .setSocketTimeout(this.socketTimeout)
-                            .build();
-                }
-				else {
-                    config = RequestConfig.DEFAULT;
-                }
-            }
-            context.setAttribute(HttpClientContext.REQUEST_CONFIG, config);
-        }
-		if (this.bufferRequestBody) {
-			return new HttpComponentsClientHttpRequest(client, httpRequest, context);
-		}
-		else {
-			return new HttpComponentsStreamingClientHttpRequest(client, httpRequest, context);
-		}
+	if (this.bufferRequestBody) {
+		return new HttpComponentsClientHttpRequest(client, httpRequest, context);
+	}
+	else {
+		return new HttpComponentsStreamingClientHttpRequest(client, httpRequest, context);
+	}
 	}
 
 	/**


### PR DESCRIPTION
The explicit (possibly again) creation of RequestConfig for HttpContext is wrong, since if someone passes default RequestConfig to the HttpClient object (via setDefaultRequestConfig, as seen here: http://hc.apache.org/httpcomponents-client-4.3.x/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html#setDefaultRequestConfig(org.apache.http.client.config.RequestConfig)) it will override it and making the developers to override for nothing the createHttpContext each time, instead of just using the already provided feature of setting default RequestConfig.

Instead of this condition, and making people overriding this class for just re-configuring RequestConfig for each HttpComponentsClientHttpRequestFactory, maybe it should be replaced with other conditions that checks if there's ANY RequestConfig, and if not then to create a new one.

Anyway, currently this condition is wrong and as my point of view it is kind of a bug.
