### PR TITLE
SPR-13320: Additional Testing Methods Added To JsonPathResultMatchers

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/util/JsonPathExpectationsHelper.java
+++ b/spring-test/src/main/java/org/springframework/test/util/JsonPathExpectationsHelper.java
@@ -16,10 +16,14 @@
 
 package org.springframework.test.util;
 
+import java.lang.Boolean;
+import java.lang.Number;
+import java.lang.String;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.text.ParseException;
 import java.util.List;
+import java.util.Map;
 
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
@@ -28,6 +32,7 @@ import org.hamcrest.Matcher;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.MatcherAssert.*;
 import static org.springframework.test.util.AssertionErrors.*;
 
@@ -138,7 +143,47 @@ public class JsonPathExpectationsHelper {
 		Object actualValue = evaluateJsonPath(responseContent);
 		assertTrue("No value for JSON path \"" + this.expression + "\"", actualValue != null);
 		String reason = "Expected array at JSON path " + this.expression + " but found " + actualValue;
-		assertTrue(reason, actualValue instanceof List);
+		assertThat(reason, actualValue, instanceOf(List.class));
+	}
+
+	/**
+	 * Apply the JSON path and assert the resulting value is a boolean.
+	 */
+	public void assertValueIsBoolean(String responseContent) throws ParseException {
+		Object actualValue = evaluateJsonPath(responseContent);
+		assertTrue("No value for JSON path \"" + this.expression + "\"", actualValue != null);
+		String reason = "Expected array at JSON path " + this.expression + " but found " + actualValue;
+		assertThat(reason, actualValue, instanceOf(Boolean.class));
+	}
+
+	/**
+	 * Apply the JSON path and assert the resulting value is a number.
+	 */
+	public void assertValueIsNumber(String responseContent) throws ParseException {
+		Object actualValue = evaluateJsonPath(responseContent);
+		assertTrue("No value for JSON path \"" + this.expression + "\"", actualValue != null);
+		String reason = "Expected array at JSON path " + this.expression + " but found " + actualValue;
+		assertThat(reason, actualValue, instanceOf(Number.class));
+	}
+
+	/**
+	 * Apply the JSON path and assert the resulting value is a map.
+	 */
+	public void assertValueIsMap(String responseContent) throws ParseException {
+		Object actualValue = evaluateJsonPath(responseContent);
+		assertTrue("No value for JSON path \"" + this.expression + "\"", actualValue != null);
+		String reason = "Expected array at JSON path " + this.expression + " but found " + actualValue;
+		assertThat(reason, actualValue, instanceOf(Map.class));
+	}
+
+	/**
+	 * Apply the JSON path and assert the resulting value is a string.
+	 */
+	public void assertValueIsString(String responseContent) throws ParseException {
+		Object actualValue = evaluateJsonPath(responseContent);
+		assertTrue("No value for JSON path \"" + this.expression + "\"", actualValue != null);
+		String reason = "Expected array at JSON path " + this.expression + " but found " + actualValue;
+		assertThat(reason, actualValue, instanceOf(String.class));
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/JsonPathResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/JsonPathResultMatchers.java
@@ -99,7 +99,7 @@ public class JsonPathResultMatchers {
 	}
 
 	/**
-	 * Evluate the JSON path and assert the content found is an array.
+	 * Evaluate the JSON path and assert the content found is an array.
 	 */
 	public ResultMatcher isArray() {
 		return new ResultMatcher() {
@@ -107,6 +107,58 @@ public class JsonPathResultMatchers {
 			public void match(MvcResult result) throws Exception {
 				String content = result.getResponse().getContentAsString();
 				jsonPathHelper.assertValueIsArray(content);
+			}
+		};
+	}
+
+	/**
+	 * Evaluate the JSON path and assert the content found is a boolean.
+	 */
+	public ResultMatcher isBoolean() {
+		return new ResultMatcher() {
+			@Override
+			public void match(MvcResult result) throws Exception {
+				String content = result.getResponse().getContentAsString();
+				jsonPathHelper.assertValueIsBoolean(content);
+			}
+		};
+	}
+
+	/**
+	 * Evaluate the JSON path and assert the content found is a number.
+	 */
+	public ResultMatcher isNumber() {
+		return new ResultMatcher() {
+			@Override
+			public void match(MvcResult result) throws Exception {
+				String content = result.getResponse().getContentAsString();
+				jsonPathHelper.assertValueIsNumber(content);
+			}
+		};
+	}
+
+	/**
+	 * Evaluate the JSON path and assert the content found is a map.
+	 */
+	public ResultMatcher isMap() {
+		return new ResultMatcher() {
+			@Override
+			public void match(MvcResult result) throws Exception {
+				String content = result.getResponse().getContentAsString();
+				jsonPathHelper.assertValueIsMap(content);
+			}
+		};
+	}
+
+	/**
+	 * Evaluate the JSON path and assert the content found is a string.
+	 */
+	public ResultMatcher isString() {
+		return new ResultMatcher() {
+			@Override
+			public void match(MvcResult result) throws Exception {
+				String content = result.getResponse().getContentAsString();
+				jsonPathHelper.assertValueIsString(content);
 			}
 		};
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/result/JsonPathResultMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/result/JsonPathResultMatchersTests.java
@@ -79,8 +79,47 @@ public class JsonPathResultMatchersTests {
 		new JsonPathResultMatchers("$.bar").isArray().match(getStubMvcResult());
 	}
 
+	@Test
+	public void isBooleanMatch() throws Exception {
+		new JsonPathResultMatchers("$.icanhaz").isBoolean().match(getStubMvcResult());
+	}
 
-	private static final String RESPONSE_CONTENT = "{\"foo\":\"bar\", \"qux\":[\"baz1\",\"baz2\"]}";
+	@Test(expected=AssertionError.class)
+	public void isBooleanNoMatch() throws Exception {
+		new JsonPathResultMatchers("$.foo").isBoolean().match(getStubMvcResult());
+	}
+
+	@Test
+	public void isNumberMatch() throws Exception {
+		new JsonPathResultMatchers("$.howmanies").isNumber().match(getStubMvcResult());
+	}
+
+	@Test(expected=AssertionError.class)
+	public void isNumberNoMatch() throws Exception {
+		new JsonPathResultMatchers("$.foo").isNumber().match(getStubMvcResult());
+	}
+
+	@Test
+	public void isMapMatch() throws Exception {
+		new JsonPathResultMatchers("$.cheeseburger").isMap().match(getStubMvcResult());
+	}
+
+	@Test(expected=AssertionError.class)
+	public void isMapNoMatch() throws Exception {
+		new JsonPathResultMatchers("$.foo").isMap().match(getStubMvcResult());
+	}
+
+	@Test
+	public void isStringMatch() throws Exception {
+		new JsonPathResultMatchers("$.foo").isString().match(getStubMvcResult());
+	}
+
+	@Test(expected=AssertionError.class)
+	public void isStringNoMatch() throws Exception {
+		new JsonPathResultMatchers("$.qux").isString().match(getStubMvcResult());
+	}
+
+	private static final String RESPONSE_CONTENT = "{\"foo\":\"bar\", \"qux\":[\"baz1\",\"baz2\"], \"icanhaz\":true, \"howmanies\": 5, \"cheeseburger\": {\"pickles\": true} }";
 
 	private StubMvcResult getStubMvcResult() throws Exception {
 		MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
JsonPathResultMatchers has some useful methods:
- doesNotExist
- exists
- isArray

This commit adds a few more useful methods:
- isBoolean
- isNumber
- isMap
- isString

Issue: https://jira.spring.io/browse/SPR-13320

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
