### PR TITLE
Add support of Callable for TaskScheduler methods.

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/scheduling/commonj/TimerManagerTaskScheduler.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/commonj/TimerManagerTaskScheduler.java
@@ -17,6 +17,7 @@
 package org.springframework.scheduling.commonj;
 
 import java.util.Date;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledFuture;
@@ -27,6 +28,7 @@ import commonj.timers.TimerListener;
 
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.support.CallableWrapperRunnable;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 import org.springframework.scheduling.support.TaskUtils;
 import org.springframework.util.ErrorHandler;
@@ -37,6 +39,7 @@ import org.springframework.util.ErrorHandler;
  *
  * @author Juergen Hoeller
  * @author Mark Fisher
+ * @author Serdar Kuzucu
  * @since 3.0
  */
 public class TimerManagerTaskScheduler extends TimerManagerAccessor implements TaskScheduler {
@@ -58,11 +61,21 @@ public class TimerManagerTaskScheduler extends TimerManagerAccessor implements T
 	}
 
 	@Override
+	public ScheduledFuture<?> schedule(Callable<?> task, Trigger trigger) {
+		return schedule(new CallableWrapperRunnable(task), trigger);
+	}
+
+	@Override
 	public ScheduledFuture<?> schedule(Runnable task, Date startTime) {
 		TimerScheduledFuture futureTask = new TimerScheduledFuture(errorHandlingTask(task, false));
 		Timer timer = getTimerManager().schedule(futureTask, startTime);
 		futureTask.setTimer(timer);
 		return futureTask;
+	}
+
+	@Override
+	public ScheduledFuture<?> schedule(Callable<?> task, Date startTime) {
+		return schedule(new CallableWrapperRunnable(task), startTime);
 	}
 
 	@Override
@@ -74,11 +87,21 @@ public class TimerManagerTaskScheduler extends TimerManagerAccessor implements T
 	}
 
 	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, Date startTime, long period) {
+		return scheduleAtFixedRate(new CallableWrapperRunnable(task), startTime, period);
+	}
+
+	@Override
 	public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long period) {
 		TimerScheduledFuture futureTask = new TimerScheduledFuture(errorHandlingTask(task, true));
 		Timer timer = getTimerManager().scheduleAtFixedRate(futureTask, 0, period);
 		futureTask.setTimer(timer);
 		return futureTask;
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, long period) {
+		return scheduleAtFixedRate(new CallableWrapperRunnable(task), period);
 	}
 
 	@Override
@@ -90,11 +113,21 @@ public class TimerManagerTaskScheduler extends TimerManagerAccessor implements T
 	}
 
 	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, Date startTime, long delay) {
+		return scheduleWithFixedDelay(new CallableWrapperRunnable(task), startTime, delay);
+	}
+
+	@Override
 	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long delay) {
 		TimerScheduledFuture futureTask = new TimerScheduledFuture(errorHandlingTask(task, true));
 		Timer timer = getTimerManager().schedule(futureTask, 0, delay);
 		futureTask.setTimer(timer);
 		return futureTask;
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, long delay) {
+		return scheduleWithFixedDelay(new CallableWrapperRunnable(task), delay);
 	}
 
 	private Runnable errorHandlingTask(Runnable delegate, boolean isRepeatingTask) {

--- a/spring-context/src/main/java/org/springframework/scheduling/TaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/TaskScheduler.java
@@ -17,11 +17,13 @@
 package org.springframework.scheduling;
 
 import java.util.Date;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledFuture;
 
 /**
  * Task scheduler interface that abstracts the scheduling of
- * {@link Runnable Runnables} based on different kinds of triggers.
+ * {@link Runnable Runnables} and {@link Callable Callables} based on 
+ * different kinds of triggers.
  *
  * <p>This interface is separate from {@link SchedulingTaskExecutor} since it
  * usually represents for a different kind of backend, i.e. a thread pool with
@@ -39,6 +41,7 @@ import java.util.concurrent.ScheduledFuture;
  * JSR-236 interfaces have not been released in official form yet.
  *
  * @author Juergen Hoeller
+ * @author Serdar Kuzucu
  * @since 3.0
  * @see org.springframework.core.task.TaskExecutor
  * @see java.util.concurrent.ScheduledExecutorService
@@ -135,5 +138,101 @@ public interface TaskScheduler {
 	 * for internal reasons (e.g. a pool overload handling policy or a pool shutdown in progress)
 	 */
 	ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long delay);
