### PR TITLE
Changed misspelled text from doc and source comments.

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/jcache/interceptor/AbstractCacheInterceptor.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/jcache/interceptor/AbstractCacheInterceptor.java
@@ -69,7 +69,7 @@ abstract class AbstractCacheInterceptor<O extends AbstractJCacheOperation<A>, A 
 	/**
 	 * Convert the collection of caches in a single expected element.
 	 * <p>Throw an {@link IllegalStateException} if the collection holds more than one element
-	 * @return the singe element or {@code null} if the collection is empty
+	 * @return the single element or {@code null} if the collection is empty
 	 */
 	static Cache extractFrom(Collection<? extends Cache> caches) {
 		if (CollectionUtils.isEmpty(caches)) {

--- a/src/asciidoc/web-reactive.adoc
+++ b/src/asciidoc/web-reactive.adoc
@@ -97,7 +97,7 @@ to declare logic to be executed after the account is deserialized.
 The above also applies to return value handling:
 
 * `Mono<Account>` -- serialize without blocking the given Account when the `Mono` completes.
-* `Singe<Account>` -- same but using RxJava.
+* `Single<Account>` -- same but using RxJava.
 * `Flux<Account>` -- streaming scenario, possibly SSE depending on the requested content type.
 * `Flux<SseEvent>` -- SSE streaming.
 * `Observable<SseEvent>` -- same but using RxJava.


### PR DESCRIPTION
I found 'Singe' words, and corrected those as 'Single'.
In two cases, 'Single' is correct words.
