### PR TITLE
SPR-13099: Prevent class leak in GenericConversionService

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *
  */
 
 package org.springframework.core.convert.support;
@@ -43,6 +45,7 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ConcurrentReferenceHashMap;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -59,6 +62,7 @@ import org.springframework.util.StringUtils;
  * @since 3.0
  */
 public class GenericConversionService implements ConfigurableConversionService {
+
 
 	/**
 	 * General NO-OP converter used when conversion is not required.
@@ -89,7 +93,7 @@ public class GenericConversionService implements ConfigurableConversionService {
 	private final Converters converters = new Converters();
 
 	private final Map<ConverterCacheKey, GenericConverter> converterCache =
-			new ConcurrentHashMap<ConverterCacheKey, GenericConverter>(64);
+			new ConcurrentReferenceHashMap<ConverterCacheKey, GenericConverter>(64);
 
 
 	// ConverterRegistry implementation


### PR DESCRIPTION
I briefly discussed this with @philwebb.

This is the (simple change) solution that I found, although it is not entirely correct.

The problem is that what is strongly reachable as long as a module is loaded is a Class object. Yet, the cache in GCS holds complex objects (keys), which in turn hold the aforementioned class object. Hence, with the proposed patch, it is possible that the `cache -> key -> class object` connection will get severed here:

```
cache -> key -> class object
      ^
```

before the class object is being disposed of, while the "correct" loose link should be here:

```
cache -> key -> class object
             ^
```

Yet, I've looked at the problem for a couple of hours and don't see how we can do better. This is in part mitigated by the use of soft (as opposed to weak) references though.
