### PR TITLE
SPR-10502 - PropertyPlaceholder multiple locations resolution

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/config/AbstractPropertyLoadingBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/AbstractPropertyLoadingBeanDefinitionParser.java
@@ -23,6 +23,9 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
 import org.springframework.util.StringUtils;
 
+import static org.springframework.util.StringUtils.commaDelimitedListToStringArray;
+import static org.springframework.util.SystemPropertyUtils.resolvePlaceholders;
+
 /**
  * Abstract parser for &lt;context:property-.../&gt; elements.
  *
@@ -42,7 +45,7 @@ abstract class AbstractPropertyLoadingBeanDefinitionParser extends AbstractSingl
 	protected void doParse(Element element, BeanDefinitionBuilder builder) {
 		String location = element.getAttribute("location");
 		if (StringUtils.hasLength(location)) {
-			String[] locations = StringUtils.commaDelimitedListToStringArray(location);
+			String[] locations = commaDelimitedListToStringArray(resolvePlaceholders(location));
 			builder.addPropertyValue("locations", locations);
 		}
 

--- a/spring-context/src/test/java/org/springframework/context/config/ContextNamespaceHandlerTests.java
+++ b/spring-context/src/test/java/org/springframework/context/config/ContextNamespaceHandlerTests.java
@@ -16,19 +16,18 @@
 
 package org.springframework.context.config;
 
-import java.util.Calendar;
-import java.util.Date;
-
 import org.junit.After;
 import org.junit.Test;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.context.support.GenericXmlApplicationContext;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.env.MockEnvironment;
 
-import static org.junit.Assert.*;
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Arjen Poutsma
@@ -87,6 +86,22 @@ public class ContextNamespaceHandlerTests {
 		assertEquals("bar", applicationContext.getBean("foo"));
 		assertEquals("foo", applicationContext.getBean("bar"));
 		assertEquals("maps", applicationContext.getBean("spam"));
+	}
+
+	@Test
+	public void shouldNotFailWhenPlaceholderInLocations() {
+		System.setProperty("system.wide.locations",
+				"classpath*:/org/springframework/context/config/test-bar.properties," +
+						"classpath*:/org/springframework/context/config/test-foo.properties");
+		try {
+			ApplicationContext applicationContext = new ClassPathXmlApplicationContext(
+					"contextNamespaceHandlerTests-placeholder-location.xml", getClass());
+
+			assertEquals("bar", applicationContext.getBean("foo"));
+			assertEquals("foo", applicationContext.getBean("bar"));
+		} finally {
+			System.clearProperty("system.wide.locations");
+		}
 	}
 
 	@Test

--- a/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-placeholder-location.xml
+++ b/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-placeholder-location.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+
+    <context:property-placeholder location="${system.wide.locations}"
+            file-encoding="ISO-8859-1" trim-values="true"/>
+
+    <bean id="foo" class="java.lang.String">
+        <constructor-arg value="${foo}"/>
+    </bean>
+
+    <bean id="bar" class="java.lang.String">
+        <constructor-arg value="${bar}"/>
+    </bean>
+
+</beans>


### PR DESCRIPTION
This commit fixes an issue, when in XML defined config there is context:property-resolver with
the value if form of value="${placeholder}" thus it should be resolved with system property. Issue occurs when property already resolved, but appropriate splitting by comma already had passed.

Issue: https://jira.spring.io/browse/SPR-10502
