### PR TITLE
Performance Optimization on getResultSetValue

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcUtils.java
@@ -144,52 +144,51 @@ public abstract class JdbcUtils {
 		Object value;
 
 		// Explicitly extract typed value, as far as possible.
-		if (String.class.equals(requiredType)) {
-			return rs.getString(index);
-		}
-		else if (boolean.class.equals(requiredType) || Boolean.class.equals(requiredType)) {
-			value = rs.getBoolean(index);
-		}
-		else if (byte.class.equals(requiredType) || Byte.class.equals(requiredType)) {
-			value = rs.getByte(index);
-		}
-		else if (short.class.equals(requiredType) || Short.class.equals(requiredType)) {
-			value = rs.getShort(index);
-		}
-		else if (int.class.equals(requiredType) || Integer.class.equals(requiredType)) {
-			value = rs.getInt(index);
-		}
-		else if (long.class.equals(requiredType) || Long.class.equals(requiredType)) {
-			value = rs.getLong(index);
-		}
-		else if (float.class.equals(requiredType) || Float.class.equals(requiredType)) {
-			value = rs.getFloat(index);
-		}
-		else if (double.class.equals(requiredType) || Double.class.equals(requiredType) ||
-				Number.class.equals(requiredType)) {
-			value = rs.getDouble(index);
-		}
-		else if (BigDecimal.class.equals(requiredType)) {
-			return rs.getBigDecimal(index);
-		}
-		else if (java.sql.Date.class.equals(requiredType)) {
-			return rs.getDate(index);
-		}
-		else if (java.sql.Time.class.equals(requiredType)) {
-			return rs.getTime(index);
-		}
-		else if (java.sql.Timestamp.class.equals(requiredType) || java.util.Date.class.equals(requiredType)) {
-			return rs.getTimestamp(index);
-		}
-		else if (byte[].class.equals(requiredType)) {
-			return rs.getBytes(index);
-		}
-		else if (Blob.class.equals(requiredType)) {
-			return rs.getBlob(index);
-		}
-		else if (Clob.class.equals(requiredType)) {
-			return rs.getClob(index);
-		}
+		if (String.class == requiredType) {
+	            return rs.getString(index);
+	        }
+	        else if (boolean.class == requiredType || Boolean.class == requiredType) {
+	            value = rs.getBoolean(index);
+	        }
+	        else if (byte.class == requiredType || Byte.class == requiredType) {
+	            value = rs.getByte(index);
+	        }
+	        else if (short.class == requiredType || Short.class == requiredType) {
+	            value = rs.getShort(index);
+	        }
+	        else if (int.class == requiredType || Integer.class == requiredType) {
+	            value = rs.getInt(index);
+	        }
+	        else if (long.class == requiredType || Long.class == requiredType) {
+	            value = rs.getLong(index);
+	        }
+	        else if (float.class == requiredType || Float.class == requiredType) {
+	            value = rs.getFloat(index);
+	        }
+	        else if (double.class == requiredType || Double.class == requiredType || Number.class == requiredType) {
+	            value = rs.getDouble(index);
+	        }
+	        else if (BigDecimal.class == requiredType) {
+	            return rs.getBigDecimal(index);
+	        }
+	        else if (java.sql.Date.class == requiredType) {
+	            return rs.getDate(index);
+	        }
+	        else if (java.sql.Time.class == requiredType) {
+	            return rs.getTime(index);
+	        }
+	        else if (java.sql.Timestamp.class == requiredType || java.util.Date.class == requiredType) {
+	            return rs.getTimestamp(index);
+	        }
+	        else if (byte[].class == requiredType) {
+	            return rs.getBytes(index);
+	        }
+	        else if (Blob.class == requiredType) {
+	            return rs.getBlob(index);
+	        }
+	        else if (Clob.class == requiredType) {
+	            return rs.getClob(index);
+	        }
 		else {
 			// Some unknown type desired -> rely on getObject.
 			if (getObjectWithTypeAvailable) {


### PR DESCRIPTION
Performance Optimization, using ".equals" is signifigantly slower than "==". 

When using "BeanPropertyRowMapper", we ran load tests and found significant lack of performance when calling "getColumnValue". I noticed that "getColumnValue" simply just calls "JdbcUtils.getResultSetValue". These tests were run on an table with roughly 70 columns.

After making change I ran three tests
1) with existing BeanPropertyRowMapper
2) with optimized BeanPropertyRowMapper
3) with a Custom RowMapper, mapped exactly to the class.
# Benchmark Results

1) round: 0.38 [+- 0.11], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 1, GC.time: 0.01, time.total: 7.98, time.warmup: 0.28, time.bench: 7.70
2) round: 0.23 [+- 0.02], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 0, GC.time: 0.00, time.total: 4.80, time.warmup: 0.22, time.bench: 4.58
3) round: 0.22 [+- 0.02], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 0, GC.time: 0.00, time.total: 4.62, time.warmup: 0.19, time.bench: 4.43

As you can see the optimized version makes BeanPropertyRowMapper almost as fast as a custom made RowMapper.
