### PR TITLE
Support servlet listener activate attribute

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/web/ServletTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/web/ServletTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,16 @@ public class ServletTestExecutionListener extends AbstractTestExecutionListener 
 	public static final String CREATED_BY_THE_TESTCONTEXT_FRAMEWORK = Conventions.getQualifiedAttributeName(
 		ServletTestExecutionListener.class, "createdByTheTestContextFramework");
 
+	/**
+	 * Attribute name for a {@link TestContext} attribute which indicates that
+	 * that the {@link ServletTestExecutionListener} should be activated. When
+	 * not specified activation occurs when the {@linkplain TestContext#getTestClass()
+	 * test class} is annotated with {@link WebAppConfiguration @WebAppConfiguration}.
+	 * @since 4.4
+	 */
+	public static final String ACTIVATE_LISTENER = Conventions.getQualifiedAttributeName(
+			ServletTestExecutionListener.class, "webApplicationConfiguration");
+
 	private static final Log logger = LogFactory.getLog(ServletTestExecutionListener.class);
 
 
@@ -167,8 +177,9 @@ public class ServletTestExecutionListener extends AbstractTestExecutionListener 
 		testContext.removeAttribute(RESET_REQUEST_CONTEXT_HOLDER_ATTRIBUTE);
 	}
 
-	private boolean notAnnotatedWithWebAppConfiguration(TestContext testContext) {
-		return AnnotationUtils.findAnnotation(testContext.getTestClass(), WebAppConfiguration.class) == null;
+	private boolean isActivated(TestContext testContext) {
+		return (Boolean.TRUE.equals(testContext.getAttribute(ACTIVATE_LISTENER))
+				|| AnnotationUtils.findAnnotation(testContext.getTestClass(), WebAppConfiguration.class) != null);
 	}
 
 	private boolean alreadyPopulatedRequestContextHolder(TestContext testContext) {
@@ -176,7 +187,7 @@ public class ServletTestExecutionListener extends AbstractTestExecutionListener 
 	}
 
 	private void setUpRequestContextIfNecessary(TestContext testContext) {
-		if (notAnnotatedWithWebAppConfiguration(testContext) || alreadyPopulatedRequestContextHolder(testContext)) {
+		if (!isActivated(testContext) || alreadyPopulatedRequestContextHolder(testContext)) {
 			return;
 		}
 

--- a/spring-test/src/test/java/org/springframework/test/context/web/ServletTestExecutionListenerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/web/ServletTestExecutionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,6 +173,18 @@ public class ServletTestExecutionListenerTests {
 		assertWebAppConfigTestCase();
 	}
 
+	@Test
+	public void activateAttributeAppConfigTestCaseWithoutExistingRequestAttributes() throws Exception {
+		BDDMockito.<Class<?>> given(testContext.getTestClass()).willReturn(NoAtWebAppConfigWebTestCase.class);
+		given(testContext.getAttribute(ServletTestExecutionListener.ACTIVATE_LISTENER)).willReturn(true);
+
+		RequestContextHolder.resetRequestAttributes();
+		listener.beforeTestClass(testContext);
+		assertAttributesNotAvailable();
+
+		assertWebAppConfigTestCase();
+	}
+
 	private void assertWebAppConfigTestCase() throws Exception {
 		listener.prepareTestInstance(testContext);
 		assertAttributeDoesNotExist();
@@ -198,6 +210,9 @@ public class ServletTestExecutionListenerTests {
 
 	@WebAppConfiguration
 	static class AtWebAppConfigWebTestCase {
+	}
+
+	static class NoAtWebAppConfigWebTestCase {
 	}
 
 }


### PR DESCRIPTION
Add a ServletTestExecutionListener.ACTIVATE_LISTENER attribute which
can be set on the TestContext to trigger activation of the listener
even if a `@WebAppConfiguration` is not present.

Issue: SPR-14035
