### PR TITLE
Conditional Error Message Formatting

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/AdviceModeImportSelector.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/AdviceModeImportSelector.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Annotation;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.util.Assert;
 
  /**
  * Convenient base class for {@link ImportSelector} implementations that select imports
@@ -62,13 +61,17 @@ public abstract class AdviceModeImportSelector<A extends Annotation> implements 
 	public final String[] selectImports(AnnotationMetadata importingClassMetadata) {
 		Class<?> annoType = GenericTypeResolver.resolveTypeArgument(getClass(), AdviceModeImportSelector.class);
 		AnnotationAttributes attributes = AnnotationConfigUtils.attributesFor(importingClassMetadata, annoType);
-		Assert.notNull(attributes, String.format(
+		if (attributes == null) {
+			throw new IllegalArgumentException(String.format(
 				"@%s is not present on importing class '%s' as expected",
 				annoType.getSimpleName(), importingClassMetadata.getClassName()));
+		}
 
 		AdviceMode adviceMode = attributes.getEnum(this.getAdviceModeAttributeName());
 		String[] imports = selectImports(adviceMode);
-		Assert.notNull(imports, String.format("Unknown AdviceMode: '%s'", adviceMode));
+		if (imports == null) {
+			throw new IllegalArgumentException(String.format("Unknown AdviceMode: '%s'", adviceMode));
+		}
 		return imports;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationAttributes.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,9 @@ public class AnnotationAttributes extends LinkedHashMap<String, Object> {
 	private <T> T doGet(String attributeName, Class<T> expectedType) {
 		Assert.hasText(attributeName, "attributeName must not be null or empty");
 		Object value = get(attributeName);
-		Assert.notNull(value, String.format("Attribute '%s' not found", attributeName));
+		if (value == null) {
+			throw new IllegalArgumentException(String.format("Attribute '%s' not found", attributeName));
+		}
 		if (!expectedType.isInstance(value)) {
 			if (expectedType.isArray() && expectedType.getComponentType().isInstance(value)) {
 				Object arrayValue = Array.newInstance(expectedType.getComponentType(), 1);

--- a/spring-core/src/main/java/org/springframework/core/env/ReadOnlySystemAttributesMap.java
+++ b/spring-core/src/main/java/org/springframework/core/env/ReadOnlySystemAttributesMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-
-import org.springframework.util.Assert;
 
 /**
  * Read-only {@code Map<String, String>} implementation that is backed by system
@@ -50,8 +48,11 @@ abstract class ReadOnlySystemAttributesMap implements Map<String, String> {
 	 */
 	@Override
 	public String get(Object key) {
-		Assert.isInstanceOf(String.class, key,
-				String.format("Expected key [%s] to be of type String, got %s", key, key.getClass().getName()));
+		if (!(key instanceof String)) {
+			throw new IllegalArgumentException(
+					"Object of class [" + (key != null ? key.getClass().getName() : "null") +
+					"] must be an instance of " + String.class);
+		}
 		return this.getSystemAttribute((String) key);
 	}
 


### PR DESCRIPTION
Create error message strings only if an actual error has happened. This
seems to be the common pattern in the code base base and saves both CPU
and memory. We found only very few places where unconditional error
message formatting happens.
- fix unconditional error message formatting in
  AdviceModeImportSelector
- fix unconditional error message formatting in AnnotationAttributes
- fix unconditional error message formatting in
  ReadOnlySystemAttributesMap, this also fixes a potential
  NullPointerException

I did sign the CLA.

Issue: SPR-13007
