### PR TITLE
Add an ObjectMapper constructor to MappingJackson2JsonView

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
@@ -87,6 +87,15 @@ public class MappingJackson2JsonView extends AbstractJackson2View {
 		super(Jackson2ObjectMapperBuilder.json().build(), DEFAULT_CONTENT_TYPE);
 	}
 
+	/**
+	 * Construct a new {@code MappingJackson2JsonView} using the configuration
+	 * provided by the given ObjectMapper and setting the content type
+	 * to {@code application/json}.
+	 */
+	public MappingJackson2JsonView(ObjectMapper objectMapper) {
+		super(objectMapper, DEFAULT_CONTENT_TYPE);
+	}
+
 
 	/**
 	 * Specify a custom prefix to use for this view's JSON output.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xml/MappingJackson2XmlView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xml/MappingJackson2XmlView.java
@@ -58,6 +58,14 @@ public class MappingJackson2XmlView extends AbstractJackson2View {
 		super(Jackson2ObjectMapperBuilder.xml().build(), DEFAULT_CONTENT_TYPE);
 	}
 
+	/**
+	 * Construct a new {@code MappingJackson2XmlView} using the configuration
+	 * provided by the given XmlMapper and setting the content type
+	 * to {@code application/xml}.
+	 */
+	public MappingJackson2XmlView(XmlMapper xmlMapper) {
+		super(xmlMapper, DEFAULT_CONTENT_TYPE);
+	}
 
 	/**
 	 * {@inheritDoc}


### PR DESCRIPTION
Instead of having to use the default constructor then calling #setObjectMapper(ObjectMapper), this constructor allows the MappingJackson2JsonView to be created and configured with the desired object mapper in one step.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
