### PR TITLE
RequestParam plus MultipartFIle

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
@@ -163,35 +163,26 @@ public class RequestParamMethodArgumentResolver extends AbstractNamedValueMethod
 				WebUtils.getNativeRequest(servletRequest, MultipartHttpServletRequest.class);
 		Object arg;
 
-		if (MultipartFile.class == parameter.getParameterType()) {
-			assertIsMultipartRequest(servletRequest);
+	        if(!isMultipartRequest(servletRequest)){
+	            return null;
+	        }
+	        if (MultipartFile.class.equals(parameter.getParameterType())) {
 			Assert.notNull(multipartRequest, "Expected MultipartHttpServletRequest: is a MultipartResolver configured?");
-			arg = multipartRequest.getFile(name);
-		}
-		else if (isMultipartFileCollection(parameter)) {
-			assertIsMultipartRequest(servletRequest);
+	            	arg = multipartRequest.getFile(name);
+		} else if (isMultipartFileCollection(parameter)) {
 			Assert.notNull(multipartRequest, "Expected MultipartHttpServletRequest: is a MultipartResolver configured?");
-			arg = multipartRequest.getFiles(name);
-		}
-		else if (isMultipartFileArray(parameter)) {
-			assertIsMultipartRequest(servletRequest);
-			Assert.notNull(multipartRequest, "Expected MultipartHttpServletRequest: is a MultipartResolver configured?");
+	            	arg = multipartRequest.getFiles(name);
+	        } else if (isMultipartFileArray(parameter)) {
+	            	Assert.notNull(multipartRequest, "Expected MultipartHttpServletRequest: is a MultipartResolver configured?");
 			List<MultipartFile> multipartFiles = multipartRequest.getFiles(name);
-			arg = multipartFiles.toArray(new MultipartFile[multipartFiles.size()]);
-		}
-		else if ("javax.servlet.http.Part".equals(parameter.getParameterType().getName())) {
-			assertIsMultipartRequest(servletRequest);
+	            	arg = multipartFiles.toArray(new MultipartFile[multipartFiles.size()]);
+		} else if ("javax.servlet.http.Part".equals(parameter.getParameterType().getName())) {
 			arg = servletRequest.getPart(name);
-		}
-		else if (isPartCollection(parameter)) {
-			assertIsMultipartRequest(servletRequest);
+	        } else if (isPartCollection(parameter)) {
 			arg = new ArrayList<Object>(servletRequest.getParts());
-		}
-		else if (isPartArray(parameter)) {
-			assertIsMultipartRequest(servletRequest);
+		} else if (isPartArray(parameter)) {
 			arg = RequestPartResolver.resolvePart(servletRequest);
-		}
-		else {
+		} else {
 			arg = null;
 			if (multipartRequest != null) {
 				List<MultipartFile> files = multipartRequest.getFiles(name);
@@ -202,13 +193,21 @@ public class RequestParamMethodArgumentResolver extends AbstractNamedValueMethod
 			if (arg == null) {
 				String[] paramValues = webRequest.getParameterValues(name);
 				if (paramValues != null) {
-					arg = (paramValues.length == 1 ? paramValues[0] : paramValues);
+					arg = paramValues.length == 1 ? paramValues[0] : paramValues;
 				}
 			}
 		}
 
 		return arg;
 	}
+
+    	private boolean isMultipartRequest(HttpServletRequest request){
+        	String contentType = request.getContentType();
+        	if (contentType == null || !contentType.toLowerCase().startsWith("multipart/")) {
+            		return false;
+        	}
+        	return true;
+    	}
 
 	private void assertIsMultipartRequest(HttpServletRequest request) {
 		String contentType = request.getContentType();


### PR DESCRIPTION
if there is a controller method with code like this:

```
public void uploadFile( @RequestParam(value = "file",required = true) MultipartFile file){
    //some code
}
```

and there is no header which name is "Content-Type" in the request,then the method "resolveName" will throw MultipartException which is from the method "assertIsMultipartRequest" even if the value of attribute which name is "required" is true. 

The expected response should be throw MissingServletRequestParameterException i think. Because it is convenient for coder to execute the same code when there is no enough parameters.
