### PR TITLE
SPR-14471 - Add autowiring support to SpringBeanJobFactory

### DIFF
--- a/spring-context-support/src/test/java/org/springframework/scheduling/quartz/SpringBeanJobFactoryTest.java
+++ b/spring-context-support/src/test/java/org/springframework/scheduling/quartz/SpringBeanJobFactoryTest.java
@@ -1,0 +1,80 @@
+package org.springframework.scheduling.quartz;
+
+import java.util.Date;
+
+import org.junit.Test;
+import org.quartz.Job;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.impl.triggers.SimpleTriggerImpl;
+import org.quartz.spi.TriggerFiredBundle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Tests for the {@link SpringBeanJobFactory}
+ *
+ * @author Marten Deinum
+ */
+public class SpringBeanJobFactoryTest {
+
+    @Test
+    public void shouldSetParameterFromContextAndAutowireDependenciesInAJob() throws Exception {
+        ApplicationContext context = loadContext();
+        TriggerFiredBundle tfb = createTrigger(context, "jobDetailWithJob");
+
+        SpringBeanJobFactory factory = context.getBean(SpringBeanJobFactory.class);
+
+        DummyJob job = (DummyJob) factory.createJobInstance(tfb);
+
+        assertThat(job.getDummyBean(), sameInstance(context.getBean(DummyBean.class)));
+        assertThat(job.getParam(), is(42));
+    }
+
+    private ApplicationContext loadContext() {
+        return new ClassPathXmlApplicationContext("scheduler-with-job-factory.xml", SpringBeanJobFactoryTest.class);
+    }
+
+
+    private TriggerFiredBundle createTrigger(ApplicationContext context, String name) {
+        final Date now = new Date();
+        final JobDetail jobDetail = context.getBean(name, JobDetail.class);
+        return new TriggerFiredBundle(jobDetail, new SimpleTriggerImpl(), null, false, now, now, now, now);
+    }
+
+
+    public static class DummyBean {
+    }
+
+    public static class DummyJob implements Job {
+
+        private int param;
+
+        @Autowired
+        private DummyBean dummyBean;
+
+
+        @Override
+        public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        }
+
+
+        public void setParam(int value) {
+            param = value;
+        }
+
+        public int getParam() {
+            return param;
+        }
+
+        public DummyBean getDummyBean() {
+            return dummyBean;
+        }
+    }
+}

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/scheduler-with-job-factory.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/scheduler-with-job-factory.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:annotation-config />
+
+    <bean id="jobDetailWithJob" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+        <property name="jobClass" value="org.springframework.scheduling.quartz.SpringBeanJobFactoryTest$DummyJob" />
+        <property name="jobDataAsMap">
+            <map>
+                <entry key="param" value="42" />
+            </map>
+        </property>
+    </bean>
+
+    <bean class="org.springframework.scheduling.quartz.SpringBeanJobFactoryTest$DummyBean" />
+
+    <bean id="jobFactory" class="org.springframework.scheduling.quartz.SpringBeanJobFactory" />
+
+</beans>


### PR DESCRIPTION
This commit introduces autowiring support to the SpringBeanJobFactory.
It will call the autowireBean method if an AutowireCapableBeanFactory has
been injected. The autowiring will be done on either the Job or the delegate
of the DelegatingJob which contains a Runnable.

A test has been added to verify the correct behavior of the autowiring and
as well as retaining the initial support of using the job data for wiring dependencies.

Issue: [SPR-14471](https://jira.spring.io/browse/SPR-14471)
