### PR TITLE
[SPR-12352,12353] deleted unused import import CollectionUtils class

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/StandardTypeComparator.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/StandardTypeComparator.java
@@ -87,7 +87,7 @@ public class StandardTypeComparator implements TypeComparator {
 
 		try {
 			if (left instanceof Comparable) {
-				return ((Comparable) left).compareTo(right);
+				return ((Comparable<Object>) left).compareTo(right);
 			}
 		}
 		catch (ClassCastException ex) {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/HttpSessionHandshakeInterceptor.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/HttpSessionHandshakeInterceptor.java
@@ -25,7 +25,6 @@ import javax.servlet.http.HttpSession;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
-import org.springframework.util.CollectionUtils;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.server.HandshakeInterceptor;


### PR DESCRIPTION
Unused import import CollectionUtils class is deleted.

For removing raw type warning, I add Object type to Comparable in StandardTypeComparator class.

ISSUE : SPR-12352, SPR-12353
