### PR TITLE
Improve explanation for how to customization default error page of the Servlet Container

### DIFF
--- a/src/asciidoc/web-mvc.adoc
+++ b/src/asciidoc/web-mvc.adoc
@@ -3822,8 +3822,8 @@ response accordingly. By default the `DispatcherServlet` registers the
 When the status of the response is set to an error status code and the body of the
 response is empty, Servlet containers commonly render an HTML formatted error page. To
 customize the default error page of the container, you can declare an `<error-page>`
-element in `web.xml`. Up until Servlet 3, that element had to be mapped to a specific
-status code or exception type. Starting with Servlet 3 an error page does not need to be
+element in `web.xml`. Up until Servlet 3.0, that element had to be mapped to a specific
+status code or exception type. In a Servlet 3.1+ environment, an error page does not need to be
 mapped, which effectively means the specified location customizes the default Servlet
 container error page.
 
@@ -3851,7 +3851,7 @@ When writing error information, the status code and the error message set on the
 		@ResponseBody
 		public Map<String, Object> handle(HttpServletRequest request) {
 
-			Map<String, Object> map = new HashMap<String, Object>();
+			Map<String, Object> map = new LinkedHashMap<String, Object>();
 			map.put("status", request.getAttribute("javax.servlet.error.status_code"));
 			map.put("reason", request.getAttribute("javax.servlet.error.message"));
 
@@ -3868,8 +3868,8 @@ or in a JSP:
 ----
 	<%@ page contentType="application/json" pageEncoding="UTF-8"%>
 	{
-		status:<%=request.getAttribute("javax.servlet.error.status_code") %>,
-		reason:<%=request.getAttribute("javax.servlet.error.message") %>
+	  "status" : <%=request.getAttribute("javax.servlet.error.status_code") %>,
+	  "reason" : "<%=request.getAttribute("javax.servlet.error.message") %>"
 	}
 ----
 


### PR DESCRIPTION
I've improved explanation for how to customization default error page of the Servlet Container.
- Specify a valid version of servlet container explicitly (3.1+).
- Change to use the `LinkedHashMap` instead of `HashMap`. The `LinkedHashMap` can be keep order of items. (I think more better that use `LinkedHashMap` in sample code)
- Change a JSON format(indent , white-space). In addition, this format is same with `indentOutput` of Jackson.

I have signed and agree to the terms of the Spring ICLA.

Thanks.
