### PR TITLE
Adapter ScrollableResults -> Spliterator

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/FixedBatchSpliteratorBase.java
+++ b/spring-core/src/main/java/org/springframework/util/FixedBatchSpliteratorBase.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.util;
+
+import static java.util.Spliterators.spliterator;
+
+import java.util.Comparator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+import org.springframework.lang.UsesJava8;
+
+/**
+ * An abstract {@code Spliterator} which implements {@link #trySplit} such that batches of
+ * configurable size are produced. Each batch will be a strict prefix of this
+ * spliterator's remaining elements.
+ * <p>
+ * An extending class need only implement {@link #tryAdvance(java.util.function.Consumer)
+ * tryAdvance()}. The extending class may also override
+ * {@link #forEachRemaining(java.util.function.Consumer) forEach()} if it can provide a
+ * more performant implementation.
+ *
+ * @apiNote This class is a useful aid for creating spliterators from I/O-based or other
+ *          sequential data sources. The sequential nature of the source precludes
+ *          ballanced parallel computation; however, good parallelism can be achieved by
+ *          providing a batch size such that the processing of one batch takes 1-10
+ *          milliseconds. Fetching the data from the spliterator is an essentially
+ *          sequential operation, therefore parallelization can help performance only as
+ *          long as the time to fetch an element is negligible compared to the CPU time
+ *          needed to process it divided by the level of parallelism.
+ *
+ * @param <T> the type of elements produced by this spliterator
+ * @author Marko Topolnik
+ * @since 4.2
+ */
+@UsesJava8
+public abstract class FixedBatchSpliteratorBase<T> implements Spliterator<T> {
+
+	public static final int DEFAULT_BATCH_SIZE = 64;
+
+	private final int batchSize;
+
+	private final int characteristics;
+
+	private long est;
+
+	/**
+	 * Creates a spliterator which will split off its strict prefix in batches of the
+	 * given size and report the given characteristics and estimated size.
+	 *
+	 * @param additionalCharacteristics properties of this spliterator's source of
+	 *        elements. If {@link #SIZED SIZED} is reported then this spliterator will
+	 *        additionally report {@link #SUBSIZED SUBSIZED}.
+	 * @param batchSize the size of the batches which will be split off this spliterator
+	 * @param est the estimated size of this spliterator if known, otherwise
+	 *        {@code Long.MAX_VALUE}
+	 */
+	protected FixedBatchSpliteratorBase(int additionalCharacteristics, int batchSize, long est) {
+        this.characteristics = ((additionalCharacteristics & SIZED) != 0)
+        		? additionalCharacteristics | SUBSIZED
+        		: additionalCharacteristics;
+		this.batchSize = batchSize;
+		this.est = est;
+	}
+
+	/**
+	 * Creates a spliterator of unknown size which will split off its strict prefix in
+	 * batches of the given size and report the given characteristics.
+	 *
+	 * @param additionalCharacteristics properties of this spliterator's source of
+	 *        elements. If {@link #SIZED SIZED} is reported then this spliterator will
+	 *        additionally report {@link #SUBSIZED SUBSIZED}.
+	 * @param batchSize the size of the batches which will be split off this spliterator
+	 */
+	protected FixedBatchSpliteratorBase(int additionalCharacteristics, int batchSize) {
+		this(additionalCharacteristics, batchSize, Long.MAX_VALUE);
+	}
+
+	/**
+	 * Creates a spliterator of unknown size which will split off its strict prefix in
+	 * batches of {@link #DEFAULT_BATCH_SIZE} and report the given characteristics.
+	 *
+	 * @param additionalCharacteristics properties of this spliterator's source of
+	 *        elements. If {@link #SIZED SIZED} is reported then this spliterator will
+	 *        additionally report {@link #SUBSIZED SUBSIZED}.
+	 */
+	protected FixedBatchSpliteratorBase(int additionalCharacteristics) {
+		this(additionalCharacteristics, 64, Long.MAX_VALUE);
+	}
+
+    /**
+	 * {@inheritDoc}
+	 * <p>
+	 * This implementation permits good parallel speedup provided that:
+	 * <ol>
+	 * <li>time taken by {@code tryAdvance()} to fetch one element is negligible compared
+	 * to the time needed to process it in the stream pipeline divided by the level of
+	 * parallelism;
+	 * <li>the batch size is appropriately chosen such that the processing of one batch
+	 * takes about 1 to 10 milliseconds.</li>
+	 * </ol>
+	 */
+	@Override
+	public Spliterator<T> trySplit() {
+		final HoldingConsumer<T> holder = new HoldingConsumer<T>();
+		if (!tryAdvance(holder)) {
+			return null;
+		}
+		final Object[] a = new Object[batchSize];
+		int j = 0;
+		do {
+			a[j] = holder.value;
+		}
+		while (++j < batchSize && tryAdvance(holder));
+		if (est != Long.MAX_VALUE) {
+			est -= j;
+		}
+		return spliterator(a, 0, j, characteristics());
+	}
+
+	@Override
+	public Comparator<? super T> getComparator() {
+		if (hasCharacteristics(SORTED)) {
+			return null;
+		}
+		throw new IllegalStateException();
+	}
+
+    /**
+	 * {@inheritDoc}
+	 *
+	 * @implSpec This implementation returns the estimated size as reported when created
+	 *           and, if the estimated size is known, decreases in size when split.
+	 */
+	@Override
+	public long estimateSize() {
+		return est;
+	}
+
+    /**
+	 * {@inheritDoc}
+	 *
+	 * @implSpec This implementation returns the characteristics as reported when created.
+	 */
+	@Override
+	public int characteristics() {
+		return characteristics;
+	}
+
+	static final class HoldingConsumer<T> implements Consumer<T> {
+
+		Object value;
+
+		@Override
+		public void accept(T value) {
+			this.value = value;
+		}
+	}
+}

