### PR TITLE
[SPR-13223] ResponseBodyEmitter skips same messages during initialization

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterTests.java
@@ -63,6 +63,19 @@ public class ResponseBodyEmitterTests {
 	}
 
 	@Test
+	public void sendDuplicateBeforeHandlerInitialized() throws Exception {
+		this.emitter.send("foo", MediaType.TEXT_PLAIN);
+		this.emitter.send("foo", MediaType.TEXT_PLAIN);
+		this.emitter.complete();
+		verifyNoMoreInteractions(this.handler);
+
+		this.emitter.initialize(this.handler);
+		verify(this.handler, times(2)).send("foo", MediaType.TEXT_PLAIN);
+		verify(this.handler).complete();
+		verifyNoMoreInteractions(this.handler);
+	}
+
+	@Test
 	public void sendBeforeHandlerInitializedWithError() throws Exception {
 		IllegalStateException ex = new IllegalStateException();
 		this.emitter.send("foo", MediaType.TEXT_PLAIN);


### PR DESCRIPTION
Before ResponseBodyEmitter initialization events were kept in a my map,
effectively discarding same messages.
Additionally this PR clears `initHandlerCache` (wasn't the case before).

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.

See: [SPR-13223](https://jira.spring.io/browse/SPR-13223).
