### PR TITLE
Support RootBeanDefinition targetResolvableType

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/GenericTypeAwareAutowireCandidateResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/GenericTypeAwareAutowireCandidateResolver.java
@@ -80,12 +80,16 @@ public class GenericTypeAwareAutowireCandidateResolver implements AutowireCandid
 			rbd = (RootBeanDefinition) bdHolder.getBeanDefinition();
 		}
 		if (rbd != null) {
-			// First, check factory method return type, if applicable
-			targetType = getReturnTypeForFactoryMethod(rbd, descriptor);
+			// First try any defined target type
+			targetType = rbd.getTargetResolvableType();
 			if (targetType == null) {
-				RootBeanDefinition dbd = getResolvedDecoratedDefinition(rbd);
-				if (dbd != null) {
-					targetType = getReturnTypeForFactoryMethod(dbd, descriptor);
+				// Check factory method return type, if applicable
+				targetType = getReturnTypeForFactoryMethod(rbd, descriptor);
+				if (targetType == null) {
+					RootBeanDefinition dbd = getResolvedDecoratedDefinition(rbd);
+					if (dbd != null) {
+						targetType = getReturnTypeForFactoryMethod(dbd, descriptor);
+					}
 				}
 			}
 		}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
@@ -25,6 +25,7 @@ import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.core.ResolvableType;
 import org.springframework.util.Assert;
 
 /**
@@ -53,6 +54,9 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 	private BeanDefinitionHolder decoratedDefinition;
 
 	private volatile Class<?> targetType;
+
+	private volatile ResolvableType targetResolvableType;
+
 
 	boolean isFactoryMethodUnique = false;
 
@@ -174,6 +178,7 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 		this.allowCaching = original.allowCaching;
 		this.decoratedDefinition = original.decoratedDefinition;
 		this.targetType = original.targetType;
+		this.targetResolvableType = original.targetResolvableType;
 		this.isFactoryMethodUnique = original.isFactoryMethodUnique;
 	}
 
@@ -215,17 +220,36 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 
 	/**
 	 * Specify the target type of this bean definition, if known in advance.
+	 * @see #setTargetResolvableType(ResolvableType)
 	 */
 	public void setTargetType(Class<?> targetType) {
 		this.targetType = targetType;
+		this.targetResolvableType = null;
 	}
 
 	/**
 	 * Return the target type of this bean definition, if known
 	 * (either specified in advance or resolved on first instantiation).
+	 * @see #getTargetResolvableType()
 	 */
 	public Class<?> getTargetType() {
 		return this.targetType;
+	}
+
+	/**
+	 * Specify the target resolvable type of this bean definition, if known in advance.
+	 */
+	public void setTargetResolvableType(ResolvableType resolvableTargetType) {
+		this.targetType = (resolvableTargetType == null ? null : resolvableTargetType.resolve());
+		this.targetResolvableType = resolvableTargetType;
+	}
+
+	/**
+	 * Return the target resolvable type of this bean definition, if known
+	 * (either specified in advance or resolved on first instantiation).
+	 */
+	public ResolvableType getTargetResolvableType() {
+		return this.targetResolvableType;
 	}
 
 	/**

--- a/spring-beans/src/test/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessorTests.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
@@ -65,6 +66,7 @@ import org.springframework.tests.sample.beans.TestBean;
 import org.springframework.util.SerializationTestUtils;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Juergen Hoeller
@@ -2048,6 +2050,24 @@ public class AutowiredAnnotationBeanPostProcessorTests {
 	}
 
 	@Test
+	public void testGenericsBasedInjectionWithBeanDefinitionTargetResolvableType() throws Exception {
+		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+		bf.setAutowireCandidateResolver(new QualifierAnnotationAutowireCandidateResolver());
+		AutowiredAnnotationBeanPostProcessor bpp = new AutowiredAnnotationBeanPostProcessor();
+		bpp.setBeanFactory(bf);
+		bf.addBeanPostProcessor(bpp);
+		RootBeanDefinition bd1 = new RootBeanDefinition(GenericInterface2Bean.class);
+		bd1.setTargetResolvableType(ResolvableType.forClassWithGenerics(GenericInterface2Bean.class, String.class));
+		bf.registerBeanDefinition("bean1", bd1);
+		RootBeanDefinition bd2 = new RootBeanDefinition(GenericInterface2Bean.class);
+		bd2.setTargetResolvableType(ResolvableType.forClassWithGenerics(GenericInterface2Bean.class, Integer.class));
+		bf.registerBeanDefinition("bean2", bd2);
+		bf.registerBeanDefinition("bean3", new RootBeanDefinition(MultiGenericFieldInjection.class));
+
+		assertEquals("bean1 a bean2 123", bf.getBean("bean3").toString());
+	}
+
+	@Test
 	public void testCircularTypeReference() {
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
 		bf.setAutowireCandidateResolver(new QualifierAnnotationAutowireCandidateResolver());
@@ -3135,6 +3155,38 @@ public class AutowiredAnnotationBeanPostProcessorTests {
 		@Override
 		public String doSomethingMoreGeneric(Object o) {
 			return "somethingMoreGeneric_" + o;
+		}
+	}
+
+
+	public static class GenericInterface2Bean<K> implements GenericInterface2<K>, BeanNameAware {
+
+		private String name;
+
+		@Override
+		public String doSomethingMoreGeneric(K o) {
+			return this.name + " " + o;
+		}
+
+		@Override
+		public void setBeanName(String name) {
+			this.name = name;
+		}
+	}
+
+
+	public static class MultiGenericFieldInjection {
+
+		@Autowired
+		private GenericInterface2<String> stringBean;
+
+		@Autowired
+		private GenericInterface2<Integer> integerBean;
+
+		@Override
+		public String toString() {
+			return this.stringBean.doSomethingMoreGeneric("a") + " "
+					+ this.integerBean.doSomethingMoreGeneric(123);
 		}
 	}
 


### PR DESCRIPTION
Update RootBeanDefinition and GenericTypeAwareAutowireCandidateResolver
to support target ResolvableTypes. This allows a bean definition to be
registered programmatically with support for generics based injection.

Issue: SPR-14580
