### PR TITLE
SPR-14370 - hide sensitive data from debug logs

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/PropertySourcesPropertyResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/env/PropertySourcesPropertyResolver.java
@@ -18,6 +18,7 @@ package org.springframework.core.env;
 
 import org.springframework.core.convert.ConversionException;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link PropertyResolver} implementation that resolves property values against
@@ -86,7 +87,10 @@ public class PropertySourcesPropertyResolver extends AbstractPropertyResolver {
 					if (resolveNestedPlaceholders && value instanceof String) {
 						value = resolveNestedPlaceholders((String) value);
 					}
-					if (debugEnabled) {
+					if (debugEnabled && key.toLowerCase().contains("password")) {
+						logger.debug(String.format("Found key '%s' in [%s] with type [%s] and value '****'",
+								key, propertySource.getName(), valueType.getSimpleName()));
+					} else if (debugEnabled) {
 						logger.debug(String.format("Found key '%s' in [%s] with type [%s] and value '%s'",
 								key, propertySource.getName(), valueType.getSimpleName(), value));
 					}


### PR DESCRIPTION
Hide property values from debug logs if key contains blacklisted-word
"password".
This is a trivial fix I am proposing for a ticket submitted this morning. As described in the ticket, I am taking Atlassian Bamboo's approach of hiding passwords from the logs files by blacklisting the word "password".
Obviously one should not enable debug log unless really necessary.

The Clever Coder's Checklist:
- I did run the JUnit tests and they did not break.
- I did not check for key being null assuming that it will be never null at that point in the code
- I skipped discussion before submitting code because it is a trivial fix

```
I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
```
