### PR TITLE
Allow non-String args in JOptCommandLinePropertySource

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/JOptCommandLinePropertySource.java
+++ b/spring-core/src/main/java/org/springframework/core/env/JOptCommandLinePropertySource.java
@@ -98,8 +98,7 @@ public class JOptCommandLinePropertySource extends CommandLinePropertySource<Opt
 		List<?> argValues = this.source.valuesOf(name);
 		List<String> stringArgValues = new ArrayList<String>();
 		for (Object argValue : argValues) {
-			Assert.isInstanceOf(String.class, argValue, "Argument values must be of type String");
-			stringArgValues.add((String) argValue);
+			stringArgValues.add(argValue instanceof String ? (String) argValue : argValue.toString());
 		}
 		if (stringArgValues.isEmpty()) {
 			return (this.source.has(name) ? Collections.<String>emptyList() : null);

--- a/spring-core/src/test/java/org/springframework/core/env/JOptCommandLinePropertySourceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/JOptCommandLinePropertySourceTests.java
@@ -159,4 +159,18 @@ public class JOptCommandLinePropertySourceTests {
 		String nonOptionArgs = ps.getProperty("NOA");
 		assertThat(nonOptionArgs, equalTo("noa1,noa2"));
 	}
+
+	@Test
+	public void withRequiredArg_ofTypeEnum() {
+		OptionParser parser = new OptionParser();
+		parser.accepts("o1").withRequiredArg().ofType(OptionEnum.class);
+		OptionSet options = parser.parse("--o1=VAL_1");
+
+		PropertySource<?> ps = new JOptCommandLinePropertySource(options);
+		assertThat(ps.getProperty("o1"), equalTo("VAL_1"));
+	}
+
+	public static enum OptionEnum {
+		VAL_1;
+	}
 }


### PR DESCRIPTION
Prior to this commit, JOptCommandLinePropertySource prevented the
possibility of non-String option arguments. This effectively prevents
the use of JOpt's #ofType support (which allows specifying custom
argument types).

Now, non-String arguments are detected and converted to strings as
necessary. JOpt's #ofType now works as expected. A test has been added
to cover this case.
