### PR TITLE
SPR-13044 MockRestRequestMatchers should have matchers for form data

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/match/ContentRequestMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/match/ContentRequestMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,9 @@ import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 
 import org.hamcrest.Matcher;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.util.MultiValueMap;
 import org.w3c.dom.Node;
 
 import org.springframework.http.MediaType;
@@ -176,6 +179,23 @@ public class ContentRequestMatchers {
 			@Override
 			protected void matchInternal(MockClientHttpRequest request) throws Exception {
 				xmlHelper.assertSource(request.getBodyAsString(), matcher);
+			}
+		};
+	}
+
+	/**
+	 * Compare the body of the request to the form given as MultiValueMap.
+	 * @since 4.3
+	 */
+	public RequestMatcher formData(final MultiValueMap<String, String> expectedContent) {
+		return new RequestMatcher() {
+			@Override
+			public void match(ClientHttpRequest request) throws IOException, AssertionError {
+				MockClientHttpRequest mockRequest = (MockClientHttpRequest) request;
+				MockHttpInputMessage mockHttpInputMessage = new MockHttpInputMessage(mockRequest.getBodyAsBytes());
+				mockHttpInputMessage.getHeaders().putAll(request.getHeaders());
+				FormHttpMessageConverter formHttpMessageConverter = new FormHttpMessageConverter();
+				assertEquals("Request formData", expectedContent, formHttpMessageConverter.read(null, mockHttpInputMessage));
 			}
 		};
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/client/match/ContentRequestMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/match/ContentRequestMatchersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import org.junit.Test;
 
 import org.springframework.http.MediaType;
 import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import static org.hamcrest.Matchers.*;
 
@@ -117,6 +119,29 @@ public class ContentRequestMatchersTests {
 		this.request.getBody().write(content.getBytes());
 
 		MockRestRequestMatchers.content().node(hasXPath("/foo/bar/bar")).match(this.request);
+	}
+
+	@Test
+	public void testFormMatcher() throws Exception {
+		String content = "foo=foo&bar=bar";
+		this.request.getHeaders().setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		this.request.getBody().write(content.getBytes());
+
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+		form.add("bar", "bar");
+		form.add("foo", "foo");
+		MockRestRequestMatchers.content().formData(form).match(this.request);
+	}
+
+	@Test(expected=AssertionError.class)
+	public void testFormMatcherNoMatch() throws Exception {
+		String content = "foo=foo&bar=bar";
+		this.request.getHeaders().setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		this.request.getBody().write(content.getBytes());
+
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+		form.add("foobar", "bar");
+		MockRestRequestMatchers.content().formData(form).match(this.request);
 	}
 
 }


### PR DESCRIPTION
Implementation of client matcher to assert if request contains expected form data

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
