### PR TITLE
Reset Pragma header when caching

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/WebContentGenerator.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/WebContentGenerator.java
@@ -436,6 +436,9 @@ public abstract class WebContentGenerator extends WebApplicationObjectSupport {
 			}
 			response.setHeader(HEADER_CACHE_CONTROL, headerValue);
 		}
+		if (response.containsHeader(HEADER_PRAGMA)) {
+			response.setHeader(HEADER_PRAGMA, "");
+		}
 	}
 
 	/**


### PR DESCRIPTION
Spring Security by default sets a `Pragma: no-cache` header (see [CacheControlHeadersWriter](https://github.com/spring-projects/spring-security/blob/master/web/src/main/java/org/springframework/security/web/header/writers/CacheControlHeadersWriter.java)). Even if explicitly calling `WebContentGenerator#applyCacheSeconds` that header is still present, preventing the browser from caching the resource. So `cacheForSeconds` should remove the Pragma header if it has been set.
