### PR TITLE
Fix YamlMapFactoryBean wrapping integer keys with square brackets

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
@@ -209,8 +209,13 @@ public abstract class YamlProcessor {
 				result.put(key.toString(), value);
 			}
 			else {
-				// It has to be a map key in this case
-				result.put("[" + key.toString() + "]", value);
+				try {
+					Integer intKey = Integer.parseInt(key.toString());
+					result.put(intKey.toString(), value);
+				} catch(NumberFormatException nfe) {
+					// It has to be a map key in this case
+					result.put("[" + key.toString() + "]", value);
+				}
 			}
 		}
 		return result;

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlProcessorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlProcessorTests.java
@@ -116,7 +116,8 @@ public class YamlProcessorTests {
 		this.processor.process(new MatchCallback() {
 			@Override
 			public void process(Properties properties, Map<String, Object> map) {
-				assertEquals("bar", properties.get("[1]"));
+				assertTrue(map.containsKey("1"));
+				assertEquals("bar", properties.get("1"));
 				assertEquals(2, properties.size());
 			}
 		});
@@ -130,7 +131,7 @@ public class YamlProcessorTests {
 
 			@Override
 			public void process(Properties properties, Map<String, Object> map) {
-				assertEquals("bar", properties.get("foo[1]"));
+				assertEquals("bar", properties.get("foo.1"));
 				assertEquals(1, properties.size());
 			}
 		});


### PR DESCRIPTION
Issue: SPR-13398

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
