### PR TITLE
Remove duplicate separators when combining

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -469,10 +469,18 @@ public class AntPathMatcher implements PathMatcher {
 	}
 
 	private String concat(String path1, String path2) {
-		if (path1.endsWith(this.pathSeparator) || path2.startsWith(this.pathSeparator)) {
+		boolean path1EndsWithSeparator = path1.endsWith(this.pathSeparator);
+		boolean path2StartsWithSeparator = path2.startsWith(this.pathSeparator);
+
+		if (path1EndsWithSeparator && path2StartsWithSeparator) {
+			return path1 + path2.substring(1);
+		}
+		else if (path1EndsWithSeparator || path2StartsWithSeparator) {
 			return path1 + path2;
 		}
-		return path1 + this.pathSeparator + path2;
+		else {
+			return path1 + this.pathSeparator + path2;
+		}
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -421,6 +421,8 @@ public class AntPathMatcherTests {
 		assertEquals("/user/user", pathMatcher.combine("/user", "/user"));	// SPR-7970
 		assertEquals("/{foo:.*[^0-9].*}/edit/", pathMatcher.combine("/{foo:.*[^0-9].*}", "/edit/")); // SPR-10062
 		assertEquals("/1.0/foo/test", pathMatcher.combine("/1.0", "/foo/test")); // SPR-10554
+		assertEquals("/hotel", pathMatcher.combine("/", "/hotel")); // SPR-12975
+		assertEquals("/hotel/booking", pathMatcher.combine("/hotel/", "/booking")); // SPR-12975
 	}
 
 	@Test

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/AbstractRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/AbstractRequestCondition.java
@@ -59,6 +59,15 @@ public abstract class AbstractRequestCondition<T extends AbstractRequestConditio
 		return builder.toString();
 	}
 
+	/**
+	 * Indicates whether this condition is empty, i.e. whether it contains any discrete
+	 * items.
+	 * @return {@code true} if empty; {@code false} otherwise
+	 */
+	public boolean isEmpty() {
+		return getContent().isEmpty();
+	}
+
 
 	/**
 	 * Return the discrete items a request condition is composed of.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
@@ -326,12 +326,24 @@ public final class RequestMappingInfo implements RequestCondition<RequestMapping
 	public String toString() {
 		StringBuilder builder = new StringBuilder("{");
 		builder.append(this.patternsCondition);
-		builder.append(",methods=").append(this.methodsCondition);
-		builder.append(",params=").append(this.paramsCondition);
-		builder.append(",headers=").append(this.headersCondition);
-		builder.append(",consumes=").append(this.consumesCondition);
-		builder.append(",produces=").append(this.producesCondition);
-		builder.append(",custom=").append(this.customConditionHolder);
+		if (!this.methodsCondition.isEmpty()) {
+			builder.append(",methods=").append(this.methodsCondition);
+		}
+		if (!this.paramsCondition.isEmpty()) {
+			builder.append(",params=").append(this.paramsCondition);
+		}
+		if (!this.headersCondition.isEmpty()) {
+			builder.append(",headers=").append(this.headersCondition);
+		}
+		if (!this.consumesCondition.isEmpty()) {
+			builder.append(",consumes=").append(this.consumesCondition);
+		}
+		if (!this.producesCondition.isEmpty()) {
+			builder.append(",produces=").append(this.producesCondition);
+		}
+		if (!this.customConditionHolder.isEmpty()) {
+			builder.append(",custom=").append(this.customConditionHolder);
+		}
 		builder.append('}');
 		return builder.toString();
 	}


### PR DESCRIPTION
Prior to this commit, AntPathMatcher would not correctly combine a path
that ends with a separator with a path that starts with a separator.
I.e. /foo/ + /bar combined into /foo//bar.

This commit removes the duplicates separator. It also improves
RequestMappingInfo's String representation.

Issue: SPR-12975
