### PR TITLE
Fix broken javadoc

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/Import.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/Import.java
@@ -54,7 +54,7 @@ import java.lang.annotation.Target;
 public @interface Import {
 
 	/**
-	 * @{@link Configuration}, {@link ImportSelector}, {@link ImportBeanDefinitionRegistrar}
+	 * {@link Configuration @Configuration}, {@link ImportSelector}, {@link ImportBeanDefinitionRegistrar}
 	 * or regular component classes to import.
 	 */
 	Class<?>[] value();

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -64,8 +64,7 @@ import org.springframework.util.StringValueResolver;
  * to the "fixedRate", "fixedDelay", or "cron" expression provided via the annotation.
  *
  * <p>This post-processor is automatically registered by Spring's
- * {@code <task:annotation-driven>} XML element, and also by the
- * @{@link EnableScheduling} annotation.
+ * {@code <task:annotation-driven>} XML element, and also by the @{@link EnableScheduling} annotation.
  *
  * <p>Autodetects any {@link SchedulingConfigurer} instances in the container,
  * allowing for customization of the scheduler to be used or for fine-grained

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/SchedulingConfiguration.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/SchedulingConfiguration.java
@@ -26,8 +26,8 @@ import org.springframework.scheduling.config.TaskManagementConfigUtils;
  * {@code @Configuration} class that registers a {@link ScheduledAnnotationBeanPostProcessor}
  * bean capable of processing Spring's @{@link Scheduled} annotation.
  *
- * <p>This configuration class is automatically imported when using the
- * @{@link EnableScheduling} annotation. See {@code @EnableScheduling}'s javadoc
+ * <p>This configuration class is automatically imported when using the @{@link EnableScheduling}
+ * annotation. See {@code @EnableScheduling}'s javadoc
  * for complete usage details.
  *
  * @author Chris Beams

--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/EnableTransactionManagement.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/EnableTransactionManagement.java
@@ -28,8 +28,8 @@ import org.springframework.core.Ordered;
 
 /**
  * Enables Spring's annotation-driven transaction management capability, similar to
- * the support found in Spring's {@code <tx:*>} XML namespace. To be used on
- * @{@link org.springframework.context.annotation.Configuration Configuration} classes
+ * the support found in Spring's {@code <tx:*>} XML namespace. To be used on @{@link org.springframework.context.annotation.Configuration Configuration}
+ * classes
  * as follows:
  *
  * <pre class="code">

--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/TransactionManagementConfigurer.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/TransactionManagementConfigurer.java
@@ -31,8 +31,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  *
  * <p>Note that in by-type lookup disambiguation cases, an alternative approach to
  * implementing this interface is to simply mark one of the offending
- * {@code PlatformTransactionManager} {@code @Bean} methods as
- * @{@link org.springframework.context.annotation.Primary Primary}.
+ * {@code PlatformTransactionManager} {@code @Bean} methods as @{@link org.springframework.context.annotation.Primary Primary}.
  * This is even generally preferred since it doesn't lead to early initialization
  * of the {@code PlatformTransactionManager} bean.
  *

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
@@ -50,8 +50,8 @@ import org.springframework.web.util.WebUtils;
  * type {@link MultipartFile} in conjunction with Spring's {@link MultipartResolver}
  * abstraction, and arguments of type {@code javax.servlet.http.Part} in conjunction
  * with Servlet 3.0 multipart requests. This resolver can also be created in default
- * resolution mode in which simple types (int, long, etc.) not annotated with
- * @{@link RequestParam} are also treated as request parameters with the
+ * resolution mode in which simple types (int, long, etc.) not annotated with @{@link RequestParam}
+ * are also treated as request parameters with the
  * parameter name derived from the argument name.
  *
  * <p>If the method parameter type is {@link Map}, the name specified in the


### PR DESCRIPTION
The javadocs are broken where lines start with "@{".

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
