### PR TITLE
SPR-14043 Update xmlunit library to version 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ configure(allprojects) { project ->
 	ext.tyrusVersion         = "1.3.5"  // constrained by WebLogic 12.1.3 support
 	ext.undertowVersion      = "1.3.19.Final"
 	ext.woodstoxVersion      = "5.0.1"
-	ext.xmlunitVersion       = "1.6"
+	ext.xmlunitVersion       = "2.1.0"
 	ext.xstreamVersion       = "1.4.9"
 
 	ext.gradleScriptDir = "${rootProject.projectDir}/gradle"
@@ -360,7 +360,7 @@ project("spring-core") {
 		optional("net.sf.jopt-simple:jopt-simple:4.9")
 		optional("log4j:log4j:1.2.17")
 		testCompile("org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}")
-		testCompile("xmlunit:xmlunit:${xmlunitVersion}")
+		testCompile("org.xmlunit:xmlunit-matchers:${xmlunitVersion}")
 		testCompile("com.fasterxml.woodstox:woodstox-core:${woodstoxVersion}") {
 			exclude group: "stax", module: "stax-api"
 		}
@@ -537,7 +537,7 @@ project("spring-messaging") {
 		testCompile("commons-dbcp:commons-dbcp:1.4")
 		testCompile("log4j:log4j:1.2.17")
 		testCompile("org.slf4j:slf4j-jcl:${slf4jVersion}")
-		testCompile("xmlunit:xmlunit:${xmlunitVersion}")
+		testCompile("org.xmlunit:xmlunit-matchers:${xmlunitVersion}")
 	}
 }
 
@@ -590,7 +590,7 @@ project("spring-oxm") {
 		}
 		optional("org.jibx:jibx-run:1.2.6")
 		testCompile(project(":spring-context"))
-		testCompile("xmlunit:xmlunit:${xmlunitVersion}")
+		testCompile("org.xmlunit:xmlunit-matchers:${xmlunitVersion}")
 		testCompile("xpp3:xpp3:1.1.4c")
 		testCompile("org.codehaus.jettison:jettison:1.3.7") {
 			exclude group: 'stax', module: 'stax-api'
@@ -729,7 +729,7 @@ project("spring-web") {
 		optional("com.google.protobuf:protobuf-java:${protobufVersion}")
 		optional("javax.mail:javax.mail-api:${javamailVersion}")
 		testCompile(project(":spring-context-support"))  // for JafMediaTypeFactory
-		testCompile("xmlunit:xmlunit:${xmlunitVersion}")
+		testCompile("org.xmlunit:xmlunit-matchers:${xmlunitVersion}")
 		testCompile("org.slf4j:slf4j-jcl:${slf4jVersion}")
 		testCompile("org.apache.taglibs:taglibs-standard-jstlel:1.2.1") {
 			exclude group: "org.apache.taglibs", module: "taglibs-standard-spec"
@@ -914,7 +914,7 @@ project("spring-webmvc") {
 		}
 		optional('org.webjars:webjars-locator:0.28')
 		testCompile("rhino:js:1.7R1")
-		testCompile("xmlunit:xmlunit:${xmlunitVersion}")
+		testCompile("org.xmlunit:xmlunit-matchers:${xmlunitVersion}")
 		testCompile("dom4j:dom4j:1.6.1") {
 			exclude group: "xml-apis", module: "xml-apis"
 		}
@@ -1018,7 +1018,7 @@ project("spring-test") {
 		optional("org.hamcrest:hamcrest-core:${hamcrestVersion}")
 		optional("com.jayway.jsonpath:json-path:${jsonpathVersion}")
 		optional("org.skyscreamer:jsonassert:${jsonassertVersion}")
-		optional("xmlunit:xmlunit:${xmlunitVersion}")
+		optional("org.xmlunit:xmlunit-matchers:${xmlunitVersion}")
 		optional("net.sourceforge.htmlunit:htmlunit:${htmlunitVersion}")
 		optional("org.seleniumhq.selenium:selenium-htmlunit-driver:${seleniumVersion}")
 		testCompile(project(":spring-context-support"))
@@ -1097,7 +1097,8 @@ project("spring-aspects") {
 
 	eclipse.project {
 		natures += "org.eclipse.ajdt.ui.ajnature"
-		buildCommands = [new org.gradle.plugins.ide.eclipse.model.BuildCommand("org.eclipse.ajdt.core.ajbuilder")]
+		buildCommands = [new org.gradle.plugins.ide.eclipse.model.
+				BuildCommand("org.eclipse.ajdt.core.ajbuilder")]
 	}
 }
 

--- a/spring-core/src/test/java/org/springframework/util/xml/AbstractStaxHandlerTestCase.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/AbstractStaxHandlerTestCase.java
@@ -16,9 +16,13 @@
 
 package org.springframework.util.xml;
 
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.net.Socket;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -26,17 +30,13 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.Result;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.stream.StreamResult;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.net.Socket;
 
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
 
 /**
  * @author Arjen Poutsma
@@ -77,7 +77,7 @@ public abstract class AbstractStaxHandlerTestCase {
 
 		xmlReader.parse(new InputSource(new StringReader(COMPLEX_XML)));
 
-		assertXMLEqual(COMPLEX_XML, stringWriter.toString());
+		assertThat(stringWriter.toString(), isSimilarTo(COMPLEX_XML));
 	}
 
 	private static boolean wwwSpringframeworkOrgIsAccessible() {
@@ -104,7 +104,7 @@ public abstract class AbstractStaxHandlerTestCase {
 
 		xmlReader.parse(new InputSource(new StringReader(COMPLEX_XML)));
 
-		assertXMLEqual(COMPLEX_XML, stringWriter.toString());
+		assertThat(stringWriter.toString(), isSimilarTo(COMPLEX_XML));
 	}
 
 	@Test
@@ -126,7 +126,7 @@ public abstract class AbstractStaxHandlerTestCase {
 
 		xmlReader.parse(new InputSource(new StringReader(SIMPLE_XML)));
 
-		assertXMLEqual(expected, result);
+		assertThat(result, isSimilarTo(expected));
 	}
 
 	@Test
@@ -148,7 +148,7 @@ public abstract class AbstractStaxHandlerTestCase {
 
 		xmlReader.parse(new InputSource(new StringReader(SIMPLE_XML)));
 
-		assertXMLEqual(expected, result);
+		assertThat(expected, isSimilarTo(result));
 	}
 
 

--- a/spring-core/src/test/java/org/springframework/util/xml/DomContentHandlerTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/DomContentHandlerTests.java
@@ -16,10 +16,6 @@
 
 package org.springframework.util.xml;
 
-import java.io.StringReader;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -28,7 +24,13 @@ import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
+
 
 /**
  * Unit tests for {@link DomContentHandler}.
@@ -73,7 +75,7 @@ public class DomContentHandlerTests {
 		expected = documentBuilder.parse(new InputSource(new StringReader(XML_1)));
 		xmlReader.setContentHandler(handler);
 		xmlReader.parse(new InputSource(new StringReader(XML_1)));
-		assertXMLEqual("Invalid result", expected, result);
+		assertThat("Invalid result", result, isSimilarTo(expected));
 	}
 
 	@Test
@@ -82,7 +84,7 @@ public class DomContentHandlerTests {
 		expected = documentBuilder.parse(new InputSource(new StringReader(XML_1)));
 		xmlReader.setContentHandler(handler);
 		xmlReader.parse(new InputSource(new StringReader(XML_1)));
-		assertXMLEqual("Invalid result", expected, result);
+		assertThat("Invalid result", result, isSimilarTo(expected));
 	}
 
 	@Test
@@ -93,7 +95,7 @@ public class DomContentHandlerTests {
 		expected = documentBuilder.parse(new InputSource(new StringReader(XML_2_EXPECTED)));
 		xmlReader.setContentHandler(handler);
 		xmlReader.parse(new InputSource(new StringReader(XML_2_SNIPPET)));
-		assertXMLEqual("Invalid result", expected, result);
+		assertThat("Invalid result", result, isSimilarTo(expected));
 
 	}
 

--- a/spring-core/src/test/java/org/springframework/util/xml/StaxResultTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/StaxResultTests.java
@@ -16,9 +16,9 @@
 
 package org.springframework.util.xml;
 
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
@@ -26,13 +26,14 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamSource;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * @author Arjen Poutsma
@@ -62,7 +63,7 @@ public class StaxResultTests {
 		assertEquals("Invalid streamWriter returned", streamWriter, result.getXMLStreamWriter());
 		assertNull("EventWriter returned", result.getXMLEventWriter());
 		transformer.transform(source, result);
-		assertXMLEqual("Invalid result", XML, stringWriter.toString());
+		assertThat("Invalid result", stringWriter.toString(), isSimilarTo(XML));
 	}
 
 	@Test
@@ -75,7 +76,7 @@ public class StaxResultTests {
 		assertEquals("Invalid eventWriter returned", eventWriter, result.getXMLEventWriter());
 		assertNull("StreamWriter returned", result.getXMLStreamWriter());
 		transformer.transform(source, result);
-		assertXMLEqual("Invalid result", XML, stringWriter.toString());
+		assertThat("Invalid result", stringWriter.toString(), isSimilarTo(XML));
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/util/xml/StaxSourceTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/StaxSourceTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.util.xml;
 
-import java.io.StringReader;
-import java.io.StringWriter;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLEventReader;
@@ -27,15 +30,13 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.stream.StreamResult;
+import java.io.StringReader;
+import java.io.StringWriter;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * @author Arjen Poutsma
@@ -68,7 +69,7 @@ public class StaxSourceTests {
 		assertNull("EventReader returned", source.getXMLEventReader());
 		StringWriter writer = new StringWriter();
 		transformer.transform(source, new StreamResult(writer));
-		assertXMLEqual("Invalid result", XML, writer.toString());
+		assertThat("Invalid result", writer.toString(), isSimilarTo(XML));
 	}
 
 	@Test
@@ -81,7 +82,7 @@ public class StaxSourceTests {
 		Document expected = documentBuilder.parse(new InputSource(new StringReader(XML)));
 		Document result = documentBuilder.newDocument();
 		transformer.transform(source, new DOMResult(result));
-		assertXMLEqual("Invalid result", expected, result);
+		assertThat("Invalid result", result, isSimilarTo(expected));
 	}
 
 	@Test
@@ -92,7 +93,7 @@ public class StaxSourceTests {
 		assertNull("StreamReader returned", source.getXMLStreamReader());
 		StringWriter writer = new StringWriter();
 		transformer.transform(source, new StreamResult(writer));
-		assertXMLEqual("Invalid result", XML, writer.toString());
+		assertThat("Invalid result", writer.toString(), isSimilarTo(XML));
 	}
 
 	@Test
@@ -105,6 +106,6 @@ public class StaxSourceTests {
 		Document expected = documentBuilder.parse(new InputSource(new StringReader(XML)));
 		Document result = documentBuilder.newDocument();
 		transformer.transform(source, new DOMResult(result));
-		assertXMLEqual("Invalid result", expected, result);
+		assertThat("Invalid result", result, isSimilarTo(expected));
 	}
 }

--- a/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamReaderTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamReaderTests.java
@@ -16,19 +16,22 @@
 
 package org.springframework.util.xml;
 
-import java.io.StringReader;
-import java.io.StringWriter;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.util.Predicate;
+
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stax.StAXSource;
 import javax.xml.transform.stream.StreamResult;
+import java.io.StringReader;
+import java.io.StringWriter;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 public class XMLEventStreamReaderTests {
 
@@ -58,7 +61,9 @@ public class XMLEventStreamReaderTests {
 		StAXSource source = new StAXSource(streamReader);
 		StringWriter writer = new StringWriter();
 		transformer.transform(source, new StreamResult(writer));
-		assertXMLEqual(XML, writer.toString());
+		Predicate<Node> nodeFilter = n ->
+				n.getNodeType() != Node.DOCUMENT_TYPE_NODE && n.getNodeType() != Node.PROCESSING_INSTRUCTION_NODE;
+		assertThat(writer.toString(), isSimilarTo(XML).withNodeFilter(nodeFilter));
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamWriterTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamWriterTests.java
@@ -16,15 +16,18 @@
 
 package org.springframework.util.xml;
 
-import java.io.StringWriter;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.util.Predicate;
+
 import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLOutputFactory;
+import java.io.StringWriter;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 public class XMLEventStreamWriterTests {
 
@@ -57,7 +60,8 @@ public class XMLEventStreamWriterTests {
 		streamWriter.writeEndElement();
 		streamWriter.writeEndDocument();
 
-		assertXMLEqual(XML, stringWriter.toString());
+		Predicate<Node> nodeFilter = n -> n.getNodeType() != Node.DOCUMENT_TYPE_NODE && n.getNodeType() != Node.PROCESSING_INSTRUCTION_NODE;
+		assertThat(stringWriter.toString(), isSimilarTo(XML).withNodeFilter(nodeFilter));
 	}
 
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/MarshallingMessageConverterTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/MarshallingMessageConverterTests.java
@@ -16,19 +16,30 @@
 
 package org.springframework.messaging.converter;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.xmlunit.diff.Comparison;
+import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.ComparisonType;
+import org.xmlunit.diff.DifferenceEvaluator;
 
-import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.junit.Assert.*;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.diff.ComparisonType.XML_STANDALONE;
+import static org.xmlunit.diff.DifferenceEvaluators.Default;
+import static org.xmlunit.diff.DifferenceEvaluators.chain;
+import static org.xmlunit.diff.DifferenceEvaluators.downgradeDifferencesToEqual;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * @author Arjen Poutsma
@@ -83,7 +94,8 @@ public class MarshallingMessageConverterTests {
 		assertNotNull(message);
 		String actual = new String((byte[]) message.getPayload(), UTF_8);
 
-		assertXMLEqual("<myBean><name>Foo</name></myBean>", actual);
+		DifferenceEvaluator ev = chain(Default, downgradeDifferencesToEqual(XML_STANDALONE));
+		assertThat(actual, isSimilarTo("<myBean><name>Foo</name></myBean>").withDifferenceEvaluator(ev));
 	}
 
 

--- a/spring-oxm/src/test/java/org/springframework/oxm/AbstractMarshallerTests.java
+++ b/spring-oxm/src/test/java/org/springframework/oxm/AbstractMarshallerTests.java
@@ -16,8 +16,14 @@
 
 package org.springframework.oxm;
 
-import java.io.ByteArrayOutputStream;
-import java.io.StringWriter;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.util.xml.StaxUtils;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Text;
+import org.xmlunit.matchers.CompareMatcher;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -28,20 +34,10 @@ import javax.xml.transform.Result;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.stax.StAXResult;
 import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
 
-import org.custommonkey.xmlunit.XMLUnit;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Text;
-
-import org.springframework.util.xml.StaxUtils;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -62,7 +58,6 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 	public final void setUp() throws Exception {
 		marshaller = createMarshaller();
 		flights = createFlights();
-		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	protected abstract M createMarshaller() throws Exception;
@@ -89,7 +84,7 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 		flightElement.appendChild(numberElement);
 		Text text = expected.createTextNode("42");
 		numberElement.appendChild(text);
-		assertXMLEqual("Marshaller writes invalid DOMResult", expected, result);
+		assertThat("Marshaller writes invalid DOMResult", result, isSimilarTo(expected));
 	}
 
 	@Test
@@ -113,7 +108,7 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 		flightElement.appendChild(numberElement);
 		Text text = expected.createTextNode("42");
 		numberElement.appendChild(text);
-		assertXMLEqual("Marshaller writes invalid DOMResult", expected, result);
+		assertThat("Marshaller writes invalid DOMResult", result, isSimilarTo(expected));
 	}
 
 	@Test
@@ -121,7 +116,7 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 		StringWriter writer = new StringWriter();
 		StreamResult result = new StreamResult(writer);
 		marshaller.marshal(flights, result);
-		assertXMLEqual("Marshaller writes invalid StreamResult", EXPECTED_STRING, writer.toString());
+		assertThat("Marshaller writes invalid StreamResult", writer.toString(), isSimilarTo(EXPECTED_STRING));
 	}
 
 	@Test
@@ -129,8 +124,8 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 		ByteArrayOutputStream os = new ByteArrayOutputStream();
 		StreamResult result = new StreamResult(os);
 		marshaller.marshal(flights, result);
-		assertXMLEqual("Marshaller writes invalid StreamResult", EXPECTED_STRING,
-				new String(os.toByteArray(), "UTF-8"));
+		assertThat("Marshaller writes invalid StreamResult", new String(os.toByteArray(), "UTF-8"),
+				isSimilarTo(EXPECTED_STRING));
 	}
 
 	@Test
@@ -140,7 +135,7 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 		XMLStreamWriter streamWriter = outputFactory.createXMLStreamWriter(writer);
 		Result result = StaxUtils.createStaxResult(streamWriter);
 		marshaller.marshal(flights, result);
-		assertXMLEqual("Marshaller writes invalid StreamResult", EXPECTED_STRING, writer.toString());
+		assertThat("Marshaller writes invalid StreamResult", writer.toString(), isSimilarTo(EXPECTED_STRING));
 	}
 
 	@Test
@@ -150,7 +145,7 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 		XMLEventWriter eventWriter = outputFactory.createXMLEventWriter(writer);
 		Result result = StaxUtils.createStaxResult(eventWriter);
 		marshaller.marshal(flights, result);
-		assertXMLEqual("Marshaller writes invalid StreamResult", EXPECTED_STRING, writer.toString());
+		assertThat("Marshaller writes invalid StreamResult", writer.toString(), isSimilarTo(EXPECTED_STRING));
 	}
 
 	@Test
@@ -160,7 +155,7 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 		XMLStreamWriter streamWriter = outputFactory.createXMLStreamWriter(writer);
 		StAXResult result = new StAXResult(streamWriter);
 		marshaller.marshal(flights, result);
-		assertXMLEqual("Marshaller writes invalid StreamResult", EXPECTED_STRING, writer.toString());
+		assertThat("Marshaller writes invalid StreamResult", writer.toString(), isSimilarTo(EXPECTED_STRING));
 	}
 
 	@Test
@@ -170,7 +165,11 @@ public abstract class AbstractMarshallerTests<M extends Marshaller> {
 		XMLEventWriter eventWriter = outputFactory.createXMLEventWriter(writer);
 		StAXResult result = new StAXResult(eventWriter);
 		marshaller.marshal(flights, result);
-		assertXMLEqual("Marshaller writes invalid StreamResult", EXPECTED_STRING, writer.toString());
+		assertThat("Marshaller writes invalid StreamResult", writer.toString(), isSimilarTo(EXPECTED_STRING));
 	}
 
+    private static CompareMatcher isSimilarTo(final Object content) {
+        return CompareMatcher.isSimilarTo(content)
+                .ignoreWhitespace();
+    }
 }

--- a/spring-oxm/src/test/java/org/springframework/oxm/castor/CastorMarshallerTests.java
+++ b/spring-oxm/src/test/java/org/springframework/oxm/castor/CastorMarshallerTests.java
@@ -16,37 +16,33 @@
 
 package org.springframework.oxm.castor;
 
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.oxm.AbstractMarshallerTests;
+import org.w3c.dom.Node;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xmlunit.builder.Input;
+import org.xmlunit.xpath.JAXPXPathEngine;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.sax.SAXResult;
+import javax.xml.transform.stream.StreamResult;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.transform.sax.SAXResult;
-import javax.xml.transform.stream.StreamResult;
-
-import org.custommonkey.xmlunit.NamespaceContext;
-import org.custommonkey.xmlunit.SimpleNamespaceContext;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.custommonkey.xmlunit.XpathEngine;
-
-import org.junit.Test;
-
-import org.mockito.InOrder;
-
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.oxm.AbstractMarshallerTests;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.ContentHandler;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * Tests the {@link CastorMarshaller} class.
@@ -163,14 +159,14 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 	public void suppressNamespacesTrue() throws Exception {
 		marshaller.setSuppressNamespaces(true);
 		String result = marshalFlights();
-		assertXMLEqual("Marshaller wrote invalid result", SUPPRESSED_NAMESPACE_EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(SUPPRESSED_NAMESPACE_EXPECTED_STRING));
 	}
 
 	@Test
 	public void suppressNamespacesFalse() throws Exception {
 		marshaller.setSuppressNamespaces(false);
 		String result = marshalFlights();
-		assertXMLEqual("Marshaller wrote invalid result", EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(EXPECTED_STRING));
 	}
 
 	@Test
@@ -179,7 +175,7 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 		marshaller.setSuppressXsiType(true);
 		marshaller.setRootElement("objects");
 		String result = marshal(Arrays.asList(castorObject));
-		assertXMLEqual("Marshaller wrote invalid result", SUPPRESSED_XSI_EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(SUPPRESSED_XSI_EXPECTED_STRING));
 	}
 
 	@Test
@@ -188,14 +184,14 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 		marshaller.setSuppressXsiType(false);
 		marshaller.setRootElement("objects");
 		String result = marshal(Arrays.asList(castorObject));
-		assertXMLEqual("Marshaller wrote invalid result", XSI_EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(XSI_EXPECTED_STRING));
 	}
 
 	@Test
 	public void marshalAsDocumentTrue() throws Exception {
 		marshaller.setMarshalAsDocument(true);
 		String result = marshalFlights();
-		assertXMLEqual("Marshaller wrote invalid result", DOCUMENT_EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(DOCUMENT_EXPECTED_STRING));
 		assertTrue("Result doesn't contain xml declaration.",
 				result.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
 	}
@@ -204,7 +200,7 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 	public void marshalAsDocumentFalse() throws Exception {
 		marshaller.setMarshalAsDocument(true);
 		String result = marshalFlights();
-		assertXMLEqual("Marshaller wrote invalid result", EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(EXPECTED_STRING));
 		assertFalse("Result contains xml declaration.", result.matches("<\\?\\s*xml"));
 	}
 
@@ -212,7 +208,7 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 	public void rootElement() throws Exception {
 		marshaller.setRootElement("canceledFlights");
 		String result = marshalFlights();
-		assertXMLEqual("Marshaller wrote invalid result", ROOT_ELEMENT_EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(ROOT_ELEMENT_EXPECTED_STRING));
 	}
 
 	@Test
@@ -222,7 +218,7 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 		String result = marshalFlights();
 		assertXpathEvaluatesTo("The xsi:noNamespaceSchemaLocation hasn't been written or has invalid value.",
 				noNamespaceSchemaLocation, "/tns:flights/@xsi:noNamespaceSchemaLocation", result);
-		assertXMLEqual("Marshaller wrote invalid result", EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(EXPECTED_STRING));
 	}
 
 	@Test
@@ -232,7 +228,7 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 		String result = marshalFlights();
 		assertXpathEvaluatesTo("The xsi:noNamespaceSchemaLocation hasn't been written or has invalid value.",
 				schemaLocation, "/tns:flights/@xsi:schemaLocation", result);
-		assertXMLEqual("Marshaller wrote invalid result", EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(EXPECTED_STRING));
 	}
 
 	@Test
@@ -242,7 +238,7 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 		marshaller.setUseXSITypeAtRoot(true);
 		marshaller.setRootElement("objects");
 		String result = marshal(Arrays.asList(castorObject));
-		assertXMLEqual("Marshaller wrote invalid result", ROOT_WITH_XSI_EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(ROOT_WITH_XSI_EXPECTED_STRING));
 	}
 
 	@Test
@@ -252,7 +248,7 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 		marshaller.setUseXSITypeAtRoot(false);
 		marshaller.setRootElement("objects");
 		String result = marshal(Arrays.asList(castorObject));
-		assertXMLEqual("Marshaller wrote invalid result", ROOT_WITHOUT_XSI_EXPECTED_STRING, result);
+		assertThat("Marshaller wrote invalid result", result, isSimilarTo(ROOT_WITHOUT_XSI_EXPECTED_STRING));
 	}
 
 
@@ -282,13 +278,12 @@ public class CastorMarshallerTests extends AbstractMarshallerTests<CastorMarshal
 		namespaces.put("tns", "http://samples.springframework.org/flight");
 		namespaces.put("xsi", "http://www.w3.org/2001/XMLSchema-instance");
 
-		NamespaceContext ctx = new SimpleNamespaceContext(namespaces);
-		XpathEngine engine = XMLUnit.newXpathEngine();
-		engine.setNamespaceContext(ctx);
+		JAXPXPathEngine engine = new JAXPXPathEngine();
+		engine.setNamespaceContext(namespaces);
 
-		Document doc = XMLUnit.buildControlDocument(xmlDoc);
-		NodeList node = engine.getMatchingNodes(xpath, doc);
-		assertEquals(msg, expected, node.item(0).getNodeValue());
+		Source source = Input.fromString(xmlDoc).build();
+		Iterable<Node> nodeList = engine.selectNodes(xpath, source);
+		assertEquals(msg, expected, nodeList.iterator().next().getNodeValue());
 	}
 
 	/**

--- a/spring-oxm/src/test/java/org/springframework/oxm/jaxb/Jaxb2MarshallerTests.java
+++ b/spring-oxm/src/test/java/org/springframework/oxm/jaxb/Jaxb2MarshallerTests.java
@@ -16,34 +16,9 @@
 
 package org.springframework.oxm.jaxb;
 
-import java.io.ByteArrayOutputStream;
-import java.io.StringWriter;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.Collections;
-import javax.activation.DataHandler;
-import javax.activation.FileDataSource;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.namespace.QName;
-import javax.xml.transform.Result;
-import javax.xml.transform.sax.SAXResult;
-import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
-
 import org.junit.Test;
-
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.ContentHandler;
-import org.xml.sax.InputSource;
-import org.xml.sax.Locator;
-
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.oxm.AbstractMarshallerTests;
@@ -55,13 +30,53 @@ import org.springframework.oxm.jaxb.test.ObjectFactory;
 import org.springframework.oxm.mime.MimeContainer;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.ReflectionUtils;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xmlunit.diff.Comparison;
+import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.ComparisonType;
+import org.xmlunit.diff.DifferenceEvaluator;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+import javax.xml.transform.Result;
+import javax.xml.transform.sax.SAXResult;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.inOrder;
+import static org.mockito.BDDMockito.isA;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.reset;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.xmlunit.diff.ComparisonType.XML_STANDALONE;
+import static org.xmlunit.diff.DifferenceEvaluators.Default;
+import static org.xmlunit.diff.DifferenceEvaluators.chain;
+import static org.xmlunit.diff.DifferenceEvaluators.downgradeDifferencesToEqual;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * @author Arjen Poutsma
@@ -122,7 +137,9 @@ public class Jaxb2MarshallerTests extends AbstractMarshallerTests<Jaxb2Marshalle
 		StringWriter writer = new StringWriter();
 		StreamResult result = new StreamResult(writer);
 		marshaller.marshal(flights, result);
-		assertXMLEqual("Marshaller writes invalid StreamResult", EXPECTED_STRING, writer.toString());
+		DifferenceEvaluator ev = chain(Default, downgradeDifferencesToEqual(XML_STANDALONE));
+		assertThat("Marshaller writes invalid StreamResult", writer.toString(),
+				isSimilarTo(EXPECTED_STRING).withDifferenceEvaluator(ev));
 	}
 
 	@Test
@@ -305,8 +322,10 @@ public class Jaxb2MarshallerTests extends AbstractMarshallerTests<Jaxb2Marshalle
 		StringWriter writer = new StringWriter();
 		Result result = new StreamResult(writer);
 		marshaller.marshal(airplane, result);
-		assertXMLEqual("Marshalling should use root Element",
-				writer.toString(), "<airplane><name>test</name></airplane>");
+		DifferenceEvaluator ev = chain(Default, downgradeDifferencesToEqual(XML_STANDALONE));
+		assertThat("Marshalling should use root Element",
+				writer.toString(),
+				isSimilarTo("<airplane><name>test</name></airplane>").withDifferenceEvaluator(ev));
 	}
 
 	// SPR-10806
@@ -407,5 +426,4 @@ public class Jaxb2MarshallerTests extends AbstractMarshallerTests<Jaxb2Marshalle
 	private JAXBElement<DummyType> createDummyType() {
 		return null;
 	}
-
 }

--- a/spring-oxm/src/test/java/org/springframework/oxm/jibx/JibxMarshallerTests.java
+++ b/spring-oxm/src/test/java/org/springframework/oxm/jibx/JibxMarshallerTests.java
@@ -16,21 +16,19 @@
 
 package org.springframework.oxm.jibx;
 
-import java.io.StringWriter;
-import javax.xml.transform.stream.StreamResult;
-
-import org.custommonkey.xmlunit.XMLUnit;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import org.springframework.oxm.AbstractMarshallerTests;
 import org.springframework.tests.Assume;
 import org.springframework.tests.TestGroup;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * NOTE: These tests fail under Eclipse/IDEA because JiBX binding does not occur by
@@ -74,11 +72,10 @@ public class JibxMarshallerTests extends AbstractMarshallerTests<JibxMarshaller>
 		marshaller.setIndent(4);
 		StringWriter writer = new StringWriter();
 		marshaller.marshal(flights, new StreamResult(writer));
-		XMLUnit.setIgnoreWhitespace(false);
 		String expected =
 				"<?xml version=\"1.0\"?>\n" + "<flights xmlns=\"http://samples.springframework.org/flight\">\n" +
 						"    <flight>\n" + "        <number>42</number>\n" + "    </flight>\n" + "</flights>";
-		assertXMLEqual(expected, writer.toString());
+		assertThat(writer.toString(), isSimilarTo(expected).ignoreWhitespace());
 	}
 
 	@Test

--- a/spring-test/src/main/java/org/springframework/test/util/XmlExpectationsHelper.java
+++ b/spring-test/src/main/java/org/springframework/test/util/XmlExpectationsHelper.java
@@ -23,12 +23,12 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 
-import org.custommonkey.xmlunit.Diff;
-import org.custommonkey.xmlunit.XMLUnit;
 import org.hamcrest.Matcher;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
 
 import static org.hamcrest.MatcherAssert.*;
 
@@ -77,15 +77,12 @@ public class XmlExpectationsHelper {
 	 * @see org.springframework.test.web.servlet.result.MockMvcResultMatchers#xpath(String, Map, Object...)
 	 */
 	public void assertXmlEqual(String expected, String actual) throws Exception {
-		XMLUnit.setIgnoreWhitespace(true);
-		XMLUnit.setIgnoreComments(true);
-		XMLUnit.setIgnoreAttributeOrder(true);
-
-		Document control = XMLUnit.buildControlDocument(expected);
-		Document test = XMLUnit.buildTestDocument(actual);
-		Diff diff = new Diff(control, test);
-		if (!diff.similar()) {
-			AssertionErrors.fail("Body content " + diff.toString());
+		Diff diffSimilar = DiffBuilder.compare(expected).withTest(actual)
+				.ignoreWhitespace().ignoreComments()
+				.checkForSimilar()
+				.build();
+		if (diffSimilar.hasDifferences()) {
+			AssertionErrors.fail("Body content " + diffSimilar.toString());
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/converter/feed/AtomFeedHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/feed/AtomFeedHttpMessageConverterTests.java
@@ -16,26 +16,28 @@
 
 package org.springframework.http.converter.feed;
 
+import com.rometools.rome.feed.atom.Entry;
+import com.rometools.rome.feed.atom.Feed;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.MockHttpInputMessage;
+import org.springframework.http.MockHttpOutputMessage;
+import org.xml.sax.SAXException;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
+import org.xmlunit.diff.NodeMatcher;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.rometools.rome.feed.atom.Entry;
-import com.rometools.rome.feed.atom.Feed;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.Before;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
-import org.springframework.http.MediaType;
-import org.springframework.http.MockHttpInputMessage;
-import org.springframework.http.MockHttpOutputMessage;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * @author Arjen Poutsma
@@ -50,7 +52,6 @@ public class AtomFeedHttpMessageConverterTests {
 	public void setUp() {
 		utf8 = Charset.forName("UTF-8");
 		converter = new AtomFeedHttpMessageConverter();
-		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -111,7 +112,9 @@ public class AtomFeedHttpMessageConverterTests {
 		String expected = "<feed xmlns=\"http://www.w3.org/2005/Atom\">" + "<title>title</title>" +
 				"<entry><id>id1</id><title>title1</title></entry>" +
 				"<entry><id>id2</id><title>title2</title></entry></feed>";
-		assertXMLEqual(expected, outputMessage.getBodyAsString(utf8));
+		NodeMatcher nm = new DefaultNodeMatcher(ElementSelectors.byName);
+		assertThat(outputMessage.getBodyAsString(utf8),
+				isSimilarTo(expected).ignoreWhitespace().withNodeMatcher(nm));
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/http/converter/feed/RssChannelHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/feed/RssChannelHttpMessageConverterTests.java
@@ -16,25 +16,24 @@
 
 package org.springframework.http.converter.feed;
 
+import com.rometools.rome.feed.rss.Channel;
+import com.rometools.rome.feed.rss.Item;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.MockHttpInputMessage;
+import org.springframework.http.MockHttpOutputMessage;
+import org.xml.sax.SAXException;
+import org.xmlunit.matchers.CompareMatcher;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.rometools.rome.feed.rss.Channel;
-import com.rometools.rome.feed.rss.Item;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.Before;
-import org.junit.Test;
-import org.xml.sax.SAXException;
-
-import org.springframework.http.MediaType;
-import org.springframework.http.MockHttpInputMessage;
-import org.springframework.http.MockHttpOutputMessage;
-
-import static org.custommonkey.xmlunit.XMLAssert.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -50,7 +49,6 @@ public class RssChannelHttpMessageConverterTests {
 	public void setUp() {
 		utf8 = Charset.forName("UTF-8");
 		converter = new RssChannelHttpMessageConverter();
-		XMLUnit.setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -98,7 +96,7 @@ public class RssChannelHttpMessageConverterTests {
 		Item item2 = new Item();
 		item2.setTitle("title2");
 
-		List<Item> items = new ArrayList<Item>(2);
+		List<Item> items = new ArrayList<>(2);
 		items.add(item1);
 		items.add(item2);
 		channel.setItems(items);
@@ -113,7 +111,7 @@ public class RssChannelHttpMessageConverterTests {
 				"<item><title>title1</title></item>" +
 				"<item><title>title2</title></item>" +
 				"</channel></rss>";
-		assertXMLEqual(expected, outputMessage.getBodyAsString(utf8));
+		assertThat(outputMessage.getBodyAsString(utf8), isSimilarTo(expected));
 	}
 
 	@Test
@@ -136,4 +134,8 @@ public class RssChannelHttpMessageConverterTests {
 				outputMessage.getHeaders().getContentType());
 	}
 
+	private static CompareMatcher isSimilarTo(final String content) {
+		return CompareMatcher.isSimilarTo(content)
+				.ignoreWhitespace();
+	}
 }

--- a/spring-web/src/test/java/org/springframework/http/converter/xml/SourceHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/xml/SourceHttpMessageConverterTests.java
@@ -48,10 +48,11 @@ import org.springframework.http.MockHttpOutputMessage;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.util.FileCopyUtils;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 // Do NOT statically import org.junit.Assert.*, since XMLAssert extends junit.framework.Assert
 
@@ -73,7 +74,7 @@ public class SourceHttpMessageConverterTests {
 
 	@Before
 	public void setUp() throws IOException {
-		converter = new SourceHttpMessageConverter<Source>();
+		converter = new SourceHttpMessageConverter<>();
 		Resource external = new ClassPathResource("external.txt", getClass());
 
 		bodyExternal = "<!DOCTYPE root SYSTEM \"http://192.168.28.42/1.jsp\" [" +
@@ -149,7 +150,7 @@ public class SourceHttpMessageConverterTests {
 		SAXSource result = (SAXSource) converter.read(SAXSource.class, inputMessage);
 		InputSource inputSource = result.getInputSource();
 		String s = FileCopyUtils.copyToString(new InputStreamReader(inputSource.getByteStream()));
-		assertXMLEqual("Invalid result", BODY, s);
+		assertThat("Invalid result", s, isSimilarTo(BODY));
 	}
 
 	@Test
@@ -277,7 +278,7 @@ public class SourceHttpMessageConverterTests {
 		inputMessage.getHeaders().setContentType(new MediaType("application", "xml"));
 		StreamSource result = (StreamSource) converter.read(StreamSource.class, inputMessage);
 		String s = FileCopyUtils.copyToString(new InputStreamReader(result.getInputStream()));
-		assertXMLEqual("Invalid result", BODY, s);
+		assertThat("Invalid result", s, isSimilarTo(BODY));
 	}
 
 	@Test
@@ -299,8 +300,8 @@ public class SourceHttpMessageConverterTests {
 
 		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
 		converter.write(domSource, null, outputMessage);
-		assertXMLEqual("Invalid result", "<root>Hello World</root>",
-				outputMessage.getBodyAsString(Charset.forName("UTF-8")));
+		assertThat("Invalid result", outputMessage.getBodyAsString(Charset.forName("UTF-8")),
+				isSimilarTo("<root>Hello World</root>"));
 		assertEquals("Invalid content-type", new MediaType("application", "xml"),
 				outputMessage.getHeaders().getContentType());
 		assertEquals("Invalid content-length", outputMessage.getBodyAsBytes().length,
@@ -314,8 +315,8 @@ public class SourceHttpMessageConverterTests {
 
 		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
 		converter.write(saxSource, null, outputMessage);
-		assertXMLEqual("Invalid result", "<root>Hello World</root>",
-				outputMessage.getBodyAsString(Charset.forName("UTF-8")));
+		assertThat("Invalid result", outputMessage.getBodyAsString(Charset.forName("UTF-8")),
+				isSimilarTo("<root>Hello World</root>"));
 		assertEquals("Invalid content-type", new MediaType("application", "xml"),
 				outputMessage.getHeaders().getContentType());
 	}
@@ -327,8 +328,8 @@ public class SourceHttpMessageConverterTests {
 
 		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
 		converter.write(streamSource, null, outputMessage);
-		assertXMLEqual("Invalid result", "<root>Hello World</root>",
-				outputMessage.getBodyAsString(Charset.forName("UTF-8")));
+		assertThat("Invalid result", outputMessage.getBodyAsString(Charset.forName("UTF-8")),
+				isSimilarTo("<root>Hello World</root>"));
 		assertEquals("Invalid content-type", new MediaType("application", "xml"),
 				outputMessage.getHeaders().getContentType());
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/feed/AtomFeedViewTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/feed/AtomFeedViewTests.java
@@ -16,26 +16,25 @@
 
 package org.springframework.web.servlet.view.feed;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.rometools.rome.feed.atom.Content;
 import com.rometools.rome.feed.atom.Entry;
 import com.rometools.rome.feed.atom.Feed;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.mock.web.test.MockHttpServletResponse;
+import org.xmlunit.matchers.CompareMatcher;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
-import static org.custommonkey.xmlunit.XMLUnit.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Arjen Poutsma
@@ -47,7 +46,6 @@ public class AtomFeedViewTests {
 	@Before
 	public void createView() throws Exception {
 		view = new MyAtomFeedView();
-		setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -55,7 +53,7 @@ public class AtomFeedViewTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
-		Map<String, String> model = new LinkedHashMap<String, String>();
+		Map<String, String> model = new LinkedHashMap<>();
 		model.put("2", "This is entry 2");
 		model.put("1", "This is entry 1");
 
@@ -64,9 +62,13 @@ public class AtomFeedViewTests {
 		String expected = "<feed xmlns=\"http://www.w3.org/2005/Atom\">" + "<title>Test Feed</title>" +
 				"<entry><title>2</title><summary>This is entry 2</summary></entry>" +
 				"<entry><title>1</title><summary>This is entry 1</summary></entry>" + "</feed>";
-		assertXMLEqual(expected, response.getContentAsString());
+		assertThat(response.getContentAsString(), isSimilarTo(expected));
 	}
 
+	private static CompareMatcher isSimilarTo(final String content) {
+		return CompareMatcher.isSimilarTo(content)
+				.ignoreWhitespace();
+	}
 
 	private static class MyAtomFeedView extends AbstractAtomFeedView {
 
@@ -78,7 +80,7 @@ public class AtomFeedViewTests {
 		@Override
 		protected List<Entry> buildFeedEntries(Map model, HttpServletRequest request, HttpServletResponse response)
 				throws Exception {
-			List<Entry> entries = new ArrayList<Entry>();
+			List<Entry> entries = new ArrayList<>();
 			for (Iterator iterator = model.keySet().iterator(); iterator.hasNext();) {
 				String name = (String) iterator.next();
 				Entry entry = new Entry();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/feed/RssFeedViewTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/feed/RssFeedViewTests.java
@@ -16,25 +16,25 @@
 
 package org.springframework.web.servlet.view.feed;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.rometools.rome.feed.rss.Channel;
 import com.rometools.rome.feed.rss.Description;
 import com.rometools.rome.feed.rss.Item;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.mock.web.test.MockHttpServletResponse;
+import org.xmlunit.matchers.CompareMatcher;
 
-import static org.custommonkey.xmlunit.XMLAssert.*;
-import static org.custommonkey.xmlunit.XMLUnit.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * @author Arjen Poutsma
@@ -46,7 +46,6 @@ public class RssFeedViewTests {
 	@Before
 	public void createView() throws Exception {
 		view = new MyRssFeedView();
-		setIgnoreWhitespace(true);
 	}
 
 	@Test
@@ -54,7 +53,7 @@ public class RssFeedViewTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
-		Map<String, String> model = new LinkedHashMap<String, String>();
+		Map<String, String> model = new LinkedHashMap<>();
 		model.put("2", "This is entry 2");
 		model.put("1", "This is entry 1");
 
@@ -64,7 +63,7 @@ public class RssFeedViewTests {
 				"<channel><title>Test Feed</title><link>http://example.com</link><description>Test feed description</description>" +
 				"<item><title>2</title><description>This is entry 2</description></item>" +
 				"<item><title>1</title><description>This is entry 1</description></item>" + "</channel></rss>";
-		assertXMLEqual(expected, response.getContentAsString());
+		assertThat(response.getContentAsString(), isSimilarTo(expected).ignoreWhitespace());
 	}
 
 
@@ -79,7 +78,7 @@ public class RssFeedViewTests {
 
 		@Override
 		protected List<Item> buildFeedItems(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
-			List<Item> items = new ArrayList<Item>();
+			List<Item> items = new ArrayList<>();
 			for (String name : model.keySet()) {
 				Item item = new Item();
 				item.setTitle(name);


### PR DESCRIPTION
xmlunit 2.0.0 is the latest major release for xmlunit.
Most of the xmlunit functionality used within spring-framework was done through the xmlunit 1.x  helper class org.custommonkey.xmlunit.XMLAssert. As of xmlunit 2.0.0 most of the XML comparison methods are done through hamcrest matchers exposed by the xmlunit-matchers library. In some cases during the migration, the matchers had to be customized with custom NodeMatcher or DifferenceEvaluator instances in order to keep correct the assertions performed with xmlunit 1.x library.

Issue: SPR-14043
