### PR TITLE
Fix logging issue with MessageConverter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -86,7 +86,6 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 		this.setDefaultCharset(DEFAULT_CHARSET);
 	}
 
-
 	/**
 	 * Set the {@code ObjectMapper} for this view.
 	 * If not set, a default {@link ObjectMapper#ObjectMapper() ObjectMapper} is used.
@@ -148,14 +147,8 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 			return true;
 		}
 		Throwable cause = causeRef.get();
-		if (cause != null) {
-			String msg = "Failed to evaluate deserialization for type " + javaType;
-			if (logger.isDebugEnabled()) {
-				logger.warn(msg, cause);
-			}
-			else {
-				logger.warn(msg + ": " + cause);
-			}
+		if (cause != null && logger.isDebugEnabled()) {
+			logger.warn("Failed to evaluate deserialization for type " + javaType, cause);
 		}
 		return false;
 	}
@@ -170,14 +163,8 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 			return true;
 		}
 		Throwable cause = causeRef.get();
-		if (cause != null) {
-			String msg = "Failed to evaluate serialization for type [" + clazz + "]";
-			if (logger.isDebugEnabled()) {
-				logger.warn(msg, cause);
-			}
-			else {
-				logger.warn(msg + ": " + cause);
-			}
+		if (cause != null && logger.isDebugEnabled()) {
+			logger.warn("Failed to evaluate serialization for type [" + clazz + "]", cause);
 		}
 		return false;
 	}


### PR DESCRIPTION
This commit fixes an issue with MappingJackson2HttpMessageConverter where it always logs a Warning, even if another message converter can handle it. Example:

2016-04-13 13:22:30.760  WARN [app-service] 15947 --- [AppClient-1] .c.j.MappingJackson2HttpMessageConverter : Failed to evaluate deserialization for type [simple type, class com.company.product.component.protobuf.Client$Configurations]: com.fasterxml.jackson.databind.JsonMappingException: Can not find a (Map) Key deserializer for type [simple type, class com.google.protobuf.Descriptors$FieldDescriptor]

Issue: SPR-14163

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
