### PR TITLE
SPR-12771 The builder port must always be set

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -307,9 +307,7 @@ public class UriComponentsBuilder implements Cloneable {
 
 		builder.scheme(scheme);
 		builder.host(host);
-		if (scheme.equals("http") && port != 80 || scheme.equals("https") && port != 443) {
-			builder.port(port);
-		}
+		builder.port(port);
 		return builder;
 	}
 


### PR DESCRIPTION
Context: [SPR-12771](https://jira.spring.io/browse/SPR-12771)

When the `X-Forwarded-Port` is set, its value should always be taken into account. When looking at the `org.springframework.web.util.UriComponentsBuilder#fromHttpRequest` code, we see in the end that the `port` must always be set into the `builder`. If not, we have cases where the `port` remains set to `80`.
