### PR TITLE
correction for single quote inside double quote

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -173,7 +173,8 @@ public abstract class ScriptUtils {
 		Assert.hasText(blockCommentEndDelimiter, "blockCommentEndDelimiter must not be null or empty");
 
 		StringBuilder sb = new StringBuilder();
-		boolean inLiteral = false;
+		boolean inQuote = false;
+		boolean inDoubleQuote = false;
 		boolean inEscape = false;
 		char[] content = script.toCharArray();
 		for (int i = 0; i < script.length(); i++) {
@@ -189,10 +190,12 @@ public abstract class ScriptUtils {
 				sb.append(c);
 				continue;
 			}
-			if (c == '\'') {
-				inLiteral = !inLiteral;
+			if (!inDoubleQuote && c == '\'') {
+				inQuote = !inQuote;
+			} else if (!inQuote && c == '"') {
+				inDoubleQuote = !inDoubleQuote;
 			}
-			if (!inLiteral) {
+			if (!inQuote && !inDoubleQuote) {
 				if (script.startsWith(separator, i)) {
 					// we've reached the end of the current statement
 					if (sb.length() > 0) {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/init/ScriptUtilsUnitTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/init/ScriptUtilsUnitTests.java
@@ -85,6 +85,19 @@ public class ScriptUtilsUnitTests {
 			statements.get(0));
 	}
 
+	@Test
+	public void splitScriptWithQuoteInsideDoubleQuote() throws Exception {
+		String statement1 = "select '1' as \"one'quote\" from dual";
+		String statement2 = "select '2' as \"one'quote\" from dual";
+		char delim = ';';
+		String script = statement1 + delim + statement2 + delim;
+		List<String> statements = new ArrayList<String>();
+		splitSqlScript(script, ';', statements);
+		assertEquals("wrong number of statements", 2, statements.size());
+		assertEquals("statement 1 not split correctly", statement1, statements.get(0));
+		assertEquals("statement 2 not split correctly", statement2, statements.get(1));
+	}
+
 	/**
 	 * See <a href="https://jira.spring.io/browse/SPR-11560">SPR-11560</a>
 	 */


### PR DESCRIPTION
Some databases (Oracle for example) allow alias of columns inside double
quote in order to have case sensitive and special characters, including
single quote.
For example :
<code>
select address as "programmer’s address" from programmer
</code>
So those single quotes must not be taken as literal beginning.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
