### PR TITLE
Fix Animal Sniffer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,6 @@ configure(allprojects) { project ->
 
 		inputs.dir sourceSets.main.output.classesDir
 		inputs.dir copyJavaApiSignature.to
-		outputs.upToDateWhen { true }
 
 		doLast {
 			ant.taskdef(
@@ -625,6 +624,7 @@ project("spring-context-support") {
 			exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
 			exclude group: "org.olap4j", module: "olap4j"
 			exclude group: "xml-apis", module: "xml-apis"
+			exclude group: "org.springframework", module: "spring-context"
 		}
 		testCompile(project(":spring-context"))
 		testCompile("org.apache.poi:poi:3.10.1")
@@ -838,6 +838,7 @@ project("spring-webmvc") {
 			exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
 			exclude group: "org.olap4j", module: "olap4j"
 			exclude group: "xml-apis", module: "xml-apis"
+			exclude group: "org.springframework", module: "spring-context"
 		}
 		optional("com.fasterxml.jackson.core:jackson-databind:${jackson2Version}")
 		optional("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jackson2Version}")


### PR DESCRIPTION
Jasper Reports’ transitive dependency on spring-context (via
castor-xml which is a new dependency in 6.0.3) was being mapped by
Gradle to a dependency on the spring-context project. For reasons that
I do not fully understand this was causing -source and -javadoc jars
to be added to the project's compile classpath which is used by the
Animal Sniffer Ant task. When the task runs these jars do not exist
which causes it to fail. This commit fixes the problem by adding an
exclusion of org.springframework:spring-context to the Jasper Reports
dependencies in spring-context-support and spring-webmvc.
