### PR TITLE
Remove OracleLobHandler from documentation

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/SimpleNativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/SimpleNativeJdbcExtractor.java
@@ -35,10 +35,6 @@ package org.springframework.jdbc.support.nativejdbc;
  * flags to "true". If none of the statement types is wrapped - or you solely need
  * Connection unwrapping in the first place -, the defaults are fine.
  *
- * <p>SimpleNativeJdbcExtractor is a common choice for use with OracleLobHandler, which
- * just needs Connection unwrapping via the {@link #getNativeConnectionFromStatement}
- * method. This usage will work with almost any connection pool.
- *
  * <p>For full usage with JdbcTemplate, i.e. to also provide Statement unwrapping:
  * <ul>
  * <li>Use a default SimpleNativeJdbcExtractor for Resin and SJSAS (no JDBC

--- a/src/asciidoc/data-access.adoc
+++ b/src/asciidoc/data-access.adoc
@@ -3230,7 +3230,7 @@ Sometimes you need to access vendor specific JDBC methods that differ from the s
 JDBC API. This can be problematic if you are running in an application server or with a
 `DataSource` that wraps the `Connection`, `Statement` and `ResultSet` objects with its
 own wrapper objects. To gain access to the native objects you can configure your
-`JdbcTemplate` or `OracleLobHandler` with a `NativeJdbcExtractor`.
+`JdbcTemplate` with a `NativeJdbcExtractor`.
 
 The `NativeJdbcExtractor` comes in a variety of flavors to match your execution
 environment:


### PR DESCRIPTION
Now that OracleLobHandler has finally been removed it should also be
removed from the documentation.

This commit includes the following changes:
- remove OracleLobHandler references from Javadoc
- remove OracleLobHandler references from Asciidoctor

I did sign and agree to the CLA.

Issue: SPR-14809
