### PR TITLE
Introduce `EnumToEnumConverter`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/DefaultConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/DefaultConversionService.java
@@ -108,6 +108,7 @@ public class DefaultConversionService extends GenericConversionService {
 		converterRegistry.addConverterFactory(new StringToEnumConverterFactory());
 		converterRegistry.addConverter(Enum.class, String.class,
 				new EnumToStringConverter((ConversionService) converterRegistry));
+		converterRegistry.addConverter(new EnumToEnumConverter());
 
 		converterRegistry.addConverter(new StringToLocaleConverter());
 		converterRegistry.addConverter(Locale.class, String.class, new ObjectToStringConverter());

--- a/spring-core/src/main/java/org/springframework/core/convert/support/EnumToEnumConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/EnumToEnumConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.convert.support;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+
+/**
+ * Calls {@link Enum#name()} to convert a source Enum to a shadow Enum.
+ * @author Yanming Zhou (zhouyanming@gmail.com)
+ * @since 4.2.1
+ */
+final class EnumToEnumConverter implements ConditionalGenericConverter {
+
+	@Override
+	public Set<ConvertiblePair> getConvertibleTypes() {
+		return Collections.singleton(new ConvertiblePair(Enum.class, Enum.class));
+	}
+
+	@Override
+	public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
+		return !sourceType.getType().equals(targetType.getType());
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+		if (source == null)
+			return null;
+		return Enum.valueOf((Class<Enum>) targetType.getType(), ((Enum<?>) source).name());
+	}
+
+}

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -540,6 +540,14 @@ public class GenericConversionServiceTests {
 		conversionService.addConverterFactory(new StringToMyEnumBaseInterfaceConverterFactory());
 		assertEquals(MyEnum.A, conversionService.convert("base1", MyEnum.class));
 	}
+	
+	@Test
+	public void testEnumToEnum() throws Exception {
+		conversionService.addConverter(new EnumToEnumConverter());
+		assertEquals(MyShadowEnum.A, conversionService.convert(MyOriginEnum.A, MyShadowEnum.class));
+		assertEquals(MyShadowEnum.B, conversionService.convert(MyOriginEnum.B, MyShadowEnum.class));
+		assertEquals(null, conversionService.convert(null, MyShadowEnum.class));
+	}
 
 	@Test
 	public void convertNullAnnotatedStringToString() throws Exception {
@@ -803,6 +811,14 @@ public class GenericConversionServiceTests {
 				return "1st";
 			}
 		}
+	}
+	
+	private static enum MyOriginEnum {
+		A, B
+	}
+	
+	private static enum MyShadowEnum {
+		A, B
 	}
 
 	@SuppressWarnings("rawtypes")


### PR DESCRIPTION
sometime we need copy a shadow package for export remote service
interface, service interface depend domain object which include domain
enum type, it is necessary to support conversion between origin Enum
type to shadow Enum.
