### PR TITLE
Add description for two exceptions which handled by DefaultHandlerExceptionResolver in reference document

### DIFF
--- a/src/asciidoc/web-mvc.adoc
+++ b/src/asciidoc/web-mvc.adoc
@@ -3775,6 +3775,12 @@ corresponding status codes:
 
 | `TypeMismatchException`
 | 400 (Bad Request)
+
+| `MissingPathVariableException`
+| 500 (Internal Server Error)
+
+| `NoHandlerFoundException`
+| 404 (Not Found)
 |===
 
 The `DefaultHandlerExceptionResolver` works transparently by setting the status of the


### PR DESCRIPTION
- MissingPathVariableException (Available since 4.2)
- NoHandlerFoundException (Available since 4.0)

Please check.
I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
