### PR TITLE
 prevent duplicate "/"

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java
@@ -166,7 +166,10 @@ public final class PatternsRequestCondition extends AbstractRequestCondition<Pat
 		if (!this.patterns.isEmpty() && !other.patterns.isEmpty()) {
 			for (String pattern1 : this.patterns) {
 				for (String pattern2 : other.patterns) {
-					result.add(this.pathMatcher.combine(pattern1, pattern2));
+					if(!("/").equals(pattern1)){
+						result.add(this.pathMatcher.combine(pattern1, pattern2));	
+					}
+					
 				}
 			}
 		}


### PR DESCRIPTION
The request url will remove the duplicate duplicate "/" by using UrlPathHelper.getLookupPathForRequest(request), but the RequestMappingInfo won't.

And "directPathMatches"  will be null at AbstractHandlerMethodMapping.lookupHandlerMethod.

For example, when I request ///c, the lookupPath will be /c, it won't match the HandlerMethod //c
