### PR TITLE
Recognize string interning feature

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/xml/AbstractStaxXMLReader.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/AbstractStaxXMLReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ abstract class AbstractStaxXMLReader extends AbstractXMLReader {
 
 	private static final String IS_STANDALONE_FEATURE_NAME = "http://xml.org/sax/features/is-standalone";
 
+	private static final String STRING_INTERNING_FEATURE_NAME = "http://xml.org/sax/features/string-interning";
 
 	private boolean namespacesFeature = true;
 
@@ -73,6 +74,9 @@ abstract class AbstractStaxXMLReader extends AbstractXMLReader {
 			else {
 				throw new SAXNotSupportedException("startDocument() callback not completed yet");
 			}
+		}
+		else if (STRING_INTERNING_FEATURE_NAME.equals(name)) {
+			return false;
 		}
 		else {
 			return super.getFeature(name);


### PR DESCRIPTION
We use the validation support in Spring WS to validate SOAP requests.
Profiling has shown that we have a lot of caught
SAXNotRecognizedException during normal program execution. They come
from AbstractXMLReader.getFeature which is called from
ValidatorHandlerImpl#validate. ValidatorHandlerImpl checks for the
value of the string interning feature. Throwing a
SAXNotRecognizedException is interpreted the same way as returning
false.

Recognizing the feature and returning false preserves the semantics but
gets rid of the SAXNotRecognizedException during normal control flow.
- recognize the "http://xml.org/sax/features/string-interning" feature
  as disabled

Issue: SPR-14047
