### PR TITLE
Proposal for easing the development of annotation driven static method advices

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/support/annotation/AnnotationMatchingMethodPointcutAdvisor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/annotation/AnnotationMatchingMethodPointcutAdvisor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.support.annotation;
+
+import java.lang.annotation.Annotation;
+
+import org.aopalliance.aop.Advice;
+
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.support.AbstractGenericPointcutAdvisor;
+
+/**
+ * Convenient class for annotation-matching method pointcuts that hold an Advice,
+ * making them an Advisor.
+ *
+ * @author Laszlo Csontos
+ * @since 4.3
+ * @see AnnotationMatchingPointcut
+ */
+@SuppressWarnings("serial")
+public class AnnotationMatchingMethodPointcutAdvisor extends AbstractGenericPointcutAdvisor {
+
+	private final AnnotationMatchingPointcut pointcut;
+
+
+	public AnnotationMatchingMethodPointcutAdvisor(Class<? extends Annotation> methodAnnotationType) {
+		pointcut = AnnotationMatchingPointcut.forMethodAnnotation(methodAnnotationType);
+	}
+
+	public AnnotationMatchingMethodPointcutAdvisor(Class<? extends Annotation> methodAnnotationType, Advice advice) {
+		this(methodAnnotationType);
+		setAdvice(advice);
+	}
+
+
+	@Override
+	public Pointcut getPointcut() {
+		return pointcut;
+	}
+
+}

--- a/spring-aop/src/main/java/org/springframework/aop/support/annotation/AnnotationMethodAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/annotation/AnnotationMethodAdvice.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.support.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Convenient class for annotation-matching method advices.
+ *
+ * @author Laszlo Csontos
+ * @since 4.3
+ * @see AnnotationMatchingPointcut
+ * @see AnnotationMatchingMethodPointcutAdvisor
+ */
+@SuppressWarnings("unchecked")
+public abstract class AnnotationMethodAdvice<A extends Annotation> implements MethodInterceptor {
+
+	protected static final Annotation NULL_ANNOTATION = new NullAnnotation();
+	protected static final Object NULL_RESULT = new Object();
+
+	private static final ConcurrentMap<Method, Map<Class<? extends Annotation>, Annotation>> METHOD_ANNOTATION_BAG =
+			new ConcurrentHashMap<Method, Map<Class<? extends Annotation>, Annotation>>();
+
+	private final Class<A> annotationType;
+
+
+	public AnnotationMethodAdvice() {
+		annotationType = getAnnotationType();
+	}
+
+
+	public abstract Class<A> getAnnotationType();
+
+	@Override
+	public final Object invoke(MethodInvocation methodInvocation) throws Throwable {
+		Method method = methodInvocation.getMethod();
+		Object target = methodInvocation.getThis();
+
+		Annotation annotation = findAnnotation(method, target.getClass());
+		if (annotation == NULL_ANNOTATION) {
+			return methodInvocation.proceed();
+		}
+
+		Object[] args = methodInvocation.getArguments();
+		Object returnValue = before((A) annotation, method, args, target);
+
+		if (returnValue != null) {
+			if (returnValue == NULL_RESULT) {
+				return null;
+			} else {
+				return returnValue;
+			}
+		}
+
+		try {
+			returnValue = methodInvocation.proceed();
+			afterReturning((A) annotation, returnValue, method, args, target);
+		} catch (Exception ex) {
+			afterThrowing((A) annotation, method, args, target, ex);
+			throw ex;
+		} finally {
+			duringFinally((A) annotation, method, args, target);
+		}
+
+		return returnValue;
+	}
+
+	protected void afterReturning(A annotation, Object returnValue, Method method, Object[] args, Object target) throws Exception {
+	}
+
+	protected void afterThrowing(A annotation, Method method, Object[] args, Object target, Exception ex) throws Exception {
+	}
+
+	protected Object before(A annotation, Method method, Object[] args, Object target) throws Exception {
+		return null;
+	}
+
+	protected void duringFinally(A annotation, Method method, Object[] args, Object target) {
+	}
+
+	private Annotation findAnnotation(Method method, Class<?> targetClass) {
+		Annotation annotation = getAnnotation(method);
+		if (annotation != null) {
+			return annotation;
+		}
+
+		Method specificMethod = ClassUtils.getMostSpecificMethod(method, targetClass);
+
+		annotation = AnnotationUtils.findAnnotation(specificMethod, annotationType);
+		if (annotation == null) {
+			annotation = NULL_ANNOTATION;
+		}
+
+		putAnnotation(method, annotation);
+
+		return annotation;
+	}
+
+	private Annotation getAnnotation(Method method) {
+		Map<Class<? extends Annotation>, Annotation> annotationMap = METHOD_ANNOTATION_BAG.get(method);
+
+		if (annotationMap == null) {
+			return null;
+		}
+
+		return annotationMap.get(annotationType);
+	}
+
+	private void putAnnotation(Method method, Annotation annotation) {
+		Map<Class<? extends Annotation>, Annotation> annotationMap = METHOD_ANNOTATION_BAG.get(method);
+		if (annotationMap != null) {
+			annotationMap.put(annotationType, annotation);
+			return;
+		}
+
+		annotationMap = new ConcurrentHashMap<Class<? extends Annotation>, Annotation>();
+		Map<Class<? extends Annotation>, Annotation> prevAnnotationMap =
+				METHOD_ANNOTATION_BAG.putIfAbsent(method, annotationMap);
+
+		if (prevAnnotationMap != null) {
+			annotationMap.putAll(prevAnnotationMap);
+		}
+
+		annotationMap.put(annotationType, annotation);
+	}
+
+
+	private static class NullAnnotation implements Annotation {
+
+		@Override
+		public Class<? extends Annotation> annotationType() {
+			return null;
+		}
+
+	}
+
+}

