### PR TITLE
Fixes SPR-14735: Exception during initialisaton of resource handling at WebReactiveConfiguration

### DIFF
--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfiguration.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfiguration.java
@@ -51,7 +51,9 @@ import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.http.codec.xml.Jaxb2XmlDecoder;
 import org.springframework.http.codec.xml.Jaxb2XmlEncoder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.PathMatcher;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.web.reactive.HandlerMapping;
@@ -69,6 +71,7 @@ import org.springframework.web.reactive.result.method.annotation.ResponseEntityR
 import org.springframework.web.reactive.result.view.ViewResolutionResultHandler;
 import org.springframework.web.reactive.result.view.ViewResolver;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.HttpRequestPathHelper;
 
 /**
  * The main class for Spring Web Reactive configuration.
@@ -198,12 +201,8 @@ public class WebReactiveConfiguration implements ApplicationContextAware {
 
 		AbstractHandlerMapping handlerMapping = registry.getHandlerMapping();
 		if (handlerMapping != null) {
-			if (getPathMatchConfigurer() != null) {
-				handlerMapping.setPathMatcher(getPathMatchConfigurer().getPathMatcher());
-			}
-			if (getPathMatchConfigurer() != null) {
-				handlerMapping.setPathHelper(getPathMatchConfigurer().getPathHelper());
-			}
+			handlerMapping.setPathMatcher(mvcPathMatcher());
+			handlerMapping.setPathHelper(mvcPathHelper());
 		}
 		else {
 			handlerMapping = new EmptyHandlerMapping();
@@ -216,6 +215,30 @@ public class WebReactiveConfiguration implements ApplicationContextAware {
 	 * @see ResourceHandlerRegistry
 	 */
 	protected void addResourceHandlers(ResourceHandlerRegistry registry) {
+	}
+
+	/**
+	 * Return a global {@link PathMatcher} instance for path matching
+	 * patterns in {@link HandlerMapping}s.
+	 * This instance can be configured using the {@link PathMatchConfigurer}
+	 * in {@link #configurePathMatching(PathMatchConfigurer)}.
+	 */
+	@Bean
+	public PathMatcher mvcPathMatcher() {
+		PathMatcher pathMatcher = getPathMatchConfigurer().getPathMatcher();
+		return (pathMatcher != null ? pathMatcher : new AntPathMatcher());
+	}
+
+	/**
+	 * Return a global {@link HttpRequestPathHelper} instance for path matching
+	 * patterns in {@link HandlerMapping}s.
+	 * This instance can be configured using the {@link PathMatchConfigurer}
+	 * in {@link #configurePathMatching(PathMatchConfigurer)}.
+	 */
+	@Bean
+	public HttpRequestPathHelper mvcPathHelper() {
+		HttpRequestPathHelper pathHelper = getPathMatchConfigurer().getPathHelper();
+		return (pathHelper != null ? pathHelper : new HttpRequestPathHelper());
 	}
 
 	@Bean


### PR DESCRIPTION
As explained at https://jira.spring.io/browse/SPR-14735, using the current `5.0.0.BUILD-SNAPSHOT` initialisation of static resources in a reactive web configuration class like:

``` java
    @Override
    protected void addResourceHandlers(final ResourceHandlerRegistry registry) {
        super.addResourceHandlers(registry);
        registry.addResourceHandler("/images/**").addResourceLocations("/images/");
        registry.addResourceHandler("/css/**").addResourceLocations("/css/");
        registry.addResourceHandler("/js/**").addResourceLocations("/js/");
    }
```

Results in an exception:

```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.web.reactive.HandlerMapping]: Factory method 'resourceHandlerMapping' threw exception; nested exception is java.lang.IllegalArgumentException: PathMatcher must not be null
    at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:189)
    at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:588)
    ... 63 more
Caused by: java.lang.IllegalArgumentException: PathMatcher must not be null
    at org.springframework.util.Assert.notNull(Assert.java:165)
    at org.springframework.web.reactive.handler.AbstractHandlerMapping.setPathMatcher(AbstractHandlerMapping.java:92)
    at org.springframework.web.reactive.config.WebReactiveConfiguration.resourceHandlerMapping(WebReactiveConfiguration.java:202)
```

In order to fix this, I've initialised both the _path matcher_ and the _path helper_ objects in `SpringReactiveWebConfig` in a fashion very similar to what is done at `WebMvcConfigurationSupport` for creating the equivalent objects.
