### PR TITLE
Fix iso date time format

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/datetime/DateFormatter.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/DateFormatter.java
@@ -48,7 +48,7 @@ public class DateFormatter implements Formatter<Date> {
 	static {
 		Map<ISO, String> formats = new HashMap<DateTimeFormat.ISO, String>(4);
 		formats.put(ISO.DATE, "yyyy-MM-dd");
-		formats.put(ISO.TIME, "HH:mm:ss.SSSZ");
+		formats.put(ISO.TIME, "HH:mm:ss.SSSX");
 		formats.put(ISO.DATE_TIME, "yyyy-MM-dd'T'HH:mm:ss.SSSX");
 		ISO_PATTERNS = Collections.unmodifiableMap(formats);
 	}

--- a/spring-context/src/main/java/org/springframework/format/datetime/DateFormatter.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/DateFormatter.java
@@ -49,7 +49,7 @@ public class DateFormatter implements Formatter<Date> {
 		Map<ISO, String> formats = new HashMap<DateTimeFormat.ISO, String>(4);
 		formats.put(ISO.DATE, "yyyy-MM-dd");
 		formats.put(ISO.TIME, "HH:mm:ss.SSSZ");
-		formats.put(ISO.DATE_TIME, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+		formats.put(ISO.DATE_TIME, "yyyy-MM-dd'T'HH:mm:ss.SSSX");
 		ISO_PATTERNS = Collections.unmodifiableMap(formats);
 	}
 

--- a/spring-context/src/test/java/org/springframework/format/datetime/DateFormatterTests.java
+++ b/spring-context/src/test/java/org/springframework/format/datetime/DateFormatterTests.java
@@ -146,6 +146,16 @@ public class DateFormatterTests {
 		assertThat(formatter.print(date, Locale.US), is("2009-06-01T14:23:05.003+0000"));
 		assertThat(formatter.parse("2009-06-01T14:23:05.003+0000", Locale.US), is(date));
 	}
+	
+	@Test
+	public void shouldPrintAndParseISODateTimeInZuluTimezone() throws Exception {
+		DateFormatter formatter = new DateFormatter();
+		formatter.setTimeZone(UTC);
+		formatter.setIso(ISO.DATE_TIME);
+		Date date = getDate(2009, Calendar.JUNE, 1, 14, 23, 5, 3);
+		assertThat(formatter.print(date, Locale.US), is("2009-06-01T14:23:05.003Z"));
+		assertThat(formatter.parse("2009-06-01T14:23:05.003Z", Locale.US), is(date));
+	}
 
 	@Test
 	public void shouldSupportJodaStylePatterns() throws Exception {


### PR DESCRIPTION
According to https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html the ISO 8601 time zone letter is `X` instead of `Z`. `Z` stands for RFC 822 time zone.

With this, we are able to parse dates which are created in JavaScript using `new Date().toISOString()`.

CC: @davidreher
