### PR TITLE
Changed the validation error message

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
@@ -229,7 +229,7 @@ final class ConfigurationClass {
 	private class FinalConfigurationProblem extends Problem {
 
 		public FinalConfigurationProblem() {
-			super(String.format("@Configuration class '%s' may not be final. Remove the final modifier to continue.",
+			super(String.format("@Configuration class '%s' may be final. Remove the final modifier to continue.",
 					getSimpleName()), new Location(getResource(), getMetadata()));
 		}
 	}


### PR DESCRIPTION
The old message is "class may not be final", however this error occurs when the annotated class is final.

Signed-off-by: Laszlo Hornyak laszlo.hornyak@gmail.com
