### PR TITLE
Fix CacheManager example in Javadoc

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/annotation/EnableCaching.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/EnableCaching.java
@@ -47,7 +47,7 @@ import org.springframework.core.Ordered;
  *     public CacheManager cacheManager() {
  *         // configure and return an implementation of Spring's CacheManager SPI
  *         SimpleCacheManager cacheManager = new SimpleCacheManager();
- *         cacheManager.addCaches(Arrays.asList(new ConcurrentMapCache("default")));
+ *         cacheManager.setCaches(Arrays.asList(new ConcurrentMapCache("default")));
  *         return cacheManager;
  *     }
  * }</pre>
@@ -117,7 +117,7 @@ import org.springframework.core.Ordered;
  *     public CacheManager cacheManager() {
  *         // configure and return an implementation of Spring's CacheManager SPI
  *         SimpleCacheManager cacheManager = new SimpleCacheManager();
- *         cacheManager.addCaches(Arrays.asList(new ConcurrentMapCache("default")));
+ *         cacheManager.setCaches(Arrays.asList(new ConcurrentMapCache("default")));
  *         return cacheManager;
  *     }
  *


### PR DESCRIPTION
Use `CacheManager#setCaches()` instead of `CacheManager#addCaches()` in the Javadoc example.
