### PR TITLE
Remove unnecessary condition in ResourceHttpRequestHandler.handleRequest()

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -336,10 +336,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 				this.resourceHttpMessageConverter.write(rangeResource, mediaType, outputMessage);
 			}
 			catch (IllegalArgumentException ex) {
-				Long contentLength = resource.contentLength();
-				if (contentLength != null) {
-					response.addHeader("Content-Range", "bytes */" + resource.contentLength());
-				}
+				response.addHeader("Content-Range", "bytes */" + resource.contentLength());
 				response.sendError(HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE);
 			}
 		}


### PR DESCRIPTION
Hey,

just stumbled upon this. `Resource.contentLength()` returns a primitive long, so the condition

```
Long contentLength = resource.contentLength();
if (contentLength != null) {
    // Something
}
```

seems to be unnecessary because it will be always true.

Keep up the good work!
Cheers
