### PR TITLE
SPR-14433 - Inline variable that is used only once

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
@@ -449,11 +449,10 @@ public class DefaultSingletonBeanRegistry extends SimpleAliasRegistry implements
 	}
 
 	private boolean isDependent(String beanName, String dependentBeanName, Set<String> alreadySeen) {
-		String canonicalName = canonicalName(beanName);
 		if (alreadySeen != null && alreadySeen.contains(beanName)) {
 			return false;
 		}
-		Set<String> dependentBeans = this.dependentBeanMap.get(canonicalName);
+		Set<String> dependentBeans = this.dependentBeanMap.get(canonicalName(beanName));
 		if (dependentBeans == null) {
 			return false;
 		}


### PR DESCRIPTION
The variable canonicalName is used only once, and there is no need
to call canonicalName() when 
"alreadySeen != null && alreadySeen.contains(beanName)" is true, 
so inline it.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
