### PR TITLE
SPR-13919 - Add JSON matcher to assert on request body

### DIFF
--- a/spring-test/src/test/java/org/springframework/test/web/client/match/ContentRequestMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/match/ContentRequestMatchersTests.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import org.springframework.http.MediaType;
 import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.test.web.servlet.result.ContentResultMatchers;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -93,6 +94,36 @@ public class ContentRequestMatchersTests {
 		this.request.getBody().write("test".getBytes());
 
 		MockRestRequestMatchers.content().bytes("Test".getBytes()).match(this.request);
+	}
+
+	@Test
+	public void testJsonLenientMatch() throws Exception {
+		this.request.getBody().write("{\n \"foo array\":[\"first\",\"second\"] , \"someExtraProperty\": \"which is allowed\" \n}".getBytes());
+
+		MockRestRequestMatchers.content().json("{\n \"foo array\":[\"second\",\"first\"] \n}").match(this.request);
+		MockRestRequestMatchers.content().json("{\n \"foo array\":[\"second\",\"first\"] \n}", false).match(this.request);
+	}
+
+	@Test
+	public void testJsonStrictMatch() throws Exception {
+		this.request.getBody().write("{\n \"foo\": \"bar\", \"foo array\":[\"first\",\"second\"] \n}".getBytes());
+
+		MockRestRequestMatchers.content().json("{\n \"foo array\":[\"first\",\"second\"] , \"foo\": \"bar\" \n}", true).match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void testJsonLenientNoMatch() throws Exception {
+		this.request.getBody().write("{\n \"bar\" : \"foo\"  \n}".getBytes());
+
+		MockRestRequestMatchers.content().json("{\n \"foo\" : \"bar\"  \n}").match(this.request);
+		MockRestRequestMatchers.content().json("{\n \"foo\" : \"bar\"  \n}", false).match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void testJsonStrictNoMatch() throws Exception {
+		this.request.getBody().write("{\n \"foo array\":[\"first\",\"second\"] , \"someExtraProperty\": \"which is NOT allowed\" \n}".getBytes());
+
+		MockRestRequestMatchers.content().json("{\n \"foo array\":[\"second\",\"first\"] \n}", true).match(this.request);
 	}
 
 	@Test


### PR DESCRIPTION
It's common for test code to want to assert that the body of a request matches a JSON document.  Without this `ContentRequestMatcher`, the only options are to do a literal string comparison or assert on individual nodes using `jsonPath()`.

The `ContentRequestMatcher.json()` provides a general-purpose means of asserting on request content in the same way `ContentResultMatcher.json()` does.

We have signed and agree to the terms of the Spring Individual Contributor
License Agreement.

```
Support asserting JSON regardless of order and formatting.
Based on same JsonExpectationHelper used in ContentResultMatchers.

Issue: SPR-13919

Signed-off-by: Bronwyn Perry-Huston <bperryhuston@corelogic.com>
Signed-off-by: Dan Neumann <dneumann@pivotal.io>
Signed-off-by: John Ryan <jryan@pivotal.io>
```
