### PR TITLE
Log unresolved exceptions at error level

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorHttpHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorHttpHandlerAdapter.java
@@ -54,7 +54,7 @@ public class ReactorHttpHandlerAdapter implements Function<HttpChannel, Mono<Voi
 
 		return this.delegate.handle(adaptedRequest, adaptedResponse)
 				.otherwise(ex -> {
-					logger.debug("Could not complete request", ex);
+					logger.error("Could not complete request", ex);
 					channel.status(HttpResponseStatus.INTERNAL_SERVER_ERROR);
 					return Mono.empty();
 				})

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/RxNettyHttpHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/RxNettyHttpHandlerAdapter.java
@@ -58,7 +58,7 @@ public class RxNettyHttpHandlerAdapter implements RequestHandler<ByteBuf, ByteBu
 
 		Publisher<Void> result = this.delegate.handle(adaptedRequest, adaptedResponse)
 				.otherwise(ex -> {
-					logger.debug("Could not complete request", ex);
+					logger.error("Could not complete request", ex);
 					response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
 					return Mono.empty();
 				})

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServletHttpHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServletHttpHandlerAdapter.java
@@ -114,7 +114,7 @@ public class ServletHttpHandlerAdapter extends HttpServlet {
 
 		@Override
 		public void onError(Throwable ex) {
-			logger.debug("Could not complete request", ex);
+			logger.error("Could not complete request", ex);
 			HttpServletResponse response = (HttpServletResponse) this.asyncContext.getResponse();
 			response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			this.asyncContext.complete();

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowHttpHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowHttpHandlerAdapter.java
@@ -72,7 +72,7 @@ public class UndertowHttpHandlerAdapter implements io.undertow.server.HttpHandle
 			}
 			@Override
 			public void onError(Throwable ex) {
-				logger.debug("Could not complete request", ex);
+				logger.error("Could not complete request", ex);
 				if (!exchange.isResponseStarted() && exchange.getStatusCode() <= 500) {
 					exchange.setStatusCode(500);
 				}

--- a/spring-web/src/main/java/org/springframework/web/server/adapter/WebHttpHandlerBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/WebHttpHandlerBuilder.java
@@ -123,10 +123,8 @@ public class WebHttpHandlerBuilder {
 			WebFilter[] array = new WebFilter[this.filters.size()];
 			webHandler = new FilteringWebHandler(webHandler, this.filters.toArray(array));
 		}
-		if (!this.exceptionHandlers.isEmpty()) {
-			WebExceptionHandler[] array = new WebExceptionHandler[this.exceptionHandlers.size()];
-			webHandler = new ExceptionHandlingWebHandler(webHandler,  this.exceptionHandlers.toArray(array));
-		}
+		WebExceptionHandler[] array = new WebExceptionHandler[this.exceptionHandlers.size()];
+		webHandler = new ExceptionHandlingWebHandler(webHandler,  this.exceptionHandlers.toArray(array));
 		HttpWebHandlerAdapter httpHandler = new HttpWebHandlerAdapter(webHandler);
 		if (this.sessionManager != null) {
 			httpHandler.setSessionManager(this.sessionManager);

--- a/spring-web/src/main/java/org/springframework/web/server/handler/ExceptionHandlingWebHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/server/handler/ExceptionHandlingWebHandler.java
@@ -128,7 +128,7 @@ public class ExceptionHandlingWebHandler extends WebHandlerDecorator {
 			}
 		}
 		else {
-			logger.debug("Could not complete request", ex);
+			logger.error("Could not complete request", ex);
 		}
 	}
 


### PR DESCRIPTION
This PR change the log level of unresolved exceptions from debug to error, in order to avoid the "no exception displayed by default" behaviour that we have currently. Are you ok with this change @rstoyanchev?
