### PR TITLE
Fix error in function org.springframework.http.HttpHeaders.getContent…

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/MessageBodyClientHttpResponseWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/client/MessageBodyClientHttpResponseWrapper.java
@@ -61,10 +61,7 @@ class MessageBodyClientHttpResponseWrapper implements ClientHttpResponse {
 				responseStatus == HttpStatus.NOT_MODIFIED) {
 			return false;
 		}
-		else if(this.getHeaders().getContentLength() == 0) {
-			return false;
-		}
-		return true;
+		return this.getHeaders().getContentLength() > 0;
 	}
 
 	/**


### PR DESCRIPTION
Function org.springframework.web.client.MessageBodyClientHttpResponseWrapper.hasMessageBody() returns wrong positive answer when http response has no body and no Content-Length header.

Important, that function org.springframework.http.HttpHeaders.getContentLength() returns -1 if header Content-Length does not exist in response and. But we rely only on 0 as answer.
