### PR TITLE
Expose @Bean method metadata in BeanDefinitions

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/BeanMethodBeanDefinition.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/BeanMethodBeanDefinition.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation;
+
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.core.type.MethodMetadata;
+
+/**
+ * Extended {@link org.springframework.beans.factory.config.BeanDefinition} for beans
+ * defined using {@code @Bean} methods. Exposes
+ * {@link org.springframework.core.type.AnnotationMetadata} about its bean class and
+ * {@link org.springframework.core.type.MethodMetadata} about its {@code @Bean} method -
+ * without requiring the class to be loaded yet.
+ *
+ * @author Phillip Webb
+ * @since 4.1
+ * @see AnnotatedBeanDefinition
+ * @see org.springframework.core.type.AnnotationMetadata
+ * @see org.springframework.core.type.MethodMetadata
+ */
+public interface BeanMethodBeanDefinition extends AnnotatedBeanDefinition {
+
+	/**
+	 * Obtain the method metadata for this bean definition's {@code @Bean} method.
+	 * @return the {@code @Bean} method metadata object (never {@code null})
+	 */
+	MethodMetadata getBeanMethodMetadata();
+
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/BeanMethodBeanDefinitionTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/BeanMethodBeanDefinitionTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link BeanMethodBeanDefinition} loading.
+ *
+ * @author Phillip Webb
+ */
+public class BeanMethodBeanDefinitionTests {
+
+	@Test
+	public void providesBeanMethodBeanDefinition() throws Exception {
+		AnnotationConfigApplicationContext context= new AnnotationConfigApplicationContext(Conf.class);
+		BeanDefinition beanDefinition = context.getBeanDefinition("myBean");
+		assertThat("should provide BeanMethodBeanDefinition", beanDefinition, instanceOf(BeanMethodBeanDefinition.class));
+		Map<String, Object> annotationAttributes = ((BeanMethodBeanDefinition) beanDefinition).getBeanMethodMetadata().getAnnotationAttributes(
+				MyAnnoation.class.getName());
+		assertThat(annotationAttributes.get("value"), equalTo("test"));
+		context.close();
+	}
+
+	@Configuration
+	static class Conf {
+
+		@Bean
+		@MyAnnoation("test")
+		public MyBean myBean() {
+			return new MyBean();
+		}
+
+	}
+
+	static class MyBean {
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public static @interface MyAnnoation {
+
+		String value();
+
+	}
+
+}


### PR DESCRIPTION
Add BeanMethodBeanDefinition which extends AnnotatedBeanDefinition and
additionally exposes @Bean MethodMetadata. The existing @Condiguration
class reader has been updated to expose the new BeanDefinition type.

Issue: 
