### PR TITLE
Fixes SPR-14138 - Removed assertion over isOpen.

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/AbstractWebSocketSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/AbstractWebSocketSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.web.socket.WebSocketSession;
  * An abstract base class for implementations of {@link WebSocketSession}.
  *
  * @author Rossen Stoyanchev
+ * @author Venil Noronha
  * @since 4.0
  */
 public abstract class AbstractWebSocketSession<T> implements NativeWebSocketSession {
@@ -95,7 +96,6 @@ public abstract class AbstractWebSocketSession<T> implements NativeWebSocketSess
 	public final void sendMessage(WebSocketMessage<?> message) throws IOException {
 
 		checkNativeSessionInitialized();
-		Assert.isTrue(isOpen(), "Cannot send message after connection closed.");
 
 		if (logger.isTraceEnabled()) {
 			logger.trace("Sending " + message + ", " + this);


### PR DESCRIPTION
Removed `Assert#isTrue(isOpen(), ...)` while performing a send operation via `sendMessage(WebSocketMessage<?>)` in `AbstractWebSocketSession`.

Please review and pull. My CLA Number is 149720151120072904.

Thanks,
Venil Noronha
