### PR TITLE
Add ContextCustomizer support to spring-test

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/ContextCustomizer.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextCustomizer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Strategy interface for customizing {@link ApplicationContext application contexts} that
+ * are created and managed by the Spring TestContext Framework.
+ *
+ * <p>Customizers are loaded via {@link ContextCustomizerFactory} classes registered in
+ * {@code spring.factories}.
+ *
+ * <p>Implementations should take care to implement correct {@code equals} and
+ * {@code hashCode} methods since customizers form part of the
+ * {@link MergedContextConfiguration} which is used as a cache key.
+ *
+ * @author Phillip Webb
+ * @since 4.3
+ * @see ContextCustomizerFactory
+ * @see org.springframework.test.context.support.AbstractContextLoader
+ */
+public interface ContextCustomizer {
+
+	/**
+	 * Called <i>before</i> bean definitions are read to customize the
+	 * {@link ConfigurableApplicationContext}.
+	 * @param context the context that should be prepared
+	 * @param mergedContextConfiguration the merged context configuration
+	 */
+	void customizeContext(ConfigurableApplicationContext context,
+			MergedContextConfiguration mergedContextConfiguration);
+
+}

--- a/spring-test/src/main/java/org/springframework/test/context/ContextCustomizerFactory.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextCustomizerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import java.util.List;
+
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Factory registered in {@code spring.factories} that is used to create
+ * {@link ContextCustomizer ContextCustomizers}. Factories are called after
+ * {@link ContextLoader ContextLoaders} have been triggered but before the
+ * {@link MergedContextConfiguration} is created.
+ *
+ * @author Phillip Webb
+ * @since 4.3
+ */
+public interface ContextCustomizerFactory {
+
+	/**
+	 * Get the {@link ContextCustomizer} (if any) that should be used to customize the
+	 * {@link ConfigurableApplicationContext} when it is created.
+	 * @param testClass the test class
+	 * @param configurationAttributes he list of context configuration attributes for the
+	 * test class, ordered <em>bottom-up</em> (i.e., as if we were traversing up the class
+	 * hierarchy); never {@code null} or empty.
+	 * @return a {@link ContextCustomizer} or {@code null}
+	 */
+	ContextCustomizer getContextCustomizer(Class<?> testClass,
+			List<ContextConfigurationAttributes> configurationAttributes);
+
+}

--- a/spring-test/src/main/java/org/springframework/test/context/support/AbstractDelegatingSmartContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/AbstractDelegatingSmartContextLoader.java
@@ -254,7 +254,7 @@ public abstract class AbstractDelegatingSmartContextLoader implements SmartConte
 
 		// If neither of the candidates supports the mergedConfig based on resources but
 		// ACIs were declared, then delegate to the annotation config loader.
-		if (!mergedConfig.getContextInitializerClasses().isEmpty()) {
+		if (!mergedConfig.getContextInitializerClasses().isEmpty() || !mergedConfig.getContextCustomizers().isEmpty()) {
 			return delegateLoading(getAnnotationConfigLoader(), mergedConfig);
 		}
 

--- a/spring-test/src/main/java/org/springframework/test/context/support/AbstractGenericContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/AbstractGenericContextLoader.java
@@ -122,6 +122,7 @@ public abstract class AbstractGenericContextLoader extends AbstractContextLoader
 		loadBeanDefinitions(context, mergedConfig);
 		AnnotationConfigUtils.registerAnnotationConfigProcessors(context);
 		customizeContext(context);
+		customizeContext(context, mergedConfig);
 		context.refresh();
 		context.registerShutdownHook();
 		return context;

--- a/spring-test/src/main/java/org/springframework/test/context/web/AbstractGenericWebContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/web/AbstractGenericWebContextLoader.java
@@ -256,15 +256,13 @@ public abstract class AbstractGenericWebContextLoader extends AbstractContextLoa
 	 * loader <i>after</i> bean definitions have been loaded into the context but
 	 * <i>before</i> the context is refreshed.
 	 *
-	 * <p>The default implementation is empty but can be overridden in subclasses
-	 * to customize the web application context.
-	 *
 	 * @param context the newly created web application context
 	 * @param webMergedConfig the merged context configuration to use to load the
 	 * web application context
 	 * @see #loadContext(MergedContextConfiguration)
 	 */
 	protected void customizeContext(GenericWebApplicationContext context, WebMergedContextConfiguration webMergedConfig) {
+		super.customizeContext(context, webMergedConfig);
 	}
 
 	// --- ContextLoader -------------------------------------------------------

--- a/spring-test/src/test/java/org/springframework/test/context/MergedContextConfigurationTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/MergedContextConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.test.context;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -28,6 +29,7 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.test.context.support.GenericXmlContextLoader;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for {@link MergedContextConfiguration}.
@@ -396,6 +398,36 @@ public class MergedContextConfigurationTests {
 				EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY, initializerClasses1, EMPTY_STRING_ARRAY, loader);
 		MergedContextConfiguration mergedConfig2 = new MergedContextConfiguration(getClass(),
 				EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY, initializerClasses2, EMPTY_STRING_ARRAY, loader);
+		assertNotEquals(mergedConfig1, mergedConfig2);
+		assertNotEquals(mergedConfig2, mergedConfig1);
+	}
+
+	@Test
+	public void equalsWithSameContextCustomizers() {
+		Set<ContextCustomizer> customizers1 = Collections.singleton(
+				mock(ContextCustomizer.class));
+		MergedContextConfiguration mergedConfig1 = new MergedContextConfiguration(
+				getClass(), EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY, null,
+				EMPTY_STRING_ARRAY, null, null, customizers1, loader, null, null);
+		MergedContextConfiguration mergedConfig2 = new MergedContextConfiguration(
+				getClass(), EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY, null,
+				EMPTY_STRING_ARRAY, null, null, customizers1, loader, null, null);
+		assertEquals(mergedConfig1, mergedConfig2);
+	}
+
+	@Test
+	public void equalsWithDifferentContextCustomizers() {
+		Set<ContextCustomizer> customizers1 = Collections.singleton(
+				mock(ContextCustomizer.class));
+		Set<ContextCustomizer> customizers2 = Collections.singleton(
+				mock(ContextCustomizer.class));
+
+		MergedContextConfiguration mergedConfig1 = new MergedContextConfiguration(
+				getClass(), EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY, null,
+				EMPTY_STRING_ARRAY, null, null, customizers1, loader, null, null);
+		MergedContextConfiguration mergedConfig2 = new MergedContextConfiguration(
+				getClass(), EMPTY_STRING_ARRAY, EMPTY_CLASS_ARRAY, null,
+				EMPTY_STRING_ARRAY, null, null, customizers2, loader, null, null);
 		assertNotEquals(mergedConfig1, mergedConfig2);
 		assertNotEquals(mergedConfig2, mergedConfig1);
 	}

