### PR TITLE
Reduce BeanDefinition cloning from isFactoryBean

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -970,7 +970,15 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 			return ((ConfigurableBeanFactory) getParentBeanFactory()).isFactoryBean(name);
 		}
 
-		return isFactoryBean(beanName, getMergedLocalBeanDefinition(beanName));
+		RootBeanDefinition mbd = this.mergedBeanDefinitions.get(beanName);
+		if (mbd != null) {
+			return isFactoryBean(beanName, mbd);
+		}
+		BeanDefinition bd = getBeanDefinition(beanName);
+		if (bd.getParentName() == null && bd instanceof RootBeanDefinition) {
+			return isFactoryBean(beanName, (RootBeanDefinition) bd);
+		}
+		return isFactoryBean(beanName, getMergedBeanDefinition(beanName, bd));
 	}
 
 	@Override


### PR DESCRIPTION
Update AbstractBeanFactory.isFactoryBean to only create the merged local
bean definition when absolutely necessary.
