### PR TITLE
Add isNotEmpty convenience method to StringUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -85,6 +85,19 @@ public abstract class StringUtils {
 	}
 
 	/**
+	 * Check that the given String is not empty.
+	 * Note: Will return {@code true} for a String that purely consists of whitespace.
+	 * Note: Will return {@code false} if the string is {@code null}.
+	 * @param string the String to check (may be {@code null})
+	 * @return {@code true} if the String is not null and has length
+	 * @see #hasLength(String)
+	 * @since 4.2.0
+	 */
+	public static boolean isNotEmpty(String string) {
+		return hasLength(string);
+	}
+
+	/**
 	 * Check that the given CharSequence is neither {@code null} nor of length 0.
 	 * Note: Will return {@code true} for a CharSequence that purely consists of whitespace.
 	 * <p><pre class="code">

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -49,6 +49,14 @@ public class StringUtilsTests {
 	}
 
 	@Test
+	public void testIsNotEmpty() {
+		assertTrue(StringUtils.isNotEmpty("hi"));
+		assertTrue(StringUtils.isNotEmpty(" "));
+		assertFalse(StringUtils.isNotEmpty(""));
+		assertFalse(StringUtils.isNotEmpty(null));
+	}
+
+	@Test
 	public void testContainsWhitespace() throws Exception {
 		assertFalse(StringUtils.containsWhitespace(null));
 		assertFalse(StringUtils.containsWhitespace(""));


### PR DESCRIPTION
In some (most?) cases `isNotEmpty(someString)` expresses your intentions better than `hasLength(someString)` and is more readable and less error-prone than `!isEmpty(someString)`
