### PR TITLE
Fixed #DATAREDIS-527 Added ErrorHandler to the AspectjCachingConfiguration

### DIFF
--- a/spring-aspects/src/main/java/org/springframework/cache/aspectj/AspectJCachingConfiguration.java
+++ b/spring-aspects/src/main/java/org/springframework/cache/aspectj/AspectJCachingConfiguration.java
@@ -39,11 +39,17 @@ public class AspectJCachingConfiguration extends AbstractCachingConfiguration {
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	public AnnotationCacheAspect cacheAspect() {
 		AnnotationCacheAspect cacheAspect = AnnotationCacheAspect.aspectOf();
+        if (this.cacheResolver != null) {
+            cacheAspect.setCacheResolver(this.cacheResolver);
+        }
 		if (this.cacheManager != null) {
 			cacheAspect.setCacheManager(this.cacheManager);
 		}
 		if (this.keyGenerator != null) {
 			cacheAspect.setKeyGenerator(this.keyGenerator);
+		}
+		if (this.errorHandler != null) {
+            cacheAspect.setErrorHandler(this.errorHandler);
 		}
 		return cacheAspect;
 	}


### PR DESCRIPTION
When enabling caching on aspectj mode, custom error handler was not getting inject.
Fix is to
set errorHandler on AspectJCachingConfiguration
