### PR TITLE
Support CALL Statement for SAP HANA

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProviderFactory.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProviderFactory.java
@@ -47,7 +47,8 @@ public class CallMetaDataProviderFactory {
 			"Microsoft SQL Server",
 			"Oracle",
 			"PostgreSQL",
-			"Sybase"
+			"Sybase",
+			"HDB"
 		);
 
 	/** List of supported database products for function calls */
@@ -117,6 +118,9 @@ public class CallMetaDataProviderFactory {
 					}
 					else if ("Microsoft SQL Server".equals(databaseProductName)) {
 						provider = new SqlServerCallMetaDataProvider((databaseMetaData));
+					}
+					else if ("HDB".equals(databaseProductName)) {
+						provider = new HDBCallMetaDataProvider((databaseMetaData));
 					}
 					else {
 						provider = new GenericCallMetaDataProvider(databaseMetaData);

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/HDBCallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/HDBCallMetaDataProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.core.metadata;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+/**
+ * SAP HANA specific implementation for the {@link CallMetaDataProvider} interface.
+ * This class is intended for internal use by the Simple JDBC classes.
+ *
+ * @author Subhobrata Dey
+ * @since 4.2
+ */
+public class HDBCallMetaDataProvider extends GenericCallMetaDataProvider {
+
+    public HDBCallMetaDataProvider(DatabaseMetaData databaseMetaData) throws SQLException {
+        super(databaseMetaData);
+    }
+
+    @Override
+    public void initializeWithMetaData(DatabaseMetaData databaseMetaData) throws SQLException {
+        super.initializeWithMetaData(databaseMetaData);
+        setStoresUpperCaseIdentifiers(false);
+    }
+}


### PR DESCRIPTION
Support for calling Stored Proedures in SAP HANA. Adding support for HANA
alongwith the already existing support for "Derby", "DB2", "Mysql",
"Microsoft SQL Server", "Oracle", "POSTgreSQL" & "Sybase".
- Bug Fixes: The names of Stored Procedures in SAP HANA can be in lowercase
  as well. The default implementation in GenericCallMetaDataProvider always
  converts name to uppercase.

Issue: SPR-13381

CLA form signed. Ref. no. : 135320150823102506
