### PR TITLE
Add 'public' visibility to facilitate tags (such as Select) extension.

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/OptionWriter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/OptionWriter.java
@@ -86,7 +86,7 @@ import org.springframework.web.servlet.support.BindStatus;
  * @author Scott Andrews
  * @since 2.0
  */
-class OptionWriter {
+public class OptionWriter {
 
 	private final Object optionSource;
 


### PR DESCRIPTION
Unless there is any side effect, when customizing JSP tags (e.g. extending SelectTag),  being able to access OptionWriter would be rather helpful.
