### PR TITLE
Fixed examples in java docs in class ResultActions.

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/ResultActions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/ResultActions.java
@@ -35,12 +35,12 @@ public interface ResultActions {
 	 * static imports: MockMvcRequestBuilders.*, MockMvcResultMatchers.*
 	 *
 	 * mockMvc.perform(get("/person/1"))
-	 *   .andExpect(status.isOk())
+	 *   .andExpect(status().isOk())
 	 *   .andExpect(content().contentType(MediaType.APPLICATION_JSON))
 	 *   .andExpect(jsonPath("$.person.name").value("Jason"));
 	 *
 	 * mockMvc.perform(post("/form"))
-	 *   .andExpect(status.isOk())
+	 *   .andExpect(status().isOk())
 	 *   .andExpect(redirectedUrl("/person/1"))
 	 *   .andExpect(model().size(1))
 	 *   .andExpect(model().attributeExists("person"))


### PR DESCRIPTION
Fixed examples in java docs in class ResultActions. 
2 changes: status -> status()

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
