### PR TITLE
TypeDescriptor.equals tests equality of annotations

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
@@ -471,7 +471,7 @@ public class TypeDescriptor implements Serializable {
 			return false;
 		}
 		for (Annotation ann : getAnnotations()) {
-			if (other.getAnnotation(ann.annotationType()) == null) {
+			if (!ObjectUtils.nullSafeEquals(ann, other.getAnnotation(ann.annotationType()))) {
 				return false;
 			}
 		}

--- a/spring-core/src/test/java/org/springframework/core/convert/TypeDescriptorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/TypeDescriptorTests.java
@@ -218,6 +218,10 @@ public class TypeDescriptorTests {
 
 	}
 
+	public void testAnnotatedMethodDifferentAnnotationValue(@ParameterAnnotation(567) String parameter) {
+
+	}
+
 	@Test
 	public void propertyComplex() throws Exception {
 		Property property = new Property(getClass(), getClass().getMethod("getComplexProperty"), getClass().getMethod("setComplexProperty", Map.class));
@@ -826,6 +830,18 @@ public class TypeDescriptorTests {
 		TypeDescriptor t11 = new TypeDescriptor(getClass().getField("mapField"));
 		TypeDescriptor t12 = new TypeDescriptor(getClass().getField("mapField"));
 		assertEquals(t11, t12);
+
+		TypeDescriptor t13 = new TypeDescriptor(new MethodParameter(getClass().getMethod("testAnnotatedMethod", String.class), 0));
+		TypeDescriptor t14 = new TypeDescriptor(new MethodParameter(getClass().getMethod("testAnnotatedMethod", String.class), 0));
+		assertEquals(t13, t14);
+
+		TypeDescriptor t15 = new TypeDescriptor(new MethodParameter(getClass().getMethod("testAnnotatedMethod", String.class), 0));
+		TypeDescriptor t16 = new TypeDescriptor(new MethodParameter(getClass().getMethod("testAnnotatedMethodDifferentAnnotationValue", String.class), 0));
+		assertNotEquals(t15, t16);
+
+		TypeDescriptor t17 = new TypeDescriptor(new MethodParameter(getClass().getMethod("testAnnotatedMethod", String.class), 0));
+		TypeDescriptor t18 = new TypeDescriptor(new MethodParameter(getClass().getMethod("test5", String.class), 0));
+		assertNotEquals(t17, t18);
 	}
 
 	@Test


### PR DESCRIPTION
The current implementation of TypeDescriptor.equals merely tests for the presence of annotations between the compared type descriptors, as apposed to also comparing annotation property values.

This ultimately lead to problems with the GenericConversionService cache returning the "wrong" conditional converter in my application.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.

Issue: SPR-13714
