### PR TITLE
Is there a better way to solve this problem？

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/multipart/commons/CommonsMultipartResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/commons/CommonsMultipartResolver.java
@@ -155,6 +155,27 @@ public class CommonsMultipartResolver extends CommonsFileUploadSupport
 		String encoding = determineEncoding(request);
 		FileUpload fileUpload = prepareFileUpload(encoding);
 		try {
+			Collection<Part> parts = request.getParts();
+			if(parts != null){
+	            		List<FileItem> items = new ArrayList<FileItem>();
+				for(Part part : parts){
+					 FileItemFactory fac = getFileItemFactory();
+					 String contentType = part.getContentType();
+					 FileItem fileItem = null;
+					 if(contentType == null){
+						 fileItem = fac.createItem(part.getName(),
+								 contentType, true,
+								 part.getName());
+					 } else {
+						 fileItem = fac.createItem(part.getName(),
+								 contentType, false,
+								 part.getName());
+					 }
+                    			Streams.copy(part.getInputStream(), fileItem.getOutputStream(), true);
+	                		items.add(fileItem);
+				}
+				return parseFileItems(items, encoding);
+			}
 			List<FileItem> fileItems = ((ServletFileUpload) fileUpload).parseRequest(request);
 			return parseFileItems(fileItems, encoding);
 		}
@@ -164,6 +185,12 @@ public class CommonsMultipartResolver extends CommonsFileUploadSupport
 		catch (FileUploadException ex) {
 			throw new MultipartException("Could not parse multipart servlet request", ex);
 		}
+		catch (IOException ex) {
+			throw new MultipartException("Could not parse multipart servlet request", ex);
+		}
+		catch (ServletException ex) {
+			throw new MultipartException("Could not parse multipart servlet request", ex);
+		} 
 	}
 
 	/**


### PR DESCRIPTION
When I call "request.getParameter" in the javax.servlet.Filter, request will be parsed into "parts" field.After then,the request reaches "org.springframework.web.multipart.commons.CommonsMultipartResolver.parseRequest" and will be parsed again,but it can not get any request parameter values.
The method in my controller is "public String saveImage(@RequestParam("imageFile") MultipartFile file, @RequestParam Integer userId)".
The logic in my filter proceed as follows.
[code]
public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
    Integer userId = request.getParameter("userId")
    if (isauthorized(userId)) {
        filterChain.doFilter(request, response);
        return;
    }
    ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
}
[/code]
I solved this problem temporarily by change "CommonsMultipartResolver.parseRequest",but it is not rigorous.Is there a better way to solve this problem？
Thanks.
