### PR TITLE
Support empty attributes in TagWriter

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/TagWriter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/TagWriter.java
@@ -94,6 +94,19 @@ public class TagWriter {
 		this.writer.append(" ").append(attributeName).append("=\"")
 				.append(attributeValue).append("\"");
 	}
+	
+	/**
+	 * Write an empty HTML attribute with the specified name.
+	 * <p>Be sure to write all attributes <strong>before</strong> writing
+	 * any inner text or nested tags.
+	 * @throws IllegalStateException if the opening tag is closed
+	 */
+	public void writeAttribute(String attributeName) throws JspException {
+		if (currentState().isBlockTag()) {
+			throw new IllegalStateException("Cannot write attributes after opening tag is closed.");
+		}
+		this.writer.append(" ").append(attributeName);
+	}
 
 	/**
 	 * Write an HTML attribute if the supplied value is not {@code null}


### PR DESCRIPTION
Support for empty HTML attributes (like "required", "ng-disabled"...)
If you want to use this tool for a custom tag in a project that is mainly Angular-oriented, you may want to write attributes without values.
And since members are private, you cannot extend TagWriter (another proposal could be "protecting" fields).