--- a/spring-aop/src/test/java/org/springframework/aop/support/annotation/AnnotationMatchingMethodPointcutAdvisorTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/support/annotation/AnnotationMatchingMethodPointcutAdvisorTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.support.annotation;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.tests.sample.beans.Person;
+import org.springframework.tests.sample.beans.SerializablePerson;
+import org.springframework.util.ReflectionUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Laszlo Csontos
+ */
+public class AnnotationMatchingMethodPointcutAdvisorTests {
+
+	protected AnnotationMatchingMethodPointcutAdvisor advisor;
+
+	protected Pointcut pc;
+
+	protected Person proxied;
+
+	protected NopAnnotationMethodAdvice nop;
+
+	/**
+	 * Create an empty pointcut, populating instance variables.
+	 */
+	@Before
+	public void setUp() {
+		ProxyFactory pf = new ProxyFactory(new SerializablePerson());
+		nop = new NopAnnotationMethodAdvice();
+		advisor = new AnnotationMatchingMethodPointcutAdvisor(NopAnnotation.class, nop);
+		pc = advisor.getPointcut();
+		pf.addAdvisor(advisor);
+		proxied = (Person) pf.getProxy();
+	}
+
+	@Test
+	public void testMatchingOnly() {
+		assertTrue(pc.getMethodMatcher().matches(ReflectionUtils.findMethod(Person.class, "echo", Object.class), SerializablePerson.class));
+		assertTrue(pc.getMethodMatcher().matches(ReflectionUtils.findMethod(Person.class, "setAge", int.class), SerializablePerson.class));
+		assertTrue(pc.getMethodMatcher().matches(ReflectionUtils.findMethod(Person.class, "setName", String.class), SerializablePerson.class));
+		assertFalse(pc.getMethodMatcher().matches(ReflectionUtils.findMethod(Person.class, "getAge"), SerializablePerson.class));
+	}
+
+	@Test
+	public void testNonAnnotatedMethods() throws Throwable {
+		testAdviceCounters(0, 0, 0, 0);
+		proxied.getName();
+		testAdviceCounters(0, 0, 0, 0);
+	}
+
+
+	@Test
+	public void testAnnotatedMethods() throws Throwable {
+		testAdviceCounters(0, 0, 0, 0);
+		proxied.echo(null);
+		testAdviceCounters(1, 1, 0, 1);
+		proxied.setName("");
+		testAdviceCounters(2, 2, 0, 2);
+		proxied.setAge(25);
+		assertEquals(25, proxied.getAge());
+		testAdviceCounters(3, 3, 0, 3);
+	}
+
+	@Test
+	public void testAnnotatedThrowingMethods() throws Throwable {
+		testAdviceCounters(0, 0, 0, 0);
+		try {
+			proxied.echo(new Exception());
+		} catch (Exception e) {
+		}
+		testAdviceCounters(1, 0, 1, 1);
+	}
+
+	private void testAdviceCounters(
+			int beforeCount, int afterReturningCount, int afterThrowingCount, int duringFinallyCount) {
+
+		assertEquals(beforeCount, nop.getBeforeCount());
+		assertEquals(afterReturningCount, nop.getAfterReturningCount());
+		assertEquals(afterThrowingCount, nop.getAfterThrowingCount());
+		assertEquals(duringFinallyCount, nop.getDuringFinallyCount());
+	}
+
+}

--- a/spring-aop/src/test/java/org/springframework/aop/support/annotation/NopAnnotation.java
+++ b/spring-aop/src/test/java/org/springframework/aop/support/annotation/NopAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,21 @@
  * limitations under the License.
  */
 
-package org.springframework.tests.sample.beans;
+package org.springframework.aop.support.annotation;
 
-import org.springframework.aop.support.annotation.NopAnnotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- *
- * @author Rod Johnson
+ * @author Laszlo Csontos
  */
