### PR TITLE
Simpler solution to provide hints

### DIFF
--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfiguration.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfiguration.java
@@ -60,6 +60,8 @@ import org.springframework.web.reactive.accept.RequestedContentTypeResolverBuild
 import org.springframework.web.reactive.handler.AbstractHandlerMapping;
 import org.springframework.web.reactive.result.SimpleHandlerAdapter;
 import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.http.codec.Jackson2ServerHttpMessageReader;
+import org.springframework.http.codec.Jackson2ServerHttpMessageWriter;
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.reactive.result.method.annotation.ResponseBodyResultHandler;
@@ -286,7 +288,7 @@ public class WebReactiveConfiguration implements ApplicationContextAware {
 			readers.add(new DecoderHttpMessageReader<>(new Jaxb2XmlDecoder()));
 		}
 		if (jackson2Present) {
-			readers.add(new DecoderHttpMessageReader<>(new Jackson2JsonDecoder()));
+			readers.add(new Jackson2ServerHttpMessageReader(new  DecoderHttpMessageReader<>(new Jackson2JsonDecoder())));
 		}
 	}
 
@@ -404,10 +406,10 @@ public class WebReactiveConfiguration implements ApplicationContextAware {
 		}
 		if (jackson2Present) {
 			Jackson2JsonEncoder jacksonEncoder = new Jackson2JsonEncoder();
-			writers.add(new EncoderHttpMessageWriter<>(jacksonEncoder));
+			writers.add(new Jackson2ServerHttpMessageWriter(new EncoderHttpMessageWriter<>(jacksonEncoder)));
 			sseDataEncoders.add(jacksonEncoder);
 		}
