### PR TITLE
SPR-12341: Support for customizing individual GuavaCache used underlying...

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/guava/GuavaCacheFactoryBean.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/guava/GuavaCacheFactoryBean.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.guava;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheBuilderSpec;
+import com.google.common.cache.CacheLoader;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * {@link FactoryBean} for creating a GuavaCache instance that can further
+ * be customized with a Guava {@link CacheBuilder} or {@link CacheBuilderSpec}
+ *
+ * @author Biju Kunjummen
+ * @since 4.1
+ * @see GuavaCache
+ */
+public class GuavaCacheFactoryBean implements FactoryBean<GuavaCache> {
+	private final String name;
+	private CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+	private CacheLoader<Object, Object> cacheLoader;
+	private final boolean allowNullValues;
+
+	/**
+	 * Create a {@link GuavaCacheFactoryBean} instance with the specified name
+	 * for the created underlying {@link GuavaCache}.
+	 * @param name the name of the cache
+	 */
+	public GuavaCacheFactoryBean(String name) {
+		this.name = name;
+		this.allowNullValues = true;
+	}
+
+	/**
+	 * Create a {@link GuavaCacheFactoryBean} instance with the specified name
+	 * for the created underlying {@link GuavaCache} and whether the cache accepts
+	 * null values.
+	 * @param name the name of the cache
+	 * @param allowNullValues whether to accept and convert {@code null}
+	 * values for this cache
+	 */
+
+	public GuavaCacheFactoryBean(String name, boolean allowNullValues) {
+		this.name = name;
+		this.allowNullValues = allowNullValues;
+	}
+
+	/**
+	 * Specify the {@link com.google.common.cache.CacheBuilder} to use to
+	 * build the underlying native {@link com.google.common.cache.Cache}
+	 */
+	public void setCacheBuilder(CacheBuilder<Object, Object> cacheBuilder) {
+		this.cacheBuilder = cacheBuilder;
+	}
+
+	/**
+	 * Specify the {@link com.google.common.cache.CacheBuilderSpec} to use to
+	 * build the underlying native {@link com.google.common.cache.Cache}
+	 */
+	public void setCacheBuilderSpec(CacheBuilderSpec cacheBuilderSpec) {
+	   this.cacheBuilder = CacheBuilder.from(cacheBuilderSpec);
+	}
+
+	/**
+	 * Specify the {@link com.google.common.cache.CacheBuilderSpec} as a String
+	 * to build the underlying native {@link com.google.common.cache.Cache}
+	 */
+	public void setCacheBuilderSpecString(String cacheBuilderSpec) {
+		this.cacheBuilder = CacheBuilder.from(cacheBuilderSpec);
+	}
+
+	/**
+	 * Specify the {@link com.google.common.cache.CacheLoader}
+	 */
+	public void setCacheLoader(CacheLoader<Object, Object> cacheLoader) {
+		this.cacheLoader = cacheLoader;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+
+
+	@Override
+	public GuavaCache getObject() {
+		if (this.cacheLoader != null) {
+			return new GuavaCache(this.name, this.cacheBuilder.build(this.cacheLoader), this.allowNullValues);
+		}
+		return new GuavaCache(this.name, this.cacheBuilder.build(), this.allowNullValues);
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return GuavaCache.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
+	}
+}

--- a/spring-context-support/src/test/java/org/springframework/cache/guava/GuavaCacheFactoryBeanTests.java
+++ b/spring-context-support/src/test/java/org/springframework/cache/guava/GuavaCacheFactoryBeanTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.guava;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Biju Kunjummen
+ */
+
+public class GuavaCacheFactoryBeanTests {
+
+	@Test
+	public void testDefaultCacheBuilder() {
+		GuavaCacheFactoryBean cb1 = new GuavaCacheFactoryBean("cb1");
+		GuavaCache guavaCache = cb1.getObject();
+		assertNotNull(guavaCache);
+		assertNotNull(guavaCache.getNativeCache());
+		assertEquals("cb1", guavaCache.getName());
+	}
+
+	@Test
+	public void testCacheBuilderExplicitlySpecified() {
+		GuavaCacheFactoryBean cb1 = new GuavaCacheFactoryBean("cb1");
+		cb1.setCacheBuilder(CacheBuilder.newBuilder().maximumSize(1));
+		GuavaCache guavaCache = cb1.getObject();
+		assertNotNull(guavaCache);
+		assertNotNull(guavaCache.getNativeCache());
+		assertEquals("cb1", guavaCache.getName());
+	}
+
+	@Test
+	public void testCacheBuilderAndCacheLoaderExplicitlySpecified() {
+		GuavaCacheFactoryBean cb1 = new GuavaCacheFactoryBean("cb1");
+		cb1.setCacheBuilder(CacheBuilder.newBuilder().maximumSize(1));
+		cb1.setCacheLoader(Mockito.mock(CacheLoader.class));
+		GuavaCache guavaCache = cb1.getObject();
+		assertNotNull(guavaCache);
+		assertTrue(guavaCache.getNativeCache() instanceof LoadingCache);
+
+	}
+}

--- a/spring-context-support/src/test/java/org/springframework/cache/guava/config/GuavaCacheManagerConfigTests.java
+++ b/spring-context-support/src/test/java/org/springframework/cache/guava/config/GuavaCacheManagerConfigTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.guava.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.springframework.cache.guava.GuavaCache;
+import org.springframework.cache.guava.GuavaCacheManager;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericXmlApplicationContext;
+
+public class GuavaCacheManagerConfigTests {
+
+	@Test
+	public void testLoadingAGuavaCacheManagerContext() {
+		ConfigurableApplicationContext context = new GenericXmlApplicationContext(
+				"/org/springframework/cache/guava/config/guavacache1.xml");
+
+		GuavaCacheManager cm = context.getBean(GuavaCacheManager.class);
+		GuavaCache c1 = context.getBean("c1", GuavaCache.class);
+		GuavaCache c2 = context.getBean("c2", GuavaCache.class);
+		GuavaCache c3 = context.getBean("c3", GuavaCache.class);
+		GuavaCache c4 = context.getBean("c4", GuavaCache.class);
+
+		assertTrue("Cache retrieved from CacheManager should be the same as the one in the context", cm.getCache("c1") == c1);
+		assertTrue("Cache retrieved from CacheManager should be the same as the one in the context", cm.getCache("c2") == c2);
+		assertTrue("Cache retrieved from CacheManager should be the same as the one in the context", cm.getCache("c3") == c3);
+		assertTrue("Cache retrieved from CacheManager should be the same as the one in the context", cm.getCache("c4") == c4);
+		assertEquals("c5", cm.getCache("c5").getName());
+
+	}
+}

--- a/spring-context-support/src/test/resources/org/springframework/cache/guava/config/guavacache1.xml
+++ b/spring-context-support/src/test/resources/org/springframework/cache/guava/config/guavacache1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean name="guavaCacheManager" class="org.springframework.cache.guava.GuavaCacheManager">
+        <property name="caches">
+            <set>
+                <ref bean="c1"/>
+                <ref bean="c2"/>
+                <ref bean="c3"/>
+                <ref bean="c4"/>
+            </set>
+        </property>
+    </bean>
+    <bean name="c1" class="org.springframework.cache.guava.GuavaCacheFactoryBean" c:name="c1" />
+    <bean name="c2" class="org.springframework.cache.guava.GuavaCacheFactoryBean" c:name="c2" p:cacheBuilder-ref="cb2"/>
+    <bean name="c3" class="org.springframework.cache.guava.GuavaCacheFactoryBean" c:name="c3" p:cacheBuilderSpecString="maximumSize=1,expireAfterAccess=5m"/>
+    <bean name="c4" class="org.springframework.cache.guava.GuavaCacheFactoryBean" c:name="c4" c:allowNullValues="false" p:cacheBuilderSpecString="maximumSize=1,expireAfterAccess=5m" />
+
+    <bean name="cb2" class="com.google.common.cache.CacheBuilder" factory-method="from">
+         <constructor-arg value="maximumSize=10,expireAfterAccess=5m"></constructor-arg>
+    </bean>
+</beans>


### PR DESCRIPTION
https://jira.spring.io/browse/SPR-12341

The issue with the current GuavaCacheManager is that only 1 level of customization is possible through
a CacheBuilder at the level of GuavaCacheManager and all further caches are created lazily from this one
CacheBuilder. Google Guava provides much more customization where it is possible to customize each underlying cache differently

For eg. say cache for list of employees having an expiry of 10 mins vs cache for list of states having an expiry of 30 days.

This is just a prelim submission, please review and see if this feels appropriate, if so I can make more comprehensive updates to the code based on your feedback and also update the reference documentation.
