### PR TITLE
Adding a try/catch to print errors when JMX published proxies cannot get their target beans

### DIFF
--- a/spring-context/src/main/java/org/springframework/jmx/export/MBeanExporter.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/MBeanExporter.java
@@ -41,6 +41,7 @@ import javax.management.modelmbean.RequiredModelMBean;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.aop.target.LazyInitTargetSource;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -1095,6 +1096,18 @@ public class MBeanExporter extends MBeanRegistrationSupport implements MBeanExpo
 
 		public void setObjectName(ObjectName objectName) {
 			this.objectName = objectName;
+		}
+
+		@Override
+		public Object getTarget() throws BeansException {
+			try {
+				return super.getTarget();
+			} catch (BeansException e) {
+				if (logger.isErrorEnabled()) {
+					logger.error("Cannot retrieve target for published JMX target bean " + objectName, e);
+				}
+				throw e;
+			}
 		}
 
 		@Override


### PR DESCRIPTION
Adding a try/catch to print errors when JMX published proxies cannot get their target beans

We use the @ManagedResource and @ManagedOperation all the time.  Since most of our singletons are lazy when it publishes the managed JMX bean it creates a cglib proxy to register with the mbean server in order to preserve the laziness.  This is good.

The first time this JMX method is invoked, the bean is retrieved from the container and the managed operation method is invoked.  If anything fails in between the mbean server calling the proxy and the proxy calling our application code inside the operation -- the exception will go back through RMI and if the client is JConsole or JVisualVm then it will fail as the exception classes aren't on those classpaths.  It would be nice if spring would provide a way to enable logging in these scenarios.  

This PR adds a try/catch to log an error when the getTarget fails as would be the case here.  This would only affect generated proxies, which I think is a narrow change that doesn't seem to have any negative consequences.  When would you not want to log an error here?

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.

Issue: SPR-12399
