### PR TITLE
Add STRICT option to DateTimeFormatter in case of pattern

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeFormatterFactory.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeFormatterFactory.java
@@ -18,6 +18,7 @@ package org.springframework.format.datetime.standard;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.time.format.ResolverStyle;
 import java.util.TimeZone;
 
 import org.springframework.format.annotation.DateTimeFormat.ISO;
@@ -174,7 +175,8 @@ public class DateTimeFormatterFactory {
 	public DateTimeFormatter createDateTimeFormatter(DateTimeFormatter fallbackFormatter) {
 		DateTimeFormatter dateTimeFormatter = null;
 		if (StringUtils.hasLength(this.pattern)) {
-			dateTimeFormatter = DateTimeFormatter.ofPattern(this.pattern);
+			dateTimeFormatter = DateTimeFormatter.ofPattern(this.pattern)
+					.withResolverStyle(ResolverStyle.STRICT);
 		}
 		else if (this.iso != null && this.iso != ISO.NONE) {
 			switch (this.iso) {

--- a/spring-context/src/test/java/org/springframework/format/datetime/standard/DateTimeFormattingTests.java
+++ b/spring-context/src/test/java/org/springframework/format/datetime/standard/DateTimeFormattingTests.java
@@ -290,6 +290,23 @@ public class DateTimeFormattingTests {
 	}
 
 	@Test
+	public void testBindLocalTimeAnnotatedPattern() {
+		MutablePropertyValues propertyValues = new MutablePropertyValues();
+		propertyValues.add("localDateAnnotatedPattern", "2015-02-28");
+		binder.bind(propertyValues);
+		assertEquals(0, binder.getBindingResult().getErrorCount());
+		assertEquals("2015-02-28", binder.getBindingResult().getFieldValue("localDateAnnotatedPattern"));
+	}
+
+	@Test
+	public void testBindLocalTimeAnnotatedPatternInValid_SPR13567() {
+		MutablePropertyValues propertyValues = new MutablePropertyValues();
+		propertyValues.add("localDateAnnotatedPattern", "2015-02-29");
+		binder.bind(propertyValues);
+		assertEquals(1, binder.getBindingResult().getErrorCount());
+	}
+
+	@Test
 	public void testBindISODate() {
 		MutablePropertyValues propertyValues = new MutablePropertyValues();
 		propertyValues.add("isoDate", "2009-10-31");
@@ -352,8 +369,11 @@ public class DateTimeFormattingTests {
 		@DateTimeFormat(style="MM")
 		private LocalDateTime localDateTimeAnnotated;
 
-		@DateTimeFormat(pattern="M/d/yy h:mm a")
+		@DateTimeFormat(pattern="M/d/uu h:mm a") // change according to SPR-13567
 		private LocalDateTime dateTimeAnnotatedPattern;
+
+		@DateTimeFormat(pattern = "uuuu-MM-dd")
+		private LocalDate localDateAnnotatedPattern;
 
 		@DateTimeFormat(iso=ISO.DATE)
 		private LocalDate isoDate;
@@ -422,6 +442,14 @@ public class DateTimeFormattingTests {
 
 		public void setDateTimeAnnotatedPattern(LocalDateTime dateTimeAnnotatedPattern) {
 			this.dateTimeAnnotatedPattern = dateTimeAnnotatedPattern;
+		}
+
+		public LocalDate getLocalDateAnnotatedPattern() {
+			return localDateAnnotatedPattern;
+		}
+
+		public void setLocalDateAnnotatedPattern(LocalDate localDateAnnotatedPattern) {
+			this.localDateAnnotatedPattern = localDateAnnotatedPattern;
 		}
 
 		public LocalDate getIsoDate() {


### PR DESCRIPTION
Issue: [SPR-13567](https://jira.spring.io/browse/SPR-13567)

Added STRICT option and changed test case.
`y` in JSR-310 is different from that of classic Date API.

https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html

`y` means not "year" but "year-of-era". This difference affects in case of STRICT mode.
