### PR TITLE
ExceptionHandlingWebHandler should log exception at "error" level

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/handler/ExceptionHandlingWebHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/server/handler/ExceptionHandlingWebHandler.java
@@ -128,7 +128,7 @@ public class ExceptionHandlingWebHandler extends WebHandlerDecorator {
 			}
 		}
 		else {
-			logger.debug("Could not complete request", ex);
+			logger.error("Could not complete request", ex);
 		}
 	}
 


### PR DESCRIPTION
This handler send status 500, so in logs should be information "why".
