### PR TITLE
Permit easier overriding of mapping

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -223,7 +223,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	 */
 	@Bean
 	public RequestMappingHandlerMapping requestMappingHandlerMapping() {
-		RequestMappingHandlerMapping handlerMapping = new RequestMappingHandlerMapping();
+		RequestMappingHandlerMapping handlerMapping = createRequestMappingHandlerMapping();
 		handlerMapping.setOrder(0);
 		handlerMapping.setInterceptors(getInterceptors());
 		handlerMapping.setContentNegotiationManager(mvcContentNegotiationManager());
@@ -246,6 +246,14 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 		}
 
 		return handlerMapping;
+	}
+
+	/**
+	 * Allow overriding of {@link RequestMappingHandlerMapping} to allow
+	 * custom implementation.
+	 */
+	protected RequestMappingHandlerMapping createRequestMappingHandlerMapping() {
+		return new RequestMappingHandlerMapping();
 	}
 
 	/**


### PR DESCRIPTION
Following the feature enabled by SPR-7812, we overrode `RequestMappingHandlerMapping.getCustomMethodCondition()` to add a custom `RequestCondition` that does some evaluation of custom headers and custom annotations on `@RequestMapping` endpoints. (The end result is beyond what is possible using `headers` on `@RequestMapping`.) We then discovered `WebMvcConfigurationSupport` instantiates its own `RequestMappingHandlerMapping` in `requestMappingHandlerMapping()`, requiring overriding of that protected method to use our new subclass. 

The existing `requestMappingHandlerMapping()` not only instantiates the mapping, but performs all of the default configuration of it. Initially, we copied that method intact into our subclass, replacing only the `new RequestMappingHandlerMapping()` with our own subclass. However, this duplicates the default config code in our code and exposes the possibility that we may miss changes to that config in future releases of Spring.

We did a simple refactor to extract the application of default configuration to into a separate method so overriders of `requestMappingHandlerMapping()` can simply pass their custom implementation into the new `configureDefaultHandlerMapping()`.

Example override in `WebMvcConfigurationSupport` subclass:

```
@Bean
public RequestMappingHandlerMapping requestMappingHandlerMapping() {
    RequestMappingHandlerMapping handlerMapping = new RequestMappingHandlerMapping() {
        protected RequestCondition getCustomMethodCondition(Method method) {
            // do custom request condition processing
        }
    };
    configureDefaultHandlerMapping(handlerMapping);

    return handlerMapping;
}
```

Issue: [SPR-12746](https://jira.spring.io/browse/SPR-12746)

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
