### PR TITLE
Improve support for custom HTTP verbs in Spring MVC Test

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
@@ -42,6 +42,7 @@ import org.springframework.test.web.servlet.RequestBuilder;
  * @author Greg Turnquist
  * @author Sebastien Deleuze
  * @author Sam Brannen
+ * @author Kamill Sokol
  * @since 3.2
  */
 public abstract class MockMvcRequestBuilders {
@@ -175,7 +176,7 @@ public abstract class MockMvcRequestBuilders {
 
 	/**
 	 * Create a {@link MockHttpServletRequestBuilder} for a request with the given HTTP method.
-	 * @param httpMethod the HTTP method
+	 * @param httpMethod the HTTP method (GET, POST, etc)
 	 * @param urlTemplate a URL template; the resulting URL will be encoded
 	 * @param urlVariables zero or more URL variables
 	 */
@@ -186,10 +187,31 @@ public abstract class MockMvcRequestBuilders {
 	/**
 	 * Create a {@link MockHttpServletRequestBuilder} for a request with the given HTTP method.
 	 * @param httpMethod the HTTP method (GET, POST, etc)
+	 * @param urlTemplate a URL template; the resulting URL will be encoded
+	 * @param urlVariables zero or more URL variables
+	 * @since 4.3
+	 */
+	public static MockHttpServletRequestBuilder request(String httpMethod, String urlTemplate, Object... urlVariables) {
+		return new MockHttpServletRequestBuilder(httpMethod, urlTemplate, urlVariables);
+	}
+
+	/**
+	 * Create a {@link MockHttpServletRequestBuilder} for a request with the given HTTP method.
+	 * @param httpMethod the HTTP method (GET, POST, etc)
 	 * @param uri the URL
 	 * @since 4.0.3
 	 */
 	public static MockHttpServletRequestBuilder request(HttpMethod httpMethod, URI uri) {
+		return new MockHttpServletRequestBuilder(httpMethod, uri);
+	}
+
+	/**
+	 * Create a {@link MockHttpServletRequestBuilder} for a request with the given HTTP method.
+	 * @param httpMethod the HTTP method (GET, POST, etc)
+	 * @param uri the URL
+	 * @since 4.3
+	 */
+	public static MockHttpServletRequestBuilder request(String httpMethod, URI uri) {
 		return new MockHttpServletRequestBuilder(httpMethod, uri);
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
@@ -471,7 +471,9 @@ public class MockHttpServletRequestBuilderTests {
 		assertEquals(user, request.getUserPrincipal());
 	}
 
-	// SPR-12945
+	/**
+	 * See SPR-12945
+	 */
 	@Test
 	public void mergeInvokesDefaultRequestPostProcessorFirst() {
 		final String ATTR = "ATTR";
@@ -490,6 +492,24 @@ public class MockHttpServletRequestBuilderTests {
 		request = builder.postProcessRequest(request);
 
 		assertEquals(EXEPCTED, request.getAttribute(ATTR));
+	}
+
+	/**
+	 * See SPR-13719
+	 */
+	@Test
+	public void arbitraryMethod() {
+		/*
+		 * http method is case-sensitive
+		 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.1
+		 */
+		String httpMethod = "REPort";
+		this.builder = new MockHttpServletRequestBuilder(httpMethod, "/foo/{bar}", 42);
+
+		MockHttpServletRequest request = this.builder.buildRequest(this.servletContext);
+
+		assertEquals(httpMethod, request.getMethod());
+		assertEquals("/foo/42", request.getPathInfo());
 	}
 
 


### PR DESCRIPTION
Issue: [SPR-13719](https://jira.spring.io/browse/SPR-13719)

Prior to this commit, Spring MVC Test only supports HTTP methods GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE, TRACE and multipart file upload. This pull adds generic methods to MockMvcRequestBuilders in order to allow testing of arbitrary HTTP methods in a Spring MVC application.

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
