### PR TITLE
SPR-14502 - Add ClientHttpRequestInterceptor for WebClient

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/reactive/ClientHttpRequestInterceptionChain.java
+++ b/spring-web/src/main/java/org/springframework/web/client/reactive/ClientHttpRequestInterceptionChain.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.reactive;
+
+import java.net.URI;
+import java.util.function.Consumer;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+
+/**
+ * Delegate to the next {@link ClientHttpRequestInterceptor} in the chain.
+ *
+ * @author Brian Clozel
+ * @since 5.0
+ */
+public interface ClientHttpRequestInterceptionChain {
+
+	/**
+	 * Delegate to the next {@link ClientHttpRequestInterceptor} in the chain.
+	 *
+	 * @param method the HTTP request method
+	 * @param uri the HTTP request URI
+	 * @param requestCallback a function that can customize the request
+	 * by changing the HTTP request headers with {@code HttpMessage.getHeaders()}.
+	 * @return a publisher of the resulting {@link ClientHttpResponse}
+	 */
+	Mono<ClientHttpResponse> intercept(HttpMethod method, URI uri, Consumer<? super HttpMessage> requestCallback);
+
+}

--- a/spring-web/src/main/java/org/springframework/web/client/reactive/ClientHttpRequestInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/web/client/reactive/ClientHttpRequestInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.reactive;
+
+import java.net.URI;
+import java.util.List;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+
+/**
+ * Contract for chain-based, interception processing of client http requests
+ * that may be used to implement cross-cutting requirements such
+ * as security, timeouts, caching, and others.
+ *
+ * <p>Implementations of this interface can be
+ * {@link WebClient#setInterceptors(List) registered} with the {@link WebClient}.
+ *
+ * @author Brian Clozel
+ * @see org.springframework.web.client.reactive.WebClient
+ * @since 5.0
+ */
+@FunctionalInterface
+public interface ClientHttpRequestInterceptor {
+
+	/**
+	 * Intercept the client HTTP request
+	 *
+	 * <p>The provided {@link ClientHttpRequestInterceptionChain}
+	 * instance allows the interceptor to delegate the request
+	 * to the next interceptor in the chain.
+	 *
+	 * <p>An implementation might follow this pattern:
+	 * <ol>
+	 * <li>Examine the {@link HttpMethod method} and {@link URI uri}</li>
+	 * <li>Optionally change those when delegating to the next interceptor
+	 * with the {@code ClientHttpRequestInterceptionChain}.</li>
+	 * <li>Optionally transform the HTTP message given as an
+	 * argument of the request callback in
+	 * {@code chain.intercept(method, uri, requestCallback)}.</li>
+	 * <li>Optionally transform the response before returning it.</li>
+	 * </ol>
+	 *
+	 * @param method the HTTP request method
+	 * @param uri the HTTP request URI
+	 * @param chain the request interception chain
+	 * @return a publisher of the {@link ClientHttpResponse}
+	 */
+	Mono<ClientHttpResponse> intercept(HttpMethod method, URI uri, ClientHttpRequestInterceptionChain chain);
+}

