### PR TITLE
Consistent descriptions for ConfigurationClass

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
@@ -103,7 +103,7 @@ final class ConfigurationClass {
 	public ConfigurationClass(Class<?> clazz, String beanName) {
 		Assert.hasText(beanName, "Bean name must not be null");
 		this.metadata = new StandardAnnotationMetadata(clazz, true);
-		this.resource = new DescriptiveResource(clazz.toString());
+		this.resource = new DescriptiveResource(clazz.getName());
 		this.beanName = beanName;
 	}
 
@@ -117,7 +117,7 @@ final class ConfigurationClass {
 	 */
 	public ConfigurationClass(Class<?> clazz, ConfigurationClass importedBy) {
 		this.metadata = new StandardAnnotationMetadata(clazz, true);
-		this.resource = new DescriptiveResource(clazz.toString());
+		this.resource = new DescriptiveResource(clazz.getName());
 		this.importedBy.add(importedBy);
 	}
 


### PR DESCRIPTION
Previously, a ConfigurationClass created from AnnotationMetadata
and a ConfigurationClass created from a class would have subtly
different descriptions. Given a class named com.example.Foo, the
former’s description would be “com.example.Foo”, whereas the latter’s
description would be “class com.example.Foo”.

This commit updates ConfigurationClass to make the description
consistent, preferring the description without “class” in it.
