### PR TITLE
Fix typo in asciidoc

### DIFF
--- a/src/asciidoc/core-beans.adoc
+++ b/src/asciidoc/core-beans.adoc
@@ -2680,7 +2680,7 @@ understand the "why" as well as the "how" behind it.
 ----
 
 To create such a proxy, you insert a child `<aop:scoped-proxy/>` element into a scoped
-bean definition. See <<beans-factory-scopes-other-injection-proxies>> and
+bean definition. (See <<beans-factory-scopes-other-injection-proxies>> and
 <<xsd-configuration>>.) Why do definitions of beans scoped at the `request`, `session`,
 `globalSession` and custom-scope levels require the `<aop:scoped-proxy/>` element ?
 Let's examine the following singleton bean definition and contrast it with what you need


### PR DESCRIPTION
It seems like "(" is missing.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
