### PR TITLE
Remove potential XSS vulnerability in Freemarker documentation

### DIFF
--- a/src/asciidoc/web-view.adoc
+++ b/src/asciidoc/web-view.adoc
@@ -331,7 +331,7 @@ Example code is shown below for the `personFormV`/`personFormF` views configured
 			<@spring.bind "myModelObject.name"/>
 			<input type="text"
 				name="${spring.status.expression}"
-				value="${spring.status.value?default("")}"/><br>
+				value="${spring.status.value?html}"/><br>
 			<#list spring.status.errorMessages as error> <b>${error}</b> <br> </#list>
 			<br>
 			...


### PR DESCRIPTION
Since the user controls the value of `spring.status.value`, one wouldn't want to echo unescaped values here in this form. Otherwise one could submit a value of, say, `"/> <script>alert("pwned")</script>` or any other arbitrary JS.

This patch changes the `input` tag to use the HTML-escaped value rather than the raw value.

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
