### PR TITLE
Backport SPR-14095 to 4.2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -552,6 +552,7 @@ project("spring-tx") {
 		optional("com.ibm.websphere:uow:6.0.2.17")
 		testCompile("org.aspectj:aspectjweaver:${aspectjVersion}")
 		testCompile("org.eclipse.persistence:javax.persistence:2.0.0")
+		testCompile("org.codehaus.groovy:groovy-all:${groovyVersion}")
 	}
 }
 

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/AbstractFallbackTransactionAttributeSource.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/AbstractFallbackTransactionAttributeSource.java
@@ -155,7 +155,7 @@ public abstract class AbstractFallbackTransactionAttributeSource implements Tran
 
 		// Second try is the transaction attribute on the target class.
 		txAtt = findTransactionAttribute(specificMethod.getDeclaringClass());
-		if (txAtt != null) {
+		if (txAtt != null && ClassUtils.isUserLevelMethod(method)) {
 			return txAtt;
 		}
 
@@ -166,8 +166,12 @@ public abstract class AbstractFallbackTransactionAttributeSource implements Tran
 				return txAtt;
 			}
 			// Last fallback is the class of the original method.
-			return findTransactionAttribute(method.getDeclaringClass());
+			txAtt = findTransactionAttribute(method.getDeclaringClass());
+			if (txAtt != null && ClassUtils.isUserLevelMethod(method)) {
+				return txAtt;
+			}
 		}
+
 		return null;
 	}
 


### PR DESCRIPTION
AnnotationTransactionAttributeSource applies class-level metadata to user-level methods only

Issue: SPR-14095
(cherry picked from commit b7819e6)

---

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
