### PR TITLE
Use synchonous API for synchonous OkHttp requests

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/OkHttpAsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/OkHttpAsyncClientHttpRequest.java
@@ -19,22 +19,27 @@ package org.springframework.http.client;
 import java.io.IOException;
 import java.net.URI;
 
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
- * {@link ClientHttpRequest} implementation that uses OkHttp to execute requests.
+ * {@link AsyncClientHttpRequest} implementation that uses OkHttp to execute requests.
  *
  * <p>Created via the {@link OkHttpClientHttpRequestFactory}.
  *
  * @author Luciano Leggieri
  * @author Arjen Poutsma
- * @since 4.2
+ * @since 4.3
  */
-class OkHttpClientHttpRequest extends AbstractBufferingClientHttpRequest {
+class OkHttpAsyncClientHttpRequest extends AbstractBufferingAsyncClientHttpRequest {
 
 	private final OkHttpClient client;
 
@@ -43,7 +48,7 @@ class OkHttpClientHttpRequest extends AbstractBufferingClientHttpRequest {
 	private final HttpMethod method;
 
 
-	public OkHttpClientHttpRequest(OkHttpClient client, URI uri, HttpMethod method) {
+	public OkHttpAsyncClientHttpRequest(OkHttpClient client, URI uri, HttpMethod method) {
 		this.client = client;
 		this.uri = uri;
 		this.method = method;
@@ -60,15 +65,40 @@ class OkHttpClientHttpRequest extends AbstractBufferingClientHttpRequest {
 		return this.uri;
 	}
 
-
 	@Override
-	protected ClientHttpResponse executeInternal(HttpHeaders headers, byte[] content)
+	protected ListenableFuture<ClientHttpResponse> executeInternal(HttpHeaders headers, byte[] content)
 			throws IOException {
 
 		Request request = OkHttpClientHttpRequestFactory
 				.buildRequest(headers, content, this.uri, this.method);
 
-		return new OkHttpClientHttpResponse(this.client.newCall(request).execute());
+		return new OkHttpListenableFuture(this.client.newCall(request));
+	}
+
+	private static class OkHttpListenableFuture
+			extends SettableListenableFuture<ClientHttpResponse> {
+
+		private final Call call;
+
+		public OkHttpListenableFuture(Call call) {
+			this.call = call;
+			this.call.enqueue(new Callback() {
+				@Override
+				public void onResponse(Response response) {
+					set(new OkHttpClientHttpResponse(response));
+				}
+
+				@Override
+				public void onFailure(Request request, IOException ex) {
+					setException(ex);
+				}
+			});
+		}
+
+		@Override
+		protected void interruptTask() {
+			this.call.cancel();
+		}
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/OkHttpClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/OkHttpClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,22 @@
 
 package org.springframework.http.client;
 
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
 
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link ClientHttpRequestFactory} implementation that uses
@@ -90,17 +98,39 @@ public class OkHttpClientHttpRequestFactory
 
 	@Override
 	public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
-		return createRequestInternal(uri, httpMethod);
+		return new OkHttpClientHttpRequest(this.client, uri, httpMethod);
 	}
 
 	@Override
 	public AsyncClientHttpRequest createAsyncRequest(URI uri, HttpMethod httpMethod) {
-		return createRequestInternal(uri, httpMethod);
+		return new OkHttpAsyncClientHttpRequest(this.client, uri, httpMethod);
 	}
 
-	private OkHttpClientHttpRequest createRequestInternal(URI uri, HttpMethod httpMethod) {
-		return new OkHttpClientHttpRequest(this.client, uri, httpMethod);
+	static Request buildRequest(HttpHeaders headers, byte[] content, URI uri,
+			HttpMethod method) throws MalformedURLException {
+		com.squareup.okhttp.MediaType contentType = getContentType(headers);
+		RequestBody body =
+				(content.length > 0 ? RequestBody.create(contentType, content) : null);
+
+		URL url = uri.toURL();
+		String methodName = method.name();
+		Request.Builder builder = new Request.Builder().url(url).method(methodName, body);
+
+		for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+			String headerName = entry.getKey();
+			for (String headerValue : entry.getValue()) {
+				builder.addHeader(headerName, headerValue);
+			}
+		}
+		return builder.build();
 	}
+
+	private static com.squareup.okhttp.MediaType getContentType(HttpHeaders headers) {
+		String rawContentType = headers.getFirst(HttpHeaders.CONTENT_TYPE);
+		return (StringUtils.hasText(rawContentType) ?
+				com.squareup.okhttp.MediaType.parse(rawContentType) : null);
+	}
+
 
 	@Override
 	public void destroy() throws Exception {


### PR DESCRIPTION
This commit changes the OkHttpClientHttpRequestFactory to use the
synchronous OkHttp API for non-async requests, as opposed to
synchronizing the async API (which it used to do).

Issue: SPR-13942
