### PR TITLE
Fix typo in asciidoc

### DIFF
--- a/src/asciidoc/web-mvc.adoc
+++ b/src/asciidoc/web-mvc.adoc
@@ -171,7 +171,7 @@ Java EE Servlet configuration in a Servlet 3.0+ environment:
 
 		@Override
 		public void onStartup(ServletContext container) {
-			ServletRegistration.Dynamic registration = container.addServlet("dispatcher", new DispatcherServlet());
+			ServletRegistration.Dynamic registration = container.addServlet("example", new DispatcherServlet());
 			registration.setLoadOnStartup(1);
 			registration.addMapping("/example/*");
 		}


### PR DESCRIPTION
Change servlet name in the code to "example", because the servlet name "example" is mentioned below.
