### PR TITLE
Fix First invocation of org.springframework.core.task.AsyncListenableTaskExecutor executes in same thread as caller

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFutureCallbackRegistry.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFutureCallbackRegistry.java
@@ -48,7 +48,7 @@ public class ListenableFutureCallbackRegistry<T> {
 	 * @param callback the callback to add
 	 */
 	@SuppressWarnings("unchecked")
-	public void addCallback(ListenableFutureCallback<? super T> callback) {
+	public void addCallback(final ListenableFutureCallback<? super T> callback) {
 		Assert.notNull(callback, "'callback' must not be null");
 		synchronized (this.mutex) {
 			switch (this.state) {
@@ -57,10 +57,20 @@ public class ListenableFutureCallbackRegistry<T> {
 					this.failureCallbacks.add(callback);
 					break;
 				case SUCCESS:
-					callback.onSuccess((T) this.result);
+					final T finalResult = (T)this.result;
+					new Thread(new Runnable() {
+						public void run() {
+							callback.onSuccess(finalResult);
+						}
+					}).start();					
 					break;
 				case FAILURE:
-					callback.onFailure((Throwable) this.result);
+					final Throwable finalThrowable = (Throwable)this.result;
+					new Thread(new Runnable() {
+						public void run() {
+							callback.onFailure(finalThrowable);
+						}
+					}).start();					
 					break;
 			}
 		}
@@ -72,7 +82,7 @@ public class ListenableFutureCallbackRegistry<T> {
 	 * @since 4.1
 	 */
 	@SuppressWarnings("unchecked")
-	public void addSuccessCallback(SuccessCallback<? super T> callback) {
+	public void addSuccessCallback(final SuccessCallback<? super T> callback) {
 		Assert.notNull(callback, "'callback' must not be null");
 		synchronized (this.mutex) {
 			switch (this.state) {
@@ -80,7 +90,12 @@ public class ListenableFutureCallbackRegistry<T> {
 					this.successCallbacks.add(callback);
 					break;
 				case SUCCESS:
-					callback.onSuccess((T) this.result);
+					final T finalResult = (T)this.result;
+					new Thread(new Runnable() {
+						public void run() {
+							callback.onSuccess(finalResult);
+						}
+					}).start();
 					break;
 			}
 		}
@@ -91,8 +106,7 @@ public class ListenableFutureCallbackRegistry<T> {
 	 * @param callback the failure callback to add
 	 * @since 4.1
 	 */
-	@SuppressWarnings("unchecked")
-	public void addFailureCallback(FailureCallback callback) {
+	public void addFailureCallback(final FailureCallback callback) {
 		Assert.notNull(callback, "'callback' must not be null");
 		synchronized (this.mutex) {
 			switch (this.state) {
@@ -100,7 +114,12 @@ public class ListenableFutureCallbackRegistry<T> {
 					this.failureCallbacks.add(callback);
 					break;
 				case FAILURE:
-					callback.onFailure((Throwable) this.result);
+					final Throwable finalThrowable = (Throwable)this.result;
+					new Thread(new Runnable() {
+						public void run() {
+							callback.onFailure(finalThrowable);
+						}
+					}).start();
 					break;
 			}
 		}


### PR DESCRIPTION
With relation to SPR-12358, as Juergen Hoeller and Sébastien Deleuze commented in the Spring JIRA, adding a special delay time in the executor looks enough. We can think that the thread in the AsyncTaskExecutor will call callback method. But if a developer puts pretty much time spending code block between AsyncTaskExecutor's submitListenable and ListenableFuture's addCallback, that will not be enough. It might be the same problem.
So I slightly changed ListenableFutureCallbackRegistry.java in order to run a callback in a new thread when AsyncTask is already finished. At least this will prevent being blocked.

Issue: SPR-12358

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
