### PR TITLE
Fix SpEL Compilation mode IMMEDIATE.

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/SpelExpression.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/SpelExpression.java
@@ -433,7 +433,7 @@ public class SpelExpression implements Expression {
 		SpelCompilerMode compilerMode = expressionState.getConfiguration().getCompilerMode();
 		if (compilerMode != SpelCompilerMode.OFF) {
 			if (compilerMode == SpelCompilerMode.IMMEDIATE) {
-				if (this.interpretedCount > 1) {
+				if (this.interpretedCount >= 1) {
 					compileExpression();
 				}
 			}


### PR DESCRIPTION
Require 1 interpreted pass only (instead of 2)

cc @aclement 
