### PR TITLE
Allow subclass adaptation of @Scheduled runnable creation.

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -281,7 +281,7 @@ public class ScheduledAnnotationBeanPostProcessor implements BeanPostProcessor, 
 				}
 			}
 
-			Runnable runnable = new ScheduledMethodRunnable(bean, method);
+			Runnable runnable = createRunnable(method, bean);
 			boolean processedSchedule = false;
 			String errorMessage =
 					"Exactly one of the 'cron', 'fixedDelay(String)', or 'fixedRate(String)' attributes is required";
@@ -383,6 +383,10 @@ public class ScheduledAnnotationBeanPostProcessor implements BeanPostProcessor, 
 			throw new IllegalStateException(
 					"Encountered invalid @Scheduled method '" + method.getName() + "': " + ex.getMessage());
 		}
+	}
+
+	protected Runnable createRunnable(Method method, Object bean) {
+		return new ScheduledMethodRunnable(bean, method);
 	}
 
 


### PR DESCRIPTION
Small change in ScheduledAnnotationBeanPostProcessor to allow subclass adaptation of @Scheduled runnable creation. This allows generic behaviour for scheduled tasks to be added in one place.
