### PR TITLE
Polish MimeTypeUtil to handle only delimiter.

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -219,6 +219,10 @@ public abstract class MimeTypeUtils {
 		if (!StringUtils.hasLength(mimeType)) {
 			throw new InvalidMimeTypeException(mimeType, "'mimeType' must not be empty");
 		}
+		if (mimeType.startsWith(";")) {
+			throw new InvalidMimeTypeException(mimeType, "does not contain any type");
+		}
+
 		String[] parts = StringUtils.tokenizeToStringArray(mimeType, ";");
 
 		String fullType = parts[0].trim();

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -165,6 +165,11 @@ public class MimeTypeTests {
 	}
 
 	@Test(expected = InvalidMimeTypeException.class)
+	public void parseMimeTypeNoType() {
+		MimeTypeUtils.parseMimeType(";");
+	}
+
+	@Test(expected = InvalidMimeTypeException.class)
 	public void parseMimeTypeNoSubtype() {
 		MimeTypeUtils.parseMimeType("audio");
 	}


### PR DESCRIPTION
I've encounter `java.lang.ArrayIndexOutOfBoundsException:` when only ";" passed in Accept Header and found `MimeTypeUtils` throws the exception.

It think it's an unexpected behavior, so added a logic to throw the dedicated exception :)
