### PR TITLE
Some methods in the org.springframework.core.task.AsyncListenableTaskExecutor class need to be added.

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/scheduling/commonj/WorkManagerTaskExecutor.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/commonj/WorkManagerTaskExecutor.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
+
 import javax.naming.NamingException;
 
 import commonj.work.Work;
@@ -36,8 +37,11 @@ import org.springframework.jndi.JndiLocatorSupport;
 import org.springframework.scheduling.SchedulingException;
 import org.springframework.scheduling.SchedulingTaskExecutor;
 import org.springframework.util.Assert;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.ListenableFutureTask;
+import org.springframework.util.concurrent.SuccessCallback;
 
 /**
  * TaskExecutor implementation that delegates to a CommonJ WorkManager,
@@ -168,6 +172,23 @@ public class WorkManagerTaskExecutor extends JndiLocatorSupport
 		execute(future);
 		return future;
 	}
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task, ListenableFutureCallback<T> callback) {
+		ListenableFutureTask<T> future = new ListenableFutureTask<T>(task);
+		future.addCallback(callback);
+		execute(future);
+		return future;
+	}	
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task,
+			SuccessCallback<T> successCallback, FailureCallback failureCallback) {
+		ListenableFutureTask<T> future = new ListenableFutureTask<T>(task);
+		future.addCallback(successCallback, failureCallback);
+		execute(future);
+		return future;
+	}	
 
 	/**
 	 * This task executor prefers short-lived work units.

--- a/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SimpleThreadPoolTaskExecutor.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SimpleThreadPoolTaskExecutor.java
@@ -22,15 +22,17 @@ import java.util.concurrent.FutureTask;
 
 import org.quartz.SchedulerConfigException;
 import org.quartz.simpl.SimpleThreadPool;
-
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.task.AsyncListenableTaskExecutor;
 import org.springframework.scheduling.SchedulingException;
 import org.springframework.scheduling.SchedulingTaskExecutor;
 import org.springframework.util.Assert;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.ListenableFutureTask;
+import org.springframework.util.concurrent.SuccessCallback;
 
 /**
  * Subclass of Quartz's SimpleThreadPool that implements Spring's
@@ -108,6 +110,23 @@ public class SimpleThreadPoolTaskExecutor extends SimpleThreadPool
 		execute(future);
 		return future;
 	}
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task, ListenableFutureCallback<T> callback) {
+		ListenableFutureTask<T> future = new ListenableFutureTask<T>(task);
+		future.addCallback(callback);		
+		execute(future);
+		return future;
+	}	
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task,
+			SuccessCallback<T> successCallback, FailureCallback failureCallback) {
+		ListenableFutureTask<T> future = new ListenableFutureTask<T>(task);
+		future.addCallback(successCallback, failureCallback);
+		execute(future);
+		return future;
+	}	
 
 	/**
 	 * This task executor prefers short-lived work units.

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ConcurrentTaskExecutor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ConcurrentTaskExecutor.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
 import javax.enterprise.concurrent.ManagedExecutors;
 import javax.enterprise.concurrent.ManagedTask;
 
@@ -30,7 +31,10 @@ import org.springframework.core.task.support.TaskExecutorAdapter;
 import org.springframework.scheduling.SchedulingAwareRunnable;
 import org.springframework.scheduling.SchedulingTaskExecutor;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.util.concurrent.SuccessCallback;
 
 /**
  * Adapter that takes a {@code java.util.concurrent.Executor} and exposes
@@ -157,6 +161,17 @@ public class ConcurrentTaskExecutor implements AsyncListenableTaskExecutor, Sche
 	public <T> ListenableFuture<T> submitListenable(Callable<T> task) {
 		return this.adaptedExecutor.submitListenable(task);
 	}
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task, ListenableFutureCallback<T> callback) {
+		return this.adaptedExecutor.submitListenable(task, callback);
+	}	
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task,
+			SuccessCallback<T> successCallback, FailureCallback failureCallback) {
+		return this.adaptedExecutor.submitListenable(task, successCallback, failureCallback);	
+	}	
 
 	/**
 	 * This task executor prefers short-lived work units.
@@ -203,6 +218,12 @@ public class ConcurrentTaskExecutor implements AsyncListenableTaskExecutor, Sche
 		public <T> ListenableFuture<T> submitListenable(Callable<T> task) {
 			return super.submitListenable(ManagedTaskBuilder.buildManagedTask(task, task.toString()));
 		}
+		
+		@Override
+		public <T> ListenableFuture<T> submitListenable(Callable<T> task,
+				SuccessCallback<T> success, FailureCallback failure) {
+			return super.submitListenable(ManagedTaskBuilder.buildManagedTask(task, task.toString()), success, failure);
+		}		
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/task/AsyncListenableTaskExecutor.java
+++ b/spring-core/src/main/java/org/springframework/core/task/AsyncListenableTaskExecutor.java
@@ -18,7 +18,10 @@ package org.springframework.core.task;
 
 import java.util.concurrent.Callable;
 
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.util.concurrent.SuccessCallback;
 
 /**
  * Extension of the {@link AsyncTaskExecutor} interface, adding the capability to submit
@@ -38,15 +41,43 @@ public interface AsyncListenableTaskExecutor extends AsyncTaskExecutor {
 	 * @throws TaskRejectedException if the given task was not accepted
 	 */
 	ListenableFuture<?> submitListenable(Runnable task);
