### PR TITLE
@AuthenticationPrincipal in handler parameters

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SimpAnnotationMethodMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SimpAnnotationMethodMessageHandler.java
@@ -299,6 +299,7 @@ public class SimpAnnotationMethodMessageHandler extends AbstractMethodMessageHan
 		resolvers.add(new HeaderMethodArgumentResolver(this.conversionService, beanFactory));
 		resolvers.add(new HeadersMethodArgumentResolver());
 		resolvers.add(new DestinationVariableMethodArgumentResolver(this.conversionService));
+		resolvers.add(new AuthenticationPrincipalArgumentResolver());
 
 		// Type-based argument resolution
 		resolvers.add(new PrincipalMethodArgumentResolver());


### PR DESCRIPTION
By adding this `AuthenticationPrincipalArgumentResolver` to the arguments resolvers, `@AuthenticationPrincipal` should be supported and we will be able to inject Spring Security principal object.
It will be useful when using `@MessageMapping` to handle remote STOMP messages over websockets.
