### PR TITLE
Allow method inlining of ObjectUtils.nullSafeEqauls()

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -298,33 +298,47 @@ public abstract class ObjectUtils {
 			return true;
 		}
 		if (o1.getClass().isArray() && o2.getClass().isArray()) {
-			if (o1 instanceof Object[] && o2 instanceof Object[]) {
-				return Arrays.equals((Object[]) o1, (Object[]) o2);
-			}
-			if (o1 instanceof boolean[] && o2 instanceof boolean[]) {
-				return Arrays.equals((boolean[]) o1, (boolean[]) o2);
-			}
-			if (o1 instanceof byte[] && o2 instanceof byte[]) {
-				return Arrays.equals((byte[]) o1, (byte[]) o2);
-			}
-			if (o1 instanceof char[] && o2 instanceof char[]) {
-				return Arrays.equals((char[]) o1, (char[]) o2);
-			}
-			if (o1 instanceof double[] && o2 instanceof double[]) {
-				return Arrays.equals((double[]) o1, (double[]) o2);
-			}
-			if (o1 instanceof float[] && o2 instanceof float[]) {
-				return Arrays.equals((float[]) o1, (float[]) o2);
-			}
-			if (o1 instanceof int[] && o2 instanceof int[]) {
-				return Arrays.equals((int[]) o1, (int[]) o2);
-			}
-			if (o1 instanceof long[] && o2 instanceof long[]) {
-				return Arrays.equals((long[]) o1, (long[]) o2);
-			}
-			if (o1 instanceof short[] && o2 instanceof short[]) {
-				return Arrays.equals((short[]) o1, (short[]) o2);
-			}
+			return checkForArrayEquality(o1, o2);
+		}
+		return false;
+	}
+
+	/**
+	 * Compares arrays with {@code Arrays.equals}, performing an equality
+	 * check based on the array elements rather than the array reference.
+	 * @param o1 first Object to compare
+	 * @param o2 second Object to compare
+	 * @return whether the given objects are equal
+	 * @see java.util.Arrays#equals
+	 * @see ObjectUtils#nullSafeEquals(Object, Object)
+	 */
+	private static boolean checkForArrayEquality(Object o1, Object o2) {
+		if (o1 instanceof Object[] && o2 instanceof Object[]) {
+			return Arrays.equals((Object[]) o1, (Object[]) o2);
+		}
+		if (o1 instanceof boolean[] && o2 instanceof boolean[]) {
+			return Arrays.equals((boolean[]) o1, (boolean[]) o2);
+		}
+		if (o1 instanceof byte[] && o2 instanceof byte[]) {
+			return Arrays.equals((byte[]) o1, (byte[]) o2);
+		}
+		if (o1 instanceof char[] && o2 instanceof char[]) {
+			return Arrays.equals((char[]) o1, (char[]) o2);
+		}
+		if (o1 instanceof double[] && o2 instanceof double[]) {
+			return Arrays.equals((double[]) o1, (double[]) o2);
+		}
+		if (o1 instanceof float[] && o2 instanceof float[]) {
+			return Arrays.equals((float[]) o1, (float[]) o2);
+		}
+		if (o1 instanceof int[] && o2 instanceof int[]) {
+			return Arrays.equals((int[]) o1, (int[]) o2);
+		}
+		if (o1 instanceof long[] && o2 instanceof long[]) {
+			return Arrays.equals((long[]) o1, (long[]) o2);
+		}
+		if (o1 instanceof short[] && o2 instanceof short[]) {
+			return Arrays.equals((short[]) o1, (short[]) o2);
 		}
 		return false;
 	}


### PR DESCRIPTION
Hey,

while doing a benchmark in our project with the JVM options
`-XX:+PrintCompilation -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining
`

I noticed that _ObjectUtils.nullSafeEquals()_ is a hot method, but unfortunately too big for the VM to inline it. At least with the defaults of 325 bytecodes as it currently shows up with 337 bytes.

```
...
 @ 8   org.springframework.util.ObjectUtils::nullSafeEquals (337 bytes)   hot method too big
...
```

I made a small improvement by simply extracting the more uncommon use-case of checking for array equality, which reduces the method to 55 bytes and allows the inlining of the method. As a small side-benefit it also reduces the cyclomatic complexity of the method itself.

```
...
@ 8   com.dreis.benchmark.ObjectUtilsInlinedEquals::nullSafeEquals (55 bytes)   inline (hot)
...
```

I also created a small microbenchmark that looks like this:

``` java
@BenchmarkMode(Mode.Throughput)
@State(Scope.Thread)
public class ObjectUtilsBenchmark {

    @State(Scope.Thread)
    public static class TestState {
        public String[] firstStringArray = new String[] {"a", "b", "c"};
        public String[] secondStringArray = new String[] {"a", "b", "c"};
        public List<String> firstStringCollection = Arrays.asList("a", "b", "c");
        public List<String> secondStringCollection = Arrays.asList("a", "b", "c");
    }

    @Benchmark
    public boolean testStringArray(TestState testState) {
        return ObjectUtils.nullSafeEquals(testState.firstStringArray, testState.secondStringArray);
    }

    @Benchmark
    public boolean testStringCollection(TestState testState) {
        return ObjectUtils.nullSafeEquals(testState.firstStringCollection, testState.secondStringCollection);
    }

    @Benchmark
    public boolean testStringArrayInlined(TestState testState) {
        return ObjectUtilsInlinedEquals.nullSafeEquals(testState.firstStringArray, testState.secondStringArray);
    }

    @Benchmark
    public boolean testStringCollectionInlined(TestState testState) {
        return ObjectUtilsInlinedEquals.nullSafeEquals(testState.firstStringCollection, testState.secondStringCollection);
    }

}
```

The results of this microbenchmark look roughly like this.

```
Benchmark                                          Mode  Cnt          Score        Error  Units
ObjectUtilsBenchmark.testStringArray              thrpt   20  127900470,357 ± 985253,526  ops/s
ObjectUtilsBenchmark.testStringArrayInlined       thrpt   20  149902422,075 ± 905479,738  ops/s
ObjectUtilsBenchmark.testStringCollection         thrpt   20   61584045,911 ± 345039,219  ops/s
ObjectUtilsBenchmark.testStringCollectionInlined  thrpt   20   70381357,642 ± 751583,252  ops/s
```

https://jira.spring.io/browse/SPR-14349

Keep up the great work :-)

Cheers,
Christoph
