### PR TITLE
Use the defined constant in MergedContextConfiguration

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/MergedContextConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/MergedContextConfiguration.java
@@ -245,7 +245,7 @@ public class MergedContextConfiguration implements Serializable {
 			MergedContextConfiguration parent) {
 		this(testClass, locations, classes, contextInitializerClasses, activeProfiles,
 				propertySourceLocations, propertySourceProperties,
-				Collections.<ContextCustomizer> emptySet(), contextLoader,
+				EMPTY_CONTEXT_CUSTOMIZERS, contextLoader,
 				cacheAwareContextLoaderDelegate, parent);
 	}
 


### PR DESCRIPTION
This PR simply uses the defined constant instead.
