### PR TITLE
The filed PropertyDescriptor in the org.springframework.beans.PropertyValue needs to be transient to avoid serialization and deserialization failure in case of resolvedDescriptor in the PropertyValue is not null.

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/PropertyValue.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyValue.java
@@ -61,7 +61,7 @@ public class PropertyValue extends BeanMetadataAttributeAccessor implements Seri
 	volatile Object resolvedTokens;
 
 	/** Package-visible field for caching the resolved PropertyDescriptor */
-	volatile PropertyDescriptor resolvedDescriptor;
+	transient volatile PropertyDescriptor resolvedDescriptor;
 
 
 	/**

--- a/spring-beans/src/test/java/org/springframework/beans/PropertyValueTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/PropertyValueTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * 
+ * @author JongMin Moon
+ * @since 4.1
+ */
+public class PropertyValueTests implements Serializable {
+
+	boolean serializable;
+
+	@Test
+	public void testSerializableWithPropertyDescriptor() throws Exception {
+		PropertyValue value = new PropertyValue("a", "b");
+		value.resolvedDescriptor = new PropertyDescriptor("serializable",
+				PropertyValueTests.class);
+
+		PropertyValue value2 = serializeAndDeserialize(value);
+		assertEquals(value.getName(), value2.getName());
+		assertEquals(value.getValue(), value2.getValue());
+	}
+
+	@Test
+	public void testSerializableWithSubPropertyDescriptor() throws Exception {
+		PropertyValue value = new PropertyValue("a", "b");
+		value.resolvedDescriptor = new SubPropertyDescriptor("serializable",
+				PropertyValueTests.class);
+
+		PropertyValue value2 = serializeAndDeserialize(value);
+		assertEquals(value.getName(), value2.getName());
+		assertEquals(value.getValue(), value2.getValue());
+	}
+
+	private PropertyValue serializeAndDeserialize(PropertyValue value) throws Exception {
+		String filename = "PropertyValue.ser";
+		new File(filename).delete(); // before test, just try to delete.
+
+		// save the object to file
+		FileOutputStream fos = null;
+		ObjectOutputStream out = null;
+		try {
+			fos = new FileOutputStream(filename);
+			out = new ObjectOutputStream(fos);
+			out.writeObject(value);
+		}
+		catch (Exception ex) {
+			ex.printStackTrace();
+			new File(filename).delete();
+			throw ex;
+		}
+		finally {
+			if (out != null) {
+				try {
+					out.close();
+				}
+				catch (Exception ignore) {
+				}
+			}
+		}
+		// read the object from file
+		FileInputStream fis = null;
+		ObjectInputStream in = null;
+		PropertyValue value2;
+		try {
+			fis = new FileInputStream(filename);
+			in = new ObjectInputStream(fis);
+			value2 = (PropertyValue) in.readObject();
+		}
+		catch (Exception ex) {
+			ex.printStackTrace();
+			throw ex;
+		}
+		finally {
+			new File(filename).delete();
+			if (in != null) {
+				try {
+					in.close();
+				}
+				catch (Exception ignore) {
+				}
+			}
+		}
+		return value2;
+	}
+
+	public boolean isSerializable() {
+		return true;
+	}
+
+	public void setSerializable(boolean serializable) {
+		this.serializable = serializable;
+	}
+
+	public class SubPropertyDescriptor extends PropertyDescriptor implements Serializable {
+
+		public SubPropertyDescriptor(String propertyName, Class<?> beanClass)
+				throws IntrospectionException {
+			super(propertyName, beanClass);
+		}
+
+		public SubPropertyDescriptor() throws IntrospectionException {
+			// There is no-args constructor in the PropertyDescriptor.
+			super("serializable", PropertyValueTests.class);
+		}
+
+	}
+
+}


### PR DESCRIPTION
org.springframework.beans.PropertyValue is Serializable and has a member PropertyDescriptor.
Even though threre is little possible to have a Exception when serialization and deSerialization
because the access modifier of PropertyDescriptor is defualt,
PropertyDescriptor needs to be transient.

1) Case 1
create a PropertyValue Object. then set resolvedDescriptor in the org.springframework.beans package then try to serialize value object.

PropertyValue value = new PropertyValue("a", "b");
value.resolvedDescriptor = new PropertyDescriptor("serializable", PropertyValueTests.class);

in this case PropertyDescriptor is not a Serializable class, when writeObject(value) is called,
Exception occurs like below as you know.

java.io.NotSerializableException: java.beans.PropertyDescriptor
    at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
    at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
    at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
    at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
  ...

2) Case 2
For avoiding serialization failure, make SubPropertyDescriptor which is serializable.

PropertyValue value = new PropertyValue("a", "b");
value.resolvedDescriptor = new SubPropertyDescriptor("serializable", PropertyValueTests.class);

```
public class SubPropertyDescriptor extends PropertyDescriptor implements Serializable {

    public SubPropertyDescriptor(String propertyName, Class<?> beanClass)
            throws IntrospectionException {
        super(propertyName, beanClass);
    }

    public SubPropertyDescriptor() throws IntrospectionException {
        // There is no-args constructor in the PropertyDescriptor.
        super("serializable", PropertyValueTests.class);
    }

}
```

in this case SubPropertyDescriptor is a Serializable class, so serialization is successful.
But when ObjectInputStream.readObject is called for deSerialization,
Exception occurs like below as you know because the parent class PropertyDescriptor does not have
no-args default constructor.

java.io.InvalidClassException: org.springframework.beans.PropertyValueTests$SubPropertyDescriptor; no valid constructor
    at java.io.ObjectStreamClass$ExceptionInfo.newInvalidClassException(ObjectStreamClass.java:150)
    at java.io.ObjectStreamClass.checkDeserialize(ObjectStreamClass.java:768)
    at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1775)
    ...

So, I think the filed PropertyDescriptor in the org.springframework.beans.PropertyValue needs to be transient.

ISSUE : SPR-12377

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
