### PR TITLE
Fix issue where FormHttpMessageConverter fails to write multipart data

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
@@ -244,7 +244,7 @@ public class FormHttpMessageConverter implements HttpMessageConverter<MultiValue
 
 	private boolean isMultipart(MultiValueMap<String, ?> map, MediaType contentType) {
 		if (contentType != null) {
-			return MediaType.MULTIPART_FORM_DATA.equals(contentType);
+			return MediaType.MULTIPART_FORM_DATA.includes(contentType);
 		}
 		for (String name : map.keySet()) {
 			for (Object value : map.get(name)) {

--- a/spring-web/src/test/java/org/springframework/http/converter/FormHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/FormHttpMessageConverterTests.java
@@ -69,6 +69,7 @@ public class FormHttpMessageConverterTests {
 	public void canWrite() {
 		assertTrue(converter.canWrite(MultiValueMap.class, new MediaType("application", "x-www-form-urlencoded")));
 		assertTrue(converter.canWrite(MultiValueMap.class, new MediaType("multipart", "form-data")));
+		assertTrue(converter.canWrite(MultiValueMap.class, new MediaType("multipart", "form-data", Charset.forName("UTF-8"))));
 		assertTrue(converter.canWrite(MultiValueMap.class, MediaType.ALL));
 	}
 
@@ -135,7 +136,7 @@ public class FormHttpMessageConverterTests {
 
 		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
 		converter.setMultipartCharset(Charset.forName("UTF-8"));
-		converter.write(parts, MediaType.MULTIPART_FORM_DATA, outputMessage);
+		converter.write(parts, new MediaType("multipart", "form-data", Charset.forName("UTF-8")), outputMessage);
 
 		final MediaType contentType = outputMessage.getHeaders().getContentType();
 		assertNotNull("No boundary found", contentType.getParameter("boundary"));


### PR DESCRIPTION
FormHttpMessageConverter incorrectly determines that the media type
"multipart/form-data; charset=utf-8" is not multipart. This commit
allows the media type to contain a charset parameter.
