### PR TITLE
MockMvcWebConnection stores cookies from response

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockWebResponseBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockWebResponseBuilder.java
@@ -112,6 +112,10 @@ final class MockWebResponseBuilder {
 	}
 
 	private String valueOfCookie(Cookie cookie) {
+		return createCookie(cookie).toString();
+	}
+
+	static com.gargoylesoftware.htmlunit.util.Cookie createCookie(Cookie cookie) {
 		Date expires = null;
 		if (cookie.getMaxAge() > -1) {
 			expires = new Date(System.currentTimeMillis() + cookie.getMaxAge() * 1000);
@@ -125,7 +129,6 @@ final class MockWebResponseBuilder {
 		if(cookie.isHttpOnly()) {
 			result.setAttribute("httponly", "true");
 		}
-		return new com.gargoylesoftware.htmlunit.util.Cookie(result).toString();
+		return new com.gargoylesoftware.htmlunit.util.Cookie(result);
 	}
-
 }


### PR DESCRIPTION
Previously MockMvcWebConnection did not update the cookie manager with the
cookies from MockHttpServletResponse. This meant that newly added cookies
are not saved to the cookie manager and thus are not presented in the next
request.

This commit ensures that MockMvcWebConnection stores the response cookies
in the cookie manager.

Issue: [SPR-14265](https://jira.spring.io/browse/SPR-14265)
