### PR TITLE
Fixes SPR-14139 - Forwarded sendMessage call to delegate.

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/handler/WebSocketSessionDecorator.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/handler/WebSocketSessionDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.web.socket.WebSocketSession;
  * and return the "last" session.
  *
  * @author Rossen Stoyanchev
+ * @author Venil Noronha
  * @since 4.0.3
  */
 public class WebSocketSessionDecorator implements WebSocketSession {
@@ -145,7 +146,7 @@ public class WebSocketSessionDecorator implements WebSocketSession {
 
 	@Override
 	public void sendMessage(WebSocketMessage<?> message) throws IOException {
-
+		this.delegate.sendMessage(message);
 	}
 
 	@Override


### PR DESCRIPTION
Calls to `WebSocketSessionDecorator#sendMessage(WebSocketMessage<?>)` are now forwarded to the `WebSocketSession` delegate.

Please review and pull. My CLA Number is 149720151120072904.

Thanks,
Venil Noronha
