### PR TITLE
Fix NativeJdbcExtractors documentation

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/SimpleNativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/SimpleNativeJdbcExtractor.java
@@ -46,9 +46,8 @@ package org.springframework.jdbc.support.nativejdbc;
  * <li>Use a SimpleNativeJdbcExtractor with all "nativeConnectionNecessaryForXxx"
  * flags set to "true" for C3P0 (all JDBC Statement objects are wrapped,
  * but none of the wrappers allow for unwrapping).
- * <li>Use a CommonsDbcpNativeJdbcExtractor for Apache Commons DBCP or a
- * JBossNativeJdbcExtractor for JBoss (all JDBC Statement objects are wrapped,
- * but all of them can be extracted by casting to implementation classes).
+ * <li>Use a JBossNativeJdbcExtractor for JBoss (all JDBC Statement objects are
+ * wrapped, but all of them can be extracted by casting to implementation classes).
  * </ul>
  *
  * @author Juergen Hoeller

--- a/src/asciidoc/data-access.adoc
+++ b/src/asciidoc/data-access.adoc
@@ -3237,11 +3237,9 @@ environment:
 
 * SimpleNativeJdbcExtractor
 * C3P0NativeJdbcExtractor
-* CommonsDbcpNativeJdbcExtractor
 * JBossNativeJdbcExtractor
 * WebLogicNativeJdbcExtractor
 * WebSphereNativeJdbcExtractor
-* XAPoolNativeJdbcExtractor
 
 Usually the `SimpleNativeJdbcExtractor` is sufficient for unwrapping a `Connection`
 object in most environments. See the javadocs for more details.


### PR DESCRIPTION
The documentation mentions various NativeJdbcExtractors that no longer
exist. To be specific CommonsDbcpNativeJdbcExtractor and
XAPoolNativeJdbcExtractor no longer exist.

This commit includes the following changes:
- remove CommonsDbcpNativeJdbcExtractor references from Asciidoctor
- remove CommonsDbcpNativeJdbcExtractor references from Javadoc
- remove XAPoolNativeJdbcExtractor references from Asciidoctor

I did sign and agree to the CLA.

Issue: SPR-14810
