### PR TITLE
Fix comments on private fields in TableMetaDataContext

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -47,13 +47,13 @@ public class TableMetaDataContext {
 	/** Logger available to subclasses */
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	/** name of procedure to call **/
+	/** name of table for this context **/
 	private String tableName;
 
-	/** name of catalog for call **/
+	/** name of catalog for this context **/
 	private String catalogName;
 
-	/** name of schema for call **/
+	/** name of schema for this context **/
 	private String schemaName;
 
 	/** List of columns objects to be used in this context */


### PR DESCRIPTION
It seems that comments on private fields in TableMetaDataContext is copied from CallMetaDataContext. This PR changes unsuitable comments for TableMetaDataContext.

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
