### PR TITLE
delegate PayloadApplicationEvent type resolution to the PayloadApplicationEvent itself

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -369,7 +369,7 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 		else {
 			applicationEvent = new PayloadApplicationEvent<Object>(this, event);
 			if (eventType == null) {
-				eventType = ResolvableType.forClassWithGenerics(PayloadApplicationEvent.class, event.getClass());
+				eventType = ((PayloadApplicationEvent)applicationEvent).getResolvableType();
 			}
 		}
 


### PR DESCRIPTION
this fix allows writing custom application events that implement ResolvableTypeProvider, as an alternative to extending ApplicationEvent. see for example this custom event implementation - https://github.com/radai-rosenblatt/spring-events/blob/master/src/main/java/net/radai/ContentsChangedEvent.java

Signed-off-by: radai-rosenblatt radai.rosenblatt@gmail.com
