### PR TITLE
Upgrade Caffeine dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 		classpath("org.asciidoctor:asciidoctor-gradle-plugin:1.5.2")
 		classpath("io.spring.gradle:docbook-reference-plugin:0.3.1")
 		classpath("ws.antonov.gradle.plugins:gradle-plugin-protobuf:0.9.1")
+		classpath("com.github.ben-manes:gradle-versions-plugin:0.11.3")
 	}
 }
 
@@ -28,7 +29,7 @@ configure(allprojects) { project ->
 	version = qualifyVersionIfNecessary(version)
 
 	ext.aspectjVersion       = "1.8.7"
-	ext.caffeineVersion      = "2.0.1"
+	ext.caffeineVersion      = "2.0.3"
 	ext.eclipselinkVersion   = "2.4.2"
 	ext.ehcacheVersion       = "2.10.1"
 	ext.ehcachejcacheVersion = "1.0.1"
@@ -84,6 +85,7 @@ configure(allprojects) { project ->
 	apply plugin: "propdeps"
 	apply plugin: "java"
 	apply plugin: "test-source-set-dependencies"
+	apply plugin: "com.github.ben-manes.versions"
 	apply from: "${gradleScriptDir}/ide.gradle"
 
 	configurations {


### PR DESCRIPTION
It seemed prudent to upgrade the dependency prior to usage in Spring.

I also added my [gradle-versions-plugin](https://github.com/ben-manes/gradle-versions-plugin) since it wasn't clear how Spring tracks dependency updates. This can be run using `gradle dependencyUpdates` or `gradle dU` for short. The list of other potential updates are below. Note that a `resolutionStrategy` rule can help filter out versions that don't conform to the Maven versioning conventions (like `rc`, `beta`).

@snicoll 

```
The following dependencies have later milestone versions:
 - com.fasterxml.jackson.core:jackson-databind [2.6.4 -> 2.7.0-rc2]
 - com.fasterxml.jackson.dataformat:jackson-dataformat-xml [2.6.4 -> 2.7.0-rc2]
 - com.fasterxml.jackson.datatype:jackson-datatype-jdk8 [2.6.4 -> 2.7.0-rc2]
 - com.fasterxml.jackson.datatype:jackson-datatype-joda [2.6.4 -> 2.7.0-rc2]
 - com.fasterxml.woodstox:woodstox-core [5.0.1 -> 5.0.2]
 - com.google.protobuf:protobuf-java [2.6.1 -> 3.0.0-beta-1]
 - com.googlecode.protobuf-java-format:protobuf-java-format [1.2 -> 1.4]
 - com.lowagie:itext [2.1.7 -> 4.2.2]
 - com.sun.xml.bind:jaxb-xjc [2.1.17 -> 2.2.11]
 - commons-beanutils:commons-beanutils [1.8.0 -> 1.9.2]
 - commons-digester:commons-digester [1.8.1 -> 2.1]
 - commons-io:commons-io [1.3 -> 2.4]
 - commons-logging:commons-logging [1.2 -> 99.0-does-not-exist]
 - dom4j:dom4j [1.6.1 -> 20040902.021138]
 - io.netty:netty-all [4.0.33.Final -> 5.0.0.Alpha2]
 - javax.el:javax.el-api [2.2.5 -> 3.0.1-b04]
 - javax.faces:javax.faces-api [2.2 -> 2.3-edr1]
 - javax.resource:connector-api [1.5 -> 1.6-alpha-1]
 - javax.servlet:javax.servlet-api [3.1.0 -> 4.0.0-b01]
 - javax.servlet.jsp:javax.servlet.jsp-api [2.2.1 -> 2.3.2-b02]
 - javax.validation:validation-api [1.1.0.GA -> 1.1.0.Final]
 - javax.websocket:javax.websocket-api [1.0 -> 1.1]
 - jaxen:jaxen [1.1.1 -> 1.1.6]
 - net.sf.ehcache:ehcache [2.10.1 -> 2.10.1-55]
 - org.apache.activemq:activemq-broker [5.8.0 -> 5.13.0]
 - org.apache.activemq:activemq-kahadb-store [5.8.0 -> 5.13.0]
 - org.apache.activemq:activemq-stomp [5.8.0 -> 5.13.0]
 - org.apache.taglibs:taglibs-standard-jstlel [1.2.1 -> 1.2.5]
 - org.apache.tomcat:catalina [6.0.16 -> 6.0.44]
 - org.apache.tomcat:tomcat-websocket [8.0.30 -> 9.0.0.M1]
 - org.apache.tomcat.embed:tomcat-embed-core [8.0.30 -> 9.0.0.M1]
 - org.apache.tomcat.embed:tomcat-embed-logging-juli [8.0.30 -> 9.0.0.M1]
 - org.apache.tomcat.embed:tomcat-embed-websocket [8.0.30 -> 9.0.0.M1]
 - org.asciidoctor:asciidoctor-gradle-plugin [1.5.2 -> 1.5.3]
 - org.asciidoctor:asciidoctorj [1.5.2 -> 1.6.0-alpha.1]
 - org.aspectj:aspectjrt [1.8.7 -> 1.9.0.BETA-2]
 - org.aspectj:aspectjweaver [1.8.7 -> 1.9.0.BETA-2]
 - org.beanshell:bsh [2.0b4 -> 2.0b5]
 - org.codehaus.fabric3.api:commonj [1.1.0 -> 1.1.1]
 - org.eclipse.persistence:javax.persistence [2.0.5 -> 2.1.1]
 - org.eclipse.persistence:org.eclipse.persistence.core [2.4.2 -> 2.6.2-RC1]
 - org.eclipse.persistence:org.eclipse.persistence.jpa [2.4.2 -> 2.6.2-RC1]
 - org.glassfish.tyrus:tyrus-container-servlet [1.3.5 -> 1.12]
 - org.glassfish.tyrus:tyrus-core [1.3.5 -> 1.12]
 - org.glassfish.tyrus:tyrus-server [1.3.5 -> 1.12]
 - org.glassfish.tyrus:tyrus-spi [1.3.5 -> 1.12]
 - org.hamcrest:hamcrest-core [1.3 -> 1.4-atlassian-1]
 - org.hibernate:hibernate-core [5.0.6.Final -> 5.0.6.Final]
 - org.hibernate:hibernate-entitymanager [5.0.6.Final -> 5.0.6.Final]
 - org.hibernate:hibernate-validator [5.2.2.Final -> 5.2.2.Final]
 - org.jacoco:org.jacoco.agent [0.7.1.201405082137 -> 0.7.5.201505241946]
 - org.jruby:jruby [1.7.23 -> 9.0.4.0]
 - org.mockito:mockito-core [1.10.19 -> 2.0.33-beta]
 - org.python:jython-standalone [2.5.3 -> 2.7.1b2]
 - org.skyscreamer:jsonassert [1.2.3 -> 1.3.0]
 - org.webjars:webjars-locator [0.28 -> 0.29]
 - rhino:js [1.7R1 -> 1.7R2]
 - velocity-tools:velocity-tools-view [1.4 -> 2.0-beta1]
 - ws.antonov.gradle.plugins:gradle-plugin-protobuf [0.9.1 -> 0.9.2]
```