+	
+	/**
+	 * Schedule the given {@link Callable}, invoking it whenever the trigger
+	 * indicates a next execution time.
+	 * <p>Execution will end once the scheduler shuts down or the returned
+	 * {@link ScheduledFuture} gets cancelled.
+	 * @param task the Callable to execute whenever the trigger fires
+	 * @param trigger an implementation of the {@link Trigger} interface,
+	 * e.g. a {@link org.springframework.scheduling.support.CronTrigger} object
+	 * wrapping a cron expression
+	 * @return a {@link ScheduledFuture} representing pending completion of the task,
+	 * or {@code null} if the given Trigger object never fires (i.e. returns
+	 * {@code null} from {@link Trigger#nextExecutionTime})
+	 * @throws org.springframework.core.task.TaskRejectedException if the given task was not accepted
+	 * for internal reasons (e.g. a pool overload handling policy or a pool shutdown in progress)
+	 * @see org.springframework.scheduling.support.CronTrigger
+	 * @since 4.2.1
+	 */
+	ScheduledFuture<?> schedule(Callable<?> task, Trigger trigger);
+
+	/**
+	 * Schedule the given {@link Callable}, invoking it at the specified execution time.
+	 * <p>Execution will end once the scheduler shuts down or the returned
+	 * {@link ScheduledFuture} gets cancelled.
+	 * @param task the Callable to execute whenever the trigger fires
+	 * @param startTime the desired execution time for the task
+	 * (if this is in the past, the task will be executed immediately, i.e. as soon as possible)
+	 * @return a {@link ScheduledFuture} representing pending completion of the task
+	 * @throws org.springframework.core.task.TaskRejectedException if the given task was not accepted
+	 * for internal reasons (e.g. a pool overload handling policy or a pool shutdown in progress)
+	 * @since 4.2.1
+	 */
+	ScheduledFuture<?> schedule(Callable<?> task, Date startTime);
+
+	/**
+	 * Schedule the given {@link Callable}, invoking it at the specified execution time
+	 * and subsequently with the given period.
+	 * <p>Execution will end once the scheduler shuts down or the returned
+	 * {@link ScheduledFuture} gets cancelled.
+	 * @param task the Callable to execute whenever the trigger fires
+	 * @param startTime the desired first execution time for the task
+	 * (if this is in the past, the task will be executed immediately, i.e. as soon as possible)
+	 * @param period the interval between successive executions of the task (in milliseconds)
+	 * @return a {@link ScheduledFuture} representing pending completion of the task
+	 * @throws org.springframework.core.task.TaskRejectedException if the given task was not accepted
+	 * for internal reasons (e.g. a pool overload handling policy or a pool shutdown in progress)
+	 * @since 4.2.1
+	 */
+	ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, Date startTime, long period);
+
+	/**
+	 * Schedule the given {@link Callable}, starting as soon as possible and
+	 * invoking it with the given period.
+	 * <p>Execution will end once the scheduler shuts down or the returned
+	 * {@link ScheduledFuture} gets cancelled.
+	 * @param task the Callable to execute whenever the trigger fires
+	 * @param period the interval between successive executions of the task (in milliseconds)
+	 * @return a {@link ScheduledFuture} representing pending completion of the task
+	 * @throws org.springframework.core.task.TaskRejectedException if the given task was not accepted
+	 * for internal reasons (e.g. a pool overload handling policy or a pool shutdown in progress)
+	 * @since 4.2.1
+	 */
+	ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, long period);
+
+	/**
+	 * Schedule the given {@link Callable}, invoking it at the specified execution time
+	 * and subsequently with the given delay between the completion of one execution
+	 * and the start of the next.
+	 * <p>Execution will end once the scheduler shuts down or the returned
+	 * {@link ScheduledFuture} gets cancelled.
+	 * @param task the Callable to execute whenever the trigger fires
+	 * @param startTime the desired first execution time for the task
+	 * (if this is in the past, the task will be executed immediately, i.e. as soon as possible)
+	 * @param delay the delay between the completion of one execution and the start
+	 * of the next (in milliseconds)
+	 * @return a {@link ScheduledFuture} representing pending completion of the task
+	 * @throws org.springframework.core.task.TaskRejectedException if the given task was not accepted
+	 * for internal reasons (e.g. a pool overload handling policy or a pool shutdown in progress)
+	 * @since 4.2.1
+	 */
+	ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, Date startTime, long delay);
+
+	/**
+	 * Schedule the given {@link Callable}, starting as soon as possible and
+	 * invoking it with the given delay between the completion of one execution
+	 * and the start of the next.
+	 * <p>Execution will end once the scheduler shuts down or the returned
+	 * {@link ScheduledFuture} gets cancelled.
+	 * @param task the Callable to execute whenever the trigger fires
+	 * @param delay the interval between successive executions of the task (in milliseconds)
+	 * @return a {@link ScheduledFuture} representing pending completion of the task
+	 * @throws org.springframework.core.task.TaskRejectedException if the given task was not accepted
+	 * for internal reasons (e.g. a pool overload handling policy or a pool shutdown in progress)
+	 * @since 4.2.1
+	 */
+	ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, long delay);
 
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ConcurrentTaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ConcurrentTaskScheduler.java
@@ -17,6 +17,7 @@
 package org.springframework.scheduling.concurrent;
 
 import java.util.Date;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -29,6 +30,7 @@ import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import org.springframework.core.task.TaskRejectedException;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.support.CallableWrapperRunnable;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 import org.springframework.scheduling.support.TaskUtils;
 import org.springframework.util.Assert;
