### PR TITLE
Update the WEBJARS_LOCATION that will be stripped from the path

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/WebJarsResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/WebJarsResourceResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ import org.springframework.core.io.Resource;
  */
 public class WebJarsResourceResolver extends AbstractResourceResolver {
 
-	private final static String WEBJARS_LOCATION = "META-INF/resources/webjars";
+	private final static String WEBJARS_LOCATION = "META-INF/resources/webjars/";
 
 	private final static int WEBJARS_LOCATION_LENGTH = WEBJARS_LOCATION.length();
 


### PR DESCRIPTION
Currently, resource paths will take the form of `/webjars//bootstrap/3.3.2/js/bootstrap.min.js`.
Note the double slash, that is still from the `/bootstrap/...`.
