### PR TITLE
Refactor WebSocket int. tests to work w/ Jetty 9.3

### DIFF
--- a/spring-websocket/src/test/java/org/springframework/web/socket/TomcatWebSocketTestServer.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/TomcatWebSocketTestServer.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 
 import javax.servlet.Filter;
+import javax.servlet.ServletContext;
 
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleEvent;
@@ -31,6 +32,7 @@ import org.apache.tomcat.util.descriptor.web.FilterDef;
 import org.apache.tomcat.util.descriptor.web.FilterMap;
 import org.apache.tomcat.websocket.server.WsContextListener;
 
+import org.springframework.mock.web.test.MockServletContext;
 import org.springframework.util.Assert;
 import org.springframework.util.SocketUtils;
 import org.springframework.web.context.WebApplicationContext;
@@ -40,6 +42,7 @@ import org.springframework.web.servlet.DispatcherServlet;
  * Tomcat based {@link WebSocketTestServer}.
  *
  * @author Rossen Stoyanchev
+ * @author Sam Brannen
  */
 public class TomcatWebSocketTestServer implements WebSocketTestServer {
 
@@ -128,6 +131,11 @@ public class TomcatWebSocketTestServer implements WebSocketTestServer {
 	@Override
 	public void stop() throws Exception {
 		this.tomcatServer.stop();
+	}
+
+	@Override
+	public ServletContext getServletContext() {
+		return new MockServletContext();
 	}
 
 }

--- a/spring-websocket/src/test/java/org/springframework/web/socket/UndertowTestServer.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/UndertowTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,6 @@
 
 package org.springframework.web.socket;
 
-import java.io.IOException;
-import javax.servlet.DispatcherType;
-import javax.servlet.Filter;
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import io.undertow.servlet.api.DeploymentInfo;
@@ -30,14 +24,24 @@ import io.undertow.servlet.api.FilterInfo;
 import io.undertow.servlet.api.InstanceFactory;
 import io.undertow.servlet.api.InstanceHandle;
 import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
-import org.xnio.ByteBufferSlicePool;
-import org.xnio.OptionMap;
-import org.xnio.Xnio;
 
+import java.io.IOException;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import javax.servlet.Servlet;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import org.springframework.mock.web.test.MockServletContext;
 import org.springframework.util.Assert;
 import org.springframework.util.SocketUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
+
+import org.xnio.ByteBufferSlicePool;
+import org.xnio.OptionMap;
+import org.xnio.Xnio;
 
 import static io.undertow.servlet.Servlets.*;
 
@@ -45,6 +49,7 @@ import static io.undertow.servlet.Servlets.*;
  * Undertow-based {@link WebSocketTestServer}.
  *
  * @author Rossen Stoyanchev
+ * @author Sam Brannen
  */
 public class UndertowTestServer implements WebSocketTestServer {
 
@@ -161,6 +166,11 @@ public class UndertowTestServer implements WebSocketTestServer {
 				public void release() {}
 			};
 		}
+	}
+
+	@Override
+	public ServletContext getServletContext() {
+		return new MockServletContext();
 	}
 
 }

--- a/spring-websocket/src/test/java/org/springframework/web/socket/WebSocketTestServer.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/WebSocketTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.web.socket;
 
 import javax.servlet.Filter;
+import javax.servlet.ServletContext;
 
 import org.springframework.web.context.WebApplicationContext;
 
@@ -24,6 +25,7 @@ import org.springframework.web.context.WebApplicationContext;
  * Contract for a test server to use for WebSocket integration tests.
  *
  * @author Rossen Stoyanchev
+ * @author Sam Brannen
  */
 public interface WebSocketTestServer {
 
@@ -38,5 +40,10 @@ public interface WebSocketTestServer {
 	void start() throws Exception;
 
 	void stop() throws Exception;
+
+	/**
+	 * @since 4.2
+	 */
+	ServletContext getServletContext();
 
 }


### PR DESCRIPTION
Recent builds of Jetty 9.3 require that Jetty's own ServletContext
implementation be supplied to WebSocketServerFactory's init() method.
Otherwise, the Jetty server will fail to start with the exception
message: "Not running on Jetty, WebSocket support unavailable".

This commit refactors AbstractSockJsIntegrationTests and all
WebSocketTestServer implementations in order to support this new
requirement. Specifically:
- WebSocketTestServer defines a new getServletContext() method.
  TomcatWebSocketTestServer and UndertowTestServer simply return a
  MockServletContext; whereas, JettyWebSocketTestServer returns the
  ServletContext created internally by Jetty's ServletContextHandler.
- The setup() method in AbstractSockJsIntegrationTests has been
  refactored so that the WebApplicationContext is supplied the
  appropriate ServletContext, after the WebSocketTestServer has been set
  up.

Issue: SPR-13162
