### PR TITLE
Request/ResponseBodyAdvice based solution to provide hints to codecs

### DIFF
--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfiguration.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.codec.ByteBufferDecoder;
 import org.springframework.core.codec.ByteBufferEncoder;
 import org.springframework.core.codec.CharSequenceEncoder;
@@ -60,8 +61,12 @@ import org.springframework.web.reactive.accept.RequestedContentTypeResolverBuild
 import org.springframework.web.reactive.handler.AbstractHandlerMapping;
 import org.springframework.web.reactive.result.SimpleHandlerAdapter;
 import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.web.reactive.result.method.annotation.JsonViewRequestBodyAdvice;
+import org.springframework.web.reactive.result.method.annotation.JsonViewResponseBodyAdvice;
+import org.springframework.web.reactive.result.method.annotation.RequestBodyAdvice;
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.reactive.result.method.annotation.ResponseBodyAdvice;
 import org.springframework.web.reactive.result.method.annotation.ResponseBodyResultHandler;
 import org.springframework.web.reactive.result.method.annotation.ResponseEntityResultHandler;
 import org.springframework.web.reactive.result.view.ViewResolutionResultHandler;
@@ -229,8 +234,15 @@ public class WebReactiveConfiguration implements ApplicationContextAware {
 		adapter.setMessageReaders(getMessageReaders());
 		adapter.setConversionService(mvcConversionService());
 		adapter.setValidator(mvcValidator());
+		adapter.setRequestBodyAdvice(getRequestBodyAdvice());
 
 		return adapter;
+	}
+
+	protected List<RequestBodyAdvice> getRequestBodyAdvice() {
+		List<RequestBodyAdvice> advice = new ArrayList<>();
+		advice.add(new JsonViewRequestBodyAdvice());
+		return advice;
 	}
 
 	/**
@@ -357,12 +369,20 @@ public class WebReactiveConfiguration implements ApplicationContextAware {
 
 	@Bean
 	public ResponseEntityResultHandler responseEntityResultHandler() {
-		return new ResponseEntityResultHandler(getMessageWriters(), mvcContentTypeResolver());
+		return new ResponseEntityResultHandler(getMessageWriters(), mvcContentTypeResolver(),
+				new ReactiveAdapterRegistry(), getResponseBodyAdvice());
 	}
 
 	@Bean
 	public ResponseBodyResultHandler responseBodyResultHandler() {
-		return new ResponseBodyResultHandler(getMessageWriters(), mvcContentTypeResolver());
+		return new ResponseBodyResultHandler(getMessageWriters(), mvcContentTypeResolver(),
+				new ReactiveAdapterRegistry(), getResponseBodyAdvice());
+	}
+
+	protected List<ResponseBodyAdvice> getResponseBodyAdvice() {
+		List<ResponseBodyAdvice> advice = new ArrayList<>();
+		advice.add(new JsonViewResponseBodyAdvice());
+		return advice;
 	}
 
 	/**

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageReaderArgumentResolver.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageReaderArgumentResolver.java
@@ -18,6 +18,7 @@ package org.springframework.web.reactive.result.method.annotation;
 import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -31,6 +32,7 @@ import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpInputMessage;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.Assert;
@@ -64,17 +66,19 @@ public abstract class AbstractMessageReaderArgumentResolver {
 
 	private final ReactiveAdapterRegistry adapterRegistry;
 
+	private final RequestBodyAdviceChain bodyAdvice;
+
 	private final List<MediaType> supportedMediaTypes;
 
 
 	/**
 	 * Constructor with {@link HttpMessageReader}'s and a {@link Validator}.
-	 * @param readers readers to convert from the request body
+	 * @param messageReaders readers to convert from the request body
 	 * @param validator validator to validate decoded objects with
 	 */