-
+	
 	/**
 	 * Submit a {@code Callable} task for execution, receiving a {@code ListenableFuture}
 	 * representing that task. The Future will return the Callable's result upon
 	 * completion.
+	 * @param <T>
 	 * @param task the {@code Callable} to execute (never {@code null})
 	 * @return a {@code ListenableFuture} representing pending completion of the task
 	 * @throws TaskRejectedException if the given task was not accepted
 	 */
 	<T> ListenableFuture<T> submitListenable(Callable<T> task);
+	
+	/**
+	 * Add a callback to be executed after task completion and
+	 * Submit a {@code Callable} task for execution, receiving a {@code ListenableFuture}
+	 * representing that task. The Future will return the Callable's result upon
+	 * completion.
+	 * @param <T>
+	 * @param task the {@code Callable} to execute (never {@code null})
+	 * @param callback the {@code ListenableFutureCallback} to be executed after task completion
+	 * @return a {@code ListenableFuture} representing pending completion of the task
+	 * @throws TaskRejectedException if the given task was not accepted
+	 */
+	<T> ListenableFuture<T> submitListenable(Callable<T> task, ListenableFutureCallback<T> callback);
+	
+	/**
+	 * Add a successCallback and a failureCallback to be executed after task completion and
+	 * Submit a {@code Callable} task for execution, receiving a {@code ListenableFuture}
+	 * representing that task. The Future will return the Callable's result upon
+	 * completion.
+	 * @param <T>
+	 * @param task the {@code Callable} to execute (never {@code null})
+	 * @param successCallback the {@code SuccessCallback} to be executed after task success
+	 * @param failureCallback the {@code FailureCallback} to be executed after task failure
+	 * @return a {@code ListenableFuture} representing pending completion of the task
+	 * @throws TaskRejectedException if the given task was not accepted
+	 */	
+	<T> ListenableFuture<T> submitListenable(Callable<T> task, SuccessCallback<T> successCallback, FailureCallback failureCallback);	
 
 }

--- a/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
+++ b/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
@@ -25,8 +25,11 @@ import java.util.concurrent.ThreadFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.ConcurrencyThrottleSupport;
 import org.springframework.util.CustomizableThreadCreator;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.ListenableFutureTask;
+import org.springframework.util.concurrent.SuccessCallback;
 
 /**
  * {@link TaskExecutor} implementation that fires up a new Thread for each task,
@@ -199,6 +202,23 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator implement
 		execute(future, TIMEOUT_INDEFINITE);
 		return future;
 	}
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task, ListenableFutureCallback<T> callback) {
+		ListenableFutureTask<T> future = new ListenableFutureTask<T>(task);
+		future.addCallback(callback);		
+		execute(future, TIMEOUT_INDEFINITE);
+		return future;
+	}	
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task,
+			SuccessCallback<T> successCallback, FailureCallback failureCallback) {
+		ListenableFutureTask<T> future = new ListenableFutureTask<T>(task);
+		future.addCallback(successCallback, failureCallback);
+		execute(future, TIMEOUT_INDEFINITE);
+		return future;
+	}	
 
 	/**
 	 * Template method for the actual execution of a task.

--- a/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFutureCallbackRegistry.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/ListenableFutureCallbackRegistry.java
@@ -48,7 +48,7 @@ public class ListenableFutureCallbackRegistry<T> {
 	 * @param callback the callback to add
 	 */
 	@SuppressWarnings("unchecked")
