### PR TITLE
Refactor AbstractResponseBodyFlushProcessor states

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractListenerServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractListenerServerHttpResponse.java
@@ -40,17 +40,7 @@ public abstract class AbstractListenerServerHttpResponse extends AbstractServerH
 
 	@Override
 	protected final Mono<Void> writeWithInternal(Publisher<DataBuffer> body) {
-		if (this.writeCalled.compareAndSet(false, true)) {
-			Processor<DataBuffer, Void> bodyProcessor = createBodyProcessor();
-			return Mono.from(subscriber -> {
-				body.subscribe(bodyProcessor);
-				bodyProcessor.subscribe(subscriber);
-			});
-
-		} else {
-			return Mono.error(new IllegalStateException(
-					"writeWith() or writeAndFlushWith() has already been called"));
-		}
+		return writeAndFlushWithInternal(Mono.just(body));
 	}
 
 	@Override
@@ -67,13 +57,6 @@ public abstract class AbstractListenerServerHttpResponse extends AbstractServerH
 					"writeWith() or writeAndFlushWith() has already been called"));
 		}
 	}
-
-	/**
-	 * Abstract template method to create a {@code Processor<DataBuffer, Void>} that
-	 * will write the response body to the underlying output. Called from
-	 * {@link #writeWithInternal(Publisher)}.
-	 */
-	protected abstract Processor<DataBuffer, Void> createBodyProcessor();
 
 	/**
 	 * Abstract template method to create a {@code Processor<Publisher<DataBuffer>, Void>}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodyFlushProcessor.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodyFlushProcessor.java
@@ -106,6 +106,10 @@ abstract class AbstractResponseBodyFlushProcessor
 	 */
 	protected abstract void flush() throws IOException;
 
+	private void cancel() {
+		this.subscription.cancel();
+	}
+
 	private void writeComplete() {
 		if (logger.isTraceEnabled()) {
 			logger.trace(this.state + " writeComplete");
@@ -157,11 +161,12 @@ abstract class AbstractResponseBodyFlushProcessor
 				else {
 					try {
 						processor.flush();
+						processor.subscription.request(1);
 					}
 					catch (IOException ex) {
+						processor.cancel();
 						processor.onError(ex);
 					}
-					processor.subscription.request(1);
 				}
 			}
 		}, COMPLETED {
@@ -231,6 +236,7 @@ abstract class AbstractResponseBodyFlushProcessor
 
 			@Override
 			public void onError(Throwable t) {
+				processor.cancel();
 				processor.onError(t);
 			}
 

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodyProcessor.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractResponseBodyProcessor.java
@@ -159,6 +159,10 @@ abstract class AbstractResponseBodyProcessor implements Processor<DataBuffer, Vo
 	 */
 	protected abstract boolean write(DataBuffer dataBuffer) throws IOException;
 
+	protected void cancel() {
+		this.subscription.cancel();
+	}
+
 	private boolean changeState(State oldState, State newState) {
 		return this.state.compareAndSet(oldState, newState);
 	}
@@ -220,7 +224,6 @@ abstract class AbstractResponseBodyProcessor implements Processor<DataBuffer, Vo
 			@Override
 			void onComplete(AbstractResponseBodyProcessor processor) {
 				if (processor.changeState(this, COMPLETED)) {
-					processor.subscriberCompleted = true;
 					processor.publisherDelegate.publishComplete();
 				}
 			}
@@ -258,6 +261,7 @@ abstract class AbstractResponseBodyProcessor implements Processor<DataBuffer, Vo
 						}
 					}
 					catch (IOException ex) {
+						processor.cancel();
 						processor.onError(ex);
 					}
 				}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpResponse.java
@@ -224,6 +224,7 @@ public class ServletServerHttpResponse extends AbstractListenerServerHttpRespons
 		@Override
 		public void onError(Throwable ex) {
 			if (bodyProcessor != null) {
+				bodyProcessor.cancel();
 				bodyProcessor.onError(ex);
 			}
 		}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpResponse.java
@@ -22,13 +22,13 @@ import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
 import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
 
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
@@ -44,7 +44,7 @@ import org.springframework.util.Assert;
  */
 public class ServletServerHttpResponse extends AbstractListenerServerHttpResponse {
 
-	private final AtomicBoolean listenerRegistered = new AtomicBoolean();
+	private final ResponseBodyWriteListener writeListener = new ResponseBodyWriteListener();
 
 	private volatile ResponseBodyProcessor bodyProcessor;
 
@@ -112,15 +112,17 @@ public class ServletServerHttpResponse extends AbstractListenerServerHttpRespons
 		}
 	}
 
