### PR TITLE
EncoderHttpMessageWriter tries to send wildcard type in response header

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/EncoderHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/EncoderHttpMessageWriter.java
@@ -110,13 +110,15 @@ public class EncoderHttpMessageWriter<T> implements HttpMessageWriter<T> {
 	 * Used when {@link #write} is called without a concrete content type.
 	 *
 	 * <p>By default returns the first of {@link Encoder#getEncodableMimeTypes()
-	 * encodableMimeTypes}, if any.
+	 * encodableMimeTypes} that is concrete({@link MediaType#isConcrete()}), if any.
 	 *
 	 * @param elementType the type of element for encoding
 	 * @return the content type, or {@code null}
 	 */
 	protected MediaType getDefaultContentType(ResolvableType elementType) {
-		return (!this.writableMediaTypes.isEmpty() ? this.writableMediaTypes.get(0) : null);
+		return writableMediaTypes.stream()
+				.filter(MediaType::isConcrete)
+				.findFirst().orElse(null);
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/codec/EncoderHttpMessageWriterTest.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/EncoderHttpMessageWriterTest.java
@@ -1,0 +1,55 @@
+package org.springframework.http.codec;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.ByteBufferEncoder;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.server.reactive.test.MockServerHttpResponse;
+import org.springframework.tests.TestSubscriber;
+import org.springframework.util.MimeTypeUtils;
+
+/**
+ * Unit tests for {@link EncoderHttpMessageWriter}.
+ *
+ * @author Marcin Kamionowski
+ */
+public class EncoderHttpMessageWriterTest {
+
+	private EncoderHttpMessageWriter<ByteBuffer> writer = new EncoderHttpMessageWriter<>(new ByteBufferEncoder());
+
+	private MockServerHttpResponse response = new MockServerHttpResponse();
+
+	@Test
+	public void writableMediaTypes() throws Exception {
+		assertThat(writer.getWritableMediaTypes(), containsInAnyOrder(MimeTypeUtils.ALL));
+	}
+
+	@Test
+	public void supportedMediaTypes() throws Exception {
+		assertTrue(writer.canWrite(ResolvableType.forClass(ByteBuffer.class),
+				MediaType.ALL));
+		assertTrue(writer.canWrite(ResolvableType.forClass(ByteBuffer.class),
+				MediaType.TEXT_PLAIN));
+	}
+
+	@Test
+	public void encodeByteBuffer(){
+		String payload = "Buffer payload";
+		Mono<ByteBuffer> source = Mono.just(ByteBuffer.wrap(payload.getBytes(StandardCharsets.UTF_8)));
+
+		writer.write(source, ResolvableType.forClass(ByteBuffer.class),
+				MediaType.APPLICATION_OCTET_STREAM, response, Collections.emptyMap());
+
+		assertThat(this.response.getHeaders().getContentType(), is(MediaType.APPLICATION_OCTET_STREAM));
+		TestSubscriber.subscribe(response.getBodyAsString()).assertComplete().assertValues(payload);
+	}
+}

--- a/spring-web/src/test/java/org/springframework/http/codec/ResourceHttpMessageWriterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/ResourceHttpMessageWriterTests.java
@@ -21,17 +21,11 @@ import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferFactory;
-import org.springframework.core.io.buffer.DataBufferUtils;
-import org.springframework.core.io.buffer.support.DataBufferTestUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRange;
 import org.springframework.http.HttpStatus;
@@ -82,7 +76,7 @@ public class ResourceHttpMessageWriterTests {
 		assertThat(this.response.getHeaders().getContentLength(), is(39L));
 		assertThat(this.response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES), is("bytes"));
 
-		Mono<String> result = reduceToString(this.response.getBody(), this.response.bufferFactory());
+		Mono<String> result = response.getBodyAsString();
 		TestSubscriber.subscribe(result).assertComplete().assertValues("Spring Framework test resource content.");
 	}
 
@@ -98,7 +92,7 @@ public class ResourceHttpMessageWriterTests {
 		assertThat(this.response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES), is("bytes"));
 		assertThat(this.response.getHeaders().getContentLength(), is(6L));
 
-		Mono<String> result = reduceToString(this.response.getBody(), this.response.bufferFactory());
+		Mono<String> result = response.getBodyAsString();
 		TestSubscriber.subscribe(result).assertComplete().assertValues("Spring");
 	}
 
@@ -111,17 +105,6 @@ public class ResourceHttpMessageWriterTests {
 
 		assertThat(this.response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES), is("bytes"));
 		assertThat(this.response.getStatusCode(), is(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE));
-	}
-
-	private Mono<String> reduceToString(Publisher<DataBuffer> buffers, DataBufferFactory bufferFactory) {
-
-		return Flux.from(buffers)
-				.reduce(bufferFactory.allocateBuffer(), (previous, current) -> {
-					previous.write(current);
-					DataBufferUtils.release(current);
-					return previous;
-				})
-				.map(buffer -> DataBufferTestUtils.dumpString(buffer, StandardCharsets.UTF_8));
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/codec/ResourceRegionHttpMessageWriterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/ResourceRegionHttpMessageWriterTests.java
@@ -16,8 +16,8 @@
 
 package org.springframework.http.codec;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -28,17 +28,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferFactory;
-import org.springframework.core.io.buffer.DataBufferUtils;
-import org.springframework.core.io.buffer.support.DataBufferTestUtils;
 import org.springframework.core.io.support.ResourceRegion;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -94,7 +89,7 @@ public class ResourceRegionHttpMessageWriterTests {
 		assertThat(this.response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE), is("bytes 0-5/39"));
 		assertThat(this.response.getHeaders().getContentLength(), is(6L));
 
-		Mono<String> result = reduceToString(this.response.getBody(), this.response.bufferFactory());
+		Mono<String> result = response.getBodyAsString();
 		TestSubscriber.subscribe(result).assertComplete().assertValues("Spring");
 	}
 
@@ -118,7 +113,7 @@ public class ResourceRegionHttpMessageWriterTests {
 		HttpHeaders headers = this.response.getHeaders();
 		assertThat(headers.getContentType().toString(), startsWith("multipart/byteranges;boundary=" + boundary));
 
-		Mono<String> result = reduceToString(this.response.getBody(), this.response.bufferFactory());
+		Mono<String> result = response.getBodyAsString();
 		TestSubscriber
 				.subscribe(result).assertNoError()
 				.assertComplete()
@@ -147,17 +142,6 @@ public class ResourceRegionHttpMessageWriterTests {
 
 					assertThat(ranges[16], is("--" + boundary + "--"));
 				});
-	}
-
-	private Mono<String> reduceToString(Publisher<DataBuffer> buffers, DataBufferFactory bufferFactory) {
-
-		return Flux.from(buffers)
-				.reduce(bufferFactory.allocateBuffer(), (previous, current) -> {
-					previous.write(current);
-					DataBufferUtils.release(current);
-					return previous;
-				})
-				.map(buffer -> DataBufferTestUtils.dumpString(buffer, StandardCharsets.UTF_8));
 	}
 
 }


