### PR TITLE
corrected punctuation in "PropertySource abstraction" chapter

### DIFF
--- a/src/asciidoc/core-beans.adoc
+++ b/src/asciidoc/core-beans.adoc
@@ -7597,6 +7597,7 @@ but rather completely overridden by a preceding entry.
 
 For a common `StandardServletEnvironment`, the full hierarchy looks as follows, with the
 highest-precedence entries at the top:
+
 * ServletConfig parameters (if applicable, e.g. in case of a `DispatcherServlet` context)
 * ServletContext parameters (web.xml context-param entries)
 * JNDI environment variables ("java:comp/env/" entries)


### PR DESCRIPTION
Punctuation was broken in TIP section in "PropertySource abstraction" chapter - everything was rendered in single line. 
