### PR TITLE
Fix for NPE when creating ProtobufHttpMessageConverter without ExtensionRegistryInitializer

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverter.java
@@ -86,7 +86,7 @@ public class ProtobufHttpMessageConverter extends AbstractHttpMessageConverter<M
 	 */
 	public ProtobufHttpMessageConverter(ExtensionRegistryInitializer registryInitializer) {
 		super(PROTOBUF, MediaType.TEXT_PLAIN, MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON);
-		if (this.extensionRegistry != null) {
+		if (registryInitializer != null) {
 			registryInitializer.initializeExtensionRegistry(this.extensionRegistry);
 		}
 	}

--- a/spring-web/src/test/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverterTests.java
@@ -59,6 +59,15 @@ public class ProtobufHttpMessageConverterTests {
 	}
 
 	@Test
+	public void extensionRegistryNull() {
+	     try {
+	     	new ProtobufHttpMessageConverter(null);
+	     } catch (Exception e) {
+	     	fail("Unable to create ProtobufHttpMessageConverter with null extensionRegistry");
+	     }
+	}
+
+	@Test
 	public void canRead() {
 		assertTrue(this.converter.canRead(Msg.class, null));
 		assertTrue(this.converter.canRead(Msg.class, ProtobufHttpMessageConverter.PROTOBUF));


### PR DESCRIPTION
Fix for NPE when creating ProtobufHttpMessageConverter without ExtensionRegistryInitializer
