### PR TITLE
Fix ambiguous static import

### DIFF
--- a/spring-test/src/test/java/org/springframework/test/context/support/TestPropertySourceUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/TestPropertySourceUtilsTests.java
@@ -32,7 +32,7 @@ import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.env.MockPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;


### PR DESCRIPTION
Since there is also a method org.mockito.Matchers.startsWith(String prefix), so the method startsWith(String) is ambiguous for the type TestPropertySourceUtilsTests, and as I don't know which one you want to use, so I just change the static import for org.hamcrest.CoreMatchers.containsString to use org.hamcrest.CoreMatchers.startsWith explicitly.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
