### PR TITLE
Cancel Subscription when onError is invoked internally

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractListenerServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractListenerServerHttpResponse.java
@@ -40,17 +40,7 @@ public abstract class AbstractListenerServerHttpResponse extends AbstractServerH
 
 	@Override
 	protected final Mono<Void> writeWithInternal(Publisher<DataBuffer> body) {
-		if (this.writeCalled.compareAndSet(false, true)) {
-			Processor<DataBuffer, Void> bodyProcessor = createBodyProcessor();
-			return Mono.from(subscriber -> {
-				body.subscribe(bodyProcessor);
-				bodyProcessor.subscribe(subscriber);
-			});
-
-		} else {
-			return Mono.error(new IllegalStateException(
-					"writeWith() or writeAndFlushWith() has already been called"));
-		}
+		return writeAndFlushWithInternal(Mono.just(body));
 	}
 
 	@Override
@@ -67,13 +57,6 @@ public abstract class AbstractListenerServerHttpResponse extends AbstractServerH
 					"writeWith() or writeAndFlushWith() has already been called"));
 		}
 	}
-
-	/**
-	 * Abstract template method to create a {@code Processor<DataBuffer, Void>} that
-	 * will write the response body to the underlying output. Called from
-	 * {@link #writeWithInternal(Publisher)}.
-	 */
-	protected abstract Processor<DataBuffer, Void> createBodyProcessor();
 
 	/**
 	 * Abstract template method to create a {@code Processor<Publisher<DataBuffer>, Void>}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodyFlushProcessor.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodyFlushProcessor.java
@@ -106,6 +106,10 @@ abstract class AbstractResponseBodyFlushProcessor
 	 */
 	protected abstract void flush() throws IOException;
 
+	private void cancel() {
+		this.subscription.cancel();
+	}
+
 	private void writeComplete() {
 		if (logger.isTraceEnabled()) {
 			logger.trace(this.state + " writeComplete");
@@ -157,11 +161,12 @@ abstract class AbstractResponseBodyFlushProcessor
 				else {
 					try {
 						processor.flush();
+						processor.subscription.request(1);
 					}
 					catch (IOException ex) {
+						processor.cancel();
 						processor.onError(ex);
 					}
-					processor.subscription.request(1);
 				}
 			}
 		}, COMPLETED {
@@ -231,6 +236,7 @@ abstract class AbstractResponseBodyFlushProcessor
 
 			@Override
 			public void onError(Throwable t) {
+				processor.cancel();
 				processor.onError(t);
 			}
 

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodyProcessor.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodyProcessor.java
@@ -159,6 +159,10 @@ abstract class AbstractResponseBodyProcessor implements Processor<DataBuffer, Vo
 	 */
 	protected abstract boolean write(DataBuffer dataBuffer) throws IOException;
 
+	protected void cancel() {
+		this.subscription.cancel();
+	}
+
 	private boolean changeState(State oldState, State newState) {
 		return this.state.compareAndSet(oldState, newState);
 	}
@@ -220,7 +224,6 @@ abstract class AbstractResponseBodyProcessor implements Processor<DataBuffer, Vo
 			@Override
 			void onComplete(AbstractResponseBodyProcessor processor) {
 				if (processor.changeState(this, COMPLETED)) {
-					processor.subscriberCompleted = true;
 					processor.publisherDelegate.publishComplete();
 				}
 			}
@@ -258,6 +261,7 @@ abstract class AbstractResponseBodyProcessor implements Processor<DataBuffer, Vo
 						}
 					}
 					catch (IOException ex) {
+						processor.cancel();
 						processor.onError(ex);
 					}
 				}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpResponse.java
@@ -224,6 +224,7 @@ public class ServletServerHttpResponse extends AbstractListenerServerHttpRespons
 		@Override
 		public void onError(Throwable ex) {
 			if (bodyProcessor != null) {
+				bodyProcessor.cancel();
 				bodyProcessor.onError(ex);
 			}
 		}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpResponse.java
@@ -22,13 +22,13 @@ import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
 import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
 
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
@@ -44,7 +44,7 @@ import org.springframework.util.Assert;
  */
 public class ServletServerHttpResponse extends AbstractListenerServerHttpResponse {
 
-	private final AtomicBoolean listenerRegistered = new AtomicBoolean();
+	private final ResponseBodyWriteListener writeListener = new ResponseBodyWriteListener();
 
 	private volatile ResponseBodyProcessor bodyProcessor;
 
@@ -112,15 +112,17 @@ public class ServletServerHttpResponse extends AbstractListenerServerHttpRespons
 		}
 	}
 
-	private void registerListener() throws IOException {
-		if (this.listenerRegistered.compareAndSet(false, true)) {
-			ResponseBodyWriteListener writeListener = new ResponseBodyWriteListener();
-			this.response.getOutputStream().setWriteListener(writeListener);
+	private void registerListener() {
+		try {
+			outputStream().setWriteListener(writeListener);
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException(e);
 		}
 	}
 
 	private void flush() throws IOException {
-		ServletOutputStream outputStream = this.response.getOutputStream();
+		ServletOutputStream outputStream = outputStream();
 		if (outputStream.isReady()) {
 			try {
 				outputStream.flush();
@@ -136,22 +138,15 @@ public class ServletServerHttpResponse extends AbstractListenerServerHttpRespons
 		}
 	}
 
-	@Override
-	protected ResponseBodyProcessor createBodyProcessor() {
-		try {
-			registerListener();
-			this.bodyProcessor = new ResponseBodyProcessor(this.response.getOutputStream(),
-					this.bufferSize);
-			return this.bodyProcessor;
-		}
-		catch (IOException ex) {
-			throw new UncheckedIOException(ex);
-		}
+	private ServletOutputStream outputStream() throws IOException {
+		return this.response.getOutputStream();
 	}
 
 	@Override
-	protected AbstractResponseBodyFlushProcessor createBodyFlushProcessor() {
-		return new ResponseBodyFlushProcessor();
+	protected Processor<Publisher<DataBuffer>, Void> createBodyFlushProcessor() {
+		Processor<Publisher<DataBuffer>, Void> processor = new ResponseBodyFlushProcessor();
+		registerListener();
+		return processor;
 	}
 
 	private class ResponseBodyProcessor extends AbstractResponseBodyProcessor {
@@ -238,7 +233,13 @@ public class ServletServerHttpResponse extends AbstractListenerServerHttpRespons
 
 		@Override
 		protected Processor<DataBuffer, Void> createBodyProcessor() {
-			return ServletServerHttpResponse.this.createBodyProcessor();
+			try {
+				bodyProcessor = new ResponseBodyProcessor(outputStream(), bufferSize);
+				return bodyProcessor;
+			}
+			catch (IOException ex) {
+				throw new UncheckedIOException(ex);
+			}
 		}
 
 		@Override

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpResponse.java
@@ -123,8 +123,7 @@ public class UndertowServerHttpResponse extends AbstractListenerServerHttpRespon
 		}
 	}
 
-	@Override
-	protected ResponseBodyProcessor createBodyProcessor() {
+	private ResponseBodyProcessor createBodyProcessor() {
 		if (this.responseChannel == null) {
 			this.responseChannel = this.exchange.getResponseChannel();
 		}


### PR DESCRIPTION
AbstractResponseBodyProcessor.onError and
AbstractResponseBodyFlushProcessor.onError will be invoked when:
- The Publisher wants to signal with onError that there are failures.
  Once onError is invoked the Subscription should be considered canceled.
- The internal implementation wants to signal with onError that there
  are failures. In this use case the implementation should invoke
  Subscription.cancel()
