### PR TITLE
UTF-8 as default for "MULTIPART_FORM_DATA" conversion

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
@@ -104,7 +104,7 @@ public class FormHttpMessageConverter implements HttpMessageConverter<MultiValue
 		this.supportedMediaTypes.add(MediaType.MULTIPART_FORM_DATA);
 
 		this.partConverters.add(new ByteArrayHttpMessageConverter());
-		StringHttpMessageConverter stringHttpMessageConverter = new StringHttpMessageConverter();
+		StringHttpMessageConverter stringHttpMessageConverter = new StringHttpMessageConverter(DEFAULT_CHARSET);
 		stringHttpMessageConverter.setWriteAcceptCharset(false);
 		this.partConverters.add(stringHttpMessageConverter);
 		this.partConverters.add(new ResourceHttpMessageConverter());

--- a/spring-web/src/test/java/org/springframework/http/converter/FormHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/FormHttpMessageConverterTests.java
@@ -247,8 +247,19 @@ public class FormHttpMessageConverterTests {
 				allOf(startsWith("<MyBean"), endsWith("><string>foo</string></MyBean>")));
 	}
 
+    @Test
+    public void writeMultipartWith_Utf8_AsDefaultEncoding() throws IOException {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<String, String>();
+        String easternEuropeCharacters = "łęąć";
+        body.set("param", easternEuropeCharacters);
+        MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+        this.converter.write(body, MediaType.MULTIPART_FORM_DATA, outputMessage);
 
-	private static class MockHttpOutputMessageRequestContext implements RequestContext {
+        assertThat("Invalid encoding of Eastern Europe characters", outputMessage.getBodyAsString(UTF_8),
+                containsString(easternEuropeCharacters));
+    }
+
+    private static class MockHttpOutputMessageRequestContext implements RequestContext {
 
 		private final MockHttpOutputMessage outputMessage;
 


### PR DESCRIPTION
FormHttpMessageConverter should use UTF-8 on default for converting "MULTIPART_FORM_DATA" to handle Eastern Europe characters. It could be overriden, however in default causes unnecessary bug.
