### PR TITLE
SPR-13080 SseEventBuilder needs event rather than name

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
@@ -171,7 +171,7 @@ public class SseEmitter extends ResponseBodyEmitter {
 
 		@Override
 		public SseEventBuilder name(String name) {
-			append("name:").append(name != null ? name : "").append("\n");
+			append("event:").append(name != null ? name : "").append("\n");
 			return this;
 		}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterReturnValueHandlerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterReturnValueHandlerTests.java
@@ -147,7 +147,7 @@ public class ResponseBodyEmitterReturnValueHandlerTests {
 		emitter.send(event().comment("a test").name("update").id("1").reconnectTime(5000L).data(bean1).data(bean2));
 
 		assertEquals(":a test\n" +
-						"name:update\n" +
+						"event:update\n" +
 						"id:1\n" +
 						"retry:5000\n" +
 						"data:{\"id\":1,\"name\":\"Joe\"}\n" +

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitterTests.java
@@ -96,7 +96,7 @@ public class SseEmitterTests {
 	public void sendEventFull() throws Exception {
 		this.emitter.send(event().comment("blah").name("test").reconnectTime(5000L).id("1").data("foo"));
 		this.handler.assertSentObjectCount(3);
-		this.handler.assertObject(0, ":blah\nname:test\nretry:5000\nid:1\ndata:", SseEmitter.TEXT_PLAIN);
+		this.handler.assertObject(0, ":blah\nevent:test\nretry:5000\nid:1\ndata:", SseEmitter.TEXT_PLAIN);
 		this.handler.assertObject(1, "foo");
 		this.handler.assertObject(2, "\n\n", SseEmitter.TEXT_PLAIN);
 	}
@@ -109,7 +109,7 @@ public class SseEmitterTests {
 		this.handler.assertObject(1, "foo");
 		this.handler.assertObject(2, "\ndata:", SseEmitter.TEXT_PLAIN);
 		this.handler.assertObject(3, "bar");
-		this.handler.assertObject(4, "\nname:test\nretry:5000\nid:1\n\n", SseEmitter.TEXT_PLAIN);
+		this.handler.assertObject(4, "\nevent:test\nretry:5000\nid:1\n\n", SseEmitter.TEXT_PLAIN);
 	}
 
 


### PR DESCRIPTION
As per the W3C recommendation (http://www.w3.org/TR/eventsource/#event-stream-interpretation) the event type field is called "event".
The SseEmitter.SseEventBuilder class erroneously builds it using "name" as a prefix.

Issue created as https://jira.spring.io/browse/SPR-13080

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
