### PR TITLE
Fix 500 error caused by If-Modified-Since=0 HTTP header

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -972,7 +972,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 */
 	public long getFirstDate(String headerName) {
 		String headerValue = getFirst(headerName);
-		if (headerValue == null) {
+		if (headerValue == null || headerValue.equals("0")) {
 			return -1;
 		}
 		for (String dateFormat : DATE_FORMATS) {

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
@@ -234,6 +234,13 @@ public class HttpHeadersTests {
 				headers.getFirst("if-modified-since"));
 	}
 
+	// SPR-14144
+	@Test
+	public void ifModifiedSinceHeaderIsZero() {
+		headers.set(HttpHeaders.IF_MODIFIED_SINCE, "0");
+		assertEquals(-1, headers.getFirstDate(HttpHeaders.IF_MODIFIED_SINCE));
+	}
+
 	@Test
 	public void pragma() {
 		String pragma = "no-cache";


### PR DESCRIPTION
I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.

Prior to this commit a 500 error would be bubbled up to the user when the
If-Modified-Since header was passed to the backend with a value of 0.

In this fix, the zero value is explicitly handled (in same way as with a null
value) by returning -1 to the caller.

Issue: SPR-14144
