### PR TITLE
Avoid char[] allocation when generates cache key

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/AbstractAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/AbstractAutoProxyCreator.java
@@ -42,6 +42,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyValues;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.SmartInstantiationAwareBeanPostProcessor;
@@ -214,8 +215,12 @@ public abstract class AbstractAutoProxyCreator extends ProxyProcessorSupport
 
 	@Override
 	public Class<?> predictBeanType(Class<?> beanClass, String beanName) {
-		Object cacheKey = getCacheKey(beanClass, beanName);
-		return this.proxyTypes.get(cacheKey);
+		if (this.proxyTypes.isEmpty()) {
+			return null;
+		} else {
+			Object cacheKey = getCacheKey(beanClass, beanName);
+			return this.proxyTypes.get(cacheKey);
+		}
 	}
 
 	@Override
@@ -304,7 +309,11 @@ public abstract class AbstractAutoProxyCreator extends ProxyProcessorSupport
 	 * @return the cache key for the given class and name
 	 */
 	protected Object getCacheKey(Class<?> beanClass, String beanName) {
-		return beanClass.getName() + "_" + beanName;
+		if (beanName == null || FactoryBean.class.isAssignableFrom(beanClass)) {
+			return beanClass.getName() + "_" + beanName;
+		} else {
+			return beanName;
+		}
 	}
 
 	/**


### PR DESCRIPTION
_org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator#getCacheKey_ generates to many string during work with context and create context, especially when in context present many beans(in my case 1200+) . 

String concatenation leads to two problems:
1) Excessive heap garbage due to throw-away string creation
2) Excessive CPU due to computing hash code for the newly created strings.
It occurs because DefaultListableBeanFactory#doGetBeanNamesForType iterates by all beans in context and try find correspond bean when specified only class and bean name absent(I think it occurs in 80% of cases when uses java configurations).

We can avoid it problem use only beanName bacause they unique in context(exception only bean creates via FactoryBean because in it case beanName for factory and result bean can be same)

Issue: [SPR-13655](https://jira.spring.io/browse/SPR-13655)

I check fix on starting application scenario, you can see results below

**Without with:**
char[] allocation:
![spring_allocation_string_by_start](https://cloud.githubusercontent.com/assets/10699594/11017535/24a23192-85b3-11e5-9f0c-c053659f3906.png)

Hot methods:
![spring_hot_methods_by_start](https://cloud.githubusercontent.com/assets/10699594/11017540/3ed2b622-85b3-11e5-870f-32bc718f509f.png)

**With current fix**
char[] allocation:
![spring_allocation_string_by_start_after_fix](https://cloud.githubusercontent.com/assets/10699594/11017572/9a6ea22e-85b4-11e5-967c-2b03fa3a8fdc.png)

Hot methods:
![spring_hot_methods_by_start_after_fix](https://cloud.githubusercontent.com/assets/10699594/11017570/848a88c4-85b4-11e5-9a90-cba93adec187.png)

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
