### PR TITLE
Add support for JdbcTempalte.queryForObject(sql,<primitive>.class)

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/NumberUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/NumberUtils.java
@@ -32,6 +32,7 @@ import java.util.Set;
  *
  * @author Juergen Hoeller
  * @author Rob Harrop
+ * @author Rob Winch
  * @since 1.1.2
  */
 public abstract class NumberUtils {
@@ -66,7 +67,7 @@ public abstract class NumberUtils {
 	 * @param targetClass the target class to convert to
 	 * @return the converted number
 	 * @throws IllegalArgumentException if the target class is not supported
-	 * (i.e. not a standard Number subclass as included in the JDK)
+	 * (i.e. not a standard Number subclass or respective primitive as included in the JDK)
 	 * @see java.lang.Byte
 	 * @see java.lang.Short
 	 * @see java.lang.Integer
@@ -86,28 +87,28 @@ public abstract class NumberUtils {
 		if (targetClass.isInstance(number)) {
 			return (T) number;
 		}
-		else if (Byte.class == targetClass) {
+		else if (Byte.class == targetClass || byte.class == targetClass) {
 			long value = number.longValue();
 			if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
 				raiseOverflowException(number, targetClass);
 			}
 			return (T) new Byte(number.byteValue());
 		}
-		else if (Short.class == targetClass) {
+		else if (Short.class == targetClass || short.class == targetClass) {
 			long value = number.longValue();
 			if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
 				raiseOverflowException(number, targetClass);
 			}
 			return (T) new Short(number.shortValue());
 		}
-		else if (Integer.class == targetClass) {
+		else if (Integer.class == targetClass || int.class == targetClass) {
 			long value = number.longValue();
 			if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
 				raiseOverflowException(number, targetClass);
 			}
 			return (T) new Integer(number.intValue());
 		}
-		else if (Long.class == targetClass) {
+		else if (Long.class == targetClass || long.class == targetClass) {
 			BigInteger bigInt = null;
 			if (number instanceof BigInteger) {
 				bigInt = (BigInteger) number;
@@ -131,10 +132,10 @@ public abstract class NumberUtils {
 				return (T) BigInteger.valueOf(number.longValue());
 			}
 		}
-		else if (Float.class == targetClass) {
+		else if (Float.class == targetClass || float.class == targetClass) {
 			return (T) new Float(number.floatValue());
 		}
-		else if (Double.class == targetClass) {
+		else if (Double.class == targetClass || double.class == targetClass) {
 			return (T) new Double(number.doubleValue());
 		}
 		else if (BigDecimal.class == targetClass) {

--- a/spring-core/src/test/java/org/springframework/util/NumberUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/NumberUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import static org.junit.Assert.*;
 /**
  * @author Rob Harrop
  * @author Juergen Hoeller
+ * @author Rob Winch
  */
 public class NumberUtilsTests {
 
@@ -412,6 +413,59 @@ public class NumberUtilsTests {
 		assertEquals(Long.valueOf(Byte.MAX_VALUE), NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) (Byte.MIN_VALUE - 1)), Long.class));
 	}
 
+	@Test
+	public void testNumberToBytePrimitive() {
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), byte.class));
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), byte.class));
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), byte.class));
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), byte.class));
+		assertEquals((byte) Byte.valueOf((byte) 1), (byte) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), byte.class));
+	}
+
+	@Test
+	public void testNumberToShortPrimitive() {
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), short.class));
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), short.class));
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), short.class));
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), short.class));
+		assertEquals((short) 1, (short) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), short.class));
+	}
+
+	@Test
+	public void testNumberToIntPrimitive() {
+		assertEquals(1, (int) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), int.class));
+		assertEquals(1, (int) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), int.class));
+		assertEquals(1, (int) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), int.class));
+		assertEquals(1, (int) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), int.class));
+		assertEquals(1, (int) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), int.class));
+	}
+
+	@Test
+	public void testNumberToLongPrimitive() {
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), long.class));
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), long.class));
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), long.class));
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), long.class));
+		assertEquals(1L, (long) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), long.class));
+	}
+
+	@Test
+	public void testNumberToFloatPrimitive() {
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), float.class), 0);
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), float.class), 0);
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), float.class), 0);
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), float.class), 0);
+		assertEquals((float) 1, (float) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), float.class), 0);
+	}
+
+	@Test
+	public void testNumberToDoublePrimitive() {
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(BigInteger.valueOf(1), double.class), 0);
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(Long.valueOf(1L), double.class), 0);
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(Integer.valueOf(1), double.class), 0);
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(Short.valueOf((short) 1), double.class), 0);
+		assertEquals((double) 1, (double) NumberUtils.convertNumberToTargetClass(Byte.valueOf((byte) 1), double.class), 0);
+	}
 
 	private void assertLongEquals(String aLong) {
 		assertEquals("Long did not parse", Long.MAX_VALUE, NumberUtils.parseNumber(aLong, Long.class).longValue());

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/SingleColumnRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/SingleColumnRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.NumberUtils;
  * and converted into the specified target type.
  *
  * @author Juergen Hoeller
+ * @author Rob Winch
  * @since 1.2
  * @see JdbcTemplate#queryForList(String, Class)
  * @see JdbcTemplate#queryForObject(String, Class)
@@ -168,7 +169,7 @@ public class SingleColumnRowMapper<T> implements RowMapper<T> {
 		if (String.class == requiredType) {
 			return value.toString();
 		}
-		else if (Number.class.isAssignableFrom(requiredType)) {
+		else if (Number.class.isAssignableFrom(requiredType) || requiredType.isPrimitive()) {
 			if (value instanceof Number) {
 				// Convert original Number to target Number class.
 				return NumberUtils.convertNumberToTargetClass(((Number) value), (Class<Number>) requiredType);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
@@ -41,6 +41,7 @@ import static org.mockito.BDDMockito.*;
 /**
  * @author Juergen Hoeller
  * @author Phillip Webb
+ * @author Rob Winch
  * @since 19.12.2004
  */
 public class JdbcTemplateQueryTests {
@@ -226,11 +227,33 @@ public class JdbcTemplateQueryTests {
 	}
 
 	@Test
+	public void testQueryForIntPrimitive() throws Exception {
+		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
+		given(this.resultSet.next()).willReturn(true, false);
+		given(this.resultSet.getInt(1)).willReturn(22);
+		int i = this.template.queryForObject(sql,int.class);
+		assertEquals("Return of an int", 22, i);
+		verify(this.resultSet).close();
+		verify(this.statement).close();
+	}
+
+	@Test
 	public void testQueryForLong() throws Exception {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
 		given(this.resultSet.next()).willReturn(true, false);
 		given(this.resultSet.getLong(1)).willReturn(87L);
 		long l = this.template.queryForObject(sql, Long.class).longValue();
+		assertEquals("Return of a long", 87, l);
+		verify(this.resultSet).close();
+		verify(this.statement).close();
+	}
+
+	@Test
+	public void testQueryForLongPrimitive() throws Exception {
+		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
+		given(this.resultSet.next()).willReturn(true, false);
+		given(this.resultSet.getLong(1)).willReturn(87L);
+		long l = this.template.queryForObject(sql, long.class);
 		assertEquals("Return of a long", 87, l);
 		verify(this.resultSet).close();
 		verify(this.statement).close();


### PR DESCRIPTION
Previously using jdbcTemplate.queryForObject(sql, int.class) produced
a TypeMismatchDataAccessException stating it could not convert an Integer
to an int.

This update allows conversion to the respective primitives instead of just
the wrapper Objects.

Issue: SPR-13220