@@ -55,6 +57,7 @@ import org.springframework.util.ErrorHandler;
  *
  * @author Juergen Hoeller
  * @author Mark Fisher
+ * @author Serdar Kuzucu
  * @since 3.0
  * @see java.util.concurrent.ScheduledExecutorService
  * @see java.util.concurrent.ScheduledThreadPoolExecutor
@@ -176,6 +179,11 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
 	}
 
 	@Override
+	public ScheduledFuture<?> schedule(Callable<?> task, Trigger trigger) {
+		return schedule(new CallableWrapperRunnable(task), trigger);
+	}
+
+	@Override
 	public ScheduledFuture<?> schedule(Runnable task, Date startTime) {
 		long initialDelay = startTime.getTime() - System.currentTimeMillis();
 		try {
@@ -184,6 +192,11 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
 		catch (RejectedExecutionException ex) {
 			throw new TaskRejectedException("Executor [" + this.scheduledExecutor + "] did not accept task: " + task, ex);
 		}
+	}
+
+	@Override
+	public ScheduledFuture<?> schedule(Callable<?> task, Date startTime) {
+		return schedule(new CallableWrapperRunnable(task), startTime);
 	}
 
 	@Override
@@ -198,6 +211,11 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
 	}
 
 	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, Date startTime, long period) {
+		return scheduleAtFixedRate(new CallableWrapperRunnable(task), startTime, period);
+	}
+
+	@Override
 	public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long period) {
 		try {
 			return this.scheduledExecutor.scheduleAtFixedRate(decorateTask(task, true), 0, period, TimeUnit.MILLISECONDS);
@@ -205,6 +223,11 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
 		catch (RejectedExecutionException ex) {
 			throw new TaskRejectedException("Executor [" + this.scheduledExecutor + "] did not accept task: " + task, ex);
 		}
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, long period) {
+		return scheduleAtFixedRate(new CallableWrapperRunnable(task), period);
 	}
 
 	@Override
@@ -219,6 +242,11 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
 	}
 
 	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, Date startTime, long delay) {
+		return scheduleWithFixedDelay(new CallableWrapperRunnable(task), startTime, delay);
+	}
+
+	@Override
 	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long delay) {
 		try {
 			return this.scheduledExecutor.scheduleWithFixedDelay(decorateTask(task, true), 0, delay, TimeUnit.MILLISECONDS);
@@ -226,6 +254,11 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
 		catch (RejectedExecutionException ex) {
 			throw new TaskRejectedException("Executor [" + this.scheduledExecutor + "] did not accept task: " + task, ex);
 		}
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, long delay) {
+		return scheduleWithFixedDelay(new CallableWrapperRunnable(task), delay);
 	}
 
 	private Runnable decorateTask(Runnable task, boolean isRepeatingTask) {

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.java
@@ -35,6 +35,7 @@ import org.springframework.lang.UsesJava7;
 import org.springframework.scheduling.SchedulingTaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.support.CallableWrapperRunnable;
 import org.springframework.scheduling.support.TaskUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -306,6 +307,11 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 	}
 
 	@Override
+	public ScheduledFuture<?> schedule(Callable<?> task, Trigger trigger) {
+		return schedule(new CallableWrapperRunnable(task), trigger);
+	}
+
+	@Override
 	public ScheduledFuture<?> schedule(Runnable task, Date startTime) {
 		ScheduledExecutorService executor = getScheduledExecutor();
 		long initialDelay = startTime.getTime() - System.currentTimeMillis();
@@ -315,6 +321,11 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 		catch (RejectedExecutionException ex) {
 			throw new TaskRejectedException("Executor [" + executor + "] did not accept task: " + task, ex);
 		}
+	}
+
+	@Override
+	public ScheduledFuture<?> schedule(Callable<?> task, Date startTime) {
+		return schedule(new CallableWrapperRunnable(task), startTime);
 	}
 
 	@Override
@@ -330,6 +341,11 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 	}
 
 	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, Date startTime, long period) {
+		return scheduleAtFixedRate(new CallableWrapperRunnable(task), startTime, period);
+	}
+
+	@Override
 	public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long period) {
 		ScheduledExecutorService executor = getScheduledExecutor();
 		try {
@@ -338,6 +354,11 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 		catch (RejectedExecutionException ex) {
 			throw new TaskRejectedException("Executor [" + executor + "] did not accept task: " + task, ex);
 		}
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, long period) {
+		return scheduleAtFixedRate(new CallableWrapperRunnable(task), period);
 	}
 
 	@Override
@@ -353,6 +374,11 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 	}
 
 	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, Date startTime, long delay) {
+		return scheduleWithFixedDelay(new CallableWrapperRunnable(task), startTime, delay);
+	}
+
+	@Override
 	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long delay) {
 		ScheduledExecutorService executor = getScheduledExecutor();
 		try {
@@ -361,6 +387,11 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 		catch (RejectedExecutionException ex) {
 			throw new TaskRejectedException("Executor [" + executor + "] did not accept task: " + task, ex);
 		}
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, long delay) {
+		return scheduleWithFixedDelay(new CallableWrapperRunnable(task), delay);
 	}
 
 

--- a/spring-context/src/main/java/org/springframework/scheduling/support/CallableWrapperRunnable.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CallableWrapperRunnable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scheduling.support;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.concurrent.Callable;
+
+import org.springframework.util.Assert;
+
+/**
+ * Runnable wrapper that executes call method of its delegate Callable.
+ * 
+ * @author Serdar Kuzucu
+ * @since 4.2.1
+ */
+public class CallableWrapperRunnable implements Runnable {
+
+	private Callable<?> delegate;
+
+	/**
+	 * Create a new CallableWrapperRunnable
+	 * 
+	 * @param delegate the Callable implementation to delegate to
+	 */
+	public CallableWrapperRunnable(Callable<?> delegate) {
+		Assert.notNull(delegate, "Delegate must not be null");
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void run() {
+		try {
+			this.delegate.call();
+		}
+		catch (Exception e) {
+			throw new UndeclaredThrowableException(e);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "CallableWrapperRunnable for " + this.delegate;
+	}
+}

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/HandlersBeanDefinitionParserTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/HandlersBeanDefinitionParserTests.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledFuture;
 
 import org.junit.Before;
@@ -321,7 +322,17 @@ class TestTaskScheduler implements TaskScheduler {
 	}
 
 	@Override
+	public ScheduledFuture<?> schedule(Callable<?> task, Trigger trigger) {
+		return null;
+	}
+
+	@Override
 	public ScheduledFuture schedule(Runnable task, Date startTime) {
+		return null;
+	}
+
+	@Override
+	public ScheduledFuture<?> schedule(Callable<?> task, Date startTime) {
 		return null;
 	}
 
@@ -331,7 +342,17 @@ class TestTaskScheduler implements TaskScheduler {
 	}
 
 	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, Date startTime, long period) {
+		return null;
+	}
+
+	@Override
 	public ScheduledFuture scheduleAtFixedRate(Runnable task, long period) {
+		return null;
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Callable<?> task, long period) {
 		return null;
 	}
 
@@ -341,7 +362,17 @@ class TestTaskScheduler implements TaskScheduler {
 	}
 
 	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, Date startTime, long delay) {
+		return null;
+	}
+
+	@Override
 	public ScheduledFuture scheduleWithFixedDelay(Runnable task, long delay) {
+		return null;
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Callable<?> task, long delay) {
 		return null;
 	}
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/WebSocketStompClientTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/WebSocketStompClientTests.java
@@ -295,7 +295,7 @@ public class WebSocketStompClientTests {
 		TcpConnection<byte[]> tcpConnection = getTcpConnection();
 
 		ScheduledFuture future = mock(ScheduledFuture.class);
-		when(this.taskScheduler.scheduleWithFixedDelay(any(), eq(1L))).thenReturn(future);
+		when(this.taskScheduler.scheduleWithFixedDelay((Runnable) any(), eq(1L))).thenReturn(future);
 
 		tcpConnection.onReadInactivity(mock(Runnable.class), 2L);
 		tcpConnection.onWriteInactivity(mock(Runnable.class), 2L);


### PR DESCRIPTION
Closes SPR-12062.
Creates class CallableWrapperRunnable to wrap Callable objects with Runnable interface. In all TaskScheduler methods which takes Callable parameter, the CallableWrapperRunnable object is used to wrap the Callable object. Then, the old TaskScheduler method which takes Runnable parameter is called.
