### PR TITLE
Fix user destination parsing in simp messaging

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
@@ -150,9 +150,17 @@ public class DefaultUserDestinationResolver implements UserDestinationResolver {
 			subscribeDestination = this.destinationPrefix.substring(0, startIndex-1) + destinationWithoutPrefix;
 			user = destination.substring(startIndex, endIndex);
 			user = StringUtils.replace(user, "%2F", "/");
-			user = user.equals(sessionId) ? null : user;
-			sessionIds = (sessionId != null ?
-					Collections.singleton(sessionId) : this.userSessionRegistry.getSessionIds(user));
+
+			if(user.equals(sessionId)) {
+				user = null;
+				sessionIds = Collections.singleton(sessionId);
+			}
+			else if (this.userSessionRegistry.getSessionIds(user).contains(sessionId)) {
+				sessionIds = Collections.singleton(sessionId);
+			}
+			else {
+				sessionIds = this.userSessionRegistry.getSessionIds(user);
+			}
 		}
 		else {
 			return null;

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolverTests.java
@@ -117,6 +117,25 @@ public class DefaultUserDestinationResolverTests {
 		assertEquals(this.user.getName(), actual.getUser());
 	}
 
+	// SPR-12444
+	@Test
+	public void handleMessageToOtherUser() {
+		final String OTHER_SESSION_ID = "456";
+		final String OTHER_USER_NAME = "anna";
+
+		String sourceDestination = "/user/"+OTHER_USER_NAME+"/queue/foo";
+		TestPrincipal otherUser = new TestPrincipal(OTHER_USER_NAME);
+		this.registry.registerSessionId(otherUser.getName(), OTHER_SESSION_ID);
+		Message<?> message = createMessage(SimpMessageType.MESSAGE, this.user, SESSION_ID, sourceDestination);
+		UserDestinationResult actual = this.resolver.resolveDestination(message);
+
+		assertEquals(sourceDestination, actual.getSourceDestination());
+		assertEquals(1, actual.getTargetDestinations().size());
+		assertEquals("/queue/foo-user" + OTHER_SESSION_ID, actual.getTargetDestinations().iterator().next());
+		assertEquals("/user/queue/foo", actual.getSubscribeDestination());
+		assertEquals(otherUser.getName(), actual.getUser());
+	}
+
 	@Test
 	public void handleMessageEncodedUserName() {
 


### PR DESCRIPTION
This commit fixes the parsing of message destinations such as
"/user/anna/queue/foo", reverting a regression introduced by SPR-11506,
which worked well with @SendToUser use cases but caused issues for
messages sent to other users.

Issue: SPR-12444
