### PR TITLE
Fix AntPathMatcher.isPattern for URI templates

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -161,7 +161,7 @@ public class AntPathMatcher implements PathMatcher {
 
 	@Override
 	public boolean isPattern(String path) {
-		return (path.indexOf('*') != -1 || path.indexOf('?') != -1);
+		return (path.indexOf('*') != -1 || path.indexOf('?') != -1 || path.indexOf('{') != -1);
 	}
 
 	@Override

--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -134,6 +134,22 @@ public class AntPathMatcherTests {
 	}
 
 	@Test
+	public void isPattern() {
+		assertTrue(pathMatcher.isPattern("/tes?"));
+		assertTrue(pathMatcher.isPattern("/bla/*"));
+		assertTrue(pathMatcher.isPattern("/bla/**"));
+		assertTrue(pathMatcher.isPattern("/{bla}.*"));
+		assertTrue(pathMatcher.isPattern("/{bla}.jpg"));
+
+		assertFalse(pathMatcher.isPattern("/test"));
+		assertFalse(pathMatcher.isPattern("test"));
+		assertFalse(pathMatcher.isPattern("test.jpg"));
+		assertFalse(pathMatcher.isPattern("bla/test.jpg"));
+		assertFalse(pathMatcher.isPattern("/bla/test.jpg"));
+	}
+
+
+	@Test
 	public void withMatchStart() {
 		// test exact matching
 		assertTrue(pathMatcher.matchStart("test", "test"));


### PR DESCRIPTION
I'm not sure but I think AntPathMatcher.isPattern("/{bla}.jpg") should return true.
