### PR TITLE
SPR-12801 Support for named parameters in SimpleJdbcCall

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -565,7 +565,7 @@ public class CallMetaDataContext {
 		String schemaNameToUse;
 
 		// For Oracle where catalogs are not supported we need to reverse the schema name
-		// and the catalog name since the cataog is used for the package name
+		// and the catalog name since the catalog is used for the package name
 		if (this.metaDataProvider.isSupportsSchemasInProcedureCalls() &&
 				!this.metaDataProvider.isSupportsCatalogsInProcedureCalls()) {
 			schemaNameToUse = this.metaDataProvider.catalogNameToUse(getCatalogName());
@@ -595,7 +595,7 @@ public class CallMetaDataContext {
 					callString += ", ";
 				}
 				if (parameterCount >= 0) {
-					callString += "?";
+					callString += constructParameterBinding(parameter);
 				}
 				parameterCount++;
 			}
@@ -605,4 +605,13 @@ public class CallMetaDataContext {
 		return callString;
 	}
 
+	/**
+	 * Build parameter binding fragment
+	 *
+	 * @param parameter call parameter
+	 * @return parameter binding fragment
+	 */
+	protected String constructParameterBinding(SqlParameter parameter) {
+		return "?";
+	}
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/NamedCallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/NamedCallMetaDataContext.java
@@ -1,0 +1,33 @@
+
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.jdbc.core.metadata;
+
+import org.springframework.jdbc.core.SqlParameter;
+
+/**
+ * Name-specific class to manage context metadata used for the configuration and execution of the call.
+ * Implementing binding like: {call some_package.some_procedure(p_parameter_1 => ?, p_parameter_2 => ?, p_parameter_3 =>?)}
+ *
+ * @author Kiril Nugmanov
+ */
+public class NamedCallMetaDataContext extends CallMetaDataContext {
+
+    @Override
+    protected String constructParameterBinding(SqlParameter parameter) {
+        return parameter.getName() + " => ?";
+    }
+}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
@@ -54,9 +54,6 @@ public abstract class AbstractJdbcCall {
 	/** Lower-level class used to execute SQL */
 	private final JdbcTemplate jdbcTemplate;
 
-	/** Context used to retrieve and manage database metadata */
-	private final CallMetaDataContext callMetaDataContext = new CallMetaDataContext();
-
 	/** List of SqlParameter objects */
 	private final List<SqlParameter> declaredParameters = new ArrayList<SqlParameter>();
 
@@ -78,6 +75,8 @@ public abstract class AbstractJdbcCall {
 	 */
 	private CallableStatementCreatorFactory callableStatementFactory;
 
+	/** Context used to retrieve and manage database metadata */
+	private CallMetaDataContext callMetaDataContext = new CallMetaDataContext();
 
 	/**
 	 * Constructor to be used when initializing using a {@link DataSource}.
@@ -88,6 +87,27 @@ public abstract class AbstractJdbcCall {
 	}
 
 	/**
+	 * Constructor to be used when initializing using a {@link DataSource} and {@link CallMetaDataContext}.
+	 * @param dataSource the DataSource to be used
+	 * @param callMetaDataContext context used to retrieve and manage database metadata
+	 */
+	protected AbstractJdbcCall(DataSource dataSource, CallMetaDataContext callMetaDataContext) {
+		this(new JdbcTemplate(dataSource), callMetaDataContext);
+	}
+
+	/**
+	 * Constructor to be used when initializing using a {@link JdbcTemplate} and {@link CallMetaDataContext}.
+	 * @param jdbcTemplate the JdbcTemplate to use
+	 * @param callMetaDataContext context used to retrieve and manage database metadata
+	 */
+	protected AbstractJdbcCall(JdbcTemplate jdbcTemplate, CallMetaDataContext callMetaDataContext) {
+		Assert.notNull(jdbcTemplate, "JdbcTemplate must not be null");
+		Assert.notNull(callMetaDataContext, "CallMetaDataContext must not be null");
+		this.jdbcTemplate = jdbcTemplate;
+		this.callMetaDataContext = callMetaDataContext;
+	}
+
+	/**
 	 * Constructor to be used when initializing using a {@link JdbcTemplate}.
 	 * @param jdbcTemplate the JdbcTemplate to use
 	 */
@@ -95,7 +115,6 @@ public abstract class AbstractJdbcCall {
 		Assert.notNull(jdbcTemplate, "JdbcTemplate must not be null");
 		this.jdbcTemplate = jdbcTemplate;
 	}
-
 
 	/**
 	 * Get the configured {@link JdbcTemplate}.

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcCall.java
@@ -24,6 +24,7 @@ import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SqlParameter;
+import org.springframework.jdbc.core.metadata.CallMetaDataContext;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 /**
@@ -78,6 +79,28 @@ public class SimpleJdbcCall extends AbstractJdbcCall implements SimpleJdbcCallOp
 		super(jdbcTemplate);
 	}
 
+	/**
+	 * Constructor that takes one parameter with the JDBC DataSource and CallMetaDataContext to use when creating the
+	 * JdbcTemplate.
+	 *
+	 * @param dataSource the {@code DataSource} to use
+	 * @param callMetaDataContext the {@code CallMetaDataContext} to use
+	 * @see org.springframework.jdbc.core.JdbcTemplate#setDataSource
+	 */
+	public SimpleJdbcCall(DataSource dataSource, CallMetaDataContext callMetaDataContext) {
+		super(dataSource, callMetaDataContext);
+	}
+
+	/**
+	 * Alternative Constructor that takes JdbcTemplate and CallMetaDataContext.
+	 *
+	 * @param jdbcTemplate        the {@code JdbcTemplate} to use
+	 * @param callMetaDataContext the {@code CallMetaDataContext} to use
+	 * @see org.springframework.jdbc.core.JdbcTemplate#setDataSource
+	 */
+	public SimpleJdbcCall(JdbcTemplate jdbcTemplate, CallMetaDataContext callMetaDataContext) {
+		super(jdbcTemplate, callMetaDataContext);
+	}
 
 	@Override
 	public SimpleJdbcCall withProcedureName(String procedureName) {


### PR DESCRIPTION
Modification to support named parameter binding in JDBC calls. See SPR-12801 for more info.
