### PR TITLE
Add @DeferredImport

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
@@ -34,7 +34,6 @@ import java.util.Stack;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.Aware;
 import org.springframework.beans.factory.BeanClassLoaderAware;
@@ -56,6 +55,7 @@ import org.springframework.context.EnvironmentAware;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.ConfigurationCondition.ConfigurationPhase;
 import org.springframework.core.NestedIOException;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.env.CompositePropertySource;
@@ -275,6 +275,17 @@ class ConfigurationClassParser {
 
 		// Process any @Import annotations
 		processImports(configClass, sourceClass, getImports(sourceClass), true);
+
+		// Process any @DeferredImport annotations
+		if (sourceClass.getMetadata().isAnnotated(DeferredImport.class.getName())) {
+			Collection<SourceClass> deferredImportClasses = sourceClass.getAnnotationAttributes(DeferredImport.class.getName(), "value");
+			int order = AnnotationConfigUtils.attributesFor(sourceClass.getMetadata(), DeferredImport.class).getNumber("order");
+			if (this.deferredImportSelectors != null){
+				this.deferredImportSelectors.add(new DeferredImportSelectorHolder(configClass, new StaticDeferredImportSelector(deferredImportClasses, order)));
+			} else {
+				processImports(configClass, sourceClass, deferredImportClasses, true);
+			}
+		}
 
 		// Process any @ImportResource annotations
 		if (sourceClass.getMetadata().isAnnotated(ImportResource.class.getName())) {
@@ -889,6 +900,29 @@ class ConfigurationClassParser {
 					"already present in the current import stack %s", importStack.peek().getSimpleName(),
 					attemptedImport.getSimpleName(), attemptedImport.getSimpleName(), importStack),
 					new Location(importStack.peek().getResource(), attemptedImport.getMetadata()));
+		}
+	}
+
+	private static class StaticDeferredImportSelector implements DeferredImportSelector, Ordered {
+		private ArrayList<String> imports;
+		private int order;
+
+		public StaticDeferredImportSelector(Collection<SourceClass> importedClasses, int order) {
+			this.imports = new ArrayList<String>(importedClasses.size());
+			for (SourceClass sourceClass : importedClasses) {
+				this.imports.add(sourceClass.getMetadata().getClassName());
+			}
+			this.order = order;
+		}
+
+		@Override
+		public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+			return this.imports.toArray(new String[this.imports.size()]);
+		}
+
+		@Override
+		public int getOrder() {
+			return this.order;
 		}
 	}
 

--- a/spring-context/src/main/java/org/springframework/context/annotation/DeferredImport.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/DeferredImport.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.Ordered;
+
+/**
+ * A variation of {@link @Import}. This annotation indicates
+ * {@link Configuration @Configuration} to be imported after all
+ * {@code @Configuration} beans have been processed. This type of import can be
+ * particularly useful when the selected imports are {@code @Conditional}.
+ *
+ * @author Johannes Edmeier
+ * @since 4.2.3
+ * @see Configuration
+ * @see DeferredImportSelector
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DeferredImport {
+
+	/**
+	 * @{@link Configuration}, {@link ImportSelector}, {@link ImportBeanDefinitionRegistrar}
+	 * or regular component classes to import.
+	 */
+	Class<?>[] value();
+
+	/**
+	 * Order to indicate a precedence against other or @{@link DeferredImport}s or
+	 * {@link DeferredImportSelector}s.
+	 */
+	int order() default Ordered.LOWEST_PRECEDENCE;
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/DeferredImportTest.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/DeferredImportTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.configuration;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DeferredImport;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link DeferredImport} annotation support.
+ * @author Johannes Edmeier
+ * @since 4.2.3
+ */
+public class DeferredImportTest {
+
+	@Test
+	public void deferredImport() {
+		DefaultListableBeanFactory beanFactory = spy(new DefaultListableBeanFactory());
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(beanFactory);
+		context.register(Config1.class);
+		context.register(Config2.class);
+		context.refresh();
+		context.getBean(Config1.class);
+		context.getBean(Config2.class);
+
+		InOrder ordered = inOrder(beanFactory);
+		ordered.verify(beanFactory).registerBeanDefinition(eq("a"), (BeanDefinition) anyObject());
+		ordered.verify(beanFactory).registerBeanDefinition(eq("b"), (BeanDefinition) anyObject());
+		ordered.verify(beanFactory).registerBeanDefinition(eq("c"), (BeanDefinition) anyObject());
+		ordered.verify(beanFactory).registerBeanDefinition(eq("d"), (BeanDefinition) anyObject());
+		ordered.verify(beanFactory).registerBeanDefinition(eq("e"), (BeanDefinition) anyObject());
+	}
+
+	@Configuration
+	@DeferredImport(Deferred1.class)
+	static class Config1 {
+	}
+
+	@Configuration
+	@Import(ImportedDeferred1.class)
+	static class Deferred1 {
+		@Bean
+		public String e() {
+			return "e";
+		}
+	}
+
+	@Configuration
+	static class ImportedDeferred1 {
+		@Bean
+		public String d() {
+			return "d";
+		}
+	}
+
+	@Configuration
+	@Import(Imported.class)
+	@DeferredImport(value = {Deferred2.class}, order = Ordered.LOWEST_PRECEDENCE -1)
+	static class Config2 {
+	}
+
+	@Configuration
+	static class Imported {
+		@Bean
+		public String a() {
+			return "a";
+		}
+	}
+
+	@Configuration
+	@DeferredImport(DeferredDeferred2.class)
+	static class Deferred2 {
+		@Bean
+		public String c() {
+			return "c";
+		}
+	}
+
+	@Configuration
+	static class DeferredDeferred2 {
+		@Bean
+		public String b() {
+			return "b";
+		}
+	}
+
+}


### PR DESCRIPTION
I ran into the issue to defer the processing of my conditional configurations.
Since the set of imported classes isn't dynamic I think its odd to implement a DeferredImportSelector and it would come in handy having an annotation complementing the selector.

CLA is signed

Issue SPR-13583
