### PR TITLE
SPR-14491: Added shallow filter etag support for REPORT method

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -30,10 +30,10 @@ import java.util.Map;
  */
 public enum HttpMethod {
 
-	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE;
+	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE, REPORT;
 
 
-	private static final Map<String, HttpMethod> mappings = new HashMap<>(8);
+	private static final Map<String, HttpMethod> mappings = new HashMap<>(9);
 
 	static {
 		for (HttpMethod httpMethod : values()) {

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMethod.java
@@ -34,6 +34,6 @@ package org.springframework.web.bind.annotation;
  */
 public enum RequestMethod {
 
-	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE
+	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE, REPORT
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/RequestMethodsRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/RequestMethodsRequestCondition.java
@@ -142,7 +142,7 @@ public final class RequestMethodsRequestCondition extends AbstractRequestConditi
 					return new RequestMethodsRequestCondition(method);
 				}
 			}
-			if (httpMethod == HttpMethod.HEAD && getMethods().contains(RequestMethod.GET)) {
+			if ((httpMethod == HttpMethod.HEAD || httpMethod == HttpMethod.REPORT) && getMethods().contains(RequestMethod.GET)) {
 				return GET_CONDITION;
 			}
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessor.java
@@ -184,8 +184,8 @@ public class HttpEntityMethodProcessor extends AbstractMessageConverterMethodPro
 		if (responseEntity instanceof ResponseEntity) {
 			outputMessage.getServletResponse().setStatus(((ResponseEntity<?>) responseEntity).getStatusCodeValue());
 			HttpMethod method = inputMessage.getMethod();
-			boolean isGetOrHead = (HttpMethod.GET == method || HttpMethod.HEAD == method);
-			if (isGetOrHead && isResourceNotModified(inputMessage, outputMessage)) {
+			boolean isEligibleForChaching = (HttpMethod.GET == method || HttpMethod.HEAD == method || HttpMethod.REPORT == method);
+			if (isEligibleForChaching && isResourceNotModified(inputMessage, outputMessage)) {
 				outputMessage.setStatusCode(HttpStatus.NOT_MODIFIED);
 				// Ensure headers are flushed, no body should be written.
 				outputMessage.flush();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/condition/RequestMethodsRequestConditionTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/condition/RequestMethodsRequestConditionTests.java
@@ -38,6 +38,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
 import static org.springframework.web.bind.annotation.RequestMethod.OPTIONS;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
+import static org.springframework.web.bind.annotation.RequestMethod.REPORT;
 
 /**
  * @author Arjen Poutsma
@@ -58,6 +59,13 @@ public class RequestMethodsRequestConditionTests {
 		testMatch(new RequestMethodsRequestCondition(GET), GET);
 		testNoMatch(new RequestMethodsRequestCondition(POST), HEAD);
 	}
+
+    @Test
+    public void getMatchingConditionWithHttpReport(){
+        testMatch(new RequestMethodsRequestCondition(REPORT), REPORT);
+        testMatch(new RequestMethodsRequestCondition(GET), GET);
+        testNoMatch(new RequestMethodsRequestCondition(POST), REPORT);
+    }
 
 	@Test
 	public void getMatchingConditionWithEmptyConditions() {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
@@ -180,7 +180,7 @@ public class RequestMappingInfoHandlerMappingTests {
 	public void getHandlerHttpOptions() throws Exception {
 		testHttpOptions("/foo", "GET,HEAD");
 		testHttpOptions("/person/1", "PUT");
-		testHttpOptions("/persons", "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS");
+		testHttpOptions("/persons", "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS,REPORT");
 		testHttpOptions("/something", "PUT,POST");
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/support/WebContentGeneratorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/support/WebContentGeneratorTests.java
@@ -39,7 +39,7 @@ public class WebContentGeneratorTests {
 	@Test
 	public void getAllowHeaderWithConstructorFalse() throws Exception {
 		WebContentGenerator generator = new TestWebContentGenerator(false);
-		assertEquals("GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS", generator.getAllowHeader());
+		assertEquals("GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS,REPORT", generator.getAllowHeader());
 	}
 
 	@Test
@@ -60,7 +60,7 @@ public class WebContentGeneratorTests {
 		WebContentGenerator generator = new TestWebContentGenerator();
 		generator.setSupportedMethods();
 		assertEquals("Effectively \"no restriction\" on supported methods",
-				"GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS", generator.getAllowHeader());
+				"GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS,REPORT", generator.getAllowHeader());
 	}
 
 	@Test


### PR DESCRIPTION
Issue: https://jira.spring.io/browse/SPR-14491

REPORT is a webDAV standard and it could be effectively used for serving reporting data with massive payload and support for caching.
