### PR TITLE
Add nullToEmpty convenience method to StringUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -85,6 +85,20 @@ public abstract class StringUtils {
 	}
 
 	/**
+	 * Convert {@code null} to empty string.
+	 * <p><pre class="code">
+	 * StringUtils.nullToEmpty(null) = ""
+	 * StringUtils.nullToEmpty("abc") = "abc"
+	 * </pre>
+	 * @param str string that may be {@code null}
+	 * @return given string if it is not {@code null} otherwise an empty string
+	 * @since 4.2.2
+	 */
+	public static String nullToEmpty(String str) {
+		return str == null ? "" : str;
+	}
+
+	/**
 	 * Check that the given {@code CharSequence} is neither {@code null} nor
 	 * of length 0.
 	 * <p>Note: this method returns {@code true} for a {@code CharSequence}

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -700,4 +700,9 @@ public class StringUtilsTests {
 		assertEquals("Variant containing country code not extracted correctly", variant, locale.getVariant());
 	}
 
+	@Test
+	public void testNullToEmpty() throws Exception {
+		assertEquals("", StringUtils.nullToEmpty(null));
+		assertEquals("abc", StringUtils.nullToEmpty("abc"));
+	}
 }


### PR DESCRIPTION
It allows you to replace common patterns like:

``` java
if(string == null) {
    string = "";
}
doSomethingWith(string);
```

or:

``` java
return string == null ? "" : string;
```

with a `nullToEmpty(string)` method call.
