### PR TITLE
SPR-14443 -Autowired method ordering in AutowiredAnnotationBeanPostProcessor

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
@@ -16,13 +16,31 @@
 
 package org.springframework.beans.factory.annotation;
 
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyValues;
 import org.springframework.beans.TypeConverter;
-import org.springframework.beans.factory.*;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.DependencyDescriptor;
 import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessorAdapter;
@@ -40,12 +58,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
-
-import java.beans.PropertyDescriptor;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * {@link org.springframework.beans.factory.config.BeanPostProcessor} implementation
@@ -437,11 +449,10 @@ public class AutowiredAnnotationBeanPostProcessor extends InstantiationAwareBean
 			});
 
 			if (methodsOffset < currElements.size()) {
-				final AnnotationAwareOrderComparator orderComparator = new AnnotationAwareOrderComparator();
 				Comparator<InjectionMetadata.InjectedElement> comparator = new Comparator<InjectionMetadata.InjectedElement>() {
 					@Override
 					public int compare(InjectionMetadata.InjectedElement o1, InjectionMetadata.InjectedElement o2) {
-						return orderComparator.compare(o1.getMember(), o2.getMember());
+						return AnnotationAwareOrderComparator.INSTANCE.compare(o1.getMember(), o2.getMember());
 					}
 				};
 				Collections.sort(currElements.subList(methodsOffset, currElements.size()), comparator);


### PR DESCRIPTION
See https://jira.spring.io/browse/SPR-14443.
At now, it's impossible to predict order of autowired methods calls. But there are use cases when a creation of ordered beans is unwanted. For example, the code snippet at https://jira.spring.io/browse/SPR-14443 tried to inject different beans for each autowired method. Without that, I have to inject all the beans into the component class that looks bad. As a workaround I can create ordered beans but this approach has a bean creation overhead.

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