-public interface Person {
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface NopAnnotation {
 
-	String getName();
+	int value() default 1;
 
-	@NopAnnotation
-	void setName(String name);
 
-	int getAge();
-
-	@NopAnnotation
-	void setAge(int i);
-
-	/**
-	 * Test for non-property method matching. If the parameter is a Throwable, it will be
-	 * thrown rather than returned.
-	 */
-	Object echo(Object o) throws Throwable;
 }

--- a/spring-aop/src/test/java/org/springframework/aop/support/annotation/NopAnnotationMethodAdvice.java
+++ b/spring-aop/src/test/java/org/springframework/aop/support/annotation/NopAnnotationMethodAdvice.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.support.annotation;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Laszlo Csontos
+ */
+public class NopAnnotationMethodAdvice extends AnnotationMethodAdvice<NopAnnotation> {
+
+	private int afterReturningCount;
+
+	private int afterThrowingCount;
+
+	private int beforeCount;
+
+	private int duringFinallyCount;
+
+
+	public int getAfterReturningCount() {
+		return afterReturningCount;
+	}
+
+	public int getAfterThrowingCount() {
+		return afterThrowingCount;
+	}
+
+	public int getBeforeCount() {
+		return beforeCount;
+	}
+
+	public int getDuringFinallyCount() {
+		return duringFinallyCount;
+	}
+
+	@Override
+	public Class<NopAnnotation> getAnnotationType() {
+		return NopAnnotation.class;
+	}
+
+	@Override
+	protected void afterReturning(NopAnnotation annotation, Object returnValue, Method method, Object[] args, Object target) throws Exception {
+		afterReturningCount += annotation.value();
+	}
+
+	@Override
+	protected void afterThrowing(NopAnnotation annotation, Method method, Object[] args, Object target, Exception ex) throws Exception {
+		afterThrowingCount += annotation.value();
+	}
+
+	@Override
+	protected Object before(NopAnnotation annotation, Method method, Object[] args, Object target) throws Exception {
+		beforeCount += annotation.value();
+		return null;
+	}
+
+	@Override
+	protected void duringFinally(NopAnnotation annotation, Method method, Object[] args, Object target) {
+		duringFinallyCount += annotation.value();
+	}
+
+
+}

--- a/spring-aop/src/test/java/org/springframework/tests/sample/beans/SerializablePerson.java
+++ b/spring-aop/src/test/java/org/springframework/tests/sample/beans/SerializablePerson.java
@@ -18,6 +18,7 @@ package org.springframework.tests.sample.beans;
 
 import java.io.Serializable;
 
+import org.springframework.aop.support.annotation.NopAnnotation;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -56,6 +57,7 @@ public class SerializablePerson implements Person, Serializable {
 	}
 
 	@Override
+	@NopAnnotation
 	public Object echo(Object o) throws Throwable {
 		if (o instanceof Throwable) {
 			throw (Throwable) o;


### PR DESCRIPTION
# Proposal for easing the development of annotation driven static method advices and pointcuts

When developmening adivces around custom annotations, I'd like to have a simple AOP support API.
Preferably, I'd like to have the annotation passed to the interceptor to be able process its
attributes in a type-safe way.
## Example
### Interceptor implementation

```
@interface LogUsage {
  String usageTypeDescription();
}
```

```
public class LogUsageMethodAdvice extends AnnotationMethodAdvice<LogUsage> {
  @Override
  public Class<LogUsage> getAnnotationType() {
    return LogUsage.class;
  }

  @Override
  protected void duringFinally(LogUsage annotation, Method method, Object[] args, Object target) {
    String usageTypeDescription = annotation.usageTypeDescription()
    // Log usage
  }
}
```
### Service bean

```
@Service
public class SummarizationServiceImpl implements SummarizationService {
  @Override
  @LogUsage(usageTypeDescription = UsageService.TYPE_SUMMARY)
  Document summarize(Document document, SummaryConfiguration summaryConfiguration) {
  // App logic.
  }
}
```
### AOP configuration

```
<?xml version="1.0" encoding="UTF-8"?>
<beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

  <bean id="logUsageMethodAdvice" class="app.usage.LogUsageMethodAdvice" />

  <bean id="logUsageMethodAdvisor" class="org.springframework.aop.support.annotation.AnnotationMatchingMethodPointcutAdvisor">
    <constructor-arg name="methodAnnotationType" value="app.usage.LogUsage" type="java.lang.Class" />
    <constructor-arg name="advice" ref="logUsageMethodAdvice"/>
  </bean>

  <bean class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator" />

</beans>
```
## Implementation

There was two new API classes added to make this happen:
- AnnotationMatchingMethodPointcutAdvisor which is a convinience advisor support wrapping the existing AnnotationMatchingPointcut.
- AnnotationMethodAdvice which is the base class of annotation driven method advices. It contains all the possible hooks for capturing the before, afterReturning, afterThrowing and duringFinally events on the intercepted method call. All these method receive the method's annotation in a type safe way.

**Issue:** [SPR-14227](https://jira.spring.io/browse/SPR-14227)

---

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
