### PR TITLE
Expose SimpleCommandLineArgsParser methods and fields

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/CommandLineArgs.java
+++ b/spring-core/src/main/java/org/springframework/core/env/CommandLineArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import java.util.Set;
  * @since 3.1
  * @see SimpleCommandLineArgsParser
  */
-class CommandLineArgs {
+public class CommandLineArgs {
 
 	private final Map<String, List<String>> optionArgs = new HashMap<String, List<String>>();
 	private final List<String> nonOptionArgs = new ArrayList<String>();

--- a/spring-core/src/main/java/org/springframework/core/env/SimpleCommandLineArgsParser.java
+++ b/spring-core/src/main/java/org/springframework/core/env/SimpleCommandLineArgsParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package org.springframework.core.env;
 
 /**
- * Parses a {@code String[]} of command line arguments in order to populate a
- * {@link CommandLineArgs} object.
+ * Parses a {@code String[]} of command line arguments in order to populate a {@link
+ * CommandLineArgs} object.
  *
  * <h3>Working with option arguments</h3>
  * Option arguments must adhere to the exact syntax:
@@ -49,28 +49,23 @@ package org.springframework.core.env;
  * @author Chris Beams
  * @since 3.1
  */
-class SimpleCommandLineArgsParser {
+public class SimpleCommandLineArgsParser {
+
+	public static final String OPTION_NAME_PREFIX = "--";
+	public static final String OPTION_VALUE_SEPARATOR = "=";
 
 	/**
 	 * Parse the given {@code String} array based on the rules described {@linkplain
-	 * SimpleCommandLineArgsParser above}, returning a fully-populated
-	 * {@link CommandLineArgs} object.
+	 * SimpleCommandLineArgsParser above}, returning a fully-populated {@link
+	 * CommandLineArgs} object.
 	 * @param args command line arguments, typically from a {@code main()} method
 	 */
 	public CommandLineArgs parse(String... args) {
 		CommandLineArgs commandLineArgs = new CommandLineArgs();
 		for (String arg : args) {
-			if (arg.startsWith("--")) {
-				String optionText = arg.substring(2, arg.length());
-				String optionName;
-				String optionValue = null;
-				if (optionText.contains("=")) {
-					optionName = optionText.substring(0, optionText.indexOf("="));
-					optionValue = optionText.substring(optionText.indexOf("=")+1, optionText.length());
-				}
-				else {
-					optionName = optionText;
-				}
+			if (arg.startsWith(OPTION_NAME_PREFIX)) {
+				String optionName = parseOptionName(arg);
+				String optionValue = parseOptionValue(arg);
 				if (optionName.isEmpty() || (optionValue != null && optionValue.isEmpty())) {
 					throw new IllegalArgumentException("Invalid argument syntax: " + arg);
 				}
@@ -81,6 +76,40 @@ class SimpleCommandLineArgsParser {
 			}
 		}
 		return commandLineArgs;
+	}
+
+	/**
+	 * Parse the given command line argument on the rules described {@linkplain
+	 * SimpleCommandLineArgsParser above}, returning option name
+	 * @param arg command line argument, typically from a {@code main()} method
+	 */
+	public String parseOptionName(String arg) {
+		String optionText = parseOptionText(arg);
+		int valueSeparatorIndex = optionText.indexOf(OPTION_VALUE_SEPARATOR);
+		return valueSeparatorIndex < 0 ? optionText
+																	 : optionText.substring(0, valueSeparatorIndex);
+	}
+
+	/**
+	 * Parse the given {@code String} command line argument on the rules described
+	 * {@linkplain SimpleCommandLineArgsParser above}, returning option text in format: <pre
+	 * class="code">optName[=optValue]</pre>
+	 * @param arg command line argument, typically from a {@code main()} method
+	 */
+	private String parseOptionText(String arg) {
+		return arg.substring(OPTION_NAME_PREFIX.length(), arg.length());
+	}
+
+	/**
+	 * Parse the given {@code String} command line argument on the rules described
+	 * {@linkplain SimpleCommandLineArgsParser above}, returning option value
+	 * @param arg command line argument, typically from a {@code main()} method
+	 */
+	public String parseOptionValue(String arg) {
+		String optionText = parseOptionText(arg);
+		int valueSeparatorIndex = optionText.indexOf(OPTION_VALUE_SEPARATOR);
+		return valueSeparatorIndex < 0 ? null : optionText
+				.substring(valueSeparatorIndex + 1, optionText.length());
 	}
 
 }


### PR DESCRIPTION
For example you work with Spring Boot + Spring Batch and you need to validate command line arguments as `JobParameters` in batch job.
By default Spring Boot uses `SimpleCommandLinePropertySource` to resolve `Environment` parameters. This `PropertySource` implementation recognize `--optName[=optValue]` as argument with name `optName` and value `optValue`.
On the other hand Spring Batch provides `DefaultJobParametersConverter` to resolve job parameters. This converter recognize `--optName[=optValue]` as _non-identifying_ argument with name `-optName` and value `optValue`. And if you want to use `JobParametersValidator` to validate requred and optional keys in `JobParameters` you need to check for `-optName` rather then `optName`. Or implement custom `JobParametersConverter` which will detect these arguments right.
This functionality is pretty common but there are no JIRA features or discussions in mailing lists. This commit is to expose `SimpleCommandLineArgsParser` methods and extract fields for `--` and `=` to implement `SimpleCommandLineJobParametersConverter` in Spring Batch project.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