--- a/spring-test/src/test/java/org/springframework/test/context/TestContextManagerVerifyAttributesTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/TestContextManagerVerifyAttributesTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.hamcrest.CoreMatchers.*;
+
+/**
+ * JUnit 4 based unit test for {@link TestContextManager}, which verifies
+ * ContextConfiguration attributes are defined.
+ *
+ * @author Phillip Webb
+ * @since 4.3
+ */
+public class TestContextManagerVerifyAttributesTests {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void processContextConfigurationWithMissingContextConfigAttributes() {
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage(containsString("was unable to detect defaults, "
+				+ "and no ApplicationContextInitializers or ContextCustomizers were "
+				+ "declared for context configuration"));
+		new TestContextManager(MissingContextAttributes.class);
+	}
+
+	@Test
+	public void processContextConfigurationWitListener() {
+		new TestContextManager(WithInitializer.class);
+	}
+
+
+	@ContextConfiguration
+	private static class MissingContextAttributes {
+
+	}
+
+	@ContextConfiguration(initializers=ExampleInitializer.class)
+	private static class WithInitializer {
+
+	}
+
+	static class ExampleInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+		@Override
+		public void initialize(ConfigurableApplicationContext applicationContext) {
+		}
+
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/ContextCustomizerSpringRunnerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/ContextCustomizerSpringRunnerTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.junit4.ContextCustomizerSpringRunnerTests.CustomTestContextBootstrapper;
+import org.springframework.test.context.support.DefaultTestContextBootstrapper;
+
+import static org.junit.Assert.*;
+
+/**
+ * JUnit 4 based integration test which verifies support of
+ * {@link ContextCustomizerFactory} and {@link ContextCustomizer}.
+ *
+ * @author Phillip Webb
+ * @since 4.3
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@BootstrapWith(CustomTestContextBootstrapper.class)
+@ContextConfiguration
+public class ContextCustomizerSpringRunnerTests {
+
+	@Autowired
+	private MyBean myBean;
+
+	@Test
+	public void injectedMyBean() throws Exception {
+		assertNotNull(this.myBean);
+	}
+
+	public static class CustomTestContextBootstrapper
+			extends DefaultTestContextBootstrapper {
+
+		@Override
+		protected List<ContextCustomizerFactory> geContextCustomizerFactories() {
+			return Collections.singletonList(new ContextCustomizerFactory() {
+
+				@Override
+				public ContextCustomizer getContextCustomizer(Class<?> testClass,
+						List<ContextConfigurationAttributes> configurationAttributes) {
+					return new TestContextCustomizers();
+				}
+
+			});
+		}
+
+	}
+
+	public static class TestContextCustomizers implements ContextCustomizer {
+
+		@Override
+		public void customizeContext(ConfigurableApplicationContext context,
+				MergedContextConfiguration mergedContextConfiguration) {
+			context.getBeanFactory().registerSingleton("mybean", new MyBean());
+		}
+
+	}
+
+	public static class MyBean {
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/support/BootstrapTestUtilsMergedConfigTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/BootstrapTestUtilsMergedConfigTests.java
@@ -63,7 +63,7 @@ public class BootstrapTestUtilsMergedConfigTests extends AbstractContextConfigur
 	public void buildMergedConfigWithContextConfigurationWithoutLocationsClassesOrInitializers() {
 		exception.expect(IllegalStateException.class);
 		exception.expectMessage(startsWith("DelegatingSmartContextLoader was unable to detect defaults, "
-				+ "and no ApplicationContextInitializers were declared for context configuration attributes"));
+				+ "and no ApplicationContextInitializers or ContextCustomizers were declared for context configuration attribute"));
 
 		buildMergedContextConfiguration(MissingContextAttributesTestCase.class);
 	}


### PR DESCRIPTION
Allow libraries to contribute ContextCustomizers that can update
ApplicationContexts create by spring-test before they are run.

A Customizer may be provided via a ContextCustomizerFactory which is
registered with `spring.factories`. Each factory is consulted whenever
a new ApplicationContext needs to be created by spring-test. Factories
may inspect various details about the test and either return a new
ContextCustomizers or `null`.

ContextCustomizers are similar to ApplicationContextInitializers and
may perform any number of tasks, including bean registration.

Issue: SPR-13998
