### PR TITLE
org.springframework.oxm.xmlbeans.XmlOptionsFactoryBean.setOptions(Map)

### DIFF
--- a/spring-oxm/src/main/java/org/springframework/oxm/xmlbeans/XmlOptionsFactoryBean.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/xmlbeans/XmlOptionsFactoryBean.java
@@ -51,8 +51,9 @@ public class XmlOptionsFactoryBean implements FactoryBean<XmlOptions> {
 	public void setOptions(Map<String, ?> optionsMap) {
 		this.xmlOptions = new XmlOptions();
 		if (optionsMap != null) {
-			for (String option : optionsMap.keySet()) {
-				this.xmlOptions.put(option, optionsMap.get(option));
+			for (Map.Entry<String, ?> optionEntry : optionsMap.entrySet()) {
+				String optionKey = optionEntry.getKey();
+				this.xmlOptions.put(optionKey, optionEntry.getValue());
 			}
 		}
 	}


### PR DESCRIPTION
It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.

Issue : SPR-12383

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
