### PR TITLE
Fix path mapping issue in default servlet mode

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,16 @@ public class UrlPathHelperTests {
 		request.setRequestURI("/petclinic/main/welcome.html");
 
 		assertEquals("Incorrect path returned", "/welcome.html", helper.getPathWithinServletMapping(request));
+	}
+
+	@Test
+	public void alwaysUseFullPath() {
+		helper.setAlwaysUseFullPath(true);
+		request.setContextPath("/petclinic");
+		request.setServletPath("/main");
+		request.setRequestURI("/petclinic/main/welcome.html");
+
+		assertEquals("Incorrect path returned", "/main/welcome.html", helper.getLookupPathForRequest(request));
 	}
 
 	// SPR-11101
@@ -192,6 +202,28 @@ public class UrlPathHelperTests {
 		request.setRequestURI("/test/foo/");
 
 		assertEquals("/foo/", helper.getLookupPathForRequest(request));
+	}
+
+	//SPR-12372
+	@Test
+	public void defaultServletEndingWithDoubleSlash() throws Exception {
+		request.setContextPath("/SPR-12372");
+		request.setPathInfo(null);
+		request.setServletPath("/foo/bar/");
+		request.setRequestURI("/SPR-12372/foo//bar/");
+
+		assertEquals("/foo//bar/", helper.getLookupPathForRequest(request));
+
+		request.setServletPath("/foo/bar/");
+		request.setRequestURI("/SPR-12372/foo/bar//");
+
+		assertEquals("/foo/bar//", helper.getLookupPathForRequest(request));
+
+		// "normal" case
+		request.setServletPath("/foo/bar//");
+		request.setRequestURI("/SPR-12372/foo/bar//");
+
+		assertEquals("/foo/bar//", helper.getLookupPathForRequest(request));
 	}
 
 	@Test
@@ -364,6 +396,26 @@ public class UrlPathHelperTests {
 	public void wasCasualServletFolderWithCompliantSetting() throws Exception {
 		request.setAttribute(WEBSPHERE_URI_ATTRIBUTE, "/test/foo/foo/");
 		tomcatCasualServletFolder();
+	}
+
+	@Test
+	public void getOriginatingRequestUri() {
+		request.setAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE, "/path");
+		request.setRequestURI("/forwarded");
+		assertEquals("/path", helper.getOriginatingRequestUri(request));
+	}
+
+	@Test
+	public void getOriginatingRequestUriWebsphere() {
+		request.setAttribute(WEBSPHERE_URI_ATTRIBUTE, "/path");
+		request.setRequestURI("/forwarded");
+		assertEquals("/path", helper.getOriginatingRequestUri(request));
+	}
+
+	@Test
+	public void getOriginatingRequestUriDefault() {
+		request.setRequestURI("/forwarded");
+		assertEquals("/forwarded", helper.getOriginatingRequestUri(request));
 	}
 
 	@Test


### PR DESCRIPTION
Prior to this commit, some requests would be wrongly mapped to "/" when:
- requests ends with "//" such as "/foo/bar//"
- the DispatcherServlet is mapped as the default ("/")
- the app container sanitizes the servletPath

In those cases, the path extraction algorithm was wrongly guessing the
path of the current request.

This commit detects if the app container sanitized the servletPath for
the current request. If so, it uses a sanitized version of the
requestUri to extract the path information.

Issue: SPR-12372
