### PR TITLE
Use method meta-data in getTypeForFactoryMethod

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AnnotatedGenericBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AnnotatedGenericBeanDefinition.java
@@ -98,6 +98,11 @@ public class AnnotatedGenericBeanDefinition extends GenericBeanDefinition implem
 	}
 
 	@Override
+	public String getFactoryMethodReturnType() {
+		return (this.factoryMethodMetadata == null ? null : this.factoryMethodMetadata.getReturnTypeName());
+	}
+
+	@Override
 	public final MethodMetadata getFactoryMethodMetadata() {
 		return this.factoryMethodMetadata;
 	}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/BeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/BeanDefinition.java
@@ -121,6 +121,11 @@ public interface BeanDefinition extends AttributeAccessor, BeanMetadataElement {
 	String getFactoryMethodName();
 
 	/**
+	 * Return the class name of the factory method return type, if known in advance.
+	 */
+	String getFactoryMethodReturnType();
+
+	/**
 	 * Specify a factory method, if any. This method will be invoked with
 	 * constructor arguments, or with no arguments if none are specified.
 	 * The method will be invoked on the specified factory bean, if any,

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinition.java
@@ -758,6 +758,11 @@ public abstract class AbstractBeanDefinition extends BeanMetadataAttributeAccess
 		return this.factoryMethodName;
 	}
 
+	@Override
+	public String getFactoryMethodReturnType() {
+		return null;
+	}
+
 	/**
 	 * Set the name of the initializer method. The default is {@code null}
 	 * in which case there is no initializer method.

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
@@ -61,6 +61,9 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 	/** Package-visible field for caching the resolved constructor or factory method */
 	Object resolvedConstructorOrFactoryMethod;
 
+	/** Package-visible field for caching the loaded factory method return type */
+	volatile Class<?> factoryMethodReturnType;
+
 	/** Package-visible field for caching the return type of a generically typed factory method */
 	volatile Class<?> resolvedFactoryMethodReturnType;
 

--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassBeanDefinitionReader.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassBeanDefinitionReader.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.annotation.AnnotatedGenericBeanDefinition;
@@ -400,6 +399,11 @@ class ConfigurationClassBeanDefinitionReader {
 		@Override
 		public AnnotationMetadata getMetadata() {
 			return this.annotationMetadata;
+		}
+
+		@Override
+		public String getFactoryMethodReturnType() {
+			return (this.factoryMethodMetadata == null ? null : this.factoryMethodMetadata.getReturnTypeName());
 		}
 
 		@Override


### PR DESCRIPTION
Update AbstractAutowireCapableBeanFactory.getTypeForFactoryMethod to
use already loaded method meta-data when deducing the type of a factory
method.