-	public void addCallback(ListenableFutureCallback<? super T> callback) {
+	public void addCallback(final ListenableFutureCallback<? super T> callback) {
 		Assert.notNull(callback, "'callback' must not be null");
 		synchronized (this.mutex) {
 			switch (this.state) {
@@ -57,10 +57,20 @@ public class ListenableFutureCallbackRegistry<T> {
 					this.failureCallbacks.add(callback);
 					break;
 				case SUCCESS:
-					callback.onSuccess((T) this.result);
+					final T finalResult = (T)this.result;
+					new Thread(new Runnable() {
+						public void run() {
+							callback.onSuccess(finalResult);
+						}
+					}).start();					
 					break;
 				case FAILURE:
-					callback.onFailure((Throwable) this.result);
+					final Throwable finalThrowable = (Throwable)this.result;
+					new Thread(new Runnable() {
+						public void run() {
+							callback.onFailure(finalThrowable);
+						}
+					}).start();					
 					break;
 			}
 		}
@@ -72,7 +82,7 @@ public class ListenableFutureCallbackRegistry<T> {
 	 * @since 4.1
 	 */
 	@SuppressWarnings("unchecked")
-	public void addSuccessCallback(SuccessCallback<? super T> callback) {
+	public void addSuccessCallback(final SuccessCallback<? super T> callback) {
 		Assert.notNull(callback, "'callback' must not be null");
 		synchronized (this.mutex) {
 			switch (this.state) {
@@ -80,7 +90,12 @@ public class ListenableFutureCallbackRegistry<T> {
 					this.successCallbacks.add(callback);
 					break;
 				case SUCCESS:
-					callback.onSuccess((T) this.result);
+					final T finalResult = (T)this.result;
+					new Thread(new Runnable() {
+						public void run() {
+							callback.onSuccess(finalResult);
+						}
+					}).start();
 					break;
 			}
 		}
@@ -91,8 +106,7 @@ public class ListenableFutureCallbackRegistry<T> {
 	 * @param callback the failure callback to add
 	 * @since 4.1
 	 */
-	@SuppressWarnings("unchecked")
-	public void addFailureCallback(FailureCallback callback) {
+	public void addFailureCallback(final FailureCallback callback) {
 		Assert.notNull(callback, "'callback' must not be null");
 		synchronized (this.mutex) {
 			switch (this.state) {
@@ -100,7 +114,12 @@ public class ListenableFutureCallbackRegistry<T> {
 					this.failureCallbacks.add(callback);
 					break;
 				case FAILURE:
-					callback.onFailure((Throwable) this.result);
+					final Throwable finalThrowable = (Throwable)this.result;
+					new Thread(new Runnable() {
+						public void run() {
+							callback.onFailure(finalThrowable);
+						}
+					}).start();
 					break;
 			}
 		}

--- a/spring-tx/src/main/java/org/springframework/jca/work/WorkManagerTaskExecutor.java
+++ b/spring-tx/src/main/java/org/springframework/jca/work/WorkManagerTaskExecutor.java
@@ -19,6 +19,7 @@ package org.springframework.jca.work;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
+
 import javax.naming.NamingException;
 import javax.resource.spi.BootstrapContext;
 import javax.resource.spi.work.ExecutionContext;
@@ -37,8 +38,11 @@ import org.springframework.jndi.JndiLocatorSupport;
 import org.springframework.scheduling.SchedulingException;
 import org.springframework.scheduling.SchedulingTaskExecutor;
 import org.springframework.util.Assert;
+import org.springframework.util.concurrent.FailureCallback;
 import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
 import org.springframework.util.concurrent.ListenableFutureTask;
+import org.springframework.util.concurrent.SuccessCallback;
 
 /**
  * {@link org.springframework.core.task.TaskExecutor} implementation
@@ -266,6 +270,23 @@ public class WorkManagerTaskExecutor extends JndiLocatorSupport
 		execute(future, TIMEOUT_INDEFINITE);
 		return future;
 	}
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task, ListenableFutureCallback<T> callback) {
+		ListenableFutureTask<T> future = new ListenableFutureTask<T>(task);
+		future.addCallback(callback);
+		execute(future, TIMEOUT_INDEFINITE);
+		return future;
+	}	
+	
+	@Override
+	public <T> ListenableFuture<T> submitListenable(Callable<T> task,
+			SuccessCallback<T> successCallback, FailureCallback failureCallback) {
+		ListenableFutureTask<T> future = new ListenableFutureTask<T>(task);
+		future.addCallback(successCallback, failureCallback);
+		execute(future, TIMEOUT_INDEFINITE);
+		return future;
+	}	
 
 	/**
 	 * This task executor prefers short-lived work units.


### PR DESCRIPTION
org.springframework.core.task.AsyncListenableTaskExecutor has submitListenable(Callable<T>) method.
This return ListenableFuture object after
ListenableFutureTask.execute(ListenableFutureTask future).
As Juergen Hoeller mentioned in the
SPR-12358(https://jira.spring.io/i#browse/SPR-12358),
if the async task has already been fully executed at the time of the
addCallback call,
Spring's ListenableFutureCallbackRegistry is executing the callback in
the caller's thread
since the async thread can't be used for it anymore.
I think AsyncListenableTaskExecutor is needed to be improved in order to
add callback
before ListenableFutureTask.execute(ListenableFutureTask future) method
is called.

ISSUE : SPR-12364

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
