### PR TITLE
MockMvc HtmlUnit support shares CookieManager

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebClientBuilder.java
@@ -106,7 +106,7 @@ public class MockMvcWebClientBuilder extends MockMvcWebConnectionBuilderSupport<
 	 */
 	public MockMvcWebClientBuilder withDelegate(WebClient webClient) {
 		Assert.notNull(webClient, "WebClient must not be null");
-		webClient.setWebConnection(createConnection(webClient.getWebConnection()));
+		webClient.setWebConnection(createConnection(webClient));
 		this.webClient = webClient;
 		return this;
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
@@ -63,6 +63,38 @@ public final class MockMvcWebConnection implements WebConnection {
 
 	private WebClient webClient;
 
+	/**
+	 * Create a new instance that assumes the context path of the application
+	 * is {@code ""} (i.e., the root context).
+	 * <p>For example, the URL {@code http://localhost/test/this} would use
+	 * {@code ""} as the context path.
+	 * @param mockMvc the {@code MockMvc} instance to use; never {@code null}
+	 * @param webClient the {@link WebClient} to use. never {@code null}
+	 */
+	public MockMvcWebConnection(MockMvc mockMvc, WebClient webClient) {
+		this(mockMvc, webClient, "");
+	}
+
+	/**
+	 * Create a new instance with the specified context path.
+	 * <p>The path may be {@code null} in which case the first path segment
+	 * of the URL is turned into the contextPath. Otherwise it must conform
+	 * to {@link javax.servlet.http.HttpServletRequest#getContextPath()}
+	 * which states that it can be an empty string and otherwise must start
+	 * with a "/" character and not end with a "/" character.
+	 * @param mockMvc the {@code MockMvc} instance to use; never {@code null}
+	 * @param webClient  the {@link WebClient} to use. never {@code null}
+	 * @param contextPath the contextPath to use
+	 */
+	public MockMvcWebConnection(MockMvc mockMvc, WebClient webClient, String contextPath) {
+		Assert.notNull(mockMvc, "MockMvc must not be null");
+		Assert.notNull(webClient, "WebClient must not be null");
+		validateContextPath(contextPath);
+
+		this.webClient = webClient;
+		this.mockMvc = mockMvc;
+		this.contextPath = contextPath;
+	}
 
 	/**
 	 * Create a new instance that assumes the context path of the application
@@ -70,7 +102,9 @@ public final class MockMvcWebConnection implements WebConnection {
 	 * <p>For example, the URL {@code http://localhost/test/this} would use
 	 * {@code ""} as the context path.
 	 * @param mockMvc the {@code MockMvc} instance to use; never {@code null}
+	 * @deprecated Use {@link #MockMvcWebConnection(MockMvc, WebClient)}
 	 */
+	@Deprecated
 	public MockMvcWebConnection(MockMvc mockMvc) {
 		this(mockMvc, "");
 	}
@@ -84,16 +118,12 @@ public final class MockMvcWebConnection implements WebConnection {
 	 * with a "/" character and not end with a "/" character.
 	 * @param mockMvc the {@code MockMvc} instance to use; never {@code null}
 	 * @param contextPath the contextPath to use
+	 * @deprecated use {@link #MockMvcWebConnection(MockMvc, WebClient, String)}
 	 */
+	@Deprecated
 	public MockMvcWebConnection(MockMvc mockMvc, String contextPath) {
-		Assert.notNull(mockMvc, "MockMvc must not be null");
-		validateContextPath(contextPath);
-
-		this.webClient = new WebClient();
-		this.mockMvc = mockMvc;
-		this.contextPath = contextPath;
+		this(mockMvc, new WebClient(), contextPath);
 	}
-
 
 	public void setWebClient(WebClient webClient) {
 		Assert.notNull(webClient, "WebClient must not be null");

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnectionBuilderSupport.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnectionBuilderSupport.java
@@ -19,6 +19,7 @@ package org.springframework.test.web.servlet.htmlunit;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebConnection;
 
 import org.springframework.test.web.servlet.MockMvc;
@@ -145,10 +146,46 @@ public abstract class MockMvcWebConnectionBuilderSupport<T extends MockMvcWebCon
 	 * @see #alwaysUseMockMvc()
 	 * @see #useMockMvc(WebRequestMatcher...)
 	 * @see #useMockMvcForHosts(String...)
+	 * @deprecated Use {@link #createConnection(WebClient)} instead
 	 */
+	@Deprecated
 	protected final WebConnection createConnection(WebConnection defaultConnection) {
 		Assert.notNull(defaultConnection, "Default WebConnection must not be null");
-		MockMvcWebConnection mockMvcWebConnection = new MockMvcWebConnection(this.mockMvc, this.contextPath);
+		return createConnection(new WebClient(), defaultConnection);
+	}
+
+	/**
+	 * Create a new {@link WebConnection} that will use a {@link MockMvc}
+	 * instance if one of the specified {@link WebRequestMatcher} instances
+	 * matches.
+	 * @param webClient the WebClient to use if none of
+	 * the specified {@code WebRequestMatcher} instances matches; never {@code null}
+	 * @return a new {@code WebConnection} that will use a {@code MockMvc}
+	 * instance if one of the specified {@code WebRequestMatcher} matches
+	 * @see #alwaysUseMockMvc()
+	 * @see #useMockMvc(WebRequestMatcher...)
+	 * @see #useMockMvcForHosts(String...)
+	 */
+	protected final WebConnection createConnection(WebClient webClient) {
+		Assert.notNull(webClient, "WebClient must not be null");
+		return createConnection(webClient, webClient.getWebConnection());
+	}
+
+	/**
+	 * Create a new {@link WebConnection} that will use a {@link MockMvc}
+	 * instance if one of the specified {@link WebRequestMatcher} instances
+	 * matches.
+	 * @param webClient the WebClient to use if none of
+	 * the specified {@code WebRequestMatcher} instances matches; never {@code null}
+	 * @param defaultConnection the WebConnection to use
+	 * @return a new {@code WebConnection} that will use a {@code MockMvc}
+	 * instance if one of the specified {@code WebRequestMatcher} matches
+	 * @see #alwaysUseMockMvc()
+	 * @see #useMockMvc(WebRequestMatcher...)
+	 * @see #useMockMvcForHosts(String...)
+	 */
+	private WebConnection createConnection(WebClient webClient, WebConnection defaultConnection) {
+		MockMvcWebConnection mockMvcWebConnection = new MockMvcWebConnection(this.mockMvc, webClient, this.contextPath);
 
 		if (this.alwaysUseMockMvc) {
 			return mockMvcWebConnection;
@@ -162,5 +199,4 @@ public abstract class MockMvcWebConnectionBuilderSupport<T extends MockMvcWebCon
 
 		return new DelegatingWebConnection(defaultConnection, delegates);
 	}
-
 }

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriverBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriverBuilder.java
@@ -129,7 +129,7 @@ public class MockMvcHtmlUnitDriverBuilder extends MockMvcWebConnectionBuilderSup
 	public MockMvcHtmlUnitDriverBuilder withDelegate(WebConnectionHtmlUnitDriver driver) {
 		Assert.notNull(driver, "HtmlUnitDriver must not be null");
 		driver.setJavascriptEnabled(this.javascriptEnabled);
-		driver.setWebConnection(createConnection(driver.getWebConnection()));
+		driver.setWebConnection(createConnection(driver.getWebClient()));
 		this.driver = driver;
 		return this;
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/WebConnectionHtmlUnitDriver.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/WebConnectionHtmlUnitDriver.java
@@ -41,7 +41,6 @@ public class WebConnectionHtmlUnitDriver extends HtmlUnitDriver {
 
 	private WebClient webClient;
 
-
 	public WebConnectionHtmlUnitDriver(BrowserVersion browserVersion) {
 		super(browserVersion);
 	}
@@ -107,4 +106,11 @@ public class WebConnectionHtmlUnitDriver extends HtmlUnitDriver {
 		this.webClient.setWebConnection(webConnection);
 	}
 
+	/**
+	 * Gets the current {@link WebClient}
+	 * @return the current {@link WebClient}
+	 */
+	public WebClient getWebClient() {
+		return this.webClient;
+	}
 }

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnectionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnectionTests.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertThat;
  * @author Rob Winch
  * @since 4.2
  */
+@SuppressWarnings("deprecation")
 public class MockMvcWebConnectionTests {
 
 	private final WebClient webClient = new WebClient();
@@ -50,7 +51,7 @@ public class MockMvcWebConnectionTests {
 
 	@Test
 	public void contextPathNull() throws IOException {
-		this.webClient.setWebConnection(new MockMvcWebConnection(this.mockMvc, null));
+		this.webClient.setWebConnection(new MockMvcWebConnection(this.mockMvc, (String) null));
 
 		Page page = this.webClient.getPage("http://localhost/context/a");
 


### PR DESCRIPTION
Previously MockMvc builders failed to share the WebConnection used for
managing cookies in the MockMvcWebConnection. This meant that the various
CookieManagers would have different states.

This commit ensures that the WebConnection is set on the
MockMvcWebConnection.

Fixes SPR-14066
