### PR TITLE
adding check if logger is in debug mode to avoid string concatenation of...

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncManager.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/WebAsyncManager.java
@@ -344,11 +344,11 @@ public final class WebAsyncManager {
 			logger.error("Could not complete async processing due to timeout or network error");
 			return;
 		}
-
-		logger.debug("Concurrent result value [" + concurrentResult + "]");
-		logger.debug("Dispatching request to resume processing");
-
-		asyncWebRequest.dispatch();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Concurrent result value [" + concurrentResult + "]");
+            logger.debug("Dispatching request to resume processing");
+        }
+        asyncWebRequest.dispatch();
 	}
 
 	/**


### PR DESCRIPTION
adding check if logger is in debug mode to avoid string concatenation of the whole response object which might get quite large.

At the moment object concatenation is done always although it's only required in debug mode.

I've been tracking CPU usage of my application and multiple times have I seen in thread dump that concatenation taking a lot of CPU where I actually don't need it (as I'm not running in debug mode)
