### PR TITLE
SPR-13752: MockHttpServletResponse.setIntHeader Content-Length

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -556,7 +556,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 			return true;
 		}
 		else if (CONTENT_LENGTH_HEADER.equalsIgnoreCase(name)) {
-			setContentLength(Integer.parseInt((String) value));
+			setContentLength(Integer.parseInt(value.toString()));
 			return true;
 		}
 		else {

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
@@ -142,6 +142,13 @@ public class MockHttpServletResponseTests {
 	}
 
 	@Test
+	public void contentLengthIntHeader() {
+		response.addIntHeader("Content-Length", 66);
+		assertEquals(66, response.getContentLength());
+		assertEquals("66", response.getHeader("Content-Length"));
+	}
+
+	@Test
 	public void httpHeaderNameCasingIsPreserved() throws Exception {
 		final String headerName = "Header1";
 		response.addHeader(headerName, "value1");

--- a/spring-web/src/test/java/org/springframework/mock/web/test/MockHttpServletResponse.java
+++ b/spring-web/src/test/java/org/springframework/mock/web/test/MockHttpServletResponse.java
@@ -542,7 +542,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 			return true;
 		}
 		else if (CONTENT_LENGTH_HEADER.equalsIgnoreCase(name)) {
-			setContentLength(Integer.parseInt((String) value));
+			setContentLength(Integer.parseInt(value.toString()));
 			return true;
 		}
 		else {


### PR DESCRIPTION
[SPR-13752: MockHttpServletResponse.setIntHeader does not support 'Content-Length' header](https://jira.spring.io/browse/SPR-13752)

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
