### PR TITLE
SPR-5580 Adding ChildOf annotation to apply MergedBeanDefinition to annotated beans.

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ChildOf.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ChildOf.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to reference an xml-declared parent.
+ * <p>
+ * Behaves like bean-parent attribute. All properties are inherited.
+ * <p>
+ * To enable the corresponding ChildOfConfigurer, add it to your spring configuration. For Example like this:
+ * <p>
+ * <code>
+ * &lt;bean class="org.springframework.context.annotation.ChildOfConfigurer"/&gt;
+ * </code>
+ *
+ * @author Jan Esser
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ChildOf {
+    String parent() default "";
+}

--- a/spring-context/src/main/java/org/springframework/context/annotation/ChildOfConfigurer.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ChildOfConfigurer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.context.annotation;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.FatalBeanException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.Iterator;
+
+/**
+ * BeanFactoryPostProcessor for ChildOf annotation.
+ * <p>
+ * Taken from https://jira.spring.io/browse/SPR-6343 and slightly adjusted.
+ *
+ * @author Jan Esser
+ */
+public class ChildOfConfigurer implements BeanFactoryPostProcessor, PriorityOrdered {
+
+    private int order = Ordered.LOWEST_PRECEDENCE;// default: same as
+                                                  // non-Ordered
+
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+    public int getOrder() {
+        return this.order;
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        final Iterator<String> iterator = beanFactory.getBeanNamesIterator();
+        while (iterator.hasNext()) {
+            try {
+                final BeanDefinition bd = beanFactory.getBeanDefinition(iterator.next());
+                final String beanClassName = bd.getBeanClassName();
+                if (StringUtils.hasText(beanClassName)) {
+                    try {
+                        final ChildOf childOf = AnnotationUtils.findAnnotation(Class.forName(beanClassName), ChildOf.class);
+                        if (childOf != null) {
+                            final String parentName = childOf.parent();
+                            if (StringUtils.hasText(parentName)) {
+                                bd.setParentName(parentName);
+                            } else
+                                throw new FatalBeanException(String.format("%s is @ChildOf annotated, but no parent set.", beanClassName));
+                        }
+                    } catch (ClassNotFoundException e) {
+                        throw new FatalBeanException("Unknown class defined.", e);
+                    }
+                }
+            } catch (NoSuchBeanDefinitionException ex) {
+                continue;
+            }
+        }
+    }
+}
+

--- a/spring-test/src/test/java/org/springframework/test/context/annotation/ParentBeanTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/annotation/ParentBeanTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.context.annotation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ChildOf;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+import javax.annotation.Resource;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for SPR-6343 asserting inheritance of XmlDeclaredBeanDefinition to
+ * AnnotatedBean.
+ * <p>
+ * To additional tests line out different ways of inheriting
+ * (value-)properties-definitions:<br />
+ * <ol>
+ * <li>classic inheritance for annotated beans and</li>
+ * <li>classic java-config shared method configuration and</li>
+ * <li>classic parent-bean-inheritance from xml-config and</li>
+ * <li>new inheritance from xml-configured parent to annotated child bean.</li>
+ * </ol>
+ *
+ * @author Jan Esser
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class })
+@ContextConfiguration("parent-bean-test.xml")
+public class ParentBeanTests {
+
+    @Resource(name = "annotatedParent")
+    private ParentBean parentBean;
+
+    @Resource(name = "annotatedChild")
+    private ChildBean childBean;
+
+    @Resource(name = "configuredChild")
+    private ChildBean configuredChild;
+
+    @Resource(name = "declaredChild")
+    private ChildBean declaredChild;
+
+    /**
+     * Annotation inheritance here.
+     */
+    @Test
+    public void testParentClassInheritance() {
+        assertEquals("test", parentBean.getAnnotatedAttribute());
+        assertEquals("test", childBean.getAnnotatedAttribute());
+    }
+
+    /**
+     * Common code in configuration class.
+     */
+    @Test
+    public void testParentConfigured() {
+        assertEquals("test", configuredChild.getConfiguredAttribute());
+    }
+
+    /**
+     * Classic xml-parent.
+     */
+    @Test
+    public void testParentDeclared() {
+        assertEquals("test", declaredChild.getDeclaredAttribute());
+    }
+
+    @Test
+    public void testChildOf() {
+        assertEquals("test", childBean.getDeclaredAttribute());
+    }
+
+    @Configuration
+    public static class TestConfig {
+
+        protected ParentBean configuredParentBean(/* inout */ParentBean pb) {
+            pb.setConfiguredAttribute("test");
+            return pb;
+        }
+
+        @Bean(name = { "configuredParent" })
+        public ParentBean createConfiguredParent() {
+            return configuredParentBean(new ParentBean());
+        }
+
+        @Bean(name = "configuredChild")
+        public ChildBean createConfiguredChild() {
+            ChildBean cb = new ChildBean();
+            configuredParentBean(cb);
+            return cb;
+        }
+    }
+
+    @Component("annotatedParent")
+    public static class ParentBean {
+        @Value("test")
+        private String annotatedAttribute;
+
+        private String configuredAttribute;
+
+        private String declaredAttribute;
+
+        public String getAnnotatedAttribute() {
+            return annotatedAttribute;
+        }
+
+        public void setAnnotatedAttribute(String annotatedAttribute) {
+            this.annotatedAttribute = annotatedAttribute;
+        }
+
+        public String getConfiguredAttribute() {
+            return configuredAttribute;
+        }
+
+        public void setConfiguredAttribute(String configuredAttribute) {
+            this.configuredAttribute = configuredAttribute;
+        }
+
+        public String getDeclaredAttribute() {
+            return declaredAttribute;
+        }
+
+        public void setDeclaredAttribute(String declaredAttribute) {
+            this.declaredAttribute = declaredAttribute;
+        }
+    }
+
+    @ChildOf(parent = "declaredParent")
+    @Component("annotatedChild")
+    public static class ChildBean extends ParentBean {
+        //
+    }
+}
+

--- a/spring-test/src/test/java/org/springframework/test/context/annotation/parent-bean-test.xml
+++ b/spring-test/src/test/java/org/springframework/test/context/annotation/parent-bean-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <bean class="org.springframework.context.annotation.ChildOfConfigurer"/>
+
+    <context:annotation-config/>
+    <context:component-scan base-package="org.springframework.test.annotation.parent"/>
+
+    <bean id="declaredParent" class="org.springframework.test.context.annotation.ParentBeanTests$ParentBean">
+        <property name="declaredAttribute" value="test"/>
+    </bean>
+
+    <bean id="declaredChild" parent="declaredParent"
+          class="org.springframework.test.context.annotation.ParentBeanTests$ChildBean"/>
+</beans>


### PR DESCRIPTION
How to reference parent-bean from annotated spring, like with component-scan?

The question came up during work life when we were trying to shift towards component-scan. Found that "historical" issue with most of the most given.

Here some pull-request extended with some comments and a test-case.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