-	protected AbstractMessageReaderArgumentResolver(List<HttpMessageReader<?>> readers, Validator validator) {
+	protected AbstractMessageReaderArgumentResolver(List<HttpMessageReader<?>> messageReaders, Validator validator) {
 
-		this(readers, validator, new ReactiveAdapterRegistry());
+		this(messageReaders, validator, new ReactiveAdapterRegistry(), Collections.emptyList());
 	}
 
 	/**
@@ -86,11 +90,26 @@ public abstract class AbstractMessageReaderArgumentResolver {
 	protected AbstractMessageReaderArgumentResolver(List<HttpMessageReader<?>> messageReaders,
 			Validator validator, ReactiveAdapterRegistry adapterRegistry) {
 
+		this(messageReaders, validator, adapterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Constructor that also accepts a {@link ReactiveAdapterRegistry} and a list of {@link RequestBodyAdvice}.
+	 * @param messageReaders readers to convert from the request body
+	 * @param validator validator to validate decoded objects with
+	 * @param adapterRegistry for adapting to other reactive types from Flux and Mono
+	 * @param bodyAdvice body advice to customize the request
+	 */
+	protected AbstractMessageReaderArgumentResolver(List<HttpMessageReader<?>> messageReaders,
+			Validator validator, ReactiveAdapterRegistry adapterRegistry, List<RequestBodyAdvice> bodyAdvice) {
+
 		Assert.notEmpty(messageReaders, "At least one HttpMessageReader is required.");
 		Assert.notNull(adapterRegistry, "'adapterRegistry' is required");
+		Assert.notNull(bodyAdvice, "'bodyAdvice' is required");
 		this.messageReaders = messageReaders;
 		this.validator = validator;
 		this.adapterRegistry = adapterRegistry;
+		this.bodyAdvice = new RequestBodyAdviceChain(bodyAdvice);
 		this.supportedMediaTypes = messageReaders.stream()
 				.flatMap(converter -> converter.getReadableMediaTypes().stream())
 				.collect(Collectors.toList());
@@ -112,6 +131,7 @@ public abstract class AbstractMessageReaderArgumentResolver {
 	}
 
 
+	@SuppressWarnings("unchecked")
 	protected Mono<Object> readBody(MethodParameter bodyParameter, boolean isBodyRequired,
 			ServerWebExchange exchange) {
 
@@ -130,10 +150,17 @@ public abstract class AbstractMessageReaderArgumentResolver {
 		}
 
 		for (HttpMessageReader<?> reader : getMessageReaders()) {
+			Class<HttpMessageReader<?>> readerType = (Class<HttpMessageReader<?>>) reader.getClass();
 			if (reader.canRead(elementType, mediaType, Collections.emptyMap())) {
+
+				ReactiveHttpInputMessage inputMessage = this.bodyAdvice.beforeRead(request,
+						bodyParameter, elementType, readerType);
+				Map<String, Object> hints = this.bodyAdvice.getHints(bodyParameter, elementType, readerType);
+
 				if (adapter != null && adapter.getDescriptor().isMultiValue()) {
-					Flux<?> flux = reader.read(elementType, request, Collections.emptyMap())
+					Flux<Object> flux = (Flux<Object>)reader.read(elementType, inputMessage, hints)
 							.onErrorResumeWith(ex -> Flux.error(getReadError(ex, bodyParameter)));
+					flux = this.bodyAdvice.afterRead(flux, inputMessage, bodyParameter, elementType, readerType);
 					if (checkRequired(adapter, isBodyRequired)) {
 						flux = flux.switchIfEmpty(Flux.error(getRequiredBodyError(bodyParameter)));
 					}
@@ -143,8 +170,9 @@ public abstract class AbstractMessageReaderArgumentResolver {
 					return Mono.just(adapter.fromPublisher(flux));
 				}
 				else {
-					Mono<?> mono = reader.readMono(elementType, request, Collections.emptyMap())
+					Mono<Object> mono = (Mono<Object>)reader.readMono(elementType, inputMessage, hints)
 							.otherwise(ex -> Mono.error(getReadError(ex, bodyParameter)));
+					mono = bodyAdvice.afterReadMono(mono, inputMessage, bodyParameter, elementType, readerType);
 					if (checkRequired(adapter, isBodyRequired)) {
 						mono = mono.otherwiseIfEmpty(Mono.error(getRequiredBodyError(bodyParameter)));
 					}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageWriterResultHandler.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageWriterResultHandler.java
@@ -17,6 +17,7 @@ package org.springframework.web.reactive.result.method.annotation;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.reactivestreams.Publisher;
@@ -46,6 +47,8 @@ public abstract class AbstractMessageWriterResultHandler extends ContentNegotiat
 
 	private final List<HttpMessageWriter<?>> messageWriters;
 
+	private final ResponseBodyAdviceChain bodyAdvice;
+
 
 	/**
 	 * Constructor with {@link HttpMessageWriter}s and a
@@ -57,9 +60,7 @@ public abstract class AbstractMessageWriterResultHandler extends ContentNegotiat
 	protected AbstractMessageWriterResultHandler(List<HttpMessageWriter<?>> messageWriters,
 			RequestedContentTypeResolver contentTypeResolver) {
 
-		super(contentTypeResolver);
-		Assert.notEmpty(messageWriters, "At least one message writer is required.");
-		this.messageWriters = messageWriters;
+		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry());
 	}
 
 	/**
@@ -74,9 +75,28 @@ public abstract class AbstractMessageWriterResultHandler extends ContentNegotiat
 			RequestedContentTypeResolver contentTypeResolver,
 			ReactiveAdapterRegistry adapterRegistry) {
 
+		this(messageWriters, contentTypeResolver, adapterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Constructor with additional {@link ReactiveAdapterRegistry} and {@link ResponseBodyAdvice}.
+	 *
+	 * @param messageWriters for serializing Objects to the response body stream
+	 * @param contentTypeResolver for resolving the requested content type
+	 * @param adapterRegistry for adapting other reactive types (e.g. rx.Observable,
+	 * rx.Single, etc.) to Flux or Mono
+	 * @param bodyAdvice body advice to customize the response
+	 */
+	protected AbstractMessageWriterResultHandler(List<HttpMessageWriter<?>> messageWriters,
+			RequestedContentTypeResolver contentTypeResolver,
+			ReactiveAdapterRegistry adapterRegistry, List<ResponseBodyAdvice> bodyAdvice) {
+
 		super(contentTypeResolver, adapterRegistry);
 		Assert.notEmpty(messageWriters, "At least one message writer is required.");
+		Assert.notNull(adapterRegistry, "'adapterRegistry' is required");
+		Assert.notNull(bodyAdvice, "'bodyAdvice' is required");
 		this.messageWriters = messageWriters;
+		this.bodyAdvice = new ResponseBodyAdviceChain(bodyAdvice);
 	}
 
 
@@ -86,7 +106,6 @@ public abstract class AbstractMessageWriterResultHandler extends ContentNegotiat
 	public List<HttpMessageWriter<?>> getMessageWriters() {
 		return this.messageWriters;
 	}
-
 
 	@SuppressWarnings("unchecked")
 	protected Mono<Void> writeBody(Object body, MethodParameter bodyType, ServerWebExchange exchange) {
@@ -120,11 +139,14 @@ public abstract class AbstractMessageWriterResultHandler extends ContentNegotiat
 		MediaType bestMediaType = selectMediaType(exchange, producibleTypes);
 
 		if (bestMediaType != null) {
-			for (HttpMessageWriter<?> messageWriter : getMessageWriters()) {
-				if (messageWriter.canWrite(elementType, bestMediaType, Collections.emptyMap())) {
+			for (HttpMessageWriter<?> writer : getMessageWriters()) {
+				Class<HttpMessageWriter<?>> writerType = (Class<HttpMessageWriter<?>>) writer.getClass();
+				Map<String, Object> hints = this.bodyAdvice.getHints(bodyType, elementType, writerType);
+				if (writer.canWrite(elementType, bestMediaType, hints)) {
 					ServerHttpResponse response = exchange.getResponse();
-					return messageWriter.write((Publisher) publisher, elementType,
-							bestMediaType, response, Collections.emptyMap());
+					publisher = this.bodyAdvice.beforeBodyWrite((Publisher) publisher, bodyType,
+						bestMediaType, writerType, response);
+					return writer.write((Publisher) publisher, elementType, bestMediaType, response, hints);
 				}
 			}
 		}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/HttpEntityArgumentResolver.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/HttpEntityArgumentResolver.java
@@ -65,6 +65,19 @@ public class HttpEntityArgumentResolver extends AbstractMessageReaderArgumentRes
 		super(readers, validator, adapterRegistry);
 	}
 
+	/**
+	 * Constructor that also accepts a {@link ReactiveAdapterRegistry} and a list of {@link RequestBodyAdvice}.
+	 * @param readers readers for de-serializing the request body with
+	 * @param validator validator to validate decoded objects with
+	 * @param adapterRegistry for adapting to other reactive types from Flux and Mono
+	 * @param bodyAdvice body advice to customize the request
+	 */
+	public HttpEntityArgumentResolver(List<HttpMessageReader<?>> readers, Validator validator,
+			ReactiveAdapterRegistry adapterRegistry, List<RequestBodyAdvice> bodyAdvice) {
+
+		super(readers, validator, adapterRegistry, bodyAdvice);
+	}
+
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/JsonViewRequestBodyAdvice.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/JsonViewRequestBodyAdvice.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.json.AbstractJackson2Codec;
+
+/**
+ * A {@link RequestBodyAdvice} implementation that adds support for Jackson's
+ * {@code @JsonView} annotation declared on a Spring Web Reactive {@code @HttpEntity}
+ * or {@code @RequestBody} method parameter.
+ *
+ * <p>The deserialization view specified in the annotation will be passed in to the
+ * {@link HttpMessageWriter} which will then use it to serialize the response body.
+ *
+ * <p>Note that despite {@code @JsonView} allowing for more than one class to
+ * be specified, the use for a response body advice is only supported with
+ * exactly one class argument. Consider the use of a composite interface.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ * @see JsonView
+ * @see com.fasterxml.jackson.databind.ObjectMapper#readerWithView(Class)
+ */
+public class JsonViewRequestBodyAdvice implements RequestBodyAdvice {
+
+	@Override
+	public boolean supports(MethodParameter methodParameter, ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType) {
+		return methodParameter.hasParameterAnnotation(JsonView.class);
+	}
+
+	@Override
+	public Map<String, Object> getHints(MethodParameter parameter, ResolvableType targetType,
+			Class<? extends HttpMessageReader<?>> readerType) {
+		JsonView annotation = parameter.getParameterAnnotation(JsonView.class);
+		Class<?>[] classes = annotation.value();
+		if (classes.length != 1) {
+			throw new IllegalArgumentException(
+					"@JsonView only supported for request body advice with exactly 1 class argument: " + parameter);
+		}
+		return Collections.singletonMap(AbstractJackson2Codec.JSON_VIEW_HINT, classes[0]);
+	}
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/JsonViewResponseBodyAdvice.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/JsonViewResponseBodyAdvice.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.json.AbstractJackson2Codec;
+
+/**
+ * A {@link ResponseBodyAdvice} implementation that adds support for Jackson's
+ * {@code @JsonView} annotation declared on a Spring Web Reactive {@code @RequestMapping}
+ * or {@code @ExceptionHandler} method.
+ *
+ * <p>The serialization view specified in the annotation will be passed in to the
+ * {@link HttpMessageWriter} which will then use it to serialize the response body.
+ *
+ * <p>Note that despite {@code @JsonView} allowing for more than one class to
+ * be specified, the use for a response body advice is only supported with
+ * exactly one class argument. Consider the use of a composite interface.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ * @see com.fasterxml.jackson.annotation.JsonView
+ * @see com.fasterxml.jackson.databind.ObjectMapper#writerWithView(Class)
+ */
+public class JsonViewResponseBodyAdvice implements ResponseBodyAdvice {
+
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageWriter<?>> writerType) {
+		return returnType.hasMethodAnnotation(JsonView.class);
+	}
+
+	@Override
+	public Map<String, Object> getHints(MethodParameter returnType, ResolvableType targetType,
+			Class<? extends HttpMessageWriter<?>> writerType) {
+		JsonView annotation = returnType.getMethodAnnotation(JsonView.class);
+		Class<?>[] classes = annotation.value();
+		if (classes.length != 1) {
+			throw new IllegalArgumentException(
+					"@JsonView only supported for response body advice with exactly 1 class argument: " + returnType);
+		}
+		return Collections.singletonMap(AbstractJackson2Codec.JSON_VIEW_HINT, classes[0]);
+	}
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyAdvice.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyAdvice.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.ReactiveHttpInputMessage;
+import org.springframework.http.codec.HttpMessageReader;
+
+/**
+ * Allows customizing the request before its body is read and converted into an
+ * Object and also allows for processing of the resulting Object before it is
+ * passed into a controller method as an {@code @RequestBody} or an
+ * {@code HttpEntity} method argument.
+ *
+ * <p>Implementations of this contract may be registered directly with the
+ * {@code RequestMappingHandlerAdapter} or more likely annotated with
+ * {@code @ControllerAdvice} in which case they are auto-detected.
+ *
+ * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public interface RequestBodyAdvice {
+
+	/**
+	 * Invoked first to determine if this interceptor applies.
+	 * @param methodParameter the method parameter
+	 * @param targetType the target type, not necessarily the same as the method
+	 * parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param readerType the selected reader type
+	 * @return whether this interceptor should be invoked or not
+	 */
+	boolean supports(MethodParameter methodParameter, ResolvableType targetType,
+			Class<? extends HttpMessageReader<?>> readerType);
+
+	/**
+	 * Return hints that can be used to customize how the body should be read
+	 * @return Additional information about how to read the body
+	 */
+	default Map<String, Object> getHints(MethodParameter methodParameter, ResolvableType targetType,
+			Class<? extends HttpMessageReader<?>> readerType) {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Invoked second before the request body is read and converted.
+	 * @param inputMessage the request
+	 * @param parameter the target method parameter
+	 * @param targetType the target type, not necessarily the same as the method
+	 * parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param readerType the reader used to deserialize the body
+	 * @return the input request or a new instance, never {@code null}
+	 */
+	default ReactiveHttpInputMessage beforeRead(ReactiveHttpInputMessage inputMessage, MethodParameter parameter,
+			ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType) {
+		return inputMessage;
+	}
+
+	/**
+	 * Invoked third (and last) after the request body is converted to a {@code Flux<Object>}.
+	 * @param body set to the converter {@code Publisher<Object>} before the 1st advice is called
+	 * @param inputMessage the request
+	 * @param parameter the target method parameter
+	 * @param targetType the target type, not necessarily the same as the method
+	 * parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param readerType the reader used to deserialize the body
+	 * @return the same body or a new instance
+	 */
+	default Flux<Object> afterRead(Flux<Object> body, ReactiveHttpInputMessage inputMessage,
+			MethodParameter parameter, ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType) {
+		return body;
+	}
+
+	/**
+	 * Invoked third (and last) after the request body is converted to a {@code Mono<Object>}.
+	 * @param body set to the converter {@code Publisher<Object>} before the 1st advice is called
+	 * @param inputMessage the request
+	 * @param parameter the target method parameter
+	 * @param targetType the target type, not necessarily the same as the method
+	 * parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param readerType the reader used to deserialize the body
+	 * @return the same body or a new instance
+	 */
+	default Mono<Object> afterReadMono(Mono<Object> body, ReactiveHttpInputMessage inputMessage,
+			MethodParameter parameter, ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType) {
+		return body;
+	}
+
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyAdviceChain.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyAdviceChain.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.ReactiveHttpInputMessage;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.web.method.ControllerAdviceBean;
+
+/**
+ * Invokes {@link RequestBodyAdvice} and {@link ResponseBodyAdvice} where each
+ * instance may be (and is most likely) wrapped with
+ * {@link ControllerAdviceBean ControllerAdviceBean}.
+ *
+ * @author Sebastien Deleuze
+ * @author Rossen Stoyanchev
+ * @since 5.0
+ */
+class RequestBodyAdviceChain implements RequestBodyAdvice {
+
+	private final List<RequestBodyAdvice> requestBodyAdvice = new ArrayList<>(4);
+
+
+	/**
+	 * Create an instance from a list of {@code RequestBodyAdvice}.
+	 */
+	public RequestBodyAdviceChain(List<RequestBodyAdvice> requestBodyAdvice) {
+		this.requestBodyAdvice.addAll(requestBodyAdvice);
+	}
+
+	@Override
+	public boolean supports(MethodParameter param, ResolvableType type,
+			Class<? extends HttpMessageReader<?>> readerType) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public Map<String, Object> getHints(MethodParameter parameter, ResolvableType targetType,
+			Class<? extends HttpMessageReader<?>> readerType) {
+
+		Map<String, Object> hints = new HashMap<>();
+		this.requestBodyAdvice
+				.stream()
+				.filter(advice -> advice.supports(parameter, targetType, readerType))
+				.forEach(advice -> hints.putAll(advice.getHints(parameter, targetType, readerType))
+		);
+		return hints;
+	}
+
+	@Override
+	public ReactiveHttpInputMessage beforeRead(ReactiveHttpInputMessage request, MethodParameter parameter,
+			ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType) {
+
+		for (RequestBodyAdvice advice : this.requestBodyAdvice) {
+			if (advice.supports(parameter, targetType, readerType)) {
+				request = advice.beforeRead(request, parameter, targetType, readerType);
+			}
+		}
+		return request;
+	}
+
+	@Override
+	public Flux<Object> afterRead(Flux<Object> body, ReactiveHttpInputMessage inputMessage, MethodParameter parameter,
+			ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType) {
+
+		for (RequestBodyAdvice advice : this.requestBodyAdvice) {
+			if (advice.supports(parameter, targetType, readerType)) {
+				body = advice.afterRead(body, inputMessage, parameter, targetType, readerType);
+			}
+		}
+		return body;
+	}
+
+	@Override
+	public Mono<Object> afterReadMono(Mono<Object> body, ReactiveHttpInputMessage inputMessage,
+			MethodParameter parameter, ResolvableType targetType, Class<? extends HttpMessageReader<?>> readerType) {
+
+		for (RequestBodyAdvice advice : this.requestBodyAdvice) {
+			if (advice.supports(parameter, targetType, readerType)) {
+				body = advice.afterReadMono(body, inputMessage, parameter, targetType, readerType);
+			}
+		}
+		return body;
+	}
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyArgumentResolver.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestBodyArgumentResolver.java
@@ -69,6 +69,19 @@ public class RequestBodyArgumentResolver extends AbstractMessageReaderArgumentRe
 		super(readers, validator, adapterRegistry);
 	}
 
+	/**
+	 * Constructor that also accepts a {@link ReactiveAdapterRegistry} and a list of {@link RequestBodyAdvice}.
+	 * @param readers readers for de-serializing the request body with
+	 * @param validator validator to validate decoded objects with
+	 * @param adapterRegistry for adapting to other reactive types from Flux and Mono
+	 * @param bodyAdvice body advice to customize the request
+	 */
+	public RequestBodyArgumentResolver(List<HttpMessageReader<?>> readers, Validator validator,
+			ReactiveAdapterRegistry adapterRegistry, List<RequestBodyAdvice> bodyAdvice) {
+
+		super(readers, validator, adapterRegistry, bodyAdvice);
+	}
+
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerAdapter.java
@@ -67,6 +67,8 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, BeanFactory
 
 	private final List<HttpMessageReader<?>> messageReaders = new ArrayList<>(10);
 
+	private final List<RequestBodyAdvice> requestBodyAdvice = new ArrayList<>();
+
 	private ReactiveAdapterRegistry reactiveAdapters = new ReactiveAdapterRegistry();
 
 	private ConversionService conversionService = new DefaultFormattingConversionService();
@@ -127,6 +129,17 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, BeanFactory
 	 */
 	public List<HttpMessageReader<?>> getMessageReaders() {
 		return this.messageReaders;
+	}
+
+	/**
+	 * Add one or more {@code RequestBodyAdvice} instances to intercept the
+	 * request before it is read and converted for {@code @RequestBody} and
+	 * {@code HttpEntity} method arguments.
+	 */
+	public void setRequestBodyAdvice(List<RequestBodyAdvice> requestBodyAdvice) {
+		if (requestBodyAdvice != null) {
+			this.requestBodyAdvice.addAll(requestBodyAdvice);
+		}
 	}
 
 	public void setReactiveAdapterRegistry(ReactiveAdapterRegistry registry) {
@@ -206,7 +219,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, BeanFactory
 		resolvers.add(new RequestParamMapMethodArgumentResolver());
 		resolvers.add(new PathVariableMethodArgumentResolver(cs, getBeanFactory()));
 		resolvers.add(new PathVariableMapMethodArgumentResolver());
-		resolvers.add(new RequestBodyArgumentResolver(getMessageReaders(), getValidator(), adapterRegistry));
+		resolvers.add(new RequestBodyArgumentResolver(getMessageReaders(), getValidator(), adapterRegistry, this.requestBodyAdvice));
 		resolvers.add(new RequestHeaderMethodArgumentResolver(cs, getBeanFactory()));
 		resolvers.add(new RequestHeaderMapMethodArgumentResolver());
 		resolvers.add(new CookieValueMethodArgumentResolver(cs, getBeanFactory()));
@@ -215,7 +228,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, BeanFactory
 		resolvers.add(new RequestAttributeMethodArgumentResolver(cs , getBeanFactory()));
 
 		// Type-based argument resolution
-		resolvers.add(new HttpEntityArgumentResolver(getMessageReaders(), getValidator(), adapterRegistry));
+		resolvers.add(new HttpEntityArgumentResolver(getMessageReaders(), getValidator(), adapterRegistry, this.requestBodyAdvice));
 		resolvers.add(new ModelArgumentResolver());
 		resolvers.add(new ServerWebExchangeArgumentResolver());
 

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyAdvice.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyAdvice.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+
+/**
+ * Allows customizing the response after the execution of an {@code @ResponseBody}
+ * or a {@code ResponseEntity} controller method but before the body is written
+ * with an {@code HttpMessageConverter}.
+ *
+ * <p>Implementations may be may be registered directly with
+ * {@code RequestMappingHandlerAdapter} and {@code ExceptionHandlerExceptionResolver}
+ * or more likely annotated with {@code @ControllerAdvice} in which case they
+ * will be auto-detected by both.
+ *
+ * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public interface ResponseBodyAdvice {
+
+	/**
+	 * Whether this component supports the given controller method return type
+	 * and the selected {@code HttpMessageConverter} type.
+	 * @param returnType the return type
+	 * @param writerType the selected writer type
+	 * @return {@code true} if {@link #beforeBodyWrite} should be invoked, {@code false} otherwise
+	 */
+	boolean supports(MethodParameter returnType, Class<? extends HttpMessageWriter<?>> writerType);
+
+	/**
+	 * Return hints that can be used to customize how the body should be written
+	 * @return Additional information about how to write the body
+	 */
+	default Map<String, Object> getHints(MethodParameter returnType, ResolvableType targetType,
+			Class<? extends HttpMessageWriter<?>> writerType) {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Invoked after an {@code HttpMessageConverter} is selected and just before
+	 * its write method is invoked.
+	 * @param body the body stream to be written
+	 * @param returnType the return type of the controller method
+	 * @param selectedContentType the content type selected through content negotiation
+	 * @param selectedWriterType the converter type selected to write to the response
+	 * @param response the current HTTP response
+	 *
+	 * @return the body stream that was passed in or a modified, possibly new instance
+	 */
+	default Publisher<Object> beforeBodyWrite(Publisher<Object> body, MethodParameter returnType,
+			MediaType selectedContentType, Class<? extends HttpMessageWriter<?>> selectedWriterType,
+			ServerHttpResponse response) {
+		return body;
+	}
+
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyAdviceChain.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyAdviceChain.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.method.ControllerAdviceBean;
+
+/**
+ * Invokes {@link RequestBodyAdvice} and {@link ResponseBodyAdvice} where each
+ * instance may be (and is most likely) wrapped with
+ * {@link ControllerAdviceBean ControllerAdviceBean}.
+ *
+ * @author Sebastien Deleuze
+ * @author Rossen Stoyanchev
+ * @since 5.0
+ */
+class ResponseBodyAdviceChain implements ResponseBodyAdvice {
+
+	private final List<ResponseBodyAdvice> responseBodyAdvice = new ArrayList<>(4);
+
+
+	/**
+	 * Create an instance from a list of {@code ResponseBodyAdvice}.
+	 */
+	public ResponseBodyAdviceChain(List<ResponseBodyAdvice> responseBodyAdvice) {
+		this.responseBodyAdvice.addAll(responseBodyAdvice);
+	}
+
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageWriter<?>> writerType) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public Map<String, Object> getHints(MethodParameter returnType, ResolvableType targetType,
+			Class<? extends HttpMessageWriter<?>> writerType) {
+
+		Map<String, Object> hints = new HashMap<>();
+		this.responseBodyAdvice
+				.stream()
+				.filter(advice -> advice.supports(returnType, writerType))
+				.forEach(advice -> hints.putAll(advice.getHints(returnType, targetType, writerType))
+		);
+		return hints;
+	}
+
+	@Override
+	public Publisher<Object> beforeBodyWrite(Publisher<Object> body, MethodParameter returnType, MediaType contentType,
+			Class<? extends HttpMessageWriter<?>> writerType, ServerHttpResponse response) {
+
+		for (ResponseBodyAdvice advice : this.responseBodyAdvice) {
+			if (advice.supports(returnType, writerType)) {
+				body = advice.beforeBodyWrite(body, returnType, contentType, writerType, response);
+			}
+		}
+		return body;
+	}
+
+}

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyResultHandler.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseBodyResultHandler.java
@@ -16,8 +16,8 @@
 
 package org.springframework.web.reactive.result.method.annotation;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import reactor.core.publisher.Mono;
 
@@ -65,7 +65,7 @@ public class ResponseBodyResultHandler extends AbstractMessageWriterResultHandle
 	public ResponseBodyResultHandler(List<HttpMessageWriter<?>> messageWriters,
 			RequestedContentTypeResolver contentTypeResolver) {
 
-		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry());
+		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry(), Collections.emptyList());
 	}
 
 	/**
@@ -80,7 +80,23 @@ public class ResponseBodyResultHandler extends AbstractMessageWriterResultHandle
 			RequestedContentTypeResolver contentTypeResolver,
 			ReactiveAdapterRegistry adapterRegistry) {
 
-		super(messageWriters, contentTypeResolver, adapterRegistry);
+		this(messageWriters, contentTypeResolver, adapterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Constructor with additional {@link ReactiveAdapterRegistry} and list of {@link ResponseBodyAdvice}
+	 *
+	 * @param messageWriters writers for serializing to the response body stream
+	 * @param contentTypeResolver for resolving the requested content type
+	 * @param adapterRegistry for adapting other reactive types (e.g. rx.Observable,
+	 * rx.Single, etc.) to Flux or Mono
+	 * @param bodyAdvice body advice to customize the response
+	 */
+	public ResponseBodyResultHandler(List<HttpMessageWriter<?>> messageWriters,
+			RequestedContentTypeResolver contentTypeResolver,
+			ReactiveAdapterRegistry adapterRegistry, List<ResponseBodyAdvice> bodyAdvice) {
+
+		super(messageWriters, contentTypeResolver, adapterRegistry, bodyAdvice);
 		setOrder(100);
 	}
 

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandler.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandler.java
@@ -17,6 +17,7 @@ package org.springframework.web.reactive.result.method.annotation;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,7 +64,7 @@ public class ResponseEntityResultHandler extends AbstractMessageWriterResultHand
 	public ResponseEntityResultHandler(List<HttpMessageWriter<?>> messageWriters,
 			RequestedContentTypeResolver contentTypeResolver) {
 
-		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry());
+		this(messageWriters, contentTypeResolver, new ReactiveAdapterRegistry(), Collections.emptyList());
 	}
 
 	/**
@@ -78,7 +79,23 @@ public class ResponseEntityResultHandler extends AbstractMessageWriterResultHand
 			RequestedContentTypeResolver contentTypeResolver,
 			ReactiveAdapterRegistry adapterRegistry) {
 
-		super(messageWriters, contentTypeResolver, adapterRegistry);
+		this(messageWriters, contentTypeResolver, adapterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Constructor with additional {@link ReactiveAdapterRegistry} and list of {@link ResponseBodyAdvice}.
+	 *
+	 * @param messageWriters writers for serializing to the response body stream
+	 * @param contentTypeResolver for resolving the requested content type
+	 * @param adapterRegistry for adapting other reactive types (e.g. rx.Observable,
+	 * rx.Single, etc.) to Flux or Mono
+	 * @param bodyAdvice body advice to customize the response
+	 */
+	public ResponseEntityResultHandler(List<HttpMessageWriter<?>> messageWriters,
+			RequestedContentTypeResolver contentTypeResolver,
+			ReactiveAdapterRegistry adapterRegistry, List<ResponseBodyAdvice> bodyAdvice) {
+
+		super(messageWriters, contentTypeResolver, adapterRegistry, bodyAdvice);
 		setOrder(0);
 	}
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestResponseBodyAdviceIntegrationTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestResponseBodyAdviceIntegrationTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.config.WebReactiveConfiguration;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class RequestResponseBodyAdviceIntegrationTests extends AbstractRequestMappingIntegrationTests {
+
+	@Override
+	protected ApplicationContext initApplicationContext() {
+		AnnotationConfigApplicationContext wac = new AnnotationConfigApplicationContext();
+		wac.register(WebConfig.class);
+		wac.refresh();
+		return wac;
+	}
+
+	@Test
+	public void jsonViewResponse() throws Exception {
+		String expected = "{\"withView1\":\"with\"}";
+		assertEquals(expected, performGet("/response/raw", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithMonoResponse() throws Exception {
+		String expected = "{\"withView1\":\"with\"}";
+		assertEquals(expected, performGet("/response/mono", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithFluxResponse() throws Exception {
+		String expected = "[{\"withView1\":\"with\"},{\"withView1\":\"with\"}]";
+		assertEquals(expected, performGet("/response/flux", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithRequest() throws Exception {
+		String expected = "{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}";
+		assertEquals(expected, performPost("/request/raw", MediaType.APPLICATION_JSON,
+				new JacksonViewBean("with", "with", "without"), MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithMonoRequest() throws Exception {
+		String expected = "{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}";
+		assertEquals(expected, performPost("/request/mono", MediaType.APPLICATION_JSON,
+				new JacksonViewBean("with", "with", "without"), MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithFluxRequest() throws Exception {
+		String expected = "[{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}," +
+				"{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}]";
+		List<JacksonViewBean> beans = Arrays.asList(new JacksonViewBean("with", "with", "without"), new JacksonViewBean("with", "with", "without"));
+		assertEquals(expected, performPost("/request/flux", MediaType.APPLICATION_JSON, beans,
+				MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+
+	@Configuration
+	@ComponentScan(resourcePattern = "**/RequestResponseBodyAdviceIntegrationTests*.class")
+	@SuppressWarnings({"unused", "WeakerAccess"})
+	static class WebConfig extends WebReactiveConfiguration {
+	}
+
+	@RestController
+	@SuppressWarnings("unused")
+	private static class JsonViewRestController {
+
+		@GetMapping("/response/raw")
+		@JsonView(MyJacksonView1.class)
+		public JacksonViewBean rawResponse() {
+			return new JacksonViewBean("with", "with", "without");
+		}
+
+		@GetMapping("/response/mono")
+		@JsonView(MyJacksonView1.class)
+		public Mono<JacksonViewBean> monoResponse() {
+			return Mono.just(new JacksonViewBean("with", "with", "without"));
+		}
+
+		@GetMapping("/response/flux")
+		@JsonView(MyJacksonView1.class)
+		public Flux<JacksonViewBean> fluxResponse() {
+			return Flux.just(new JacksonViewBean("with", "with", "without"), new JacksonViewBean("with", "with", "without"));
+		}
+
+		@PostMapping("/request/raw")
+		public JacksonViewBean rawRequest(@JsonView(MyJacksonView1.class) @RequestBody JacksonViewBean bean) {
+			return bean;
+		}
+
+		@PostMapping("/request/mono")
+		public Mono<JacksonViewBean> monoRequest(@JsonView(MyJacksonView1.class) @RequestBody Mono<JacksonViewBean> mono) {
+			return mono;
+		}
+
+		@PostMapping("/request/flux")
+		public Flux<JacksonViewBean> fluxRequest(@JsonView(MyJacksonView1.class) @RequestBody Flux<JacksonViewBean> flux) {
+			return flux;
+		}
+
+	}
+
+	private interface MyJacksonView1 {}
+
+	private interface MyJacksonView2 {}
+
+
+	@SuppressWarnings("unused")
+	private static class JacksonViewBean {
+
+		@JsonView(MyJacksonView1.class)
+		private String withView1;
+
+		@JsonView(MyJacksonView2.class)
+		private String withView2;
+
+		private String withoutView;
+
+
+		public JacksonViewBean() {
+		}
+
+		public JacksonViewBean(String withView1, String withView2, String withoutView) {
+			this.withView1 = withView1;
+			this.withView2 = withView2;
+			this.withoutView = withoutView;
+		}
+
+		public String getWithView1() {
+			return withView1;
+		}
+
+		public void setWithView1(String withView1) {
+			this.withView1 = withView1;
+		}
+
+		public String getWithView2() {
+			return withView2;
+		}
+
+		public void setWithView2(String withView2) {
+			this.withView2 = withView2;
+		}
+
+		public String getWithoutView() {
+			return withoutView;
+		}
+
+		public void setWithoutView(String withoutView) {
+			this.withoutView = withoutView;
+		}
+	}
+
+}


### PR DESCRIPTION
In order to continue the discussion began in [SPR-14557](https://jira.spring.io/browse/SPR-14557) and PR https://github.com/spring-projects/spring-framework/pull/1163, here is a proposal to provide hints like `@JsonView` from annotated controllers to codecs.

I have proposed this mechanism because I think:
- We need a pluggable mechanism
- I guess `Request/ResponseBodyAdvice` will still be needed in Reactive world, and hints are related to request/response body
- I am not in favor using `ResolvableType` source because to do so we need to pass the stream type and not just the element type to the codecs, and that create some issues by exposing specific Reactive type information (dealing with `Foo` versus Flux<Foo>`versus`Observable<Foo>`) at codec level)
- I am in favor of handling hints in a consistent way for our 3 main use cases : annotation based controller model, new functional model introduced by [SPR-12954](https://jira.spring.io/browse/SPR-12954) and the new Reactive HTTP client at codec level.

A possible alternative is to provide a lighter pluggable mechanism specific to providing hints.

Thanks in advance for your feedbacks.
