### PR TITLE
Adapters for RxJava types to DeferredResult and SseEmitter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -912,6 +912,7 @@ project("spring-webmvc") {
 			exclude group: "org.springframework", module: "spring-web"
 		}
 		optional('org.webjars:webjars-locator:0.28')
+		optional('io.reactivex:rxjava:1.1.1')
 		testCompile("rhino:js:1.7R1")
 		testCompile("xmlunit:xmlunit:${xmlunitVersion}")
 		testCompile("dom4j:dom4j:1.6.1") {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/DeferredResultMethodReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/DeferredResultMethodReturnValueHandler.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
+import rx.Single;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.lang.UsesJava8;
 import org.springframework.util.Assert;
@@ -35,8 +37,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
  * Handler for return values of type {@link DeferredResult}, {@link ListenableFuture},
- * {@link CompletionStage} and any other async type with a {@link #getAdapterMap()
- * registered adapter}.
+ * {@link CompletionStage}, {@link rx.Single} and any other async type with a
+ * {@link #getAdapterMap() registered adapter}.
  *
  * @author Rossen Stoyanchev
  * @since 3.2
@@ -52,6 +54,9 @@ public class DeferredResultMethodReturnValueHandler implements AsyncHandlerMetho
 		this.adapterMap.put(ListenableFuture.class, new ListenableFutureAdapter());
 		if (ClassUtils.isPresent("java.util.concurrent.CompletionStage", getClass().getClassLoader())) {
 			this.adapterMap.put(CompletionStage.class, new CompletionStageAdapter());
+		}
+		if (ClassUtils.isPresent("rx.Single", getClass().getClassLoader())) {
+			this.adapterMap.put(Single.class, new RxJavaReturnValueAdapter());
 		}
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterReturnValueHandler.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import rx.Observable;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ResolvableType;
@@ -37,6 +38,7 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.context.request.async.WebAsyncUtils;
@@ -46,8 +48,9 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
  * Handler for return values of type {@link ResponseBodyEmitter} (and the
- * {@code ResponseEntity<ResponseBodyEmitter>} sub-class) as well as any other
- * async type with a {@link #getAdapterMap() registered adapter}.
+ * {@code ResponseEntity<ResponseBodyEmitter>} sub-class), {@link rx.Observable},
+ * as well as any other async type with a {@link #getAdapterMap()
+ * registered adapter}.
  *
  * @author Rossen Stoyanchev
  * @since 4.2
@@ -67,6 +70,9 @@ public class ResponseBodyEmitterReturnValueHandler implements AsyncHandlerMethod
 		this.messageConverters = messageConverters;
 		this.adapterMap = new HashMap<Class<?>, ResponseBodyEmitterAdapter>(3);
 		this.adapterMap.put(ResponseBodyEmitter.class, new SimpleResponseBodyEmitterAdapter());
+		if (ClassUtils.isPresent("rx.Observable", getClass().getClassLoader())) {
+			this.adapterMap.put(Observable.class, new RxJavaReturnValueAdapter());
+		}
 	}
 
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RxJavaReturnValueAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RxJavaReturnValueAdapter.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.web.servlet.mvc.method.annotation;
+
+import java.io.IOException;
+
+import rx.Observable;
+import rx.Single;
+import rx.SingleSubscriber;
+import rx.Subscriber;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.util.Assert;
+import org.springframework.web.context.request.async.DeferredResult;
+
+/**
+ * Adapters for RxJava's {@link rx.Single} and {@link rx.Observable} to be
+ * supported as return values in Spring MVC.
+ *
+ * @author Rossen Stoyanchev
+ * @since 4.3
+ */
+public class RxJavaReturnValueAdapter implements ResponseBodyEmitterAdapter, DeferredResultAdapter {
+
+	private static final MediaType SSE_MEDIA_TYPE = new MediaType("text", "event-stream");
+
+
+	@Override
+	public DeferredResult<?> adaptToDeferredResult(Object returnValue) {
+		Assert.isInstanceOf(Single.class, returnValue);
+		Single<?> single = (Single<?>) returnValue;
+		DeferredResult<Object> result = createDeferredResult();
+		single.subscribe(new SingleSubscriberAdapter(result));
+		return result;
+	}
+
+	protected DeferredResult<Object> createDeferredResult() {
+		return new DeferredResult<Object>();
+	}
+
+	@Override
+	public ResponseBodyEmitter adaptToEmitter(Object returnValue, ServerHttpResponse response) {
+		Assert.isInstanceOf(Observable.class, returnValue);
+		ResponseBodyEmitter emitter = createEmitter(response);
+		((Observable<?>) returnValue).subscribe(new SubscriberAdapter(emitter));
+		return emitter;
+	}
+
+	protected ResponseBodyEmitter createEmitter(ServerHttpResponse response) {
+		MediaType contentType = response.getHeaders().getContentType();
+		if (contentType != null && contentType.isCompatibleWith(SSE_MEDIA_TYPE)) {
+			return new SseEmitter();
+		}
+		else {
+			return new ResponseBodyEmitter();
+		}
+	}
+
+
+	private static class SingleSubscriberAdapter extends SingleSubscriber<Object> implements Runnable {
+
+		private final DeferredResult<Object> deferredResult;
+
+
+		public SingleSubscriberAdapter(DeferredResult<Object> deferredResult) {
+			this.deferredResult = deferredResult;
+			this.deferredResult.onTimeout(this);
+			this.deferredResult.onCompletion(this);
+		}
+
+
+		@Override
+		public void onSuccess(Object value) {
+			this.deferredResult.setResult(value);
+		}
+
+		@Override
+		public void onError(Throwable error) {
+			this.deferredResult.setErrorResult(error);
+		}
+
+		@Override
+		public void run() {
+			unsubscribe();
+		}
+	}
+
+	private static class SubscriberAdapter extends Subscriber<Object> implements Runnable {
+
+		private final ResponseBodyEmitter emitter;
+
+
+		public SubscriberAdapter(ResponseBodyEmitter emitter) {
+			this.emitter = emitter;
+			this.emitter.onTimeout(this);
+			this.emitter.onCompletion(this);
+		}
+
+
+		@Override
+		public void onNext(Object value) {
+			try {
+				this.emitter.send(value);
+			}
+			catch (IOException ex) {
+				unsubscribe();
+			}
+		}
+
+		@Override
+		public void onError(Throwable ex) {
+			this.emitter.completeWithError(ex);
+		}
+
+		@Override
+		public void onCompleted() {
+			this.emitter.complete();
+		}
+
+		@Override
+		public void run() {
+			unsubscribe();
+		}
+	}
+
+}


### PR DESCRIPTION
`rx.Single` is adapted to `DeferredResult` which is a straight-forward fit. 

`rx.Observable` is adapted to `SseEmitter` with `Content-Type: text/event-stream` (also a straight-forward fit) or to `ResponseBodyEmitter` otherwise (HTTP streaming minus SSE formatting).

Note: there is no support for `Observable` in non-HTTP streaming/SSE scenarios. The [spring-reactive](https://github.com/spring-projects/spring-reactive) project and Spring Framework 5 aim to provide comprehensive support for reactive programming models.

https://jira.spring.io/browse/SPR-14046
