### PR TITLE
Fix CronTrigger example in documentation

### DIFF
--- a/src/asciidoc/integration.adoc
+++ b/src/asciidoc/integration.adoc
@@ -6410,7 +6410,7 @@ during the 9-to-5 "business hours" on weekdays.
 [source,java,indent=0]
 [subs="verbatim"]
 ----
-	scheduler.schedule(task, new CronTrigger("* 15 9-17 * * MON-FRI"));
+	scheduler.schedule(task, new CronTrigger("0 15 9-17 * * MON-FRI"));
 ----
 
 The other out-of-the-box implementation is a `PeriodicTrigger` that accepts a fixed


### PR DESCRIPTION
The original example would fire every second of the 15th minute, not
just once as stated in the paragraph before.

Issue: SPR-10474

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
