### PR TITLE
DefaultListableBeanFactory getBeansOfType initialize beans when includeNonSingletons is false

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -446,7 +446,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 						// In case of FactoryBean, match object created by FactoryBean.
 						boolean isFactoryBean = isFactoryBean(beanName, mbd);
 						boolean matchFound = (allowEagerInit || !isFactoryBean || containsSingleton(beanName)) &&
-								(includeNonSingletons || isSingleton(beanName)) && isTypeMatch(beanName, type);
+								isTypeMatch(beanName, type) && (includeNonSingletons || isSingleton(beanName));
 						if (!matchFound && isFactoryBean) {
 							// In case of FactoryBean, try to match FactoryBean instance itself next.
 							beanName = FACTORY_BEAN_PREFIX + beanName;

--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -206,21 +206,7 @@ public class DefaultListableBeanFactoryTests {
 	}
 
 	@Test
-	public void testSingletonFactoryBeanInitialized() {
-		DummyFactoryInitialized.reset();
-		DefaultListableBeanFactory lbf = new DefaultListableBeanFactory();
-		Properties p = new Properties();
-		p.setProperty("x1.(class)", DummyFactoryInitialized.class.getName());
-		assertTrue("bean not initialized", !DummyFactoryInitialized.beanInitialized());
-		(new PropertiesBeanDefinitionReader(lbf)).registerBeanDefinitions(p);
-		assertTrue("bean not initialized", !DummyFactoryInitialized.beanInitialized());
-		lbf.preInstantiateSingletons();
-
-		assertTrue("bean initialized", DummyFactoryInitialized.beanInitialized());
-	}
-
-	@Test
-	public void testLazySingletonFactoryBeanInitialized() {
+	public void testLazySingletonFactoryBeanInitializedIncludePrototypes() {
 		DummyFactoryInitialized.reset();
 		DefaultListableBeanFactory lbf = new DefaultListableBeanFactory();
 		Properties p = new Properties();
@@ -232,14 +218,12 @@ public class DefaultListableBeanFactoryTests {
 		lbf.preInstantiateSingletons();
 
 		assertTrue("bean not initialized", !DummyFactoryInitialized.beanInitialized());
+		lbf.getBeansOfType(KnowsIfInstantiated.class, true, true);
+		assertTrue("bean not initialized", !DummyFactoryInitialized.beanInitialized());
+
+		// ignore prototypes
 		lbf.getBeansOfType(KnowsIfInstantiated.class, false, true);
 		assertTrue("bean not initialized", !DummyFactoryInitialized.beanInitialized());
-
-		lbf.getBeansOfType(TestBean.class, false, false);
-		assertTrue("bean not initialized", !DummyFactoryInitialized.beanInitialized());
-
-		lbf.getBeansOfType(TestBean.class, false, true);
-		assertTrue("bean initialized", DummyFactoryInitialized.beanInitialized());
 	}
 
 	@Test


### PR DESCRIPTION
Hi,

I have a question:  
in DefaultListableBeanFactory the method call getBeansOfType(MyClass.class, false, true) will initialize lazy singleton beans, but the call getBeansOfType(class, true, true) not. 
Is this a correct behaviour?

Regards,
Sergej
