### PR TITLE
DelegatingFilterProxy looks at "registered" WebApplicationContexts

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/NumberUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/NumberUtils.java
@@ -32,6 +32,7 @@ import java.util.Set;
  *
  * @author Juergen Hoeller
  * @author Rob Harrop
+ * @author Rob Winch
  * @since 1.1.2
  */
 public abstract class NumberUtils {
@@ -66,7 +67,7 @@ public abstract class NumberUtils {
 	 * @param targetClass the target class to convert to
 	 * @return the converted number
 	 * @throws IllegalArgumentException if the target class is not supported
-	 * (i.e. not a standard Number subclass as included in the JDK)
+	 * (i.e. not a standard Number subclass or respective primitive as included in the JDK)
 	 * @see java.lang.Byte
 	 * @see java.lang.Short
 	 * @see java.lang.Integer
@@ -86,28 +87,28 @@ public abstract class NumberUtils {
 		if (targetClass.isInstance(number)) {
 			return (T) number;
 		}
-		else if (Byte.class == targetClass) {
+		else if (Byte.class == targetClass || byte.class == targetClass) {
 			long value = number.longValue();
 			if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
 				raiseOverflowException(number, targetClass);
 			}
 			return (T) new Byte(number.byteValue());
 		}
-		else if (Short.class == targetClass) {
+		else if (Short.class == targetClass || short.class == targetClass) {
 			long value = number.longValue();
 			if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
 				raiseOverflowException(number, targetClass);
 			}
 			return (T) new Short(number.shortValue());
 		}
-		else if (Integer.class == targetClass) {
+		else if (Integer.class == targetClass || int.class == targetClass) {
 			long value = number.longValue();
 			if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
 				raiseOverflowException(number, targetClass);
 			}
 			return (T) new Integer(number.intValue());
 		}
-		else if (Long.class == targetClass) {
+		else if (Long.class == targetClass || long.class == targetClass) {
 			BigInteger bigInt = null;
 			if (number instanceof BigInteger) {
 				bigInt = (BigInteger) number;
@@ -131,10 +132,10 @@ public abstract class NumberUtils {
 				return (T) BigInteger.valueOf(number.longValue());
 			}
 		}
-		else if (Float.class == targetClass) {
+		else if (Float.class == targetClass || float.class == targetClass) {
 			return (T) new Float(number.floatValue());
 		}
-		else if (Double.class == targetClass) {
+		else if (Double.class == targetClass || double.class == targetClass) {
 			return (T) new Double(number.doubleValue());
 		}
 		else if (BigDecimal.class == targetClass) {

--- a/spring-core/src/test/java/org/springframework/util/NumberUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/NumberUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import static org.junit.Assert.*;
 /**
  * @author Rob Harrop
  * @author Juergen Hoeller
+ * @author Rob Winch
  */
 public class NumberUtilsTests {
 
@@ -412,6 +413,59 @@ public class NumberUtilsTests {
 		assertEquals(Long.valueOf(Byte.MAX_VALUE), NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) (Byte.MIN_VALUE - 1)), Long.class));
 	}
 
+	@Test
+	public void testNumberToBytePrimitive() {
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), byte.class));
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), byte.class));
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), byte.class));
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), byte.class));
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), byte.class));
+	}
+
+	@Test
+	public void testNumberToShortPrimitive() {
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), short.class));
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), short.class));
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), short.class));
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), short.class));
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), short.class));
+	}
+
+	@Test
+	public void testNumberToIntPrimitive() {
+		assertEquals((int) 1, (int) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), int.class));
+		assertEquals((int) 1, (int) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), int.class));
+		assertEquals((int) 1, (int) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), int.class));
+		assertEquals((int) 1, (int) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), int.class));
+		assertEquals((int) 1, (int) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), int.class));
+	}
+
+	@Test
+	public void testNumberToLongPrimitive() {
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), long.class));
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), long.class));
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), long.class));
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), long.class));
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), long.class));
+	}
+
+	@Test
+	public void testNumberToFloatPrimitive() {
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), float.class), 0);
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), float.class), 0);
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), float.class), 0);
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), float.class), 0);
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), float.class), 0);
+	}
+
+	@Test
+	public void testNumberToDoublePrimitive() {
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), double.class), 0);
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), double.class), 0);
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), double.class), 0);
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), double.class), 0);
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), double.class), 0);
+	}
 
 	private void assertLongEquals(String aLong) {
 		assertEquals("Long did not parse", Long.MAX_VALUE, NumberUtils.parseNumber(aLong, Long.class).longValue());

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/SingleColumnRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/SingleColumnRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.NumberUtils;
  * and converted into the specified target type.
  *
  * @author Juergen Hoeller
+ * @author Rob Winch
  * @since 1.2
  * @see JdbcTemplate#queryForList(String, Class)
  * @see JdbcTemplate#queryForObject(String, Class)
@@ -168,7 +169,7 @@ public class SingleColumnRowMapper<T> implements RowMapper<T> {
 		if (String.class == requiredType) {
 			return value.toString();
 		}
-		else if (Number.class.isAssignableFrom(requiredType)) {
+		else if (Number.class.isAssignableFrom(requiredType) || requiredType.isPrimitive()) {
 			if (value instanceof Number) {
 				// Convert original Number to target Number class.
 				return NumberUtils.convertNumberToTargetClass(((Number) value), (Class<Number>) requiredType);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
@@ -41,6 +41,7 @@ import static org.mockito.BDDMockito.*;
 /**
  * @author Juergen Hoeller
  * @author Phillip Webb
+ * @author Rob Winch
  * @since 19.12.2004
  */
 public class JdbcTemplateQueryTests {
@@ -226,11 +227,33 @@ public class JdbcTemplateQueryTests {
 	}
 
 	@Test
+	public void testQueryForIntPrimitive() throws Exception {
+		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
+		given(this.resultSet.next()).willReturn(true, false);
+		given(this.resultSet.getInt(1)).willReturn(22);
+		int i = this.template.queryForObject(sql,int.class);
+		assertEquals("Return of an int", 22, i);
+		verify(this.resultSet).close();
+		verify(this.statement).close();
+	}
+
+	@Test
 	public void testQueryForLong() throws Exception {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getLong(1)).willReturn(87L);
 		long l = this.template.queryForObject(sql, Long.class).longValue();
+		assertEquals("Return of a long", 87, l);
+		verify(this.resultSet).close();
+		verify(this.statement).close();
+	}
+
+	@Test
+	public void testQueryForLongPrimitive() throws Exception {
+		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
+		given(this.resultSet.next()).willReturn(true, false);
+		given(this.resultSet.getLong(1)).willReturn(87L);
+		long l = this.template.queryForObject(sql, long.class);
 		assertEquals("Return of a long", 87, l);
 		verify(this.resultSet).close();
 		verify(this.statement).close();

--- a/spring-web/src/test/java/org/springframework/web/context/support/WebApplicationContextUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/support/WebApplicationContextUtilsTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.web.context.support;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.mock.web.test.MockServletContext;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * @author Rob Winch
+ */
+public class WebApplicationContextUtilsTests {
+	private MockServletContext sc;
+
+	private String attrName;
+	private String attrName2;
+
+	private AnnotationConfigWebApplicationContext rootContext;
+	private AnnotationConfigWebApplicationContext context;
+	private AnnotationConfigWebApplicationContext context2;
+
+	@Before
+	public void setup() {
+		sc = new MockServletContext();
+		attrName = "attrName";
+		attrName2 = "attrName2";
+		rootContext = new AnnotationConfigWebApplicationContext();
+		context = new AnnotationConfigWebApplicationContext();
+		context2 = new AnnotationConfigWebApplicationContext();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void registerWebApplicationContextNullSc() {
+		WebApplicationContextUtils.registerWebApplicationContext(null, attrName, context);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void registerWebApplicationContextNullAttrName() {
+		WebApplicationContextUtils.registerWebApplicationContext(sc, null, context);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void registerWebApplicationContextNullContext() {
+		WebApplicationContextUtils.registerWebApplicationContext(sc, attrName, null);
+	}
+
+	@Test
+	public void registerWebApplicationContextNoRoot() {
+		WebApplicationContextUtils.registerWebApplicationContext(sc, attrName, context);
+
+		assertEquals(Arrays.asList(context),
+				WebApplicationContextUtils.getRegisteredWebApplicationContexts(sc));
+	}
+
+	@Test
+	public void registerWebApplicationContextWithRoot() {
+		sc.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, rootContext);
+		WebApplicationContextUtils.registerWebApplicationContext(sc, attrName, context);
+
+		assertEquals(Arrays.asList(rootContext, context),
+				WebApplicationContextUtils.getRegisteredWebApplicationContexts(sc));
+	}
+
+	@Test
+	public void registerWebApplicationContextMultiChild() {
+		WebApplicationContextUtils.registerWebApplicationContext(sc, attrName, context);
+		WebApplicationContextUtils.registerWebApplicationContext(sc, attrName2, context2);
+		sc.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, rootContext);
+
+		assertEquals(Arrays.asList(rootContext, context, context2),
+				WebApplicationContextUtils.getRegisteredWebApplicationContexts(sc));
+	}
+
+	@Test
+	public void registerWebApplicationContextMultiWithSameAttr() {
+		WebApplicationContextUtils.registerWebApplicationContext(sc, attrName, context);
+		WebApplicationContextUtils.registerWebApplicationContext(sc, attrName, context2);
+
+		assertEquals(Arrays.asList(context2),
+				WebApplicationContextUtils.getRegisteredWebApplicationContexts(sc));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getRegisteredWebApplicationContextNull() {
+		WebApplicationContextUtils.getRegisteredWebApplicationContexts(null);
+	}
+
+	@Test
+	public void getRegisteredWebApplicationContext() {
+		assertEquals(Collections.emptyList(),
+				WebApplicationContextUtils.getRegisteredWebApplicationContexts(sc));
+	}
+}

--- a/spring-web/src/test/java/org/springframework/web/filter/DelegatingFilterProxyTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/DelegatingFilterProxyTests.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004, 2005 Acegi Technology Pty Limited
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,14 @@ import org.springframework.mock.web.test.MockHttpServletResponse;
 import org.springframework.mock.web.test.MockServletContext;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.StaticWebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import static org.junit.Assert.*;
 
 /**
  * @author Juergen Hoeller
  * @author Chris Beams
+ * @author Rob Winch
  * @since 08.05.2005
  */
 public class DelegatingFilterProxyTests {
@@ -268,6 +270,168 @@ public class DelegatingFilterProxyTests {
 		assertNull(targetFilter.filterConfig);
 	}
 
+	@Test
+	public void testDelegatingFilterProxyRegistered() throws ServletException, IOException {
+		ServletContext sc = new MockServletContext();
+
+		StaticWebApplicationContext wac = new StaticWebApplicationContext();
+		wac.setServletContext(sc);
+		wac.registerSingleton("targetFilter", MockFilter.class);
+		wac.refresh();
+		WebApplicationContextUtils.registerWebApplicationContext(sc, "org.springframework.web.servlet.FrameworkServlet.CONTEXT.dispatcher", wac);
+
+		MockFilter targetFilter = (MockFilter) wac.getBean("targetFilter");
+
+		MockFilterConfig proxyConfig = new MockFilterConfig(sc);
+		proxyConfig.addInitParameter("targetBeanName", "targetFilter");
+		DelegatingFilterProxy filterProxy = new DelegatingFilterProxy();
+		filterProxy.init(proxyConfig);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filterProxy.doFilter(request, response, null);
+
+		assertNull(targetFilter.filterConfig);
+		assertEquals(Boolean.TRUE, request.getAttribute("called"));
+
+		filterProxy.destroy();
+		assertNull(targetFilter.filterConfig);
+	}
+
+	@Test
+	public void testDelegatingFilterProxyInjectedPreferred() throws ServletException, IOException {
+		ServletContext sc = new MockServletContext();
+
+		StaticWebApplicationContext wac = new StaticWebApplicationContext();
+		wac.setServletContext(sc);
+		wac.refresh();
+
+		WebApplicationContextUtils.registerWebApplicationContext(sc, "org.springframework.web.servlet.FrameworkServlet.CONTEXT.dispatcher", wac);
+
+		StaticWebApplicationContext injectedWac = new StaticWebApplicationContext();
+		injectedWac.setServletContext(sc);
+		String beanName = "targetFilter";
+		injectedWac.registerSingleton(beanName, MockFilter.class);
+		injectedWac.refresh();
+
+		MockFilter targetFilter = (MockFilter) injectedWac.getBean(beanName);
+
+		DelegatingFilterProxy filterProxy = new DelegatingFilterProxy(beanName, injectedWac);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filterProxy.doFilter(request, response, null);
+
+		assertNull(targetFilter.filterConfig);
+		assertEquals(Boolean.TRUE, request.getAttribute("called"));
+
+		filterProxy.destroy();
+		assertNull(targetFilter.filterConfig);
+	}
+
+	@Test
+	public void testDelegatingFilterProxyNotInjectedWacServletAttrPreferred() throws ServletException, IOException {
+		ServletContext sc = new MockServletContext();
+
+		StaticWebApplicationContext wac = new StaticWebApplicationContext();
+		wac.setServletContext(sc);
+		wac.refresh();
+
+		sc.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, wac);
+		WebApplicationContextUtils.registerWebApplicationContext(sc, "org.springframework.web.servlet.FrameworkServlet.CONTEXT.dispatcher", wac);
+
+		StaticWebApplicationContext wacToUse = new StaticWebApplicationContext();
+		wacToUse.setServletContext(sc);
+		String beanName = "targetFilter";
+		String attrName = "customAttrName";
+		wacToUse.registerSingleton(beanName, MockFilter.class);
+		wacToUse.refresh();
+		sc.setAttribute(attrName, wacToUse);
+
+		MockFilter targetFilter = (MockFilter) wacToUse.getBean(beanName);
+
+		DelegatingFilterProxy filterProxy = new DelegatingFilterProxy(beanName);
+		filterProxy.setContextAttribute(attrName);
+		filterProxy.setServletContext(sc);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filterProxy.doFilter(request, response, null);
+
+		assertNull(targetFilter.filterConfig);
+		assertEquals(Boolean.TRUE, request.getAttribute("called"));
+
+		filterProxy.destroy();
+		assertNull(targetFilter.filterConfig);
+	}
+
+	@Test
+	public void testDelegatingFilterProxyNotInjectedNoAttrRootPreferred() throws ServletException, IOException {
+		ServletContext sc = new MockServletContext();
+
+		StaticWebApplicationContext wac = new StaticWebApplicationContext();
+		wac.setServletContext(sc);
+		wac.refresh();
+
+		WebApplicationContextUtils.registerWebApplicationContext(sc, "org.springframework.web.servlet.FrameworkServlet.CONTEXT.dispatcher", wac);
+		WebApplicationContextUtils.registerWebApplicationContext(sc, "another", wac);
+
+		StaticWebApplicationContext wacToUse = new StaticWebApplicationContext();
+		wacToUse.setServletContext(sc);
+		String beanName = "targetFilter";
+		wacToUse.registerSingleton(beanName, MockFilter.class);
+		wacToUse.refresh();
+		sc.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, wacToUse);
+
+		MockFilter targetFilter = (MockFilter) wacToUse.getBean(beanName);
+
+		DelegatingFilterProxy filterProxy = new DelegatingFilterProxy(beanName);
+		filterProxy.setServletContext(sc);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filterProxy.doFilter(request, response, null);
+
+		assertNull(targetFilter.filterConfig);
+		assertEquals(Boolean.TRUE, request.getAttribute("called"));
+
+		filterProxy.destroy();
+		assertNull(targetFilter.filterConfig);
+	}
+
+	@Test
+	public void testDelegatingFilterProxyNotInjectedNoAttrFirstContextWithBean() throws ServletException, IOException {
+		ServletContext sc = new MockServletContext();
+
+		StaticWebApplicationContext wac = new StaticWebApplicationContext();
+		wac.setServletContext(sc);
+		wac.refresh();
+
+		WebApplicationContextUtils.registerWebApplicationContext(sc, "org.springframework.web.servlet.FrameworkServlet.CONTEXT.dispatcher", wac);
+		sc.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, wac);
+
+		StaticWebApplicationContext wacToUse = new StaticWebApplicationContext();
+		wacToUse.setServletContext(sc);
+		String beanName = "targetFilter";
+		wacToUse.registerSingleton(beanName, MockFilter.class);
+		wacToUse.refresh();
+		WebApplicationContextUtils.registerWebApplicationContext(sc, "another", wacToUse);
+
+		MockFilter targetFilter = (MockFilter) wacToUse.getBean(beanName);
+
+		DelegatingFilterProxy filterProxy = new DelegatingFilterProxy(beanName);
+		filterProxy.setServletContext(sc);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filterProxy.doFilter(request, response, null);
+
+		assertNull(targetFilter.filterConfig);
+		assertEquals(Boolean.TRUE, request.getAttribute("called"));
+
+		filterProxy.destroy();
+		assertNull(targetFilter.filterConfig);
+	}
 
 	public static class MockFilter implements Filter {
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/FrameworkServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/FrameworkServlet.java
@@ -128,6 +128,7 @@ import org.springframework.web.util.WebUtils;
  * @author Chris Beams
  * @author Rossen Stoyanchev
  * @author Phillip Webb
+ * @author Rob Winch
  * @see #doService
  * @see #setContextClass
  * @see #setContextConfigLocation
@@ -562,7 +563,7 @@ public abstract class FrameworkServlet extends HttpServletBean implements Applic
 		if (this.publishContext) {
 			// Publish the context as a servlet context attribute.
 			String attrName = getServletContextAttributeName();
-			getServletContext().setAttribute(attrName, wac);
+			WebApplicationContextUtils.registerWebApplicationContext(getServletContext(), attrName, wac);
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug("Published WebApplicationContext of servlet '" + getServletName() +
 						"' as ServletContext attribute with name [" + attrName + "]");

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
@@ -17,6 +17,7 @@
 package org.springframework.web.servlet;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Locale;
 import javax.servlet.Servlet;
 import javax.servlet.ServletConfig;
@@ -48,6 +49,7 @@ import org.springframework.web.context.ServletContextAwareBean;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.StandardServletEnvironment;
 import org.springframework.web.context.support.StaticWebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.multipart.MultipartResolver;
@@ -114,6 +116,7 @@ public class DispatcherServletTests extends TestCase {
 				simpleDispatcherServlet.getServletContextAttributeName()));
 		assertTrue("Context published", simpleDispatcherServlet.getWebApplicationContext() ==
 				getServletContext().getAttribute(FrameworkServlet.SERVLET_CONTEXT_PREFIX + "simple"));
+		assertEquals("Context registered using WebApplicationUtils", Arrays.asList(simpleDispatcherServlet.getWebApplicationContext()), WebApplicationContextUtils.getRegisteredWebApplicationContexts(getServletContext()));
 
 		assertTrue("Correct namespace", "test".equals(complexDispatcherServlet.getNamespace()));
 		assertTrue("Correct attribute", (FrameworkServlet.SERVLET_CONTEXT_PREFIX + "complex").equals(

--- a/src/asciidoc/whats-new.adoc
+++ b/src/asciidoc/whats-new.adoc
@@ -525,6 +525,8 @@ public @interface MyTestConfig {
 * When using GSON or Jackson 2.6+, the handler method return type is used to improve
   serialization of parameterized types like `List<Foo>`.
 * Default JSON prefix has been changed from "{} && " to the safer ")]}', " one.
+* `DelegatingFilterProxy` will (by default) try additional "registered" (i.e. DispatcherServlet)
+  `WebApplicationContext` if the bean name is not found in the "root" context.
 
 === WebSocket Messaging Improvements
 


### PR DESCRIPTION
Previously when users registered an additional Filter in the
DispatcherServlet the DelegatingFilterProxy would not find it unless
the context attribute was set. The value for which was difficult to
remember and added quite a bit of additional "if" statements to setting
up Spring Security successfully.

This change allows registering additional known WebApplicationContext
instances. The DispatcherServlet uses this mechanism to register its
context. With that change DelegatingFilterProxy searches for the first
registered WebApplicationContext that contains the bean name.

This change also sets up the ability for Spring Security to lookup
Beans defined in the child context within the Tag libs.

Issue: SPR-13191