--- a/spring-web/src/test/java/org/springframework/web/client/reactive/ClientHttpRequestInterceptorTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/reactive/ClientHttpRequestInterceptorTests.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.reactive;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.springframework.web.client.reactive.ClientWebRequestBuilders.*;
+import static org.springframework.web.client.reactive.ResponseExtractors.*;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.tests.TestSubscriber;
+import org.springframework.web.client.reactive.test.MockClientHttpRequest;
+import org.springframework.web.client.reactive.test.MockClientHttpResponse;
+
+/**
+ * @author Brian Clozel
+ */
+public class ClientHttpRequestInterceptorTests {
+
+	private MockClientHttpRequest mockRequest;
+
+	private MockClientHttpResponse mockResponse;
+
+	private MockClientHttpConnector mockClientHttpConnector;
+
+	private WebClient webClient;
+
+
+	@Before
+	public void setUp() throws Exception {
+		this.mockClientHttpConnector = new MockClientHttpConnector();
+		this.webClient = new WebClient(this.mockClientHttpConnector);
+		this.mockResponse = new MockClientHttpResponse();
+		this.mockResponse.setStatus(HttpStatus.OK);
+		this.mockResponse.getHeaders().setContentType(MediaType.TEXT_PLAIN);
+		this.mockResponse.setBody("Spring Framework");
+	}
+
+	@Test
+	public void shouldExecuteInterceptors() throws Exception {
+		List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
+		interceptors.add(new NoOpInterceptor());
+		interceptors.add(new NoOpInterceptor());
+		interceptors.add(new NoOpInterceptor());
+		this.webClient.setInterceptors(interceptors);
+
+		Mono<String> result = this.webClient.perform(get("http://example.org/resource"))
+				.extract(body(String.class));
+
+		TestSubscriber.subscribe(result)
+				.assertNoError()
+				.assertValues("Spring Framework")
+				.assertComplete();
+		interceptors.stream().forEach(interceptor -> {
+			Assert.assertTrue(((NoOpInterceptor) interceptor).invoked);
+		});
+	}
+
+	@Test
+	public void shouldChangeRequest() throws Exception {
+		ClientHttpRequestInterceptor interceptor = new ClientHttpRequestInterceptor() {
+			@Override
+			public Mono<ClientHttpResponse> intercept(HttpMethod method, URI uri,
+					ClientHttpRequestInterceptionChain interception) {
+
+				return interception.intercept(HttpMethod.POST, URI.create("http://example.org/other"),
+						(request) -> {
+							request.getHeaders().set("X-Custom", "Spring Framework");
+						});
+			}
+		};
+		this.webClient.setInterceptors(Collections.singletonList(interceptor));
+
+		Mono<String> result = this.webClient.perform(get("http://example.org/resource"))
+				.extract(body(String.class));
+
+		TestSubscriber.subscribe(result)
+				.assertNoError()
+				.assertValues("Spring Framework")
+				.assertComplete();
+
+		assertThat(this.mockRequest.getMethod(), is(HttpMethod.POST));
+		assertThat(this.mockRequest.getURI().toString(), is("http://example.org/other"));
+		assertThat(this.mockRequest.getHeaders().getFirst("X-Custom"), is("Spring Framework"));
+	}
+
+	@Test
+	public void shouldShortCircuitConnector() throws Exception {
+
+		MockClientHttpResponse otherResponse = new MockClientHttpResponse();
+		otherResponse.setStatus(HttpStatus.OK);
+		otherResponse.setBody("Other content");
+
+		List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
+		interceptors.add((method, uri, interception) -> Mono.just(otherResponse));
+		interceptors.add(new NoOpInterceptor());
+		this.webClient.setInterceptors(interceptors);
+
+		Mono<String> result = this.webClient.perform(get("http://example.org/resource"))
+				.extract(body(String.class));
+
+		TestSubscriber.subscribe(result)
+				.assertNoError()
+				.assertValues("Other content")
+				.assertComplete();
+
+		assertFalse(((NoOpInterceptor) interceptors.get(1)).invoked);
+	}
+
+	private class MockClientHttpConnector implements ClientHttpConnector {
+
+		@Override
+		public Mono<ClientHttpResponse> connect(HttpMethod method, URI uri,
+				Function<? super ClientHttpRequest, Mono<Void>> requestCallback) {
+
+			mockRequest = new MockClientHttpRequest(method, uri);
+			return requestCallback.apply(mockRequest).then(Mono.just(mockResponse));
+		}
+	}
+
+
+	private static class NoOpInterceptor implements ClientHttpRequestInterceptor {
+
+		public boolean invoked = false;
+
+		@Override
+		public Mono<ClientHttpResponse> intercept(HttpMethod method, URI uri,
+				ClientHttpRequestInterceptionChain interception) {
+
+			this.invoked = true;
+			return interception.intercept(method, uri, (request) -> { });
+		}
+	}
+}

