### PR TITLE
FutureAdapter should wrap RuntimeExceptions

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/concurrent/FutureAdapter.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/FutureAdapter.java
@@ -107,6 +107,12 @@ public abstract class FutureAdapter<T, S> implements Future<T> {
 						this.state = State.FAILURE;
 						throw ex;
 					}
+					catch (RuntimeException ex) {
+						ExecutionException execEx = new ExecutionException(ex);
+						this.result = execEx;
+						this.state = State.FAILURE;
+						throw execEx;
+					}
 				default:
 					throw new IllegalStateException();
 			}


### PR DESCRIPTION
RuntimeExceptions thrown from FutureAdapter.adapt() should be wrapped in
an ExecutionException, not thrown as is.

Issue: SPR-12887
