### PR TITLE
Make AbstractAdaptableMessageListener getResponseDestination aware of response JMS Destination if set

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/adapter/AbstractAdaptableMessageListener.java
@@ -304,7 +304,11 @@ public abstract class AbstractAdaptableMessageListener
 
 	/**
 	 * Determine a response destination for the given message.
-	 * <p>The default implementation first checks the JMS Reply-To
+	 * <p>The default implementation first checks the JMS {@link Destination}
+	 * of retrieved response and uses it if not {@code null}.
+	 * This allows to dynamically override {@link SendTo} annotation value
+         * as well as the JMS Reply-To {@link Destination} of the handled request.
+	 * <p>Then the default implementation checks the JMS Reply-To
 	 * {@link Destination} of the supplied request; if that is not {@code null}
 	 * it is returned; if it is {@code null}, then the configured
 	 * {@link #resolveDefaultResponseDestination default response destination}
@@ -321,6 +325,9 @@ public abstract class AbstractAdaptableMessageListener
 	 */
 	protected Destination getResponseDestination(Message request, Message response, Session session)
 			throws JMSException {
+		if (response.getJMSDestination() != null) {
+			return response.getJMSDestination();
+                }
 
 		Destination replyTo = request.getJMSReplyTo();
 		if (replyTo == null) {


### PR DESCRIPTION
I was trying to implement a kind of router - retrieve a message in JmsListener annotated method, create a new message inside it (that basically embraces the request message) and send it to dynamically chosen queue, based on some processing logic. Unfortunately SendTo annotation doesn't allow for dynamic destination choosing and my incoming messages can't have ReplyTo field set. I've ended witch the following code, that works:

```
@JmsListener(destination = "inbound.queue")
//@SendTo("Only static queue possible")
public Message router(Message src, Session s) throws JMSException {
    TextMessage dst = s.createTextMessage(((TextMessage) src).getText());
    // based on some processing logic, we want dst to be placed in some queue
    // This works, but is a "hack":
    src.setJMSReplyTo(new MQQueue("some.queue"));
    // This doesn't work but is much more clean solution provided with this pull request
    dst.setJMSDestination(new MQQueue("some.queue"));
    return dst;
}
```

There are some good reasons why modifying request (incoming) message is bad idea. First of all, it is good to treat inbound messages as immutable objects and not mess with changing their properties. Second, not all listener use cases are suitable for request/reply patterns. The original meaning for JMSDestination is informative one (to be used by receiving party to check what queue message originates from). Therefore message brokers ignore those properties when sending messages, while try to keep it informative on message reception. So reusing JMSDestination for hinting Spring Container about overriding SendTo annotation is not abusive and will allow to write a more clean code.
