### PR TITLE
Add an option to set an Origin whitelist for Websocket and SockJS

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/HandlersBeanDefinitionParser.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/HandlersBeanDefinitionParser.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.socket.server.support.OriginHandshakeInterceptor;
 import org.springframework.web.socket.server.support.WebSocketHttpRequestHandler;
 import org.springframework.web.socket.sockjs.support.SockJsHttpRequestHandler;
 
@@ -79,7 +80,14 @@ class HandlersBeanDefinitionParser implements BeanDefinitionParser {
 		else {
 			RuntimeBeanReference handshakeHandler = WebSocketNamespaceUtils.registerHandshakeHandler(element, context, source);
 			Element interceptorsElement = DomUtils.getChildElementByTagName(element, "handshake-interceptors");
-			ManagedList<?> interceptors = WebSocketNamespaceUtils.parseBeanSubElements(interceptorsElement, context);
+			ManagedList<? super Object> interceptors = WebSocketNamespaceUtils.parseBeanSubElements(interceptorsElement, context);
+			String allowedOriginsAttribute = element.getAttribute("allowed-origins");
+			List<String> allowedOrigins = Arrays.asList(StringUtils.tokenizeToStringArray(allowedOriginsAttribute, ","));
+			if(!allowedOrigins.isEmpty()) {
+				OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+				interceptor.setAllowedOrigins(allowedOrigins);
+				interceptors.add(interceptor);
+			}
 			strategy = new WebSocketHandlerMappingStrategy(handshakeHandler, interceptors);
 		}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParser.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParser.java
@@ -62,6 +62,7 @@ import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
 import org.springframework.web.socket.messaging.StompSubProtocolHandler;
 import org.springframework.web.socket.messaging.SubProtocolWebSocketHandler;
+import org.springframework.web.socket.server.support.OriginHandshakeInterceptor;
 import org.springframework.web.socket.server.support.WebSocketHttpRequestHandler;
 import org.springframework.web.socket.sockjs.support.SockJsHttpRequestHandler;
 
@@ -282,7 +283,14 @@ class MessageBrokerBeanDefinitionParser implements BeanDefinitionParser {
 		else {
 			RuntimeBeanReference handshakeHandler = WebSocketNamespaceUtils.registerHandshakeHandler(element, context, source);
 			Element interceptorsElement = DomUtils.getChildElementByTagName(element, "handshake-interceptors");
-			ManagedList<?> interceptors = WebSocketNamespaceUtils.parseBeanSubElements(interceptorsElement, context);
+			ManagedList<? super Object> interceptors = WebSocketNamespaceUtils.parseBeanSubElements(interceptorsElement, context);
+			String allowedOriginsAttribute = element.getAttribute("allowed-origins");
+			List<String> allowedOrigins = Arrays.asList(StringUtils.tokenizeToStringArray(allowedOriginsAttribute, ","));
+			if(!allowedOrigins.isEmpty()) {
+				OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+				interceptor.setAllowedOrigins(allowedOrigins);
+				interceptors.add(interceptor);
+			}
 			ConstructorArgumentValues cavs = new ConstructorArgumentValues();
 			cavs.addIndexedArgumentValue(0, subProtoHandler);
 			if (handshakeHandler != null) {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/WebSocketNamespaceUtils.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/WebSocketNamespaceUtils.java
@@ -16,6 +16,9 @@
 
 package org.springframework.web.socket.config;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -25,8 +28,10 @@ import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+import org.springframework.web.socket.server.support.OriginHandshakeInterceptor;
 import org.springframework.web.socket.sockjs.transport.TransportHandlingSockJsService;
 import org.springframework.web.socket.sockjs.transport.handler.DefaultSockJsService;
 import org.springframework.web.socket.sockjs.transport.handler.WebSocketTransportHandler;
@@ -97,7 +102,15 @@ class WebSocketNamespaceUtils {
 			}
 
 			Element interceptorsElement = DomUtils.getChildElementByTagName(element, "handshake-interceptors");
-			ManagedList<?> interceptors = WebSocketNamespaceUtils.parseBeanSubElements(interceptorsElement, context);
+			ManagedList<? super Object> interceptors = WebSocketNamespaceUtils.parseBeanSubElements(interceptorsElement, context);
+			String allowedOriginsAttribute = element.getAttribute("allowed-origins");
+			List<String> allowedOrigins = Arrays.asList(StringUtils.tokenizeToStringArray(allowedOriginsAttribute, ","));
+			if(!allowedOrigins.isEmpty()) {
+				sockJsServiceDef.getPropertyValues().add("allowedOrigins", allowedOrigins);
+				OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+				interceptor.setAllowedOrigins(allowedOrigins);
+				interceptors.add(interceptor);
+			}
 			sockJsServiceDef.getPropertyValues().add("handshakeInterceptors", interceptors);
 
 			String attrValue = sockJsElement.getAttribute("name");

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/AbstractWebSocketHandlerRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/AbstractWebSocketHandlerRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,19 @@
 
 package org.springframework.web.socket.config.annotation;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.socket.server.support.OriginHandshakeInterceptor;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 import org.springframework.web.socket.sockjs.SockJsService;
 import org.springframework.web.socket.sockjs.transport.handler.WebSocketTransportHandler;
@@ -34,6 +38,7 @@ import org.springframework.web.socket.sockjs.transport.handler.WebSocketTranspor
  * options but allows sub-classes to put together the actual HTTP request mappings.
  *
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  * @since 4.0
  */
 public abstract class AbstractWebSocketHandlerRegistration<M> implements WebSocketHandlerRegistration {
@@ -44,7 +49,9 @@ public abstract class AbstractWebSocketHandlerRegistration<M> implements WebSock
 
 	private HandshakeHandler handshakeHandler;
 
-	private HandshakeInterceptor[] interceptors;
+	private final List<HandshakeInterceptor> interceptors = new ArrayList<HandshakeInterceptor>();
+
+	private final List<String> allowedOrigins = new ArrayList<String>();
 
 	private SockJsServiceRegistration sockJsServiceRegistration;
 
@@ -74,25 +81,47 @@ public abstract class AbstractWebSocketHandlerRegistration<M> implements WebSock
 
 	@Override
 	public WebSocketHandlerRegistration addInterceptors(HandshakeInterceptor... interceptors) {
-		this.interceptors = interceptors;
+		if (!ObjectUtils.isEmpty(interceptors)) {
+			this.interceptors.addAll(Arrays.asList(interceptors));
+		}
 		return this;
 	}
 
-	protected HandshakeInterceptor[] getInterceptors() {
-		return this.interceptors;
+	@Override
+	public WebSocketHandlerRegistration setAllowedOrigins(String... origins) {
+		this.allowedOrigins.clear();
+		if (!ObjectUtils.isEmpty(origins)) {
+			this.allowedOrigins.addAll(Arrays.asList(origins));
+		}
+		return this;
 	}
 
 	@Override
 	public SockJsServiceRegistration withSockJS() {
 		this.sockJsServiceRegistration = new SockJsServiceRegistration(this.sockJsTaskScheduler);
-		if (this.interceptors != null) {
-			this.sockJsServiceRegistration.setInterceptors(this.interceptors);
+		HandshakeInterceptor[] interceptors = getInterceptors();
+		if (interceptors.length > 0) {
+			this.sockJsServiceRegistration.setInterceptors(interceptors);
 		}
 		if (this.handshakeHandler != null) {
 			WebSocketTransportHandler transportHandler = new WebSocketTransportHandler(this.handshakeHandler);
 			this.sockJsServiceRegistration.setTransportHandlerOverrides(transportHandler);
 		}
+		if (!this.allowedOrigins.isEmpty()) {
+			this.sockJsServiceRegistration.setAllowedOrigins(this.allowedOrigins.toArray(new String[this.allowedOrigins.size()]));
+		}
 		return this.sockJsServiceRegistration;
+	}
+
+	protected HandshakeInterceptor[] getInterceptors() {
+		List<HandshakeInterceptor> interceptors = new ArrayList<HandshakeInterceptor>();
+		interceptors.addAll(this.interceptors);
+		if(!this.allowedOrigins.isEmpty()) {
+			OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+			interceptor.setAllowedOrigins(this.allowedOrigins);
+			interceptors.add(interceptor);
+		}
+		return interceptors.toArray(new HandshakeInterceptor[interceptors.size()]);
 	}
 
 	protected final M getMappings() {
@@ -108,9 +137,10 @@ public abstract class AbstractWebSocketHandlerRegistration<M> implements WebSock
 		}
 		else {
 			HandshakeHandler handshakeHandler = getOrCreateHandshakeHandler();
+			HandshakeInterceptor[] interceptors = getInterceptors();
 			for (WebSocketHandler wsHandler : this.handlerMap.keySet()) {
 				for (String path : this.handlerMap.get(wsHandler)) {
-					addWebSocketHandlerMapping(mappings, wsHandler, handshakeHandler, this.interceptors, path);
+					addWebSocketHandlerMapping(mappings, wsHandler, handshakeHandler, interceptors, path);
 				}
 			}
 		}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
@@ -62,6 +62,8 @@ public class SockJsServiceRegistration {
 
 	private final List<HandshakeInterceptor> interceptors = new ArrayList<HandshakeInterceptor>();
 
+	private final List<String> allowedOrigins = new ArrayList<String>();
+
 	private SockJsMessageCodec messageCodec;
 
 
@@ -195,6 +197,7 @@ public class SockJsServiceRegistration {
 	}
 
 	public SockJsServiceRegistration setInterceptors(HandshakeInterceptor... interceptors) {
+		this.interceptors.clear();
 		if (!ObjectUtils.isEmpty(interceptors)) {
 			this.interceptors.addAll(Arrays.asList(interceptors));
 		}
@@ -210,6 +213,17 @@ public class SockJsServiceRegistration {
 	 */
 	public SockJsServiceRegistration setMessageCodec(SockJsMessageCodec codec) {
 		this.messageCodec = codec;
+		return this;
+	}
+
+	/**
+	 * @since 4.1.2
+	 */
+	protected SockJsServiceRegistration setAllowedOrigins(String... origins) {
+		this.allowedOrigins.clear();
+		if (!ObjectUtils.isEmpty(origins)) {
+			this.allowedOrigins.addAll(Arrays.asList(origins));
+		}
 		return this;
 	}
 
@@ -236,6 +250,9 @@ public class SockJsServiceRegistration {
 		}
 		if (this.webSocketEnabled != null) {
 			service.setWebSocketEnabled(this.webSocketEnabled);
+		}
+		if (!this.allowedOrigins.isEmpty()) {
+			service.setAllowedOrigins(this.allowedOrigins);
 		}
 		if (this.messageCodec != null) {
 			service.setMessageCodec(this.messageCodec);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/StompWebSocketEndpointRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/StompWebSocketEndpointRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,5 +41,20 @@ public interface StompWebSocketEndpointRegistration {
 	 * Configure the HandshakeInterceptor's to use.
 	 */
 	StompWebSocketEndpointRegistration addInterceptors(HandshakeInterceptor... interceptors);
+
+	/**
+	 * Configure allowed {@code Origin} header values. This check is mostly designed for browser
+	 * clients. There is noting preventing other types of client to modify the Origin header value.
+	 *
+	 * <p>When SockJS is enabled and allowed origins are restricted, transport types that do not
+	 * use {@code Origin} headers for cross origin requests (jsonp-polling, iframe-xhr-polling,
+	 * iframe-eventsource and iframe-htmlfile) are disabled. As a consequence, IE6/IE7 won't be
+	 * supported anymore and IE8/IE9 will only be supported without cookies.
+	 *
+	 * <p>By default, all origins are allowed.
+	 * @since 4.1.2
+	 * @see <a href="https://github.com/sockjs/sockjs-client#supported-transports-by-browser-html-served-from-http-or-https">SockJS supported transports by browser</a>
+	 */
+	StompWebSocketEndpointRegistration setAllowedOrigins(String... origins);
 
 }

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,15 +22,19 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.socket.server.support.OriginHandshakeInterceptor;
 import org.springframework.web.socket.server.support.WebSocketHttpRequestHandler;
 import org.springframework.web.socket.sockjs.SockJsService;
 import org.springframework.web.socket.sockjs.support.SockJsHttpRequestHandler;
 import org.springframework.web.socket.sockjs.transport.handler.WebSocketTransportHandler;
 
+import java.util.ArrayList;
+import java.util.List;
 /**
  * An abstract base class class for configuring STOMP over WebSocket/SockJS endpoints.
  *
@@ -47,7 +51,9 @@ public class WebMvcStompWebSocketEndpointRegistration implements StompWebSocketE
 
 	private HandshakeHandler handshakeHandler;
 
-	private HandshakeInterceptor[] interceptors;
+	private final List<HandshakeInterceptor> interceptors = new ArrayList<HandshakeInterceptor>();
+
+	private final List<String> allowedOrigins = new ArrayList<String>();
 
 	private StompSockJsServiceRegistration registration;
 
@@ -72,25 +78,47 @@ public class WebMvcStompWebSocketEndpointRegistration implements StompWebSocketE
 
 	@Override
 	public StompWebSocketEndpointRegistration addInterceptors(HandshakeInterceptor... interceptors) {
-		this.interceptors = interceptors;
+		if (!ObjectUtils.isEmpty(interceptors)) {
+			this.interceptors.addAll(Arrays.asList(interceptors));
+		}
 		return this;
 	}
 
-	protected HandshakeInterceptor[] getInterceptors() {
-		return this.interceptors;
+	@Override
+	public StompWebSocketEndpointRegistration setAllowedOrigins(String... origins) {
+		this.allowedOrigins.clear();
+		if (!ObjectUtils.isEmpty(origins)) {
+			this.allowedOrigins.addAll(Arrays.asList(origins));
+		}
+		return this;
 	}
 
 	@Override
 	public SockJsServiceRegistration withSockJS() {
 		this.registration = new StompSockJsServiceRegistration(this.sockJsTaskScheduler);
-		if (this.interceptors != null) {
-			this.registration.setInterceptors(this.interceptors);
+		HandshakeInterceptor[] interceptors = getInterceptors();
+		if (interceptors.length > 0) {
+			this.registration.setInterceptors(interceptors);
 		}
 		if (this.handshakeHandler != null) {
 			WebSocketTransportHandler transportHandler = new WebSocketTransportHandler(this.handshakeHandler);
 			this.registration.setTransportHandlerOverrides(transportHandler);
 		}
+		if (!this.allowedOrigins.isEmpty()) {
+			this.registration.setAllowedOrigins(this.allowedOrigins.toArray(new String[this.allowedOrigins.size()]));
+		}
 		return this.registration;
+	}
+
+	protected HandshakeInterceptor[] getInterceptors() {
+		List<HandshakeInterceptor> interceptors = new ArrayList<HandshakeInterceptor>();
+		interceptors.addAll(this.interceptors);
+		if(!this.allowedOrigins.isEmpty()) {
+			OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+			interceptor.setAllowedOrigins(this.allowedOrigins);
+			interceptors.add(interceptor);
+		}
+		return interceptors.toArray(new HandshakeInterceptor[interceptors.size()]);
 	}
 
 	public final MultiValueMap<HttpRequestHandler, String> getMappings() {
@@ -112,8 +140,9 @@ public class WebMvcStompWebSocketEndpointRegistration implements StompWebSocketE
 				else {
 					handler = new WebSocketHttpRequestHandler(this.webSocketHandler);
 				}
-				if (this.interceptors != null) {
-					handler.setHandshakeInterceptors(Arrays.asList(this.interceptors));
+				HandshakeInterceptor[] interceptors = getInterceptors();
+				if (interceptors.length > 0) {
+					handler.setHandshakeInterceptors(Arrays.asList(interceptors));
 				}
 				mappings.add(handler, path);
 			}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebSocketHandlerRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebSocketHandlerRegistration.java
@@ -45,8 +45,26 @@ public interface WebSocketHandlerRegistration {
 	WebSocketHandlerRegistration addInterceptors(HandshakeInterceptor... interceptors);
 
 	/**
+	 * Configure allowed {@code Origin} header values. This check is mostly designed for browser
+	 * clients. There is noting preventing other types of client to modify the Origin header value.
+	 *
+	 * <p>When SockJS is enabled and allowed origins are restricted, transport types that do not
+	 * use {@code Origin} headers for cross origin requests (jsonp-polling, iframe-xhr-polling,
+	 * iframe-eventsource and iframe-htmlfile) are disabled. As a consequence, IE6/IE7 won't be
+	 * supported anymore and IE8/IE9 will only be supported without cookies.
+	 *
+	 * <p>By default, all origins are allowed.
+	 *
+	 * @since 4.1.2
+	 * @see <a href="https://github.com/sockjs/sockjs-client#supported-transports-by-browser-html-served-from-http-or-https">SockJS supported transports by browser</a>
+	 */
+	WebSocketHandlerRegistration setAllowedOrigins(String... origins);
+
+	/**
 	 * Enable SockJS fallback options.
 	 */
 	SockJsServiceRegistration withSockJS();
+
+
 
 }

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/DefaultHandshakeHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/DefaultHandshakeHandler.java
@@ -260,6 +260,11 @@ public class DefaultHandshakeHandler implements HandshakeHandler {
 				Arrays.asList(StringUtils.arrayToCommaDelimitedString(getSupportedVersions())));
 	}
 
+	/**
+	 * Return whether the request {@code Origin} header value is valid or not.
+	 * By default, all origins as considered as valid. Consider using an
+	 * {@link OriginHandshakeInterceptor} for filtering origins if needed.
+	 */
 	protected boolean isValidOrigin(ServerHttpRequest request) {
 		return true;
 	}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/OriginHandshakeInterceptor.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/OriginHandshakeInterceptor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.socket.server.support;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+/**
+ * An interceptor to check request {@code Origin} header value against a collection of
+ * allowed origins.
+ *
+ * @author Sebastien Deleuze
+ * @since 4.1.2
+ */
+public class OriginHandshakeInterceptor implements HandshakeInterceptor {
+
+	protected Log logger = LogFactory.getLog(getClass());
+
+	private final List<String> allowedOrigins;
+
+
+	/**
+	 * Default constructor with no origin allowed.
+	 */
+	public OriginHandshakeInterceptor() {
+		this.allowedOrigins = new ArrayList<String>();
+	}
+
+	/**
+	 * Use this property to define a collection of allowed origins.
+	 */
+	public void setAllowedOrigins(Collection<String> allowedOrigins) {
+		this.allowedOrigins.clear();
+		if (allowedOrigins != null) {
+			this.allowedOrigins.addAll(allowedOrigins);
+		}
+	}
+
+	@Override
+	public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+			WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+		if(!isValidOrigin(request)) {
+			response.setStatusCode(HttpStatus.FORBIDDEN);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Handshake request rejected, Origin header value "
+						+ request.getHeaders().getOrigin() + " not allowed");
+			}
+			return false;
+		}
+		return true;
+	}
+
+	protected boolean isValidOrigin(ServerHttpRequest request) {
+		return this.allowedOrigins.contains(request.getHeaders().getOrigin());
+	}
+
+	@Override
+	public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+			WebSocketHandler wsHandler, Exception exception) {
+	}
+
+}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/TransportHandlingSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/TransportHandlingSockJsService.java
@@ -207,9 +207,10 @@ public class TransportHandlingSockJsService extends AbstractSockJsService implem
 		HttpMethod supportedMethod = transportType.getHttpMethod();
 		if (!supportedMethod.equals(request.getMethod())) {
 			if (HttpMethod.OPTIONS.equals(request.getMethod()) && transportType.supportsCors()) {
-				response.setStatusCode(HttpStatus.NO_CONTENT);
-				addCorsHeaders(request, response, HttpMethod.OPTIONS, supportedMethod);
-				addCacheHeaders(response);
+				if(checkAndAddCorsHeaders(request, response, HttpMethod.OPTIONS, supportedMethod)) {
+					response.setStatusCode(HttpStatus.NO_CONTENT);
+					addCacheHeaders(response);
+				}
 			}
 			else if (transportType.supportsCors()) {
 				sendMethodNotAllowed(response, supportedMethod, HttpMethod.OPTIONS);
@@ -250,7 +251,9 @@ public class TransportHandlingSockJsService extends AbstractSockJsService implem
 			}
 
 			if (transportType.supportsCors()) {
-				addCorsHeaders(request, response);
+				if(!checkAndAddCorsHeaders(request, response)) {
+					return;
+				}
 			}
 
 			transportHandler.handleRequest(request, response, handler, session);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/TransportType.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/TransportType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,11 +28,12 @@ import org.springframework.http.HttpMethod;
  * SockJS transport types.
  *
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  * @since 4.0
  */
 public enum TransportType {
 
-	WEBSOCKET("websocket", HttpMethod.GET),
+	WEBSOCKET("websocket", HttpMethod.GET, "origin"),
 
 	XHR("xhr", HttpMethod.POST, "cors", "jsessionid", "no_cache"),
 
@@ -89,6 +90,10 @@ public enum TransportType {
 
 	public boolean supportsCors() {
 		return this.headerHints.contains("cors");
+	}
+
+	public boolean supportsOrigin() {
+		return this.headerHints.contains("cors") || this.headerHints.contains("origin");
 	}
 
 	public boolean sendsSessionCookie() {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/HtmlFileTransportHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/HtmlFileTransportHandler.java
@@ -37,7 +37,7 @@ import org.springframework.web.socket.sockjs.transport.session.StreamingSockJsSe
 import org.springframework.web.util.JavaScriptUtils;
 
 /**
- * An HTTP {@link TransportHandler} that uses a famous browsder document.domain technique:
+ * An HTTP {@link TransportHandler} that uses a famous browser document.domain technique:
  * <a href="http://stackoverflow.com/questions/1481251/what-does-document-domain-document-domain-do">
  * http://stackoverflow.com/questions/1481251/what-does-document-domain-document-domain-do</a>
  *

--- a/spring-websocket/src/main/resources/org/springframework/web/socket/config/spring-websocket-4.1.xsd
+++ b/spring-websocket/src/main/resources/org/springframework/web/socket/config/spring-websocket-4.1.xsd
@@ -474,6 +474,24 @@
                 ]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="allowed-origins" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+		Configure allowed {@code Origin} header values. Multiple origins may be specified
+		as a comma-separated list.
+
+		This check is mostly designed for browser clients. There is noting preventing other
+		types of client to modify the Origin header value.
+
+		When SockJS is enabled and allowed origins are restricted, transport types that do not
+		use {@code Origin} headers for cross origin requests (jsonp-polling, iframe-xhr-polling,
+		iframe-eventsource and iframe-htmlfile) are disabled. As a consequence, IE6/IE7 won't be
+		supported anymore and IE8/IE9 will only be supported without cookies.
+
+		By default, all origins are allowed.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -639,6 +657,24 @@
 	A path that maps a particular message destination to a handler method.
 	Exact path mapping URIs (such as "/myPath") are supported as well as Ant-stype path patterns (such as /myPath/**).
                 				]]></xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="allowed-origins" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+		Configure allowed {@code Origin} header values. Multiple origins may be specified
+		as a comma-separated list.
+
+		This check is mostly designed for browser clients. There is noting preventing other
+		types of client to modify the Origin header value.
+
+		When SockJS is enabled and allowed origins are restricted, transport types that do not
+		use {@code Origin} headers for cross origin requests (jsonp-polling, iframe-xhr-polling,
+		iframe-eventsource and iframe-htmlfile) are disabled. As a consequence, IE6/IE7 won't be
+		supported anymore and IE8/IE9 will only be supported without cookies.
+
+		By default, all origins are allowed.
+								]]></xsd:documentation>
 							</xsd:annotation>
 						</xsd:attribute>
 					</xsd:complexType>

--- a/spring-websocket/src/test/java/org/springframework/web/socket/AbstractHttpRequestTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/AbstractHttpRequestTests.java
@@ -54,6 +54,10 @@ public abstract class AbstractHttpRequestTests {
 		this.servletRequest.setRequestURI(requestUri);
 	}
 
+	protected void setOrigin(String origin) {
+		this.servletRequest.addHeader("Origin", origin);
+	}
+
 	protected void resetRequestAndResponse() {
 		resetRequest();
 		resetResponse();

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParserTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParserTests.java
@@ -68,6 +68,7 @@ import org.springframework.web.socket.messaging.StompSubProtocolHandler;
 import org.springframework.web.socket.messaging.SubProtocolWebSocketHandler;
 import org.springframework.web.socket.server.HandshakeHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.socket.server.support.OriginHandshakeInterceptor;
 import org.springframework.web.socket.server.support.WebSocketHttpRequestHandler;
 import org.springframework.web.socket.sockjs.support.SockJsHttpRequestHandler;
 import org.springframework.web.socket.sockjs.transport.TransportType;
@@ -115,7 +116,8 @@ public class MessageBrokerBeanDefinitionParserTests {
 		assertNotNull(handshakeHandler);
 		assertTrue(handshakeHandler instanceof TestHandshakeHandler);
 		List<HandshakeInterceptor> interceptors = wsHttpRequestHandler.getHandshakeInterceptors();
-		assertThat(interceptors, contains(instanceOf(FooTestInterceptor.class), instanceOf(BarTestInterceptor.class)));
+		assertThat(interceptors, contains(instanceOf(FooTestInterceptor.class),
+				instanceOf(BarTestInterceptor.class), instanceOf(OriginHandshakeInterceptor.class)));
 
 		WebSocketSession session = new TestWebSocketSession("id");
 		wsHttpRequestHandler.getWebSocketHandler().afterConnectionEstablished(session);
@@ -158,7 +160,9 @@ public class MessageBrokerBeanDefinitionParserTests {
 		assertTrue(scheduler.getScheduledThreadPoolExecutor().getRemoveOnCancelPolicy());
 
 		interceptors = defaultSockJsService.getHandshakeInterceptors();
-		assertThat(interceptors, contains(instanceOf(FooTestInterceptor.class), instanceOf(BarTestInterceptor.class)));
+		assertThat(interceptors, contains(instanceOf(FooTestInterceptor.class),
+				instanceOf(BarTestInterceptor.class), instanceOf(OriginHandshakeInterceptor.class)));
+		assertEquals(Arrays.asList("http://mydomain3.com", "http://mydomain4.com"), defaultSockJsService.getAllowedOrigins());
 
 		UserSessionRegistry userSessionRegistry = this.appContext.getBean(UserSessionRegistry.class);
 		assertNotNull(userSessionRegistry);

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistrationTests.java
@@ -29,6 +29,7 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.socket.messaging.SubProtocolWebSocketHandler;
+import org.springframework.web.socket.server.support.OriginHandshakeInterceptor;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 import org.springframework.web.socket.server.support.WebSocketHttpRequestHandler;
@@ -70,19 +71,60 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 
 		Map.Entry<HttpRequestHandler, List<String>> entry = mappings.entrySet().iterator().next();
 		assertNotNull(((WebSocketHttpRequestHandler) entry.getKey()).getWebSocketHandler());
+		assertTrue(((WebSocketHttpRequestHandler) entry.getKey()).getHandshakeInterceptors().isEmpty());
 		assertEquals(Arrays.asList("/foo"), entry.getValue());
 	}
 
 	@Test
-	public void handshakeHandlerAndInterceptors() {
+	public void allowedOrigins() {
+		WebMvcStompWebSocketEndpointRegistration registration =
+				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
+
+		registration.setAllowedOrigins("http://mydomain.com");
+
+		MultiValueMap<HttpRequestHandler, String> mappings = registration.getMappings();
+		assertEquals(1, mappings.size());
+		WebSocketHttpRequestHandler requestHandler = (WebSocketHttpRequestHandler)mappings.entrySet().iterator().next().getKey();
+		assertNotNull(requestHandler.getWebSocketHandler());
+		assertEquals(1, requestHandler.getHandshakeInterceptors().size());
+		assertEquals(OriginHandshakeInterceptor.class, requestHandler.getHandshakeInterceptors().get(0).getClass());
+	}
+
+	@Test
+	public void allowedOriginsWithSockJsService() {
+		WebMvcStompWebSocketEndpointRegistration registration =
+				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
+
+		String origin = "http://mydomain.com";
+		registration.setAllowedOrigins(origin).withSockJS();
+
+		MultiValueMap<HttpRequestHandler, String> mappings = registration.getMappings();
+		assertEquals(1, mappings.size());
+		SockJsHttpRequestHandler requestHandler = (SockJsHttpRequestHandler)mappings.entrySet().iterator().next().getKey();
+		assertNotNull(requestHandler.getSockJsService());
+		DefaultSockJsService sockJsService = (DefaultSockJsService)requestHandler.getSockJsService();
+		assertEquals(Arrays.asList(origin), sockJsService.getAllowedOrigins());
+
+		registration =
+				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
+		registration.withSockJS().setAllowedOrigins(origin);
+		mappings = registration.getMappings();
+		assertEquals(1, mappings.size());
+		requestHandler = (SockJsHttpRequestHandler)mappings.entrySet().iterator().next().getKey();
+		assertNotNull(requestHandler.getSockJsService());
+		sockJsService = (DefaultSockJsService)requestHandler.getSockJsService();
+		assertEquals(Arrays.asList(origin), sockJsService.getAllowedOrigins());
+	}
+
+	@Test
+	public void handshakeHandlerAndInterceptor() {
 		WebMvcStompWebSocketEndpointRegistration registration =
 				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
 
 		DefaultHandshakeHandler handshakeHandler = new DefaultHandshakeHandler();
 		HttpSessionHandshakeInterceptor interceptor = new HttpSessionHandshakeInterceptor();
 
-		registration.setHandshakeHandler(handshakeHandler);
-		registration.addInterceptors(interceptor);
+		registration.setHandshakeHandler(handshakeHandler).addInterceptors(interceptor);
 
 		MultiValueMap<HttpRequestHandler, String> mappings = registration.getMappings();
 		assertEquals(1, mappings.size());
@@ -97,16 +139,38 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 	}
 
 	@Test
-	public void handshakeHandlerAndInterceptorsWithSockJsService() {
+	public void handshakeHandlerAndInterceptorWithAllowedOrigins() {
+		WebMvcStompWebSocketEndpointRegistration registration =
+				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
+
+		DefaultHandshakeHandler handshakeHandler = new DefaultHandshakeHandler();
+		HttpSessionHandshakeInterceptor interceptor = new HttpSessionHandshakeInterceptor();
+		String origin = "http://mydomain.com";
+		registration.setHandshakeHandler(handshakeHandler).addInterceptors(interceptor).setAllowedOrigins(origin);
+
+		MultiValueMap<HttpRequestHandler, String> mappings = registration.getMappings();
+		assertEquals(1, mappings.size());
+
+		Map.Entry<HttpRequestHandler, List<String>> entry = mappings.entrySet().iterator().next();
+		assertEquals(Arrays.asList("/foo"), entry.getValue());
+
+		WebSocketHttpRequestHandler requestHandler = (WebSocketHttpRequestHandler) entry.getKey();
+		assertNotNull(requestHandler.getWebSocketHandler());
+		assertSame(handshakeHandler, requestHandler.getHandshakeHandler());
+		assertEquals(2, requestHandler.getHandshakeInterceptors().size());
+		assertEquals(interceptor, requestHandler.getHandshakeInterceptors().get(0));
+		assertEquals(OriginHandshakeInterceptor.class, requestHandler.getHandshakeInterceptors().get(1).getClass());
+	}
+
+	@Test
+	public void handshakeHandlerInterceptorWithSockJsService() {
 		WebMvcStompWebSocketEndpointRegistration registration =
 				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
 
 		DefaultHandshakeHandler handshakeHandler = new DefaultHandshakeHandler();
 		HttpSessionHandshakeInterceptor interceptor = new HttpSessionHandshakeInterceptor();
 
-		registration.setHandshakeHandler(handshakeHandler);
-		registration.addInterceptors(interceptor);
-		registration.withSockJS();
+		registration.setHandshakeHandler(handshakeHandler).addInterceptors(interceptor).withSockJS();
 
 		MultiValueMap<HttpRequestHandler, String> mappings = registration.getMappings();
 		assertEquals(1, mappings.size());
@@ -124,6 +188,39 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 		WebSocketTransportHandler transportHandler = (WebSocketTransportHandler) handlers.get(TransportType.WEBSOCKET);
 		assertSame(handshakeHandler, transportHandler.getHandshakeHandler());
 		assertEquals(Arrays.asList(interceptor), sockJsService.getHandshakeInterceptors());
+	}
+
+	@Test
+	public void handshakeHandlerInterceptorWithSockJsServiceAndAllowedOrigins() {
+		WebMvcStompWebSocketEndpointRegistration registration =
+				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
+
+		DefaultHandshakeHandler handshakeHandler = new DefaultHandshakeHandler();
+		HttpSessionHandshakeInterceptor interceptor = new HttpSessionHandshakeInterceptor();
+		String origin = "http://mydomain.com";
+
+		registration.setHandshakeHandler(handshakeHandler).addInterceptors(interceptor).setAllowedOrigins(origin).withSockJS();
+
+		MultiValueMap<HttpRequestHandler, String> mappings = registration.getMappings();
+		assertEquals(1, mappings.size());
+
+		Map.Entry<HttpRequestHandler, List<String>> entry = mappings.entrySet().iterator().next();
+		assertEquals(Arrays.asList("/foo/**"), entry.getValue());
+
+		SockJsHttpRequestHandler requestHandler = (SockJsHttpRequestHandler) entry.getKey();
+		assertNotNull(requestHandler.getWebSocketHandler());
+
+		DefaultSockJsService sockJsService = (DefaultSockJsService) requestHandler.getSockJsService();
+		assertNotNull(sockJsService);
+
+		Map<TransportType, TransportHandler> handlers = sockJsService.getTransportHandlers();
+		WebSocketTransportHandler transportHandler = (WebSocketTransportHandler) handlers.get(TransportType.WEBSOCKET);
+		assertSame(handshakeHandler, transportHandler.getHandshakeHandler());
+		assertEquals(2, sockJsService.getHandshakeInterceptors().size());
+		assertEquals(interceptor, sockJsService.getHandshakeInterceptors().get(0));
+		assertEquals(OriginHandshakeInterceptor.class,
+				sockJsService.getHandshakeInterceptors().get(1).getClass());
+		assertEquals(Arrays.asList(origin), sockJsService.getAllowedOrigins());
 	}
 
 }

--- a/spring-websocket/src/test/java/org/springframework/web/socket/server/support/AllowedOriginsInterceptorTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/server/support/AllowedOriginsInterceptorTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.socket.server.support;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.socket.AbstractHttpRequestTests;
+import org.springframework.web.socket.WebSocketHandler;
+
+/**
+ * Test fixture for {@link OriginHandshakeInterceptor}.
+ *
+ * @author Sebastien Deleuze
+ */
+public class AllowedOriginsInterceptorTests extends AbstractHttpRequestTests {
+
+	@Test
+	public void originValueMatch() throws Exception {
+		Map<String, Object> attributes = new HashMap<String, Object>();
+		WebSocketHandler wsHandler = Mockito.mock(WebSocketHandler.class);
+		setOrigin("http://mydomain1.com");
+		OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+		interceptor.setAllowedOrigins(Arrays.asList("http://mydomain1.com"));
+		assertTrue(interceptor.beforeHandshake(request, response, wsHandler, attributes));
+		assertNotEquals(servletResponse.getStatus(), HttpStatus.FORBIDDEN.value());
+	}
+
+	@Test
+	public void originValueNoMatch() throws Exception {
+		Map<String, Object> attributes = new HashMap<String, Object>();
+		WebSocketHandler wsHandler = Mockito.mock(WebSocketHandler.class);
+		setOrigin("http://mydomain1.com");
+		OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+		interceptor.setAllowedOrigins(Arrays.asList("http://mydomain2.com"));
+		assertFalse(interceptor.beforeHandshake(request, response, wsHandler, attributes));
+		assertEquals(servletResponse.getStatus(), HttpStatus.FORBIDDEN.value());
+	}
+
+	@Test
+	public void originListMatch() throws Exception {
+		Map<String, Object> attributes = new HashMap<String, Object>();
+		WebSocketHandler wsHandler = Mockito.mock(WebSocketHandler.class);
+		setOrigin("http://mydomain2.com");
+		OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+		interceptor.setAllowedOrigins(Arrays.asList("http://mydomain1.com", "http://mydomain2.com", "http://mydomain3.com"));
+		assertTrue(interceptor.beforeHandshake(request, response, wsHandler, attributes));
+		assertNotEquals(servletResponse.getStatus(), HttpStatus.FORBIDDEN.value());
+	}
+
+	@Test
+	public void originListNoMatch() throws Exception {
+		Map<String, Object> attributes = new HashMap<String, Object>();
+		WebSocketHandler wsHandler = Mockito.mock(WebSocketHandler.class);
+		setOrigin("http://mydomain4.com");
+		OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+		interceptor.setAllowedOrigins(Arrays.asList("http://mydomain1.com", "http://mydomain2.com", "http://mydomain3.com"));
+		assertFalse(interceptor.beforeHandshake(request, response, wsHandler, attributes));
+		assertEquals(servletResponse.getStatus(), HttpStatus.FORBIDDEN.value());
+	}
+
+	@Test
+	public void noOriginNoMatchWithNullHostileCollection() throws Exception {
+		Map<String, Object> attributes = new HashMap<String, Object>();
+		WebSocketHandler wsHandler = Mockito.mock(WebSocketHandler.class);
+		Set<String> allowedOrigins = new ConcurrentSkipListSet<String>();
+		allowedOrigins.add("http://mydomain1.com");
+		OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+		interceptor.setAllowedOrigins(allowedOrigins);
+		assertFalse(interceptor.beforeHandshake(request, response, wsHandler, attributes));
+		assertEquals(servletResponse.getStatus(), HttpStatus.FORBIDDEN.value());
+	}
+
+	@Test
+	 public void noOriginNoMatch() throws Exception {
+		Map<String, Object> attributes = new HashMap<String, Object>();
+		WebSocketHandler wsHandler = Mockito.mock(WebSocketHandler.class);
+		OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor();
+		assertFalse(interceptor.beforeHandshake(request, response, wsHandler, attributes));
+		assertEquals(servletResponse.getStatus(), HttpStatus.FORBIDDEN.value());
+	}
+
+}

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-simple.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-simple.xml
@@ -15,7 +15,7 @@
 			</websocket:decorator-factories>
 		</websocket:transport>
 
-		<websocket:stomp-endpoint path=" /foo,/bar">
+		<websocket:stomp-endpoint path=" /foo,/bar" allowed-origins="http://mydomain1.com,http://mydomain2.com">
 			<websocket:handshake-handler ref="myHandler"/>
 			<websocket:handshake-interceptors>
 				<bean class="org.springframework.web.socket.config.FooTestInterceptor"/>
@@ -23,7 +23,7 @@
 			</websocket:handshake-interceptors>
 		</websocket:stomp-endpoint>
 
-		<websocket:stomp-endpoint path="/test,/sockjs">
+		<websocket:stomp-endpoint path="/test,/sockjs" allowed-origins="http://mydomain3.com,http://mydomain4.com">
 			<websocket:handshake-handler ref="myHandler"/>
 			<websocket:handshake-interceptors>
 				<bean class="org.springframework.web.socket.config.FooTestInterceptor"/>

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-attributes.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-attributes.xml
@@ -5,7 +5,7 @@
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
-	<websocket:handlers order="2">
+	<websocket:handlers order="2" allowed-origins="http://mydomain1.com, http://mydomain2.com">
 		<websocket:mapping path="/foo" handler="fooHandler"/>
 		<websocket:mapping path="/test" handler="testHandler"/>
 		<websocket:handshake-handler ref="testHandshakeHandler"/>

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs-attributes.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs-attributes.xml
@@ -5,7 +5,7 @@
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
-	<websocket:handlers >
+	<websocket:handlers allowed-origins="http://mydomain1.com, http://mydomain2.com">
 		<websocket:mapping path="/test" handler="testHandler"/>
 		<websocket:sockjs name="testSockJsService" scheduler="testTaskScheduler" websocket-enabled="false"
 						  session-cookie-needed="false" stream-bytes-limit="2048" disconnect-delay="256"


### PR DESCRIPTION
This commit introduces a new AllowedOriginInterceptor WebSocket
HandshakeInterceptor. It filters Origin header value against a list of
allowed origins.

AbstractSockJsService as been modified to:
- Reject CORS requests with forbidden origins
- Disable transport types that does not support CORS when an origin check is
  required
- Use the Origin request header value instead of "*" for
  Access-Control-Allow-Origin response header value
  (mandatory when  Access-Control-Allow-Credentials=true)
- Return CORS header only if the request contains an Origin header

It is possible to configure easily this behavior thanks to
StompWebSocketEndpointRegistration#setAllowedOrigins(String...).

Please notice that this commit does not change the default behavior:
cross origin requests are enabled by default.

XML namespace configuration is not included yet, I plan to add it when this PR will be reviewed.

Issues: [SPR-12226](https://jira.spring.io/browse/SPR-12226)
