### PR TITLE
Spring Jdbc add Postgresql ?-contained operator support

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
@@ -152,6 +152,12 @@ public abstract class NamedParameterUtils {
 					}
 				}
 				if (c == '?') {
+					int j = i + 1;
+					if (j < statement.length && statement[j] == '?') {
+						// Postgres-style "??" ?-operator - to be skipped.
+						i = i + 2;
+						continue;
+					}
 					unnamedParameterCount++;
 					totalParameterCount++;
 				}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterUtilsTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterUtilsTests.java
@@ -186,6 +186,18 @@ public class NamedParameterUtilsTests {
 	}
 
 	/*
+	 * SPR-13582
+	 */
+	@Test
+	public void parseSqlStatementWithPostgresContainedOperator() throws Exception {
+		String expectedSql = "select 'first name' from artists where info->'stat'->'albums' = ?? ? and '[\"1\",\"2\",\"3\"]'::jsonb ?? '4'";
+		String sql = "select 'first name' from artists where info->'stat'->'albums' = ?? :album and '[\"1\",\"2\",\"3\"]'::jsonb ?? '4'";
+		ParsedSql parsedSql = NamedParameterUtils.parseSqlStatement(sql);
+		assertEquals(1, parsedSql.getTotalParameterCount());
+		assertEquals(expectedSql, NamedParameterUtils.substituteNamedParameters(parsedSql, null));
+	}
+
+	/*
 	 * SPR-7476
 	 */
 	@Test


### PR DESCRIPTION
ISSUE: https://jira.spring.io/browse/SPR-13582

Postgresql have a many functional oparators such as "?" (for example jsonb operators http://www.postgresql.org/docs/9.4/static/functions-json.html)

Spring jdbc processing this case not correct. When run sql

```
SELECT '["1","2","3"]'::jsonb ? '4'
```

I see exception like this:

```
class org.springframework.dao.InvalidDataAccessApiUsageException
SQL [SELECT '["1","2","3"]'::jsonb ? '4']: given 1 parameters but expected 0
```

In pgjdbc this bug fixed in 2014 (https://github.com/pgjdbc/pgjdbc/pull/227)
