### PR TITLE
AutowireUtils$ObjectFactoryDelegatingInvocationHandler.invoke() Parameter value must be null check. 

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
@@ -50,7 +50,7 @@ import org.springframework.util.ReflectionUtils;
  * migrate to {@code ShadowMatch.getVariablesInvolvedInRuntimeTest()}
  * or some similar operation.
  *
- * <p>See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=151593"/>.
+ * <p>See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=151593"/>related data</a>
  *
  * @author Adrian Colyer
  * @author Ramnivas Laddad

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
@@ -291,6 +291,10 @@ abstract class AutowireUtils {
 
 		@Override
 		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			Assert.notNull(proxy, "proxy must not be null");
+			Assert.notNull(method, "method must not be null");
+			Assert.notNull(args, "Argument array must not be null");
+			
 			String methodName = method.getName();
 			if (methodName.equals("equals")) {
 				// Only consider equal when proxies are identical.

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
@@ -67,7 +67,7 @@ abstract class AutowireUtils {
 				}
 				int c1pl = c1.getParameterTypes().length;
 				int c2pl = c2.getParameterTypes().length;
-				return (new Integer(c1pl)).compareTo(c2pl) * -1;
+				return (Integer.valueOf(c1pl)).compareTo(c2pl) * -1;
 			}
 		});
 	}


### PR DESCRIPTION
In AutowireUtils$ObjectFactoryDelegatingInvocationHandler.invoke(Object proxy, Method method, Object[] args) 
Parameter value must be null check. 
Otherwise, NPE will occur.
So, I added this

Assert.notNull(proxy, "proxy must not be null");
Assert.notNull(method, "method must not be null");
Assert.notNull(args, "Argument array must not be null");
