### PR TITLE
Added text/markdown to MediaType

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -41,9 +41,11 @@ import org.springframework.util.comparator.CompoundComparator;
  * @author Juergen Hoeller
  * @author Rossen Stoyanchev
  * @author Sebastien Deleuze
+ * @author Venil Noronha
  * @since 3.0
  * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.1.1">HTTP 1.1: Semantics
  * and Content, section 3.1.1.1</a>
+ * @see <a href="https://tools.ietf.org/html/rfc7763">The text/markdown Media Type</a>
  */
 public class MediaType extends MimeType implements Serializable {
 
@@ -192,6 +194,16 @@ public class MediaType extends MimeType implements Serializable {
 	public final static String TEXT_HTML_VALUE = "text/html";
 
 	/**
+	 * Public constant media type for {@code text/markdown}.
+	 */
+	public final static MediaType TEXT_MARKDOWN;
+
+	/**
+	 * A String equivalent of {@link MediaType#TEXT_MARKDOWN}.
+	 */
+	public final static String TEXT_MARKDOWN_VALUE = "text/markdown";
+
+	/**
 	 * Public constant media type for {@code text/plain}.
 	 *  */
 	public final static MediaType TEXT_PLAIN;
@@ -230,6 +242,7 @@ public class MediaType extends MimeType implements Serializable {
 		IMAGE_PNG = valueOf(IMAGE_PNG_VALUE);
 		MULTIPART_FORM_DATA = valueOf(MULTIPART_FORM_DATA_VALUE);
 		TEXT_HTML = valueOf(TEXT_HTML_VALUE);
+		TEXT_MARKDOWN = valueOf(TEXT_MARKDOWN_VALUE);
 		TEXT_PLAIN = valueOf(TEXT_PLAIN_VALUE);
 		TEXT_XML = valueOf(TEXT_XML_VALUE);
 	}


### PR DESCRIPTION
I've added `text/markdown` entry to `MediaType` as per https://tools.ietf.org/html/rfc7763.

I've signed the ICLA. Please review and pull.

Thanks,
Venil Noronha
