### PR TITLE
SPR-13616 - Support Spring-WS's MessageDispatcherServlet in AbstractD…

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractDispatcherServletInitializer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractDispatcherServletInitializer.java
@@ -92,10 +92,10 @@ public abstract class AbstractDispatcherServletInitializer extends AbstractConte
 				"createServletApplicationContext() did not return an application " +
 				"context for servlet [" + servletName + "]");
 
-		FrameworkServlet dispatcherServlet = createDispatcherServlet(servletAppContext);
-		dispatcherServlet.setContextInitializers(getServletApplicationContextInitializers());
+		FrameworkServlet frameworkServlet = createDispatcherServlet(servletAppContext);
+		frameworkServlet.setContextInitializers(getServletApplicationContextInitializers());
 
-		ServletRegistration.Dynamic registration = servletContext.addServlet(servletName, dispatcherServlet);
+		ServletRegistration.Dynamic registration = servletContext.addServlet(servletName, frameworkServlet);
 		Assert.notNull(registration,
 				"Failed to register servlet with name '" + servletName + "'." +
 				"Check if there is another servlet registered under the same name.");

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractDispatcherServletInitializer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractDispatcherServletInitializer.java
@@ -32,6 +32,7 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.web.context.AbstractContextLoaderInitializer;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.FrameworkServlet;
 
 /**
  * Base class for {@link org.springframework.web.WebApplicationInitializer}
@@ -54,6 +55,7 @@ import org.springframework.web.servlet.DispatcherServlet;
  * @author Rossen Stoyanchev
  * @author Juergen Hoeller
  * @author Stephane Nicoll
+ * @author Kamill Sokol
  * @since 3.2
  */
 public abstract class AbstractDispatcherServletInitializer extends AbstractContextLoaderInitializer {
@@ -90,7 +92,7 @@ public abstract class AbstractDispatcherServletInitializer extends AbstractConte
 				"createServletApplicationContext() did not return an application " +
 				"context for servlet [" + servletName + "]");
 
-		DispatcherServlet dispatcherServlet = createDispatcherServlet(servletAppContext);
+		FrameworkServlet dispatcherServlet = createDispatcherServlet(servletAppContext);
 		dispatcherServlet.setContextInitializers(getServletApplicationContextInitializers());
 
 		ServletRegistration.Dynamic registration = servletContext.addServlet(servletName, dispatcherServlet);
@@ -132,9 +134,9 @@ public abstract class AbstractDispatcherServletInitializer extends AbstractConte
 	protected abstract WebApplicationContext createServletApplicationContext();
 
 	/**
-	 * Create a {@link DispatcherServlet} with the specified {@link WebApplicationContext}.
+	 * Create a {@link FrameworkServlet} with the specified {@link WebApplicationContext}.
 	 */
-	protected DispatcherServlet createDispatcherServlet(WebApplicationContext servletAppContext) {
+	protected FrameworkServlet createDispatcherServlet(WebApplicationContext servletAppContext) {
 		return new DispatcherServlet(servletAppContext);
 	}
 


### PR DESCRIPTION
https://jira.spring.io/browse/SPR-13616

Problem:
Right now we have to override AbstractDispatcherServletInitializer.registerDispatcherServlet(...) in order to register Spring-WS's MessageDispatcherServlet (tested with Version 2.2.0.RELEASE). AbstractDispatcherServletInitializer.registerDispatcherServlet(...) calls createDispatcherServlet which returns a DispatcherServlet instance whereas MessageDispatcherServlet directly derives from FrameworkServlet. Both DispatcherServlet and MessageDispatcherServlet have the same base class in common that said FrameworkServlet.

Solution:
AbstractDispatcherServletInitializer.registerDispatcherServlet(...) should return FrameworkServlet in order to support both Spring MVC's DispatcherServlet and Spring-WS's MessageDispatcherServlet.
