### PR TITLE
merge plugin: fix broken reference to merged projects if gradle daemon used

### DIFF
--- a/buildSrc/src/main/groovy/org/springframework/build/gradle/MergePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/springframework/build/gradle/MergePlugin.groovy
@@ -56,8 +56,6 @@ import org.gradle.api.invocation.*
  */
 class MergePlugin implements Plugin<Project> {
 
-	private static boolean attachedProjectsEvaluated;
-
 	public void apply(Project project) {
 		project.plugins.apply(MavenPlugin)
 		project.plugins.apply(EclipsePlugin)
@@ -79,11 +77,12 @@ class MergePlugin implements Plugin<Project> {
 		}
 
 		// Hook to build runtimeMerge dependencies
+		def attachedProjectsEvaluated = project.rootProject.extensions.findByName('attachedProjectsEvaluated')
 		if (!attachedProjectsEvaluated) {
 			project.gradle.projectsEvaluated{
 				postProcessProjects(it)
 			}
-			attachedProjectsEvaluated  = true;
+			project.rootProject.extensions.add('attachedProjectsEvaluated', true)
 		}
 	}
 


### PR DESCRIPTION
Caching 'attachedProjectsEvaluated' flag using static plugin field may broke reference to merged projects for subsequent build executions if gradle daemon used
