### PR TITLE
Prevent methods of GroovyObject from becoming transactional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -993,6 +993,7 @@ project("spring-webmvc-portlet") {
 
 project("spring-test") {
 	description = "Spring TestContext Framework"
+	apply plugin: "groovy"
 
 	dependencies {
 		compile(project(":spring-core"))
@@ -1046,6 +1047,21 @@ project("spring-test") {
 		testCompile("javax.cache:cache-api:1.0.0")
 		testRuntime("org.ehcache:ehcache:${ehcache3Version}")
 		testRuntime("org.terracotta:management-model:2.0.0")
+	}
+
+	// this module's Java and Groovy sources need to be compiled together
+	compileTestJava.enabled=false
+	sourceSets {
+		test {
+			groovy {
+				srcDirs = ["src/test/java", "src/test/groovy"]
+			}
+		}
+	}
+
+	compileGroovy {
+		sourceCompatibility = 1.6
+		targetCompatibility = 1.6
 	}
 
 	task testNG(type: Test) {

--- a/spring-test/src/test/groovy/org/springframework/test/context/junit4/spr14095/TransactionalGroovyService.groovy
+++ b/spring-test/src/test/groovy/org/springframework/test/context/junit4/spr14095/TransactionalGroovyService.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4.spr14095
+
+/**
+ * Simple Groovy Service interface.
+ *
+ * @author László Csontos
+ * @since 4.3
+ * @see AnnotationTransactionAttributeSourceTests
+ */
+interface TransactionalGroovyService {
+
+    void doTransaction()
+
+}

--- a/spring-test/src/test/groovy/org/springframework/test/context/junit4/spr14095/TransactionalGroovyServiceImpl.groovy
+++ b/spring-test/src/test/groovy/org/springframework/test/context/junit4/spr14095/TransactionalGroovyServiceImpl.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4.spr14095
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Simple Groovy Service implementation.
+ *
+ * @author László Csontos
+ * @since 4.3
+ * @see AnnotationTransactionAttributeSourceTests
+ */
+@Service
+@Transactional
+class TransactionalGroovyServiceImpl implements TransactionalGroovyService {
+
+    @Override
+    void doTransaction() {
+    }
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/spr14095/AnnotationTransactionAttributeSourceTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/spr14095/AnnotationTransactionAttributeSourceTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4.spr14095;
+
+import static org.junit.Assert.assertEquals;
+
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.tests.transaction.CallCountingTransactionManager;
+
+/**
+ * Integration tests used to assess claims raised in
+ * <a href="https://jira.spring.io/browse/SPR-14095" target="_blank">SPR-14095</a>.
+ *
+ * @author László Csontos
+ * @since 4.3
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TransactionManagementConfiguration.class, loader = AnnotationConfigContextLoader.class)
+public class AnnotationTransactionAttributeSourceTests {
+
+    @Autowired
+    private TransactionalGroovyService transactionalGroovyService;
+
+    @Autowired
+    private CallCountingTransactionManager callCountingTransactionManager;
+
+    @Before
+    public void setUp() {
+        callCountingTransactionManager.clear();
+    }
+
+    @Test
+    public void testDoTransaction() {
+        DefaultGroovyMethods.invokeMethod(transactionalGroovyService, "doTransaction", null);
+
+        assertEquals(1, callCountingTransactionManager.commits);
+        assertEquals(0, callCountingTransactionManager.rollbacks);
+    }
+
+    @Test
+    public void testGetMetaClass() {
+        DefaultGroovyMethods.getMetaClass(transactionalGroovyService);
+
+        assertEquals(0, callCountingTransactionManager.commits);
+        assertEquals(0, callCountingTransactionManager.rollbacks);
+    }
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/spr14095/TransactionManagementConfiguration.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/spr14095/TransactionManagementConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit4.spr14095;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.tests.transaction.CallCountingTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.annotation.ProxyTransactionManagementConfiguration;
+import org.springframework.transaction.annotation.TransactionManagementConfigurer;
+import org.springframework.transaction.interceptor.TransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+
+/**
+ * Integration tests used to assess claims raised in
+ * <a href="https://jira.spring.io/browse/SPR-14095" target="_blank">SPR-14095</a>.
+ *
+ * @author László Csontos
+ * @since 4.3
+ * @see AnnotationTransactionAttributeSourceTests
+ */
+@EnableTransactionManagement
+public class TransactionManagementConfiguration extends ProxyTransactionManagementConfiguration implements TransactionManagementConfigurer {
+
+    private static CallCountingTransactionManager transactionManager = new CallCountingTransactionManager();
+
+    @Bean
+    public TransactionalGroovyService testTransactionService() {
+        return new TransactionalGroovyServiceImpl();
+    }
+
+    @Bean
+    public CallCountingTransactionManager transactionManager() {
+        return transactionManager;
+    }
+
+    @Override
+    public PlatformTransactionManager annotationDrivenTransactionManager() {
+        return transactionManager();
+    }
+
+    @Override
+    public TransactionAttributeSource transactionAttributeSource() {
+        return new AnnotationTransactionAttributeSource();
+    }
+
+    @Override
+    public TransactionInterceptor transactionInterceptor() {
+        TransactionInterceptor interceptor = new TransactionInterceptor();
+
+        interceptor.setTransactionAttributeSource(transactionAttributeSource());
+        interceptor.setTransactionManager(transactionManager());
+
+        return interceptor;
+    }
+
+}

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/AbstractFallbackTransactionAttributeSource.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/AbstractFallbackTransactionAttributeSource.java
@@ -134,6 +134,11 @@ public abstract class AbstractFallbackTransactionAttributeSource implements Tran
 	 * @see #getTransactionAttribute
 	 */
 	protected TransactionAttribute computeTransactionAttribute(Method method, Class<?> targetClass) {
+		// Ignore non-user level methods.
+		if (!ClassUtils.isUserLevelMethod(method)) {
+			return null;
+		}
+
 		// Don't allow no-public methods as required.
 		if (allowPublicMethodsOnly() && !Modifier.isPublic(method.getModifiers())) {
 			return null;


### PR DESCRIPTION
As Jürgen pointed out, we exclude GroovyObject methods for a couple of other
TransactionAttributeSource implementations already, but not for
AnnotationTransactionAttributeSource since we expected it to be clearly
annotation-driven.

Yet, if @Transactional is applied at the class-level, in this case Groovy methods will be considered transactional.
- Added an integration test to reproduce the issue.
- Added exclusion to method computeTransactionAttribute() in AbstractFallbackTransactionAttributeSource, this way, the fact that a method should be excluded can be cached.

Issue: SPR-14095

---

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
