### PR TITLE
Format-string method called with 2 arguments but is given 3.

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/env/PropertySourceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/PropertySourceTests.java
@@ -110,8 +110,7 @@ public class PropertySourceTests {
 					ps.toString(),
 					equalTo(String.format("%s [name='%s']",
 							ps.getClass().getSimpleName(),
-							name,
-							map.size())));
+							name)));
 		} finally {
 			logger.setLevel(original);
 		}


### PR DESCRIPTION
I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
