### PR TITLE
Add null check to enable creation of triggers without JobDetail.

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/scheduling/quartz/CronTriggerFactoryBean.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/quartz/CronTriggerFactoryBean.java
@@ -237,8 +237,10 @@ public class CronTriggerFactoryBean implements FactoryBean<CronTrigger>, BeanNam
 		CronTriggerImpl cti = new CronTriggerImpl();
 		cti.setName(this.name);
 		cti.setGroup(this.group);
-		cti.setJobKey(this.jobDetail.getKey());
-		cti.setJobDataMap(this.jobDataMap);
+		if (this.jobDetail != null) {
+			cti.setJobKey(this.jobDetail.getKey());
+			cti.setJobDataMap(this.jobDataMap);
+		}
 		cti.setStartTime(this.startTime);
 		cti.setCronExpression(this.cronExpression);
 		cti.setTimeZone(this.timeZone);

--- a/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SimpleTriggerFactoryBean.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SimpleTriggerFactoryBean.java
@@ -228,8 +228,10 @@ public class SimpleTriggerFactoryBean implements FactoryBean<SimpleTrigger>, Bea
 		SimpleTriggerImpl sti = new SimpleTriggerImpl();
 		sti.setName(this.name);
 		sti.setGroup(this.group);
-		sti.setJobKey(this.jobDetail.getKey());
-		sti.setJobDataMap(this.jobDataMap);
+		if (this.jobDetail != null) {
+			sti.setJobKey(this.jobDetail.getKey());
+			sti.setJobDataMap(this.jobDataMap);
+		}
 		sti.setStartTime(this.startTime);
 		sti.setRepeatInterval(this.repeatInterval);
 		sti.setRepeatCount(this.repeatCount);


### PR DESCRIPTION
This change allows SimpleTriggerFactoryBean and CronTriggerFactoryBean to create triggers without associated job details. This is something that we need in our project (we are using spring to configure triggers, but we associate them with jobs programmatically) and it worked fine in Spring 3.x.

Issue: [SPR-13604](https://jira.spring.io/browse/SPR-13604)

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
