### PR TITLE
In, AutowireUtils.sortConstructors(), Using valueOf is faster than using constructor

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
@@ -50,7 +50,7 @@ import org.springframework.util.ReflectionUtils;
  * migrate to {@code ShadowMatch.getVariablesInvolvedInRuntimeTest()}
  * or some similar operation.
  *
- * <p>See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=151593"/>.
+ * <p>See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=151593"/>related data</a>
  *
  * @author Adrian Colyer
  * @author Ramnivas Laddad

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
@@ -90,7 +90,7 @@ abstract class AutowireUtils {
 				}
 				int c1pl = fm1.getParameterTypes().length;
 				int c2pl = fm2.getParameterTypes().length;
-				return (new Integer(c1pl)).compareTo(c2pl) * -1;
+				return (Integer.valueOf(c1pl)).compareTo(c2pl) * -1;
 			}
 		});
 	}


### PR DESCRIPTION
Using valueOf is approximately 3.5 times faster than using constructor

Because Using new Integer(int) is guaranteed to always result in a new object whereas Integer.valueOf(int) allows caching of values to be done by the compiler, class library, or JVM.

So, I changed source like(70line) this
return (new Integer(c1pl)).compareTo(c2pl) \* -1;
==> return (Integer.valueOf(c1pl)).compareTo(c2pl) \* -1;
