### PR TITLE
Fixed the output stream incomplete data by explicitly flushing the OutputStreamWriter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverter.java
@@ -166,16 +166,24 @@ public class ProtobufHttpMessageConverter extends AbstractHttpMessageConverter<M
 		Charset charset = getCharset(contentType);
 
 		if (MediaType.TEXT_HTML.isCompatibleWith(contentType)) {
-			HtmlFormat.print(message, new OutputStreamWriter(outputMessage.getBody(), charset));
+			final OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputMessage.getBody(), charset);
+			HtmlFormat.print(message, outputStreamWriter);
+			outputStreamWriter.flush();
 		}
 		else if (MediaType.APPLICATION_JSON.isCompatibleWith(contentType)) {
-			JsonFormat.print(message, new OutputStreamWriter(outputMessage.getBody(), charset));
+			final OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputMessage.getBody(), charset);
+			JsonFormat.print(message, outputStreamWriter);
+			outputStreamWriter.flush();
 		}
 		else if (MediaType.TEXT_PLAIN.isCompatibleWith(contentType)) {
-			TextFormat.print(message, new OutputStreamWriter(outputMessage.getBody(), charset));
+			final OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputMessage.getBody(), charset);
+			TextFormat.print(message, outputStreamWriter);
+			outputStreamWriter.flush();
 		}
 		else if (MediaType.APPLICATION_XML.isCompatibleWith(contentType)) {
-			XmlFormat.print(message, new OutputStreamWriter(outputMessage.getBody(), charset));
+			final OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputMessage.getBody(), charset);
+			XmlFormat.print(message, outputStreamWriter);
+			outputStreamWriter.flush();
 		}
 		else if (PROTOBUF.isCompatibleWith(contentType)) {
 			setProtoHeader(outputMessage, message);


### PR DESCRIPTION
Fixed the output stream incomplete data by explicitly flushing the OutputStreamWriter

Don't readily have a unit test for this issue, as it only happens when there is a very large dataset, like in the tens of megs.  This fix has been tested in an enterprise production environment and is fully working.
