### PR TITLE
SPR-14592: Reactive response extractor does not invoke error handler

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/reactive/ResponseExtractors.java
+++ b/spring-web/src/main/java/org/springframework/web/client/reactive/ResponseExtractors.java
@@ -123,8 +123,10 @@ public class ResponseExtractors {
 	@SuppressWarnings("unchecked")
 	public static <T> ResponseExtractor<Mono<ResponseEntity<T>>> response(ResolvableType bodyType) {
 
-		return (clientResponse, webClientConfig) -> clientResponse.then(response ->
-				Mono.when(
+		return (clientResponse, webClientConfig) -> clientResponse.doOnNext(response ->
+				webClientConfig.getResponseErrorHandler()
+							   .handleError(response, webClientConfig.getMessageReaders()))
+				.then(response -> Mono.when(
 						decodeResponseBodyAsMono(response, bodyType,
 								webClientConfig.getMessageReaders()).defaultIfEmpty(EMPTY_BODY),
 						Mono.just(response.getHeaders()),

--- a/spring-web/src/test/java/org/springframework/web/client/reactive/ResponseExtractorsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/reactive/ResponseExtractorsTests.java
@@ -97,6 +97,19 @@ public class ResponseExtractorsTests {
 	}
 
 	@Test
+	public void shouldGetErrorWhenBadResponseCodeInResponseEntity() throws Exception {
+		this.headers.setContentType(MediaType.TEXT_PLAIN);
+		given(this.response.getStatusCode()).willReturn(HttpStatus.FORBIDDEN);
+		given(this.webClientConfig.getResponseErrorHandler()).willReturn(new DefaultResponseErrorHandler());
+
+		Mono<ResponseEntity<String>> result = ResponseExtractors.response(String.class)
+				.extract(Mono.just(this.response), this.webClientConfig);
+
+		TestSubscriber.subscribe(result)
+				.assertError(WebClientErrorException.class);
+	}
+
+	@Test
 	public void shouldExtractResponseEntityFlux() throws Exception {
 		this.headers.setContentType(MediaType.TEXT_PLAIN);
 		given(this.response.getStatusCode()).willReturn(HttpStatus.OK);


### PR DESCRIPTION
Fix for SPR-14592. When getting a `response()` from the `ResponseExtractors`, the `responseErrorHandler` is now consulted before passing forward the `ResponseEntity`.
