### PR TITLE
SpringJUnit4ClassRunner should be thread safe

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunner.java
+++ b/spring-test/src/main/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunner.java
@@ -110,9 +110,12 @@ public class SpringJUnit4ClassRunner extends BlockJUnit4ClassRunner {
 		ReflectionUtils.makeAccessible(withRulesMethod);
 	}
 
-
-	private final TestContextManager testContextManager;
-
+	private final ThreadLocal<TestContextManager> testContextManagerHolder = new ThreadLocal<TestContextManager>() {
+		@Override
+		protected TestContextManager initialValue() {
+			return createTestContextManager(getTestClass().getJavaClass());
+		}
+	};
 
 	private static void ensureSpringRulesAreNotPresent(Class<?> testClass) {
 		for (Field field : testClass.getFields()) {
@@ -130,7 +133,6 @@ public class SpringJUnit4ClassRunner extends BlockJUnit4ClassRunner {
 	 * {@link TestContextManager} to provide Spring testing functionality to
 	 * standard JUnit tests.
 	 * @param clazz the test class to be run
-	 * @see #createTestContextManager(Class)
 	 */
 	public SpringJUnit4ClassRunner(Class<?> clazz) throws InitializationError {
 		super(clazz);
@@ -138,7 +140,7 @@ public class SpringJUnit4ClassRunner extends BlockJUnit4ClassRunner {
 			logger.debug("SpringJUnit4ClassRunner constructor called with [" + clazz + "]");
 		}
 		ensureSpringRulesAreNotPresent(clazz);
-		this.testContextManager = createTestContextManager(clazz);
+
 	}
 
 	/**
@@ -154,7 +156,7 @@ public class SpringJUnit4ClassRunner extends BlockJUnit4ClassRunner {
 	 * Get the {@link TestContextManager} associated with this runner.
 	 */
 	protected final TestContextManager getTestContextManager() {
-		return this.testContextManager;
+		return this.testContextManagerHolder.get();
 	}
 
 	/**

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunnerAppCtxTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/SpringJUnit4ClassRunnerAppCtxTests.java
@@ -246,14 +246,12 @@ public class SpringJUnit4ClassRunnerAppCtxTests implements ApplicationContextAwa
 		final Set<TestContextManager> managers = new HashSet<>();
 		class SimpleRunner implements Runnable {
 
-			private volatile TestContextManager tcm;
-
 			@Override
 			public void run() {
 				try {
 					managers.add(runner.getTestContextManager());
 				} catch (Exception e) {
-					fail("Exception not expected.");
+					fail("Exception not expected. ("+e.getMessage()+")");
 				}
 			}
 		}


### PR DESCRIPTION
This commit changes the SpringJunit4ClassRunner to use a ThreadLocal
to store the TestContextManager instead of using a single instance.

Initial code from Bastian Voigt (https://github.com/BastianVoigt/spring-framework/commit/a5e466e12edca26fb3637d7acafc214f83019345)

Issue: SPR-12421
