### PR TITLE
MockWebResponseBuilder defaults cookie domain

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockWebResponseBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockWebResponseBuilder.java
@@ -29,6 +29,7 @@ import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.WebResponseData;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 
+import org.apache.http.impl.cookie.BasicClientCookie;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.util.Assert;
@@ -115,9 +116,16 @@ final class MockWebResponseBuilder {
 		if (cookie.getMaxAge() > -1) {
 			expires = new Date(System.currentTimeMillis() + cookie.getMaxAge() * 1000);
 		}
-		return new com.gargoylesoftware.htmlunit.util.Cookie(
-				cookie.getDomain(), cookie.getName(), cookie.getValue(),
-				cookie.getPath(), expires, cookie.getSecure(), cookie.isHttpOnly()).toString();
+		BasicClientCookie result = new BasicClientCookie(cookie.getName(), cookie.getValue());
+		result.setDomain(cookie.getDomain());
+		result.setComment(cookie.getComment());
+		result.setExpiryDate(expires);
+		result.setPath(cookie.getPath());
+		result.setSecure(cookie.getSecure());
+		if(cookie.isHttpOnly()) {
+			result.setAttribute("httponly", "true");
+		}
+		return new com.gargoylesoftware.htmlunit.util.Cookie(result).toString();
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockWebResponseBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockWebResponseBuilderTests.java
@@ -119,6 +119,20 @@ public class MockWebResponseBuilderTests {
 		assertThat(header.getValue(), endsWith(";secure;httpOnly"));
 	}
 
+	// SPR-14169
+	@Test
+	public void buildResponseHeadersNullDomainDefaulted() throws Exception {
+		Cookie cookie = new Cookie("cookieA", "valueA");
+		this.response.addCookie(cookie);
+		WebResponse webResponse = this.responseBuilder.build();
+
+		List<NameValuePair> responseHeaders = webResponse.getResponseHeaders();
+		assertThat(responseHeaders.size(), equalTo(1));
+		NameValuePair header = responseHeaders.get(0);
+		assertThat(header.getName(), equalTo("Set-Cookie"));
+		assertThat(header.getValue(), equalTo("cookieA=valueA"));
+	}
+
 	@Test
 	public void buildStatus() throws Exception {
 		WebResponse webResponse = this.responseBuilder.build();


### PR DESCRIPTION
Previously MockWebResponseBuilder would use the cookie domain of the cookie
received from MockMvc response. This caused problems because the cookie
domain can be null, but HtmlUnit forbids a null domain.

This commit defaults the domain of the cookie to the domain of the
WebRequest.

Issues SPR-14169