--- a/spring-web/src/test/java/org/springframework/web/client/reactive/test/MockClientHttpRequest.java
+++ b/spring-web/src/test/java/org/springframework/web/client/reactive/test/MockClientHttpRequest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.reactive.test;
+
+import java.net.URI;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.AbstractClientHttpRequest;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+
+/**
+ * Mock implementation of {@link ClientHttpRequest}.
+ * @author Brian Clozel
+ */
+public class MockClientHttpRequest extends AbstractClientHttpRequest {
+
+	private HttpMethod httpMethod;
+
+	private URI uri;
+
+	private final DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
+
+	private Publisher<DataBuffer> body;
+
+	private Publisher<Publisher<DataBuffer>> bodyWithFlushes;
+
+
+	public MockClientHttpRequest() {
+	}
+
+	public MockClientHttpRequest(HttpMethod httpMethod, String uri) {
+		this(httpMethod, (uri != null ? URI.create(uri) : null));
+	}
+
+	public MockClientHttpRequest(HttpMethod httpMethod, URI uri) {
+		super();
+		this.httpMethod = httpMethod;
+		this.uri = uri;
+	}
+
+	@Override
+	public HttpMethod getMethod() {
+		return this.httpMethod;
+	}
+
+	public MockClientHttpRequest setMethod(HttpMethod httpMethod) {
+		this.httpMethod = httpMethod;
+		return this;
+	}
+
+	@Override
+	public URI getURI() {
+		return this.uri;
+	}
+
+	public MockClientHttpRequest setUri(String uri) {
+		this.uri = URI.create(uri);
+		return this;
+	}
+
+	public MockClientHttpRequest setUri(URI uri) {
+		this.uri = uri;
+		return this;
+	}
+
+	@Override
+	public DataBufferFactory bufferFactory() {
+		return this.bufferFactory;
+	}
+
+	@Override
+	public Mono<Void> writeWith(Publisher<DataBuffer> body) {
+		this.body = body;
+		return applyBeforeCommit().then(Flux.from(this.body).then());
+	}
+
+	@Override
+	public Mono<Void> writeAndFlushWith(Publisher<Publisher<DataBuffer>> body) {
+		this.bodyWithFlushes = body;
+		return applyBeforeCommit().then(Flux.from(this.bodyWithFlushes).then());
+	}
+
+	public Publisher<DataBuffer> getBody() {
+		return body;
+	}
+
+	public Publisher<Publisher<DataBuffer>> getBodyWithFlush() {
+		return bodyWithFlushes;
+	}
+
+	@Override
+	public Mono<Void> setComplete() {
+		return applyBeforeCommit().then();
+	}
+
+	@Override
+	protected void writeHeaders() { }
+
+	@Override
+	protected void writeCookies() { }
+}

--- a/spring-web/src/test/java/org/springframework/web/client/reactive/test/MockClientHttpResponse.java
+++ b/spring-web/src/test/java/org/springframework/web/client/reactive/test/MockClientHttpResponse.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.reactive.test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * Mock implementation of {@link ClientHttpResponse}.
+ * @author Brian Clozel
+ */
+public class MockClientHttpResponse implements ClientHttpResponse {
+
+	private HttpStatus status;
+
+	private final HttpHeaders headers = new HttpHeaders();
+
+	private final MultiValueMap<String, ResponseCookie> cookies = new LinkedMultiValueMap<>();
+
+	private Flux<DataBuffer> body = Flux.empty();
+
+	@Override
+	public HttpHeaders getHeaders() {
+		return headers;
+	}
+
+	public MockClientHttpResponse addHeader(String name, String value) {
+		getHeaders().add(name, value);
+		return this;
+	}
+
+	public MockClientHttpResponse setHeader(String name, String value) {
+		getHeaders().set(name, value);
+		return this;
+	}
+
+	@Override
+	public HttpStatus getStatusCode() {
+		return this.status;
+	}
+
+	public void setStatus(HttpStatus status) {
+		this.status = status;
+	}
+
+	@Override
+	public Flux<DataBuffer> getBody() {
+		return this.body;
+	}
+
+	public MockClientHttpResponse setBody(Publisher<DataBuffer> body) {
+		this.body = Flux.from(body);
+		return this;
+	}
+
+	public MockClientHttpResponse setBody(String body) {
+		DataBuffer buffer = toDataBuffer(body, StandardCharsets.UTF_8);
+		this.body = Flux.just(buffer);
+		return this;
+	}
+
+	public MockClientHttpResponse setBody(String body, Charset charset) {
+		DataBuffer buffer = toDataBuffer(body, charset);
+		this.body = Flux.just(buffer);
+		return this;
+	}
+
+	private DataBuffer toDataBuffer(String body, Charset charset) {
+		byte[] bytes = body.getBytes(charset);
+		ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+		return new DefaultDataBufferFactory().wrap(byteBuffer);
+	}
+
+	@Override
+	public MultiValueMap<String, ResponseCookie> getCookies() {
+		return this.cookies;
+	}
+}


### PR DESCRIPTION
`ClientHttpRequestInterceptor`s are meant for:
1. storing HTTP responses in a Cache and serving those instead of sending the actual request
2. client-side load-balancing, especially if it needs to periodically fetch the list of available nodes, or retry with another node if one fails
3. creating an authentication/authorization interceptor that fetches tokens from a 3rd party API (like an OAuth2 interceptor?)

Note that the current design does not allow to compose/modify the outgoing request body. I thought that this can ben done easily with a request post processor, whereas composing on a Publisher<DataBuffer> in an interceptor would be more complex. 

Also, there are different ways to write the request body depending on the chosen semantics at the message encoding level: request.write(Publisher<DataBuffer>) versus request.writeAndFlush(Publisher<Publisher<DataBuffer>>). This make it harder to compose the request body at the interceptor level without making the API complex.

Not exposing the request body in the interceptor may be a limiting choice in some cases, so that can still be reconsidered.
