### PR TITLE
CharacterEditor.setAsText() and setAsUnicode(), Using valueOf is faster than using constructor

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
@@ -50,7 +50,7 @@ import org.springframework.util.ReflectionUtils;
  * migrate to {@code ShadowMatch.getVariablesInvolvedInRuntimeTest()}
  * or some similar operation.
  *
- * <p>See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=151593"/>.
+ * <p>See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=151593"/>related data</a>
  *
  * @author Adrian Colyer
  * @author Ramnivas Laddad

--- a/spring-beans/src/main/java/org/springframework/beans/propertyeditors/CharacterEditor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/propertyeditors/CharacterEditor.java
@@ -86,7 +86,7 @@ public class CharacterEditor extends PropertyEditorSupport {
 					text.length() + " cannot be converted to char type");
 		}
 		else {
-			setValue(new Character(text.charAt(0)));
+			setValue(Character.valueOf(text.charAt(0)));
 		}
 	}
 
@@ -103,7 +103,7 @@ public class CharacterEditor extends PropertyEditorSupport {
 
 	private void setAsUnicode(String text) {
 		int code = Integer.parseInt(text.substring(UNICODE_PREFIX.length()), 16);
-		setValue(new Character((char) code));
+		setValue(Character.valueOf((char) code));
 	}
 
 }


### PR DESCRIPTION
The java.lang.Character.valueOf(char c) returns a Character instance representing the specified char value. If a new Character instance is not required, this method should generally be used in preference to the constructor Character(char), as this method is likely to yield significantly better space and time performance by caching frequently requested values.

This method will always cache values in the range '\u0000' to '\u007F', inclusive, and may cache other values outside of this range.

So I changed source like this

setValue(new Character(text.charAt(0)));
-> setValue(Character.valueOf(text.charAt(0)));

setValue(new Character((char)code));
-> setValue(Character.valueOf((char) code));
