### PR TITLE
Primary bean override restriction for non primary beans with same names

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -821,6 +821,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 
 		oldBeanDefinition = this.beanDefinitionMap.get(beanName);
 		if (oldBeanDefinition != null) {
+			boolean skipBeanDefinitionOverride = false;
 			if (!isAllowBeanDefinitionOverriding()) {
 				throw new BeanDefinitionStoreException(beanDefinition.getResourceDescription(), beanName,
 						"Cannot register bean definition [" + beanDefinition + "] for bean '" + beanName +
@@ -833,8 +834,14 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 							"' with a framework-generated bean definition: replacing [" +
 							oldBeanDefinition + "] with [" + beanDefinition + "]");
 				}
-			}
-			else if (!beanDefinition.equals(oldBeanDefinition)) {
+			} else if (isOverridingPrimaryBean(oldBeanDefinition, beanDefinition)) {
+				skipBeanDefinitionOverride = true;
+				if (this.logger.isDebugEnabled()) {
+					this.logger.debug("Skipping bean definition override of '" + beanName +
+							"', because existing bean definition [" + oldBeanDefinition +
+							"] is primary and new definition [" + beanDefinition + "] is not.");
+				}
+			} else if (!beanDefinition.equals(oldBeanDefinition)) {
 				if (this.logger.isInfoEnabled()) {
 					this.logger.info("Overriding bean definition for bean '" + beanName +
 							"' with a different definition: replacing [" + oldBeanDefinition +
@@ -848,7 +855,9 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 							"] with [" + beanDefinition + "]");
 				}
 			}
-			this.beanDefinitionMap.put(beanName, beanDefinition);
+			if (!skipBeanDefinitionOverride) {
+				this.beanDefinitionMap.put(beanName, beanDefinition);
+			}
 		}
 		else {
 			if (hasBeanCreationStarted()) {
@@ -878,6 +887,10 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 		if (oldBeanDefinition != null || containsSingleton(beanName)) {
 			resetBeanDefinition(beanName);
 		}
+	}
+
+	private boolean isOverridingPrimaryBean(BeanDefinition oldBeanDefinition, BeanDefinition newBeanDefinition) {
+		return oldBeanDefinition.isPrimary() && !newBeanDefinition.isPrimary();
 	}
 
 	@Override

--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -1443,6 +1443,28 @@ public class DefaultListableBeanFactoryTests {
 	}
 
 	@Test
+	public void testGetBeanByTypeWithExistingPrimaryBeanDefinition() throws Exception {
+		DefaultListableBeanFactory lbf = new DefaultListableBeanFactory();
+		RootBeanDefinition bd1 = new RootBeanDefinition(PrimaryTestBean.class);
+		bd1.setPrimary(true);
+		RootBeanDefinition bd2 = new RootBeanDefinition(TestBean.class);
+		lbf.registerBeanDefinition("bd", bd1);
+		lbf.registerBeanDefinition("bd", bd2);
+		lbf.getBean(PrimaryTestBean.class);
+	}
+
+	@Test
+	public void testGetBeanByTypeWhenOverridingNonPrimaryBeanDefinition() throws Exception {
+		DefaultListableBeanFactory lbf = new DefaultListableBeanFactory();
+		RootBeanDefinition bd1 = new RootBeanDefinition(TestBean.class);
+		RootBeanDefinition bd2 = new RootBeanDefinition(PrimaryTestBean.class);
+		bd2.setPrimary(true);
+		lbf.registerBeanDefinition("bd", bd1);
+		lbf.registerBeanDefinition("bd", bd2);
+		lbf.getBean(PrimaryTestBean.class);
+	}
+
+	@Test
 	public void testGetBeanByTypeWithMultiplePrimary() throws Exception {
 		DefaultListableBeanFactory lbf = new DefaultListableBeanFactory();
 		RootBeanDefinition bd1 = new RootBeanDefinition(TestBean.class);
@@ -3237,7 +3259,9 @@ public class DefaultListableBeanFactoryTests {
 	@Priority(500)
 	private static class LowPriorityTestBean extends TestBean {
 	}
-
+	
+	private static class PrimaryTestBean extends TestBean {
+	}
 
 	private static class NullTestBeanFactoryBean<T> implements FactoryBean<TestBean> {
 

--- a/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassPostProcessorTests.java
@@ -598,6 +598,12 @@ public class ConfigurationClassPostProcessorTests {
 	}
 
 	@Test
+	public void testConfigurationBeanWithSameNameOverride() {
+		ApplicationContext ctx = new AnnotationConfigApplicationContext(ConfigWithPrimaryBeanSingleton.class, ConfigWithNonPrimaryBeanSingleton.class);
+		assertSame("Primary", ctx.getBean(TestBean.class).getName());
+	}
+
+	@Test
 	public void testSingletonArgumentThroughBeanMethodCall() {
 		ApplicationContext ctx = new AnnotationConfigApplicationContext(BeanArgumentConfigWithSingleton.class);
 		ctx.getBean(FooFactory.class).createFoo(new BarArgument());
@@ -1136,6 +1142,23 @@ public class ConfigurationClassPostProcessorTests {
 	}
 
 	public static class Z {
+	}
+	
+	@Configuration
+	static class ConfigWithPrimaryBeanSingleton {
+		@Bean
+		@Primary
+		TestBean testBean(){
+			return new TestBean("Primary");
+		}
+	}
+
+	@Configuration
+	static class ConfigWithNonPrimaryBeanSingleton {
+		@Bean
+		TestBean testBean(){
+			return new TestBean("NonPrimary");
+		}
 	}
 
 	@Configuration


### PR DESCRIPTION
Disabled overriding primary bean, when creating non primary bean with the same name.
Please read below issue description for more info.

Issue: [SPR-13980](https://jira.spring.io/browse/SPR-13980)

Note: I have received an explanation, that factory bean name override is higher than `Primary` annotation override. Is that true?