### PR DESCRIPTION
This PR fix issue when endpoint produce ByteBuffer's with content type octet-stream:

``` java
    @RequestMapping(value = "/proxy", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
    @ResponseBody
    @ResponseStatus(code = HttpStatus.OK)
    public Flux<ByteBuffer> proxy() {
       //impl
    }
```

As a result I get stacktrace:

```
java.lang.IllegalArgumentException: 'Content-Type' cannot contain wildcard type '*'
    at org.springframework.util.Assert.isTrue(Assert.java:86) ~[spring-core-5.0.0.M2.jar:5.0.0.M2]
    at org.springframework.http.HttpHeaders.setContentType(HttpHeaders.java:735) ~[spring-web-5.0.0.BUILD-20160926.160659-291.jar:5.0.0.BUILD-SNAPSHOT]
    at org.springframework.http.codec.EncoderHttpMessageWriter.write(EncoderHttpMessageWriter.java:99) ~[spring-web-5.0.0.BUILD-20160926.160659-291.jar:5.0.0.BUILD-SNAPSHOT]
    at org.springframework.web.reactive.result.method.annotation.AbstractMessageWriterResultHandler.writeBody(AbstractMessageWriterResultHandler.java:131) ~[spring-web-reactive-5.0.0.BUILD-20160926.160659-234.jar:5.0.0.BUILD-SNAPSHOT]
    at org.springframework.web.reactive.result.method.annotation.ResponseBodyResultHandler.handleResult(ResponseBodyResultHandler.java:121) ~[spring-web-reactive-5.0.0.BUILD-20160926.160659-234.jar:5.0.0.BUILD-SNAPSHOT]
    at org.springframework.web.reactive.DispatcherHandler.handleResult(DispatcherHandler.java:142) ~[spring-web-reactive-5.0.0.BUILD-20160926.160659-234.jar:5.0.0.BUILD-SNAPSHOT]
    at org.springframework.web.reactive.DispatcherHandler.lambda$handle$2(DispatcherHandler.java:129) ~[spring-web-reactive-5.0.0.BUILD-20160926.160659-234.jar:5.0.0.BUILD-SNAPSHOT]
[more]
```
