### PR TITLE
let BeanUtils.copyProperties support to copy generic property

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -614,7 +614,7 @@ public abstract class BeanUtils {
 				if (sourcePd != null) {
 					Method readMethod = sourcePd.getReadMethod();
 					if (readMethod != null &&
-							ClassUtils.isAssignable(writeMethod.getParameterTypes()[0], readMethod.getReturnType())) {
+							ClassUtils.isAssignable(writeMethod.getParameterTypes()[0], sourcePd.getPropertyType())) {
 						try {
 							if (!Modifier.isPublic(readMethod.getDeclaringClass().getModifiers())) {
 								readMethod.setAccessible(true);

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -31,6 +31,7 @@ import org.springframework.core.io.ResourceEditor;
 import org.springframework.tests.sample.beans.DerivedTestBean;
 import org.springframework.tests.sample.beans.ITestBean;
 import org.springframework.tests.sample.beans.TestBean;
+import org.springframework.tests.sample.beans.TestStringGenericBean;
 
 import static org.junit.Assert.*;
 
@@ -196,6 +197,16 @@ public final class BeanUtilsTests {
 		assertEquals(target.getName(), "name");
 		assertTrue(target.getFlag1());
 		assertTrue(target.getFlag2());
+	}
+
+	@Test
+	public void testCopyPropertiesWithGenericProperty() throws Exception {
+		TestStringGenericBean tb = new TestStringGenericBean();
+		tb.setName("bla");
+		TestBean tb2 = new TestBean();
+		assertTrue("Name empty", tb2.getName()== null);
+		BeanUtils.copyProperties(tb, tb2);
+		assertTrue("Name copied", tb2.getName().equals(tb.getName()));
 	}
 
 	@Test

--- a/spring-beans/src/test/java/org/springframework/tests/sample/beans/TestGenericBean.java
+++ b/spring-beans/src/test/java/org/springframework/tests/sample/beans/TestGenericBean.java
@@ -1,0 +1,17 @@
+package org.springframework.tests.sample.beans;
+
+/**
+ * @author luzhonghao
+ * @since 2016.05.28
+ */
+public class TestGenericBean<T> {
+    private T name;
+
+    public T getName() {
+        return name;
+    }
+
+    public void setName(T name) {
+        this.name = name;
+    }
+}

--- a/spring-beans/src/test/java/org/springframework/tests/sample/beans/TestStringGenericBean.java
+++ b/spring-beans/src/test/java/org/springframework/tests/sample/beans/TestStringGenericBean.java
@@ -1,0 +1,9 @@
+package org.springframework.tests.sample.beans;
+
+/**
+ * @author luzhonghao
+ * @since 2016.05.28
+ */
+public class TestStringGenericBean extends TestGenericBean<String> {
+
+}


### PR DESCRIPTION
modify BeanUtils.copyProperties, let it support to copy generic property, and add unit test
