### PR TITLE
Fix location checks for servlet 3 resources

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
+import org.springframework.web.context.support.ServletContextResource;
 
 /**
  * A simple {@code ResourceResolver} that tries to find a resource under the given
@@ -171,6 +172,10 @@ public class PathResourceResolver extends AbstractResourceResolver {
 		else if (resource instanceof UrlResource) {
 			resourcePath = resource.getURL().toExternalForm();
 			locationPath = location.getURL().toExternalForm();
+		}
+		else if(resource instanceof ServletContextResource) {
+			resourcePath = ((ServletContextResource) resource).getPath();
+			locationPath = ((ServletContextResource) location).getPath();
 		}
 		else {
 			resourcePath = resource.getURL().getPath();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/PathResourceResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/PathResourceResolverTests.java
@@ -15,10 +15,7 @@
  */
 package org.springframework.web.servlet.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -28,6 +25,8 @@ import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
+import org.springframework.mock.web.test.MockServletContext;
+import org.springframework.web.context.support.ServletContextResource;
 
 /**
  * Unit tests for
@@ -91,6 +90,19 @@ public class PathResourceResolverTests {
 		Resource location = new ClassPathResource("test/main.css", PathResourceResolver.class);
 		String actual = this.resolver.resolveUrlPath("../testalternatepath/bar.css", Arrays.asList(location), null);
 		assertEquals("../testalternatepath/bar.css", actual);
+	}
+
+	// SPR-12432
+	@Test
+	public void checkServletContextResource() throws Exception {
+		Resource classpathLocation = new ClassPathResource("test/", PathResourceResolver.class);
+		MockServletContext context = new MockServletContext();
+
+		ServletContextResource servletContextLocation = new ServletContextResource(context, "/webjars/");
+		ServletContextResource resource = new ServletContextResource(context, "/webjars/webjar-foo/1.0/foo.js");
+
+		assertFalse(this.resolver.checkResource(resource, classpathLocation));
+		assertTrue(this.resolver.checkResource(resource, servletContextLocation));
 	}
 
 	private void testCheckResource(Resource location, String requestPath) throws IOException {


### PR DESCRIPTION
SPR-12354 applied new checks to make sure that served static resources
are under authorized locations.

Prior to this change, serving static resources from Servlet 3 locations
such as "/webjars/" would not work since those locations can be within
one of the JARs on path. In that case, the checkLocation method would
return false and disallow serving that static resource.

This change fixes this issue by making sure to call the
`ServletContextResource.getPath()` method for servlet context resources.

Note that there's a known workaround for this issue, which is using a
classpath scheme as location, such as:
"classpath:/META-INF/resources/webjars/" instead of "/webjars".

Issue: SPR-12432
