### PR TITLE
Remove @BootstrapWith from @WebAppConfiguration

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/web/WebAppConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/web/WebAppConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import org.springframework.test.context.BootstrapWith;
 
 /**
  * {@code @WebAppConfiguration} is a class-level annotation that is used to
@@ -53,7 +51,6 @@ import org.springframework.test.context.BootstrapWith;
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@BootstrapWith(WebTestContextBootstrapper.class)
 public @interface WebAppConfiguration {
 
 	/**

--- a/spring-test/src/test/java/org/springframework/test/context/BootstrapUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/BootstrapUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import org.springframework.test.context.support.DefaultTestContextBootstrapper;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.context.web.WebTestContextBootstrapper;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -46,6 +48,11 @@ public class BootstrapUtilsTests {
 	@Test
 	public void resolveTestContextBootstrapperForNonAnnotatedClass() {
 		assertBootstrapper(NonAnnotatedClass.class, DefaultTestContextBootstrapper.class);
+	}
+
+	@Test
+	public void resolveTestContextBootstrapperForWithWebAppConfigurationAnnotatedClass() throws Exception {
+		assertBootstrapper(WithWebAppConfiguration.class, WebTestContextBootstrapper.class);
 	}
 
 	@Test
@@ -123,5 +130,8 @@ public class BootstrapUtilsTests {
 	@BootWithBar
 	@BootWithFoo
 	static class DoubleMetaAnnotatedBootstrapWithAnnotationClass {}
+
+	@WebAppConfiguration
+	static class WithWebAppConfiguration {}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/context/web/WebbAppConfigurationBootstrapWithTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/web/WebbAppConfigurationBootstrapWithTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.web;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebbAppConfigurationBootstrapWithTests.TestWebTestContextBootstrapper;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.junit.Assert.*;
+
+/**
+ * JUnit-based integration tests that verify support for loading a
+ * {@link WebApplicationContext} with a custom {@code @BootstrapWith}.
+ *
+ * @author Phillip Webb
+ * @since 4.3
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@WebAppConfiguration
+@BootstrapWith(TestWebTestContextBootstrapper.class)
+public class WebbAppConfigurationBootstrapWithTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+
+	@Test
+	public void testApplicationContextIsWebApplicationContext() throws Exception {
+		assertTrue(this.context instanceof WebApplicationContext);
+	}
+
+
+	@Configuration
+	static class Config {
+
+	}
+
+
+	static class TestWebTestContextBootstrapper extends WebTestContextBootstrapper {
+
+	}
+
+}


### PR DESCRIPTION
Update @WebAppConfiguration so that it no longer directly specifies
a TestContextBootstrapper. This allows third parties to use the
annotation in combination with their own bootstrapper.

BootstrapUtils now provides the detection logic for when
WebTestContextBootstrapper should be used.

Issue: SPR-13991
