### PR TITLE
Introduce specific exceptions for field and method autowiring failures

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -587,7 +587,7 @@ public class AutowiredAnnotationBeanPostProcessor extends InstantiationAwareBean
 				}
 			}
 			catch (Throwable ex) {
-				throw new BeanCreationException("Could not autowire field: " + field, ex);
+				throw new FieldAutowiringException(field, ex);
 			}
 		}
 	}
@@ -675,7 +675,7 @@ public class AutowiredAnnotationBeanPostProcessor extends InstantiationAwareBean
 				throw ex.getTargetException();
 			}
 			catch (Throwable ex) {
-				throw new BeanCreationException("Could not autowire method: " + method, ex);
+				throw new MethodAutowiringException(method, ex);
 			}
 		}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/FieldAutowiringException.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/FieldAutowiringException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.annotation;
+
+import java.lang.reflect.Field;
+
+import org.springframework.beans.factory.BeanCreationException;
+
+/**
+ * Exception thrown when a failure occurs when attempting to autowire a field.
+ * 
+ * @author Andy Wilkinson
+ * @since 4.3.0
+ */
+@SuppressWarnings("serial")
+public class FieldAutowiringException extends BeanCreationException {
+
+	private final Field field;
+
+	/**
+	 * Create a new FieldAutowiringException.
+	 * @param field the field that could not be autowired
+	 * @param cause the cause of the failure
+	 */
+	public FieldAutowiringException(Field field, Throwable cause) {
+		super("Could not autowire field: " + field, cause);
+		this.field = field;
+	}
+
+	/**
+	 * Returns the field that could not be autowired.
+	 */
+	public Field getField() {
+		return field;
+	}
+
+}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/MethodAutowiringException.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/MethodAutowiringException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.annotation;
+
+import java.lang.reflect.Method;
+
+import org.springframework.beans.factory.BeanCreationException;
+
+/**
+ * Exception thrown when a failure occurs when attempting to autowire a method.
+ * 
+ * @author Andy Wilkinson
+ * @since 4.3.0
+ */
+@SuppressWarnings("serial")
+public class MethodAutowiringException extends BeanCreationException {
+
+	private final Method method;
+
+	/**
+	 * Create a new MethodAutowiringException.
+	 * @param method the method that could not be autowired
+	 * @param cause the cause of the failure
+	 */
+	public MethodAutowiringException(Method method, Throwable cause) {
+		super("Could not autowire method: " + method, cause);
+		this.method = method;
+	}
+
+	/**
+	 * Returns the method that could not be autowired.
+	 */
+	public Method getMethod() {
+		return method;
+	}
+
+}


### PR DESCRIPTION
Previously, a BeanCreationException was used when autowiring of a field or method failed. Details of the field or method were included in the exception message. This meant that anyone who wanted to access
information about the field or method had to resort to the error-prone approach of parsing the exception’s message.

This pull request introduces two new exceptions, FieldAutowiringException and MethodAutowiringException, that provide access to the Field or Method for which autowiring has failed.
