### PR TITLE
extendHandlerExceptionResolvers is not supported yet.

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfiguration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfiguration.java
@@ -133,6 +133,11 @@ public class DelegatingWebMvcConfiguration extends WebMvcConfigurationSupport {
 	}
 
 	@Override
+	protected void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> exceptionResolvers) {
+		this.configurers.extendHandlerExceptionResolvers(exceptionResolvers);
+	}
+
+	@Override
 	protected void addCorsMappings(CorsRegistry registry) {
 		this.configurers.addCorsMappings(registry);
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurerComposite.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurerComposite.java
@@ -109,7 +109,7 @@ class WebMvcConfigurerComposite implements WebMvcConfigurer {
 	@Override
 	public void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> exceptionResolvers) {
 		for (WebMvcConfigurer delegate : this.delegates) {
-			delegate.configureHandlerExceptionResolvers(exceptionResolvers);
+			delegate.extendHandlerExceptionResolvers(exceptionResolvers);
 		}
 	}
 


### PR DESCRIPTION
In current version, extendHandlerExceptionResolvers method overrided by
my custom WebMvcConfigurer is not triggered.
This patch trigger extendHandlerExceptionResolvers and I think this
would be useful.
And, WebMvcConfigurerComposite seems like a bug.
