### PR TITLE
Speed up AntPathMatcher by doing prefix-match

### DIFF
--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -618,10 +618,42 @@ public class AntPathMatcherTests {
 		assertTrue(pathMatcher.stringMatcherCache.size() > 20);
 
 		for (int i = 0; i < 65536; i++) {
-			pathMatcher.match("test" + i, "test");
+			pathMatcher.match("test" + i, "test" + i);
 		}
 		// Cache keeps being alive due to the explicit cache setting
 		assertTrue(pathMatcher.stringMatcherCache.size() > 65536);
+	}
+
+	@Test
+	public void preventCreatingStringMatchersIfPathDoesNotStartsWithPatternPrefix() {
+		pathMatcher.setCachePatterns(true);
+		assertEquals(0, pathMatcher.stringMatcherCache.size());
+
+		pathMatcher.match("test?", "test");
+		assertEquals(1, pathMatcher.stringMatcherCache.size());
+
+		pathMatcher.match("test?", "best");
+		pathMatcher.match("test/*", "view/test.jpg");
+		pathMatcher.match("test/**/test.jpg", "view/test.jpg");
+		pathMatcher.match("test/{name}.jpg", "view/test.jpg");
+		assertEquals(1, pathMatcher.stringMatcherCache.size());
+	}
+
+	@Test
+	public void creatingStringMatchersIfPatternPrefixCannotDetermineIfPathMatch() {
+		pathMatcher.setCachePatterns(true);
+		assertEquals(0, pathMatcher.stringMatcherCache.size());
+
+		pathMatcher.match("test", "testian");
+		pathMatcher.match("test?", "testFf");
+		pathMatcher.match("test/*", "test/dir/name.jpg");
+		pathMatcher.match("test/{name}.jpg", "test/lorem.jpg");
+		pathMatcher.match("bla/**/test.jpg", "bla/test.jpg");
+		pathMatcher.match("**/{name}.jpg", "test/lorem.jpg");
+		pathMatcher.match("/**/{name}.jpg", "/test/lorem.jpg");
+		pathMatcher.match("/*/dir/{name}.jpg", "/*/dir/lorem.jpg");
+
+		assertEquals(7, pathMatcher.stringMatcherCache.size());
 	}
 
 	@Test


### PR DESCRIPTION
Many ant style patterns has prefix that can be used to determine if there is no need to do complicated and costly matching. 
For example pattern "/static/css/*" have prefix "/static/css/" that can be used to say that path "/api/resource/1234" will not match. 

This was tested with https://gist.github.com/soldierkam/c80e433aa9fbec35df5a
Before:

| Benchmark | Mode | Cnt | Score | Error | Units |
| --- | --- | --- | --- | --- | --- |
| MyBenchmark.isMatching | thrpt | 5 | 425995,288 ± | 162966,573 | ops/s |
| MyBenchmark.isNotMatching | thrpt | 5 | 864690,507 ± | 130643,210 | ops/s |
| MyBenchmark.suffix | thrpt | 5 | 748551,270 ± | 17229,496 | ops/s |

After:

| Benchmark | Mode | Cnt | Score | Error | Units |
| --- | --- | --- | --- | --- | --- |
| MyBenchmark.isMatching | thrpt | 5 | 483815,001  ± | 105669,816 | ops/s |
| MyBenchmark.isNotMatching | thrpt | 5 | 10208718,438 ± | 125879,376 | ops/s |
| MyBenchmark.suffix | thrpt | 5 | 624841,454  ± | 349001,674 | ops/s |

Result: over 10x faster for isNotMatching and 17% slower for "suffix" case.

I tested it with https://github.com/spring-projects/spring-boot/tree/master/spring-boot-samples/spring-boot-sample-data-rest (wrk -c 40 -d 30 -t 2 http://127.0.0.1:8080/api/hotels) but results are almost the same (before: 310.15req/seq, after: 305.41req/sec).
For https://github.com/spring-projects/spring-boot/tree/master/spring-boot-samples/spring-boot-sample-actuator-ui (wrk -c 40 -d 30 -t 2 http://localhost:8080/css/bootstrap.min.css) there is small perf improvement - before: 2237.90req/seq, after: 2353.93req/sec
For real world application (that contains many more endpoints) I've got 17% more throughput for endpoint serving static resource (baseline is at 1812req/sec).

Let me know what you think.
