### PR TITLE
Add reactive multipart request support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ configure(allprojects) { project ->
 	ext.servletVersion         = "3.1.0"
 	ext.slf4jVersion           = "1.7.25"
 	ext.snakeyamlVersion       = "1.18"
+	ext.nioMultipartVersion    = "1.0.2"
 	ext.testngVersion          = "6.11"
 	ext.tiles3Version          = "3.0.7"
 	ext.tomcatVersion          = "8.5.14"
@@ -747,7 +748,7 @@ project("spring-web") {
 		optional("javax.xml.bind:jaxb-api:${jaxbVersion}")
 		optional("javax.xml.ws:jaxws-api:${jaxwsVersion}")
 		optional("javax.mail:javax.mail-api:${javamailVersion}")
-		optional("org.synchronoss.cloud:nio-multipart-parser:1.0.2")
+		optional("org.synchronoss.cloud:nio-multipart-parser:${nioMultipartVersion}")
 		optional("org.jetbrains.kotlin:kotlin-stdlib-jre8:${kotlinVersion}")
 		testCompile(project(":spring-context-support"))  // for JafMediaTypeFactory
 		testCompile("io.projectreactor.addons:reactor-test")
@@ -839,6 +840,10 @@ project("spring-webflux") {
 		testRuntime("org.jetbrains.kotlin:kotlin-compiler:${kotlinVersion}")
 		testCompile("org.jetbrains.kotlin:kotlin-script-runtime:${kotlinVersion}")
 		testRuntime("org.jetbrains.kotlin:kotlin-script-util:${kotlinVersion}")
+		testRuntime("org.synchronoss.cloud:nio-multipart-parser:${nioMultipartVersion}")
+		testRuntime("com.sun.mail:javax.mail:${javamailVersion}")
+		testRuntime("com.sun.xml.bind:jaxb-core:${jaxbVersion}")
+		testRuntime("com.sun.xml.bind:jaxb-impl:${jaxbVersion}")
 	}
 
 	if (JavaVersion.current().java9Compatible) {

--- a/build.gradle
+++ b/build.gradle
@@ -747,6 +747,7 @@ project("spring-web") {
 		optional("javax.xml.bind:jaxb-api:${jaxbVersion}")
 		optional("javax.xml.ws:jaxws-api:${jaxwsVersion}")
 		optional("javax.mail:javax.mail-api:${javamailVersion}")
+		optional("org.synchronoss.cloud:nio-multipart-parser:1.0.2")
 		optional("org.jetbrains.kotlin:kotlin-stdlib-jre8:${kotlinVersion}")
 		testCompile(project(":spring-context-support"))  // for JafMediaTypeFactory
 		testCompile("io.projectreactor.addons:reactor-test")

--- a/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerWebExchange.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerWebExchange.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.mock.http.server.reactive;
 
+import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.web.server.ServerWebExchangeDecorator;
 import org.springframework.web.server.adapter.DefaultServerWebExchange;
 import org.springframework.web.server.session.DefaultWebSessionManager;
@@ -35,7 +36,8 @@ public class MockServerWebExchange extends ServerWebExchangeDecorator {
 
 	public MockServerWebExchange(MockServerHttpRequest request) {
 		super(new DefaultServerWebExchange(
-				request, new MockServerHttpResponse(), new DefaultWebSessionManager()));
+				request, new MockServerHttpResponse(), new DefaultWebSessionManager(),
+				ServerCodecConfigurer.create()));
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/http/codec/DefaultClientCodecConfigurer.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/DefaultClientCodecConfigurer.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.springframework.core.codec.Decoder;
 import org.springframework.core.codec.StringDecoder;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.codec.multipart.MultipartHttpMessageWriter;
 
 /**
  * Default implementation of {@link ClientCodecConfigurer}.
@@ -57,6 +58,7 @@ class DefaultClientCodecConfigurer extends DefaultCodecConfigurer implements Cli
 		protected void addTypedWritersTo(List<HttpMessageWriter<?>> result) {
 			super.addTypedWritersTo(result);
 			addWriterTo(result, FormHttpMessageWriter::new);
+			addWriterTo(result, MultipartHttpMessageWriter::new);
 		}
 
 		@Override

--- a/spring-web/src/main/java/org/springframework/http/codec/DefaultServerCodecConfigurer.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/DefaultServerCodecConfigurer.java
@@ -21,6 +21,8 @@ import java.util.List;
 import org.springframework.core.codec.Encoder;
 import org.springframework.core.codec.StringDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.http.codec.multipart.SynchronossMultipartHttpMessageReader;
+import org.springframework.util.ClassUtils;
 
 /**
  * Default implementation of {@link ServerCodecConfigurer}.
@@ -29,6 +31,11 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder;
  * @since 5.0
  */
 class DefaultServerCodecConfigurer extends DefaultCodecConfigurer implements ServerCodecConfigurer {
+
+	static final boolean synchronossMultipartPresent =
+			ClassUtils.isPresent("org.synchronoss.cloud.nio.multipart.NioMultipartParser",
+					org.springframework.http.codec.DefaultCodecConfigurer.class.getClassLoader());
+
 
 	public DefaultServerCodecConfigurer() {
 		super(new DefaultServerDefaultCodecsConfigurer());
@@ -57,6 +64,9 @@ class DefaultServerCodecConfigurer extends DefaultCodecConfigurer implements Ser
 		public void addTypedReadersTo(List<HttpMessageReader<?>> result) {
 			super.addTypedReadersTo(result);
 			addReaderTo(result, FormHttpMessageReader::new);
+			if (synchronossMultipartPresent) {
+				addReaderTo(result, SynchronossMultipartHttpMessageReader::new);
+			}
 		}
 
 		@Override

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageReader.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpInputMessage;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * Interface for reading multipart HTML forms with {@code "multipart/form-data"} media
+ * type in accordance with <a href="https://tools.ietf.org/html/rfc7578">RFC 7578</a>.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public interface MultipartHttpMessageReader extends HttpMessageReader<MultiValueMap<String, Part>> {
+
+	ResolvableType MULTIPART_VALUE_TYPE =
+			ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Part.class);
+
+	@Override
+	default List<MediaType> getReadableMediaTypes() {
+		return Collections.singletonList(MediaType.MULTIPART_FORM_DATA);
+	}
+
+	@Override
+	default boolean canRead(ResolvableType elementType, MediaType mediaType) {
+		return MULTIPART_VALUE_TYPE.isAssignableFrom(elementType) &&
+				(mediaType == null || MediaType.MULTIPART_FORM_DATA.isCompatibleWith(mediaType));
+	}
+
+	@Override
+	default Flux<MultiValueMap<String, Part>> read(ResolvableType elementType, ReactiveHttpInputMessage message, Map<String, Object> hints) {
+		return Flux.from(readMono(elementType, message, hints));
+	}
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageWriter.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import javax.mail.internet.MimeUtility;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuples;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.CharSequenceEncoder;
+import org.springframework.core.codec.CodecException;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpOutputMessage;
+import org.springframework.http.codec.EncoderHttpMessageWriter;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.ResourceHttpMessageWriter;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * Implementation of {@link HttpMessageWriter} to write multipart HTML
+ * forms with {@code "multipart/form-data"} media type.
+ *
+ * <p>When writing multipart data, this writer uses other
+ * {@link HttpMessageWriter HttpMessageWriters} to write the respective
+ * MIME parts. By default, basic writers are registered (for {@code Strings}
+ * and {@code Resources}). These can be overridden through the provided
+ * constructors.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public class MultipartHttpMessageWriter implements HttpMessageWriter<MultiValueMap<String, ?>> {
+
+	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+
+	private List<HttpMessageWriter<?>> partWriters;
+
+	private Charset filenameCharset = DEFAULT_CHARSET;
+
+	private final DataBufferFactory bufferFactory;
+
+
+	public MultipartHttpMessageWriter() {
+		this(new DefaultDataBufferFactory());
+	}
+
+	public MultipartHttpMessageWriter(DataBufferFactory bufferFactory) {
+		this.partWriters = Arrays.asList(
+				new EncoderHttpMessageWriter<>(CharSequenceEncoder.textPlainOnly()),
+				new ResourceHttpMessageWriter()
+		);
+		this.bufferFactory = bufferFactory;
+	}
+
+	public MultipartHttpMessageWriter(List<HttpMessageWriter<?>> partWriters) {
+		this(partWriters, new DefaultDataBufferFactory());
+	}
+
+	public MultipartHttpMessageWriter(List<HttpMessageWriter<?>> partWriters, DataBufferFactory bufferFactory) {
+		this.partWriters = partWriters;
+		this.bufferFactory = bufferFactory;
+	}
+
+	/**
+	 * Set the character set to use for writing file names in the multipart request.
+	 * <p>By default this is set to "UTF-8".
+	 */
+	public void setFilenameCharset(Charset charset) {
+		Assert.notNull(charset, "'charset' must not be null");
+		this.filenameCharset = charset;
+	}
+
+	/**
+	 * Return the configured filename charset.
+	 */
+	public Charset getFilenameCharset() {
+		return this.filenameCharset;
+	}
+
+
+	@Override
+	public boolean canWrite(ResolvableType elementType, MediaType mediaType) {
+		return (mediaType == null || MediaType.MULTIPART_FORM_DATA.isCompatibleWith(mediaType)) &&
+				(MultiValueMap.class.isAssignableFrom(elementType.getRawClass()) && String.class.isAssignableFrom(elementType.resolveGeneric(0)));
+	}
+
+	@Override
+	public Mono<Void> write(Publisher<? extends MultiValueMap<String, ?>> inputStream,
+			ResolvableType elementType, MediaType mediaType, ReactiveHttpOutputMessage outputMessage,
+			Map<String, Object> hints) {
+
+		final byte[] boundary = generateMultipartBoundary();
+		Map<String, String> parameters = Collections.singletonMap("boundary", new String(boundary, StandardCharsets.US_ASCII));
+
+		MediaType contentType = new MediaType(MediaType.MULTIPART_FORM_DATA, parameters);
+		HttpHeaders headers = outputMessage.getHeaders();
+		headers.setContentType(contentType);
+
+		return Flux
+				.from(inputStream)
+				.single()
+				.flatMap(form -> {
+					Flux<DataBuffer> body = Flux.fromIterable(form.entrySet())
+						.concatMap(entry -> Flux.fromIterable(entry.getValue()).map(value -> Tuples.of(entry.getKey(), value)))
+						.concatMap(part -> generatePart(part.getT1(), getHttpEntity(part.getT2()), boundary))
+						.concatWith(Mono.just(generateLastLine(boundary)));
+					return outputMessage.writeWith(body);
+				});
+	}
+
+	@SuppressWarnings("unchecked")
+	private Flux<DataBuffer> generatePart(String name, HttpEntity<?> partEntity, byte[] boundary) {
+		Object partBody = partEntity.getBody();
+		ResolvableType partType = ResolvableType.forClass(partBody.getClass());
+		MultipartHttpOutputMessage outputMessage = new MultipartHttpOutputMessage(this.bufferFactory);
+		HttpHeaders partHeaders = outputMessage.getHeaders();
+		outputMessage.getHeaders().putAll(partHeaders);
+		MediaType partContentType = partHeaders.getContentType();
+		partHeaders.setContentDispositionFormData(name, getFilename(partBody));
+
+		Optional<HttpMessageWriter<?>> writer = this.partWriters
+				.stream()
+				.filter(e -> e.canWrite(partType, partContentType))
+				.findFirst();
+
+		if(!writer.isPresent()) {
+			return Flux.error(new CodecException("No suitable writer found!"));
+		}
+		Mono<Void> partWritten = ((HttpMessageWriter<Object>)writer.get())
+				.write(Mono.just(partBody), partType, partContentType, outputMessage, Collections.emptyMap());
+
+		// partWritten.subscribe() is required in order to make sure MultipartHttpOutputMessage#getBody()
+		// returns a non-null value (occurs with ResourceHttpMessageWriter that invokes
+		// ReactiveHttpOutputMessage.writeWith() only when at least one element has been
+		// requested).
+		partWritten.subscribe();
+
+		return Flux.concat(
+				Mono.just(generateBoundaryLine(boundary)),
+				outputMessage.getBody(),
+				Mono.just(generateNewLine())
+		);
+	}
+
+	/**
+	 * Generate a multipart boundary.
+	 * <p>This implementation delegates to
+	 * {@link MimeTypeUtils#generateMultipartBoundary()}.
+	 */
+	protected byte[] generateMultipartBoundary() {
+		return MimeTypeUtils.generateMultipartBoundary();
+	}
+
+	/**
+	 * Return an {@link HttpEntity} for the given part Object.
+	 * @param part the part to return an {@link HttpEntity} for
+	 * @return the part Object itself it is an {@link HttpEntity},
+	 * or a newly built {@link HttpEntity} wrapper for that part
+	 */
+	protected HttpEntity<?> getHttpEntity(Object part) {
+		if (part instanceof HttpEntity) {
+			return (HttpEntity<?>) part;
+		}
+		else {
+			return new HttpEntity<>(part);
+		}
+	}
+
+	/**
+	 * Return the filename of the given multipart part. This value will be used for the
+	 * {@code Content-Disposition} header.
+	 * <p>The default implementation returns {@link Resource#getFilename()} if the part is a
+	 * {@code Resource}, and {@code null} in other cases. Can be overridden in subclasses.
+	 * @param part the part to determine the file name for
+	 * @return the filename, or {@code null} if not known
+	 */
+	protected String getFilename(Object part) {
+		if (part instanceof Resource) {
+			Resource resource = (Resource) part;
+			String filename = resource.getFilename();
+			filename = MimeDelegate.encode(filename, this.filenameCharset.name());
+			return filename;
+		}
+		else {
+			return null;
+		}
+	}
+
+
+	private DataBuffer generateBoundaryLine(byte[] boundary) {
+		DataBuffer buffer = this.bufferFactory.allocateBuffer(boundary.length + 4);
+		buffer.write((byte)'-');
+		buffer.write((byte)'-');
+		buffer.write(boundary);
+		buffer.write((byte)'\r');
+		buffer.write((byte)'\n');
+		return buffer;
+	}
+
+	private DataBuffer generateNewLine() {
+		DataBuffer buffer = this.bufferFactory.allocateBuffer(2);
+		buffer.write((byte)'\r');
+		buffer.write((byte)'\n');
+		return buffer;
+	}
+
+	private DataBuffer generateLastLine(byte[] boundary) {
+		DataBuffer buffer = this.bufferFactory.allocateBuffer(boundary.length + 6);
+		buffer.write((byte)'-');
+		buffer.write((byte)'-');
+		buffer.write(boundary);
+		buffer.write((byte)'-');
+		buffer.write((byte)'-');
+		buffer.write((byte)'\r');
+		buffer.write((byte)'\n');
+		return buffer;
+	}
+
+	@Override
+	public List<MediaType> getWritableMediaTypes() {
+		return Collections.singletonList(MediaType.MULTIPART_FORM_DATA);
+	}
+
+
+	private static class MultipartHttpOutputMessage implements ReactiveHttpOutputMessage {
+
+		private final DataBufferFactory bufferFactory;
+
+		private final HttpHeaders headers = new HttpHeaders();
+
+		private final AtomicBoolean commited = new AtomicBoolean();
+
+		private Flux<DataBuffer> body;
+
+
+		public MultipartHttpOutputMessage(DataBufferFactory bufferFactory) {
+			this.bufferFactory = bufferFactory;
+		}
+
+
+		@Override
+		public HttpHeaders getHeaders() {
+			return (this.body != null ? HttpHeaders.readOnlyHttpHeaders(this.headers) : this.headers);
+		}
+
+		@Override
+		public DataBufferFactory bufferFactory() {
+			return this.bufferFactory;
+		}
+
+		@Override
+		public void beforeCommit(Supplier<? extends Mono<Void>> action) {
+			this.commited.set(true);
+		}
+
+		@Override
+		public boolean isCommitted() {
+			return this.commited.get();
+		}
+
+		@Override
+		public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+			if (this.body != null) {
+				return Mono.error(new IllegalStateException("Multiple calls to writeWith() not supported"));
+			}
+			this.body = Flux.just(generateHeaders()).concatWith(body);
+			return this.body.then();
+		}
+
+		@Override
+		public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<? extends DataBuffer>> body) {
+			return Mono.error(new UnsupportedOperationException());
+		}
+
+		private DataBuffer generateHeaders() {
+			DataBuffer buffer = this.bufferFactory.allocateBuffer();
+			for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+				byte[] headerName = entry.getKey().getBytes(StandardCharsets.US_ASCII);
+				for (String headerValueString : entry.getValue()) {
+					byte[] headerValue = headerValueString.getBytes(StandardCharsets.US_ASCII);
+					buffer.write(headerName);
+					buffer.write((byte)':');
+					buffer.write((byte)' ');
+					buffer.write(headerValue);
+					buffer.write((byte)'\r');
+					buffer.write((byte)'\n');
+				}
+			}
+			buffer.write((byte)'\r');
+			buffer.write((byte)'\n');
+			return buffer;
+		}
+
+		@Override
+		public Mono<Void> setComplete() {
+			return (this.body != null ? this.body.then() : Mono.error(new IllegalStateException("Body has not been written yet")));
+		}
+
+		public Flux<DataBuffer> getBody() {
+			return (this.body != null ? this.body : Flux.error(new IllegalStateException("Body has not been written yet")));
+		}
+	}
+
+	/**
+	 * Inner class to avoid a hard dependency on the JavaMail API.
+	 */
+	private static class MimeDelegate {
+
+		public static String encode(String value, String charset) {
+			try {
+				return MimeUtility.encodeText(value, charset, null);
+			}
+			catch (UnsupportedEncodingException ex) {
+				throw new IllegalStateException(ex);
+			}
+		}
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/Part.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/Part.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import java.io.File;
+import java.util.Optional;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * A representation of a part received in a multipart request. Could contain a file, the
+ * string or json value of a parameter.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ */
+public interface Part {
+
+	/**
+	 * @return the headers of this part
+	 */
+	HttpHeaders getHeaders();
+
+	/**
+	 * @return the name of the parameter in the multipart form
+	 */
+	String getName();
+
+	/**
+	 * @return optionally the filename if the part contains a file
+	 */
+	Optional<String> getFilename();
+
+	/**
+	 * @return the content of the part as a String using the charset specified in the
+	 * {@code Content-Type} header if any, or else using {@code UTF-8} by default.
+	 */
+	Mono<String> getContentAsString();
+
+	/**
+	 * @return the content of the part as a stream of bytes
+	 */
+	Flux<DataBuffer> getContent();
+
+	/**
+	 * Transfer the file contained in this part to the specified destination.
+	 * @param dest the destination file
+	 * @return a {@link Mono} that indicates completion of the file transfer or an error,
+	 * for example an {@link IllegalStateException} if the part does not contain a file
+	 */
+	Mono<Void> transferTo(File dest);
+
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/SynchronossMultipartHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/SynchronossMultipartHttpMessageReader.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.synchronoss.cloud.nio.multipart.Multipart;
+import org.synchronoss.cloud.nio.multipart.MultipartContext;
+import org.synchronoss.cloud.nio.multipart.MultipartUtils;
+import org.synchronoss.cloud.nio.multipart.NioMultipartParser;
+import org.synchronoss.cloud.nio.multipart.NioMultipartParserListener;
+import org.synchronoss.cloud.nio.stream.storage.StreamStorage;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpInputMessage;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StreamUtils;
+
+/**
+ * Implementation of {@link HttpMessageReader} to read multipart HTML
+ * forms with {@code "multipart/form-data"} media type in accordance
+ * with <a href="https://tools.ietf.org/html/rfc7578">RFC 7578</a> based
+ * on the Synchronoss NIO Multipart library.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.0
+ * @see <a href="https://github.com/synchronoss/nio-multipart">Synchronoss NIO Multipart</a>
+ */
+public class SynchronossMultipartHttpMessageReader implements MultipartHttpMessageReader {
+
+	@Override
+	public Mono<MultiValueMap<String, Part>> readMono(ResolvableType elementType, ReactiveHttpInputMessage inputMessage, Map<String, Object> hints) {
+
+		return Flux.create(new NioMultipartConsumer(inputMessage))
+				.collectMultimap(part -> part.getName())
+				.map(partsMap -> new LinkedMultiValueMap<>(partsMap
+						.entrySet()
+						.stream()
+						.collect(Collectors.toMap(
+							entry -> entry.getKey(),
+							entry -> new ArrayList<>(entry.getValue()))
+						)));
+	}
+
+
+	private static class NioMultipartConsumer implements Consumer<FluxSink<Part>> {
+
+		private final ReactiveHttpInputMessage inputMessage;
+
+
+		public NioMultipartConsumer(ReactiveHttpInputMessage inputMessage) {
+			this.inputMessage = inputMessage;
+		}
+
+
+		@Override
+		public void accept(FluxSink<Part> emitter) {
+			HttpHeaders headers = inputMessage.getHeaders();
+			MultipartContext context = new MultipartContext(
+					headers.getContentType().toString(),
+					Math.toIntExact(headers.getContentLength()),
+					headers.getFirst(HttpHeaders.ACCEPT_CHARSET));
+			NioMultipartParserListener listener = new ReactiveNioMultipartParserListener(emitter);
+			NioMultipartParser parser = Multipart.multipart(context).forNIO(listener);
+
+			inputMessage.getBody().subscribe(buffer -> {
+				byte[] resultBytes = new byte[buffer.readableByteCount()];
+				buffer.read(resultBytes);
+				try {
+					parser.write(resultBytes);
+				}
+				catch (IOException ex) {
+					listener.onError("Exception thrown while closing the parser", ex);
+				}
+
+			}, (e) -> {
+				try {
+					listener.onError("Exception thrown while reading the request body", e);
+					parser.close();
+				}
+				catch (IOException ex) {
+					listener.onError("Exception thrown while closing the parser", ex);
+				}
+			}, () -> {
+				try {
+					parser.close();
+				}
+				catch (IOException ex) {
+					listener.onError("Exception thrown while closing the parser", ex);
+				}
+			});
+
+		}
+
+		private static class ReactiveNioMultipartParserListener implements NioMultipartParserListener {
+
+			private FluxSink<Part> emitter;
+
+			private final AtomicInteger errorCount = new AtomicInteger(0);
+
+
+			public ReactiveNioMultipartParserListener(FluxSink<Part> emitter) {
+				this.emitter = emitter;
+			}
+
+
+			@Override
+			public void onPartFinished(StreamStorage streamStorage, Map<String, List<String>> headersFromPart) {
+				HttpHeaders headers = new HttpHeaders();
+				headers.putAll(headersFromPart);
+				emitter.next(new NioPart(headers, streamStorage));
+			}
+
+			@Override
+			public void onFormFieldPartFinished(String fieldName, String fieldValue, Map<String, List<String>> headersFromPart) {
+				HttpHeaders headers = new HttpHeaders();
+				headers.putAll(headersFromPart);
+				emitter.next(new NioPart(headers, fieldValue));
+			}
+
+			@Override
+			public void onAllPartsFinished() {
+				emitter.complete();
+			}
+
+			@Override
+			public void onNestedPartStarted(Map<String, List<String>> headersFromParentPart) {
+			}
+
+			@Override
+			public void onNestedPartFinished() {
+			}
+
+			@Override
+			public void onError(String message, Throwable cause) {
+				if (errorCount.getAndIncrement() == 1) {
+					emitter.error(new RuntimeException(message, cause));
+				}
+			}
+
+		}
+	}
+
+	/**
+	 * {@link Part} implementation based on the NIO Multipart library.
+	 */
+	private static class NioPart implements Part {
+
+		private final HttpHeaders headers;
+
+		private final StreamStorage streamStorage;
+
+		private final String content;
+
+		private final DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
+
+
+		public NioPart(HttpHeaders headers, StreamStorage streamStorage) {
+			this.headers = headers;
+			this.streamStorage = streamStorage;
+			this.content = null;
+		}
+
+		public NioPart(HttpHeaders headers, String content) {
+			this.headers = headers;
+			this.streamStorage = null;
+			this.content = content;
+		}
+
+
+		@Override
+		public String getName() {
+			return MultipartUtils.getFieldName(headers);
+		}
+
+		@Override
+		public HttpHeaders getHeaders() {
+			return this.headers;
+		}
+
+		@Override
+		public Optional<String> getFilename() {
+			return Optional.ofNullable(MultipartUtils.getFileName(this.headers));
+		}
+
+		@Override
+		public Mono<Void> transferTo(File dest) {
+			if (!getFilename().isPresent()) {
+				return Mono.error(new IllegalStateException("The part does not contain a file."));
+			}
+			try {
+				InputStream inputStream = this.streamStorage.getInputStream();
+				// Get a FileChannel when possible in order to use zero copy mechanism
+				ReadableByteChannel inChannel = Channels.newChannel(inputStream);
+				FileChannel outChannel = new FileOutputStream(dest).getChannel();
+				// NIO Multipart has previously limited the size of the content
+				long count = (inChannel instanceof FileChannel ? ((FileChannel)inChannel).size() : Long.MAX_VALUE);
+				long result = outChannel.transferFrom(inChannel, 0, count);
+				if (result < count) {
+					return Mono.error(new IOException(
+							"Could only write " + result + " out of " + count + " bytes"));
+				}
+			}
+			catch (IOException ex) {
+				return Mono.error(ex);
+			}
+			return Mono.empty();
+		}
+
+		@Override
+		public Mono<String> getContentAsString() {
+			if (this.content != null) {
+				return Mono.just(this.content);
+			}
+			MediaType contentType = this.headers.getContentType();
+			Charset charset = (contentType.getCharset() == null ? StandardCharsets.UTF_8 : contentType.getCharset());
+			try {
+				return Mono.just(StreamUtils.copyToString(this.streamStorage.getInputStream(), charset));
+			}
+			catch (IOException e) {
+				return Mono.error(new IllegalStateException("Error while reading part content as a string", e));
+			}
+		}
+
+		@Override
+		public Flux<DataBuffer> getContent() {
+			if (this.content != null) {
+				DataBuffer buffer = this.bufferFactory.allocateBuffer(this.content.length());
+				buffer.write(this.content.getBytes());
+				return Flux.just(buffer);
+			}
+			InputStream inputStream = this.streamStorage.getInputStream();
+			return DataBufferUtils.read(inputStream, this.bufferFactory, 4096);
+		}
+
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/server/ServerWebExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/server/ServerWebExchange.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 
 import reactor.core.publisher.Mono;
 
+import org.springframework.http.codec.multipart.Part;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.MultiValueMap;
@@ -81,6 +82,12 @@ public interface ServerWebExchange {
 	 * {@code "application/x-www-form-urlencoded"} or an empty map.
 	 */
 	Mono<MultiValueMap<String, String>> getFormData();
+
+	/**
+	 * Return the form parts from the body of the request or an empty {@code Mono}
+	 * if the Content-Type is not "multipart/form-data".
+	 */
+	Mono<MultiValueMap<String, Part>> getMultipartData();
 
 	/**
 	 * Return a combined map that represents both

--- a/spring-web/src/main/java/org/springframework/web/server/ServerWebExchangeDecorator.java
+++ b/spring-web/src/main/java/org/springframework/web/server/ServerWebExchangeDecorator.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import reactor.core.publisher.Mono;
 
+import org.springframework.http.codec.multipart.Part;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.Assert;
@@ -91,6 +92,11 @@ public class ServerWebExchangeDecorator implements ServerWebExchange {
 	@Override
 	public Mono<MultiValueMap<String, String>> getFormData() {
 		return getDelegate().getFormData();
+	}
+
+	@Override
+	public Mono<MultiValueMap<String, Part>> getMultipartData() {
+		return getDelegate().getMultipartData();
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/http/codec/ClientCodecConfigurerTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/ClientCodecConfigurerTests.java
@@ -40,6 +40,7 @@ import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.http.codec.multipart.MultipartHttpMessageWriter;
 import org.springframework.http.codec.xml.Jaxb2XmlDecoder;
 import org.springframework.http.codec.xml.Jaxb2XmlEncoder;
 import org.springframework.util.MimeTypeUtils;
@@ -76,13 +77,14 @@ public class ClientCodecConfigurerTests {
 	@Test
 	public void defaultWriters() throws Exception {
 		List<HttpMessageWriter<?>> writers = this.configurer.getWriters();
-		assertEquals(9, writers.size());
+		assertEquals(10, writers.size());
 		assertEquals(ByteArrayEncoder.class, getNextEncoder(writers).getClass());
 		assertEquals(ByteBufferEncoder.class, getNextEncoder(writers).getClass());
 		assertEquals(DataBufferEncoder.class, getNextEncoder(writers).getClass());
 		assertEquals(ResourceHttpMessageWriter.class, writers.get(index.getAndIncrement()).getClass());
 		assertStringEncoder(getNextEncoder(writers), true);
 		assertEquals(FormHttpMessageWriter.class, writers.get(this.index.getAndIncrement()).getClass());
+		assertEquals(MultipartHttpMessageWriter.class, writers.get(this.index.getAndIncrement()).getClass());
 		assertEquals(Jaxb2XmlEncoder.class, getNextEncoder(writers).getClass());
 		assertEquals(Jackson2JsonEncoder.class, getNextEncoder(writers).getClass());
 		assertStringEncoder(getNextEncoder(writers), false);

--- a/spring-web/src/test/java/org/springframework/http/codec/ServerCodecConfigurerTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/ServerCodecConfigurerTests.java
@@ -41,6 +41,7 @@ import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.http.codec.multipart.SynchronossMultipartHttpMessageReader;
 import org.springframework.http.codec.xml.Jaxb2XmlDecoder;
 import org.springframework.http.codec.xml.Jaxb2XmlEncoder;
 import org.springframework.util.MimeTypeUtils;
@@ -62,13 +63,14 @@ public class ServerCodecConfigurerTests {
 	@Test
 	public void defaultReaders() throws Exception {
 		List<HttpMessageReader<?>> readers = this.configurer.getReaders();
-		assertEquals(9, readers.size());
+		assertEquals(10, readers.size());
 		assertEquals(ByteArrayDecoder.class, getNextDecoder(readers).getClass());
 		assertEquals(ByteBufferDecoder.class, getNextDecoder(readers).getClass());
 		assertEquals(DataBufferDecoder.class, getNextDecoder(readers).getClass());
 		assertEquals(ResourceDecoder.class, getNextDecoder(readers).getClass());
 		assertStringDecoder(getNextDecoder(readers), true);
 		assertEquals(FormHttpMessageReader.class, readers.get(this.index.getAndIncrement()).getClass());
+		assertEquals(SynchronossMultipartHttpMessageReader.class, readers.get(this.index.getAndIncrement()).getClass());
 		assertEquals(Jaxb2XmlDecoder.class, getNextDecoder(readers).getClass());
 		assertEquals(Jackson2JsonDecoder.class, getNextDecoder(readers).getClass());
 		assertStringDecoder(getNextDecoder(readers), false);

--- a/spring-web/src/test/java/org/springframework/http/codec/multipart/MultipartHttpMessageReaderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/multipart/MultipartHttpMessageReaderTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class MultipartHttpMessageReaderTests {
+
+	private MultipartHttpMessageReader reader;
+
+	@Before
+	public void setUp() throws Exception {
+		this.reader = (elementType, message, hints) -> {
+			throw new UnsupportedOperationException();
+		};
+	}
+
+	@Test
+	public void canRead() {
+		assertTrue(this.reader.canRead(
+				ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Part.class),
+				MediaType.MULTIPART_FORM_DATA));
+
+		assertFalse(this.reader.canRead(
+				ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Object.class),
+				MediaType.MULTIPART_FORM_DATA));
+
+		assertFalse(this.reader.canRead(
+				ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, String.class),
+				MediaType.MULTIPART_FORM_DATA));
+
+		assertFalse(this.reader.canRead(
+				ResolvableType.forClassWithGenerics(Map.class, String.class, String.class),
+				MediaType.MULTIPART_FORM_DATA));
+
+		assertFalse(this.reader.canRead(
+				ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Part.class),
+				MediaType.APPLICATION_FORM_URLENCODED));
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/http/codec/multipart/MultipartHttpMessageWriterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/multipart/MultipartHttpMessageWriterTests.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.CharSequenceEncoder;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.EncoderHttpMessageWriter;
+import org.springframework.http.codec.ResourceHttpMessageWriter;
+import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.mock.http.server.reactive.test.MockServerHttpRequest;
+import org.springframework.mock.http.server.reactive.test.MockServerHttpResponse;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class MultipartHttpMessageWriterTests {
+
+	private final MultipartHttpMessageWriter writer = new MultipartHttpMessageWriter(
+			Arrays.asList(
+				new EncoderHttpMessageWriter<>(CharSequenceEncoder.textPlainOnly()),
+				new ResourceHttpMessageWriter(),
+				new EncoderHttpMessageWriter<>(new Jackson2JsonEncoder())
+	));
+
+	@Test
+	public void canWrite() {
+		assertTrue(this.writer.canWrite(ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Object.class),
+				MediaType.MULTIPART_FORM_DATA));
+		assertTrue(this.writer.canWrite(ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, String.class),
+				MediaType.MULTIPART_FORM_DATA));
+		assertFalse(this.writer.canWrite(ResolvableType.forClassWithGenerics(MultiValueMap.class, Object.class, Object.class),
+				MediaType.MULTIPART_FORM_DATA));
+		assertFalse(this.writer.canWrite(ResolvableType.forClassWithGenerics(Map.class, String.class, Object.class),
+				MediaType.MULTIPART_FORM_DATA));
+		assertFalse(this.writer.canWrite(ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Object.class),
+				MediaType.APPLICATION_FORM_URLENCODED));
+	}
+
+	@Test
+	public void writeMultipart() throws Exception {
+		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+		parts.add("name 1", "value 1");
+		parts.add("name 2", "value 2+1");
+		parts.add("name 2", "value 2+2");
+
+		Resource logo = new ClassPathResource("/org/springframework/http/converter/logo.jpg");
+		parts.add("logo", logo);
+
+		// SPR-12108
+		Resource utf8 = new ClassPathResource("/org/springframework/http/converter/logo.jpg") {
+			@Override
+			public String getFilename() {
+				return "Hall\u00F6le.jpg";
+			}
+		};
+		parts.add("utf8", utf8);
+
+		Foo foo = new Foo("bar");
+		HttpHeaders entityHeaders = new HttpHeaders();
+		entityHeaders.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<Foo> entity = new HttpEntity<>(foo, entityHeaders);
+		parts.add("json", entity);
+
+		MockServerHttpResponse response = new MockServerHttpResponse();
+		this.writer.write(Mono.just(parts), null, MediaType.MULTIPART_FORM_DATA, response, Collections.emptyMap()).block();
+
+		final MediaType contentType = response.getHeaders().getContentType();
+		assertNotNull("No boundary found", contentType.getParameter("boundary"));
+
+		// see if NIO Multipart can read what we wrote
+		MultipartHttpMessageReader multipartReader = new SynchronossMultipartHttpMessageReader();
+		MockServerHttpRequest request = MockServerHttpRequest.post("/foo")
+				.header(CONTENT_TYPE, contentType.toString())
+				.body(response.getBody());
+
+		MultiValueMap<String, Part> requestParts = multipartReader.
+				readMono(MultipartHttpMessageReader.MULTIPART_VALUE_TYPE, request, Collections.emptyMap()).block();
+		assertEquals(5, requestParts.size());
+
+
+		Part part = requestParts.getFirst("name 1");
+		assertEquals("name 1", part.getName());
+		assertEquals("value 1", part.getContentAsString().block());
+		assertFalse(part.getFilename().isPresent());
+
+		List<Part> part2 = requestParts.get("name 2");
+		assertEquals(2, part2.size());
+		part = part2.get(0);
+		assertEquals("name 2", part.getName());
+		assertEquals("value 2+1", part.getContentAsString().block());
+		part = part2.get(1);
+		assertEquals("name 2", part.getName());
+		assertEquals("value 2+2", part.getContentAsString().block());
+
+		part = requestParts.getFirst("logo");
+		assertEquals("logo", part.getName());
+		assertTrue(part.getFilename().isPresent());
+		assertEquals("logo.jpg", part.getFilename().get());
+		assertEquals(MediaType.IMAGE_JPEG, part.getHeaders().getContentType());
+		assertEquals(logo.getFile().length(), part.getHeaders().getContentLength());
+
+		part = requestParts.getFirst("utf8");
+		assertEquals("utf8", part.getName());
+		assertTrue(part.getFilename().isPresent());
+		assertEquals("Hall\u00F6le.jpg", part.getFilename().get());
+		assertEquals(MediaType.IMAGE_JPEG, part.getHeaders().getContentType());
+		assertEquals(utf8.getFile().length(), part.getHeaders().getContentLength());
+
+		part = requestParts.getFirst("json");
+		assertEquals("json", part.getName());
+		assertEquals(MediaType.APPLICATION_JSON_UTF8, part.getHeaders().getContentType());
+		assertEquals("{\"bar\":\"bar\"}", part.getContentAsString().block());
+	}
+
+	private class Foo {
+
+		private String bar;
+
+		public Foo() {
+		}
+
+		public Foo(String bar) {
+			this.bar = bar;
+		}
+
+		public String getBar() {
+			return bar;
+		}
+
+		public void setBar(String bar) {
+			this.bar = bar;
+		}
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/http/codec/multipart/SynchronossMultipartHttpMessageReaderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/multipart/SynchronossMultipartHttpMessageReaderTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
+import static org.springframework.http.codec.multipart.MultipartHttpMessageReader.*;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.MockHttpOutputMessage;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.test.MockServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Sebastien Deleuze
+ */
+public class SynchronossMultipartHttpMessageReaderTests {
+
+	@Test
+	public void resolveParts() throws IOException {
+		ServerHttpRequest request = generateMultipartRequest();
+		MultipartHttpMessageReader multipartReader = new SynchronossMultipartHttpMessageReader();
+		MultiValueMap<String, Part> parts = multipartReader.readMono(MULTIPART_VALUE_TYPE, request, emptyMap()).block();
+		assertEquals(2, parts.size());
+
+		assertTrue(parts.containsKey("fooPart"));
+		Part part = parts.getFirst("fooPart");
+		assertEquals("fooPart", part.getName());
+		Optional<String> filename = part.getFilename();
+		assertTrue(filename.isPresent());
+		assertEquals("foo.txt", filename.get());
+		DataBuffer buffer = part
+				.getContent()
+				.reduce((s1, s2) -> s1.write(s2))
+				.block();
+		assertEquals(12, buffer.readableByteCount());
+		byte[] byteContent = new byte[12];
+		buffer.read(byteContent);
+		assertEquals("Lorem\nIpsum\n", new String(byteContent));
+
+		assertTrue(parts.containsKey("barPart"));
+		part = parts.getFirst("barPart");
+		assertEquals("barPart", part.getName());
+		filename = part.getFilename();
+		assertFalse(filename.isPresent());
+		assertEquals("bar", part.getContentAsString().block());
+	}
+
+	@Test
+	public void bodyError() {
+		ServerHttpRequest request = generateErrorMultipartRequest();
+		MultipartHttpMessageReader multipartReader = new SynchronossMultipartHttpMessageReader();
+		StepVerifier.create(multipartReader.readMono(MULTIPART_VALUE_TYPE, request, emptyMap()))
+				.verifyError();
+	}
+
+	private ServerHttpRequest generateMultipartRequest() throws IOException {
+		HttpHeaders fooHeaders = new HttpHeaders();
+		fooHeaders.setContentType(MediaType.TEXT_PLAIN);
+		ClassPathResource fooResource = new ClassPathResource("org/springframework/http/codec/multipart/foo.txt");
+		HttpEntity<ClassPathResource> fooPart = new HttpEntity<>(fooResource, fooHeaders);
+		HttpEntity<String> barPart = new HttpEntity<>("bar");
+		FormHttpMessageConverter converter = new FormHttpMessageConverter();
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+		parts.add("fooPart", fooPart);
+		parts.add("barPart", barPart);
+		converter.write(parts, MULTIPART_FORM_DATA, outputMessage);
+		byte[] content = outputMessage.getBodyAsBytes();
+		MockServerHttpRequest request = MockServerHttpRequest
+				.post("/foo")
+				.header(CONTENT_TYPE, outputMessage.getHeaders().getContentType().toString())
+				.header(CONTENT_LENGTH, String.valueOf(content.length))
+				.body(new String(content));
+		return request;
+	}
+
+	private ServerHttpRequest generateErrorMultipartRequest() {
+		DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
+		MockServerHttpRequest request = MockServerHttpRequest
+				.post("/foo")
+				.header(CONTENT_TYPE, MULTIPART_FORM_DATA.toString())
+				.body(Flux.just(bufferFactory.wrap("invalid content".getBytes())));
+		return request;
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/MultipartIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/MultipartIntegrationTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server.reactive;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.codec.multipart.Part;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebHandler;
+import org.springframework.web.server.adapter.HttpWebHandlerAdapter;
+
+public class MultipartIntegrationTests extends AbstractHttpHandlerIntegrationTests {
+
+	@Override
+	protected HttpHandler createHttpHandler() {
+		HttpWebHandlerAdapter handler = new HttpWebHandlerAdapter(new CheckRequestHandler());
+		return handler;
+	}
+
+	@Test
+	public void getFormParts() throws Exception {
+		RestTemplate restTemplate = new RestTemplate();
+		RequestEntity<MultiValueMap<String, Object>> request = RequestEntity
+				.post(new URI("http://localhost:" + port + "/form-parts"))
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.body(generateBody());
+		ResponseEntity<Void> response = restTemplate.exchange(request, Void.class);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	private MultiValueMap<String, Object> generateBody() {
+		HttpHeaders fooHeaders = new HttpHeaders();
+		fooHeaders.setContentType(MediaType.TEXT_PLAIN);
+		ClassPathResource fooResource = new ClassPathResource("org/springframework/http/codec/multipart/foo.txt");
+		HttpEntity<ClassPathResource> fooPart = new HttpEntity<>(fooResource, fooHeaders);
+		HttpEntity<String> barPart = new HttpEntity<>("bar");
+		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+		parts.add("fooPart", fooPart);
+		parts.add("barPart", barPart);
+		return parts;
+	}
+
+	public static class CheckRequestHandler implements WebHandler {
+
+		@Override
+		public Mono<Void> handle(ServerWebExchange exchange) {
+
+			if (exchange.getRequest().getURI().getPath().equals("/form-parts")) {
+				return assertGetFormParts(exchange);
+			}
+			return Mono.error(new AssertionError());
+		}
+
+		private Mono<Void> assertGetFormParts(ServerWebExchange exchange) {
+			return exchange
+					.getMultipartData()
+					.doOnNext(parts -> {
+						assertEquals(2, parts.size());
+						assertTrue(parts.containsKey("fooPart"));
+						assertFooPart(parts.getFirst("fooPart"));
+						assertTrue(parts.containsKey("barPart"));
+						assertBarPart(parts.getFirst("barPart"));
+					})
+					.then();
+		}
+
+		private void assertFooPart(Part part) {
+			assertEquals("fooPart", part.getName());
+			Optional<String> filename = part.getFilename();
+			assertTrue(filename.isPresent());
+			assertEquals("foo.txt", filename.get());
+			DataBuffer buffer = part
+					.getContent()
+					.reduce((s1, s2) -> s1.write(s2))
+					.block();
+			assertEquals(12, buffer.readableByteCount());
+			byte[] byteContent = new byte[12];
+			buffer.read(byteContent);
+			assertEquals("Lorem\nIpsum\n", new String(byteContent));
+		}
+
+		private void assertBarPart(Part part) {
+			assertEquals("barPart", part.getName());
+			Optional<String> filename = part.getFilename();
+			assertFalse(filename.isPresent());
+			assertEquals("bar", part.getContentAsString().block());
+		}
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/mock/http/server/reactive/test/MockServerWebExchange.java
+++ b/spring-web/src/test/java/org/springframework/mock/http/server/reactive/test/MockServerWebExchange.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.mock.http.server.reactive.test;
 
+import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.web.server.ServerWebExchangeDecorator;
 import org.springframework.web.server.adapter.DefaultServerWebExchange;
 import org.springframework.web.server.session.DefaultWebSessionManager;
@@ -35,7 +36,7 @@ public class MockServerWebExchange extends ServerWebExchangeDecorator {
 
 	public MockServerWebExchange(MockServerHttpRequest request) {
 		super(new DefaultServerWebExchange(
-				request, new MockServerHttpResponse(), new DefaultWebSessionManager()));
+				request, new MockServerHttpResponse(), new DefaultWebSessionManager(), ServerCodecConfigurer.create()));
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/web/server/session/DefaultWebSessionManagerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/session/DefaultWebSessionManagerTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.mock.http.server.reactive.test.MockServerHttpRequest;
 import org.springframework.mock.http.server.reactive.test.MockServerHttpResponse;
 import org.springframework.web.server.ServerWebExchange;
@@ -59,7 +60,7 @@ public class DefaultWebSessionManagerTests {
 
 		MockServerHttpRequest request = MockServerHttpRequest.get("/path").build();
 		MockServerHttpResponse response = new MockServerHttpResponse();
-		this.exchange = new DefaultServerWebExchange(request, response, this.manager);
+		this.exchange = new DefaultServerWebExchange(request, response, this.manager, ServerCodecConfigurer.create());
 	}
 
 

--- a/spring-web/src/test/resources/org/springframework/http/codec/multipart/foo.txt
+++ b/spring-web/src/test/resources/org/springframework/http/codec/multipart/foo.txt
@@ -1,0 +1,2 @@
+Lorem
+Ipsum

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurationSupport.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurationSupport.java
@@ -81,8 +81,6 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 
 	private PathMatchConfigurer pathMatchConfigurer;
 
-	private ServerCodecConfigurer messageCodecsConfigurer;
-
 	private ApplicationContext applicationContext;
 
 
@@ -242,7 +240,7 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	@Bean
 	public RequestMappingHandlerAdapter requestMappingHandlerAdapter() {
 		RequestMappingHandlerAdapter adapter = createRequestMappingHandlerAdapter();
-		adapter.setMessageCodecConfigurer(getMessageCodecsConfigurer());
+		adapter.setMessageCodecConfigurer(serverCodecConfigurer());
 		adapter.setWebBindingInitializer(getConfigurableWebBindingInitializer());
 		adapter.setReactiveAdapterRegistry(webFluxAdapterRegistry());
 
@@ -267,16 +265,15 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	}
 
 	/**
-	 * Main method to access the configurer for HTTP message readers and writers.
+	 * Return the configurer for HTTP message readers and writers.
 	 * <p>Use {@link #configureHttpMessageCodecs(ServerCodecConfigurer)} to
 	 * configure the readers and writers.
 	 */
-	protected final ServerCodecConfigurer getMessageCodecsConfigurer() {
-		if (this.messageCodecsConfigurer == null) {
-			this.messageCodecsConfigurer = ServerCodecConfigurer.create();
-			configureHttpMessageCodecs(this.getMessageCodecsConfigurer());
-		}
-		return this.messageCodecsConfigurer;
+	@Bean
+	public ServerCodecConfigurer serverCodecConfigurer() {
+		ServerCodecConfigurer serverCodecConfigurer = ServerCodecConfigurer.create();
+		configureHttpMessageCodecs(serverCodecConfigurer);
+		return serverCodecConfigurer;
 	}
 
 	/**
@@ -372,13 +369,13 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 
 	@Bean
 	public ResponseEntityResultHandler responseEntityResultHandler() {
-		return new ResponseEntityResultHandler(getMessageCodecsConfigurer().getWriters(),
+		return new ResponseEntityResultHandler(serverCodecConfigurer().getWriters(),
 				webFluxContentTypeResolver(), webFluxAdapterRegistry());
 	}
 
 	@Bean
 	public ResponseBodyResultHandler responseBodyResultHandler() {
-		return new ResponseBodyResultHandler(getMessageCodecsConfigurer().getWriters(),
+		return new ResponseBodyResultHandler(serverCodecConfigurer().getWriters(),
 				webFluxContentTypeResolver(), webFluxAdapterRegistry());
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/AbstractHandlerMethodMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/AbstractHandlerMethodMapping.java
@@ -262,6 +262,7 @@ public abstract class AbstractHandlerMethodMapping<T> extends AbstractHandlerMap
 		try {
 			// Ensure form data is parsed for "params" conditions...
 			return exchange.getRequestParams()
+					.then(exchange.getMultipartData())
 					.then(Mono.defer(() -> {
 						HandlerMethod handlerMethod = null;
 						try {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ControllerMethodResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ControllerMethodResolver.java
@@ -133,6 +133,7 @@ class ControllerMethodResolver {
 
 		// Annotation-based...
 		registrar.add(new RequestParamMethodArgumentResolver(beanFactory, reactiveRegistry, false));
+		registrar.add(new RequestPartMethodArgumentResolver(beanFactory, reactiveRegistry, false));
 		registrar.add(new RequestParamMapMethodArgumentResolver(reactiveRegistry));
 		registrar.add(new PathVariableMethodArgumentResolver(beanFactory, reactiveRegistry));
 		registrar.add(new PathVariableMapMethodArgumentResolver(reactiveRegistry));

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/config/DelegatingWebFluxConfigurationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/config/DelegatingWebFluxConfigurationTests.java
@@ -103,7 +103,7 @@ public class DelegatingWebFluxConfigurationTests {
 		verify(webFluxConfigurer).configureArgumentResolvers(any());
 
 		assertSame(formatterRegistry.getValue(), initializerConversionService);
-		assertEquals(9, codecsConfigurer.getValue().getReaders().size());
+		assertEquals(10, codecsConfigurer.getValue().getReaders().size());
 	}
 
 	@Test

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/config/WebFluxConfigurationSupportTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/config/WebFluxConfigurationSupportTests.java
@@ -127,7 +127,7 @@ public class WebFluxConfigurationSupportTests {
 		assertNotNull(adapter);
 
 		List<HttpMessageReader<?>> readers = adapter.getMessageCodecConfigurer().getReaders();
-		assertEquals(9, readers.size());
+		assertEquals(10, readers.size());
 
 		assertHasMessageReader(readers, forClass(byte[].class), APPLICATION_OCTET_STREAM);
 		assertHasMessageReader(readers, forClass(ByteBuffer.class), APPLICATION_OCTET_STREAM);

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/MultipartIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/MultipartIntegrationTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function;
+
+import java.util.Map;
+
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.multipart.Part;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.AbstractRouterFunctionIntegrationTests;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+public class MultipartIntegrationTests extends AbstractRouterFunctionIntegrationTests {
+
+	private final WebClient webClient = WebClient.create();
+
+	@Test
+	public void multipart() {
+		Mono<ClientResponse> result = webClient
+				.post()
+				.uri("http://localhost:" + this.port + "/")
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.body(BodyInserters.fromMultipartData(generateBody()))
+				.exchange();
+
+		StepVerifier
+				.create(result)
+				.consumeNextWith(response -> {
+					assertEquals(HttpStatus.OK, response.statusCode());
+				})
+				.verifyComplete();
+	}
+
+	private MultiValueMap<String, Object> generateBody() {
+		HttpHeaders fooHeaders = new HttpHeaders();
+		fooHeaders.setContentType(MediaType.TEXT_PLAIN);
+		ClassPathResource fooResource = new ClassPathResource("org/springframework/http/codec/multipart/foo.txt");
+		HttpEntity<ClassPathResource> fooPart = new HttpEntity<>(fooResource, fooHeaders);
+		HttpEntity<String> barPart = new HttpEntity<>("bar");
+		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+		parts.add("fooPart", fooPart);
+		parts.add("barPart", barPart);
+		return parts;
+	}
+
+	@Override
+	protected RouterFunction<ServerResponse> routerFunction() {
+		MultipartHandler multipartHandler = new MultipartHandler();
+		return route(POST("/"), multipartHandler::handle);
+	}
+
+	private static class MultipartHandler {
+
+		public Mono<ServerResponse> handle(ServerRequest request) {
+			return request
+					.body(BodyExtractors.toMultipartData())
+					.flatMap(map -> {
+						Map<String, Part> parts = map.toSingleValueMap();
+						try {
+							assertEquals(2, parts.size());
+							assertEquals("foo.txt", parts.get("fooPart").getFilename().get());
+							assertEquals("bar", parts.get("barPart").getContentAsString().block());
+						}
+						catch(Exception e) {
+							return Mono.error(e);
+						}
+						return ServerResponse.ok().build();
+					});
+		}
+	}
+
+}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/DispatcherHandlerIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/DispatcherHandlerIntegrationTests.java
@@ -125,13 +125,13 @@ public class DispatcherHandlerIntegrationTests extends AbstractHttpHandlerIntegr
 					new HandlerStrategies() {
 						@Override
 						public Supplier<Stream<HttpMessageReader<?>>> messageReaders() {
-							return () -> getMessageCodecsConfigurer().getReaders().stream()
+							return () -> serverCodecConfigurer().getReaders().stream()
 									.map(reader -> (HttpMessageReader<?>) reader);
 						}
 
 						@Override
 						public Supplier<Stream<HttpMessageWriter<?>>> messageWriters() {
-							return () -> getMessageCodecsConfigurer().getWriters().stream()
+							return () -> serverCodecConfigurer().getWriters().stream()
 									.map(writer -> (HttpMessageWriter<?>) writer);
 						}
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ControllerMethodResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ControllerMethodResolverTests.java
@@ -91,6 +91,7 @@ public class ControllerMethodResolverTests {
 
 		AtomicInteger index = new AtomicInteger(-1);
 		assertEquals(RequestParamMethodArgumentResolver.class, next(resolvers, index).getClass());
+		assertEquals(RequestPartMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(RequestParamMapMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(PathVariableMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(PathVariableMapMethodArgumentResolver.class, next(resolvers, index).getClass());
@@ -129,6 +130,7 @@ public class ControllerMethodResolverTests {
 
 		AtomicInteger index = new AtomicInteger(-1);
 		assertEquals(RequestParamMethodArgumentResolver.class, next(resolvers, index).getClass());
+		assertEquals(RequestPartMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(RequestParamMapMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(PathVariableMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(PathVariableMapMethodArgumentResolver.class, next(resolvers, index).getClass());
@@ -165,6 +167,7 @@ public class ControllerMethodResolverTests {
 
 		AtomicInteger index = new AtomicInteger(-1);
 		assertEquals(RequestParamMethodArgumentResolver.class, next(resolvers, index).getClass());
+		assertEquals(RequestPartMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(RequestParamMapMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(PathVariableMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(PathVariableMapMethodArgumentResolver.class, next(resolvers, index).getClass());
@@ -195,6 +198,7 @@ public class ControllerMethodResolverTests {
 
 		AtomicInteger index = new AtomicInteger(-1);
 		assertEquals(RequestParamMethodArgumentResolver.class, next(resolvers, index).getClass());
+		assertEquals(RequestPartMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(RequestParamMapMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(PathVariableMethodArgumentResolver.class, next(resolvers, index).getClass());
 		assertEquals(PathVariableMapMethodArgumentResolver.class, next(resolvers, index).getClass());

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/MultipartIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/MultipartIntegrationTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method.annotation;
+
+import java.io.File;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.multipart.Part;
+import org.springframework.http.server.reactive.AbstractHttpHandlerIntegrationTests;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.bootstrap.JettyHttpServer;
+import org.springframework.http.server.reactive.bootstrap.ReactorHttpServer;
+import org.springframework.http.server.reactive.bootstrap.RxNettyHttpServer;
+import org.springframework.http.server.reactive.bootstrap.TomcatHttpServer;
+import org.springframework.http.server.reactive.bootstrap.UndertowHttpServer;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.DispatcherHandler;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
+
+import static org.junit.Assert.assertEquals;
+
+public class MultipartIntegrationTests extends AbstractHttpHandlerIntegrationTests {
+
+	private AnnotationConfigApplicationContext wac;
+
+	private WebClient webClient;
+
+	@Override
+	@Before
+	public void setup() throws Exception {
+		super.setup();
+		this.webClient = WebClient.create("http://localhost:" + this.port);
+	}
+
+
+	@Override
+	protected HttpHandler createHttpHandler() {
+		this.wac = new AnnotationConfigApplicationContext();
+		this.wac.register(TestConfiguration.class);
+		this.wac.refresh();
+
+		return WebHttpHandlerBuilder.webHandler(new DispatcherHandler(this.wac)).build();
+	}
+
+	@Test
+	public void map() {
+		test("/map");
+	}
+
+	@Test
+	public void multiValueMap() {
+		test("/multivaluemap");
+	}
+
+	@Test
+	public void partParam() {
+		test("/partparam");
+	}
+
+	@Test
+	public void part() {
+		test("/part");
+	}
+
+	private void test(String uri) {
+		Mono<ClientResponse> result = webClient
+				.post()
+				.uri(uri)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.body(BodyInserters.fromMultipartData(generateBody()))
+				.exchange();
+
+		StepVerifier
+				.create(result)
+				.consumeNextWith(response -> assertEquals(HttpStatus.OK, response.statusCode()))
+				.verifyComplete();
+	}
+
+	private MultiValueMap<String, Object> generateBody() {
+		HttpHeaders fooHeaders = new HttpHeaders();
+		fooHeaders.setContentType(MediaType.TEXT_PLAIN);
+		ClassPathResource fooResource = new ClassPathResource("org/springframework/http/codec/multipart/foo.txt");
+		HttpEntity<ClassPathResource> fooPart = new HttpEntity<>(fooResource, fooHeaders);
+		HttpEntity<String> barPart = new HttpEntity<>("bar");
+		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+		parts.add("fooPart", fooPart);
+		parts.add("barPart", barPart);
+		return parts;
+	}
+
+	@RestController
+	@SuppressWarnings("unused")
+	static class MultipartController {
+
+		@PostMapping("/map")
+		void map(@RequestParam Map<String, Part> parts) {
+			assertEquals(2, parts.size());
+			assertEquals("foo.txt", parts.get("fooPart").getFilename().get());
+			assertEquals("bar", parts.get("barPart").getContentAsString().block());
+		}
+
+		@PostMapping("/multivaluemap")
+		void multiValueMap(@RequestParam MultiValueMap<String, Part> parts) {
+			Map<String, Part> map = parts.toSingleValueMap();
+			assertEquals(2, map.size());
+			assertEquals("foo.txt", map.get("fooPart").getFilename().get());
+			assertEquals("bar", map.get("barPart").getContentAsString().block());
+		}
+
+		@PostMapping("/partparam")
+		void partParam(@RequestParam Part fooPart) {
+			assertEquals("foo.txt", fooPart.getFilename().get());
+		}
+
+		@PostMapping("/part")
+		void part(@RequestPart Part fooPart) {
+			assertEquals("foo.txt", fooPart.getFilename().get());
+		}
+
+	}
+
+	@Configuration
+	@EnableWebFlux
+	@SuppressWarnings("unused")
+	static class TestConfiguration {
+
+		@Bean
+		public MultipartController multipartController() {
+			return new MultipartController();
+		}
+	}
+
+}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/SessionAttributeMethodArgumentResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/SessionAttributeMethodArgumentResolverTests.java
@@ -31,6 +31,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.annotation.SynthesizingMethodParameter;
 import org.springframework.format.support.DefaultFormattingConversionService;
+import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.mock.http.server.reactive.test.MockServerHttpRequest;
 import org.springframework.mock.http.server.reactive.test.MockServerHttpResponse;
@@ -81,7 +82,7 @@ public class SessionAttributeMethodArgumentResolverTests {
 		WebSessionManager sessionManager = new MockWebSessionManager(this.session);
 
 		ServerHttpRequest request = MockServerHttpRequest.get("/").build();
-		this.exchange = new DefaultServerWebExchange(request, new MockServerHttpResponse(), sessionManager);
+		this.exchange = new DefaultServerWebExchange(request, new MockServerHttpResponse(), sessionManager, ServerCodecConfigurer.create());
 
 		this.handleMethod = ReflectionUtils.findMethod(getClass(), "handleWithSessionAttribute", (Class<?>[]) null);
 	}


### PR DESCRIPTION
This draft PR is a first Multipart support implementation here for high-level feedbacks and discussion.

It does not include RequestMapping level support, integration tests do not work yet with Reactor and RxNetty and `NioMultipartResolver` need to be rewritten using `Flux.create()` instead of `ReplayProcessor`.
