### PR TITLE
Add strategy for handling Stomp client errors (SPR-12732)

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/AbstractStompSubProtocolErrorHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/AbstractStompSubProtocolErrorHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.socket.messaging;
+
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompEncoder;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+/**
+ * A base class providing methods to create error messages and send them to a connected
+ * WebSocket client through their session.
+ *
+ * @author Jaymes Bearden
+ * @since 4.1.4
+ */
+public abstract class AbstractStompSubProtocolErrorHandler implements StompSubProtocolErrorHandler {
+
+    private static final byte[] EMPTY_PAYLOAD = new byte[0];
+
+    private StompEncoder stompEncoder = new StompEncoder();
+
+    /**
+     * Craft and return a Stomp ERROR frame
+     * @return StompHeaderAccessor representing a Stomp ERROR
+     */
+    protected StompHeaderAccessor getStompErrorMessage() {
+        return StompHeaderAccessor.create(StompCommand.ERROR);
+    }
+
+    /**
+     * Encode and send the supplied errorHeaders to the client
+     * @param session the client session
+     * @param errorHeaders to send
+     * @throws IOException
+     */
+    protected void sendErrorMessage(WebSocketSession session, StompHeaderAccessor errorHeaders) throws IOException {
+        byte[] errorMessage = stompEncoder.encode(errorHeaders.getMessageHeaders(), EMPTY_PAYLOAD);
+        session.sendMessage(new TextMessage(errorMessage));
+    }
+}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolErrorHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolErrorHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.socket.messaging;
+
+import org.springframework.web.socket.WebSocketSession;
+
+/**
+ * A strategy for handling errors that occur during client message handling.
+ *
+ * @see {@link AbstractStompSubProtocolErrorHandler} for utility methods
+ *
+ * @author Jaymes Bearden
+ * @since 4.1.4
+ */
+public interface StompSubProtocolErrorHandler {
+
+    /**
+     * Handle an exception for the given WebSocketSession
+     * @param session the client session
+     * @param error the exception that occurred
+     */
+    void handleError(WebSocketSession session, Throwable error);
+}


### PR DESCRIPTION
As mentioned in SPR-12732, the current implementation does not allow for sufficient information to be return in a STOMP ERROR frame to the client during errors resulting from either client message error parsing, or output channel processing (perhaps through the use of an output channel interceptor).

This commit enhances the StompSubProtocolHandler by adding the StompSubProtocolErrorHandler strategy with a default implementation matching the existing behavior.

Developers will be able to configure the StompSubProtocolHandler with customized versions of the error handler strategy to delegate error handling behavior. For example, this can allow developers to have different behavior for different types of exceptions.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.

Issue: SPR-12732
