### PR TITLE
SPR-14453 - MethodBasedEvaluationContext.lazyLoadArguments() fails for variable arguments method call

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/expression/MethodBasedEvaluationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/expression/MethodBasedEvaluationContext.java
@@ -89,7 +89,7 @@ public class MethodBasedEvaluationContext extends StandardEvaluationContext {
 		String[] parameterNames = this.paramDiscoverer.getParameterNames(this.method);
 		// save parameter names (if discovered)
 		if (parameterNames != null) {
-			for (int i = 0; i < parameterNames.length; i++) {
+			for (int i = 0; i < args.length; i++) {
 				setVariable(parameterNames[i], this.args[i]);
 			}
 		}

--- a/spring-context/src/test/java/org/springframework/context/expression/MethodBasedEvaluationContextTests.java
+++ b/spring-context/src/test/java/org/springframework/context/expression/MethodBasedEvaluationContextTests.java
@@ -62,6 +62,42 @@ public class MethodBasedEvaluationContextTests {
 		assertNull(context.lookupVariable("p0"));
 	}
 
+	@Test
+	public void varArgEmpty() {
+		Method method = ReflectionUtils.findMethod(SampleMethods.class, "hello", Boolean.class, String[].class);
+		MethodBasedEvaluationContext context = createEvaluationContext(method, new Object[] {null});
+
+		assertNull(context.lookupVariable("p0"));
+		assertNull(context.lookupVariable("p1"));
+	}
+
+	@Test
+	public void varArgNull() {
+		Method method = ReflectionUtils.findMethod(SampleMethods.class, "hello", Boolean.class, String[].class);
+		MethodBasedEvaluationContext context = createEvaluationContext(method, new Object[] {null, null});
+
+		assertNull(context.lookupVariable("p0"));
+		assertNull(context.lookupVariable("p1"));
+	}
+
+	@Test
+	public void varArgSingle() {
+		Method method = ReflectionUtils.findMethod(SampleMethods.class, "hello", Boolean.class, String[].class);
+		MethodBasedEvaluationContext context = createEvaluationContext(method, new Object[] {null, "hello"});
+
+		assertNull(context.lookupVariable("p0"));
+		assertEquals("hello", context.lookupVariable("p1"));
+	}
+
+	@Test
+	public void varArgMultiple() {
+		Method method = ReflectionUtils.findMethod(SampleMethods.class, "hello", Boolean.class, String[].class);
+		MethodBasedEvaluationContext context = createEvaluationContext(method, new Object[] {null, new String[]{"hello", "hi"}});
+
+		assertNull(context.lookupVariable("p0"));
+		assertNotNull(context.lookupVariable("p1"));
+	}
+
 	private MethodBasedEvaluationContext createEvaluationContext(Method method, Object[] args) {
 		return new MethodBasedEvaluationContext(this, method, args, this.paramDiscover);
 	}
@@ -73,6 +109,9 @@ public class MethodBasedEvaluationContextTests {
 		private void hello(String foo, Boolean flag) {
 		}
 
+		private void hello(Boolean flag, String ... vararg){
+
+		}
 	}
 
 }


### PR DESCRIPTION
MethodBasedEvaluationContext.lazyLoadArguments  fails for an empty variable arguments method call
`java.lang.ArrayIndexOutOfBoundsException at MethodBasedEvaluationContextTests.java:70`

No similar issue is found in project JIRA
ICLA signed.
