### PR TITLE
SPR-5503 - Fix get message from resource of basename with dots and refactor license ResourceBundleMessageSourceTests

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/ReloadableResourceBundleMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/ReloadableResourceBundleMessageSource.java
@@ -16,6 +16,7 @@
 
 package org.springframework.context.support;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -397,6 +398,13 @@ public class ReloadableResourceBundleMessageSource extends AbstractResourceBased
 		Resource resource = this.resourceLoader.getResource(filename + PROPERTIES_SUFFIX);
 		if (!resource.exists()) {
 			resource = this.resourceLoader.getResource(filename + XML_SUFFIX);
+		}
+		if (!resource.exists()) {
+			String fileNameFromDoted = filename.replace((char) 46, File.separatorChar);
+			resource = this.resourceLoader.getResource(fileNameFromDoted + PROPERTIES_SUFFIX);
+			if (!resource.exists()) {
+				resource = this.resourceLoader.getResource(fileNameFromDoted + XML_SUFFIX);
+			}
 		}
 
 		if (resource.exists()) {

--- a/spring-context/src/test/java/org/springframework/context/support/ResourceBundleMessageSourceTests.java
+++ b/spring-context/src/test/java/org/springframework/context/support/ResourceBundleMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ public class ResourceBundleMessageSourceTests {
 			pvs.add("alwaysUseMessageFormat", Boolean.TRUE);
 		}
 		Class<?> clazz = reloadable ?
-				(Class<?>) ReloadableResourceBundleMessageSource.class : ResourceBundleMessageSource.class;
+				ReloadableResourceBundleMessageSource.class : ResourceBundleMessageSource.class;
 		ac.registerSingleton("messageSource", clazz, pvs);
 		ac.refresh();
 
@@ -362,6 +362,13 @@ public class ResourceBundleMessageSourceTests {
 		ms.setFileEncodings(fileCharsets);
 		assertEquals("message1", ms.getMessage("code1", null, Locale.ENGLISH));
 		assertEquals("message2", ms.getMessage("code2", null, Locale.GERMAN));
+	}
+
+	@Test
+	public void testReloadableResourceBundleMessageSourceFileNameDotSeparatorDefaultCharset() {
+		ReloadableResourceBundleMessageSource ms = new ReloadableResourceBundleMessageSource();
+		ms.setBasename("org.springframework.context.support.more-messages");
+		assertEquals("message3", ms.getMessage("code3", null, Locale.ENGLISH));
 	}
 
 	@Test


### PR DESCRIPTION
Fix get message from resource of basename with dots and refactor license ResourceBundleMessageSourceTests

Prior to this commit, doesn't get message from ReloadableResourceBundleMessageSource if basename exist dots but slashes, for example "package.name.messages.properties". Following that change, these names are valid for getting messages

Issue: SPR-5503
