### PR TITLE
Added selection of compare mode for Json

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/util/JsonExpectationsHelper.java
+++ b/spring-test/src/main/java/org/springframework/test/util/JsonExpectationsHelper.java
@@ -32,26 +32,42 @@ public class JsonExpectationsHelper {
 	/**
 	 * Parse the expected and actual strings as JSON and assert the two
 	 * are "similar" - i.e. they contain the same attribute-value pairs
-	 * regardless of order and formatting.
+	 * regardless of formatting.
+	 *
+	 * <p>Can compare in two modes:
+	 * <ul>
+	 *     <li>Strict checking.  Not extensible, and strict array ordering.</li>
+	 *     <li>Lenient checking.  Extensible, and non-strict array ordering.</li>
+	 * </ul>
+	 * Setting {@code strict} to true enables strict checking, false &mdash; lenient checking.
 	 *
 	 * @param expected the expected JSON content
 	 * @param actual the actual JSON content
-	 * @since 4.1
+	 * @param strict enables strict checking
+	 * @since 4.2
 	 */
-	public void assertJsonEqual(String expected, String actual) throws Exception {
-		JSONAssert.assertEquals(expected, actual, false);
+	public void assertJsonEqual(String expected, String actual, boolean strict) throws Exception {
+		JSONAssert.assertEquals(expected, actual, strict);
 	}
 
 	/**
 	 * Parse the expected and actual strings as JSON and assert the two
 	 * are "not similar" - i.e. they contain different attribute-value pairs
-	 * regardless of order and formatting.
+	 * regardless of formatting.
+	 *
+	 * <p>Can compare in two modes:
+	 * <ul>
+	 *     <li>Strict checking.  Not extensible, and strict array ordering.</li>
+	 *     <li>Lenient checking.  Extensible, and non-strict array ordering.</li>
+	 * </ul>
+	 * Setting {@code strict} to true enables strict checking, false &mdash; lenient checking.
 	 *
 	 * @param expected the expected JSON content
 	 * @param actual the actual JSON content
-	 * @since 4.1
+	 * @param strict enables strict checking
+	 * @since 4.2
 	 */
-	public void assertJsonNotEqual(String expected, String actual) throws Exception {
-		JSONAssert.assertNotEquals(expected, actual, false);
+	public void assertJsonNotEqual(String expected, String actual, boolean strict) throws Exception {
+		JSONAssert.assertNotEquals(expected, actual, strict);
 	}
 }

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/ContentResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/ContentResultMatchers.java
@@ -213,20 +213,36 @@ public class ContentResultMatchers {
 	}
 
 	/**
-	 * Parse the response content and the given string as JSON and assert the two
-	 * are "similar" &mdash; i.e. they contain the same attribute-value pairs
-	 * regardless of order and formatting.
-	 * <p>Use of this matcher requires the <a
-	 * href="http://jsonassert.skyscreamer.org/">JSONassert<a/> library.
+	 * Uses {@link #json(String, boolean)} with second parameter set to false.
 	 * @param jsonContent the expected JSON content
 	 * @since 4.1
 	 */
 	public ResultMatcher json(final String jsonContent) {
+		return json(jsonContent, false);
+	}
+
+	/**
+	 * Parse the response content and the given string as JSON and assert the two
+	 * are "similar" &mdash; i.e. they contain the same attribute-value pairs
+	 * regardless of formatting.
+	 * <p>Can compare in two modes:
+	 * <ul>
+	 *     <li>Strict checking.  Not extensible, and strict array ordering.</li>
+	 *     <li>Lenient checking.  Extensible, and non-strict array ordering.</li>
+	 * </ul>
+	 * Setting {@code strict} to true enables strict checking, false &mdash; lenient checking.
+	 * <p>Use of this matcher requires the <a
+	 * href="http://jsonassert.skyscreamer.org/">JSONassert<a/> library.
+	 * @param jsonContent the expected JSON content
+	 * @param strict enables strict checking
+	 * @since 4.2
+	 */
+	public ResultMatcher json(final String jsonContent, final boolean strict) {
 		return new ResultMatcher() {
 			@Override
 			public void match(MvcResult result) throws Exception {
 				String content = result.getResponse().getContentAsString();
-				jsonHelper.assertJsonEqual(jsonContent, content);
+				jsonHelper.assertJsonEqual(jsonContent, content, strict);
 			}
 		};
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/result/ContentResultMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/result/ContentResultMatchersTests.java
@@ -79,8 +79,23 @@ public class ContentResultMatchersTests {
 	}
 
 	@Test
-	public void json() throws Exception {
-		new ContentResultMatchers().json("{\n \"foo\" : \"bar\"         \n}").match(getStubMvcResult());
+	public void json1() throws Exception {
+		new ContentResultMatchers().json("{\n \"foo\" : \"bar\"  \n}").match(getStubMvcResult());
+	}
+
+	@Test
+	public void json2() throws Exception {
+		new ContentResultMatchers().json("{\n \"foo\" : \"bar\"  \n}", false).match(getStubMvcResult());
+	}
+
+	@Test
+	public void json3() throws Exception {
+		new ContentResultMatchers().json("{\n \"foo\":\"bar\",   \"foo array\":[\"foo\",\"bar\"] \n}", true).match(getStubMvcResult());
+	}
+
+	@Test
+	public void json4() throws Exception {
+		new ContentResultMatchers().json("{\n \"foo array\":[\"foo\",\"bar\"], \"foo\":\"bar\" \n}", true).match(getStubMvcResult());
 	}
 
 	@Test(expected=AssertionError.class)
@@ -88,8 +103,17 @@ public class ContentResultMatchersTests {
 		new ContentResultMatchers().json("{\n\"fooo\":\"bar\"\n}").match(getStubMvcResult());
 	}
 
+	@Test(expected=AssertionError.class)
+	public void jsonNoMatch2() throws Exception {
+		new ContentResultMatchers().json("{\n\"fooo\":\"bar\"\n}", false).match(getStubMvcResult());
+	}
 
-	private static final String CONTENT = "{\"foo\":\"bar\"}";
+	@Test(expected=AssertionError.class)
+	public void jsonNoMatch3() throws Exception {
+		new ContentResultMatchers().json("{\"foo\":\"bar\",   \"foo array\":[\"bar\",\"foo\"]}", true).match(getStubMvcResult());
+	}
+
+	private static final String CONTENT = "{\"foo\":\"bar\",\"foo array\":[\"foo\",\"bar\"]}";
 
 	private StubMvcResult getStubMvcResult() throws Exception {
 		MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
Greetings everyone!

`spring-test` for comparing json use external library called `jsonassert`.

This lib has several mods of comparing json:
- `STRICT` - Strict checking.  Not extensible, and strict array ordering.
- `LENIENT` - Lenient checking.  Extensible, and non-strict array ordering.
- `NON_EXTENSIBLE` - Non-extensible checking.  Not extensible, and non-strict array ordering.
- `STRICT_ORDER` - Strict order checking.  Extensible, and strict array ordering.

By default `spring-test` in method `org.springframework.test.web.servlet.result.ContentResultMatchers#json` use this library in mod `LENIENT`.

This mod is not strict enough. In situation when in your json new field has added, your tests not failed, so app that use API with this json can crash when try to deserialize this in some POJO!

Also this is not acceptable, when you want compare json in other useful mods, for example `NON_EXTENSIBLE`.

I have added changes and for now, developer can select mod that he want.

Issue: [SPR-13607](https://jira.spring.io/browse/SPR-13607)

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
