### PR TITLE
Support non-blocking receiveTimeout.

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
@@ -417,7 +417,8 @@ public abstract class AbstractPollingMessageListenerContainer extends AbstractMe
 	 * @throws JMSException if thrown by JMS methods
 	 */
 	protected Message receiveMessage(MessageConsumer consumer) throws JMSException {
-		return (this.receiveTimeout < 0 ? consumer.receive() : consumer.receive(this.receiveTimeout));
+		return (this.receiveTimeout < 0 ? consumer.receive() :
+			(this.receiveTimeout > 0 ? consumer.receive(this.receiveTimeout) : consumer.receiveNoWait()));
 	}
 
 	/**


### PR DESCRIPTION
AbstractPollingMessageListenerContainer#receiveMessage currently blocks
indefinitely both on -1 and 0 as receiveTimeout. This is because
MessageConsumer#receive blocks if the timeout is 0 and it is not
possible to poll without a timeout. This commit fixes that by calling
receiveNoWait if the timeout is 0 as receive(0) blocks.
In some cases (specifically AQ) this can yield better performance.

Issue: SPR-14212
