### PR TITLE
SPR-13713: Add mandatory behavior to SimpleNamespaceContext

### DIFF
--- a/spring-core/src/test/java/org/springframework/util/xml/SimpleNamespaceContextTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/SimpleNamespaceContextTests.java
@@ -16,101 +16,182 @@
 
 package org.springframework.util.xml;
 
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 import javax.xml.XMLConstants;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 public class SimpleNamespaceContextTests {
 
-	private final SimpleNamespaceContext context = new SimpleNamespaceContext() {{
-		bindNamespaceUri("prefix", "namespaceURI");
-	}};
+	private final String unboundPrefix = "unbound";
+	private final String prefix = "prefix";
+	private final String unboundNamespaceUri = "http://Unbound-namespace-name-URI";
+	private final String defaultNamespaceUri = "http://Default-namespace-name-URI";
+	private final String namespaceUri = "http://Namespace-name-URI";
+	private final String additionalNamespaceUri = "http://Additional-namespace-name-URI";
 
+	private SimpleNamespaceContext context;
+
+	@Before
+	public void initObjects() {
+		context = new SimpleNamespaceContext();
+	}
+
+	private Set<String> getItemSet(Iterator<String> iterator) {
+		Set<String> itemSet = new HashSet<String>();
+		while (iterator.hasNext()) {
+			itemSet.add(iterator.next());
+		}
+		return itemSet;
+	}
+
+	private Set<String> makeSet(String... items) {
+		Set<String> itemSet = new HashSet<String>();
+		for (String item : items) {
+			itemSet.add(item);
+		}
+		return itemSet;
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getNamespaceURI_withNull() throws Exception {
+		context.getNamespaceURI(null);
+	}
 
 	@Test
 	public void getNamespaceURI() {
-		assertEquals("Invalid namespaceURI for default namespace", "",
-				context.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX));
-		String defaultNamespaceUri = "defaultNamespace";
-		context.bindNamespaceUri(XMLConstants.DEFAULT_NS_PREFIX, defaultNamespaceUri);
-		assertEquals("Invalid namespaceURI for default namespace", defaultNamespaceUri,
-				context.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX));
-		assertEquals("Invalid namespaceURI for bound prefix", "namespaceURI", context.getNamespaceURI("prefix"));
-		assertEquals("Invalid namespaceURI for unbound prefix", "", context.getNamespaceURI("unbound"));
-		assertEquals("Invalid namespaceURI for namespace prefix", XMLConstants.XML_NS_URI,
-				context.getNamespaceURI(XMLConstants.XML_NS_PREFIX));
-		assertEquals("Invalid namespaceURI for attribute prefix", XMLConstants.XMLNS_ATTRIBUTE_NS_URI,
-				context.getNamespaceURI(XMLConstants.XMLNS_ATTRIBUTE));
+		context.bindNamespaceUri(XMLConstants.XMLNS_ATTRIBUTE, additionalNamespaceUri);
+		assertThat("Always returns \"http://www.w3.org/2000/xmlns/\" for \"xmlns\"",
+				context.getNamespaceURI(XMLConstants.XMLNS_ATTRIBUTE), is(XMLConstants.XMLNS_ATTRIBUTE_NS_URI));
+		context.bindNamespaceUri(XMLConstants.XML_NS_PREFIX, additionalNamespaceUri);
+		assertThat("Always returns \"http://www.w3.org/XML/1998/namespace\" for \"xml\"",
+				context.getNamespaceURI(XMLConstants.XML_NS_PREFIX), is(XMLConstants.XML_NS_URI));
+
+		assertThat("Returns \"\" for an unbound prefix", context.getNamespaceURI(unboundPrefix),
+				is(XMLConstants.NULL_NS_URI));
+		context.bindNamespaceUri(prefix, namespaceUri);
+		assertThat("Returns the bound namespace URI for a bound prefix", context.getNamespaceURI(prefix),
+				is(namespaceUri));
+
+		assertThat("By default returns URI \"\" for the default namespace prefix",
+				context.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX), is(XMLConstants.NULL_NS_URI));
+		context.bindDefaultNamespaceUri(defaultNamespaceUri);
+		assertThat("Returns the set URI for the default namespace prefix",
+				context.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX), is(defaultNamespaceUri));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getPrefix_withNull() throws Exception {
+		context.getPrefix(null);
 	}
 
 	@Test
 	public void getPrefix() {
-		assertEquals("Invalid prefix for default namespace", XMLConstants.DEFAULT_NS_PREFIX, context.getPrefix(""));
-		assertEquals("Invalid prefix for bound namespace", "prefix", context.getPrefix("namespaceURI"));
-		assertNull("Invalid prefix for unbound namespace", context.getPrefix("unbound"));
-		assertEquals("Invalid prefix for namespace", XMLConstants.XML_NS_PREFIX,
-				context.getPrefix(XMLConstants.XML_NS_URI));
-		assertEquals("Invalid prefix for attribute namespace", XMLConstants.XMLNS_ATTRIBUTE,
-				context.getPrefix(XMLConstants.XMLNS_ATTRIBUTE_NS_URI));
+		assertThat("Always returns \"xmlns\" for \"http://www.w3.org/2000/xmlns/\"",
+				context.getPrefix(XMLConstants.XMLNS_ATTRIBUTE_NS_URI), is(XMLConstants.XMLNS_ATTRIBUTE));
+		assertThat("Always returns \"xml\" for \"http://www.w3.org/XML/1998/namespace\"",
+				context.getPrefix(XMLConstants.XML_NS_URI), is(XMLConstants.XML_NS_PREFIX));
+
+		assertThat("Returns null for an unbound namespace URI", context.getPrefix(unboundNamespaceUri),
+				is(nullValue()));
+		context.bindNamespaceUri("prefix1", namespaceUri);
+		context.bindNamespaceUri("prefix2", namespaceUri);
+		assertThat("Returns a prefix for a bound namespace URI", context.getPrefix(namespaceUri),
+				anyOf(is("prefix1"), is("prefix2")));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getPrefixes_withNull() throws Exception {
+		context.getPrefixes(null);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void getPrefixes_IteratorIsNotModifiable() throws Exception {
+		context.bindNamespaceUri(prefix, namespaceUri);
+		Iterator<String> iterator = context.getPrefixes(namespaceUri);
+		iterator.remove();
 	}
 
 	@Test
 	public void getPrefixes() {
-		assertPrefixes("", XMLConstants.DEFAULT_NS_PREFIX);
-		assertPrefixes("namespaceURI", "prefix");
-		assertFalse("Invalid prefix for unbound namespace", context.getPrefixes("unbound").hasNext());
-		assertPrefixes(XMLConstants.XML_NS_URI, XMLConstants.XML_NS_PREFIX);
-		assertPrefixes(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, XMLConstants.XMLNS_ATTRIBUTE);
+		assertThat("Returns only \"xmlns\" for \"http://www.w3.org/2000/xmlns/\"",
+				getItemSet(context.getPrefixes(XMLConstants.XMLNS_ATTRIBUTE_NS_URI)),
+				is(makeSet(XMLConstants.XMLNS_ATTRIBUTE)));
+		assertThat("Returns only \"xml\" for \"http://www.w3.org/XML/1998/namespace\"",
+				getItemSet(context.getPrefixes(XMLConstants.XML_NS_URI)), is(makeSet(XMLConstants.XML_NS_PREFIX)));
+
+		assertThat("Returns empty iterator for unbound prefix", context.getPrefixes("unbound Namespace URI").hasNext(),
+				is(false));
+		context.bindNamespaceUri("prefix1", namespaceUri);
+		context.bindNamespaceUri("prefix2", namespaceUri);
+		assertThat("Returns all prefixes (and only those) bound to the namespace URI",
+				getItemSet(context.getPrefixes(namespaceUri)), is(makeSet("prefix1", "prefix2")));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void bindNamespaceUri_withNullNamespaceUri() {
+		context.bindNamespaceUri("prefix", null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void bindNamespaceUri_withNullPrefix() {
+		context.bindNamespaceUri(null, namespaceUri);
 	}
 
 	@Test
-	public void multiplePrefixes() {
-		context.bindNamespaceUri("prefix1", "namespace");
-		context.bindNamespaceUri("prefix2", "namespace");
-		Iterator<String> iterator = context.getPrefixes("namespace");
-		assertNotNull("getPrefixes returns null", iterator);
-		assertTrue("iterator is empty", iterator.hasNext());
-		String result = iterator.next();
-		assertTrue("Invalid prefix", result.equals("prefix1") || result.equals("prefix2"));
-		assertTrue("iterator is empty", iterator.hasNext());
-		result = iterator.next();
-		assertTrue("Invalid prefix", result.equals("prefix1") || result.equals("prefix2"));
-		assertFalse("iterator contains more than two values", iterator.hasNext());
-	}
-
-	private void assertPrefixes(String namespaceUri, String prefix) {
-		Iterator<String> iterator = context.getPrefixes(namespaceUri);
-		assertNotNull("getPrefixes returns null", iterator);
-		assertTrue("iterator is empty", iterator.hasNext());
-		String result = iterator.next();
-		assertEquals("Invalid prefix", prefix, result);
-		assertFalse("iterator contains multiple values", iterator.hasNext());
+	public void bindNamespaceUri() {
+		context.bindNamespaceUri(prefix, namespaceUri);
+		assertThat("The Namespace URI was bound to the prefix", context.getNamespaceURI(prefix), is(namespaceUri));
+		assertThat("The prefix was bound to the namespace URI", getItemSet(context.getPrefixes(namespaceUri)),
+				hasItem(prefix));
 	}
 
 	@Test
-	public void getBoundPrefixes() throws Exception {
-		Iterator<String> iterator = context.getBoundPrefixes();
-		assertNotNull("getPrefixes returns null", iterator);
-		assertTrue("iterator is empty", iterator.hasNext());
-		String result = iterator.next();
-		assertEquals("Invalid prefix", "prefix", result);
-		assertFalse("iterator contains multiple values", iterator.hasNext());
+	public void getBoundPrefixes() {
+		context.bindNamespaceUri("prefix1", namespaceUri);
+		context.bindNamespaceUri("prefix2", namespaceUri);
+		context.bindNamespaceUri("prefix3", additionalNamespaceUri);
+		assertThat("Returns all bound prefixes", getItemSet(context.getBoundPrefixes()),
+				is(makeSet("prefix1", "prefix2", "prefix3")));
 	}
 
 	@Test
-	public void setBindings() throws Exception {
-		context.setBindings(Collections.singletonMap("prefix", "namespace"));
-		assertEquals("Invalid namespace uri", "namespace", context.getNamespaceURI("prefix"));
+	public void clear() {
+		context.bindNamespaceUri("prefix1", namespaceUri);
+		context.bindNamespaceUri("prefix2", namespaceUri);
+		context.bindNamespaceUri("prefix3", additionalNamespaceUri);
+		context.clear();
+		assertThat("All bound prefixes were removed", context.getBoundPrefixes().hasNext(), is(false));
+		assertThat("All bound namespace URIs were removed", context.getPrefixes(namespaceUri).hasNext(), is(false));
 	}
 
 	@Test
-	public void removeBinding() throws Exception {
-		context.removeBinding("prefix");
-		assertNull("Invalid prefix for unbound namespace", context.getPrefix("prefix"));
+	public void removeBinding() {
+		context.removeBinding(unboundPrefix);
+
+		context.bindNamespaceUri(prefix, namespaceUri);
+		context.removeBinding(prefix);
+		assertThat("Returns default namespace URI for removed prefix", context.getNamespaceURI(prefix),
+				is(XMLConstants.NULL_NS_URI));
+		assertThat("#getPrefix returns null when all prefixes for a namespace URI were removed",
+				context.getPrefix(namespaceUri), is(nullValue()));
+		assertThat("#getPrefixes returns an empty iterator when all prefixes for a namespace URI were removed",
+				context.getPrefixes(namespaceUri).hasNext(), is(false));
+
+		context.bindNamespaceUri("prefix1", additionalNamespaceUri);
+		context.bindNamespaceUri("prefix2", additionalNamespaceUri);
+		context.removeBinding("prefix1");
+		assertThat("Prefix was unbound", context.getNamespaceURI("prefix1"), is(XMLConstants.NULL_NS_URI));
+		assertThat("#getPrefix returns a bound prefix after removal of another prefix for the same namespace URI",
+				context.getPrefix(additionalNamespaceUri), is("prefix2"));
+		assertThat("Prefix was removed from namespace URI", getItemSet(context.getPrefixes(additionalNamespaceUri)),
+				is(makeSet("prefix2")));
 	}
 
 }


### PR DESCRIPTION
SimpleNamespaceContext did not implement the following behavior
mandated by javax.xml.namespace.NamespaceContext (as per Java 8):
- # getPrefix and #getPrefixes with Argument `null` did not throw
  
  an IllegalArgumentException
- The iterator returned by #getPrefixes(boundPrefix) was modifiable,
  i.e. failed to throw an UnsupportedOperationException upon #remove
- # clear did not clear the map `namespaceUriToPrefixes`, hence after
  # clear an iterator returned by #getPrefixes could be non-empty
- Some mandatory functionality was implemented, but lacked unit tests

There were also code smells:
- # getPrefixesInternal used to modify the field `namespaceUriToPrefixes`
  
  despite being a getter method
- After removing all prefixes bound to a namespace URI, the map
  `namespaceUriToPrefixes` still contained the URI as key mapped to
  an empty list.

The unit testing class was extensively rewritten to ensure implementation
of the full contract. All assertions now use Hamcrest matchers for
type safety and better error messages in case of failure.

Changes to the class SimpleNamespaceContext:
- All missing functionality (described above) was added
- # getPrefixesInternal is now a clean accessor
- The field `namespaceUriToPrefixes` is now mutated via new private
  methods #addPrefixToNamespaceUri and #removePrefixFromNamespaceUri
- After removing all prefixes bound to a namespace URI, the URI is also
  removed (as key) from the map `namespaceUriToPrefixes`
- The private method #getPrefixesInternal was renamed to
  # getPrefixesList as a more telling name

Issue: SPR-13713

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
