### PR TITLE
Fix AllowedOrigins according to RFC 6454

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -345,27 +345,26 @@ public class UriComponentsBuilder implements Cloneable {
 	 * @see <a href="https://tools.ietf.org/html/rfc6454">RFC 6454: The Web Origin Concept</a>
 	 */
 	public static UriComponentsBuilder fromOriginHeader(String origin) {
-		UriComponentsBuilder builder = new UriComponentsBuilder();
+		final UriComponentsBuilder builder = new UriComponentsBuilder().scheme(null).host(null).port(null);
 
-		Matcher matcher = URI_PATTERN.matcher(origin);
-		if (matcher.matches()) {
-			String scheme = matcher.group(2);
-			String host = matcher.group(6);
-			String port = matcher.group(8);
+		if (StringUtils.hasLength(origin)) {
+			Matcher matcher = URI_PATTERN.matcher(origin);
+			if (matcher.matches()) {
+				String scheme = matcher.group(2);
+				String host = matcher.group(6);
+				String port = matcher.group(8);
 
-			if (StringUtils.hasLength(scheme)) {
-				int schemaIdx = origin.indexOf("://");
-				scheme = (schemaIdx != -1 ? origin.substring(0, schemaIdx) : "http");
+				if (StringUtils.hasLength(scheme)) {
+					int schemaIdx = origin.indexOf("://");
+					scheme = (schemaIdx != -1 ? origin.substring(0, schemaIdx) : null);
+				}
+				builder.scheme(scheme);
+
+				builder.host(host);
+				if (StringUtils.hasLength(port)) {
+					builder.port(port);
+				}
 			}
-			builder.scheme(scheme);
-
-			builder.host(host);
-			if (StringUtils.hasLength(port)) {
-				builder.port(port);
-			}
-		}
-		else {
-			builder.scheme("http").host(null).port(null);
 		}
 
 		return builder;

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -50,6 +50,7 @@ import org.springframework.web.util.HierarchicalUriComponents.PathComponent;
  * @author Rossen Stoyanchev
  * @author Phillip Webb
  * @author Oliver Gierke
+ * @author Georgij Cernysiov
  * @since 3.1
  * @see #newInstance()
  * @see #fromPath(String)
@@ -338,24 +339,35 @@ public class UriComponentsBuilder implements Cloneable {
 
 
 	/**
-	 * Create an instance by parsing the "origin" header of an HTTP request.
+	 * Creates a new {@code UriComponents} instance from the {@code ORIGIN} header of an HTTP request.
+	 * @param origin the {@code ORIGIN} header value
+	 * @return the URI components of the {@code ORIGIN} value
+	 * @see <a href="https://tools.ietf.org/html/rfc6454">RFC 6454: The Web Origin Concept</a>
 	 */
 	public static UriComponentsBuilder fromOriginHeader(String origin) {
-		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
-		if (StringUtils.hasText(origin)) {
-			int schemaIdx = origin.indexOf("://");
-			String schema = (schemaIdx != -1 ? origin.substring(0, schemaIdx) : "http");
-			builder.scheme(schema);
-			String hostString = (schemaIdx != -1 ? origin.substring(schemaIdx + 3) : origin);
-			if (hostString.contains(":")) {
-				String[] hostAndPort = StringUtils.split(hostString, ":");
-				builder.host(hostAndPort[0]);
-				builder.port(Integer.parseInt(hostAndPort[1]));
+		UriComponentsBuilder builder = new UriComponentsBuilder();
+
+		Matcher matcher = URI_PATTERN.matcher(origin);
+		if (matcher.matches()) {
+			String scheme = matcher.group(2);
+			String host = matcher.group(6);
+			String port = matcher.group(8);
+
+			if (StringUtils.hasLength(scheme)) {
+				int schemaIdx = origin.indexOf("://");
+				scheme = (schemaIdx != -1 ? origin.substring(0, schemaIdx) : "http");
 			}
-			else {
-				builder.host(hostString);
+			builder.scheme(scheme);
+
+			builder.host(host);
+			if (StringUtils.hasLength(port)) {
+				builder.port(port);
 			}
 		}
+		else {
+			builder.scheme("http").host(null).port(null);
+		}
+
 		return builder;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -345,7 +345,7 @@ public class UriComponentsBuilder implements Cloneable {
 	 * @see <a href="https://tools.ietf.org/html/rfc6454">RFC 6454: The Web Origin Concept</a>
 	 */
 	public static UriComponentsBuilder fromOriginHeader(String origin) {
-		final UriComponentsBuilder builder = new UriComponentsBuilder().scheme(null).host(null).port(null);
+		final UriComponentsBuilder builder = new UriComponentsBuilder().scheme("").host("").port(-1);
 
 		if (StringUtils.hasLength(origin)) {
 			Matcher matcher = URI_PATTERN.matcher(origin);
@@ -356,7 +356,7 @@ public class UriComponentsBuilder implements Cloneable {
 
 				if (StringUtils.hasLength(scheme)) {
 					int schemaIdx = origin.indexOf("://");
-					scheme = (schemaIdx != -1 ? origin.substring(0, schemaIdx) : null);
+					scheme = (schemaIdx != -1 ? origin.substring(0, schemaIdx) : "");
 				}
 				builder.scheme(scheme);
 

--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -800,7 +800,7 @@ public abstract class WebUtils {
 				UriComponents allowedOriginUrl;
 				for (String allowed : allowedOrigins) {
 					allowedOriginUrl = UriComponentsBuilder.fromOriginHeader(allowed).build();
-					if (isSameHostAndPort(headerOriginUrl, allowedOriginUrl)) {
+					if (isSameHostAndPort(allowedOriginUrl, headerOriginUrl)) {
 						return true;
 					}
 				}

--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -793,10 +793,6 @@ public abstract class WebUtils {
 			return isSameOrigin(request);
 		}
 		else {
-			if((origin.length() > 0) && ('/' == origin.charAt(origin.length() - 1))) {
-				origin = origin.substring(0, origin.length() - 1);
-			}
-		
 			return allowedOrigins.contains(origin);
 		}
 	}

--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -793,19 +793,11 @@ public abstract class WebUtils {
 			return isSameOrigin(request);
 		}
 		else {
-			if(allowedOrigins.contains(origin)) {
-				return true;
-			} else {
-				UriComponents headerOriginUrl = UriComponentsBuilder.fromOriginHeader(origin).build();
-				UriComponents allowedOriginUrl;
-				for (String allowed : allowedOrigins) {
-					allowedOriginUrl = UriComponentsBuilder.fromOriginHeader(allowed).build();
-					if (isSameHostAndPort(allowedOriginUrl, headerOriginUrl)) {
-						return true;
-					}
-				}
-				return false;
+			if((origin.length() > 0) && ('/' == origin.charAt(origin.length() - 1))) {
+				origin = origin.substring(0, origin.length() - 1);
 			}
+		
+			return allowedOrigins.contains(origin);
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
@@ -108,12 +108,22 @@ public class WebUtilsTests {
 
 	@Test
 	public void isValidOrigin() {
-		List<String> allowed = Collections.emptyList();
+		List<String> allowed = Collections.emptyList();		
 		assertTrue(checkValidOrigin("mydomain1.com", -1, "http://mydomain1.com", allowed));
 		assertTrue(checkValidOrigin("mydomain1.com", -1, "http://mydomain1.com/", allowed));
+		assertTrue(checkValidOrigin("mydomain1.com", 80, "http://mydomain1.com:80/", allowed));
+		assertTrue(checkValidOrigin("mydomain1.com", -1, null, allowed));
+
+		assertFalse(checkValidOrigin("mydomain1.com", -1, "", allowed));
+		assertFalse(checkValidOrigin("mydomain1.com", -1, "null", allowed));
+		assertFalse(checkValidOrigin("mydomain1.com", -1, "http://mydomain1.com:9090/", allowed));
 		assertFalse(checkValidOrigin("mydomain1.com", -1, "http://mydomain2.com", allowed));
 
 		allowed = Collections.singletonList("*");
+		assertTrue(checkValidOrigin("mydomain1.com", -1, "", allowed));
+		assertTrue(checkValidOrigin("mydomain1.com", -1, "null", allowed));
+		assertTrue(checkValidOrigin("mydomain1.com", -1, null, allowed));
+		
 		assertTrue(checkValidOrigin("mydomain1.com", -1, "http://mydomain2.com", allowed));
 		assertTrue(checkValidOrigin("mydomain1.com", -1, "http://mydomain2.com/", allowed));
 		assertTrue(checkValidOrigin("mydomain1.com:8080", -1, "http://mydomain2.com:8080/", allowed));
@@ -121,7 +131,10 @@ public class WebUtilsTests {
 		allowed = Collections.singletonList("http://mydomain1.com");
 		assertTrue(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com", allowed));
 		assertTrue(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com/", allowed));
+		assertTrue(checkValidOrigin("mydomain1.com", -1, null, allowed));
 
+		assertFalse(checkValidOrigin("mydomain1.com", -1, "", allowed));
+		assertFalse(checkValidOrigin("mydomain1.com", -1, "null", allowed));
 		assertFalse(checkValidOrigin("mydomain2.com", -1, "http://mydomain3.com", allowed));
 	}
 
@@ -131,19 +144,29 @@ public class WebUtilsTests {
 		assertTrue(checkSameOrigin("mydomain1.com", -1, "http://mydomain1.com:80"));
 		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com"));
 		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com/"));
-		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com/////"));
+		assertTrue(checkSameOrigin("mydomain1.com", 80, "http://mydomain1.com:80/"));
+		assertTrue(checkSameOrigin("mydomain1.com", 80, "http://mydomain1.com:80/path/file"));
+		assertTrue(checkSameOrigin("mydomain1.com", 80, "http://mydomain1.com:80/path/file/"));
 		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com:443"));
 		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com:443/"));
 		assertTrue(checkSameOrigin("mydomain1.com", 123, "http://mydomain1.com:123"));
 		assertTrue(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com"));
 		assertTrue(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com/"));
-		assertTrue(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com///"));
+		assertTrue(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com/path/file"));
+		assertTrue(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com/path/file/"));
 		assertTrue(checkSameOrigin("mydomain1.com", 443, "wss://mydomain1.com"));
-
+		assertTrue(checkSameOrigin("mydomain1.com", -1, null));
+		
+		assertFalse(checkSameOrigin("mydomain1.com", -1, "mydomain1.org"));
 		assertFalse(checkSameOrigin("mydomain1.com", -1, "http://mydomain2.com"));
 		assertFalse(checkSameOrigin("mydomain1.com", -1, "https://mydomain1.com"));
 		assertFalse(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com:8080"));
+		assertFalse(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com:8080/"));
+		assertFalse(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com:8080/path/file"));
+		assertFalse(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com:8080/path/file/"));
 		assertFalse(checkSameOrigin("mydomain1.com", -1, "invalid-origin"));
+		assertFalse(checkSameOrigin("mydomain1.com", -1, "null"));
+		assertFalse(checkSameOrigin("mydomain1.com", -1, ""));
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
@@ -130,9 +130,9 @@ public class WebUtilsTests {
 
 		allowed = Collections.singletonList("http://mydomain1.com");
 		assertTrue(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com", allowed));
-		assertTrue(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com/", allowed));
 		assertTrue(checkValidOrigin("mydomain1.com", -1, null, allowed));
 
+		assertFalse(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com/", allowed));
 		assertFalse(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com/path/file", allowed));
 		assertFalse(checkValidOrigin("mydomain1.com", -1, "", allowed));
 		assertFalse(checkValidOrigin("mydomain1.com", -1, "null", allowed));

--- a/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.*;
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
  * @author Sebastien Deleuze
+ * @author Georgij Cernysiov
  */
 public class WebUtilsTests {
 
@@ -109,13 +110,18 @@ public class WebUtilsTests {
 	public void isValidOrigin() {
 		List<String> allowed = Collections.emptyList();
 		assertTrue(checkValidOrigin("mydomain1.com", -1, "http://mydomain1.com", allowed));
+		assertTrue(checkValidOrigin("mydomain1.com", -1, "http://mydomain1.com/", allowed));
 		assertFalse(checkValidOrigin("mydomain1.com", -1, "http://mydomain2.com", allowed));
 
 		allowed = Collections.singletonList("*");
 		assertTrue(checkValidOrigin("mydomain1.com", -1, "http://mydomain2.com", allowed));
+		assertTrue(checkValidOrigin("mydomain1.com", -1, "http://mydomain2.com/", allowed));
+		assertTrue(checkValidOrigin("mydomain1.com:8080", -1, "http://mydomain2.com:8080/", allowed));
 
 		allowed = Collections.singletonList("http://mydomain1.com");
 		assertTrue(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com", allowed));
+		assertTrue(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com/", allowed));
+
 		assertFalse(checkValidOrigin("mydomain2.com", -1, "http://mydomain3.com", allowed));
 	}
 
@@ -124,13 +130,19 @@ public class WebUtilsTests {
 		assertTrue(checkSameOrigin("mydomain1.com", -1, "http://mydomain1.com"));
 		assertTrue(checkSameOrigin("mydomain1.com", -1, "http://mydomain1.com:80"));
 		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com"));
+		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com/"));
+		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com/////"));
 		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com:443"));
+		assertTrue(checkSameOrigin("mydomain1.com", 443, "https://mydomain1.com:443/"));
 		assertTrue(checkSameOrigin("mydomain1.com", 123, "http://mydomain1.com:123"));
 		assertTrue(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com"));
+		assertTrue(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com/"));
+		assertTrue(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com///"));
 		assertTrue(checkSameOrigin("mydomain1.com", 443, "wss://mydomain1.com"));
 
 		assertFalse(checkSameOrigin("mydomain1.com", -1, "http://mydomain2.com"));
 		assertFalse(checkSameOrigin("mydomain1.com", -1, "https://mydomain1.com"));
+		assertFalse(checkSameOrigin("mydomain1.com", -1, "ws://mydomain1.com:8080"));
 		assertFalse(checkSameOrigin("mydomain1.com", -1, "invalid-origin"));
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
@@ -133,6 +133,7 @@ public class WebUtilsTests {
 		assertTrue(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com/", allowed));
 		assertTrue(checkValidOrigin("mydomain1.com", -1, null, allowed));
 
+		assertFalse(checkValidOrigin("mydomain2.com", -1, "http://mydomain1.com/path/file", allowed));
 		assertFalse(checkValidOrigin("mydomain1.com", -1, "", allowed));
 		assertFalse(checkValidOrigin("mydomain1.com", -1, "null", allowed));
 		assertFalse(checkValidOrigin("mydomain2.com", -1, "http://mydomain3.com", allowed));


### PR DESCRIPTION
- Transformation of the origin into uri components used 
  to fail with a `NumberFormatException` when origin string
  contained a character after the port definition like `[port]/`.
  - The slash straight after the port will ruin the integer parsing.
    `DefaultCorsProcessor.processRequest` will fail during call to `WebUtils.isSameOrigin`.
- Origin  validity check was considering 
  'http://domain1.com' and 'http://domain1.com/' to be different. The same applies to allowed origins comparison. This doesn't meet RFC 6454 standard.

> 3.2.1. Examples
> 
> ```
> All of the following resources have the same origin:
> 
> http://example.com/
> http://example.com:80/
> http://example.com/path/file
> ```

**Notes**
1. In order to improve performance the `allowedOrigins` collection can convert provided `Strings` directly to `UriComponents` or parsing for the header `origin` and `allowedOrigins` can be further simplified.
2. I'm not totally sure about `UriComponentsBuilder.fromHttpRequest` but based on the code it may fail the same way as `UriComponentsBuilder fromOriginHeader` did. It depends what value can be stored in `X-Forwarded-Host`.

Issue: Nothing has been reported so far. However, the issue becomes noticeable: [SocketRocket](https://github.com/square/SocketRocket/pull/256)

_I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement._
