### PR TITLE
SPR-13033: Use @RequestMapping of correct class

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilderTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilderTests.java
@@ -229,6 +229,14 @@ public class MvcUriComponentsBuilderTests {
 		assertThat(uriComponents.toUriString(), endsWith("/something/else"));
 	}
 
+ 	@Test
+	public void testFromMethodCallOnSubclass() {
+		UriComponents uriComponents = fromMethodCall(on(ExtendedController.class).myMethod(null)).build();
+
+		assertThat(uriComponents.toUriString(), startsWith("http://localhost"));
+		assertThat(uriComponents.toUriString(), endsWith("/extended/else"));
+	}
+ 
 	@Test
 	public void testFromMethodCallWithTypeLevelUriVars() {
 		UriComponents uriComponents = fromMethodCall(on(
@@ -418,6 +426,11 @@ public class MvcUriComponentsBuilderTests {
 		}
 	}
 
+	@RequestMapping("/extended")
+	static class ExtendedController extends ControllerWithMethods {
+
+	}
+	
 	@RequestMapping("/user/{userId}/contacts")
 	static class UserContactController {
 


### PR DESCRIPTION
`MvcUriComponentsBuilder::fromMethodCall` creates wrong URLs with derived controller classes. The `@RequestMapping` of the declaring class of the method that is called is used instead of the `@RequstMapping` of the given controller class.

The same issue exists for the `fromMethod(Method method, ...)` methods. You'd also need to add the class of the controller to get the correct type level `@RequestMapping`. I'm not sure how you want to handle such API breaking changes though...

https://jira.spring.io/browse/SPR-13033
