### PR TITLE
Allow StopWatch to be started on construction

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StopWatch.java
+++ b/spring-core/src/main/java/org/springframework/util/StopWatch.java
@@ -86,28 +86,6 @@ public class StopWatch {
 		this.id = id;
 	}
 
-	/**
-	 * Construct a new stop watch and optionally start an unnamed task.
-	 * @param start if true starts an unnamed task.
-	 * @since 4.2
-	 */
-	public StopWatch(boolean start) {
-		this("", start);
-	}
-
-	/**
-	 * Construct a new stop watch with the given id and optionally start an unnamed task.
-	 * @param id identifier for this stop watch.
-	 * @param start if true starts an unnamed task.
-	 * @since 4.2
-	 */
-	public StopWatch(String id, boolean start) {
-		this.id = id;
-		if(start){
-			start();
-		}
-	}
-
 
 	/**
 	 * Determine whether the TaskInfo array is built over time. Set this to
@@ -122,25 +100,28 @@ public class StopWatch {
 	/**
 	 * Start an unnamed task. The results are undefined if {@link #stop()}
 	 * or timing methods are called without invoking this method.
+	 * @return this StopWatch
 	 * @see #stop()
 	 */
-	public void start() throws IllegalStateException {
-		start("");
+	public StopWatch start() throws IllegalStateException {
+		return start("");
 	}
 
 	/**
 	 * Start a named task. The results are undefined if {@link #stop()}
 	 * or timing methods are called without invoking this method.
 	 * @param taskName the name of the task to start
+	 * @return this StopWatch
 	 * @see #stop()
 	 */
-	public void start(String taskName) throws IllegalStateException {
+	public StopWatch start(String taskName) throws IllegalStateException {
 		if (this.running) {
 			throw new IllegalStateException("Can't start StopWatch: it's already running");
 		}
 		this.startTimeMillis = System.currentTimeMillis();
 		this.running = true;
 		this.currentTaskName = taskName;
+		return this;
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/StopWatch.java
+++ b/spring-core/src/main/java/org/springframework/util/StopWatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,28 @@ public class StopWatch {
 	 */
 	public StopWatch(String id) {
 		this.id = id;
+	}
+
+	/**
+	 * Construct a new stop watch and optionally start an unnamed task.
+	 * @param start if true starts an unnamed task.
+	 * @since 4.2
+	 */
+	public StopWatch(boolean start) {
+		this("", start);
+	}
+
+	/**
+	 * Construct a new stop watch with the given id and optionally start an unnamed task.
+	 * @param id identifier for this stop watch.
+	 * @param start if true starts an unnamed task.
+	 * @since 4.2
+	 */
+	public StopWatch(String id, boolean start) {
+		this.id = id;
+		if(start){
+			start();
+		}
 	}
 
 

--- a/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
@@ -141,8 +141,8 @@ public class StopWatchTests extends TestCase {
 		}
 	}
 
-	public void testStartOnConstruction() {
-		StopWatch sw = new StopWatch(true);
+	public void testStopWatchStartBuilder() {
+		StopWatch sw = new StopWatch().start();
 		assertTrue(sw.isRunning());
 	}
 

--- a/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,6 +139,11 @@ public class StopWatchTests extends TestCase {
 		catch (IllegalStateException ex) {
 			// Ok
 		}
+	}
+
+	public void testStartOnConstruction() {
+		StopWatch sw = new StopWatch(true);
+		assertTrue(sw.isRunning());
 	}
 
 }


### PR DESCRIPTION
Simplify starting stopwatch after construction

Return "this" from the start method of the stopwatch,
so that a stopwatch can be constructed and started in one line.
Most of the time you use the stopwatch you want to start it
right away, this saves a line of code and makes the stopwatch
a preferable approach to a simple system time comparison.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.

Issue: SPR-13106
