### PR TITLE
SPR-11055 REST parameter annotations on supertypes/interfaces

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractCookieValueMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractCookieValueMethodArgumentResolver.java
@@ -50,7 +50,7 @@ public abstract class AbstractCookieValueMethodArgumentResolver extends Abstract
 
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
+	protected boolean supportsLocalParameter(MethodParameter parameter) {
 		return parameter.hasParameterAnnotation(CookieValue.class);
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractNamedValueMethodArgumentResolver.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.ValueConstants;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.RequestScope;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.AbstractAnnotationBasedHandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
@@ -57,7 +57,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * @author Juergen Hoeller
  * @since 3.1
  */
-public abstract class AbstractNamedValueMethodArgumentResolver implements HandlerMethodArgumentResolver {
+public abstract class AbstractNamedValueMethodArgumentResolver
+		extends AbstractAnnotationBasedHandlerMethodArgumentResolver {
 
 	private final ConfigurableBeanFactory configurableBeanFactory;
 
@@ -83,8 +84,9 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements Handle
 
 
 	@Override
-	public final Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+	protected Object resolveLocalArgument(MethodParameter parameter,
+			ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory) throws Exception {
 
 		NamedValueInfo namedValueInfo = getNamedValueInfo(parameter);
 		MethodParameter nestedParameter = parameter.nestedIfOptional();

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/ExpressionValueMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/ExpressionValueMethodArgumentResolver.java
@@ -50,7 +50,7 @@ public class ExpressionValueMethodArgumentResolver extends AbstractNamedValueMet
 
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
+	protected boolean supportsLocalParameter(MethodParameter parameter) {
 		return parameter.hasParameterAnnotation(Value.class);
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestHeaderMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestHeaderMethodArgumentResolver.java
@@ -54,7 +54,7 @@ public class RequestHeaderMethodArgumentResolver extends AbstractNamedValueMetho
 
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
+	protected boolean supportsLocalParameter(MethodParameter parameter) {
 		return (parameter.hasParameterAnnotation(RequestHeader.class) &&
 				!Map.class.isAssignableFrom(parameter.nestedIfOptional().getNestedParameterType()));
 	}

--- a/spring-web/src/main/java/org/springframework/web/method/support/AbstractAnnotationBasedHandlerMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/AbstractAnnotationBasedHandlerMethodArgumentResolver.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.method.support;
+
+import java.util.Iterator;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+
+/**
+ * Annotation-based {@link HandlerMethodArgumentResolver} structure, respecting
+ * inheritance of method parameter annotations.
+ *
+ * @author Matt Benson
+ * @since 4.3.0
+ */
+public abstract class AbstractAnnotationBasedHandlerMethodArgumentResolver
+		implements HandlerMethodArgumentResolver {
+
+	@Override
+	public final boolean supportsParameter(MethodParameter parameter) {
+		return supportedMethodParameter(parameter) != null;
+	}
+
+	/**
+	 * Determine whether the specified {@link MethodParameter} from some level of the
+	 * original method's override hierarchy is supported by this resolver.
+	 *
+	 * @param parameter the method parameter to check
+	 * @return {@code true} if this resolver supports the supplied parameter;
+	 *         {@code false} otherwise
+	 */
+	protected abstract boolean supportsLocalParameter(MethodParameter parameter);
+
+	@Override
+	public final Object resolveArgument(MethodParameter parameter,
+			ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory) throws Exception {
+		MethodParameter mp = supportedMethodParameter(parameter);
+		return (mp == null ? null
+				: resolveLocalArgument(mp, mavContainer, webRequest, binderFactory));
+	}
+
+	/**
+	 * Resolve a {@link MethodParameter} from some level of the original method's
+	 * override hierarchy into an argument value from a given message.
+	 *
+	 * @param parameter the method parameter to resolve. This parameter must have
+	 *        previously been passed to
+	 *        {@link #supportsParameter(org.springframework.core.MethodParameter)} which
+	 *        must have returned {@code true}.
+	 * @param message the currently processed message
+	 * @return the resolved argument value, or {@code null}
+	 * @throws Exception in case of errors with the preparation of argument values
+	 */
+	protected abstract Object resolveLocalArgument(MethodParameter parameter,
+			ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory) throws Exception;
+
+	private MethodParameter supportedMethodParameter(MethodParameter parameter) {
+		for (Iterator<MethodParameter> parameters = MethodParameterUtils.parameterHierarchy(
+				parameter).iterator(); parameters.hasNext();) {
+			MethodParameter p = parameters.next();
+			if (supportsLocalParameter(p)) {
+				return p;
+			}
+		}
+		return null;
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/method/support/MethodParameterUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/MethodParameterUtils.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.method.support;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.core.annotation.SynthesizingMethodParameter;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.ReflectionUtils.MethodCallback;
+import org.springframework.util.ReflectionUtils.MethodFilter;
+
+/**
+ * {@link MethodParameter} utility methods.
+ *
+ * @author Matt Benson
+ * @since 4.3.0
+ */
+public abstract class MethodParameterUtils {
+
+	private static final ParameterNameDiscoverer PARAMETER_NAME_DISCOVERER =
+			new DefaultParameterNameDiscoverer();
+
+
+	private MethodParameterUtils() {
+	}
+
+	/**
+	 * Return an {@link Iterable} representing the sequence of {@link MethodParameter}
+	 * instances from the original argument up the method override hierarchy.
+	 *
+	 * @param parameter to expand
+	 * @return {@link Iterable} of {@link MethodParameter}
+	 */
+	public static Iterable<MethodParameter> parameterHierarchy(
+			final MethodParameter parameter) {
+		final Iterator<Method> wrapped = overriddenMethods(
+				parameter.getMethod()).iterator();
+
+		return new Iterable<MethodParameter>() {
+
+			@Override
+			public Iterator<MethodParameter> iterator() {
+				return new Iterator<MethodParameter>() {
+
+					@Override
+					public MethodParameter next() {
+						MethodParameter result = new SynthesizingMethodParameter(
+								wrapped.next(), parameter.getParameterIndex());
+						result.initParameterNameDiscovery(PARAMETER_NAME_DISCOVERER);
+						return result;
+					}
+
+					@Override
+					public boolean hasNext() {
+						return wrapped.hasNext();
+					}
+				};
+			}
+		};
+	}
+
+	private static Iterable<Method> overriddenMethods(final Method m) {
+		final Set<Method> result = new LinkedHashSet<Method>();
+
+		ReflectionUtils.doWithMethods(m.getDeclaringClass(), new MethodCallback() {
+
+			@Override
+			public void doWith(Method method)
+					throws IllegalArgumentException, IllegalAccessException {
+				result.add(method);
+			}
+		}, new MethodFilter() {
+
+			@Override
+			public boolean matches(Method method) {
+				return method == m
+						|| method.getName().equals(m.getName()) && Arrays.equals(
+								method.getParameterTypes(), m.getParameterTypes());
+			}
+		});
+		if (!m.getDeclaringClass().isInterface()) {
+			for (Iterator<Class<?>> intrfaces = ClassUtils.getAllInterfacesForClassAsSet(
+					m.getDeclaringClass()).iterator(); intrfaces.hasNext();) {
+				result.add(ReflectionUtils.findMethod(intrfaces.next(), m.getName(),
+						m.getParameterTypes()));
+			}
+			result.remove(null);
+		}
+		return result;
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/ExpressionValueMethodArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/ExpressionValueMethodArgumentResolverTests.java
@@ -17,11 +17,16 @@
 package org.springframework.web.method.annotation;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.MethodParameter;
 import org.springframework.mock.web.test.MockHttpServletRequest;
@@ -38,7 +43,20 @@ import static org.junit.Assert.*;
  *
  * @author Rossen Stoyanchev
  */
+@RunWith(Parameterized.class)
 public class ExpressionValueMethodArgumentResolverTests {
+
+	@Parameters(name = "{0}")
+	public static List<Object[]> createParameters() {
+		List<Object[]> parameters = new ArrayList<Object[]>();
+		parameters.add(new Object[] { Foo.class });
+		parameters.add(new Object[] { Bar.class });
+		parameters.add(new Object[] { Baz.class });
+		return parameters;
+	}
+
+	@Parameter(0)
+	public Class<?> target;
 
 	private ExpressionValueMethodArgumentResolver resolver;
 
@@ -57,7 +75,7 @@ public class ExpressionValueMethodArgumentResolverTests {
 		context.refresh();
 		resolver = new ExpressionValueMethodArgumentResolver(context.getBeanFactory());
 
-		Method method = getClass().getMethod("params", int.class, String.class, String.class);
+		Method method = target.getMethod("params", int.class, String.class, String.class);
 		paramSystemProperty = new MethodParameter(method, 0);
 		paramContextPath = new MethodParameter(method, 1);
 		paramNotSupported = new MethodParameter(method, 2);
@@ -97,9 +115,19 @@ public class ExpressionValueMethodArgumentResolverTests {
 		assertEquals("/contextPath", value);
 	}
 
-	public void params(@Value("#{systemProperties.systemProperty}") int param1,
-					   @Value("#{request.contextPath}") String param2,
-					   String notSupported) {
+	public interface Foo {
+		void params(@Value("#{systemProperties.systemProperty}") int param1,
+						   @Value("#{request.contextPath}") String param2,
+						   String notSupported);
 	}
 
+	public static abstract class Bar implements Foo {
+	}
+
+	public static class Baz extends Bar {
+
+		@Override
+		public void params(int param1, String param2, String notSupported) {
+		}
+	}
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MatrixVariableMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MatrixVariableMethodArgumentResolver.java
@@ -50,7 +50,7 @@ public class MatrixVariableMethodArgumentResolver extends AbstractNamedValueMeth
 
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
+	protected boolean supportsLocalParameter(MethodParameter parameter) {
 		if (!parameter.hasParameterAnnotation(MatrixVariable.class)) {
 			return false;
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.AbstractAnnotationBasedHandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.servlet.HandlerMapping;
 
@@ -40,10 +40,10 @@ import org.springframework.web.servlet.HandlerMapping;
  * @since 3.2
  * @see PathVariableMethodArgumentResolver
  */
-public class PathVariableMapMethodArgumentResolver implements HandlerMethodArgumentResolver {
+public class PathVariableMapMethodArgumentResolver extends AbstractAnnotationBasedHandlerMethodArgumentResolver {
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
+	protected boolean supportsLocalParameter(MethodParameter parameter) {
 		PathVariable ann = parameter.getParameterAnnotation(PathVariable.class);
 		return (ann != null && (Map.class.isAssignableFrom(parameter.getParameterType()))
 				&& !StringUtils.hasText(ann.value()));
@@ -53,8 +53,9 @@ public class PathVariableMapMethodArgumentResolver implements HandlerMethodArgum
 	 * Return a Map with all URI template variables or an empty map.
 	 */
 	@Override
-	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+	protected Object resolveLocalArgument(MethodParameter parameter,
+			ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory) throws Exception {
 
 		@SuppressWarnings("unchecked")
 		Map<String, String> uriTemplateVars =

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMethodArgumentResolver.java
@@ -70,7 +70,7 @@ public class PathVariableMethodArgumentResolver extends AbstractNamedValueMethod
 
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
+	protected boolean supportsLocalParameter(MethodParameter parameter) {
 		if (!parameter.hasParameterAnnotation(PathVariable.class)) {
 			return false;
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolver.java
@@ -35,7 +35,7 @@ public class RequestAttributeMethodArgumentResolver extends AbstractNamedValueMe
 
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
+	protected boolean supportsLocalParameter(MethodParameter parameter) {
 		return parameter.hasParameterAnnotation(RequestAttribute.class);
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SessionAttributeMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SessionAttributeMethodArgumentResolver.java
@@ -35,7 +35,7 @@ public class SessionAttributeMethodArgumentResolver extends AbstractNamedValueMe
 
 
 	@Override
-	public boolean supportsParameter(MethodParameter parameter) {
+	protected boolean supportsLocalParameter(MethodParameter parameter) {
 		return parameter.hasParameterAnnotation(SessionAttribute.class);
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/AbstractRequestAttributesArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/AbstractRequestAttributesArgumentResolverTests.java
@@ -16,13 +16,18 @@
 package org.springframework.web.servlet.mvc.method.annotation;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.MethodParameter;
@@ -57,7 +62,20 @@ import static org.mockito.Mockito.mock;
  * @author Rossen Stoyanchev
  * @since 4.3
  */
+@RunWith(Parameterized.class)
 public abstract class AbstractRequestAttributesArgumentResolverTests {
+
+	@Parameters(name = "{0}")
+	public static List<Object[]> createParameters() {
+		List<Object[]> parameters = new ArrayList<Object[]>();
+		parameters.add(new Object[] { A.class });
+		parameters.add(new Object[] { B.class });
+		parameters.add(new Object[] { C.class });
+		return parameters;
+	}
+
+	@Parameter(0)
+	public Class<?> target;
 
 	private ServletWebRequest webRequest;
 
@@ -72,8 +90,8 @@ public abstract class AbstractRequestAttributesArgumentResolverTests {
 		HttpServletResponse response = new MockHttpServletResponse();
 		this.webRequest = new ServletWebRequest(request, response);
 		this.resolver = createResolver();
-		this.handleMethod = AbstractRequestAttributesArgumentResolverTests.class
-				.getDeclaredMethod(getHandleMethodName(), Foo.class, Foo.class, Foo.class, Optional.class);
+		this.handleMethod = target.getMethod(getHandleMethodName(), Foo.class, Foo.class,
+				Foo.class, Optional.class);
 	}
 
 
@@ -164,20 +182,35 @@ public abstract class AbstractRequestAttributesArgumentResolverTests {
 	}
 
 
-	@SuppressWarnings("unused")
-	private void handleWithRequestAttribute(
-			@RequestAttribute Foo foo,
-			@RequestAttribute("specialFoo") Foo namedFoo,
-			@RequestAttribute(name="foo", required = false) Foo notRequiredFoo,
-			@RequestAttribute(name="foo") Optional<Foo> optionalFoo) {
+	public interface A {
+		void handleWithRequestAttribute(
+				@RequestAttribute Foo foo,
+				@RequestAttribute("specialFoo") Foo namedFoo,
+				@RequestAttribute(name="foo", required = false) Foo notRequiredFoo,
+				@RequestAttribute(name="foo") Optional<Foo> optionalFoo);
+
+		void handleWithSessionAttribute(
+				@SessionAttribute Foo foo,
+				@SessionAttribute("specialFoo") Foo namedFoo,
+				@SessionAttribute(name="foo", required = false) Foo notRequiredFoo,
+				@SessionAttribute(name="foo") Optional<Foo> optionalFoo);
 	}
 
-	@SuppressWarnings("unused")
-	private void handleWithSessionAttribute(
-			@SessionAttribute Foo foo,
-			@SessionAttribute("specialFoo") Foo namedFoo,
-			@SessionAttribute(name="foo", required = false) Foo notRequiredFoo,
-			@SessionAttribute(name="foo") Optional<Foo> optionalFoo) {
+	public static abstract class B implements A {
+	}
+
+	public static class C extends B {
+
+		@Override
+		public void handleWithRequestAttribute(Foo foo, Foo namedFoo, Foo notRequiredFoo,
+				Optional<Foo> optionalFoo) {
+		}
+
+		@Override
+		public void handleWithSessionAttribute(Foo foo, Foo namedFoo, Foo notRequiredFoo,
+				Optional<Foo> optionalFoo) {
+		}
+
 	}
 
 	private static class Foo {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/MatrixVariablesMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/MatrixVariablesMethodArgumentResolverTests.java
@@ -17,6 +17,7 @@
 package org.springframework.web.servlet.mvc.method.annotation;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,7 +25,10 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
 import org.springframework.mock.web.test.MockHttpServletRequest;
@@ -44,8 +48,20 @@ import static org.junit.Assert.*;
  *
  * @author Rossen Stoyanchev
  */
+@RunWith(Parameterized.class)
 public class MatrixVariablesMethodArgumentResolverTests {
 
+	@Parameters(name = "{0}")
+	public static List<Object[]> createParameters() {
+		List<Object[]> parameters = new ArrayList<Object[]>();
+		parameters.add(new Object[] { Foo.class });
+		parameters.add(new Object[] { Bar.class });
+		parameters.add(new Object[] { Baz.class });
+		return parameters;
+	}
+
+	@Parameter(0)
+	public Class<?> target;
 	private MatrixVariableMethodArgumentResolver resolver;
 
 	private MethodParameter paramString;
@@ -63,7 +79,7 @@ public class MatrixVariablesMethodArgumentResolverTests {
 	public void setUp() throws Exception {
 		this.resolver = new MatrixVariableMethodArgumentResolver();
 
-		Method method = getClass().getMethod("handle", String.class, List.class, int.class);
+		Method method = target.getMethod("handle", String.class, List.class, int.class);
 		this.paramString = new MethodParameter(method, 0);
 		this.paramColors = new MethodParameter(method, 1);
 		this.paramYear = new MethodParameter(method, 2);
@@ -149,10 +165,19 @@ public class MatrixVariablesMethodArgumentResolverTests {
 	}
 
 
-	public void handle(
+	public interface Foo {
+		void handle(
 			String stringArg,
 			@MatrixVariable List<String> colors,
-			@MatrixVariable(name = "year", pathVar = "cars", required = false, defaultValue = "2013") int preferredYear) {
+			@MatrixVariable(name = "year", pathVar = "cars", required = false, defaultValue = "2013") int preferredYear);
 	}
 
+	public static abstract class Bar implements Foo {
+	}
+
+	public static class Baz extends Bar {
+		@Override
+		public void handle(String stringArg, List<String> colors, int preferredYear) {
+		}
+	}
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolverTests.java
@@ -17,13 +17,18 @@
 package org.springframework.web.servlet.mvc.method.annotation;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.springframework.core.MethodParameter;
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.mock.web.test.MockHttpServletResponse;
@@ -39,7 +44,20 @@ import static org.junit.Assert.*;
  *
  * @author Rossen Stoyanchev
  */
+@RunWith(Parameterized.class)
 public class PathVariableMapMethodArgumentResolverTests {
+
+	@Parameters(name = "{0}")
+	public static List<Object[]> createParameters() {
+		List<Object[]> parameters = new ArrayList<Object[]>();
+		parameters.add(new Object[] { Foo.class });
+		parameters.add(new Object[] { Bar.class });
+		parameters.add(new Object[] { Baz.class });
+		return parameters;
+	}
+
+	@Parameter(0)
+	public Class<?> target;
 
 	private PathVariableMapMethodArgumentResolver resolver;
 
@@ -59,7 +77,7 @@ public class PathVariableMapMethodArgumentResolverTests {
 	public void setUp() throws Exception {
 		resolver = new PathVariableMapMethodArgumentResolver();
 
-		Method method = getClass().getMethod("handle", Map.class, Map.class, Map.class);
+		Method method = target.getMethod("handle", Map.class, Map.class, Map.class);
 		paramMap = new MethodParameter(method, 0);
 		paramNamedMap = new MethodParameter(method, 1);
 		paramMapNoAnnot = new MethodParameter(method, 2);
@@ -97,10 +115,22 @@ public class PathVariableMapMethodArgumentResolverTests {
 	}
 
 
-	public void handle(
+	public interface Foo {
+		void handle(
 			@PathVariable Map<String, String> map,
 			@PathVariable(value = "name") Map<String, String> namedMap,
-			Map<String, String> mapWithoutAnnotat) {
+			Map<String, String> mapWithoutAnnotat);
 	}
 
+	public static abstract class Bar implements Foo {
+	}
+
+	public class Baz extends Bar {
+
+		@Override
+		public void handle(Map<String, String> map, Map<String, String> namedMap,
+				Map<String, String> mapWithoutAnnotat) {
+		}
+
+	}
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMethodArgumentResolverTests.java
@@ -19,12 +19,17 @@ package org.springframework.web.servlet.mvc.method.annotation;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.springframework.core.MethodParameter;
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.mock.web.test.MockHttpServletResponse;
@@ -40,7 +45,20 @@ import org.springframework.web.servlet.View;
  *
  * @author Rossen Stoyanchev
  */
+@RunWith(Parameterized.class)
 public class PathVariableMethodArgumentResolverTests {
+
+	@Parameters(name = "{0}")
+	public static List<Object[]> createParameters() {
+		List<Object[]> parameters = new ArrayList<Object[]>();
+		parameters.add(new Object[] { Foo.class });
+		parameters.add(new Object[] { Bar.class });
+		parameters.add(new Object[] { Baz.class });
+		return parameters;
+	}
+
+	@Parameter(0)
+	public Class<?> target;
 
 	private PathVariableMethodArgumentResolver resolver;
 
@@ -58,7 +76,7 @@ public class PathVariableMethodArgumentResolverTests {
 	public void setUp() throws Exception {
 		resolver = new PathVariableMethodArgumentResolver();
 
-		Method method = getClass().getMethod("handle", String.class, String.class);
+		Method method = target.getMethod("handle", String.class, String.class);
 		paramNamedString = new MethodParameter(method, 0);
 		paramString = new MethodParameter(method, 1);
 
@@ -116,8 +134,18 @@ public class PathVariableMethodArgumentResolverTests {
 		fail("Unresolved path variable should lead to exception.");
 	}
 
-	@SuppressWarnings("unused")
-	public void handle(@PathVariable(value = "name") String param1, String param2) {
+
+	public interface Foo {
+		void handle(@PathVariable(value = "name") String param1, String param2);
+	}
+
+	public static abstract class Bar implements Foo {
+	}
+
+	public static class Baz extends Bar {
+		@Override
+		public void handle(String param1, String param2) {
+		}
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletCookieValueMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletCookieValueMethodArgumentResolverTests.java
@@ -17,11 +17,17 @@
 package org.springframework.web.servlet.mvc.method.annotation;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.servlet.http.Cookie;
 
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.annotation.SynthesizingMethodParameter;
 import org.springframework.mock.web.test.MockHttpServletRequest;
@@ -37,7 +43,20 @@ import static org.junit.Assert.*;
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
  */
+@RunWith(Parameterized.class)
 public class ServletCookieValueMethodArgumentResolverTests {
+
+	@Parameters
+	public static List<Object[]> createParameters() {
+		List<Object[]> parameters = new ArrayList<Object[]>();
+		parameters.add(new Object[] { Foo.class });
+		parameters.add(new Object[] { Bar.class });
+		parameters.add(new Object[] { Baz.class });
+		return parameters;
+	}
+
+	@Parameter(0)
+	public Class<?> target;
 
 	private ServletCookieValueMethodArgumentResolver resolver;
 
@@ -54,7 +73,7 @@ public class ServletCookieValueMethodArgumentResolverTests {
 	public void setUp() throws Exception {
 		resolver = new ServletCookieValueMethodArgumentResolver(null);
 
-		Method method = getClass().getMethod("params", Cookie.class, String.class);
+		Method method = target.getMethod("params", Cookie.class, String.class);
 		cookieParameter = new SynthesizingMethodParameter(method, 0);
 		cookieStringParameter = new SynthesizingMethodParameter(method, 1);
 
@@ -81,9 +100,19 @@ public class ServletCookieValueMethodArgumentResolverTests {
 		assertEquals("Invalid result", cookie.getValue(), result);
 	}
 
+	public interface Foo {
 
-	public void params(@CookieValue("name") Cookie cookie,
-			@CookieValue(name = "name", defaultValue = "bar") String cookieString) {
+		void params(@CookieValue("name") Cookie cookie,
+				@CookieValue(name = "name", defaultValue = "bar") String cookieString);
 	}
 
+	public static abstract class Bar implements Foo {
+	}
+
+	public static class Baz extends Bar {
+
+		@Override
+		public void params(Cookie cookie, String cookieString) {
+		}
+	}
 }


### PR DESCRIPTION
Walk up the method override hierarchy in order to discover
REST parameter annotations declared on superclasses and
interfaces. Because method parameter annotations are not
inherited, this is not otherwise (and therefore was not
previously) possible.

Issue: SPR-11055
