### PR TITLE
Fix markup in reference section 9.4.2

### DIFF
--- a/src/asciidoc/core-validation.adoc
+++ b/src/asciidoc/core-validation.adoc
@@ -349,7 +349,7 @@ the properties of instantiated `Companies` and `Employees`:
 Spring uses the concept of `PropertyEditors` to effect the conversion between an
 `Object` and a `String`. If you think about it, it sometimes might be handy to be able
 to represent properties in a different way than the object itself. For example, a `Date`
-can be represented in a human readable way (as the `String` ' `2007-14-09`'), while
+can be represented in a human readable way (as the `String` `'2007-14-09'`), while
 we're still able to convert the human readable form back to the original date (or even
 better: convert any date entered in a human readable form, back to `Date` objects). This
 behavior can be achieved by __registering custom editors__, of type


### PR DESCRIPTION
Trivial markup fix in the 'Built-in PropertyEditor implementations' section of core-validation.

Before: 
![before](https://cloud.githubusercontent.com/assets/172363/11918963/3d528d9c-a744-11e5-9a0e-0befaa5d3cbc.PNG)

After: 
![after](https://cloud.githubusercontent.com/assets/172363/11918964/448bc3e4-a744-11e5-967d-585eb03f7d5d.PNG)

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
