### PR TITLE
Consider servlet context path in path matching

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,5 +39,15 @@ public interface HttpRequest extends HttpMessage {
 	 * @return the URI of the request (never {@code null})
 	 */
 	URI getURI();
+
+	/**
+	 * Return the path of the request.
+	 * <p>Default implementation returns {@link URI#getRawPath()} of the URI provided by
+	 * {@link #getURI()}.
+	 * @return the path of the request
+	 */
+	default String getPath() {
+		return getURI().getRawPath();
+	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpRequest.java
@@ -91,6 +91,22 @@ public class ServletServerHttpRequest extends AbstractServerHttpRequest {
 		return new URI(url.toString());
 	}
 
+	/**
+	 * This implementation strips off the {@linkplain HttpServletRequest#getContextPath() context path}
+	 * from the {@link URI#getRawPath()} of the URI provided by {@link #getURI()}.
+	 */
+	@Override
+	public String getPath() {
+		String rawPath = getURI().getRawPath();
+		String contextPath = this.request.getContextPath();
+		if (!StringUtils.isEmpty(contextPath) && rawPath.startsWith(contextPath)) {
+			return rawPath.substring(contextPath.length());
+		}
+		else {
+			return rawPath;
+		}
+	}
+
 	@Override
 	protected HttpHeaders initHeaders() {
 		HttpHeaders headers = new HttpHeaders();

--- a/spring-web/src/main/java/org/springframework/web/util/HttpRequestPathHelper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HttpRequestPathHelper.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.web.util;
 
 import java.io.UnsupportedEncodingException;
@@ -54,7 +55,7 @@ public class HttpRequestPathHelper {
 
 
 	public String getLookupPathForRequest(ServerWebExchange exchange) {
-		String path = exchange.getRequest().getURI().getRawPath();
+		String path = exchange.getRequest().getPath();
 		return (this.shouldUrlDecode() ? decode(exchange, path) : path);
 	}
 


### PR DESCRIPTION
Prior to this commit, the reactive HttpRequestPathHelper used the path
as returned from HttpRequest.getURI().getRawPath() as lookup path.
However, when running in a servlet environment, this lookup path
represents the entire path (including servlet context), which is not
desirable.

This commit adds a getPath() method to HttpRequest, defaulting to return
getURI().getRawPath(), but with an override in ServletServerHttpRequest
to return the proper lookup path (obtained from UrlPathHelper).

Issue: SPR-14714
