### PR TITLE
[SPR 12363] org.springframework.ui.ModelMap.mergeAttributes(Map) makes inefficient use of keySet iterator instead of entrySet iterator

### DIFF
--- a/spring-context/src/main/java/org/springframework/ui/ModelMap.java
+++ b/spring-context/src/main/java/org/springframework/ui/ModelMap.java
@@ -129,6 +129,7 @@ public class ModelMap extends LinkedHashMap<String, Object> {
 		if (attributes != null) {
 			for (Map.Entry<String, ?> attributeEntry : attributes.entrySet()) {
 				String attributeKey = attributeEntry.getKey();
+				
 				if (!containsKey(attributeKey)) {
 					put(attributeKey, attributeEntry.getValue());
 				}

--- a/spring-context/src/main/java/org/springframework/ui/ModelMap.java
+++ b/spring-context/src/main/java/org/springframework/ui/ModelMap.java
@@ -127,9 +127,10 @@ public class ModelMap extends LinkedHashMap<String, Object> {
 	 */
 	public ModelMap mergeAttributes(Map<String, ?> attributes) {
 		if (attributes != null) {
-			for (String key : attributes.keySet()) {
-				if (!containsKey(key)) {
-					put(key, attributes.get(key));
+			for (Map.Entry<String, ?> attributeEntry : attributes.entrySet()) {
+				String attributeKey = attributeEntry.getKey();
+				if (!containsKey(attributeKey)) {
+					put(attributeKey, attributeEntry.getValue());
 				}
 			}
 		}


### PR DESCRIPTION
It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.
Test is ModelMapTests.java
@Test
public void testMergeMapWithOverriding() throws Exception {
Map beans = new HashMap();
beans.put("one", new TestBean("one"));
beans.put("two", new TestBean("two"));
beans.put("three", new TestBean("three"));
ModelMap model = new ModelMap();
model.put("one", new TestBean("oneOld"));
model.mergeAttributes(beans);
assertEquals(3, model.size());
assertEquals("oneOld", ((TestBean) model.get("one")).getName());
}
