### PR TITLE
Fixed NPEs in AntPathMatcher

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -161,7 +161,7 @@ public class AntPathMatcher implements PathMatcher {
 
 	@Override
 	public boolean isPattern(String path) {
-		return (path.indexOf('*') != -1 || path.indexOf('?') != -1);
+		return path != null && (path.indexOf('*') != -1 || path.indexOf('?') != -1);
 	}
 
 	@Override
@@ -183,7 +183,7 @@ public class AntPathMatcher implements PathMatcher {
 	 * @return {@code true} if the supplied {@code path} matched, {@code false} if it didn't
 	 */
 	protected boolean doMatch(String pattern, String path, boolean fullMatch, Map<String, String> uriTemplateVariables) {
-		if (path.startsWith(this.pathSeparator) != pattern.startsWith(this.pathSeparator)) {
+		if (path == null || pattern == null || path.startsWith(this.pathSeparator) != pattern.startsWith(this.pathSeparator)) {
 			return false;
 		}
 

--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -638,4 +638,17 @@ public class AntPathMatcherTests {
 				"/*.html.hotel.*", pathMatcher.combine("/*.html", "hotel.*"));
 	}
 
+	@Test
+	public void testMatch_Nulls() {
+		assertFalse(pathMatcher.match("/test", null));
+		assertFalse(pathMatcher.match("/", null));
+		assertFalse(pathMatcher.match("", null));
+		assertFalse(pathMatcher.match(null, null));
+	}
+
+	@Test
+	public void testIsPattern_Null() {
+		assertFalse(pathMatcher.isPattern(null));
+	}
+
 }

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/result/MockMvcResultMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/result/MockMvcResultMatchersTests.java
@@ -31,6 +31,18 @@ public class MockMvcResultMatchersTests {
 				.match(getRedirectedUrlStubMvcResult("/resource/1"));
 	}
 
+	@Test( expected = java.lang.AssertionError.class )
+	public void testFailRedirect() throws Exception {
+		MockMvcResultMatchers.redirectedUrl("/resource/2")
+				.match(getRedirectedUrlStubMvcResult("/resource/1"));
+	}
+
+	@Test( expected = java.lang.AssertionError.class )
+	public void testFailRedirect_NotRedirect() throws Exception {
+		MockMvcResultMatchers.redirectedUrl("/resource/1")
+				.match(getForwardedUrlStubMvcResult("/resource/1"));
+	}
+
 	@Test
 	public void testRedirectPattern() throws Exception {
 		MockMvcResultMatchers.redirectedUrlPattern("/resource/*")
@@ -43,10 +55,28 @@ public class MockMvcResultMatchersTests {
 				.match(getRedirectedUrlStubMvcResult("/resource/1"));
 	}
 
+	@Test( expected = java.lang.AssertionError.class)
+	public void testFailRedirectPattern_NotRedirect() throws Exception {
+		MockMvcResultMatchers.redirectedUrlPattern("/resource/")
+				.match(getForwardedUrlStubMvcResult("/resource/1"));
+	}
+
 	@Test
 	public void testForward() throws Exception {
 		MockMvcResultMatchers.forwardedUrl("/api/resource/1")
 				.match(getForwardedUrlStubMvcResult("/api/resource/1"));
+	}
+
+	@Test( expected = java.lang.AssertionError.class )
+	public void testFailForward() throws Exception {
+		MockMvcResultMatchers.forwardedUrl("/api/resource/2")
+				.match(getForwardedUrlStubMvcResult("/api/resource/1"));
+	}
+
+	@Test( expected = java.lang.AssertionError.class )
+	public void testFailForward_NotForward() throws Exception {
+		MockMvcResultMatchers.forwardedUrl("/api/resource/1")
+				.match(getRedirectedUrlStubMvcResult("/api/resource/1"));
 	}
 
 	@Test
@@ -59,6 +89,18 @@ public class MockMvcResultMatchersTests {
 	public void testForwardPattern() throws Exception {
 		MockMvcResultMatchers.forwardedUrlPattern("/api/**/?")
 				.match(getForwardedUrlStubMvcResult("/api/resource/1"));
+	}
+
+	@Test( expected = java.lang.AssertionError.class )
+	public void testFailForwardPattern() throws Exception {
+		MockMvcResultMatchers.forwardedUrlPattern("/api/resource/")
+				.match(getForwardedUrlStubMvcResult("/api/resource/1"));
+	}
+
+	@Test( expected = java.lang.AssertionError.class )
+	public void testFailForwardPattern_NotForward() throws Exception {
+		MockMvcResultMatchers.forwardedUrlPattern("/api/resource/")
+				.match(getRedirectedUrlStubMvcResult("/api/resource/1"));
 	}
 
 	private StubMvcResult getRedirectedUrlStubMvcResult(String redirectUrl) throws Exception {


### PR DESCRIPTION
I noticed that the MVC Test **redirectedUrl** matcher fails with a NullPointerException if there happens to be no Redirected URL on the response (the test should still fail, but with a proper assertion error).

One way to fix this would be to **assertNotNull** in the respective **MockMvcResultMatchers** method before calling the **AntPathMatcher**, but I thought it would be more appropriate to fix the underlying null-safety issues. You may disagree.
