### PR TITLE
Support for @ExceptionHandler exclusions

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/ExceptionHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,7 @@ import java.lang.annotation.Target;
  *
  * @author Arjen Poutsma
  * @author Juergen Hoeller
+ * @author Martin Macko
  * @since 3.0
  * @see org.springframework.web.context.request.WebRequest
  * @see org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerExceptionResolver
@@ -129,4 +130,9 @@ public @interface ExceptionHandler {
 	 */
 	Class<? extends Throwable>[] value() default {};
 
+	/**
+	 * Exceptions excluded from handling by the annotated method.
+	 * @since 5.0
+	 */
+	Class<? extends Throwable>[] exclude() default {};
 }

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import static org.junit.Assert.*;
  * Test fixture for {@link ExceptionHandlerMethodResolver} tests.
  *
  * @author Rossen Stoyanchev
+ * @author Martin Macko
  */
 public class ExceptionHandlerMethodResolverTests {
 
@@ -88,9 +89,36 @@ public class ExceptionHandlerMethodResolverTests {
 		new ExceptionHandlerMethodResolver(AmbiguousController.class);
 	}
 
+	@Test(expected = IllegalStateException.class)
+	public void misconfiguredExclusion() {
+		new ExceptionHandlerMethodResolver(MisconfiguredExclusionController.class);
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void noExceptionMapping() {
 		new ExceptionHandlerMethodResolver(NoExceptionController.class);
+	}
+
+	@Test
+	public void bubblingUpSocketExpection() {
+		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(BubblingUpSocketExclusionController.class);
+		SocketException exception = new SocketException();
+		assertNotEquals("handleIOExceptionButNoSocketException", resolver.resolveMethod(exception));
+		assertEquals("handle", resolver.resolveMethod(exception).getName());
+	}
+
+	@Test
+	public void noExceptionMappingWithExclusion() {
+		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(ExceptionWithExclusionsController.class);
+		SocketException exception = new SocketException();
+		assertNull(resolver.resolveMethod(exception));
+	}
+
+	@Test
+	public void higherExceptionInExclusion() {
+		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(HigherExceptionInExclusionController.class);
+		SocketException exception = new SocketException();
+		assertEquals("handle", resolver.resolveMethod(exception).getName());
 	}
 
 	@Controller
@@ -108,6 +136,41 @@ public class ExceptionHandlerMethodResolverTests {
 
 		@ExceptionHandler
 		public void handleIllegalArgumentException(IllegalArgumentException exception) {
+		}
+	}
+
+	@Controller
+	static class BubblingUpSocketExclusionController {
+
+		@ExceptionHandler(value = Exception.class)
+		public void handle() {}
+
+
+		@ExceptionHandler(value = IOException.class, exclude = SocketException.class)
+		public void handleIOExceptionButNoSocketException() {
+		}
+	}
+
+	@Controller
+	static class ExceptionWithExclusionsController {
+
+		@ExceptionHandler(value = IOException.class, exclude = SocketException.class)
+		public void handleIOException() {
+		}
+	}
+
+	@Controller
+	static class MisconfiguredExclusionController {
+
+		@ExceptionHandler(value = SocketException.class, exclude = SocketException.class)
+		public void handleIOException() {
+		}
+	}
+
+	@Controller
+	static class HigherExceptionInExclusionController {
+		@ExceptionHandler(value = SocketException.class, exclude = Exception.class)
+		public void handle() {
 		}
 	}
 


### PR DESCRIPTION
Added support for excluding an exception from being handled in a method
annotated with @ExceptionHandler.

Issue: SPR-13932

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
