### PR TITLE
added unprocessableEntity() to ResponseEntity

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -246,6 +246,14 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 		return status(HttpStatus.NOT_FOUND);
 	}
 
+	/**
+	 * Create a builder with a {@linkplain HttpStatus#UNPROCESSABLE_ENTITY UNPROCESSABLE_ENTITY} status.
+	 * @return the created builder
+	 * @since 4.1
+	 */
+	public static HeadersBuilder<?> unprocessableEntity() {
+		return status(HttpStatus.UNPROCESSABLE_ENTITY);
+	}
 
 	/**
 	 * Defines a builder that adds headers to the response entity.

--- a/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
@@ -120,6 +120,15 @@ public class ResponseEntityTests {
 	}
 
 	@Test
+	public void unprocessableEntity() throws URISyntaxException {
+		ResponseEntity<Void> responseEntity = ResponseEntity.unprocessableEntity().build();
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, responseEntity.getStatusCode());
+		assertNull(responseEntity.getBody());
+	}
+
+	@Test
 	public void headers() throws URISyntaxException {
 		String eTag = "\"foo\"";
 		URI location = new URI("location");


### PR DESCRIPTION
https://jira.spring.io/browse/SPR-12515

Lately I'm using http 422 Unprocessable Entity for returning validation errors. instead of a 400. It seems many public api's are changing to this (like github api).
So please add a static unprocessableEntity() builder method to ResponseEntity to have a shortcut for returning this http code.
This just like earlier request like SPR-12070 and SPR-12112.
