### PR TITLE
SPR-14293: StringIndexOutOfBoundsException 

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -943,7 +943,9 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 					}
 					String key = propertyName.substring(keyStart + PROPERTY_KEY_PREFIX.length(), keyEnd);
 					if ((key.startsWith("'") && key.endsWith("'")) || (key.startsWith("\"") && key.endsWith("\""))) {
-						key = key.substring(1, key.length() - 1);
+						if (key.length() > 1) {
+							key = key.substring(1, key.length() - 1);
+						}
 					}
 					keys.add(key);
 					searchIndex = keyEnd + PROPERTY_KEY_SUFFIX.length();

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperTests.java
@@ -202,6 +202,22 @@ public class BeanWrapperTests extends AbstractPropertyAccessorTests {
 		assertEquals("x", accessor.getPropertyValue("object.name"));
 	}
 
+	@Test
+	public void checkNotWritablePropertyIsInvalidCharacter() {
+		TestBean target = new TestBean();
+		try {
+			BeanWrapper accessor = createAccessor(target);
+			accessor.setPropertyValue("[']", "foobar");
+			fail("Should throw exception on invalid property");
+		}
+		catch (NotWritablePropertyException ex) {
+			assertNull(ex.getPossibleMatches());
+		}
+		catch (RuntimeException re) {
+			fail("Should not throw runtime exception on invalid property");
+		}
+	}
+
 
 	@SuppressWarnings("unused")
 	private interface AliasedProperty {


### PR DESCRIPTION
I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.

An error occurs while binding request parameters for this path as soon as the uri contains special charaters.

http://myserver/request?type=1&testA=123&testB=abc&[']

```
May 17, 2016 6:20:34 PM org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/].[OPASpringMVC] invoke
SEVERE: Servlet.service() for servlet [OPASpringMVC] in context with path [] threw exception [Request processing failed; nested exception is java.lang.StringIndexOutOfBoundsException: String index out of range: -1] with root cause
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
    at java.lang.String.substring(String.java:1911)
    at org.springframework.beans.BeanWrapperImpl.getPropertyNameTokens(BeanWrapperImpl.java:694)
    at org.springframework.beans.BeanWrapperImpl.setPropertyValue(BeanWrapperImpl.java:923)
    at org.springframework.beans.AbstractPropertyAccessor.setPropertyValues(AbstractPropertyAccessor.java:95)
    at org.springframework.validation.DataBinder.applyPropertyValues(DataBinder.java:750)
    at org.springframework.validation.DataBinder.doBind(DataBinder.java:646)
    at org.springframework.web.bind.WebDataBinder.doBind(WebDataBinder.java:189)
    at org.springframework.web.bind.ServletRequestDataBinder.bind(ServletRequestDataBinder.java:106)
    at org.springframework.web.servlet.mvc.method.annotation.ServletModelAttributeMethodProcessor.bindRequestParameters(ServletModelAttributeMethodProcessor.java:150)
    at org.springframework.web.method.annotation.ModelAttributeMethodProcessor.resolveArgument(ModelAttributeMethodProcessor.java:110)
    at org.springframework.web.method.support.HandlerMethodArgumentResolverComposite.resolveArgument(HandlerMethodArgumentResolverComposite.java:77)
    at org.springframework.web.method.support.InvocableHandlerMethod.getMethodArgumentValues(InvocableHandlerMethod.java:162)
    at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:129)
    at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:110)
    at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandleMethod(RequestMappingHandlerAdapter.java:776)
    at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:705)
    at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:85)
    at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:959)
    at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:893)
    at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:967)
    at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:858)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:620)
    at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:843)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
```