-		writers.add(new ServerSentEventHttpMessageWriter(sseDataEncoders));
+		writers.add(new Jackson2ServerHttpMessageWriter(new ServerSentEventHttpMessageWriter(sseDataEncoders)));
 	}
 	/**
 	 * Override this to modify the list of message writers after it has been

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/JacksonHintsIntegrationTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/JacksonHintsIntegrationTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.config.WebReactiveConfiguration;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class JacksonHintsIntegrationTests extends AbstractRequestMappingIntegrationTests {
+
+	@Override
+	protected ApplicationContext initApplicationContext() {
+		AnnotationConfigApplicationContext wac = new AnnotationConfigApplicationContext();
+		wac.register(WebConfig.class);
+		wac.refresh();
+		return wac;
+	}
+
+	@Test
+	public void jsonViewResponse() throws Exception {
+		String expected = "{\"withView1\":\"with\"}";
+		assertEquals(expected, performGet("/response/raw", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithMonoResponse() throws Exception {
+		String expected = "{\"withView1\":\"with\"}";
+		assertEquals(expected, performGet("/response/mono", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithFluxResponse() throws Exception {
+		String expected = "[{\"withView1\":\"with\"},{\"withView1\":\"with\"}]";
+		assertEquals(expected, performGet("/response/flux", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithRequest() throws Exception {
+		String expected = "{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}";
+		assertEquals(expected, performPost("/request/raw", MediaType.APPLICATION_JSON,
+				new JacksonViewBean("with", "with", "without"), MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithMonoRequest() throws Exception {
+		String expected = "{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}";
+		assertEquals(expected, performPost("/request/mono", MediaType.APPLICATION_JSON,
+				new JacksonViewBean("with", "with", "without"), MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test
+	public void jsonViewWithFluxRequest() throws Exception {
+		String expected = "[{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}," +
+				"{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}]";
+		List<JacksonViewBean> beans = Arrays.asList(new JacksonViewBean("with", "with", "without"), new JacksonViewBean("with", "with", "without"));
+		assertEquals(expected, performPost("/request/flux", MediaType.APPLICATION_JSON, beans,
+				MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+
+	@Configuration
+	@ComponentScan(resourcePattern = "**/JacksonHintsIntegrationTests*.class")
+	@SuppressWarnings({"unused", "WeakerAccess"})
+	static class WebConfig extends WebReactiveConfiguration {
+	}
+
+	@RestController
+	@SuppressWarnings("unused")
+	private static class JsonViewRestController {
+
+		@GetMapping("/response/raw")
+		@JsonView(MyJacksonView1.class)
+		public JacksonViewBean rawResponse() {
+			return new JacksonViewBean("with", "with", "without");
+		}
+
+		@GetMapping("/response/mono")
+		@JsonView(MyJacksonView1.class)
+		public Mono<JacksonViewBean> monoResponse() {
+			return Mono.just(new JacksonViewBean("with", "with", "without"));
+		}
+
+		@GetMapping("/response/flux")
+		@JsonView(MyJacksonView1.class)
+		public Flux<JacksonViewBean> fluxResponse() {
+			return Flux.just(new JacksonViewBean("with", "with", "without"), new JacksonViewBean("with", "with", "without"));
+		}
+
+		@PostMapping("/request/raw")
+		public JacksonViewBean rawRequest(@JsonView(MyJacksonView1.class) @RequestBody JacksonViewBean bean) {
+			return bean;
+		}
+
+		@PostMapping("/request/mono")
+		public Mono<JacksonViewBean> monoRequest(@JsonView(MyJacksonView1.class) @RequestBody Mono<JacksonViewBean> mono) {
+			return mono;
+		}
+
+		@PostMapping("/request/flux")
+		public Flux<JacksonViewBean> fluxRequest(@JsonView(MyJacksonView1.class) @RequestBody Flux<JacksonViewBean> flux) {
+			return flux;
+		}
+
+	}
+
+	private interface MyJacksonView1 {}
+
+	private interface MyJacksonView2 {}
+
+
+	@SuppressWarnings("unused")
+	private static class JacksonViewBean {
+
+		@JsonView(MyJacksonView1.class)
+		private String withView1;
+
+		@JsonView(MyJacksonView2.class)
+		private String withView2;
+
+		private String withoutView;
+
+
+		public JacksonViewBean() {
+		}
+
+		public JacksonViewBean(String withView1, String withView2, String withoutView) {
+			this.withView1 = withView1;
+			this.withView2 = withView2;
+			this.withoutView = withoutView;
+		}
+
+		public String getWithView1() {
+			return withView1;
+		}
+
+		public void setWithView1(String withView1) {
+			this.withView1 = withView1;
+		}
+
+		public String getWithView2() {
+			return withView2;
+		}
+
+		public void setWithView2(String withView2) {
+			this.withView2 = withView2;
+		}
+
+		public String getWithoutView() {
+			return withoutView;
+		}
+
+		public void setWithoutView(String withoutView) {
+			this.withoutView = withoutView;
+		}
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/AbstractServerHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/AbstractServerHttpMessageReader.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec;
+
+import java.util.List;
+import java.util.Map;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpInputMessage;
+
+/**
+ * {@link HttpMessageReader} wrapper to extend that implements {@link ServerHttpMessageReader} in order
+ * to allow providing hints.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public abstract class AbstractServerHttpMessageReader<T> implements ServerHttpMessageReader<T> {
+
+	private HttpMessageReader<T> reader;
+
+
+	public AbstractServerHttpMessageReader(HttpMessageReader<T> reader) {
+		this.reader = reader;
+	}
+
+	@Override
+	public boolean canRead(ResolvableType elementType, MediaType mediaType, Map<String, Object> hints) {
+		return this.reader.canRead(elementType, mediaType, hints);
+	}
+
+	@Override
+	public Flux<T> read(ResolvableType elementType, ReactiveHttpInputMessage inputMessage, Map<String, Object> hints) {
+		return this.reader.read(elementType, inputMessage, hints);
+	}
+
+	@Override
+	public Mono<T> readMono(ResolvableType elementType, ReactiveHttpInputMessage inputMessage, Map<String, Object> hints) {
+		return this.reader.readMono(elementType, inputMessage, hints);
+	}
+
+	@Override
+	public List<MediaType> getReadableMediaTypes() {
+		return this.reader.getReadableMediaTypes();
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/AbstractServerHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/AbstractServerHttpMessageWriter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec;
+
+import java.util.List;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpOutputMessage;
+
+/**
+ * {@link HttpMessageWriter} wrapper to extend that implements {@link ServerHttpMessageWriter} in order
+ * to allow providing hints.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public abstract class AbstractServerHttpMessageWriter<T> implements ServerHttpMessageWriter<T> {
+
+	private HttpMessageWriter<T> writer;
+
+
+	public AbstractServerHttpMessageWriter(HttpMessageWriter<T> writer) {
+		this.writer = writer;
+	}
+
+	@Override
+	public boolean canWrite(ResolvableType elementType, MediaType mediaType, Map<String, Object> hints) {
+		return this.writer.canWrite(elementType, mediaType, hints);
+	}
+
+	@Override
+	public Mono<Void> write(Publisher<? extends T> inputStream, ResolvableType elementType, MediaType mediaType, ReactiveHttpOutputMessage outputMessage, Map<String, Object> hints) {
+		return this.writer.write(inputStream, elementType, mediaType, outputMessage, hints);
+	}
+
+	@Override
+	public List<MediaType> getWritableMediaTypes() {
+		return this.writer.getWritableMediaTypes();
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/Jackson2ServerHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/Jackson2ServerHttpMessageReader.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.json.AbstractJackson2Codec;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * Jackson 2 {@link ServerHttpMessageReader} that resolves those annotation or request based hints:
+ * <ul>
+ *   <li>{@code @JsonView} + {@code @RequestBody} annotated handler method parameter</li>
+ * </ul>
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ * @see com.fasterxml.jackson.annotation.JsonView
+ */
+public class Jackson2ServerHttpMessageReader extends AbstractServerHttpMessageReader<Object> {
+
+	public Jackson2ServerHttpMessageReader(HttpMessageReader<Object> reader) {
+		super(reader);
+	}
+
+	@Override
+	public Map<String, Object> resolveHints(ResolvableType streamType, ResolvableType elementType, MediaType mediaType, ServerHttpRequest request) {
+		Object source = streamType.getSource();
+		MethodParameter parameter = (source instanceof MethodParameter ? (MethodParameter)source : null);
+		if (parameter != null) {
+			JsonView annotation = parameter.getParameterAnnotation(JsonView.class);
+			if (annotation != null) {
+				Class<?>[] classes = annotation.value();
+				if (classes.length != 1) {
+					throw new IllegalArgumentException(
+							"@JsonView only supported for reading hints with exactly 1 class argument: " + parameter);
+				}
+				return Collections.singletonMap(AbstractJackson2Codec.JSON_VIEW_HINT, classes[0]);
+			}
+		}
+		return Collections.emptyMap();
+	}
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/Jackson2ServerHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/Jackson2ServerHttpMessageWriter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.json.AbstractJackson2Codec;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * Jackson 2 {@link ServerHttpMessageWriter} that resolves those annotation or request based hints:
+ * <ul>
+ *   <li>{@code @JsonView} annotated handler method</li>
+ * </ul>
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ * @see com.fasterxml.jackson.annotation.JsonView
+ */
+public class Jackson2ServerHttpMessageWriter extends AbstractServerHttpMessageWriter<Object> {
+
+	public Jackson2ServerHttpMessageWriter(HttpMessageWriter<Object> writer) {
+		super(writer);
+	}
+
+	@Override
+	public Map<String, Object> resolveHints(ResolvableType streamType, ResolvableType elementType, MediaType mediaType, ServerHttpRequest request) {
+		Object source = streamType.getSource();
+		MethodParameter returnValue = (source instanceof MethodParameter ? (MethodParameter)source : null);
+		if (returnValue != null) {
+			JsonView annotation = returnValue.getMethodAnnotation(JsonView.class);
+			if (annotation != null) {
+				Class<?>[] classes = annotation.value();
+				if (classes.length != 1) {
+					throw new IllegalArgumentException(
+							"@JsonView only supported for writing hints with exactly 1 class argument: " + returnValue);
+				}
+				return Collections.singletonMap(AbstractJackson2Codec.JSON_VIEW_HINT, classes[0]);
+			}
+		}
+		return Collections.emptyMap();
+	}
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/ServerHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerHttpMessageReader.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec;
+
+import java.util.Map;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * Server and annotation based controller specific {@link HttpMessageReader} that allows to
+ * resolve hints using annotations or request based information.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public interface ServerHttpMessageReader<T> extends HttpMessageReader<T> {
+
+	/**
+	 * Return hints that can be used to customize how the body should be read
+	 * @param streamType the original type used in the method parameter. For annotation
+	 * based controllers, the {@link MethodParameter} is available via {@link ResolvableType#getSource()}.
+	 * @param elementType the stream element type to return
+	 * @param mediaType the media type to read, can be {@code null} if not specified.
+	 * Typically the value of a {@code Content-Type} header.
+
+	 * @param request the current HTTP request
+	 * annotation based controllers for example.
+	 * @return Additional information about how to read the body
+	 */
+	Map<String, Object> resolveHints(ResolvableType streamType, ResolvableType elementType,
+			MediaType mediaType, ServerHttpRequest request);
+
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/ServerHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerHttpMessageWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec;
+
+import java.util.Map;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * Server oriented {@link HttpMessageWriter} that allows to resolve hints using annotations or
+ * request based information.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public interface ServerHttpMessageWriter<T> extends HttpMessageWriter<T> {
+
+	/**
+	 * Return hints that can be used to customize how the body should be written
+	 * @param streamType the original type used for the method return value. For annotation
+	 * based controllers, the {@link MethodParameter} is available via {@link ResolvableType#getSource()}.
+	 * @param elementType the stream element type to process
+	 * @param mediaType the content type to use when writing. May be {@code null} to
+	 * indicate that the default content type of the converter must be used.
+	 * @param request the current HTTP request
+	 *
+	 * @return Additional information about how to write the body
+	 */
+	Map<String, Object> resolveHints(ResolvableType streamType, ResolvableType elementType,
+			MediaType mediaType, ServerHttpRequest request);
+
+}


### PR DESCRIPTION
As proposed by @rstoyanchev, here is a draft PR that allow to provide hints without implementing `Request/ResponseBodyAdvice`. I have used an `Object source` parameter to allow using this mechanism for the HTTP client and the server functional programming model if need, without exposed `MethodParameter` in the codec/reader/writer API.

Any thoughts?
