### PR TITLE
Refactor how hints (like JsonView) are passed to codecs

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/codec/AbstractDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/AbstractDecoder.java
@@ -18,6 +18,7 @@ package org.springframework.core.codec;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -49,7 +50,7 @@ public abstract class AbstractDecoder<T> implements Decoder<T> {
 	}
 
 	@Override
-	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		if (mimeType == null) {
 			return true;
 		}
@@ -58,7 +59,7 @@ public abstract class AbstractDecoder<T> implements Decoder<T> {
 
 	@Override
 	public Mono<T> decodeToMono(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		throw new UnsupportedOperationException();
 	}

--- a/spring-core/src/main/java/org/springframework/core/codec/AbstractEncoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/AbstractEncoder.java
@@ -18,6 +18,7 @@ package org.springframework.core.codec;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.util.MimeType;
@@ -45,7 +46,7 @@ public abstract class AbstractEncoder<T> implements Encoder<T> {
 	}
 
 	@Override
-	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		if (mimeType == null) {
 			return true;
 		}

--- a/spring-core/src/main/java/org/springframework/core/codec/AbstractSingleValueEncoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/AbstractSingleValueEncoder.java
@@ -16,6 +16,8 @@
 
 package org.springframework.core.codec;
 
+import java.util.Map;
+
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
@@ -41,13 +43,13 @@ public abstract class AbstractSingleValueEncoder<T> extends AbstractEncoder<T> {
 
 	@Override
 	public final Flux<DataBuffer> encode(Publisher<? extends T> inputStream, DataBufferFactory bufferFactory,
-			ResolvableType elementType, MimeType mimeType, Object... hints) {
+			ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 
 		return Flux.from(inputStream).
 				take(1).
 				concatMap(t -> {
 					try {
-						return encode(t, bufferFactory, elementType, mimeType);
+						return encode(t, bufferFactory, elementType, mimeType, hints);
 					}
 					catch (Exception ex) {
 						return Flux.error(ex);
@@ -66,6 +68,6 @@ public abstract class AbstractSingleValueEncoder<T> extends AbstractEncoder<T> {
 	 * @throws Exception in case of errors
 	 */
 	protected abstract Flux<DataBuffer> encode(T t, DataBufferFactory dataBufferFactory,
-			ResolvableType type, MimeType mimeType, Object... hints) throws Exception;
+			ResolvableType type, MimeType mimeType, Map<String, Object> hints) throws Exception;
 
 }

--- a/spring-core/src/main/java/org/springframework/core/codec/ByteBufferDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ByteBufferDecoder.java
@@ -17,6 +17,7 @@
 package org.springframework.core.codec;
 
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -42,14 +43,14 @@ public class ByteBufferDecoder extends AbstractDecoder<ByteBuffer> {
 
 
 	@Override
-	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		Class<?> clazz = elementType.getRawClass();
 		return (super.canDecode(elementType, mimeType, hints) && ByteBuffer.class.isAssignableFrom(clazz));
 	}
 
 	@Override
 	public Flux<ByteBuffer> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		return Flux.from(inputStream).map((dataBuffer) -> {
 			ByteBuffer copy = ByteBuffer.allocate(dataBuffer.readableByteCount());

--- a/spring-core/src/main/java/org/springframework/core/codec/ByteBufferEncoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ByteBufferEncoder.java
@@ -17,6 +17,7 @@
 package org.springframework.core.codec;
 
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -41,7 +42,7 @@ public class ByteBufferEncoder extends AbstractEncoder<ByteBuffer> {
 
 
 	@Override
-	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		Class<?> clazz = elementType.getRawClass();
 		return (super.canEncode(elementType, mimeType, hints) && ByteBuffer.class.isAssignableFrom(clazz));
 	}
@@ -49,7 +50,7 @@ public class ByteBufferEncoder extends AbstractEncoder<ByteBuffer> {
 	@Override
 	public Flux<DataBuffer> encode(Publisher<? extends ByteBuffer> inputStream,
 			DataBufferFactory bufferFactory, ResolvableType elementType, MimeType mimeType,
-			Object... hints) {
+			Map<String, Object> hints) {
 
 		return Flux.from(inputStream).map(bufferFactory::wrap);
 	}

--- a/spring-core/src/main/java/org/springframework/core/codec/CharSequenceEncoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/CharSequenceEncoder.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -48,7 +49,7 @@ public class CharSequenceEncoder extends AbstractEncoder<CharSequence> {
 
 
 	@Override
-	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		Class<?> clazz = elementType.getRawClass();
 		return (super.canEncode(elementType, mimeType, hints) && CharSequence.class.isAssignableFrom(clazz));
 	}
@@ -56,7 +57,7 @@ public class CharSequenceEncoder extends AbstractEncoder<CharSequence> {
 	@Override
 	public Flux<DataBuffer> encode(Publisher<? extends CharSequence> inputStream,
 			DataBufferFactory bufferFactory, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		Charset charset;
 		if (mimeType != null && mimeType.getCharset() != null) {

--- a/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
@@ -16,7 +16,9 @@
 
 package org.springframework.core.codec;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -42,10 +44,17 @@ public interface Decoder<T> {
 	 * type of the source stream.
 	 * @param elementType the target element type for the output stream
 	 * @param mimeType the mime type associated with the stream to decode
-	 * @param hints additional information about how to do decode, optional
+	 * @param hints additional information about how to do encode
 	 * @return {@code true} if supported, {@code false} otherwise
 	 */
-	boolean canDecode(ResolvableType elementType, MimeType mimeType, Object... hints);
+	boolean canDecode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints);
+
+	/**
+	 * @see #canDecode(ResolvableType, MimeType, Map)
+	 */
+	default boolean canDecode(ResolvableType elementType, MimeType mimeType) {
+		return canDecode(elementType, mimeType, Collections.emptyMap());
+	}
 
 	/**
 	 * Decode a {@link DataBuffer} input stream into a Flux of {@code T}.
@@ -54,11 +63,19 @@ public interface Decoder<T> {
 	 * this type must have been previously passed to the {@link #canDecode}
 	 * method and it must have returned {@code true}.
 	 * @param mimeType the MIME type associated with the input stream, optional
-	 * @param hints additional information about how to do decode, optional
+	 * @param hints additional information about how to do encode
 	 * @return the output stream with decoded elements
 	 */
 	Flux<T> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints);
+			MimeType mimeType, Map<String, Object> hints);
+
+	/**
+	 * @see #decode(Publisher, ResolvableType, MimeType, Map)
+	 */
+	default Flux<T> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
+			MimeType mimeType) {
+		return decode(inputStream, elementType, mimeType, Collections.emptyMap());
+	}
 
 	/**
 	 * Decode a {@link DataBuffer} input stream into a Mono of {@code T}.
@@ -67,15 +84,30 @@ public interface Decoder<T> {
 	 * this type must have been previously passed to the {@link #canDecode}
 	 * method and it must have returned {@code true}.
 	 * @param mimeType the MIME type associated with the input stream, optional
-	 * @param hints additional information about how to do decode, optional
+	 * @param hints additional information about how to do encode
 	 * @return the output stream with the decoded element
 	 */
 	Mono<T> decodeToMono(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints);
+			MimeType mimeType, Map<String, Object> hints);
+
+	/**
+	 * @see #decodeToMono(Publisher, ResolvableType, MimeType, Map)
+	 */
+	default Mono<T> decodeToMono(Publisher<DataBuffer> inputStream, ResolvableType elementType,
+			MimeType mimeType) {
+		return decodeToMono(inputStream, elementType, mimeType, Collections.emptyMap());
+	}
 
 	/**
 	 * Return the list of MIME types this decoder supports.
 	 */
 	List<MimeType> getDecodableMimeTypes();
+
+	/**
+	 * Return the list of hints keys this decoder supports.
+	 */
+	default List<String> getSupportedDecodingHints() {
+		return Collections.emptyList();
+	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/codec/Encoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Encoder.java
@@ -16,7 +16,9 @@
 
 package org.springframework.core.codec;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -42,10 +44,17 @@ public interface Encoder<T> {
 	 * type for the output stream.
 	 * @param elementType the type of elements in the source stream
 	 * @param mimeType the MIME type for the output stream
-	 * @param hints additional information about how to do encode, optional
+	 * @param hints additional information about how to do encode
 	 * @return {@code true} if supported, {@code false} otherwise
 	 */
-	boolean canEncode(ResolvableType elementType, MimeType mimeType, Object... hints);
+	boolean canEncode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints);
+
+	/**
+	 * @see #canEncode(ResolvableType, MimeType, Map)
+	 */
+	default boolean canEncode(ResolvableType elementType, MimeType mimeType) {
+		return canEncode(elementType, mimeType, Collections.emptyMap());
+	}
 
 	/**
 	 * Encode a stream of Objects of type {@code T} into a {@link DataBuffer}
@@ -56,15 +65,30 @@ public interface Encoder<T> {
 	 * this type must have been previously passed to the {@link #canEncode}
 	 * method and it must have returned {@code true}.
 	 * @param mimeType the MIME type for the output stream
-	 * @param hints additional information about how to do encode, optional
+	 * @param hints additional information about how to do encode
 	 * @return the output stream
 	 */
 	Flux<DataBuffer> encode(Publisher<? extends T> inputStream, DataBufferFactory bufferFactory,
-			ResolvableType elementType, MimeType mimeType, Object... hints);
+			ResolvableType elementType, MimeType mimeType, Map<String, Object> hints);
+
+	/**
+	 * @see #encode(Publisher, DataBufferFactory, ResolvableType, MimeType, Map)
+	 */
+	default Flux<DataBuffer> encode(Publisher<? extends T> inputStream, DataBufferFactory bufferFactory,
+			ResolvableType elementType, MimeType mimeType) {
+		return encode(inputStream, bufferFactory, elementType, mimeType, Collections.emptyMap());
+	}
 
 	/**
 	 * Return the list of mime types this encoder supports.
 	 */
 	List<MimeType> getEncodableMimeTypes();
+
+	/**
+	 * Return the list of hints keys this encoder supports.
+	 */
+	default List<String> getSupportedEncodingHints() {
+		return Collections.emptyList();
+	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/codec/ResourceDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ResourceDecoder.java
@@ -17,6 +17,7 @@
 package org.springframework.core.codec;
 
 import java.io.ByteArrayInputStream;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -45,7 +46,7 @@ public class ResourceDecoder extends AbstractDecoder<Resource> {
 
 
 	@Override
-	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		Class<?> clazz = elementType.getRawClass();
 		return (InputStreamResource.class.equals(clazz) ||
 				clazz.isAssignableFrom(ByteArrayResource.class)) &&
@@ -54,7 +55,7 @@ public class ResourceDecoder extends AbstractDecoder<Resource> {
 
 	@Override
 	public Flux<Resource> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		Class<?> clazz = elementType.getRawClass();
 

--- a/spring-core/src/main/java/org/springframework/core/codec/ResourceEncoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ResourceEncoder.java
@@ -18,6 +18,7 @@ package org.springframework.core.codec;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 
 import reactor.core.publisher.Flux;
 
@@ -56,14 +57,14 @@ public class ResourceEncoder extends AbstractSingleValueEncoder<Resource> {
 
 
 	@Override
-	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		Class<?> clazz = elementType.getRawClass();
 		return (super.canEncode(elementType, mimeType, hints) && Resource.class.isAssignableFrom(clazz));
 	}
 
 	@Override
 	protected Flux<DataBuffer> encode(Resource resource, DataBufferFactory dataBufferFactory,
-			ResolvableType type, MimeType mimeType, Object... hints) throws IOException {
+			ResolvableType type, MimeType mimeType, Map<String, Object> hints) throws IOException {
 
 		InputStream is = resource.getInputStream();
 		return DataBufferUtils.read(is, dataBufferFactory, bufferSize);

--- a/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.IntPredicate;
 
 import org.reactivestreams.Publisher;
@@ -77,14 +78,14 @@ public class StringDecoder extends AbstractDecoder<String> {
 
 
 	@Override
-	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		return (super.canDecode(elementType, mimeType, hints) &&
 				String.class.equals(elementType.getRawClass()));
 	}
 
 	@Override
 	public Flux<String> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		Flux<DataBuffer> inputFlux = Flux.from(inputStream);
 		if (this.splitOnNewline) {
@@ -95,7 +96,7 @@ public class StringDecoder extends AbstractDecoder<String> {
 
 	@Override
 	public Mono<String> decodeToMono(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		return Flux.from(inputStream)
 				.reduce(DataBuffer::write)

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfiguration.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.codec.ByteBufferDecoder;
 import org.springframework.core.codec.ByteBufferEncoder;
 import org.springframework.core.codec.CharSequenceEncoder;
@@ -60,8 +61,12 @@ import org.springframework.web.reactive.accept.RequestedContentTypeResolverBuild
 import org.springframework.web.reactive.handler.AbstractHandlerMapping;
 import org.springframework.web.reactive.result.SimpleHandlerAdapter;
 import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.web.reactive.result.method.annotation.JsonViewRequestBodyAdvice;
+import org.springframework.web.reactive.result.method.annotation.JsonViewResponseBodyAdvice;
+import org.springframework.web.reactive.result.method.annotation.RequestBodyAdvice;
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.reactive.result.method.annotation.ResponseBodyAdvice;
 import org.springframework.web.reactive.result.method.annotation.ResponseBodyResultHandler;
 import org.springframework.web.reactive.result.method.annotation.ResponseEntityResultHandler;
 import org.springframework.web.reactive.result.view.ViewResolutionResultHandler;
@@ -229,8 +234,15 @@ public class WebReactiveConfiguration implements ApplicationContextAware {
 		adapter.setMessageReaders(getMessageReaders());
 		adapter.setConversionService(mvcConversionService());
 		adapter.setValidator(mvcValidator());
+		adapter.setRequestBodyAdvice(getRequestBodyAdvice());
 
 		return adapter;
+	}
+
+	protected List<RequestBodyAdvice> getRequestBodyAdvice() {
+		List<RequestBodyAdvice> advice = new ArrayList<>();
+		advice.add(new JsonViewRequestBodyAdvice());
+		return advice;
 	}
 
 	/**
@@ -357,12 +369,20 @@ public class WebReactiveConfiguration implements ApplicationContextAware {
 
 	@Bean
 	public ResponseEntityResultHandler responseEntityResultHandler() {
-		return new ResponseEntityResultHandler(getMessageWriters(), mvcContentTypeResolver());
+		return new ResponseEntityResultHandler(getMessageWriters(), mvcContentTypeResolver(),
+				new ReactiveAdapterRegistry(), getResponseBodyAdvice());
 	}
 
 	@Bean
 	public ResponseBodyResultHandler responseBodyResultHandler() {
-		return new ResponseBodyResultHandler(getMessageWriters(), mvcContentTypeResolver());
+		return new ResponseBodyResultHandler(getMessageWriters(), mvcContentTypeResolver(),
+				new ReactiveAdapterRegistry(), getResponseBodyAdvice());
+	}
+
+	protected List<ResponseBodyAdvice> getResponseBodyAdvice() {
+		List<ResponseBodyAdvice> advice = new ArrayList<>();
+		advice.add(new JsonViewResponseBodyAdvice());
+		return advice;
 	}
 
 	/**

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/HttpEntityArgumentResolver.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/HttpEntityArgumentResolver.java
@@ -65,6 +65,19 @@ public class HttpEntityArgumentResolver extends AbstractMessageReaderArgumentRes
 		super(readers, validator, adapterRegistry);
 	}
 
+	/**
+	 * Constructor that also accepts a {@link ReactiveAdapterRegistry} and a list of {@link RequestBodyAdvice}.
+	 * @param readers readers for de-serializing the request body with
+	 * @param validator validator to validate decoded objects with
+	 * @param adapterRegistry for adapting to other reactive types from Flux and Mono
+	 * @param bodyAdvice body advice to customize the request
+	 */
+	public HttpEntityArgumentResolver(List<HttpMessageReader<?>> readers, Validator validator,
+			ReactiveAdapterRegistry adapterRegistry, List<RequestBodyAdvice> bodyAdvice) {
+
+		super(readers, validator, adapterRegistry, bodyAdvice);
+	}
+
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/JsonViewRequestBodyAdvice.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/JsonViewRequestBodyAdvice.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.json.AbstractJackson2Codec;
+
+/**
+ * A {@link RequestBodyAdvice} implementation that adds support for Jackson's
+ * {@code @JsonView} annotation declared on a Spring Web Reactive {@code @HttpEntity}
+ * or {@code @RequestBody} method parameter.
+ *
+ * <p>The deserialization view specified in the annotation will be passed in to the
+ * {@link HttpMessageWriter} which will then use it to serialize the response body.
+ *
+ * <p>Note that despite {@code @JsonView} allowing for more than one class to
+ * be specified, the use for a response body advice is only supported with
+ * exactly one class argument. Consider the use of a composite interface.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ * @see JsonView
+ * @see com.fasterxml.jackson.databind.ObjectMapper#readerWithView(Class)
+ */
+public class JsonViewRequestBodyAdvice implements RequestBodyAdvice {
+
+	@Override
+	public boolean supports(MethodParameter methodParameter, ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType, List<String> supportedHints) {
+		return methodParameter.hasParameterAnnotation(JsonView.class) && supportedHints.contains(AbstractJackson2Codec.JSON_VIEW_HINT);
+	}
+
+	@Override
+	public Map<String, Object> getHints(MethodParameter parameter, ResolvableType targetType,
+			Class<? extends HttpMessageReader<?>> readerType, List<String> supportedHints) {
+		JsonView annotation = parameter.getParameterAnnotation(JsonView.class);
+		Class<?>[] classes = annotation.value();
+		if (classes.length != 1) {
+			throw new IllegalArgumentException(
+					"@JsonView only supported for request body advice with exactly 1 class argument: " + parameter);
+		}
+		return Collections.singletonMap(AbstractJackson2Codec.JSON_VIEW_HINT, classes[0]);
+	}
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/JsonViewResponseBodyAdvice.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/JsonViewResponseBodyAdvice.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.json.AbstractJackson2Codec;
+
+/**
+ * A {@link ResponseBodyAdvice} implementation that adds support for Jackson's
+ * {@code @JsonView} annotation declared on a Spring Web Reactive {@code @RequestMapping}
+ * or {@code @ExceptionHandler} method.
+ *
+ * <p>The serialization view specified in the annotation will be passed in to the
+ * {@link HttpMessageWriter} which will then use it to serialize the response body.
+ *
+ * <p>Note that despite {@code @JsonView} allowing for more than one class to
+ * be specified, the use for a response body advice is only supported with
+ * exactly one class argument. Consider the use of a composite interface.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ * @see com.fasterxml.jackson.annotation.JsonView
+ * @see com.fasterxml.jackson.databind.ObjectMapper#writerWithView(Class)
+ */
+public class JsonViewResponseBodyAdvice implements ResponseBodyAdvice {
+
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageWriter<?>> writerType,
+			List<String> supportedHints) {
+		return returnType.hasMethodAnnotation(JsonView.class) && supportedHints.contains(AbstractJackson2Codec.JSON_VIEW_HINT);
+	}
+
+	@Override
+	public Map<String, Object> getHints(MethodParameter returnType, ResolvableType targetType,
+			Class<? extends HttpMessageWriter<?>> writerType, List<String> supportedHints) {
+		JsonView annotation = returnType.getMethodAnnotation(JsonView.class);
+		Class<?>[] classes = annotation.value();
+		if (classes.length != 1) {
+			throw new IllegalArgumentException(
+					"@JsonView only supported for response body advice with exactly 1 class argument: " + returnType);
+		}
+		return Collections.singletonMap(AbstractJackson2Codec.JSON_VIEW_HINT, classes[0]);
+	}
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyAdvice.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyAdvice.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.ReactiveHttpInputMessage;
+import org.springframework.http.codec.HttpMessageReader;
+
+/**
+ * Allows customizing the request before its body is read and converted into an
+ * Object and also allows for processing of the resulting Object before it is
+ * passed into a controller method as an {@code @RequestBody} or an
+ * {@code HttpEntity} method argument.
+ *
+ * <p>Implementations of this contract may be registered directly with the
+ * {@code RequestMappingHandlerAdapter} or more likely annotated with
+ * {@code @ControllerAdvice} in which case they are auto-detected.
+ *
+ * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public interface RequestBodyAdvice {
+
+	/**
+	 * Invoked first to determine if this interceptor applies.
+	 * @param methodParameter the method parameter
+	 * @param targetType the target type, not necessarily the same as the method
+	 * parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param readerType the selected reader type
+	 * @param supportedHints thins supported by this {@link HttpMessageReader}
+	 * @return whether this interceptor should be invoked or not
+	 */
+	boolean supports(MethodParameter methodParameter, ResolvableType targetType,
+			Class<? extends HttpMessageReader<?>> readerType, List<String> supportedHints);
+
+	/**
+	 * Return hints that can be used to customize how the body should be read
+	 * @return Additional information about how to read the body
+	 */
+	default Map<String, Object> getHints(MethodParameter methodParameter, ResolvableType targetType,
+			Class<? extends HttpMessageReader<?>> readerType, List<String> supportedHints) {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Invoked second before the request body is read and converted.
+	 * @param inputMessage the request
+	 * @param parameter the target method parameter
+	 * @param targetType the target type, not necessarily the same as the method
+	 * parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param readerType the reader used to deserialize the body
+	 * @return the input request or a new instance, never {@code null}
+	 */
+	default ReactiveHttpInputMessage beforeRead(ReactiveHttpInputMessage inputMessage, MethodParameter parameter,
+			ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType,
+			List<String> supportedHints) {
+		return inputMessage;
+	}
+
+	/**
+	 * Invoked third (and last) after the request body is converted to a {@code Flux<Object>}.
+	 * @param body set to the converter {@code Publisher<Object>} before the 1st advice is called
+	 * @param inputMessage the request
+	 * @param parameter the target method parameter
+	 * @param targetType the target type, not necessarily the same as the method
+	 * parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param readerType the reader used to deserialize the body
+	 * @return the same body or a new instance
+	 */
+	default Flux<Object> afterRead(Flux<Object> body, ReactiveHttpInputMessage inputMessage,
+			MethodParameter parameter, ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType,
+			List<String> supportedHints) {
+		return body;
+	}
+
+	/**
+	 * Invoked third (and last) after the request body is converted to a {@code Mono<Object>}.
+	 * @param body set to the converter {@code Publisher<Object>} before the 1st advice is called
+	 * @param inputMessage the request
+	 * @param parameter the target method parameter
+	 * @param targetType the target type, not necessarily the same as the method
+	 * parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param readerType the reader used to deserialize the body
+	 * @return the same body or a new instance
+	 */
+	default Mono<Object> afterReadMono(Mono<Object> body, ReactiveHttpInputMessage inputMessage,
+			MethodParameter parameter, ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType,
+			List<String> supportedHints) {
+		return body;
+	}
+
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyAdviceChain.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyAdviceChain.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.ReactiveHttpInputMessage;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.web.method.ControllerAdviceBean;
+
+/**
+ * Invokes {@link RequestBodyAdvice} and {@link ResponseBodyAdvice} where each
+ * instance may be (and is most likely) wrapped with
+ * {@link ControllerAdviceBean ControllerAdviceBean}.
+ *
+ * @author Sebastien Deleuze
+ * @author Rossen Stoyanchev
+ * @since 5.0
+ */
+class RequestBodyAdviceChain implements RequestBodyAdvice {
+
+	private final List<RequestBodyAdvice> requestBodyAdvice = new ArrayList<>(4);
+
+
+	/**
+	 * Create an instance from a list of {@code RequestBodyAdvice}.
+	 */
+	public RequestBodyAdviceChain(List<RequestBodyAdvice> requestBodyAdvice) {
+		this.requestBodyAdvice.addAll(requestBodyAdvice);
+	}
+
+	@Override
+	public boolean supports(MethodParameter param, ResolvableType type,
+			Class<? extends HttpMessageReader<?>> readerType, List<String> supportedHints) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public Map<String, Object> getHints(MethodParameter parameter, ResolvableType targetType,
+			Class<? extends HttpMessageReader<?>> readerType, List<String> supportedHints) {
+
+		Map<String, Object> hints = new HashMap<>();
+		this.requestBodyAdvice
+				.stream()
+				.filter(advice -> advice.supports(parameter, targetType, readerType, supportedHints))
+				.forEach(advice -> hints.putAll(advice.getHints(parameter, targetType, readerType, supportedHints))
+		);
+		return hints;
+	}
+
+	@Override
+	public ReactiveHttpInputMessage beforeRead(ReactiveHttpInputMessage request, MethodParameter parameter,
+			ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType, List<String> supportedHints) {
+
+		for (RequestBodyAdvice advice : this.requestBodyAdvice) {
+			if (advice.supports(parameter, targetType, readerType, supportedHints)) {
+				request = advice.beforeRead(request, parameter, targetType, readerType, supportedHints);
+			}
+		}
+		return request;
+	}
+
+	@Override
+	public Flux<Object> afterRead(Flux<Object> body, ReactiveHttpInputMessage inputMessage, MethodParameter parameter,
+			ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType, List<String> supportedHints) {
+
+		for (RequestBodyAdvice advice : this.requestBodyAdvice) {
+			if (advice.supports(parameter, targetType, readerType, supportedHints)) {
+				body = advice.afterRead(body, inputMessage, parameter, targetType, readerType, supportedHints);
+			}
+		}
+		return body;
+	}
+
+	@Override
+	public Mono<Object> afterReadMono(Mono<Object> body, ReactiveHttpInputMessage inputMessage,
+			MethodParameter parameter, ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType,
+			List<String> supportedHints) {
+
+		for (RequestBodyAdvice advice : this.requestBodyAdvice) {
+			if (advice.supports(parameter, targetType, readerType, supportedHints)) {
+				body = advice.afterReadMono(body, inputMessage, parameter, targetType, readerType, supportedHints);
+			}
+		}
+		return body;
+	}
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyArgumentResolver.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyArgumentResolver.java
@@ -69,6 +69,19 @@ public class RequestBodyArgumentResolver extends AbstractMessageReaderArgumentRe
 		super(readers, validator, adapterRegistry);
 	}
 
+	/**
+	 * Constructor that also accepts a {@link ReactiveAdapterRegistry} and a list of {@link RequestBodyAdvice}.
+	 * @param readers readers for de-serializing the request body with
+	 * @param validator validator to validate decoded objects with
+	 * @param adapterRegistry for adapting to other reactive types from Flux and Mono
+	 * @param bodyAdvice body advice to customize the request
+	 */
+	public RequestBodyArgumentResolver(List<HttpMessageReader<?>> readers, Validator validator,
+			ReactiveAdapterRegistry adapterRegistry, List<RequestBodyAdvice> bodyAdvice) {
+
+		super(readers, validator, adapterRegistry, bodyAdvice);
+	}
+
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerAdapter.java
@@ -67,6 +67,8 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, BeanFactory
 
 	private final List<HttpMessageReader<?>> messageReaders = new ArrayList<>(10);
 
+	private final List<RequestBodyAdvice> requestBodyAdvice = new ArrayList<>();
+
 	private ReactiveAdapterRegistry reactiveAdapters = new ReactiveAdapterRegistry();
 
 	private ConversionService conversionService = new DefaultFormattingConversionService();
@@ -127,6 +129,17 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, BeanFactory
 	 */
 	public List<HttpMessageReader<?>> getMessageReaders() {
 		return this.messageReaders;
+	}
+
+	/**
+	 * Add one or more {@code RequestBodyAdvice} instances to intercept the
+	 * request before it is read and converted for {@code @RequestBody} and
+	 * {@code HttpEntity} method arguments.
+	 */
+	public void setRequestBodyAdvice(List<RequestBodyAdvice> requestBodyAdvice) {
+		if (requestBodyAdvice != null) {
+			this.requestBodyAdvice.addAll(requestBodyAdvice);
+		}
 	}
 
 	public void setReactiveAdapterRegistry(ReactiveAdapterRegistry registry) {
@@ -206,7 +219,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, BeanFactory
 		resolvers.add(new RequestParamMapMethodArgumentResolver());
 		resolvers.add(new PathVariableMethodArgumentResolver(cs, getBeanFactory()));
 		resolvers.add(new PathVariableMapMethodArgumentResolver());
-		resolvers.add(new RequestBodyArgumentResolver(getMessageReaders(), getValidator(), adapterRegistry));
+		resolvers.add(new RequestBodyArgumentResolver(getMessageReaders(), getValidator(), adapterRegistry, this.requestBodyAdvice));
 		resolvers.add(new RequestHeaderMethodArgumentResolver(cs, getBeanFactory()));
 		resolvers.add(new RequestHeaderMapMethodArgumentResolver());
 		resolvers.add(new CookieValueMethodArgumentResolver(cs, getBeanFactory()));
@@ -215,7 +228,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, BeanFactory
 		resolvers.add(new RequestAttributeMethodArgumentResolver(cs , getBeanFactory()));
 
 		// Type-based argument resolution
-		resolvers.add(new HttpEntityArgumentResolver(getMessageReaders(), getValidator(), adapterRegistry));
+		resolvers.add(new HttpEntityArgumentResolver(getMessageReaders(), getValidator(), adapterRegistry, this.requestBodyAdvice));
 		resolvers.add(new ModelArgumentResolver());
 		resolvers.add(new ServerWebExchangeArgumentResolver());
 

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyAdvice.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyAdvice.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+
+/**
+ * Allows customizing the response after the execution of an {@code @ResponseBody}
+ * or a {@code ResponseEntity} controller method but before the body is written
+ * with an {@code HttpMessageConverter}.
+ *
+ * <p>Implementations may be may be registered directly with
+ * {@code RequestMappingHandlerAdapter} and {@code ExceptionHandlerExceptionResolver}
+ * or more likely annotated with {@code @ControllerAdvice} in which case they
+ * will be auto-detected by both.
+ *
+ * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public interface ResponseBodyAdvice {
+
+	/**
+	 * Whether this component supports the given controller method return type
+	 * and the selected {@code HttpMessageConverter} type.
+	 * @param returnType the return type
+	 * @param writerType the selected writer type
+	 * @param supportedHints thins supported by this {@link HttpMessageWriter}
+	 * @return {@code true} if {@link #beforeBodyWrite} should be invoked, {@code false} otherwise
+	 */
+	boolean supports(MethodParameter returnType, Class<? extends HttpMessageWriter<?>> writerType, List<String> supportedHints);
+
+	/**
+	 * Return hints that can be used to customize how the body should be written
+	 * @return Additional information about how to write the body
+	 */
+	default Map<String, Object> getHints(MethodParameter returnType, ResolvableType targetType,
+			Class<? extends HttpMessageWriter<?>> writerType, List<String> supportedHints) {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Invoked after an {@code HttpMessageConverter} is selected and just before
+	 * its write method is invoked.
+	 * @param body the body stream to be written
+	 * @param returnType the return type of the controller method
+	 * @param selectedContentType the content type selected through content negotiation
+	 * @param selectedWriterType the converter type selected to write to the response
+	 * @param response the current HTTP response
+	 *
+	 * @return the body stream that was passed in or a modified, possibly new instance
+	 */
+	default Publisher<Object> beforeBodyWrite(Publisher<Object> body, MethodParameter returnType,
+			MediaType selectedContentType, Class<? extends HttpMessageWriter<?>> selectedWriterType,
+			ServerHttpResponse response, List<String> supportedHints) {
+		return body;
+	}
+
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyAdviceChain.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyAdviceChain.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.method.ControllerAdviceBean;
+
+/**
+ * Invokes {@link RequestBodyAdvice} and {@link ResponseBodyAdvice} where each
+ * instance may be (and is most likely) wrapped with
+ * {@link ControllerAdviceBean ControllerAdviceBean}.
+ *
+ * @author Sebastien Deleuze
+ * @author Rossen Stoyanchev
+ * @since 5.0
+ */
+class ResponseBodyAdviceChain implements ResponseBodyAdvice {
+
+	private final List<ResponseBodyAdvice> responseBodyAdvice = new ArrayList<>(4);
+
+
+	/**
+	 * Create an instance from a list of {@code ResponseBodyAdvice}.
+	 */
+	public ResponseBodyAdviceChain(List<ResponseBodyAdvice> responseBodyAdvice) {
+		this.responseBodyAdvice.addAll(responseBodyAdvice);
+	}
+
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageWriter<?>> writerType, List<String> supportedHints) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public Map<String, Object> getHints(MethodParameter returnType, ResolvableType targetType,
+			Class<? extends HttpMessageWriter<?>> writerType, List<String> supportedHints) {
+
+		Map<String, Object> hints = new HashMap<>();
+		this.responseBodyAdvice
+				.stream()
+				.filter(advice -> advice.supports(returnType, writerType, supportedHints))
+				.forEach(advice -> hints.putAll(advice.getHints(returnType, targetType, writerType, supportedHints))
+		);
+		return hints;
+	}
+
+	@Override
+	public Publisher<Object> beforeBodyWrite(Publisher<Object> body, MethodParameter returnType, MediaType contentType,
+			Class<? extends HttpMessageWriter<?>> writerType,
+			ServerHttpResponse response, List<String> supportedHints) {
+
+		for (ResponseBodyAdvice advice : this.responseBodyAdvice) {
+			if (advice.supports(returnType, writerType, supportedHints)) {
+				body = advice.beforeBodyWrite(body, returnType, contentType, writerType, response, supportedHints);
+			}
+		}
+		return body;
+	}
+
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyResultHandler.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyResultHandler.java
@@ -16,8 +16,8 @@
 
 package org.springframework.web.reactive.result.method.annotation;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import reactor.core.publisher.Mono;
 
@@ -65,7 +65,7 @@ public class ResponseBodyResultHandler extends AbstractMessageWriterResultHandle
 	public ResponseBodyResultHandler(List<HttpMessageWriter<?>> messageWriters,
 			RequestedContentTypeResolver contentTypeResolver) {
 
-		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry());
+		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry(), Collections.emptyList());
 	}
 
 	/**
@@ -80,7 +80,23 @@ public class ResponseBodyResultHandler extends AbstractMessageWriterResultHandle
 			RequestedContentTypeResolver contentTypeResolver,
 			ReactiveAdapterRegistry adapterRegistry) {
 
-		super(messageWriters, contentTypeResolver, adapterRegistry);
+		this(messageWriters, contentTypeResolver, adapterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Constructor with additional {@link ReactiveAdapterRegistry} and list of {@link ResponseBodyAdvice}
+	 *
+	 * @param messageWriters writers for serializing to the response body stream
+	 * @param contentTypeResolver for resolving the requested content type
+	 * @param adapterRegistry for adapting other reactive types (e.g. rx.Observable,
+	 * rx.Single, etc.) to Flux or Mono
+	 * @param bodyAdvice body advice to customize the response
+	 */
+	public ResponseBodyResultHandler(List<HttpMessageWriter<?>> messageWriters,
+			RequestedContentTypeResolver contentTypeResolver,
+			ReactiveAdapterRegistry adapterRegistry, List<ResponseBodyAdvice> bodyAdvice) {
+
+		super(messageWriters, contentTypeResolver, adapterRegistry, bodyAdvice);
 		setOrder(100);
 	}
 

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandler.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandler.java
@@ -17,6 +17,7 @@ package org.springframework.web.reactive.result.method.annotation;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,7 +64,7 @@ public class ResponseEntityResultHandler extends AbstractMessageWriterResultHand
 	public ResponseEntityResultHandler(List<HttpMessageWriter<?>> messageWriters,
 			RequestedContentTypeResolver contentTypeResolver) {
 
-		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry());
+		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry(), Collections.emptyList());
 	}
 
 	/**
@@ -78,7 +79,23 @@ public class ResponseEntityResultHandler extends AbstractMessageWriterResultHand
 			RequestedContentTypeResolver contentTypeResolver,
 			ReactiveAdapterRegistry adapterRegistry) {
 
-		super(messageWriters, contentTypeResolver, adapterRegistry);
+		this(messageWriters, contentTypeResolver, adapterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Constructor with additional {@link ReactiveAdapterRegistry} and list of {@link ResponseBodyAdvice}.
+	 *
+	 * @param messageWriters writers for serializing to the response body stream
+	 * @param contentTypeResolver for resolving the requested content type
+	 * @param adapterRegistry for adapting other reactive types (e.g. rx.Observable,
+	 * rx.Single, etc.) to Flux or Mono
+	 * @param bodyAdvice body advice to customize the response
+	 */
+	public ResponseEntityResultHandler(List<HttpMessageWriter<?>> messageWriters,
+			RequestedContentTypeResolver contentTypeResolver,
+			ReactiveAdapterRegistry adapterRegistry, List<ResponseBodyAdvice> bodyAdvice) {
+
+		super(messageWriters, contentTypeResolver, adapterRegistry, bodyAdvice);
 		setOrder(0);
 	}
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/function/RouterTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/function/RouterTests.java
@@ -18,6 +18,7 @@ package org.springframework.web.reactive.function;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -163,7 +164,7 @@ public class RouterTests {
 	private static class DummyMessageWriter implements HttpMessageWriter<Object> {
 
 		@Override
-		public boolean canWrite(ResolvableType type, MediaType mediaType) {
+		public boolean canWrite(ResolvableType type, MediaType mediaType, Map<String, Object> hints) {
 			return false;
 		}
 
@@ -175,7 +176,8 @@ public class RouterTests {
 		@Override
 		public Mono<Void> write(Publisher<?> inputStream, ResolvableType type,
 				MediaType contentType,
-				ReactiveHttpOutputMessage outputMessage) {
+				ReactiveHttpOutputMessage outputMessage,
+				Map<String, Object> hints) {
 			return Mono.empty();
 		}
 	}
@@ -183,7 +185,7 @@ public class RouterTests {
 	private static class DummyMessageReader implements HttpMessageReader<Object> {
 
 		@Override
-		public boolean canRead(ResolvableType type, MediaType mediaType) {
+		public boolean canRead(ResolvableType type, MediaType mediaType, Map<String, Object> hints) {
 			return false;
 		}
 
@@ -193,12 +195,14 @@ public class RouterTests {
 		}
 
 		@Override
-		public Flux<Object> read(ResolvableType type, ReactiveHttpInputMessage inputMessage) {
+		public Flux<Object> read(ResolvableType type, ReactiveHttpInputMessage inputMessage,
+				Map<String, Object> hints) {
 			return Flux.empty();
 		}
 
 		@Override
-		public Mono<Object> readMono(ResolvableType type, ReactiveHttpInputMessage inputMessage) {
+		public Mono<Object> readMono(ResolvableType type, ReactiveHttpInputMessage inputMessage,
+				Map<String, Object> hints) {
 			return Mono.empty();
 		}
 	}

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestResponseBodyAdviceIntegrationTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestResponseBodyAdviceIntegrationTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.config.WebReactiveConfiguration;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class RequestResponseBodyAdviceIntegrationTests extends AbstractRequestMappingIntegrationTests {
+
+	@Override
+	protected ApplicationContext initApplicationContext() {
+		AnnotationConfigApplicationContext wac = new AnnotationConfigApplicationContext();
+		wac.register(WebConfig.class);
+		wac.refresh();
+		return wac;
+	}
+
+	@Test
+	public void jsonViewResponse() throws Exception {
+		String expected = "{\"withView1\":\"with\"}";
+		assertEquals(expected, performGet("/response/raw", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithMonoResponse() throws Exception {
+		String expected = "{\"withView1\":\"with\"}";
+		assertEquals(expected, performGet("/response/mono", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithFluxResponse() throws Exception {
+		String expected = "[{\"withView1\":\"with\"},{\"withView1\":\"with\"}]";
+		assertEquals(expected, performGet("/response/flux", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithRequest() throws Exception {
+		String expected = "{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}";
+		assertEquals(expected, performPost("/request/raw", MediaType.APPLICATION_JSON,
+				new JacksonViewBean("with", "with", "without"), MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithMonoRequest() throws Exception {
+		String expected = "{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}";
+		assertEquals(expected, performPost("/request/mono", MediaType.APPLICATION_JSON,
+				new JacksonViewBean("with", "with", "without"), MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithFluxRequest() throws Exception {
+		String expected = "[{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}," +
+				"{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}]";
+		List<JacksonViewBean> beans = Arrays.asList(new JacksonViewBean("with", "with", "without"), new JacksonViewBean("with", "with", "without"));
+		assertEquals(expected, performPost("/request/flux", MediaType.APPLICATION_JSON, beans,
+				MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+
+	@Configuration
+	@ComponentScan(resourcePattern = "**/RequestResponseBodyAdviceIntegrationTests*.class")
+	@SuppressWarnings({"unused", "WeakerAccess"})
+	static class WebConfig extends WebReactiveConfiguration {
+	}
+
+	@RestController
+	@SuppressWarnings("unused")
+	private static class JsonViewRestController {
+
+		@GetMapping("/response/raw")
+		@JsonView(MyJacksonView1.class)
+		public JacksonViewBean rawResponse() {
+			return new JacksonViewBean("with", "with", "without");
+		}
+
+		@GetMapping("/response/mono")
+		@JsonView(MyJacksonView1.class)
+		public Mono<JacksonViewBean> monoResponse() {
+			return Mono.just(new JacksonViewBean("with", "with", "without"));
+		}
+
+		@GetMapping("/response/flux")
+		@JsonView(MyJacksonView1.class)
+		public Flux<JacksonViewBean> fluxResponse() {
+			return Flux.just(new JacksonViewBean("with", "with", "without"), new JacksonViewBean("with", "with", "without"));
+		}
+
+		@PostMapping("/request/raw")
+		public JacksonViewBean rawRequest(@JsonView(MyJacksonView1.class) @RequestBody JacksonViewBean bean) {
+			return bean;
+		}
+
+		@PostMapping("/request/mono")
+		public Mono<JacksonViewBean> monoRequest(@JsonView(MyJacksonView1.class) @RequestBody Mono<JacksonViewBean> mono) {
+			return mono;
+		}
+
+		@PostMapping("/request/flux")
+		public Flux<JacksonViewBean> fluxRequest(@JsonView(MyJacksonView1.class) @RequestBody Flux<JacksonViewBean> flux) {
+			return flux;
+		}
+
+	}
+
+	private interface MyJacksonView1 {}
+
+	private interface MyJacksonView2 {}
+
+
+	@SuppressWarnings("unused")
+	private static class JacksonViewBean {
+
+		@JsonView(MyJacksonView1.class)
+		private String withView1;
+
+		@JsonView(MyJacksonView2.class)
+		private String withView2;
+
+		private String withoutView;
+
+
+		public JacksonViewBean() {
+		}
+
+		public JacksonViewBean(String withView1, String withView2, String withoutView) {
+			this.withView1 = withView1;
+			this.withView2 = withView2;
+			this.withoutView = withoutView;
+		}
+
+		public String getWithView1() {
+			return withView1;
+		}
+
+		public void setWithView1(String withView1) {
+			this.withView1 = withView1;
+		}
+
+		public String getWithView2() {
+			return withView2;
+		}
+
+		public void setWithView2(String withView2) {
+			this.withView2 = withView2;
+		}
+
+		public String getWithoutView() {
+			return withoutView;
+		}
+
+		public void setWithoutView(String withoutView) {
+			this.withoutView = withoutView;
+		}
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/DecoderHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/DecoderHttpMessageReader.java
@@ -18,6 +18,7 @@ package org.springframework.http.codec;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -55,8 +56,8 @@ public class DecoderHttpMessageReader<T> implements HttpMessageReader<T> {
 
 
 	@Override
-	public boolean canRead(ResolvableType type, MediaType mediaType) {
-		return this.decoder != null && this.decoder.canDecode(type, mediaType);
+	public boolean canRead(ResolvableType type, MediaType mediaType, Map<String, Object> hints) {
+		return this.decoder != null && this.decoder.canDecode(type, mediaType, hints);
 	}
 
 	@Override
@@ -66,21 +67,21 @@ public class DecoderHttpMessageReader<T> implements HttpMessageReader<T> {
 
 
 	@Override
-	public Flux<T> read(ResolvableType type, ReactiveHttpInputMessage inputMessage) {
+	public Flux<T> read(ResolvableType type, ReactiveHttpInputMessage inputMessage, Map<String, Object> hints) {
 		if (this.decoder == null) {
 			return Flux.error(new IllegalStateException("No decoder set"));
 		}
 		MediaType contentType = getContentType(inputMessage);
-		return this.decoder.decode(inputMessage.getBody(), type, contentType);
+		return this.decoder.decode(inputMessage.getBody(), type, contentType, hints);
 	}
 
 	@Override
-	public Mono<T> readMono(ResolvableType type, ReactiveHttpInputMessage inputMessage) {
+	public Mono<T> readMono(ResolvableType type, ReactiveHttpInputMessage inputMessage, Map<String, Object> hints) {
 		if (this.decoder == null) {
 			return Mono.error(new IllegalStateException("No decoder set"));
 		}
 		MediaType contentType = getContentType(inputMessage);
-		return this.decoder.decodeToMono(inputMessage.getBody(), type, contentType);
+		return this.decoder.decodeToMono(inputMessage.getBody(), type, contentType, hints);
 	}
 
 	private MediaType getContentType(ReactiveHttpInputMessage inputMessage) {
@@ -88,4 +89,8 @@ public class DecoderHttpMessageReader<T> implements HttpMessageReader<T> {
 		return (contentType != null ? contentType : MediaType.APPLICATION_OCTET_STREAM);
 	}
 
+	@Override
+	public List<String> getSupportedReadingHints() {
+		return this.decoder.getSupportedDecodingHints();
+	}
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/EncoderHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/EncoderHttpMessageWriter.java
@@ -18,6 +18,7 @@ package org.springframework.http.codec;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -59,8 +60,8 @@ public class EncoderHttpMessageWriter<T> implements HttpMessageWriter<T> {
 
 
 	@Override
-	public boolean canWrite(ResolvableType type, MediaType mediaType) {
-		return this.encoder != null && this.encoder.canEncode(type, mediaType);
+	public boolean canWrite(ResolvableType type, MediaType mediaType, Map<String, Object> hints) {
+		return this.encoder != null && this.encoder.canEncode(type, mediaType, hints);
 	}
 
 	@Override
@@ -71,7 +72,8 @@ public class EncoderHttpMessageWriter<T> implements HttpMessageWriter<T> {
 
 	@Override
 	public Mono<Void> write(Publisher<? extends T> inputStream, ResolvableType type,
-			MediaType contentType, ReactiveHttpOutputMessage outputMessage) {
+			MediaType contentType, ReactiveHttpOutputMessage outputMessage,
+			Map<String, Object> hints) {
 
 		if (this.encoder == null) {
 			return Mono.error(new IllegalStateException("No decoder set"));
@@ -99,7 +101,7 @@ public class EncoderHttpMessageWriter<T> implements HttpMessageWriter<T> {
 		}
 
 		DataBufferFactory bufferFactory = outputMessage.bufferFactory();
-		Flux<DataBuffer> body = this.encoder.encode(inputStream, bufferFactory, type, contentType);
+		Flux<DataBuffer> body = this.encoder.encode(inputStream, bufferFactory, type, contentType, hints);
 		return outputMessage.writeWith(body);
 	}
 
@@ -117,4 +119,8 @@ public class EncoderHttpMessageWriter<T> implements HttpMessageWriter<T> {
 		return (!this.writableMediaTypes.isEmpty() ? this.writableMediaTypes.get(0) : null);
 	}
 
+	@Override
+	public List<String> getSupportedWritingHints() {
+		return this.encoder.getSupportedEncodingHints();
+	}
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/HttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/HttpMessageReader.java
@@ -16,7 +16,9 @@
 
 package org.springframework.http.codec;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -40,9 +42,53 @@ public interface HttpMessageReader<T> {
 	 * @param type the type to test for readability
 	 * @param mediaType the media type to read, can be {@code null} if not specified.
 	 * Typically the value of a {@code Content-Type} header.
+	 * @param hints additional information about how to do read
 	 * @return {@code true} if readable; {@code false} otherwise
 	 */
-	boolean canRead(ResolvableType type, MediaType mediaType);
+	boolean canRead(ResolvableType type, MediaType mediaType, Map<String, Object> hints);
+
+	/**
+	 * @see #canRead(ResolvableType, MediaType, Map)
+	 */
+	default boolean canRead(ResolvableType type, MediaType mediaType) {
+		return canRead(type, mediaType, Collections.emptyMap());
+	}
+
+	/**
+	 * Read a {@link Flux} of the given type form the given input message, and returns it.
+	 * @param type the type of object to return. This type must have previously been
+	 * passed to the {@link #canRead canRead} method of this interface, which must have
+	 * returned {@code true}.
+	 * @param inputMessage the HTTP input message to read from
+	 * @param hints additional information about how to do read
+	 * @return the converted {@link Flux} of elements
+	 */
+	Flux<T> read(ResolvableType type, ReactiveHttpInputMessage inputMessage, Map<String, Object> hints);
+
+	/**
+	 * @see #read(ResolvableType, ReactiveHttpInputMessage, Map)
+	 */
+	default Flux<T> read(ResolvableType type, ReactiveHttpInputMessage inputMessage) {
+		return read(type, inputMessage, Collections.emptyMap());
+	}
+
+	/**
+	 * Read a {@link Mono} of the given type form the given input message, and returns it.
+	 * @param type the type of object to return. This type must have previously been
+	 * passed to the {@link #canRead canRead} method of this interface, which must have
+	 * returned {@code true}.
+	 * @param inputMessage the HTTP input message to read from
+	 * @param hints additional information about how to do read
+	 * @return the converted {@link Mono} of object
+	 */
+	Mono<T> readMono(ResolvableType type, ReactiveHttpInputMessage inputMessage, Map<String, Object> hints);
+
+	/**
+	 * @see #readMono(ResolvableType, ReactiveHttpInputMessage, Map)
+	 */
+	default Mono<T> readMono(ResolvableType type, ReactiveHttpInputMessage inputMessage) {
+		return readMono(type, inputMessage, Collections.emptyMap());
+	}
 
 	/**
 	 * Return the list of {@link MediaType} objects that can be read by this converter.
@@ -51,23 +97,10 @@ public interface HttpMessageReader<T> {
 	List<MediaType> getReadableMediaTypes();
 
 	/**
-	 * Read a {@link Flux} of the given type form the given input message, and returns it.
-	 * @param type the type of object to return. This type must have previously been
-	 * passed to the {@link #canRead canRead} method of this interface, which must have
-	 * returned {@code true}.
-	 * @param inputMessage the HTTP input message to read from
-	 * @return the converted {@link Flux} of elements
+	 * Return the list of hints keys this reader supports.
 	 */
-	Flux<T> read(ResolvableType type, ReactiveHttpInputMessage inputMessage);
-
-	/**
-	 * Read a {@link Mono} of the given type form the given input message, and returns it.
-	 * @param type the type of object to return. This type must have previously been
-	 * passed to the {@link #canRead canRead} method of this interface, which must have
-	 * returned {@code true}.
-	 * @param inputMessage the HTTP input message to read from
-	 * @return the converted {@link Mono} of object
-	 */
-	Mono<T> readMono(ResolvableType type, ReactiveHttpInputMessage inputMessage);
+	default List<String> getSupportedReadingHints() {
+		return Collections.emptyList();
+	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/HttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/HttpMessageWriter.java
@@ -16,7 +16,9 @@
 
 package org.springframework.http.codec;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -40,15 +42,17 @@ public interface HttpMessageWriter<T> {
 	 * @param type the class to test for writability
 	 * @param mediaType the media type to write, can be {@code null} if not specified.
 	 * Typically the value of an {@code Accept} header.
+	 * @param hints additional information about how to do write
 	 * @return {@code true} if writable; {@code false} otherwise
 	 */
-	boolean canWrite(ResolvableType type, MediaType mediaType);
+	boolean canWrite(ResolvableType type, MediaType mediaType, Map<String, Object> hints);
 
 	/**
-	 * Return the list of {@link MediaType} objects that can be written by this converter.
-	 * @return the list of supported readable media types
+	 * @see #canWrite(ResolvableType, MediaType, Map)
 	 */
-	List<MediaType> getWritableMediaTypes();
+	default boolean canWrite(ResolvableType type, MediaType mediaType) {
+		return canWrite(type, mediaType, Collections.emptyMap());
+	}
 
 	/**
 	 * Write an given object to the given output message.
@@ -57,9 +61,31 @@ public interface HttpMessageWriter<T> {
 	 * @param contentType the content type to use when writing. May be {@code null} to
 	 * indicate that the default content type of the converter must be used.
 	 * @param outputMessage the message to write to
+	 * @param hints additional information about how to do write
 	 * @return the converted {@link Mono} of object
 	 */
 	Mono<Void> write(Publisher<? extends T> inputStream, ResolvableType type,
-			MediaType contentType, ReactiveHttpOutputMessage outputMessage);
+			MediaType contentType, ReactiveHttpOutputMessage outputMessage, Map<String, Object> hints);
+
+	/**
+	 * @see #write(Publisher, ResolvableType, MediaType, ReactiveHttpOutputMessage, Map)
+	 */
+	default Mono<Void> write(Publisher<? extends T> inputStream, ResolvableType type,
+			MediaType contentType, ReactiveHttpOutputMessage outputMessage) {
+		return write(inputStream, type, contentType, outputMessage, Collections.emptyMap());
+	}
+
+	/**
+	 * Return the list of {@link MediaType} objects that can be written by this converter.
+	 * @return the list of supported readable media types
+	 */
+	List<MediaType> getWritableMediaTypes();
+
+	/**
+	 * Return the list of hints keys this writer supports.
+	 */
+	default List<String> getSupportedWritingHints() {
+		return Collections.emptyList();
+	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/ResourceHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ResourceHttpMessageWriter.java
@@ -18,6 +18,7 @@ package org.springframework.http.codec;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 
 import org.reactivestreams.Publisher;
@@ -59,14 +60,14 @@ public class ResourceHttpMessageWriter extends EncoderHttpMessageWriter<Resource
 
 	@Override
 	public Mono<Void> write(Publisher<? extends Resource> inputStream, ResolvableType type,
-			MediaType contentType, ReactiveHttpOutputMessage outputMessage) {
+			MediaType contentType, ReactiveHttpOutputMessage outputMessage, Map<String, Object> hints) {
 
 		return Mono.from(Flux.from(inputStream).
 				take(1).
 				concatMap(resource -> {
 					HttpHeaders headers = outputMessage.getHeaders();
 					addHeaders(headers, resource, contentType);
-					return writeContent(resource, type, outputMessage);
+					return writeContent(resource, type, outputMessage, hints);
 				}));
 	}
 
@@ -84,7 +85,7 @@ public class ResourceHttpMessageWriter extends EncoderHttpMessageWriter<Resource
 		}
 	}
 
-	private Mono<Void> writeContent(Resource resource, ResolvableType type, ReactiveHttpOutputMessage outputMessage) {
+	private Mono<Void> writeContent(Resource resource, ResolvableType type, ReactiveHttpOutputMessage outputMessage, Map<String, Object> hints) {
 		if (outputMessage instanceof ZeroCopyHttpOutputMessage) {
 			Optional<File> file = getFile(resource);
 			if (file.isPresent()) {
@@ -97,7 +98,7 @@ public class ResourceHttpMessageWriter extends EncoderHttpMessageWriter<Resource
 
 		// non-zero copy fallback, using ResourceEncoder
 		return super.write(Mono.just(resource), type,
-				outputMessage.getHeaders().getContentType(), outputMessage);
+				outputMessage.getHeaders().getContentType(), outputMessage, hints);
 	}
 
 	private static Optional<Long> contentLength(Resource resource) {

--- a/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageWriter.java
@@ -19,6 +19,7 @@ package org.springframework.http.codec;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.reactivestreams.Publisher;
@@ -61,7 +62,7 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 	}
 
 	@Override
-	public boolean canWrite(ResolvableType type, MediaType mediaType) {
+	public boolean canWrite(ResolvableType type, MediaType mediaType, Map<String, Object> hints) {
 		return mediaType == null || TEXT_EVENT_STREAM.isCompatibleWith(mediaType);
 	}
 
@@ -71,19 +72,19 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 	}
 
 	@Override
-	public Mono<Void> write(Publisher<?> inputStream, ResolvableType type,
-							MediaType contentType, ReactiveHttpOutputMessage outputMessage) {
+	public Mono<Void> write(Publisher<?> inputStream, ResolvableType type, MediaType contentType,
+			ReactiveHttpOutputMessage outputMessage, Map<String, Object> hints) {
 
 		outputMessage.getHeaders().setContentType(TEXT_EVENT_STREAM);
 
 		DataBufferFactory bufferFactory = outputMessage.bufferFactory();
-		Flux<Publisher<DataBuffer>> body = encode(inputStream, bufferFactory, type);
+		Flux<Publisher<DataBuffer>> body = encode(inputStream, bufferFactory, type, hints);
 
 		return outputMessage.writeAndFlushWith(body);
 	}
 
-	private Flux<Publisher<DataBuffer>> encode(Publisher<?> inputStream,
-											   DataBufferFactory bufferFactory, ResolvableType type) {
+	private Flux<Publisher<DataBuffer>> encode(Publisher<?> inputStream, DataBufferFactory bufferFactory,
+			ResolvableType type, Map<String, Object> hints) {
 
 		return Flux.from(inputStream)
 				.map(o -> toSseEvent(o, type))
@@ -105,7 +106,7 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 									return Flux.empty();
 								}
 								else {
-									return applyEncoder(data, bufferFactory);
+									return applyEncoder(data, bufferFactory, hints);
 								}
 							}).orElse(Flux.empty());
 
@@ -129,14 +130,14 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T> Flux<DataBuffer> applyEncoder(Object data, DataBufferFactory bufferFactory) {
+	private <T> Flux<DataBuffer> applyEncoder(Object data, DataBufferFactory bufferFactory, Map<String, Object> hints) {
 		ResolvableType elementType = ResolvableType.forClass(data.getClass());
 		Optional<Encoder<?>> encoder = dataEncoders
 				.stream()
 				.filter(e -> e.canEncode(elementType, MimeTypeUtils.APPLICATION_JSON))
 				.findFirst();
 		return ((Encoder<T>) encoder.orElseThrow(() -> new CodecException("No suitable encoder found!")))
-				.encode(Mono.just((T) data), bufferFactory, elementType, MimeTypeUtils.APPLICATION_JSON)
+				.encode(Mono.just((T) data), bufferFactory, elementType, MimeTypeUtils.APPLICATION_JSON, hints)
 				.concatWith(encodeString("\n", bufferFactory));
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Codec.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Codec.java
@@ -38,6 +38,9 @@ import org.springframework.util.MimeType;
  */
 public class AbstractJackson2Codec {
 
+	public static final String JSON_VIEW_HINT = AbstractJackson2Codec.class.getName() + ".jsonView";
+
+
 	protected static final List<MimeType> JSON_MIME_TYPES = Arrays.asList(
 				new MimeType("application", "json", StandardCharsets.UTF_8),
 				new MimeType("application", "*+json", StandardCharsets.UTF_8));

--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonDecoder.java
@@ -17,7 +17,9 @@
 package org.springframework.http.codec.json;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JavaType;
@@ -62,7 +64,7 @@ public class Jackson2JsonDecoder extends AbstractJackson2Codec implements Decode
 
 
 	@Override
-	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		if (mimeType == null) {
 			return true;
 		}
@@ -76,7 +78,7 @@ public class Jackson2JsonDecoder extends AbstractJackson2Codec implements Decode
 
 	@Override
 	public Flux<Object> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		JsonObjectDecoder objectDecoder = this.fluxObjectDecoder;
 		return decodeInternal(objectDecoder, inputStream, elementType, mimeType, hints);
@@ -84,14 +86,14 @@ public class Jackson2JsonDecoder extends AbstractJackson2Codec implements Decode
 
 	@Override
 	public Mono<Object> decodeToMono(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		JsonObjectDecoder objectDecoder = this.monoObjectDecoder;
 		return decodeInternal(objectDecoder, inputStream, elementType, mimeType, hints).singleOrEmpty();
 	}
 
 	private Flux<Object> decodeInternal(JsonObjectDecoder objectDecoder, Publisher<DataBuffer> inputStream,
-			ResolvableType elementType, MimeType mimeType, Object[] hints) {
+			ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 
 		Assert.notNull(inputStream, "'inputStream' must not be null");
 		Assert.notNull(elementType, "'elementType' must not be null");
@@ -102,14 +104,10 @@ public class Jackson2JsonDecoder extends AbstractJackson2Codec implements Decode
 		JavaType javaType = getJavaType(elementType.getType(), contextClass);
 
 		ObjectReader reader;
-		JsonView jsonView = (methodParam != null ? methodParam.getParameterAnnotation(JsonView.class) : null);
+		Class<?> jsonView = (Class<?>)hints.get(AbstractJackson2Codec.JSON_VIEW_HINT);
+
 		if (jsonView != null) {
-			Class<?>[] classes = jsonView.value();
-			if (classes.length != 1) {
-				throw new IllegalArgumentException("@JsonView only supported for response body advice " +
-						"with exactly 1 class argument: " + methodParam);
-			}
-			reader = this.mapper.readerWithView(classes[0]).forType(javaType);
+			reader = this.mapper.readerWithView(jsonView).forType(javaType);
 		}
 		else {
 			reader = this.mapper.readerFor(javaType);
@@ -126,6 +124,11 @@ public class Jackson2JsonDecoder extends AbstractJackson2Codec implements Decode
 						return Flux.error(new CodecException("Error while reading the data", ex));
 					}
 				});
+	}
+
+	@Override
+	public List<String> getSupportedDecodingHints() {
+		return Collections.singletonList(AbstractJackson2Codec.JSON_VIEW_HINT);
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonEncoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonEncoder.java
@@ -19,7 +19,9 @@ package org.springframework.http.codec.json;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JavaType;
@@ -68,7 +70,7 @@ public class Jackson2JsonEncoder extends AbstractJackson2Codec implements Encode
 
 
 	@Override
-	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		if (mimeType == null) {
 			return true;
 		}
@@ -82,14 +84,14 @@ public class Jackson2JsonEncoder extends AbstractJackson2Codec implements Encode
 
 	@Override
 	public Flux<DataBuffer> encode(Publisher<?> inputStream, DataBufferFactory bufferFactory,
-			ResolvableType elementType, MimeType mimeType, Object... hints) {
+			ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 
 		Assert.notNull(inputStream, "'inputStream' must not be null");
 		Assert.notNull(bufferFactory, "'bufferFactory' must not be null");
 		Assert.notNull(elementType, "'elementType' must not be null");
 
 		if (inputStream instanceof Mono) {
-			return Flux.from(inputStream).map(value -> encodeValue(value, bufferFactory, elementType));
+			return Flux.from(inputStream).map(value -> encodeValue(value, bufferFactory, elementType, hints));
 		}
 
 		Mono<DataBuffer> startArray = Mono.just(bufferFactory.wrap(START_ARRAY_BUFFER));
@@ -98,31 +100,23 @@ public class Jackson2JsonEncoder extends AbstractJackson2Codec implements Encode
 		Flux<DataBuffer> array = Flux.from(inputStream)
 				.concatMap(value -> {
 					DataBuffer arraySeparator = bufferFactory.wrap(SEPARATOR_BUFFER);
-					return Flux.just(encodeValue(value, bufferFactory, elementType), arraySeparator);
+					return Flux.just(encodeValue(value, bufferFactory, elementType, hints), arraySeparator);
 				});
 
 		return Flux.concat(startArray, array.skipLast(1), endArray);
 	}
 
-	private DataBuffer encodeValue(Object value, DataBufferFactory bufferFactory, ResolvableType type) {
+	private DataBuffer encodeValue(Object value, DataBufferFactory bufferFactory, ResolvableType type, Map<String, Object> hints) {
 		TypeFactory typeFactory = this.mapper.getTypeFactory();
 		JavaType javaType = typeFactory.constructType(type.getType());
-		MethodParameter returnType =
-				(type.getSource() instanceof MethodParameter ? (MethodParameter) type.getSource() : null);
-
 		if (type.isInstance(value)) {
 			javaType = getJavaType(type.getType(), null);
 		}
 
 		ObjectWriter writer;
-		JsonView jsonView = (returnType != null ? returnType.getMethodAnnotation(JsonView.class) : null);
+		Class<?> jsonView = (Class<?>)hints.get(AbstractJackson2Codec.JSON_VIEW_HINT);
 		if (jsonView != null) {
-			Class<?>[] classes = jsonView.value();
-			if (classes.length != 1) {
-				throw new IllegalArgumentException("@JsonView only supported for response body advice " +
-						"with exactly 1 class argument: " + returnType);
-			}
-			writer = this.mapper.writerWithView(classes[0]);
+			writer = this.mapper.writerWithView(jsonView);
 		}
 		else {
 			writer = this.mapper.writer();
@@ -144,4 +138,8 @@ public class Jackson2JsonEncoder extends AbstractJackson2Codec implements Encode
 		return buffer;
 	}
 
+	@Override
+	public List<String> getSupportedEncodingHints() {
+		return Collections.singletonList(AbstractJackson2Codec.JSON_VIEW_HINT);
+	}
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/json/JsonObjectDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/JsonObjectDecoder.java
@@ -19,6 +19,7 @@ package org.springframework.http.codec.json;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import io.netty.buffer.ByteBuf;
@@ -96,7 +97,7 @@ class JsonObjectDecoder extends AbstractDecoder<DataBuffer> {
 
 	@Override
 	public Flux<DataBuffer> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		return Flux.from(inputStream)
 				.flatMap(new Function<DataBuffer, Publisher<? extends DataBuffer>>() {

--- a/spring-web/src/main/java/org/springframework/http/codec/xml/Jaxb2XmlDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/xml/Jaxb2XmlDecoder.java
@@ -18,6 +18,7 @@ package org.springframework.http.codec.xml;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBElement;
@@ -75,7 +76,7 @@ public class Jaxb2XmlDecoder extends AbstractDecoder<Object> {
 
 
 	@Override
-	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canDecode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		if (super.canDecode(elementType, mimeType, hints)) {
 			Class<?> outputClass = elementType.getRawClass();
 			return outputClass.isAnnotationPresent(XmlRootElement.class) ||
@@ -88,7 +89,7 @@ public class Jaxb2XmlDecoder extends AbstractDecoder<Object> {
 
 	@Override
 	public Flux<Object> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		Class<?> outputClass = elementType.getRawClass();
 		Flux<XMLEvent> xmlEventFlux =

--- a/spring-web/src/main/java/org/springframework/http/codec/xml/Jaxb2XmlEncoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/xml/Jaxb2XmlEncoder.java
@@ -18,6 +18,7 @@ package org.springframework.http.codec.xml;
 
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -52,7 +53,7 @@ public class Jaxb2XmlEncoder extends AbstractSingleValueEncoder<Object> {
 
 
 	@Override
-	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Object... hints) {
+	public boolean canEncode(ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
 		if (super.canEncode(elementType, mimeType, hints)) {
 			Class<?> outputClass = elementType.getRawClass();
 			return (outputClass.isAnnotationPresent(XmlRootElement.class) ||
@@ -66,7 +67,7 @@ public class Jaxb2XmlEncoder extends AbstractSingleValueEncoder<Object> {
 
 	@Override
 	protected Flux<DataBuffer> encode(Object value, DataBufferFactory dataBufferFactory,
-			ResolvableType type, MimeType mimeType, Object... hints) {
+			ResolvableType type, MimeType mimeType, Map<String, Object> hints) {
 		try {
 			DataBuffer buffer = dataBufferFactory.allocateBuffer(1024);
 			OutputStream outputStream = buffer.asOutputStream();

--- a/spring-web/src/main/java/org/springframework/http/codec/xml/XmlEventDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/xml/XmlEventDecoder.java
@@ -19,6 +19,7 @@ package org.springframework.http.codec.xml;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -89,7 +90,7 @@ public class XmlEventDecoder extends AbstractDecoder<XMLEvent> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Flux<XMLEvent> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
-			MimeType mimeType, Object... hints) {
+			MimeType mimeType, Map<String, Object> hints) {
 
 		Flux<DataBuffer> flux = Flux.from(inputStream);
 		if (useAalto && aaltoPresent) {

--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonEncoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonEncoderTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.http.codec.json;
 
+import java.util.Collections;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -87,14 +90,15 @@ public class Jackson2JsonEncoderTests extends AbstractDataBufferAllocatingTestCa
 	}
 
 	@Test
-	public void jsonView() throws Exception {
+	public void jsonView() {
 		JacksonViewBean bean = new JacksonViewBean();
 		bean.setWithView1("with");
 		bean.setWithView2("with");
 		bean.setWithoutView("without");
 
-		ResolvableType type =  ResolvableType.forMethodReturnType(JacksonController.class.getMethod("foo"));
-		Flux<DataBuffer> output = this.encoder.encode(Mono.just(bean), this.bufferFactory, type, null);
+		ResolvableType type =  ResolvableType.forClass(JacksonViewBean.class);
+		Map<String, Object> hints = Collections.singletonMap(AbstractJackson2Codec.JSON_VIEW_HINT, MyJacksonView1.class);
+		Flux<DataBuffer> output = this.encoder.encode(Mono.just(bean), this.bufferFactory, type, null, hints);
 
 		TestSubscriber.subscribe(output)
 				.assertComplete()
@@ -154,15 +158,6 @@ public class Jackson2JsonEncoderTests extends AbstractDataBufferAllocatingTestCa
 
 		public void setWithoutView(String withoutView) {
 			this.withoutView = withoutView;
-		}
-	}
-
-
-	private static class JacksonController {
-
-		@JsonView(MyJacksonView1.class)
-		public JacksonViewBean foo() {
-			return null;
 		}
 	}
 


### PR DESCRIPTION
This draft PR brings the new hints API based on `Map<String, Object>`, a reactive port of `RequestBodyAdvice` and `ResponseBodyAdvice` and a concrete use case with the `JsonView` support for both request and response body.

Thanks in advance for your feedback @rstoyanchev, @bclozel, @poutsma !