-	private void registerListener() throws IOException {
-		if (this.listenerRegistered.compareAndSet(false, true)) {
-			ResponseBodyWriteListener writeListener = new ResponseBodyWriteListener();
-			this.response.getOutputStream().setWriteListener(writeListener);
+	private void registerListener() {
+		try {
+			outputStream().setWriteListener(writeListener);
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException(e);
 		}
 	}
 
 	private void flush() throws IOException {
-		ServletOutputStream outputStream = this.response.getOutputStream();
+		ServletOutputStream outputStream = outputStream();
 		if (outputStream.isReady()) {
 			try {
 				outputStream.flush();
@@ -136,22 +138,15 @@ public class ServletServerHttpResponse extends AbstractListenerServerHttpRespons
 		}
 	}
 
-	@Override
-	protected ResponseBodyProcessor createBodyProcessor() {
-		try {
-			registerListener();
-			this.bodyProcessor = new ResponseBodyProcessor(this.response.getOutputStream(),
-					this.bufferSize);
-			return this.bodyProcessor;
-		}
-		catch (IOException ex) {
-			throw new UncheckedIOException(ex);
-		}
+	private ServletOutputStream outputStream() throws IOException {
+		return this.response.getOutputStream();
 	}
 
 	@Override
-	protected AbstractResponseBodyFlushProcessor createBodyFlushProcessor() {
-		return new ResponseBodyFlushProcessor();
+	protected Processor<Publisher<DataBuffer>, Void> createBodyFlushProcessor() {
+		Processor<Publisher<DataBuffer>, Void> processor = new ResponseBodyFlushProcessor();
+		registerListener();
+		return processor;
 	}
 
 	private class ResponseBodyProcessor extends AbstractResponseBodyProcessor {
@@ -238,7 +233,13 @@ public class ServletServerHttpResponse extends AbstractListenerServerHttpRespons
 
 		@Override
 		protected Processor<DataBuffer, Void> createBodyProcessor() {
-			return ServletServerHttpResponse.this.createBodyProcessor();
+			try {
+				bodyProcessor = new ResponseBodyProcessor(outputStream(), bufferSize);
+				return bodyProcessor;
+			}
+			catch (IOException ex) {
+				throw new UncheckedIOException(ex);
+			}
 		}
 
 		@Override

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpResponse.java
@@ -123,8 +123,7 @@ public class UndertowServerHttpResponse extends AbstractListenerServerHttpRespon
 		}
 	}
 
-	@Override
-	protected ResponseBodyProcessor createBodyProcessor() {
+	private ResponseBodyProcessor createBodyProcessor() {
 		if (this.responseChannel == null) {
 			this.responseChannel = this.exchange.getResponseChannel();
 		}

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/WriteOnlyHandlerIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/WriteOnlyHandlerIntegrationTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server.reactive;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import org.junit.Test;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.Assert.*;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Violeta Georgieva
+ * @since 5.0
+ */
+public class WriteOnlyHandlerIntegrationTests extends AbstractHttpHandlerIntegrationTests {
+
+	private static final int REQUEST_SIZE = 4096 * 3;
+
+	private Random rnd = new Random();
+
+	private byte[] body;
+
+
+	@Override
+	protected WriteOnlyHandler createHttpHandler() {
+		return new WriteOnlyHandler();
+	}
+
+
+	@Test
+	public void writeOnly() throws Exception {
+		RestTemplate restTemplate = new RestTemplate();
+
+		this.body = randomBytes();
+		RequestEntity<byte[]> request = RequestEntity.post(
+				new URI("http://localhost:" + port)).body(
+						"".getBytes(StandardCharsets.UTF_8));
+		ResponseEntity<byte[]> response = restTemplate.exchange(request, byte[].class);
+
+		assertArrayEquals(body, response.getBody());
+	}
+
+
+	private byte[] randomBytes() {
+		byte[] buffer = new byte[REQUEST_SIZE];
+		rnd.nextBytes(buffer);
+		return buffer;
+	}
+
+
+	public class WriteOnlyHandler implements HttpHandler {
+
+		@Override
+		public Mono<Void> handle(ServerHttpRequest request, ServerHttpResponse response) {
+			DataBuffer buffer = response.bufferFactory().allocateBuffer(body.length);
+			buffer.write(body);
+			return response.writeAndFlushWith(Flux.just(Flux.just(buffer)));
+		}
+	}
+}


### PR DESCRIPTION
With the current state machine
- the implementation can hang after the last element when executing
  on Jetty.
- in some cases there will be no flush after the last
  Publisher<DataBuffer>.