--- a/spring-orm-hibernate4/src/main/java/org/springframework/orm/hibernate4/support/ScrollableResultsSpliterator.java
+++ b/spring-orm-hibernate4/src/main/java/org/springframework/orm/hibernate4/support/ScrollableResultsSpliterator.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.hibernate4.support;
+
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.hibernate.Criteria;
+import org.hibernate.Query;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.springframework.lang.UsesJava8;
+import org.springframework.util.FixedBatchSpliteratorBase;
+
+import static org.hibernate.ScrollMode.*;
+
+/**
+ * Adapts Hibernate's {@link ScrollableResults} into a {@code Spliterator} which
+ * implements {@link Spliterator#trySplit trySplit()} such that batches of configurable
+ * size are produced. Each batch will be a strict prefix of this spliterator's remaining
+ * elements. The spliterator is {@link #ORDERED ORDERED} and {@link #NONNULL NONNULL}.
+ * <p>
+ * The type of elements produced by this spliterator is either {@code Object[]} for
+ * results whose {@link ScrollableResults#get get()} method returns an array of length
+ * above 1, or the type of the sole member when the array is of length 1 (the element will
+ * be unwrapped). The type conforming with the above logic must be passed into the
+ * constructor.
+ * <p>
+ * This spliterator can be used to achieve good parallel speedup, provided that:
+ * <ol>
+ * <li>typical time taken to fetch one element from the underlying
+ * {@code ScrollableResults} is negligible compared to the time needed to process it in
+ * the stream pipeline;
+ * <li>the batch size is appropriately chosen such that the processing of one batch takes
+ * about 1 to 10 milliseconds (fetch time is not included in this).</li>
+ * </ol>
+ *
+ * @param <T> The type of elements produced by this Spliterator
+ * @author Marko Topolnik
+ * @since 4.2
+ */
+@UsesJava8
+public class ScrollableResultsSpliterator<T> extends FixedBatchSpliteratorBase<T> {
+
+	private final ScrollableResults results;
+
+	private boolean closed;
+
+	private Boolean canUnwrap;
+
+	/**
+	 * Creates a spliterator from {@code ScrollableResults} obtained by invoking
+	 * {@link Query#scroll(ScrollMode) scroll(ScrollMode.FORWARD_ONLY)} on the supplied
+	 * {@code Query}. Spliterator's {@code trySplit()} method will split off its strict
+	 * prefix with the default batch size (defined by
+	 * {@link #DEFAULT_BATCH_SIZE DEFAULT_BATCH_SIZE}).
+	 *
+	 * @param clazz the type of the elements which will be produced by the spliterator
+	 * @param query the Hibernate query
+	 */
+	public ScrollableResultsSpliterator(Class<T> clazz, Query query) {
+		this(clazz, query.scroll(FORWARD_ONLY));
+	}
+
+	/**
+	 * Creates a spliterator from {@code ScrollableResults} obtained by invoking
+	 * {@link Criteria#scroll(ScrollMode) scroll(ScrollMode.FORWARD_ONLY)} on the supplied
+	 * {@code Criteria}. Spliterator's {@code trySplit()} method will split off its strict
+	 * prefix with the default batch size (defined by
+	 * {@link #DEFAULT_BATCH_SIZE DEFAULT_BATCH_SIZE}).
+	 *
+	 * @param clazz the type of the elements which will be produced by the spliterator
+	 * @param criteria the Hibernate criteria
+	 */
+	public ScrollableResultsSpliterator(Class<T> clazz, Criteria criteria) {
+		this(clazz, criteria.scroll(FORWARD_ONLY));
+	}
+
+	/**
+	 * Creates a spliterator from Hibernate's {@code ScrollableResults}. Spliterator's
+	 * {@code trySplit()} method will split off its strict prefix with the default batch
+	 * size (defined by {@link #DEFAULT_BATCH_SIZE DEFAULT_BATCH_SIZE}). Callers should be
+	 * careful in choosing the scroll mode for the {@code ScrollableResults} because the
+	 * JDBC driver implementation may need to retrieve the entire result set for modes
+	 * other than {@link ScrollMode#FORWARD_ONLY} .
+	 *
+	 * @param clazz the type of the elements which will be produced by the spliterator
+	 * @param results the Hibernate scrollable results
+	 */
+	public ScrollableResultsSpliterator(Class<T> clazz, ScrollableResults results) {
+		this(clazz, DEFAULT_BATCH_SIZE, results);
+	}
+
+	/**
+	 * Creates a spliterator from {@code ScrollableResults} obtained by invoking
+	 * {@link Query#scroll(ScrollMode) scroll(ScrollMode.FORWARD_ONLY)} on the supplied
+	 * {@code Query}. Spliterator's {@code trySplit()} method will split off its strict
+	 * prefix with the given batch size.
+	 *
+	 * @param clazz the type of the elements which will be produced by the spliterator
+	 * @param batchSize this spliterator's batch size
+	 * @param query the Hibernate query
+	 */
+	public ScrollableResultsSpliterator(Class<T> clazz, int batchSize, Query query) {
+		this(clazz, batchSize, query.scroll(FORWARD_ONLY));
+	}
+
+	/**
+	 * Creates a spliterator from {@code ScrollableResults} obtained by invoking
+	 * {@link Criteria#scroll(ScrollMode) scroll(ScrollMode.FORWARD_ONLY)} on the supplied
+	 * {@code Criteria}. Spliterator's {@code trySplit()} method will split off its strict
+	 * prefix with the given batch size.
+	 *
+	 * @param clazz the type of the elements which will be produced by the spliterator
+	 * @param batchSize this spliterator's batch size
+	 * @param criteria the Hibernate criteria
+	 */
+	public ScrollableResultsSpliterator(Class<T> clazz, int batchSize, Criteria criteria) {
+		this(clazz, batchSize, criteria.scroll(FORWARD_ONLY));
+	}
+
+	/**
+	 * Creates a spliterator from Hibernate's {@code ScrollableResults}. Spliterator's
+	 * {@code trySplit()} method will split off its strict prefix with the given batch
+	 * size. Callers should be careful in choosing the scroll mode for
+	 * {@code ScrollableResults} because the JDBC driver implementation may need to
+	 * retrieve the entire result set for modes other than {@link ScrollMode#FORWARD_ONLY}
+	 * .
+	 *
+	 * @param clazz the type of the elements which will be produced by the spliterator
+	 * @param batchSize this spliterator's batch size
+	 * @param results the Hibernate scrollable results
+	 */
+	public ScrollableResultsSpliterator(Class<T> clazz, int batchSize, ScrollableResults results) {
+		super(ORDERED | NONNULL, batchSize);
+		if (results == null) {
+			throw new NullPointerException("ScrollableResults must not be null");
+		}
+		this.results = results;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws ClassCastException if the type of element derived from the invocation of
+	 *         {@link ScrollableResults#get} (as explained in the class-level
+	 *         documentation above) cannot be cast into the type passed to the
+	 *         constructor.
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean tryAdvance(Consumer<? super T> action) {
+		if (closed) {
+			return false;
+		}
+		if (!results.next()) {
+			close();
+			return false;
+		}
+		if (canUnwrap == null) {
+			final Object[] r = results.get();
+			canUnwrap = r.length == 1;
+			action.accept((T) (canUnwrap ? r[0] : r));
+		}
+		else {
+			action.accept((T) (canUnwrap ? results.get(0) : results.get()));
+		}
+		return true;
+	}
+
+	/**
+	 * Closes the underlying {@code ScrollableResults}, releasing all JDBC resources it
+	 * has acquired. After this method is called, {@link #tryAdvance tryAdvace()} will
+	 * always return {@code false}.
+	 */
+	public void close() {
+		if (!closed) {
+			results.close();
+			closed = true;
+		}
+	}
+
+	/**
+	 * Builds a {@code Stream} backed by {@code ScrollableResults} obtained from the given
+	 * {@code Query}. Convenience around
+	 * {@link #ScrollableResultsSpliterator(Class, Query)}. Closing the stream will
+	 * propagate to the underlying {@code ScrollableResults}.
+	 *
+	 * @param clazz the type of the stream elements in reified form
+	 * @param query the Hibernate query
+	 * @param <T> the type of stream elements inferred from {@code clazz}
+	 * @return a {@code Stream} of elements returned by the query
+	 */
+	public static <T> Stream<T> resultStream(Class<T> clazz, Query query) {
+		return resultStream(new ScrollableResultsSpliterator<T>(clazz, query));
+	}
+
+	/**
+	 * Builds a {@code Stream} backed by {@code ScrollableResults} obtained from the given
+	 * {@code Criteria}. Convenience around
+	 * {@link #ScrollableResultsSpliterator(Class, Criteria)}. Closing the stream will
+	 * propagate to the underlying {@code ScrollableResults}.
+	 *
+	 * @param clazz the type of the stream elements in reified form
+	 * @param criteria the Hibernate criteria
+	 * @param <T> the type of stream elements inferred from {@code clazz}
+	 * @return a {@code Stream} of elements returned by the criteria.
+	 */
+	public static <T> Stream<T> resultStream(Class<T> clazz, Criteria criteria) {
+		return resultStream(new ScrollableResultsSpliterator<T>(clazz, criteria));
+	}
+
+	/**
+	 * Builds a {@code Stream} backed by the supplied {@code ScrollableResults}.
+	 * Convenience around {@link #ScrollableResultsSpliterator(Class, ScrollableResults)}.
+	 * Closing the stream will propagate to the underlying {@code ScrollableResults}.
+	 *
+	 * @param clazz the type of the stream elements in reified form
+	 * @param results the Hibernate scrollable results.
+	 * @param <T> the type of stream elements inferred from {@code clazz}
+	 * @return a {@code Stream} of elements returned by the scrollable results
+	 */
+	public static <T> Stream<T> resultStream(Class<T> clazz, ScrollableResults results) {
+		return resultStream(new ScrollableResultsSpliterator<T>(clazz, results));
+	}
+
+	/**
+	 * Builds a {@code Stream} backed by {@code ScrollableResults} obtained from the given
+	 * {@code Query}. Convenience around
+	 * {@link #ScrollableResultsSpliterator(Class, int, Query)}. Closing the stream will
+	 * propagate to the underlying {@code ScrollableResults}.
+	 *
+	 * @param clazz the type of the stream elements in reified form
+	 * @param batchSize the underlying spliterator's batch size.
+	 * @param query the Hibernate query.
+	 * @param <T> the type of stream elements inferred from {@code clazz}
+	 * @return a {@code Stream} of elements returned by the query
+	 */
+	public static <T> Stream<T> resultStream(Class<T> clazz, int batchSize, Query query) {
+		return resultStream(new ScrollableResultsSpliterator<T>(clazz, batchSize, query));
+	}
+
+	/**
+	 * Builds a {@code Stream} backed by {@code ScrollableResults} obtained from the given
+	 * {@code Criteria}. Convenience around
+	 * {@link #ScrollableResultsSpliterator(Class, int, Criteria)}. Closing the stream
+	 * will propagate to the underlying {@code ScrollableResults}.
+	 *
+	 * @param clazz the type of the stream elements in reified form
+	 * @param batchSize the underlying spliterator's batch size
+	 * @param criteria the Hibernate criteria
+	 * @param <T> the type of stream elements inferred from {@code clazz}
+	 * @return a {@code Stream} of elements returned by the criteria
+	 */
+	public static <T> Stream<T> resultStream(Class<T> clazz, int batchSize, Criteria criteria) {
+		return resultStream(new ScrollableResultsSpliterator<T>(clazz, batchSize, criteria));
+	}
+
+	/**
+	 * Builds a {@code Stream} backed by the supplied {@code ScrollableResults}.
+	 * Convenience around
+	 * {@link #ScrollableResultsSpliterator(Class, int, ScrollableResults)}. Closing the
+	 * stream will propagate to the underlying {@code ScrollableResults}.
+	 *
+	 * @param clazz the type of the stream elements in reified form
+	 * @param batchSize the underlying spliterator's batch size
+	 * @param results the Hibernate scrollable results
+	 * @param <T> the type of stream elements inferred from {@code clazz}
+	 * @return a {@code Stream} of elements returned by the scrollable results
+	 */
+	public static <T> Stream<T> resultStream(Class<T> clazz, int batchSize, ScrollableResults results) {
+		return resultStream(new ScrollableResultsSpliterator<T>(clazz, batchSize, results));
+	}
+
+	/**
+	 * Returns an initially sequential {@code Stream} based on the supplied spliterator.
+	 * Closing the stream will invoke {@link #close} on the spliterator.
+	 *
+	 * @param spliterator the spliterator
+	 * @param <T> the type of stream elements inferred from {@code spliterator}
+	 * @return a {@code Stream} of elements produced by the spliterator
+	 */
+	public static <T> Stream<T> resultStream(final ScrollableResultsSpliterator<T> spliterator) {
+		return StreamSupport.stream(spliterator, false).onClose(new Runnable() {
+			public void run() {
+				spliterator.close();
+			}
+		});
+	}
+}

--- a/spring-orm-hibernate4/src/test/java/org/springframework/orm/hibernate4/support/ScrollableResultsSpliteratorTests.java
+++ b/spring-orm-hibernate4/src/test/java/org/springframework/orm/hibernate4/support/ScrollableResultsSpliteratorTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.hibernate4.support;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.hibernate.ScrollableResults;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.orm.hibernate4.support.ScrollableResultsSpliterator.*;
+
+
+/**
+ * @author Marko Topolnik
+ * @since 4.2
+ */
+public class ScrollableResultsSpliteratorTests {
+
+	@Test
+	public void testUnaryTuple() {
+		final ScrollableResults sr = mockScrollableResults(new Object[][] {
+			{42},
+			{24},
+		});
+		assertEquals("Sum of two unary result rows", 66,
+				resultStream(Integer.class, sr).mapToInt(i->i).sum());
+	}
+
+	@Test
+	public void testBinaryTuple() {
+		final ScrollableResults sr = mockScrollableResults(new Object[][] {
+				{42, 17},
+				{24, 37},
+		});
+		assertEquals("Sum of second result column", 54,
+				resultStream(Object[].class, sr).mapToInt(row->(int)row[1]).sum());
+	}
+
+	@Test
+	public void testParallel() {
+		final Object[][] data = new Object[10_000][];
+		Arrays.setAll(data, i -> new Object[] {i});
+		final ScrollableResults sr = mockScrollableResults(data);
+		assertEquals("Sum 0..9999",
+				Stream.of(data).mapToInt(row -> (int)row[0]).sum(),
+				resultStream(Integer.class, sr).parallel().mapToInt(this::aLotOfWork).sum());
+	}
+
+	int aLotOfWork(Integer input) {
+		double d = 1.001;
+		for (int i = 0; i < 1000; i++) {
+			d = Math.pow(d, (d < 1e18)? 1.001 : 0.999);
+		}
+		return d < 0? -input : input;
+	}
+
+	static ScrollableResults mockScrollableResults(Object[][] rows) {
+		final ScrollableResults sr = mock(ScrollableResults.class);
+		final int[] cursor = {-1};
+		given(sr.next()).willAnswer(x -> (++cursor[0] < rows.length));
+		given(sr.get()).willAnswer(x -> rows[cursor[0]]);
+		given(sr.get(0)).willAnswer(x -> rows[cursor[0]][0]);
+		return sr;
+	}
+}


### PR DESCRIPTION
Spliterator is the source of data for the Java 8 Stream. This commit
contributes a Spliterator that wraps Hibernate's ScrollableResults.

The commit also contributes an abstract base class which captures
the concern of splitting into batches of configurable size, thus
supporting automatic parallelization of the stream.

Issues: SPR-12349, SPR-12388

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
