### PR TITLE
Fix getFieldValues to allow proper extending

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -16,31 +16,19 @@
 
 package org.springframework.http;
 
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedCaseInsensitiveMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.springframework.util.Assert;
-import org.springframework.util.LinkedCaseInsensitiveMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.util.StringUtils;
 
 /**
  * Represents HTTP request and response headers, mapping string header names to a list of string values.
@@ -511,7 +499,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	}
 
 	protected String getFieldValues(String headerName) {
-		List<String> headerValues = this.headers.get(headerName);
+		List<String> headerValues = get(headerName);
 		if (headerValues != null) {
 			StringBuilder builder = new StringBuilder();
 			for (Iterator<String> iterator = headerValues.iterator(); iterator.hasNext(); ) {

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -16,19 +16,31 @@
 
 package org.springframework.http;
 
-import org.springframework.util.Assert;
-import org.springframework.util.LinkedCaseInsensitiveMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.util.StringUtils;
-
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedCaseInsensitiveMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 
 /**
  * Represents HTTP request and response headers, mapping string header names to a list of string values.

--- a/spring-web/src/test/java/org/springframework/http/server/ServletServerHttpResponseTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/ServletServerHttpResponseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-web/src/test/java/org/springframework/http/server/ServletServerHttpResponseTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/ServletServerHttpResponseTests.java
@@ -16,22 +16,19 @@
 
 package org.springframework.http.server;
 
-import java.nio.charset.Charset;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.test.MockHttpServletResponse;
 import org.springframework.util.FileCopyUtils;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Arjen Poutsma
@@ -56,6 +53,15 @@ public class ServletServerHttpResponseTests {
 		response.setStatusCode(HttpStatus.NOT_FOUND);
 		assertEquals("Invalid status code", 404, mockResponse.getStatus());
 	}
+
+    @Test
+    public void testAccessControlOriginHeader() throws Exception {
+        mockResponse.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "domain1.com");
+
+        String allowedOrigin = response.getHeaders().getAccessControlAllowOrigin();
+        assertNotNull("The Access-Control-Allow-Origin header should be set", allowedOrigin);
+        assertTrue("The Access-Control-Allow-Origin header should contain domain1.com", allowedOrigin.contains("domain1.com"));
+    }
 
 	@Test
 	public void getHeaders() throws Exception {


### PR DESCRIPTION
I'm currently using Spring 4.3.0.RC2 (via Spring Boot 1.4.0.M3) and I noticed that in some circumstances CORS headers were added multiple times, which causes the request to fail.

I noticed that the DefaultCorsProcessor does perform a check to see if the headers were already added, however that check didn't seem to work.

I traced the problem back further to ServletServerHttpResponse and its class ServletResponseHttpHeaders which extends HttpHeaders. The DefaultCorsProcessor uses the getAccessControlAllowOrigin function to check for the headers. That function in turn uses the protected function getFieldValues to build a comma delimited string. This function accesses this.headers directly, instead of using the get function which causes this problem, since ServletResponseHttpHeaders only overwrites the get function.

I changed the protected getFieldValues function to use the get function which should fix the problem, but is a fairly trivial change.

As a workaround I registered the CorsFilter manually instead of relying on Spring Boots autoconfiguration (which uses an HttpInterceptor instead of a filter)
