### PR TITLE
Separate java tokens by a single space

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
@@ -285,7 +285,7 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 				this.discoveredReturningType = ClassUtils.forName(name, getAspectClassLoader());
 			}
 			catch (Throwable ex) {
-				throw new IllegalArgumentException("Returning name '" + name  +
+				throw new IllegalArgumentException("Returning name '" + name +
 						"' is neither a valid argument name nor the fully-qualified name of a Java type on the classpath. " +
 						"Root cause: " + ex);
 			}
@@ -319,7 +319,7 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 				this.discoveredThrowingType = ClassUtils.forName(name, getAspectClassLoader());
 			}
 			catch (Throwable ex) {
-				throw new IllegalArgumentException("Throwing name '" + name  +
+				throw new IllegalArgumentException("Throwing name '" + name +
 						"' is neither a valid argument name nor the fully-qualified name of a Java type on the classpath. " +
 						"Root cause: " + ex);
 			}

--- a/spring-aop/src/test/java/org/springframework/aop/config/AopNamespaceHandlerEventTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/config/AopNamespaceHandlerEventTests.java
@@ -44,8 +44,8 @@ public final class AopNamespaceHandlerEventTests {
 
 	private static final Class<?> CLASS = AopNamespaceHandlerEventTests.class;
 
-	private static final Resource CONTEXT =  qualifiedResource(CLASS, "context.xml");
-	private static final Resource POINTCUT_EVENTS_CONTEXT =  qualifiedResource(CLASS, "pointcutEvents.xml");
+	private static final Resource CONTEXT = qualifiedResource(CLASS, "context.xml");
+	private static final Resource POINTCUT_EVENTS_CONTEXT = qualifiedResource(CLASS, "pointcutEvents.xml");
 	private static final Resource POINTCUT_REF_CONTEXT = qualifiedResource(CLASS, "pointcutRefEvents.xml");
 	private static final Resource DIRECT_POINTCUT_EVENTS_CONTEXT = qualifiedResource(CLASS, "directPointcutEvents.xml");
 

--- a/spring-aspects/src/test/java/org/springframework/context/annotation/aspectj/AnnotationBeanConfigurerTests.java
+++ b/spring-aspects/src/test/java/org/springframework/context/annotation/aspectj/AnnotationBeanConfigurerTests.java
@@ -36,7 +36,7 @@ public class AnnotationBeanConfigurerTests {
 
 	@Test
 	public void testInjection() {
-		AnnotationConfigApplicationContext context = new  AnnotationConfigApplicationContext(Config.class);
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
 		ShouldBeConfiguredBySpring myObject = new ShouldBeConfiguredBySpring();
 		Assert.assertEquals("Rod", myObject.getName());
 	}

--- a/spring-beans-groovy/src/main/java/org/springframework/beans/factory/groovy/GroovyBeanDefinitionReader.java
+++ b/spring-beans-groovy/src/main/java/org/springframework/beans/factory/groovy/GroovyBeanDefinitionReader.java
@@ -469,7 +469,7 @@ public class GroovyBeanDefinitionReader extends AbstractBeanDefinitionReader imp
 						this.currentBeanDefinition = new GroovyBeanDefinitionWrapper(beanName, beanClass);
 					}
 				}
-				else  {
+				else {
 					this.currentBeanDefinition = new GroovyBeanDefinitionWrapper(
 							beanName, beanClass, resolveConstructorArguments(args,1,args.length));
 				}
@@ -483,7 +483,7 @@ public class GroovyBeanDefinitionReader extends AbstractBeanDefinitionReader imp
 		else if (args[0] instanceof Map) {
 			// named constructor arguments
 			if (args.length > 1 && args[1] instanceof Class) {
-				List constructorArgs = resolveConstructorArguments(args, 2, hasClosureArgument ? args.length-1 :  args.length);
+				List constructorArgs = resolveConstructorArguments(args, 2, hasClosureArgument ? args.length-1 : args.length);
 				this.currentBeanDefinition = new GroovyBeanDefinitionWrapper(beanName, (Class)args[1], constructorArgs);
 				Map namedArgs = (Map)args[0];
 				for (Object o : namedArgs.keySet()) {

--- a/spring-beans/src/main/java/org/springframework/beans/CachedIntrospectionResults.java
+++ b/spring-beans/src/main/java/org/springframework/beans/CachedIntrospectionResults.java
@@ -289,7 +289,7 @@ public class CachedIntrospectionResults {
 			PropertyDescriptor[] pds = this.beanInfo.getPropertyDescriptors();
 			for (PropertyDescriptor pd : pds) {
 				if (Class.class == beanClass &&
-						("classLoader".equals(pd.getName()) ||  "protectionDomain".equals(pd.getName()))) {
+						("classLoader".equals(pd.getName()) || "protectionDomain".equals(pd.getName()))) {
 					// Ignore Class.getClassLoader() and getProtectionDomain() methods - nobody needs to bind to those
 					continue;
 				}

--- a/spring-beans/src/main/java/org/springframework/beans/GenericTypeAwarePropertyDescriptor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/GenericTypeAwarePropertyDescriptor.java
@@ -62,7 +62,7 @@ final class GenericTypeAwarePropertyDescriptor extends PropertyDescriptor {
 
 		super(propertyName, null, null);
 
-		if (beanClass == null)  {
+		if (beanClass == null) {
 			throw new IntrospectionException("Bean class must not be null");
 		}
 		this.beanClass = beanClass;

--- a/spring-beans/src/main/java/org/springframework/beans/annotation/AnnotationBeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/annotation/AnnotationBeanUtils.java
@@ -59,7 +59,7 @@ public abstract class AnnotationBeanUtils {
 	 * @see org.springframework.beans.BeanWrapper
 	 */
 	public static void copyPropertiesToBean(Annotation ann, Object bean, StringValueResolver valueResolver, String... excludedProperties) {
-		Set<String> excluded =  new HashSet<String>(Arrays.asList(excludedProperties));
+		Set<String> excluded = new HashSet<String>(Arrays.asList(excludedProperties));
 		Method[] annotationProperties = ann.annotationType().getDeclaredMethods();
 		BeanWrapper bw = PropertyAccessorFactory.forBeanPropertyAccess(bean);
 		for (Method annotationProperty : annotationProperties) {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -1014,7 +1014,7 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 					"Bean class isn't public, and non-public access not allowed: " + beanClass.getName());
 		}
 
-		if (mbd.getFactoryMethodName() != null)  {
+		if (mbd.getFactoryMethodName() != null) {
 			return instantiateUsingFactoryMethod(beanName, mbd, args);
 		}
 
@@ -1042,7 +1042,7 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 		Constructor<?>[] ctors = determineConstructorsFromBeanPostProcessors(beanClass, beanName);
 		if (ctors != null ||
 				mbd.getResolvedAutowireMode() == RootBeanDefinition.AUTOWIRE_CONSTRUCTOR ||
-				mbd.hasConstructorArgumentValues() || !ObjectUtils.isEmpty(args))  {
+				mbd.hasConstructorArgumentValues() || !ObjectUtils.isEmpty(args)) {
 			return autowireConstructor(beanName, mbd, ctors, args);
 		}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/SimpleInstantiationStrategy.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/SimpleInstantiationStrategy.java
@@ -77,7 +77,7 @@ public class SimpleInstantiationStrategy implements InstantiationStrategy {
 							});
 						}
 						else {
-							constructorToUse =	clazz.getDeclaredConstructor((Class[]) null);
+							constructorToUse = clazz.getDeclaredConstructor((Class[]) null);
 						}
 						bd.resolvedConstructorOrFactoryMethod = constructorToUse;
 					}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -1057,7 +1057,7 @@ public class DefaultListableBeanFactoryTests {
 		assertEquals(singletonObject, lbf.getBean("singletonObject"));
 		assertEquals(singletonObject, test.getSpouse());
 
-		Map<?, ?>  beansOfType = lbf.getBeansOfType(TestBean.class, false, true);
+		Map<?, ?> beansOfType = lbf.getBeansOfType(TestBean.class, false, true);
 		assertEquals(2, beansOfType.size());
 		assertTrue(beansOfType.containsValue(test));
 		assertTrue(beansOfType.containsValue(singletonObject));

--- a/spring-beans/src/test/java/org/springframework/beans/factory/parsing/NullSourceExtractorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/parsing/NullSourceExtractorTests.java
@@ -28,7 +28,7 @@ public final class NullSourceExtractorTests {
 
 	@Test
 	public void testPassThroughContract() throws Exception {
-		Object source  = new Object();
+		Object source = new Object();
 		Object extractedSource = new NullSourceExtractor().extractSource(source, null);
 		assertNull("The contract of NullSourceExtractor states that the extraction *always* return null", extractedSource);
 	}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/parsing/PassThroughSourceExtractorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/parsing/PassThroughSourceExtractorTests.java
@@ -30,7 +30,7 @@ public final class PassThroughSourceExtractorTests {
 
 	@Test
 	public void testPassThroughContract() throws Exception {
-		Object source  = new Object();
+		Object source = new Object();
 		Object extractedSource = new PassThroughSourceExtractor().extractSource(source, null);
 		assertSame("The contract of PassThroughSourceExtractor states that the supplied " +
 				"source object *must* be returned as-is", source, extractedSource);

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderImpl.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderImpl.java
@@ -511,7 +511,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	 * @see #getProtocol()
 	 */
 	protected Transport getTransport(Session session) throws NoSuchProviderException {
-		String protocol	= getProtocol();
+		String protocol = getProtocol();
 		if (protocol == null) {
 			protocol = session.getProperty("mail.transport.protocol");
 			if (protocol == null) {

--- a/spring-context-support/src/test/java/org/springframework/cache/jcache/interceptor/AnnotationCacheOperationSourceTests.java
+++ b/spring-context-support/src/test/java/org/springframework/cache/jcache/interceptor/AnnotationCacheOperationSourceTests.java
@@ -47,7 +47,7 @@ public class AnnotationCacheOperationSourceTests extends AbstractJCacheTests {
 
 	private final DefaultJCacheOperationSource source = new DefaultJCacheOperationSource();
 
-	private final DefaultListableBeanFactory beanFactory =  new DefaultListableBeanFactory();
+	private final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 
 
 	@Before

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/AbstractCacheResolver.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/AbstractCacheResolver.java
@@ -61,7 +61,7 @@ public abstract class AbstractCacheResolver implements CacheResolver, Initializi
 	}
 
 	@Override
-	public void afterPropertiesSet()  {
+	public void afterPropertiesSet() {
 		Assert.notNull(this.cacheManager, "CacheManager must not be null");
 	}
 

--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
@@ -428,7 +428,7 @@ public class ConfigurationClassPostProcessor implements BeanDefinitionRegistryPo
 		}
 
 		@Override
-		public Object postProcessBeforeInitialization(Object bean, String beanName)  {
+		public Object postProcessBeforeInitialization(Object bean, String beanName) {
 			if (bean instanceof ImportAware) {
 				ImportRegistry importRegistry = this.beanFactory.getBean(IMPORT_REGISTRY_BEAN_NAME, ImportRegistry.class);
 				AnnotationMetadata importingClass = importRegistry.getImportingClassFor(bean.getClass().getSuperclass().getName());

--- a/spring-context/src/main/java/org/springframework/format/datetime/DateTimeFormatAnnotationFormatterFactory.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/DateTimeFormatAnnotationFormatterFactory.java
@@ -37,7 +37,7 @@ import org.springframework.format.annotation.DateTimeFormat;
  * @since 3.2
  * @see org.springframework.format.datetime.joda.JodaDateTimeFormatAnnotationFormatterFactory
  */
-public class DateTimeFormatAnnotationFormatterFactory  extends EmbeddedValueResolutionSupport
+public class DateTimeFormatAnnotationFormatterFactory extends EmbeddedValueResolutionSupport
 		implements AnnotationFormatterFactory<DateTimeFormat> {
 
 

--- a/spring-context/src/main/java/org/springframework/remoting/rmi/RmiServiceExporter.java
+++ b/spring-context/src/main/java/org/springframework/remoting/rmi/RmiServiceExporter.java
@@ -299,7 +299,7 @@ public class RmiServiceExporter extends RmiBasedExporter implements Initializing
 			// Already an RMI object bound for the specified service name...
 			unexportObjectSilently();
 			throw new IllegalStateException(
-					"Already an RMI object bound for name '"  + this.serviceName + "': " + ex.toString());
+					"Already an RMI object bound for name '" + this.serviceName + "': " + ex.toString());
 		}
 		catch (RemoteException ex) {
 			// Registry binding failed: let's unexport the RMI object as well.

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationBeanPostProcessor.java
@@ -144,7 +144,7 @@ public class AsyncAnnotationBeanPostProcessor extends AbstractAdvisingBeanPostPr
 			}
 		}
 
-		AsyncAnnotationAdvisor advisor =  new AsyncAnnotationAdvisor(executorToUse, this.exceptionHandler);
+		AsyncAnnotationAdvisor advisor = new AsyncAnnotationAdvisor(executorToUse, this.exceptionHandler);
 		if (this.asyncAnnotationType != null) {
 			advisor.setAsyncAnnotationType(this.asyncAnnotationType);
 		}

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolExecutorFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolExecutorFactoryBean.java
@@ -133,7 +133,7 @@ public class ThreadPoolExecutorFactoryBean extends ExecutorConfigurationSupport
 			ThreadFactory threadFactory, RejectedExecutionHandler rejectedExecutionHandler) {
 
 		BlockingQueue<Runnable> queue = createQueue(this.queueCapacity);
-		ThreadPoolExecutor executor  = createExecutor(this.corePoolSize, this.maxPoolSize,
+		ThreadPoolExecutor executor = createExecutor(this.corePoolSize, this.maxPoolSize,
 				this.keepAliveSeconds, queue, threadFactory, rejectedExecutionHandler);
 		if (this.allowCoreThreadTimeOut) {
 			executor.allowCoreThreadTimeOut(true);

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.java
@@ -183,7 +183,7 @@ public class ThreadPoolTaskExecutor extends ExecutorConfigurationSupport
 			ThreadFactory threadFactory, RejectedExecutionHandler rejectedExecutionHandler) {
 
 		BlockingQueue<Runnable> queue = createQueue(this.queueCapacity);
-		ThreadPoolExecutor executor  = new ThreadPoolExecutor(
+		ThreadPoolExecutor executor = new ThreadPoolExecutor(
 				this.corePoolSize, this.maxPoolSize, this.keepAliveSeconds, TimeUnit.SECONDS,
 				queue, threadFactory, rejectedExecutionHandler);
 		if (this.allowCoreThreadTimeOut) {

--- a/spring-context/src/test/java/org/springframework/aop/aspectj/AroundAdviceBindingTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/aspectj/AroundAdviceBindingTests.java
@@ -51,7 +51,7 @@ public class AroundAdviceBindingTests {
 	public void onSetUp() throws Exception {
 		ctx = new ClassPathXmlApplicationContext(getClass().getSimpleName() + ".xml", getClass());
 
-		AroundAdviceBindingTestAspect  aroundAdviceAspect = ((AroundAdviceBindingTestAspect) ctx.getBean("testAspect"));
+		AroundAdviceBindingTestAspect aroundAdviceAspect = ((AroundAdviceBindingTestAspect) ctx.getBean("testAspect"));
 
 		ITestBean injectedTestBean = (ITestBean) ctx.getBean("testBean");
 		assertTrue(AopUtils.isAopProxy(injectedTestBean));

--- a/spring-context/src/test/java/org/springframework/aop/framework/AbstractAopProxyTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/AbstractAopProxyTests.java
@@ -166,7 +166,7 @@ public abstract class AbstractAopProxyTests {
 		sw.start("Create " + howMany + " proxies");
 		testManyProxies(howMany);
 		sw.stop();
-		assertTrue("Proxy creation was too slow",  sw.getTotalTimeMillis() < 5000);
+		assertTrue("Proxy creation was too slow", sw.getTotalTimeMillis() < 5000);
 	}
 
 	private void testManyProxies(int howMany) {

--- a/spring-context/src/test/java/org/springframework/aop/framework/autoproxy/BeanNameAutoProxyCreatorTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/autoproxy/BeanNameAutoProxyCreatorTests.java
@@ -171,7 +171,7 @@ public class BeanNameAutoProxyCreatorTests {
 		assertTrue(((Advised)testBean).isFrozen());
 	}
 
-	private void jdkAssertions(ITestBean tb, int nopInterceptorCount)  {
+	private void jdkAssertions(ITestBean tb, int nopInterceptorCount) {
 		NopInterceptor nop = (NopInterceptor) beanFactory.getBean("nopInterceptor");
 		assertEquals(0, nop.getCount());
 		assertTrue(AopUtils.isJdkDynamicProxy(tb));

--- a/spring-context/src/test/java/org/springframework/beans/factory/xml/XmlBeanFactoryTestTypes.java
+++ b/spring-context/src/test/java/org/springframework/beans/factory/xml/XmlBeanFactoryTestTypes.java
@@ -524,7 +524,7 @@ abstract class OverrideOneMethod extends MethodReplaceCandidate implements Overr
 
 	@Override
 	public String replaceMe(String someParam) {
-		return "replaceMe:"  + someParam;
+		return "replaceMe:" + someParam;
 	}
 }
 

--- a/spring-context/src/test/java/org/springframework/cache/annotation/AnnotationCacheOperationSourceTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/annotation/AnnotationCacheOperationSourceTests.java
@@ -263,7 +263,7 @@ public class AnnotationCacheOperationSourceTests {
 
 	private void assertSharedConfig(CacheOperation actual, String keyGenerator, String cacheManager,
 									String cacheResolver, String... cacheNames) {
-		assertEquals("Wrong key manager",  keyGenerator, actual.getKeyGenerator());
+		assertEquals("Wrong key manager", keyGenerator, actual.getKeyGenerator());
 		assertEquals("Wrong cache manager", cacheManager, actual.getCacheManager());
 		assertEquals("Wrong cache resolver", cacheResolver, actual.getCacheResolver());
 		assertEquals("Wrong number of cache names", cacheNames.length, actual.getCacheNames().size());

--- a/spring-context/src/test/java/org/springframework/cache/concurrent/ConcurrentCacheTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/concurrent/ConcurrentCacheTests.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.*;
  * @author Juergen Hoeller
  * @author Stephane Nicoll
  */
-public class ConcurrentCacheTests  {
+public class ConcurrentCacheTests {
 
 	protected final static String CACHE_NAME = "testCache";
 

--- a/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -174,7 +174,7 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	}
 
 	@Override
-	@Caching(evict = { @CacheEvict("primary"), @CacheEvict(cacheNames = "secondary", key = "#a0"),  @CacheEvict(cacheNames = "primary", key = "#p0 + 'A'") })
+	@Caching(evict = { @CacheEvict("primary"), @CacheEvict(cacheNames = "secondary", key = "#a0"), @CacheEvict(cacheNames = "primary", key = "#p0 + 'A'") })
 	public Object multiEvict(Object arg1) {
 		return counter.getAndIncrement();
 	}

--- a/spring-context/src/test/java/org/springframework/cache/interceptor/DefaultKeyGeneratorTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/interceptor/DefaultKeyGeneratorTests.java
@@ -56,7 +56,7 @@ public class DefaultKeyGeneratorTests {
 	}
 
 	@Test
-	public void multipleValues()  {
+	public void multipleValues() {
 		Object k1 = generateKey(new Object[] { "a", 1, "b" });
 		Object k2 = generateKey(new Object[] { "a", 1, "b" });
 		Object k3 = generateKey(new Object[] { "b", 1, "a" });

--- a/spring-context/src/test/java/org/springframework/cache/interceptor/SimpleKeyGeneratorTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/interceptor/SimpleKeyGeneratorTests.java
@@ -56,7 +56,7 @@ public class SimpleKeyGeneratorTests {
 	}
 
 	@Test
-	public void multipleValues()  {
+	public void multipleValues() {
 		Object k1 = generateKey(new Object[] { "a", 1, "b" });
 		Object k2 = generateKey(new Object[] { "a", 1, "b" });
 		Object k3 = generateKey(new Object[] { "b", 1, "a" });

--- a/spring-context/src/test/java/org/springframework/context/access/ContextJndiBeanFactoryLocatorTests.java
+++ b/spring-context/src/test/java/org/springframework/context/access/ContextJndiBeanFactoryLocatorTests.java
@@ -64,7 +64,7 @@ public final class ContextJndiBeanFactoryLocatorTests {
 	}
 
 	@Test
-	public void beanFactoryPathFromJndiEnvironmentNotFound() throws Exception  {
+	public void beanFactoryPathFromJndiEnvironmentNotFound() throws Exception {
 		SimpleNamingContextBuilder sncb = SimpleNamingContextBuilder.emptyActivatedContextBuilder();
 
 		String bogusPath = "RUBBISH/com/xxxx/framework/server/test1.xml";

--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/Spr10744Tests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/Spr10744Tests.java
@@ -120,7 +120,7 @@ public class Spr10744Tests {
 	static class MyTestConfiguration extends MyConfiguration {
 
 		@Bean
-		@Scope(value = "myTestScope",  proxyMode = ScopedProxyMode.TARGET_CLASS)
+		@Scope(value = "myTestScope", proxyMode = ScopedProxyMode.TARGET_CLASS)
 		@Override
 		public Foo foo() {
 			return new Foo();

--- a/spring-context/src/test/java/org/springframework/context/annotation/spr12334/Spr12334Tests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/spr12334/Spr12334Tests.java
@@ -58,7 +58,7 @@ public class Spr12334Tests {
 		private static boolean scanned = false;
 
 		@Override
-		public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry)  {
+		public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
 			if (scanned) {
 				throw new IllegalStateException("Already scanned");
 			}

--- a/spring-context/src/test/java/org/springframework/context/annotation4/FactoryMethodComponent.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation4/FactoryMethodComponent.java
@@ -37,7 +37,7 @@ public final class FactoryMethodComponent {
 
 	private int i;
 
-	public static TestBean nullInstance()  {
+	public static TestBean nullInstance() {
 		return null;
 	}
 

--- a/spring-context/src/test/java/org/springframework/context/support/DefaultLifecycleProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/context/support/DefaultLifecycleProcessorTests.java
@@ -592,7 +592,7 @@ public class DefaultLifecycleProcessorTests {
 			return new TestLifecycleBean(null, stoppedBeans);
 		}
 
-		private TestLifecycleBean(CopyOnWriteArrayList<Lifecycle> startedBeans,  CopyOnWriteArrayList<Lifecycle> stoppedBeans) {
+		private TestLifecycleBean(CopyOnWriteArrayList<Lifecycle> startedBeans, CopyOnWriteArrayList<Lifecycle> stoppedBeans) {
 			this.startedBeans = startedBeans;
 			this.stoppedBeans = stoppedBeans;
 		}

--- a/spring-context/src/test/java/org/springframework/ejb/access/LocalStatelessSessionProxyFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/ejb/access/LocalStatelessSessionProxyFactoryBeanTests.java
@@ -188,7 +188,7 @@ public class LocalStatelessSessionProxyFactoryBeanTests {
 	}
 
 
-	public static interface MyBusinessMethods  {
+	public static interface MyBusinessMethods {
 
 		int getValue();
 	}

--- a/spring-context/src/test/java/org/springframework/ejb/access/SimpleRemoteStatelessSessionProxyFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/ejb/access/SimpleRemoteStatelessSessionProxyFactoryBeanTests.java
@@ -285,13 +285,13 @@ public class SimpleRemoteStatelessSessionProxyFactoryBeanTests extends SimpleRem
 	}
 
 
-	protected static interface MyBusinessMethods  {
+	protected static interface MyBusinessMethods {
 
 		int getValue() throws RemoteException;
 	}
 
 
-	protected static interface MyLocalBusinessMethods  {
+	protected static interface MyLocalBusinessMethods {
 
 		int getValue();
 	}

--- a/spring-core/src/main/java/org/springframework/core/io/UrlResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/UrlResource.java
@@ -104,7 +104,7 @@ public class UrlResource extends AbstractFileResolvingResource {
 	 * @throws MalformedURLException if the given URL specification is not valid
 	 * @see java.net.URI#URI(String, String, String)
 	 */
-	public UrlResource(String protocol, String location) throws MalformedURLException  {
+	public UrlResource(String protocol, String location) throws MalformedURLException {
 		this(protocol, location, null);
 	}
 
@@ -120,7 +120,7 @@ public class UrlResource extends AbstractFileResolvingResource {
 	 * @throws MalformedURLException if the given URL specification is not valid
 	 * @see java.net.URI#URI(String, String, String)
 	 */
-	public UrlResource(String protocol, String location, String fragment) throws MalformedURLException  {
+	public UrlResource(String protocol, String location, String fragment) throws MalformedURLException {
 		try {
 			this.uri = new URI(protocol, location, fragment);
 			this.url = this.uri.toURL();

--- a/spring-core/src/main/java/org/springframework/core/serializer/support/SerializingConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/serializer/support/SerializingConverter.java
@@ -59,7 +59,7 @@ public class SerializingConverter implements Converter<Object, byte[]> {
 	@Override
 	public byte[] convert(Object source) {
 		ByteArrayOutputStream byteStream = new ByteArrayOutputStream(1024);
-		try  {
+		try {
 			this.serializer.serialize(source, byteStream);
 			return byteStream.toByteArray();
 		}

--- a/spring-core/src/test/java/org/springframework/core/BridgeMethodResolverTests.java
+++ b/spring-core/src/test/java/org/springframework/core/BridgeMethodResolverTests.java
@@ -292,7 +292,7 @@ public class BridgeMethodResolverTests {
 		Method bridgedMethod = MegaMessageProducerImpl.class.getDeclaredMethod("receive", MegaMessageEvent.class);
 		assertFalse(bridgedMethod.isBridge());
 
-		Method bridgeMethod  = MegaMessageProducerImpl.class.getDeclaredMethod("receive", MegaEvent.class);
+		Method bridgeMethod = MegaMessageProducerImpl.class.getDeclaredMethod("receive", MegaEvent.class);
 		assertTrue(bridgeMethod.isBridge());
 
 		assertEquals(bridgedMethod, BridgeMethodResolver.findBridgedMethod(bridgeMethod));

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -662,7 +662,7 @@ public class GenericConversionServiceTests {
 		}
 	}
 
-	private static class MyStringToIntegerArrayConverter implements Converter<String, Integer[]>	{
+	private static class MyStringToIntegerArrayConverter implements Converter<String, Integer[]> {
 
 		@Override
 		public Integer[] convert(String source) {

--- a/spring-core/src/test/java/org/springframework/core/env/CustomEnvironmentTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/CustomEnvironmentTests.java
@@ -74,7 +74,7 @@ public class CustomEnvironmentTests {
 			@Override
 			@SuppressWarnings("serial")
 			protected Set<String> getReservedDefaultProfiles() {
-				return new HashSet<String>() {{ add("rd1"); add("rd2");  }};
+				return new HashSet<String>() {{ add("rd1"); add("rd2"); }};
 			}
 		}
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
@@ -131,7 +131,7 @@ public enum SpelMessage {
 	PROBLEM_LOCATING_METHOD(Kind.ERROR, 1031,
 			"Problem locating method {0} on type {1}"),
 
-	SETVALUE_NOT_SUPPORTED(	Kind.ERROR, 1032,
+	SETVALUE_NOT_SUPPORTED( Kind.ERROR, 1032,
 			"setValue(ExpressionState, Object) not supported for ''{0}''"),
 
 	MULTIPLE_POSSIBLE_METHODS(Kind.ERROR, 1033,

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/InlineMap.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/InlineMap.java
@@ -125,7 +125,7 @@ public class InlineMap extends SpelNodeImpl {
 					key = keyChild.getValue(expressionState);
 				}
 				Object value = getChild(c).getValue(expressionState);
-				returnValue.put(key,  value);
+				returnValue.put(key, value);
 			}
 			return new TypedValue(returnValue);
 		}

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/OpNE.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/OpNE.java
@@ -57,7 +57,7 @@ public class OpNE extends Operator {
 
 		String leftDesc = left.exitTypeDescriptor;
 		String rightDesc = right.exitTypeDescriptor;
-		DescriptorComparison dc =  DescriptorComparison.checkNumericCompatibility(leftDesc, rightDesc, leftActualDescriptor, rightActualDescriptor);
+		DescriptorComparison dc = DescriptorComparison.checkNumericCompatibility(leftDesc, rightDesc, leftActualDescriptor, rightActualDescriptor);
 		return (!dc.areNumbers || dc.areCompatible);
 	}
 	

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/PropertyOrFieldReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/PropertyOrFieldReference.java
@@ -136,7 +136,7 @@ public class PropertyOrFieldReference extends SpelNodeImpl {
 				// 'simple' object
 				try {
 					if (isWritableProperty(this.name,contextObject, evalContext)) {
-						Object newObject  = result.getTypeDescriptor().getType().newInstance();
+						Object newObject = result.getTypeDescriptor().getType().newInstance();
 						writeProperty(contextObject, evalContext, this.name, newObject);
 						result = readProperty(contextObject, evalContext, this.name);
 					}

--- a/spring-expression/src/test/java/org/springframework/expression/spel/EvaluationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/EvaluationTests.java
@@ -713,7 +713,7 @@ public class EvaluationTests extends AbstractExpressionTests {
 		// Add a new element to the list
 		StandardEvaluationContext ctx = new StandardEvaluationContext(instance);
 		ExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
-		Expression e =  parser.parseExpression("listOfStrings[++index3]='def'");
+		Expression e = parser.parseExpression("listOfStrings[++index3]='def'");
 		e.getValue(ctx);
 		assertEquals(2,instance.listOfStrings.size());
 		assertEquals("def",instance.listOfStrings.get(1));
@@ -721,20 +721,20 @@ public class EvaluationTests extends AbstractExpressionTests {
 		// Check reference beyond end of collection
 		ctx = new StandardEvaluationContext(instance);
 		parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
-		e =  parser.parseExpression("listOfStrings[0]");
+		e = parser.parseExpression("listOfStrings[0]");
 		String value = e.getValue(ctx,String.class);
 		assertEquals("abc",value);
-		e =  parser.parseExpression("listOfStrings[1]");
+		e = parser.parseExpression("listOfStrings[1]");
 		value = e.getValue(ctx,String.class);
 		assertEquals("def",value);
-		e =  parser.parseExpression("listOfStrings[2]");
+		e = parser.parseExpression("listOfStrings[2]");
 		value = e.getValue(ctx,String.class);
 		assertEquals("",value);
 
 		// Now turn off growing and reference off the end
 		ctx = new StandardEvaluationContext(instance);
 		parser = new SpelExpressionParser(new SpelParserConfiguration(false, false));
-		e =  parser.parseExpression("listOfStrings[3]");
+		e = parser.parseExpression("listOfStrings[3]");
 		try {
 			e.getValue(ctx,String.class);
 			fail();
@@ -766,7 +766,7 @@ public class EvaluationTests extends AbstractExpressionTests {
 		Integer i = 42;
 		StandardEvaluationContext ctx = new StandardEvaluationContext(i);
 		ExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
-		Expression e =  parser.parseExpression("#this++");
+		Expression e = parser.parseExpression("#this++");
 		assertEquals(42,i.intValue());
 		try {
 			e.getValue(ctx,Integer.class);
@@ -914,14 +914,14 @@ public class EvaluationTests extends AbstractExpressionTests {
 		StandardEvaluationContext ctx = new StandardEvaluationContext(i);
 		ExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
 		try {
-			Expression e =  parser.parseExpression("++1");
+			Expression e = parser.parseExpression("++1");
 			e.getValue(ctx,Integer.class);
 			fail();
 		} catch (SpelEvaluationException see) {
 			assertEquals(SpelMessage.NOT_ASSIGNABLE,see.getMessageCode());
 		}
 		try {
-			Expression e =  parser.parseExpression("1++");
+			Expression e = parser.parseExpression("1++");
 			e.getValue(ctx,Integer.class);
 			fail();
 		} catch (SpelEvaluationException see) {
@@ -933,7 +933,7 @@ public class EvaluationTests extends AbstractExpressionTests {
 		Integer i = 42;
 		StandardEvaluationContext ctx = new StandardEvaluationContext(i);
 		ExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
-		Expression e =  parser.parseExpression("#this--");
+		Expression e = parser.parseExpression("#this--");
 		assertEquals(42,i.intValue());
 		try {
 			e.getValue(ctx,Integer.class);
@@ -1080,14 +1080,14 @@ public class EvaluationTests extends AbstractExpressionTests {
 		StandardEvaluationContext ctx = new StandardEvaluationContext(i);
 		ExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
 		try {
-			Expression e =  parser.parseExpression("--1");
+			Expression e = parser.parseExpression("--1");
 			e.getValue(ctx,Integer.class);
 			fail();
 		} catch (SpelEvaluationException see) {
 			assertEquals(SpelMessage.NOT_ASSIGNABLE,see.getMessageCode());
 		}
 		try {
-			Expression e =  parser.parseExpression("1--");
+			Expression e = parser.parseExpression("1--");
 			e.getValue(ctx,Integer.class);
 			fail();
 		} catch (SpelEvaluationException see) {
@@ -1110,13 +1110,13 @@ public class EvaluationTests extends AbstractExpressionTests {
 		assertEquals(4,helper.intArray[2]);
 
 		// index1 is 3 intArray[3] is 4
-		e =  parser.parseExpression("intArray[#root.index1++]--");
+		e = parser.parseExpression("intArray[#root.index1++]--");
 		assertEquals(4,e.getValue(ctx,Integer.class).intValue());
 		assertEquals(4,helper.index1);
 		assertEquals(3,helper.intArray[3]);
 
 		// index1 is 4, intArray[3] is 3
-		e =  parser.parseExpression("intArray[--#root.index1]++");
+		e = parser.parseExpression("intArray[--#root.index1]++");
 		assertEquals(3,e.getValue(ctx,Integer.class).intValue());
 		assertEquals(3,helper.index1);
 		assertEquals(4,helper.intArray[3]);

--- a/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
@@ -62,7 +62,7 @@ public class IndexingTests {
 	@Test
 	public void indexIntoGenericPropertyContainingMapObject() {
 		Map<String, Map<String, String>> property = new HashMap<String, Map<String, String>>();
-		Map<String, String> map =  new HashMap<String, String>();
+		Map<String, String> map = new HashMap<String, String>();
 		map.put("foo", "bar");
 		property.put("property", map);
 		SpelExpressionParser parser = new SpelExpressionParser();

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
@@ -784,7 +784,7 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 	// Confirms visibility of what is being called.
 	@Test
 	public void functionReferenceVisibility_SPR12359() throws Exception {
-		StandardEvaluationContext context = new StandardEvaluationContext(new  Object[] { "1" });
+		StandardEvaluationContext context = new StandardEvaluationContext(new Object[] { "1" });
 		context.registerFunction("doCompare", SomeCompareMethod.class.getDeclaredMethod(
 				"compare", Object.class, Object.class));
 		context.setVariable("arg", "2");
@@ -794,7 +794,7 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 		assertCantCompile(expression);
 
 		// type not public but method is
-		context = new StandardEvaluationContext(new  Object[] { "1" });
+		context = new StandardEvaluationContext(new Object[] { "1" });
 		context.registerFunction("doCompare", SomeCompareMethod.class.getDeclaredMethod(
 				"compare2", Object.class, Object.class));
 		context.setVariable("arg", "2");
@@ -805,7 +805,7 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 
 	@Test
 	public void functionReferenceNonCompilableArguments_SPR12359() throws Exception {
-		StandardEvaluationContext context = new StandardEvaluationContext(new  Object[] { "1" });
+		StandardEvaluationContext context = new StandardEvaluationContext(new Object[] { "1" });
 		context.registerFunction("negate", SomeCompareMethod2.class.getDeclaredMethod(
 				"negate", Integer.TYPE));
 		context.setVariable("arg", "2");
@@ -4509,7 +4509,7 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 	}
 
 	@SuppressWarnings("serial")
-	public static class MessageHeaders extends HashMap<String,Object> {	}
+	public static class MessageHeaders extends HashMap<String,Object> { }
 
 	public static class GenericMessageTestHelper<T> {
 		private T payload;

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
@@ -154,7 +154,7 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 		String helloWorld = (String) parser.parseExpression("'Hello World'").getValue(); // evals to "Hello World"
 		assertEquals("Hello World",helloWorld);
 
-		double avogadrosNumber  = (Double) parser.parseExpression("6.0221415E+23").getValue();
+		double avogadrosNumber = (Double) parser.parseExpression("6.0221415E+23").getValue();
 		assertEquals(6.0221415E+23, avogadrosNumber, 0);
 
 		int maxValue = (Integer) parser.parseExpression("0x7FFFFFFF").getValue();  // evals to 2147483647
@@ -288,7 +288,7 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 		boolean falseValue = parser.parseExpression("true and false").getValue(Boolean.class);
 		assertFalse(falseValue);
 		// evaluates to true
-		String expression =  "isMember('Nikola Tesla') and isMember('Mihajlo Pupin')";
+		String expression = "isMember('Nikola Tesla') and isMember('Mihajlo Pupin')";
 		boolean trueValue = parser.parseExpression(expression).getValue(societyContext, Boolean.class);
 
 		// -- OR --
@@ -298,7 +298,7 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 		assertTrue(trueValue);
 
 		// evaluates to true
-		expression =  "isMember('Nikola Tesla') or isMember('Albert Einstien')";
+		expression = "isMember('Nikola Tesla') or isMember('Albert Einstien')";
 		trueValue = parser.parseExpression(expression).getValue(societyContext, Boolean.class);
 		assertTrue(trueValue);
 
@@ -310,7 +310,7 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 
 
 		// -- AND and NOT --
-		expression =  "isMember('Nikola Tesla') and !isMember('Mihajlo Pupin')";
+		expression = "isMember('Nikola Tesla') and !isMember('Mihajlo Pupin')";
 		falseValue = parser.parseExpression(expression).getValue(societyContext, Boolean.class);
 		assertFalse(falseValue);
 	}
@@ -327,28 +327,28 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 		assertEquals("test string",testString);
 
 		// Subtraction
-		int four =  parser.parseExpression("1 - -3").getValue(Integer.class); // 4
+		int four = parser.parseExpression("1 - -3").getValue(Integer.class); // 4
 		assertEquals(4,four);
 
 		double d = parser.parseExpression("1000.00 - 1e4").getValue(Double.class); // -9000
 		assertEquals(-9000.0d, d, 0);
 
 		// Multiplication
-		int six =  parser.parseExpression("-2 * -3").getValue(Integer.class); // 6
+		int six = parser.parseExpression("-2 * -3").getValue(Integer.class); // 6
 		assertEquals(6,six);
 
 		double twentyFour = parser.parseExpression("2.0 * 3e0 * 4").getValue(Double.class); // 24.0
 		assertEquals(24.0d, twentyFour, 0);
 
 		// Division
-		int minusTwo =  parser.parseExpression("6 / -3").getValue(Integer.class); // -2
+		int minusTwo = parser.parseExpression("6 / -3").getValue(Integer.class); // -2
 		assertEquals(-2,minusTwo);
 
 		double one = parser.parseExpression("8.0 / 4e0 / 2").getValue(Double.class); // 1.0
 		assertEquals(1.0d, one, 0);
 
 		// Modulus
-		int three =  parser.parseExpression("7 % 4").getValue(Integer.class); // 3
+		int three = parser.parseExpression("7 % 4").getValue(Integer.class); // 3
 		assertEquals(3,three);
 
 		int oneInt = parser.parseExpression("8 / 5 % 2").getValue(Integer.class); // 1

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1059,7 +1059,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 		Assert.notNull(action, "Callback object must not be null");
 		if (logger.isDebugEnabled()) {
 			String sql = getSql(csc);
-			logger.debug("Calling stored procedure" + (sql != null ? " [" + sql  + "]" : ""));
+			logger.debug("Calling stored procedure" + (sql != null ? " [" + sql + "]" : ""));
 		}
 
 		Connection con = DataSourceUtils.getConnection(getDataSource());

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -515,7 +515,7 @@ public class CallMetaDataContext {
 		Map<String, String> callParameterNames = new HashMap<String, String>(this.callParameters.size());
 		for (SqlParameter parameter : this.callParameters) {
 			if (parameter.isInputValueProvided()) {
-				String parameterName =  parameter.getName();
+				String parameterName = parameter.getName();
 				String parameterNameToMatch = this.metaDataProvider.parameterNameToUse(parameterName);
 				if (parameterNameToMatch != null) {
 					callParameterNames.put(parameterNameToMatch.toLowerCase(), parameterName);
@@ -564,7 +564,7 @@ public class CallMetaDataContext {
 		int i = 0;
 		for (SqlParameter parameter : this.callParameters) {
 			if (parameter.isInputValueProvided()) {
-				String parameterName =  parameter.getName();
+				String parameterName = parameter.getName();
 				matchedParameters.put(parameterName, parameterValues[i++]);
 			}
 		}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericCallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericCallMetaDataProvider.java
@@ -109,7 +109,7 @@ public class GenericCallMetaDataProvider implements CallMetaDataProvider {
 			String schemaName, String procedureName) throws SQLException {
 
 		this.procedureColumnMetaDataUsed = true;
-		processProcedureColumns(databaseMetaData, catalogName, schemaName,  procedureName);
+		processProcedureColumns(databaseMetaData, catalogName, schemaName, procedureName);
 	}
 
 	@Override
@@ -345,7 +345,7 @@ public class GenericCallMetaDataProvider implements CallMetaDataProvider {
 				String columnName = procs.getString("COLUMN_NAME");
 				int columnType = procs.getInt("COLUMN_TYPE");
 				if (columnName == null && (
-						columnType == DatabaseMetaData.procedureColumnIn  ||
+						columnType == DatabaseMetaData.procedureColumnIn ||
 						columnType == DatabaseMetaData.procedureColumnInOut ||
 						columnType == DatabaseMetaData.procedureColumnOut)) {
 					if (logger.isDebugEnabled()) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
@@ -395,7 +395,7 @@ public abstract class AbstractJdbcCall {
 			logger.debug("The following parameters are used for call " + getCallString() + " with " + args);
 			int i = 1;
 			for (SqlParameter param : getCallParameters()) {
-				logger.debug(i + ": " +  param.getName() + ", SQL type "+ param.getSqlType() + ", type name " +
+				logger.debug(i + ": " + param.getName() + ", SQL type "+ param.getSqlType() + ", type name " +
 						param.getTypeName() + ", parameter class [" + param.getClass().getName() + "]");
 				i++;
 			}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
@@ -456,7 +456,7 @@ public abstract class AbstractJdbcInsert {
 			if (getGeneratedKeyNames().length > 1) {
 				throw new InvalidDataAccessApiUsageException(
 						"Current database only supports retrieving the key for a single column. There are " +
-						getGeneratedKeyNames().length  + " columns specified: " + Arrays.asList(getGeneratedKeyNames()));
+						getGeneratedKeyNames().length + " columns specified: " + Arrays.asList(getGeneratedKeyNames()));
 			}
 			// This is a hack to be able to get the generated key from a database that doesn't support
 			// get generated keys feature. HSQL is one, PostgreSQL is another. Postgres uses a RETURNING

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/SqlValue.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/SqlValue.java
@@ -41,7 +41,7 @@ public interface SqlValue {
 	 * @param paramIndex the index of the parameter for which we need to set the value
 	 * @throws SQLException if a SQLException is encountered while setting parameter values
 	 */
-	void setValue(PreparedStatement ps, int paramIndex)	throws SQLException;
+	void setValue(PreparedStatement ps, int paramIndex) throws SQLException;
 
 	/**
 	 * Clean up resources held by this value object.

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/rowset/SqlRowSet.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/rowset/SqlRowSet.java
@@ -279,7 +279,7 @@ public interface SqlRowSet extends Serializable {
 	 * @return a Object representing the column value
 	 * @see java.sql.ResultSet#getObject(int, Map)
 	 */
-	Object getObject(int columnIndex,  Map<String, Class<?>> map) throws InvalidResultSetAccessException;
+	Object getObject(int columnIndex, Map<String, Class<?>> map) throws InvalidResultSetAccessException;
 
 	/**
 	 * Retrieve the value of the indicated column in the current row
@@ -289,7 +289,7 @@ public interface SqlRowSet extends Serializable {
 	 * @return a Object representing the column value
 	 * @see java.sql.ResultSet#getObject(String, Map)
 	 */
-	Object getObject(String columnLabel,  Map<String, Class<?>> map) throws InvalidResultSetAccessException;
+	Object getObject(String columnLabel, Map<String, Class<?>> map) throws InvalidResultSetAccessException;
 
 	/**
 	 * Retrieve the value of the indicated column in the current row

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplateTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplateTests.java
@@ -83,7 +83,7 @@ public class NamedParameterJdbcTemplateTests {
 	public void setUp() throws Exception {
 		connection = mock(Connection.class);
 		dataSource = mock(DataSource.class);
-		preparedStatement =	mock(PreparedStatement.class);
+		preparedStatement = mock(PreparedStatement.class);
 		resultSet = mock(ResultSet.class);
 		namedParameterTemplate = new NamedParameterJdbcTemplate(dataSource);
 		databaseMetaData = mock(DatabaseMetaData.class);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/TableMetaDataContextTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/TableMetaDataContextTests.java
@@ -40,7 +40,7 @@ import static org.mockito.BDDMockito.*;
  *
  * @author Thomas Risberg
  */
-public class TableMetaDataContextTests  {
+public class TableMetaDataContextTests {
 
 	private Connection connection;
 	private DataSource dataSource;

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/support/SqlLobValueTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/support/SqlLobValueTests.java
@@ -53,7 +53,7 @@ import static org.mockito.BDDMockito.*;
  *
  * @author Alef Arendsen
  */
-public class SqlLobValueTests  {
+public class SqlLobValueTests {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/DataSourceJtaTransactionTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/DataSourceJtaTransactionTests.java
@@ -660,7 +660,7 @@ public class DataSourceJtaTransactionTests {
 	}
 
 	private void doTestJtaTransactionWithIsolationLevelDataSourceRouter(boolean dataSourceLookup) throws Exception {
-given(		userTransaction.getStatus()).willReturn(Status.STATUS_NO_TRANSACTION, Status.STATUS_ACTIVE, Status.STATUS_ACTIVE, Status.STATUS_NO_TRANSACTION, Status.STATUS_ACTIVE, Status.STATUS_ACTIVE);
+		given(userTransaction.getStatus()).willReturn(Status.STATUS_NO_TRANSACTION, Status.STATUS_ACTIVE, Status.STATUS_ACTIVE, Status.STATUS_NO_TRANSACTION, Status.STATUS_ACTIVE, Status.STATUS_ACTIVE);
 
 		final DataSource dataSource1 = mock(DataSource.class);
 		final Connection connection1 = mock(Connection.class);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/DataSourceTransactionManagerTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/DataSourceTransactionManagerTests.java
@@ -54,7 +54,7 @@ import static org.mockito.BDDMockito.*;
  * @author Juergen Hoeller
  * @since 04.07.2003
  */
-public class DataSourceTransactionManagerTests  {
+public class DataSourceTransactionManagerTests {
 
 	private Connection con;
 
@@ -66,7 +66,7 @@ public class DataSourceTransactionManagerTests  {
 	@Before
 	public void setUp() throws Exception {
 		con = mock(Connection.class);
-		ds	= mock(DataSource.class);
+		ds = mock(DataSource.class);
 		tm = new DataSourceTransactionManager(ds);
 		given(ds.getConnection()).willReturn(con);
 	}
@@ -167,32 +167,32 @@ public class DataSourceTransactionManagerTests  {
 	}
 
 	@Test
-	public void testTransactionRollbackWithAutoCommitTrue() throws Exception  {
+	public void testTransactionRollbackWithAutoCommitTrue() throws Exception {
 		doTestTransactionRollbackRestoringAutoCommit(true, false, false);
 	}
 
 	@Test
-	public void testTransactionRollbackWithAutoCommitFalse() throws Exception  {
+	public void testTransactionRollbackWithAutoCommitFalse() throws Exception {
 		doTestTransactionRollbackRestoringAutoCommit(false, false, false);
 	}
 
 	@Test
-	public void testTransactionRollbackWithAutoCommitTrueAndLazyConnection() throws Exception  {
+	public void testTransactionRollbackWithAutoCommitTrueAndLazyConnection() throws Exception {
 		doTestTransactionRollbackRestoringAutoCommit(true, true, false);
 	}
 
 	@Test
-	public void testTransactionRollbackWithAutoCommitFalseAndLazyConnection() throws Exception  {
+	public void testTransactionRollbackWithAutoCommitFalseAndLazyConnection() throws Exception {
 		doTestTransactionRollbackRestoringAutoCommit(false, true, false);
 	}
 
 	@Test
-	public void testTransactionRollbackWithAutoCommitTrueAndLazyConnectionAndCreateStatement() throws Exception  {
+	public void testTransactionRollbackWithAutoCommitTrueAndLazyConnectionAndCreateStatement() throws Exception {
 		doTestTransactionRollbackRestoringAutoCommit(true, true, true);
 	}
 
 	@Test
-	public void testTransactionRollbackWithAutoCommitFalseAndLazyConnectionAndCreateStatement() throws Exception  {
+	public void testTransactionRollbackWithAutoCommitFalseAndLazyConnectionAndCreateStatement() throws Exception {
 		doTestTransactionRollbackRestoringAutoCommit(false, true, true);
 	}
 

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/object/GenericSqlQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/object/GenericSqlQueryTests.java
@@ -44,7 +44,7 @@ import static org.mockito.BDDMockito.*;
 /**
  * @author Thomas Risberg
  */
-public class GenericSqlQueryTests  {
+public class GenericSqlQueryTests {
 
 	private static final String SELECT_ID_FORENAME_NAMED_PARAMETERS_PARSED =
 		"select id, forename from custmr where id = ? and country = ?";

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/object/SqlQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/object/SqlQueryTests.java
@@ -48,7 +48,7 @@ import static org.mockito.BDDMockito.*;
  * @author Thomas Risberg
  * @author Juergen Hoeller
  */
-public class SqlQueryTests  {
+public class SqlQueryTests {
 
 	//FIXME inline?
 	private static final String SELECT_ID =

--- a/spring-jms/src/main/java/org/springframework/jms/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/adapter/AbstractAdaptableMessageListener.java
@@ -208,7 +208,7 @@ public abstract class AbstractAdaptableMessageListener
 	 * listener method as argument
 	 * @throws MessageConversionException if the message could not be unmarshaled
 	 */
-	protected Object extractMessage(Message message)  {
+	protected Object extractMessage(Message message) {
 		try {
 			MessageConverter converter = getMessageConverter();
 			if (converter != null) {

--- a/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/JmsMessageEndpointFactory.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/JmsMessageEndpointFactory.java
@@ -45,7 +45,7 @@ import org.springframework.jca.endpoint.AbstractMessageEndpointFactory;
  * @see #setTransactionManager
  * @see JmsMessageEndpointManager
  */
-public class JmsMessageEndpointFactory extends AbstractMessageEndpointFactory  {
+public class JmsMessageEndpointFactory extends AbstractMessageEndpointFactory {
 
 	private MessageListener messageListener;
 

--- a/spring-jms/src/test/java/org/springframework/jms/listener/adapter/MessageContentsDelegate.java
+++ b/spring-jms/src/test/java/org/springframework/jms/listener/adapter/MessageContentsDelegate.java
@@ -28,7 +28,7 @@ public interface MessageContentsDelegate {
 
 	void handleMessage(CharSequence message);
 
-	void handleMessage(Map<String, Object>  message);
+	void handleMessage(Map<String, Object> message);
 
 	void handleMessage(byte[] message);
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/HeadersMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/HeadersMethodArgumentResolver.java
@@ -68,7 +68,7 @@ public class HeadersMethodArgumentResolver implements HandlerMethodArgumentResol
 			}
 			else {
 				Method method = ReflectionUtils.findMethod(paramType, "wrap", Message.class);
-				Assert.notNull(method, "Cannot create accessor of type " + paramType + " for message " +  message);
+				Assert.notNull(method, "Cannot create accessor of type " + paramType + " for message " + message);
 				return ReflectionUtils.invokeMethod(method, null, message);
 			}
 		}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
@@ -428,7 +428,7 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 			return;
 		}
 		if (connect[0] > 0 && connected[1] > 0) {
-			long interval = Math.max(connect[0],  connected[1]);
+			long interval = Math.max(connect[0], connected[1]);
 			this.connection.onWriteInactivity(new WriteInactivityTask(), interval);
 		}
 		if (connect[1] > 0 && connected[0] > 0) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
@@ -664,7 +664,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 			long serverReceiveInterval = connectedHeaders.getHeartbeat()[1];
 
 			if (clientSendInterval > 0 && serverReceiveInterval > 0) {
-				long interval = Math.max(clientSendInterval,  serverReceiveInterval);
+				long interval = Math.max(clientSendInterval, serverReceiveInterval);
 				this.tcpConnection.onWriteInactivity(new Runnable() {
 					@Override
 					public void run() {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompClientSupport.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompClientSupport.java
@@ -101,7 +101,7 @@ public abstract class StompClientSupport {
 	 */
 	public void setDefaultHeartbeat(long[] heartbeat) {
 		Assert.notNull(heartbeat);
-		Assert.isTrue(heartbeat[0] >= 0 && heartbeat[1] >=0 , "Invalid heart-beat: "  + Arrays.toString(heartbeat));
+		Assert.isTrue(heartbeat[0] >= 0 && heartbeat[1] >=0 , "Invalid heart-beat: " + Arrays.toString(heartbeat));
 		this.defaultHeartbeat = heartbeat;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompEncoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompEncoder.java
@@ -40,7 +40,7 @@ import org.springframework.util.Assert;
  * @author Rossen Stoyanchev
  * @since 4.0
  */
-public final class StompEncoder  {
+public final class StompEncoder {
 
 	private static final byte LF = '\n';
 
@@ -92,7 +92,7 @@ public final class StompEncoder  {
 			return baos.toByteArray();
 		}
 		catch (IOException ex) {
-			throw new StompConversionException("Failed to encode STOMP frame, headers=" + headers,  ex);
+			throw new StompConversionException("Failed to encode STOMP frame, headers=" + headers, ex);
 		}
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaders.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaders.java
@@ -225,7 +225,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	public void setHeartbeat(long[] heartbeat) {
 		Assert.notNull(heartbeat);
 		String value = heartbeat[0] + "," + heartbeat[1];
-		Assert.isTrue(heartbeat[0] >= 0 && heartbeat[1] >= 0, "Heart-beat values cannot be negative: "  + value);
+		Assert.isTrue(heartbeat[0] >= 0 && heartbeat[1] >= 0, "Heart-beat values cannot be negative: " + value);
 		set(HEARTBEAT, value);
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/MultiServerUserRegistry.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/MultiServerUserRegistry.java
@@ -160,7 +160,7 @@ public class MultiServerUserRegistry implements SimpUserRegistry, SmartApplicati
 
 	@Override
 	public String toString() {
-		return "local=[" + this.localRegistry +	"], remote=" + this.remoteRegistries + "]";
+		return "local=[" + this.localRegistry + "], remote=" + this.remoteRegistries + "]";
 	}
 
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
@@ -580,7 +580,7 @@ public class MessageHeaderAccessor {
 		if (messageHeaders instanceof MutableMessageHeaders) {
 			MutableMessageHeaders mutableHeaders = (MutableMessageHeaders) messageHeaders;
 			MessageHeaderAccessor headerAccessor = mutableHeaders.getMessageHeaderAccessor();
-			if (requiredType.isAssignableFrom(headerAccessor.getClass()))  {
+			if (requiredType.isAssignableFrom(headerAccessor.getClass())) {
 				return (T) headerAccessor;
 			}
 		}

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/AnnotationExceptionHandlerMethodResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/AnnotationExceptionHandlerMethodResolverTests.java
@@ -113,7 +113,7 @@ public class AnnotationExceptionHandlerMethodResolverTests {
 	static class InheritedController extends ExceptionController {
 
 		@Override
-		public void handleIOException()	{
+		public void handleIOException() {
 		}
 	}
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandlerIntegrationTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandlerIntegrationTests.java
@@ -476,7 +476,7 @@ public class StompBrokerRelayMessageHandlerIntegrationTests {
 
 		@Override
 		public String toString() {
-			return "command=" + this.command  + ", session=\"" + this.sessionId + "\"";
+			return "command=" + this.command + ", session=\"" + this.sessionId + "\"";
 		}
 	}
 
@@ -518,7 +518,7 @@ public class StompBrokerRelayMessageHandlerIntegrationTests {
 
 		@Override
 		protected boolean matchInternal(StompHeaderAccessor headers, Object payload) {
-			if (!this.subscriptionId.equals(headers.getSubscriptionId()) ||  !this.destination.equals(headers.getDestination())) {
+			if (!this.subscriptionId.equals(headers.getSubscriptionId()) || !this.destination.equals(headers.getDestination())) {
 				return false;
 			}
 			if (payload instanceof byte[] && this.payload instanceof byte[]) {

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompCodecTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompCodecTests.java
@@ -280,7 +280,7 @@ public class StompCodecTests {
 	@Test
 	public void encodeFrameWithHeadersThatShouldBeEscaped() {
 		StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.DISCONNECT);
-		headers.addNativeHeader("a:\r\n\\b",  "alpha:bravo\r\n\\");
+		headers.addNativeHeader("a:\r\n\\b", "alpha:bravo\r\n\\");
 
 		Message<byte[]> frame = MessageBuilder.createMessage(new byte[0], headers.getMessageHeaders());
 

--- a/spring-orm-hibernate4/src/main/java/org/springframework/orm/hibernate4/SessionFactoryUtils.java
+++ b/spring-orm-hibernate4/src/main/java/org/springframework/orm/hibernate4/SessionFactoryUtils.java
@@ -159,7 +159,7 @@ public abstract class SessionFactoryUtils {
 		}
 		if (ex instanceof ConstraintViolationException) {
 			ConstraintViolationException jdbcEx = (ConstraintViolationException) ex;
-			return new DataIntegrityViolationException(ex.getMessage()  + "; SQL [" + jdbcEx.getSQL() +
+			return new DataIntegrityViolationException(ex.getMessage() + "; SQL [" + jdbcEx.getSQL() +
 					"]; constraint [" + jdbcEx.getConstraintName() + "]", ex);
 		}
 		if (ex instanceof DataException) {

--- a/spring-orm-hibernate4/src/test/java/org/springframework/orm/hibernate4/HibernateTemplateTests.java
+++ b/spring-orm-hibernate4/src/test/java/org/springframework/orm/hibernate4/HibernateTemplateTests.java
@@ -91,7 +91,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testExecuteWithNewSession()  {
+	public void testExecuteWithNewSession() {
 		given(sessionFactory.getCurrentSession()).willThrow(new HibernateException("no current session"));
 		given(sessionFactory.openSession()).willReturn(session);
 
@@ -99,7 +99,7 @@ public class HibernateTemplateTests {
 		l.add("test");
 		List result = hibernateTemplate.execute(new HibernateCallback<List>() {
 			@Override
-			public List doInHibernate(Session session)  {
+			public List doInHibernate(Session session) {
 				return l;
 			}
 		});
@@ -108,7 +108,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testExecuteWithNewSessionAndFilter()  {
+	public void testExecuteWithNewSessionAndFilter() {
 		given(sessionFactory.getCurrentSession()).willThrow(new HibernateException("no current session"));
 		given(sessionFactory.openSession()).willReturn(session);
 		hibernateTemplate.setFilterNames("myFilter");
@@ -127,7 +127,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testExecuteWithNewSessionAndFilters()  {
+	public void testExecuteWithNewSessionAndFilters() {
 		given(sessionFactory.getCurrentSession()).willThrow(new HibernateException("no current session"));
 		given(sessionFactory.openSession()).willReturn(session);
 		hibernateTemplate.setFilterNames("myFilter", "yourFilter");
@@ -136,7 +136,7 @@ public class HibernateTemplateTests {
 		l.add("test");
 		List result = hibernateTemplate.execute(new HibernateCallback<List>() {
 			@Override
-			public List doInHibernate(Session session)  {
+			public List doInHibernate(Session session) {
 				return l;
 			}
 		});
@@ -153,7 +153,7 @@ public class HibernateTemplateTests {
 		l.add("test");
 		List result = hibernateTemplate.execute(new HibernateCallback<List>() {
 			@Override
-			public List doInHibernate(Session session)  {
+			public List doInHibernate(Session session) {
 				return l;
 			}
 		});
@@ -168,7 +168,7 @@ public class HibernateTemplateTests {
 		l.add("test");
 		List result = hibernateTemplate.execute(new HibernateCallback<List>() {
 			@Override
-			public List doInHibernate(Session session)  {
+			public List doInHibernate(Session session) {
 				return l;
 			}
 		});
@@ -187,7 +187,7 @@ public class HibernateTemplateTests {
 		l.add("test");
 		List result = hibernateTemplate.execute(new HibernateCallback<List>() {
 			@Override
-			public List doInHibernate(Session session)  {
+			public List doInHibernate(Session session) {
 				return l;
 			}
 		});
@@ -231,7 +231,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testExecuteWithCacheQueries()  {
+	public void testExecuteWithCacheQueries() {
 		Query query1 = mock(Query.class);
 		Query query2 = mock(Query.class);
 		Criteria criteria = mock(Criteria.class);
@@ -259,7 +259,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testExecuteWithCacheQueriesAndCacheRegion()  {
+	public void testExecuteWithCacheQueriesAndCacheRegion() {
 		Query query1 = mock(Query.class);
 		Query query2 = mock(Query.class);
 		Criteria criteria = mock(Criteria.class);
@@ -291,7 +291,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testExecuteWithCacheQueriesAndCacheRegionAndNativeSession()  {
+	public void testExecuteWithCacheQueriesAndCacheRegionAndNativeSession() {
 		Query query1 = mock(Query.class);
 		Query query2 = mock(Query.class);
 		Criteria criteria = mock(Criteria.class);
@@ -305,7 +305,7 @@ public class HibernateTemplateTests {
 		hibernateTemplate.setQueryCacheRegion("myRegion");
 		hibernateTemplate.execute(new HibernateCallback<Object>() {
 			@Override
-			public Object doInHibernate(Session sess)  {
+			public Object doInHibernate(Session sess) {
 				assertSame(session, sess);
 				sess.createQuery("some query");
 				sess.getNamedQuery("some query name");
@@ -316,7 +316,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testExecuteWithFetchSizeAndMaxResults()  {
+	public void testExecuteWithFetchSizeAndMaxResults() {
 		Query query1 = mock(Query.class);
 		Query query2 = mock(Query.class);
 		Criteria criteria = mock(Criteria.class);
@@ -335,7 +335,7 @@ public class HibernateTemplateTests {
 		hibernateTemplate.setMaxResults(20);
 		hibernateTemplate.execute(new HibernateCallback<Object>() {
 			@Override
-			public Object doInHibernate(Session sess)  {
+			public Object doInHibernate(Session sess) {
 				sess.createQuery("some query");
 				sess.getNamedQuery("some query name");
 				sess.createCriteria(TestBean.class);
@@ -345,7 +345,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testGet()  {
+	public void testGet() {
 		TestBean tb = new TestBean();
 		given(session.get(TestBean.class, "")).willReturn(tb);
 		Object result = hibernateTemplate.get(TestBean.class, "");
@@ -353,7 +353,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testGetWithEntityName()  {
+	public void testGetWithEntityName() {
 		TestBean tb = new TestBean();
 		given(session.get("myEntity", "")).willReturn(tb);
 		Object result = hibernateTemplate.get("myEntity", "");
@@ -361,7 +361,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testLoad()  {
+	public void testLoad() {
 		TestBean tb = new TestBean();
 		given(session.load(TestBean.class, "")).willReturn(tb);
 		Object result = hibernateTemplate.load(TestBean.class, "");
@@ -369,7 +369,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testLoadWithNotFound()  {
+	public void testLoadWithNotFound() {
 		ObjectNotFoundException onfex = new ObjectNotFoundException("id", TestBean.class.getName());
 		given(session.load(TestBean.class, "id")).willThrow(onfex);
 		try {
@@ -385,7 +385,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testLoadWithEntityName()  {
+	public void testLoadWithEntityName() {
 		TestBean tb = new TestBean();
 		given(session.load("myEntity", "")).willReturn(tb);
 		Object result = hibernateTemplate.load("myEntity", "");
@@ -393,14 +393,14 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testLoadWithObject()  {
+	public void testLoadWithObject() {
 		TestBean tb = new TestBean();
 		hibernateTemplate.load(tb, "");
 		verify(session).load(tb, "");
 	}
 
 	@Test
-	public void testLoadAll()  {
+	public void testLoadAll() {
 		Criteria criteria = mock(Criteria.class);
 		List list = new ArrayList();
 		given(session.createCriteria(TestBean.class)).willReturn(criteria);
@@ -411,7 +411,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testLoadAllWithCacheable()  {
+	public void testLoadAllWithCacheable() {
 		Criteria criteria = mock(Criteria.class);
 		List list = new ArrayList();
 		given(session.createCriteria(TestBean.class)).willReturn(criteria);
@@ -426,7 +426,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testLoadAllWithCacheableAndCacheRegion()  {
+	public void testLoadAllWithCacheableAndCacheRegion() {
 		Criteria criteria = mock(Criteria.class);
 		List list = new ArrayList();
 		given(session.createCriteria(TestBean.class)).willReturn(criteria);
@@ -443,27 +443,27 @@ public class HibernateTemplateTests {
 		verify(criteria).setCacheRegion("myCacheRegion");
 	}
 
-	@Test public void testRefresh()  {
+	@Test public void testRefresh() {
 		TestBean tb = new TestBean();
 		hibernateTemplate.refresh(tb);
 		verify(session).refresh(tb);
 	}
 
-	@Test public void testContains()  {
+	@Test public void testContains() {
 		TestBean tb = new TestBean();
 		given(session.contains(tb)).willReturn(true);
 		assertTrue(hibernateTemplate.contains(tb));
 	}
 
 	@Test
-	public void testEvict()  {
+	public void testEvict() {
 		TestBean tb = new TestBean();
 		hibernateTemplate.evict(tb);
 		verify(session).evict(tb);
 	}
 
 	@Test
-	public void testSave()  {
+	public void testSave() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		given(session.save(tb)).willReturn(0);
@@ -471,7 +471,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testSaveWithEntityName()  {
+	public void testSaveWithEntityName() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		given(session.save("myEntity", tb)).willReturn(0);
@@ -479,7 +479,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testUpdate()  {
+	public void testUpdate() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.update(tb);
@@ -487,7 +487,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testUpdateWithEntityName()  {
+	public void testUpdateWithEntityName() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.update("myEntity", tb);
@@ -495,7 +495,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testSaveOrUpdate()  {
+	public void testSaveOrUpdate() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.saveOrUpdate(tb);
@@ -503,7 +503,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testSaveOrUpdateWithFlushModeNever()  {
+	public void testSaveOrUpdateWithFlushModeNever() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.MANUAL);
 		try {
@@ -516,7 +516,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testSaveOrUpdateWithEntityName()  {
+	public void testSaveOrUpdateWithEntityName() {
 		TestBean tb = new TestBean();
 
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
@@ -525,7 +525,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testReplicate()  {
+	public void testReplicate() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.replicate(tb, ReplicationMode.LATEST_VERSION);
@@ -533,7 +533,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testReplicateWithEntityName()  {
+	public void testReplicateWithEntityName() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.replicate("myEntity", tb, ReplicationMode.LATEST_VERSION);
@@ -541,7 +541,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testPersist()  {
+	public void testPersist() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.persist(tb);
@@ -549,7 +549,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testPersistWithEntityName()  {
+	public void testPersistWithEntityName() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.persist("myEntity", tb);
@@ -557,7 +557,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testMerge()  {
+	public void testMerge() {
 		TestBean tb = new TestBean();
 		TestBean tbMerged = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
@@ -566,7 +566,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testMergeWithEntityName()  {
+	public void testMergeWithEntityName() {
 		TestBean tb = new TestBean();
 		TestBean tbMerged = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
@@ -575,7 +575,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testDelete()  {
+	public void testDelete() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.delete(tb);
@@ -583,7 +583,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testDeleteWithEntityName()  {
+	public void testDeleteWithEntityName() {
 		TestBean tb = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
 		hibernateTemplate.delete("myEntity", tb);
@@ -591,7 +591,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testDeleteAll()  {
+	public void testDeleteAll() {
 		TestBean tb1 = new TestBean();
 		TestBean tb2 = new TestBean();
 		given(session.getFlushMode()).willReturn(FlushMode.AUTO);
@@ -604,19 +604,19 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFlush()  {
+	public void testFlush() {
 		hibernateTemplate.flush();
 		verify(session).flush();
 	}
 
 	@Test
-	public void testClear()  {
+	public void testClear() {
 		hibernateTemplate.clear();
 		verify(session).clear();
 	}
 
 	@Test
-	public void testFind()  {
+	public void testFind() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -626,7 +626,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindWithParameter()  {
+	public void testFindWithParameter() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -638,7 +638,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindWithParameters()  {
+	public void testFindWithParameters() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -652,7 +652,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindWithNamedParameter()  {
+	public void testFindWithNamedParameter() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -664,7 +664,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindWithNamedParameters()  {
+	public void testFindWithNamedParameters() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -680,7 +680,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByValueBean()  {
+	public void testFindByValueBean() {
 		Query query = mock(Query.class);
 		TestBean tb = new TestBean();
 		List list = new ArrayList();
@@ -693,7 +693,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByNamedQuery()  {
+	public void testFindByNamedQuery() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.getNamedQuery("some query name")).willReturn(query);
@@ -703,7 +703,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByNamedQueryWithParameter()  {
+	public void testFindByNamedQueryWithParameter() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.getNamedQuery("some query name")).willReturn(query);
@@ -715,7 +715,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByNamedQueryWithParameters()  {
+	public void testFindByNamedQueryWithParameters() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.getNamedQuery("some query name")).willReturn(query);
@@ -729,7 +729,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByNamedQueryWithNamedParameter()  {
+	public void testFindByNamedQueryWithNamedParameter() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.getNamedQuery("some query name")).willReturn(query);
@@ -741,7 +741,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByNamedQueryWithNamedParameters()  {
+	public void testFindByNamedQueryWithNamedParameters() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.getNamedQuery("some query name")).willReturn(query);
@@ -757,7 +757,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByNamedQueryAndValueBean()  {
+	public void testFindByNamedQueryAndValueBean() {
 		Query query = mock(Query.class);
 		TestBean tb = new TestBean();
 		List list = new ArrayList();
@@ -770,7 +770,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindWithCacheable()  {
+	public void testFindWithCacheable() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -783,7 +783,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindWithCacheableAndCacheRegion()  {
+	public void testFindWithCacheableAndCacheRegion() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -799,7 +799,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByNamedQueryWithCacheable()  {
+	public void testFindByNamedQueryWithCacheable() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.getNamedQuery("some query name")).willReturn(query);
@@ -812,7 +812,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testFindByNamedQueryWithCacheableAndCacheRegion()  {
+	public void testFindByNamedQueryWithCacheableAndCacheRegion() {
 		Query query = mock(Query.class);
 		List list = new ArrayList();
 		given(session.getNamedQuery("some query name")).willReturn(query);
@@ -828,7 +828,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testIterate()  {
+	public void testIterate() {
 		Query query = mock(Query.class);
 		Iterator it = Collections.EMPTY_LIST.iterator();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -838,7 +838,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testIterateWithParameter()  {
+	public void testIterateWithParameter() {
 		Query query = mock(Query.class);
 		Iterator it = Collections.EMPTY_LIST.iterator();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -850,7 +850,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testIterateWithParameters()  {
+	public void testIterateWithParameters() {
 		Query query = mock(Query.class);
 		Iterator it = Collections.EMPTY_LIST.iterator();
 		given(session.createQuery("some query string")).willReturn(query);
@@ -864,7 +864,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testBulkUpdate()  {
+	public void testBulkUpdate() {
 		Query query = mock(Query.class);
 		given(session.createQuery("some query string")).willReturn(query);
 		given(query.executeUpdate()).willReturn(5);
@@ -873,7 +873,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testBulkUpdateWithParameter()  {
+	public void testBulkUpdateWithParameter() {
 		Query query = mock(Query.class);
 		given(session.createQuery("some query string")).willReturn(query);
 		given(query.setParameter(0, "myvalue")).willReturn(query);
@@ -884,7 +884,7 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testBulkUpdateWithParameters()  {
+	public void testBulkUpdateWithParameters() {
 		Query query = mock(Query.class);
 		given(session.createQuery("some query string")).willReturn(query);
 		given(query.setParameter(0, "myvalue1")).willReturn(query);
@@ -897,14 +897,14 @@ public class HibernateTemplateTests {
 	}
 
 	@Test
-	public void testExceptions()  {
+	public void testExceptions() {
 		SQLException sqlEx = new SQLException("argh", "27");
 
 		final JDBCConnectionException jcex = new JDBCConnectionException("mymsg", sqlEx);
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw jcex;
 				}
 			});
@@ -920,7 +920,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw sgex;
 				}
 			});
@@ -936,7 +936,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw laex;
 				}
 			});
@@ -952,7 +952,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw cvex;
 				}
 			});
@@ -968,7 +968,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw dex;
 				}
 			});
@@ -984,7 +984,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw jdex;
 				}
 			});
@@ -1000,7 +1000,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw pvex;
 				}
 			});
@@ -1015,7 +1015,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw new PersistentObjectException("");
 				}
 			});
@@ -1028,7 +1028,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw new TransientObjectException("");
 				}
 			});
@@ -1042,7 +1042,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw odex;
 				}
 			});
@@ -1057,7 +1057,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw qex;
 				}
 			});
@@ -1073,7 +1073,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw uoex;
 				}
 			});
@@ -1090,7 +1090,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw onfe;
 				}
 			});
@@ -1107,7 +1107,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw wcex;
 				}
 			});
@@ -1124,7 +1124,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw nuex;
 				}
 			});
@@ -1140,7 +1140,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw sosex;
 				}
 			});
@@ -1157,7 +1157,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw ssex;
 				}
 			});
@@ -1174,7 +1174,7 @@ public class HibernateTemplateTests {
 		try {
 			hibernateTemplate.execute(new HibernateCallback<Object>() {
 				@Override
-				public Object doInHibernate(Session session)  {
+				public Object doInHibernate(Session session) {
 					throw hex;
 				}
 			});

--- a/spring-orm-hibernate5/src/main/java/org/springframework/orm/hibernate5/SessionFactoryUtils.java
+++ b/spring-orm-hibernate5/src/main/java/org/springframework/orm/hibernate5/SessionFactoryUtils.java
@@ -160,7 +160,7 @@ public abstract class SessionFactoryUtils {
 		}
 		if (ex instanceof ConstraintViolationException) {
 			ConstraintViolationException jdbcEx = (ConstraintViolationException) ex;
-			return new DataIntegrityViolationException(ex.getMessage()  + "; SQL [" + jdbcEx.getSQL() +
+			return new DataIntegrityViolationException(ex.getMessage() + "; SQL [" + jdbcEx.getSQL() +
 					"]; constraint [" + jdbcEx.getConstraintName() + "]", ex);
 		}
 		if (ex instanceof DataException) {

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate3/SessionFactoryUtils.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate3/SessionFactoryUtils.java
@@ -655,7 +655,7 @@ public abstract class SessionFactoryUtils {
 		}
 		if (ex instanceof ConstraintViolationException) {
 			ConstraintViolationException jdbcEx = (ConstraintViolationException) ex;
-			return new DataIntegrityViolationException(ex.getMessage()  + "; SQL [" + jdbcEx.getSQL() +
+			return new DataIntegrityViolationException(ex.getMessage() + "; SQL [" + jdbcEx.getSQL() +
 					"]; constraint [" + jdbcEx.getConstraintName() + "]", ex);
 		}
 		if (ex instanceof DataException) {

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate3/SpringSessionSynchronization.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate3/SpringSessionSynchronization.java
@@ -206,7 +206,7 @@ class SpringSessionSynchronization implements TransactionSynchronization, Ordere
 				SessionFactoryUtils.closeSessionOrRegisterDeferredClose(this.sessionHolder.getSession(), this.sessionFactory);
 			}
 		}
-		else  {
+		else {
 			Session session = this.sessionHolder.getSession();
 			if (this.sessionHolder.getPreviousFlushMode() != null) {
 				// In case of pre-bound Session, restore previous flush mode.

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate3/support/BlobByteArrayType.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate3/support/BlobByteArrayType.java
@@ -39,7 +39,7 @@ import org.springframework.jdbc.support.lob.LobHandler;
  * @since 1.2
  * @see org.springframework.orm.hibernate3.LocalSessionFactoryBean#setLobHandler
  */
-public class BlobByteArrayType extends AbstractLobType  {
+public class BlobByteArrayType extends AbstractLobType {
 
 	/**
 	 * Constructor used by Hibernate: fetches config-time LobHandler and

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaDialect.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaDialect.java
@@ -255,7 +255,7 @@ public class HibernateJpaDialect extends DefaultJpaDialect {
 		}
 		if (ex instanceof ConstraintViolationException) {
 			ConstraintViolationException jdbcEx = (ConstraintViolationException) ex;
-			return new DataIntegrityViolationException(ex.getMessage()  + "; SQL [" + jdbcEx.getSQL() +
+			return new DataIntegrityViolationException(ex.getMessage() + "; SQL [" + jdbcEx.getSQL() +
 					"]; constraint [" + jdbcEx.getConstraintName() + "]", ex);
 		}
 		if (ex instanceof DataException) {

--- a/spring-oxm/src/main/java/org/springframework/oxm/jibx/JibxMarshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/jibx/JibxMarshaller.java
@@ -224,7 +224,7 @@ public class JibxMarshaller extends AbstractMarshaller implements InitializingBe
 				bindingName = DEFAULT_BINDING_NAME;
 			}
 			if (logger.isInfoEnabled()) {
-				logger.info("Configured for target package [" + this.targetPackage	+ "] using binding [" + this.bindingName + "]");
+				logger.info("Configured for target package [" + this.targetPackage + "] using binding [" + this.bindingName + "]");
 			}
 			this.bindingFactory = BindingDirectory.getFactory(this.bindingName, this.targetPackage);
 		}

--- a/spring-oxm/src/main/java/org/springframework/oxm/xmlbeans/XmlBeansMarshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/xmlbeans/XmlBeansMarshaller.java
@@ -320,7 +320,7 @@ public class XmlBeansMarshaller extends AbstractMarshaller {
 		}
 		else if (ex instanceof XmlException || ex instanceof SAXException) {
 			if (marshalling) {
-				return new MarshallingFailureException("XMLBeans marshalling exception",  ex);
+				return new MarshallingFailureException("XMLBeans marshalling exception", ex);
 			}
 			else {
 				return new UnmarshallingFailureException("XMLBeans unmarshalling exception", ex);

--- a/spring-oxm/src/main/java/org/springframework/oxm/xstream/XStreamMarshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/xstream/XStreamMarshaller.java
@@ -833,7 +833,7 @@ public class XStreamMarshaller extends AbstractMarshaller implements Initializin
 		if (ex instanceof StreamException || ex instanceof CannotResolveClassException ||
 				ex instanceof ConversionException) {
 			if (marshalling) {
-				return new MarshallingFailureException("XStream marshalling exception",  ex);
+				return new MarshallingFailureException("XStream marshalling exception", ex);
 			}
 			else {
 				return new UnmarshallingFailureException("XStream unmarshalling exception", ex);

--- a/spring-test/src/main/java/org/springframework/test/util/XmlExpectationsHelper.java
+++ b/spring-test/src/main/java/org/springframework/test/util/XmlExpectationsHelper.java
@@ -48,7 +48,7 @@ public class XmlExpectationsHelper {
 		assertThat("Body content", document, matcher);
 	}
 
-	private Document parseXmlString(String xml) throws Exception  {
+	private Document parseXmlString(String xml) throws Exception {
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		factory.setNamespaceAware(true);
 		DocumentBuilder documentBuilder = factory.newDocumentBuilder();

--- a/spring-test/src/main/java/org/springframework/test/util/XpathExpectationsHelper.java
+++ b/spring-test/src/main/java/org/springframework/test/util/XpathExpectationsHelper.java
@@ -176,7 +176,7 @@ public class XpathExpectationsHelper {
 	 */
 	public void assertString(byte[] content, String encoding, Matcher<? super String> matcher) throws Exception {
 		Document document = parseXmlByteArray(content, encoding);
-		String result = evaluateXpath(document,  XPathConstants.STRING, String.class);
+		String result = evaluateXpath(document, XPathConstants.STRING, String.class);
 		assertThat("XPath " + this.expression, result, matcher);
 	}
 
@@ -186,7 +186,7 @@ public class XpathExpectationsHelper {
 	 */
 	public void assertString(byte[] content, String encoding, String expectedValue) throws Exception {
 		Document document = parseXmlByteArray(content, encoding);
-		String actual = evaluateXpath(document,  XPathConstants.STRING, String.class);
+		String actual = evaluateXpath(document, XPathConstants.STRING, String.class);
 		assertEquals("XPath " + this.expression, expectedValue, actual);
 	}
 

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StubWebApplicationContext.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StubWebApplicationContext.java
@@ -144,7 +144,7 @@ class StubWebApplicationContext implements WebApplicationContext {
 			return;
 		}
 		for (Object bean : beans) {
-			String name = bean.getClass().getName() + "#" +  ObjectUtils.getIdentityHexString(bean);
+			String name = bean.getClass().getName() + "#" + ObjectUtils.getIdentityHexString(bean);
 			this.beanFactory.addBean(name, bean);
 		}
 	}

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/TransactionalInlinedStatementsSqlScriptsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/TransactionalInlinedStatementsSqlScriptsTests.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.*;
 @ContextConfiguration(classes = EmptyDatabaseConfig.class)
 @Transactional
 @Sql(
-	scripts    = "schema.sql",
+	scripts = "schema.sql",
 	statements = "INSERT INTO user VALUES('Dilbert')"
 )
 @DirtiesContext

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/result/ModelResultMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/result/ModelResultMatchersTests.java
@@ -74,7 +74,7 @@ public class ModelResultMatchersTests {
 	}
 
     @Test
-    public void  attributeDoesNotExist() throws Exception {
+    public void attributeDoesNotExist() throws Exception {
         this.matchers.attributeDoesNotExist("bad").match(this.mvcResult);
     }
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilderTests.java
@@ -70,7 +70,7 @@ public class StandaloneMockMvcBuilderTests {
 	public void applicationContextAttribute() {
 		TestStandaloneMockMvcBuilder builder = new TestStandaloneMockMvcBuilder(new PlaceholderController());
 		builder.addPlaceHolderValue("sys.login.ajax", "/foo");
-		WebApplicationContext  wac = builder.initWebAppContext();
+		WebApplicationContext wac = builder.initWebAppContext();
 		assertEquals(wac, WebApplicationContextUtils
 				.getRequiredWebApplicationContext(wac.getServletContext()));
 	}

--- a/spring-tx/src/main/java/org/springframework/transaction/config/JtaTransactionManagerBeanDefinitionParser.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/config/JtaTransactionManagerBeanDefinitionParser.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.xml.ParserContext;
  * @see org.springframework.transaction.jta.WebLogicJtaTransactionManager
  * @see org.springframework.transaction.jta.WebSphereUowTransactionManager
  */
-public class JtaTransactionManagerBeanDefinitionParser extends AbstractSingleBeanDefinitionParser  {
+public class JtaTransactionManagerBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
 
 	@Override
 	protected String getBeanClassName(Element element) {

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/MethodMapTransactionAttributeSource.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/MethodMapTransactionAttributeSource.java
@@ -142,7 +142,7 @@ public class MethodMapTransactionAttributeSource
 	public void addTransactionalMethod(Class<?> clazz, String mappedName, TransactionAttribute attr) {
 		Assert.notNull(clazz, "Class must not be null");
 		Assert.notNull(mappedName, "Mapped name must not be null");
-		String name = clazz.getName() + '.'  + mappedName;
+		String name = clazz.getName() + '.' + mappedName;
 
 		Method[] methods = clazz.getDeclaredMethods();
 		List<Method> matchingMethods = new ArrayList<Method>();

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/TransactionInterceptorTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/TransactionInterceptorTests.java
@@ -224,7 +224,7 @@ public class TransactionInterceptorTests extends AbstractTransactionAspectTests 
 		TransactionInterceptor ti = transactionInterceptorWithTransactionManagerName(
 				"fooTransactionManager", beanFactory);
 
-		PlatformTransactionManager txManager = 	associateTransactionManager(beanFactory, "fooTransactionManager");
+		PlatformTransactionManager txManager = associateTransactionManager(beanFactory, "fooTransactionManager");
 
 		DefaultTransactionAttribute attribute = new DefaultTransactionAttribute();
 		PlatformTransactionManager actual = ti.determineTransactionManager(attribute);

--- a/spring-web/src/main/java/org/springframework/web/context/request/RequestContextHolder.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/RequestContextHolder.java
@@ -43,7 +43,7 @@ import org.springframework.util.ClassUtils;
  * @see org.springframework.web.servlet.DispatcherServlet
  * @see org.springframework.web.portlet.DispatcherPortlet
  */
-public abstract class RequestContextHolder  {
+public abstract class RequestContextHolder {
 
 	private static final boolean jsfPresent =
 			ClassUtils.isPresent("javax.faces.context.FacesContext", RequestContextHolder.class.getClassLoader());

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/CallableProcessingInterceptor.java
@@ -62,7 +62,7 @@ public interface CallableProcessingInterceptor {
 	 * @param task the task for the current async request
 	 * @throws Exception in case of errors
 	 */
-	<T> void  beforeConcurrentHandling(NativeWebRequest request, Callable<T> task) throws Exception;
+	<T> void beforeConcurrentHandling(NativeWebRequest request, Callable<T> task) throws Exception;
 
 	/**
 	 * Invoked <em>after</em> the start of concurrent handling in the async

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/DeferredResultInterceptorChain.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/DeferredResultInterceptorChain.java
@@ -55,7 +55,7 @@ class DeferredResultInterceptorChain {
 		}
 	}
 
-	public Object applyPostProcess(NativeWebRequest request,  DeferredResult<?> deferredResult, Object concurrentResult) {
+	public Object applyPostProcess(NativeWebRequest request, DeferredResult<?> deferredResult, Object concurrentResult) {
 		try {
 			for (int i = this.preProcessingIndex; i >= 0; i--) {
 				this.interceptors.get(i).postProcess(request, deferredResult, concurrentResult);

--- a/spring-web/src/main/java/org/springframework/web/filter/HttpPutFormContentFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/HttpPutFormContentFilter.java
@@ -117,7 +117,7 @@ public class HttpPutFormContentFilter extends OncePerRequestFilter {
 		public String getParameter(String name) {
 			String queryStringValue = super.getParameter(name);
 			String formValue = this.formParameters.getFirst(name);
-			return (queryStringValue != null) ?  queryStringValue : formValue;
+			return (queryStringValue != null) ? queryStringValue : formValue;
 		}
 
 		@Override

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/ModelFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/ModelFactory.java
@@ -190,7 +190,7 @@ public final class ModelFactory {
 	public static String getNameForParameter(MethodParameter parameter) {
 		ModelAttribute annot = parameter.getParameterAnnotation(ModelAttribute.class);
 		String attrName = (annot != null) ? annot.value() : null;
-		return StringUtils.hasText(attrName) ? attrName :  Conventions.getVariableNameForParameter(parameter);
+		return StringUtils.hasText(attrName) ? attrName : Conventions.getVariableNameForParameter(parameter);
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/multipart/commons/CommonsMultipartFile.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/commons/CommonsMultipartFile.java
@@ -84,7 +84,7 @@ public class CommonsMultipartFile implements MultipartFile, Serializable {
 			// Check for Windows-style path
 			pos = filename.lastIndexOf("\\");
 		}
-		if (pos != -1)  {
+		if (pos != -1) {
 			// Any sort of path separator found...
 			return filename.substring(pos + 1);
 		}

--- a/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -673,7 +673,8 @@ final class HierarchicalUriComponents extends UriComponents {
 		@Override
 		public PathComponent encode(String encoding) throws UnsupportedEncodingException {
 			String encodedPath = encodeUriComponent(getPath(),encoding, Type.PATH);
-			return new FullPathComponent(encodedPath);		}
+			return new FullPathComponent(encodedPath);
+		}
 
 		@Override
 		public void verify() {

--- a/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityReferences.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityReferences.java
@@ -79,7 +79,7 @@ class HtmlCharacterEntityReferences {
 		}
 		catch (IOException ex) {
 			throw new IllegalStateException(
-					"Failed to parse reference definition file [HtmlCharacterEntityReferences.properties]: " +  ex.getMessage());
+					"Failed to parse reference definition file [HtmlCharacterEntityReferences.properties]: " + ex.getMessage());
 		}
 
 		// Parse reference definition properties

--- a/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -550,7 +550,7 @@ public class UrlPathHelper {
 			return vars;
 		}
 		else {
-			MultiValueMap<String, String> decodedVars = new LinkedMultiValueMap	<String, String>(vars.size());
+			MultiValueMap<String, String> decodedVars = new LinkedMultiValueMap <String, String>(vars.size());
 			for (String key : vars.keySet()) {
 				for (String value : vars.get(key)) {
 					decodedVars.add(key, decodeInternal(request, value));

--- a/spring-web/src/test/java/org/springframework/http/converter/json/SpringHandlerInstantiatorTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/SpringHandlerInstantiatorTests.java
@@ -123,7 +123,7 @@ public class SpringHandlerInstantiatorTests {
 		private Capitalizer capitalizer;
 
 		@Override
-		public User deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws  IOException {
+		public User deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
 			ObjectCodec oc = jsonParser.getCodec();
 			JsonNode node = oc.readTree(jsonParser);
 			return new User(this.capitalizer.capitalize(node.get("username").asText()));

--- a/spring-web/src/test/java/org/springframework/http/converter/xml/Jaxb2CollectionHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/xml/Jaxb2CollectionHttpMessageConverterTests.java
@@ -135,7 +135,7 @@ public class Jaxb2CollectionHttpMessageConverterTests {
 	public void readXmlRootElementExternalEntityDisabled() throws Exception {
 
 		Resource external = new ClassPathResource("external.txt", getClass());
-		String content =  "<!DOCTYPE root [" +
+		String content = "<!DOCTYPE root [" +
 				"  <!ELEMENT external ANY >\n" +
 				"  <!ENTITY ext SYSTEM \"" + external.getURI() + "\" >]>" +
 				"  <list><rootElement><type s=\"1\"/><external>&ext;</external></rootElement></list>";
@@ -166,7 +166,7 @@ public class Jaxb2CollectionHttpMessageConverterTests {
 	public void readXmlRootElementExternalEntityEnabled() throws Exception {
 
 		Resource external = new ClassPathResource("external.txt", getClass());
-		String content =  "<!DOCTYPE root [" +
+		String content = "<!DOCTYPE root [" +
 				"  <!ELEMENT external ANY >\n" +
 				"  <!ENTITY ext SYSTEM \"" + external.getURI() + "\" >]>" +
 				"  <list><rootElement><type s=\"1\"/><external>&ext;</external></rootElement></list>";

--- a/spring-web/src/test/java/org/springframework/http/converter/xml/Jaxb2RootElementHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/xml/Jaxb2RootElementHttpMessageConverterTests.java
@@ -119,7 +119,7 @@ public class Jaxb2RootElementHttpMessageConverterTests {
 	@Test
 	public void readXmlRootElementExternalEntityDisabled() throws Exception {
 		Resource external = new ClassPathResource("external.txt", getClass());
-		String content =  "<!DOCTYPE root SYSTEM \"http://192.168.28.42/1.jsp\" [" +
+		String content = "<!DOCTYPE root SYSTEM \"http://192.168.28.42/1.jsp\" [" +
 				"  <!ELEMENT external ANY >\n" +
 				"  <!ENTITY ext SYSTEM \"" + external.getURI() + "\" >]>" +
 				"  <rootElement><external>&ext;</external></rootElement>";
@@ -133,7 +133,7 @@ public class Jaxb2RootElementHttpMessageConverterTests {
 	@Test
 	public void readXmlRootElementExternalEntityEnabled() throws Exception {
 		Resource external = new ClassPathResource("external.txt", getClass());
-		String content =  "<!DOCTYPE root [" +
+		String content = "<!DOCTYPE root [" +
 				"  <!ELEMENT external ANY >\n" +
 				"  <!ENTITY ext SYSTEM \"" + external.getURI() + "\" >]>" +
 				"  <rootElement><external>&ext;</external></rootElement>";

--- a/spring-web/src/test/java/org/springframework/protobuf/Msg.java
+++ b/spring-web/src/test/java/org/springframework/protobuf/Msg.java
@@ -6,7 +6,7 @@ package org.springframework.protobuf;
 /**
  * Protobuf type {@code Msg}
  */
-public  final class Msg extends
+public final class Msg extends
     com.google.protobuf.GeneratedMessage
     implements MsgOrBuilder {
   // Use Msg.newBuilder() to construct.

--- a/spring-web/src/test/java/org/springframework/protobuf/SecondMsg.java
+++ b/spring-web/src/test/java/org/springframework/protobuf/SecondMsg.java
@@ -6,7 +6,7 @@ package org.springframework.protobuf;
 /**
  * Protobuf type {@code SecondMsg}
  */
-public  final class SecondMsg extends
+public final class SecondMsg extends
     com.google.protobuf.GeneratedMessage
     implements SecondMsgOrBuilder {
   // Use SecondMsg.newBuilder() to construct.

--- a/spring-web/src/test/java/org/springframework/web/client/AsyncRestTemplateIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/AsyncRestTemplateIntegrationTests.java
@@ -174,7 +174,7 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void postForLocation() throws Exception  {
+	public void postForLocation() throws Exception {
 		HttpHeaders entityHeaders = new HttpHeaders();
 		entityHeaders.setContentType(new MediaType("text", "plain", Charset.forName("ISO-8859-15")));
 		HttpEntity<String> entity = new HttpEntity<String>(helloWorld, entityHeaders);
@@ -184,7 +184,7 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void postForLocationCallback() throws Exception  {
+	public void postForLocationCallback() throws Exception {
 		HttpHeaders entityHeaders = new HttpHeaders();
 		entityHeaders.setContentType(new MediaType("text", "plain", Charset.forName("ISO-8859-15")));
 		HttpEntity<String> entity = new HttpEntity<String>(helloWorld, entityHeaders);
@@ -205,7 +205,7 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void postForLocationCallbackWithLambdas() throws Exception  {
+	public void postForLocationCallbackWithLambdas() throws Exception {
 		HttpHeaders entityHeaders = new HttpHeaders();
 		entityHeaders.setContentType(new MediaType("text", "plain", Charset.forName("ISO-8859-15")));
 		HttpEntity<String> entity = new HttpEntity<String>(helloWorld, entityHeaders);
@@ -218,7 +218,7 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void postForEntity() throws Exception  {
+	public void postForEntity() throws Exception {
 		HttpEntity<String> requestEntity = new HttpEntity<>(helloWorld);
 		Future<ResponseEntity<String>> responseEntityFuture =
 				template.postForEntity(baseUrl + "/{method}", requestEntity, String.class, "post");
@@ -227,7 +227,7 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void postForEntityCallback() throws Exception  {
+	public void postForEntityCallback() throws Exception {
 		HttpEntity<String> requestEntity = new HttpEntity<>(helloWorld);
 		ListenableFuture<ResponseEntity<String>> responseEntityFuture =
 				template.postForEntity(baseUrl + "/{method}", requestEntity, String.class, "post");
@@ -246,7 +246,7 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void postForEntityCallbackWithLambdas() throws Exception  {
+	public void postForEntityCallbackWithLambdas() throws Exception {
 		HttpEntity<String> requestEntity = new HttpEntity<>(helloWorld);
 		ListenableFuture<ResponseEntity<String>> responseEntityFuture =
 				template.postForEntity(baseUrl + "/{method}", requestEntity, String.class, "post");
@@ -257,14 +257,14 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void put() throws Exception  {
+	public void put() throws Exception {
 		HttpEntity<String> requestEntity = new HttpEntity<>(helloWorld);
 		Future<?> responseEntityFuture = template.put(baseUrl + "/{method}", requestEntity, "put");
 		responseEntityFuture.get();
 	}
 
 	@Test
-	public void putCallback() throws Exception  {
+	public void putCallback() throws Exception {
 		HttpEntity<String> requestEntity = new HttpEntity<>(helloWorld);
 		ListenableFuture<?> responseEntityFuture = template.put(baseUrl + "/{method}", requestEntity, "put");
 		responseEntityFuture.addCallback(new ListenableFutureCallback<Object>() {
@@ -282,13 +282,13 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void delete() throws Exception  {
+	public void delete() throws Exception {
 		Future<?> deletedFuture = template.delete(new URI(baseUrl + "/delete"));
 		deletedFuture.get();
 	}
 
 	@Test
-	public void deleteCallback() throws Exception  {
+	public void deleteCallback() throws Exception {
 		ListenableFuture<?> deletedFuture = template.delete(new URI(baseUrl + "/delete"));
 		deletedFuture.addCallback(new ListenableFutureCallback<Object>() {
 			@Override
@@ -305,7 +305,7 @@ public class AsyncRestTemplateIntegrationTests extends AbstractJettyServerTestCa
 	}
 
 	@Test
-	public void deleteCallbackWithLambdas() throws Exception  {
+	public void deleteCallbackWithLambdas() throws Exception {
 		ListenableFuture<?> deletedFuture = template.delete(new URI(baseUrl + "/delete"));
 		deletedFuture.addCallback(result -> assertNull(result), ex -> fail(ex.getMessage()));
 		while (!deletedFuture.isDone()) {

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
@@ -115,7 +115,7 @@ public class ExceptionHandlerMethodResolverTests {
 	static class InheritedController extends ExceptionController {
 
 		@Override
-		public void handleIOException()	{
+		public void handleIOException() {
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolverTests.java
@@ -106,8 +106,8 @@ public class RequestParamMethodArgumentResolverTests {
 		paramMultipartFileList = new SynthesizingMethodParameter(method, 4);
 		paramMultipartFileArray = new SynthesizingMethodParameter(method, 5);
 		paramPart = new SynthesizingMethodParameter(method, 6);
-		paramPartList  = new SynthesizingMethodParameter(method, 7);
-		paramPartArray  = new SynthesizingMethodParameter(method, 8);
+		paramPartList = new SynthesizingMethodParameter(method, 7);
+		paramPartArray = new SynthesizingMethodParameter(method, 8);
 		paramMap = new SynthesizingMethodParameter(method, 9);
 		paramStringNotAnnot = new SynthesizingMethodParameter(method, 10);
 		paramStringNotAnnot.initParameterNameDiscovery(paramNameDiscoverer);

--- a/spring-webmvc-portlet/src/main/java/org/springframework/web/portlet/DispatcherPortlet.java
+++ b/spring-webmvc-portlet/src/main/java/org/springframework/web/portlet/DispatcherPortlet.java
@@ -376,7 +376,7 @@ public class DispatcherPortlet extends FrameworkPortlet {
 			// Default is no multipart resolver.
 			this.multipartResolver = null;
 			if (logger.isDebugEnabled()) {
-				logger.debug("Unable to locate PortletMultipartResolver with name '"	+ MULTIPART_RESOLVER_BEAN_NAME +
+				logger.debug("Unable to locate PortletMultipartResolver with name '" + MULTIPART_RESOLVER_BEAN_NAME +
 						"': no multipart request handling provided");
 			}
 		}

--- a/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/mvc/annotation/AnnotationMethodHandlerExceptionResolverTests.java
+++ b/spring-webmvc-portlet/src/test/java/org/springframework/web/portlet/mvc/annotation/AnnotationMethodHandlerExceptionResolverTests.java
@@ -92,7 +92,7 @@ public class AnnotationMethodHandlerExceptionResolverTests {
 	}
 
 	@Test
-	public void inherited()	{
+	public void inherited() {
 		IOException ex = new IOException();
 		InheritedController controller = new InheritedController();
 		ModelAndView mav = exceptionResolver.resolveException(request, response, controller, ex);
@@ -147,7 +147,7 @@ public class AnnotationMethodHandlerExceptionResolverTests {
 	private static class InheritedController extends SimpleController {
 
 		@Override
-		public String handleIOException(IOException ex, PortletRequest request)	{
+		public String handleIOException(IOException ex, PortletRequest request) {
 			return "GenericError";
 		}
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/ResourceChainRegistration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/ResourceChainRegistration.java
@@ -114,7 +114,7 @@ public class ResourceChainRegistration {
 	}
 
 	protected List<ResourceTransformer> getResourceTransformers() {
-		if (this.hasVersionResolver  && !this.hasCssLinkTransformer) {
+		if (this.hasVersionResolver && !this.hasCssLinkTransformer) {
 			List<ResourceTransformer> result = new ArrayList<ResourceTransformer>(this.transformers);
 			boolean hasTransformers = !this.transformers.isEmpty();
 			boolean hasCaching = hasTransformers && this.transformers.get(0) instanceof CachingResourceTransformer;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
@@ -559,8 +559,8 @@ public abstract class AbstractHandlerMethodMapping<T> extends AbstractHandlerMap
 			HandlerMethod handlerMethod = this.mappingLookup.get(mapping);
 			if (handlerMethod != null && !handlerMethod.equals(newHandlerMethod)) {
 				throw new IllegalStateException(
-						"Ambiguous mapping. Cannot map '" +	newHandlerMethod.getBean() + "' method \n" +
-								newHandlerMethod + "\nto " +	mapping + ": There is already '" +
+						"Ambiguous mapping. Cannot map '" + newHandlerMethod.getBean() + "' method \n" +
+								newHandlerMethod + "\nto " + mapping + ": There is already '" +
 								handlerMethod.getBean() + "' bean method\n" + handlerMethod + " mapped.");
 			}
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RedirectAttributesMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RedirectAttributesMethodArgumentResolver.java
@@ -54,7 +54,7 @@ public class RedirectAttributesMethodArgumentResolver implements HandlerMethodAr
 			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 
 		DataBinder dataBinder = binderFactory.createBinder(webRequest, null, null);
-		ModelMap redirectAttributes  = new RedirectAttributesModelMap(dataBinder);
+		ModelMap redirectAttributes = new RedirectAttributesModelMap(dataBinder);
 		mavContainer.setRedirectModel(redirectAttributes);
 		return redirectAttributes;
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
@@ -109,7 +109,7 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 
 	@Override
 	public void setEmbeddedValueResolver(StringValueResolver resolver) {
-		this.embeddedValueResolver  = resolver;
+		this.embeddedValueResolver = resolver;
 	}
 
 	@Override

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/AbstractControllerUrlHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/AbstractControllerUrlHandlerMapping.java
@@ -32,7 +32,7 @@ import org.springframework.web.servlet.handler.AbstractDetectingUrlHandlerMappin
  * @see ControllerClassNameHandlerMapping
  * @see ControllerBeanNameHandlerMapping
  */
-public abstract class AbstractControllerUrlHandlerMapping extends AbstractDetectingUrlHandlerMapping  {
+public abstract class AbstractControllerUrlHandlerMapping extends AbstractDetectingUrlHandlerMapping {
 
 	private ControllerTypePredicate predicate = new AnnotationControllerTypePredicate();
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/AppCacheManifestTransformer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/AppCacheManifestTransformer.java
@@ -131,7 +131,7 @@ public class AppCacheManifestTransformer extends ResourceTransformerSupport {
 			}
 			else {
 				contentWriter.write(
-						currentTransformer.transform(line, hashBuilder, resource, transformerChain, request)  + "\n");
+						currentTransformer.transform(line, hashBuilder, resource, transformerChain, request) + "\n");
 			}
 		}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
@@ -125,7 +125,7 @@ public class PathResourceResolver extends AbstractResourceResolver {
 			}
 			else if (logger.isTraceEnabled()) {
 				logger.trace("Resource path=\"" + resourcePath + "\" was successfully resolved " +
-						"but resource=\"" +	resource.getURL() + "\" is neither under the " +
+						"but resource=\"" + resource.getURL() + "\" is neither under the " +
 						"current location=\"" + location.getURL() + "\" nor under any of the " +
 						"allowed locations=" + Arrays.asList(getAllowedLocations()));
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/AbstractTemplateView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/AbstractTemplateView.java
@@ -176,7 +176,7 @@ public abstract class AbstractTemplateView extends AbstractUrlBasedView {
 	 * @param response current HTTP response
 	 * @see #setContentType
 	 */
-	protected void applyContentType(HttpServletResponse response)	{
+	protected void applyContentType(HttpServletResponse response) {
 		if (response.getContentType() == null) {
 			response.setContentType(getContentType());
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/freemarker/FreeMarkerView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/freemarker/FreeMarkerView.java
@@ -212,7 +212,7 @@ public class FreeMarkerView extends AbstractTemplateView {
 		}
 		catch (ParseException ex) {
 			throw new ApplicationContextException(
-					"Failed to parse FreeMarker template for URL [" +  getUrl() + "]", ex);
+					"Failed to parse FreeMarker template for URL [" + getUrl() + "]", ex);
 		}
 		catch (IOException ex) {
 			throw new ApplicationContextException(

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/groovy/GroovyMarkupView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/groovy/GroovyMarkupView.java
@@ -126,7 +126,7 @@ public class GroovyMarkupView extends AbstractTemplateView {
 		catch (ClassNotFoundException ex) {
 			Throwable cause = (ex.getCause() != null ? ex.getCause() : ex);
 			throw new NestedServletException("Could not find class while rendering Groovy Markup view with name '" +
-					getUrl() + "': " + ex.getMessage() +  "'", cause);
+					getUrl() + "': " + ex.getMessage() + "'", cause);
 		}
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/ViewResolverRegistryTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/ViewResolverRegistryTests.java
@@ -234,7 +234,7 @@ public class ViewResolverRegistryTests {
 	}
 
 	private void checkPropertyValues(ViewResolver resolver, Object... nameValuePairs) {
-		DirectFieldAccessor accessor =  new DirectFieldAccessor(resolver);
+		DirectFieldAccessor accessor = new DirectFieldAccessor(resolver);
 		for (int i = 0; i < nameValuePairs.length ; i++, i++) {
 			Object expected = nameValuePairs[i + 1];
 			Object actual = accessor.getPropertyValue((String) nameValuePairs[i]);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/annotation/AnnotationMethodHandlerExceptionResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/annotation/AnnotationMethodHandlerExceptionResolverTests.java
@@ -108,7 +108,7 @@ public class AnnotationMethodHandlerExceptionResolverTests {
 	}
 
 	@Test
-	public void inherited()	{
+	public void inherited() {
 		IOException ex = new IOException();
 		InheritedController controller = new InheritedController();
 		ModelAndView mav = exceptionResolver.resolveException(request, response, controller, ex);
@@ -199,7 +199,7 @@ public class AnnotationMethodHandlerExceptionResolverTests {
 	private static class InheritedController extends SimpleController {
 
 		@Override
-		public String handleIOException(IOException ex, HttpServletRequest request)	{
+		public String handleIOException(IOException ex, HttpServletRequest request) {
 			return "GenericError";
 		}
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/annotation/ServletAnnotationControllerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/annotation/ServletAnnotationControllerTests.java
@@ -3200,7 +3200,7 @@ public class ServletAnnotationControllerTests {
 	}
 
 	@Controller
-	public static class TrailingSlashController  {
+	public static class TrailingSlashController {
 
 		@RequestMapping(value = "/", method = RequestMethod.GET)
 		public void root(Writer writer) throws IOException {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorMockTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorMockTests.java
@@ -329,7 +329,7 @@ public class HttpEntityMethodProcessorMockTests {
 		processor.handleReturnValue(returnValue, returnTypeResponseEntity, mavContainer, webRequest);
 
 		ArgumentCaptor<HttpOutputMessage> outputMessage = ArgumentCaptor.forClass(HttpOutputMessage.class);
-		verify(messageConverter).write(eq("body"), eq(MediaType.TEXT_PLAIN),  outputMessage.capture());
+		verify(messageConverter).write(eq("body"), eq(MediaType.TEXT_PLAIN), outputMessage.capture());
 		assertTrue(mavContainer.isRequestHandled());
 		assertEquals("headerValue", outputMessage.getValue().getHeaders().get("header").get(0));
 	}
@@ -337,7 +337,7 @@ public class HttpEntityMethodProcessorMockTests {
 	@Test
 	public void handleReturnTypeLastModified() throws Exception {
 		long currentTime = new Date().getTime();
-		long oneMinuteAgo  = currentTime - (1000 * 60);
+		long oneMinuteAgo = currentTime - (1000 * 60);
 		servletRequest.addHeader(HttpHeaders.IF_MODIFIED_SINCE, dateFormat.format(currentTime));
 		HttpHeaders responseHeaders = new HttpHeaders();
 		responseHeaders.setDate(HttpHeaders.LAST_MODIFIED, oneMinuteAgo);
@@ -380,7 +380,7 @@ public class HttpEntityMethodProcessorMockTests {
 	@Test
 	public void handleReturnTypeETagAndLastModified() throws Exception {
 		long currentTime = new Date().getTime();
-		long oneMinuteAgo  = currentTime - (1000 * 60);
+		long oneMinuteAgo = currentTime - (1000 * 60);
 		String etagValue = "\"deadb33f8badf00d\"";
 		servletRequest.addHeader(HttpHeaders.IF_MODIFIED_SINCE, dateFormat.format(currentTime));
 		servletRequest.addHeader(HttpHeaders.IF_NONE_MATCH, etagValue);
@@ -407,7 +407,7 @@ public class HttpEntityMethodProcessorMockTests {
 	@Test
 	public void handleReturnTypeNotModified() throws Exception {
 		long currentTime = new Date().getTime();
-		long oneMinuteAgo  = currentTime - (1000 * 60);
+		long oneMinuteAgo = currentTime - (1000 * 60);
 		String etagValue = "\"deadb33f8badf00d\"";
 		HttpHeaders responseHeaders = new HttpHeaders();
 		responseHeaders.setDate(HttpHeaders.LAST_MODIFIED, oneMinuteAgo);
@@ -432,7 +432,7 @@ public class HttpEntityMethodProcessorMockTests {
 	@Test
 	public void handleReturnTypeChangedETagAndLastModified() throws Exception {
 		long currentTime = new Date().getTime();
-		long oneMinuteAgo  = currentTime - (1000 * 60);
+		long oneMinuteAgo = currentTime - (1000 * 60);
 		String etagValue = "\"deadb33f8badf00d\"";
 		String changedEtagValue = "\"changed-etag-value\"";
 		servletRequest.addHeader(HttpHeaders.IF_MODIFIED_SINCE, dateFormat.format(currentTime));
@@ -480,7 +480,7 @@ public class HttpEntityMethodProcessorMockTests {
 		assertEquals(1, servletResponse.getHeaderValues(HttpHeaders.ETAG).size());
 		assertEquals(etagValue, servletResponse.getHeader(HttpHeaders.ETAG));
 		ArgumentCaptor<HttpOutputMessage> outputMessage = ArgumentCaptor.forClass(HttpOutputMessage.class);
-		verify(messageConverter).write(eq("body"), eq(MediaType.TEXT_PLAIN),  outputMessage.capture());
+		verify(messageConverter).write(eq("body"), eq(MediaType.TEXT_PLAIN), outputMessage.capture());
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ModelAndViewMethodReturnValueHandlerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ModelAndViewMethodReturnValueHandlerTests.java
@@ -88,7 +88,7 @@ public class ModelAndViewMethodReturnValueHandlerTests {
 
 	@Test
 	public void handleRedirectAttributesWithViewReference() throws Exception {
-		RedirectAttributesModelMap redirectAttributes  = new RedirectAttributesModelMap();
+		RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
 		mavContainer.setRedirectModel(redirectAttributes);
 
 		ModelAndView mav = new ModelAndView(new RedirectView(), "attrName", "attrValue");
@@ -102,7 +102,7 @@ public class ModelAndViewMethodReturnValueHandlerTests {
 
 	@Test
 	public void handleRedirectAttributesWithViewName() throws Exception {
-		RedirectAttributesModelMap redirectAttributes  = new RedirectAttributesModelMap();
+		RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
 		mavContainer.setRedirectModel(redirectAttributes);
 
 		ModelAndView mav = new ModelAndView("redirect:viewName", "attrName", "attrValue");
@@ -116,7 +116,7 @@ public class ModelAndViewMethodReturnValueHandlerTests {
 
 	@Test
 	public void handleRedirectAttributesWithCustomPrefix() throws Exception {
-		RedirectAttributesModelMap redirectAttributes  = new RedirectAttributesModelMap();
+		RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
 		mavContainer.setRedirectModel(redirectAttributes);
 
 		ModelAndView mav = new ModelAndView("myRedirect:viewName", "attrName", "attrValue");
@@ -131,7 +131,7 @@ public class ModelAndViewMethodReturnValueHandlerTests {
 
 	@Test
 	public void handleRedirectAttributesWithoutRedirect() throws Exception {
-		RedirectAttributesModelMap redirectAttributes  = new RedirectAttributesModelMap();
+		RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
 		mavContainer.setRedirectModel(redirectAttributes);
 
 		ModelAndView mav = new ModelAndView();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterTests.java
@@ -157,7 +157,7 @@ public class ResponseBodyEmitterTests {
 	}
 
 	@Test
-	public void onTimeoutBeforeHandlerInitialized() throws Exception  {
+	public void onTimeoutBeforeHandlerInitialized() throws Exception {
 		Runnable runnable = mock(Runnable.class);
 		this.emitter.onTimeout(runnable);
 		this.emitter.initialize(this.handler);
@@ -172,7 +172,7 @@ public class ResponseBodyEmitterTests {
 	}
 
 	@Test
-	public void onTimeoutAfterHandlerInitialized() throws Exception  {
+	public void onTimeoutAfterHandlerInitialized() throws Exception {
 		this.emitter.initialize(this.handler);
 
 		ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
@@ -188,7 +188,7 @@ public class ResponseBodyEmitterTests {
 	}
 
 	@Test
-	public void onCompletionBeforeHandlerInitialized() throws Exception  {
+	public void onCompletionBeforeHandlerInitialized() throws Exception {
 		Runnable runnable = mock(Runnable.class);
 		this.emitter.onCompletion(runnable);
 		this.emitter.initialize(this.handler);
@@ -203,7 +203,7 @@ public class ResponseBodyEmitterTests {
 	}
 
 	@Test
-	public void onCompletionAfterHandlerInitialized() throws Exception  {
+	public void onCompletionAfterHandlerInitialized() throws Exception {
 		this.emitter.initialize(this.handler);
 
 		ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletAnnotationControllerHandlerMethodTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletAnnotationControllerHandlerMethodTests.java
@@ -692,7 +692,7 @@ public class ServletAnnotationControllerHandlerMethodTests extends AbstractServl
 		final MockServletContext servletContext = new MockServletContext();
 		final MockServletConfig servletConfig = new MockServletConfig(servletContext);
 
-		WebApplicationContext  webAppContext =
+		WebApplicationContext webAppContext =
 			initServlet(new ApplicationContextInitializer<GenericWebApplicationContext>() {
 				@Override
 				public void initialize(GenericWebApplicationContext wac) {
@@ -2878,7 +2878,7 @@ public class ServletAnnotationControllerHandlerMethodTests extends AbstractServl
 	}
 
 	@Controller
-	public static class TrailingSlashController  {
+	public static class TrailingSlashController {
 
 		@RequestMapping(value = "/", method = RequestMethod.GET)
 		public void root(Writer writer) throws IOException {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/DummyMacroRequestContext.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/DummyMacroRequestContext.java
@@ -84,7 +84,7 @@ public class DummyMacroRequestContext {
 	 */
 	public String getMessage(String code, List args, String defaultMsg) {
 		String msg = (String) this.messageMap.get(code);
-		return (msg != null ? msg  + args.toString(): defaultMsg);
+		return (msg != null ? msg + args.toString(): defaultMsg);
 	}
 
 	/**
@@ -114,7 +114,7 @@ public class DummyMacroRequestContext {
 	 */
 	public String getThemeMessage(String code, List args, String defaultMsg) {
 		String msg = (String) this.themeMessageMap.get(code);
-		return (msg != null ? msg  + args.toString(): defaultMsg);
+		return (msg != null ? msg + args.toString(): defaultMsg);
 	}
 
 	public void setContextPath(String contextPath) {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/CloseStatus.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/CloseStatus.java
@@ -47,7 +47,7 @@ public final class CloseStatus {
 	 * "1002 indicates that an endpoint is terminating the connection due to a protocol
 	 * error."
 	 */
-	public static final CloseStatus PROTOCOL_ERROR  = new CloseStatus(1002);
+	public static final CloseStatus PROTOCOL_ERROR = new CloseStatus(1002);
 
 	/**
 	 * "1003 indicates that an endpoint is terminating the connection because it has

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
@@ -152,7 +152,7 @@ public class JettyWebSocketClient extends AbstractWebSocketClient implements Lif
 	@Override
 	public ListenableFuture<WebSocketSession> doHandshakeInternal(WebSocketHandler wsHandler,
 			HttpHeaders headers, final URI uri, List<String> protocols,
-			List<WebSocketExtension> extensions,  Map<String, Object> attributes) {
+			List<WebSocketExtension> extensions, Map<String, Object> attributes) {
 
 		final ClientUpgradeRequest request = new ClientUpgradeRequest();
 		request.setSubProtocols(protocols);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/handler/LoggingWebSocketHandlerDecorator.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/handler/LoggingWebSocketHandlerDecorator.java
@@ -43,7 +43,7 @@ public class LoggingWebSocketHandlerDecorator extends WebSocketHandlerDecorator 
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
 		if (logger.isDebugEnabled()) {
-			logger.debug("New "	+ session);
+			logger.debug("New " + session);
 		}
 		super.afterConnectionEstablished(session);
 	}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java
@@ -458,7 +458,7 @@ public class StompSubProtocolHandler implements SubProtocolHandler, ApplicationE
 		}
 	}
 
-	private  StompHeaderAccessor getStompHeaderAccessor(Message<?> message) {
+	private StompHeaderAccessor getStompHeaderAccessor(Message<?> message) {
 		MessageHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, MessageHeaderAccessor.class);
 		if (accessor == null) {
 			// Shouldn't happen (only broker broadcasts directly to clients)

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/WebSocketStompClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/WebSocketStompClient.java
@@ -495,7 +495,7 @@ public class WebSocketStompClient extends StompClientSupport implements SmartLif
 			byte[] payload = message.getPayload();
 			byte[] bytes = ENCODER.encode(accessor.getMessageHeaders(), payload);
 
-			boolean useBinary = (payload.length > 0  &&
+			boolean useBinary = (payload.length > 0 &&
 					!(SockJsSession.class.isAssignableFrom(sessionType)) &&
 					MimeTypeUtils.APPLICATION_OCTET_STREAM.isCompatibleWith(accessor.getContentType()));
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/AbstractClientSockJsSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/AbstractClientSockJsSession.java
@@ -159,7 +159,7 @@ public abstract class AbstractClientSockJsSession implements WebSocketSession {
 	public final void close(CloseStatus status) {
 		Assert.isTrue(status != null && isUserSetStatus(status), "Invalid close status: " + status);
 		if (logger.isDebugEnabled()) {
-			logger.debug("Closing session with " +  status + " in " + this);
+			logger.debug("Closing session with " + status + " in " + this);
 		}
 		closeInternal(status);
 	}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/JettyXhrTransport.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/JettyXhrTransport.java
@@ -195,7 +195,7 @@ public class JettyXhrTransport extends AbstractXhrTransport implements Lifecycle
 		private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
 
-		public SockJsResponseListener(URI url, HttpHeaders headers,	XhrClientSockJsSession sockJsSession,
+		public SockJsResponseListener(URI url, HttpHeaders headers, XhrClientSockJsSession sockJsSession,
 				SettableListenableFuture<WebSocketSession> connectFuture) {
 
 			this.transportUrl = url;

--- a/spring-websocket/src/test/java/org/springframework/web/socket/WebSocketIntegrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/WebSocketIntegrationTests.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.*;
  * @author Rossen Stoyanchev
  */
 @RunWith(Parameterized.class)
-public class WebSocketIntegrationTests extends  AbstractWebSocketIntegrationTests {
+public class WebSocketIntegrationTests extends AbstractWebSocketIntegrationTests {
 
 	@Parameters(name = "server [{0}], client [{1}]")
 	public static Iterable<Object[]> arguments() {

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParserTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParserTests.java
@@ -440,12 +440,12 @@ public class MessageBrokerBeanDefinitionParserTests {
 	}
 
 
-	private void testChannel(String channelName, List<Class<? extends  MessageHandler>> subscriberTypes,
+	private void testChannel(String channelName, List<Class<? extends MessageHandler>> subscriberTypes,
 			int interceptorCount) {
 
 		AbstractSubscribableChannel channel = this.appContext.getBean(channelName, AbstractSubscribableChannel.class);
 
-		for (Class<? extends  MessageHandler> subscriberType : subscriberTypes) {
+		for (Class<? extends MessageHandler> subscriberType : subscriberTypes) {
 			MessageHandler subscriber = this.appContext.getBean(subscriberType);
 			assertNotNull("No subsription for " + subscriberType, subscriber);
 			assertTrue(channel.hasSubscription(subscriber));

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebSocketHandlerRegistrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebSocketHandlerRegistrationTests.java
@@ -192,7 +192,7 @@ public class WebSocketHandlerRegistrationTests {
 	}
 
 
-	private static class TestWebSocketHandlerRegistration  extends AbstractWebSocketHandlerRegistration<List<Mapping>> {
+	private static class TestWebSocketHandlerRegistration extends AbstractWebSocketHandlerRegistration<List<Mapping>> {
 
 		public TestWebSocketHandlerRegistration(TaskScheduler sockJsTaskScheduler) {
 			super(sockJsTaskScheduler);

--- a/spring-websocket/src/test/java/org/springframework/web/socket/handler/BeanCreatingHandlerProviderTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/handler/BeanCreatingHandlerProviderTests.java
@@ -90,6 +90,6 @@ public class BeanCreatingHandlerProviderTests {
 		}
 	}
 
-	private static class EchoService {	}
+	private static class EchoService { }
 
 }

--- a/spring-websocket/src/test/java/org/springframework/web/socket/server/standard/ServerEndpointRegistrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/server/standard/ServerEndpointRegistrationTests.java
@@ -88,6 +88,6 @@ public class ServerEndpointRegistrationTests {
 		}
 	}
 
-	private static class EchoService {	}
+	private static class EchoService { }
 
 }

--- a/spring-websocket/src/test/java/org/springframework/web/socket/server/standard/SpringConfiguratorTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/server/standard/SpringConfiguratorTests.java
@@ -136,6 +136,6 @@ public class SpringConfiguratorTests {
 		}
 	}
 
-	private static class EchoService {	}
+	private static class EchoService { }
 
 }

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/handler/HttpSendingTransportHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/handler/HttpSendingTransportHandlerTests.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  *
  * @author Rossen Stoyanchev
  */
-public class HttpSendingTransportHandlerTests  extends AbstractHttpRequestTests {
+public class HttpSendingTransportHandlerTests extends AbstractHttpRequestTests {
 
 	private WebSocketHandler webSocketHandler;
 


### PR DESCRIPTION
Replacing multiple spaces and tabs, which separates java tokens, by a
single space.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
