### PR TITLE
Replace J2EE with Java EE

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/access/BeanFactoryLocator.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/access/BeanFactoryLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import org.springframework.beans.BeansException;
  * {@code BeanFactory} from which it gets the real object, to which it
  * delegates, then proper Dependency Injection has been achieved.
  *
- * <p>As another example, in a complex J2EE app with multiple layers, with each
+ * <p>As another example, in a complex Java EE app with multiple layers, with each
  * layer having its own {@code ApplicationContext} definition (in a
  * hierarchy), a class like {@code SingletonBeanFactoryLocator} may be used
  * to demand load these contexts.

--- a/spring-context/src/main/java/org/springframework/ejb/access/AbstractRemoteSlsbInvokerInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/ejb/access/AbstractRemoteSlsbInvokerInterceptor.java
@@ -53,7 +53,7 @@ public abstract class AbstractRemoteSlsbInvokerInterceptor extends AbstractSlsbI
 	 * Set a home interface that this invoker will narrow to before performing
 	 * the parameterless SLSB {@code create()} call that returns the actual
 	 * SLSB proxy.
-	 * <p>Default is none, which will work on all J2EE servers that are not based
+	 * <p>Default is none, which will work on all Java EE servers that are not based
 	 * on CORBA. A plain {@code javax.ejb.EJBHome} interface is known to be
 	 * sufficient to make a WebSphere 5.0 Remote SLSB work. On other servers,
 	 * the specific home interface for the target SLSB might be necessary.

--- a/spring-context/src/main/java/org/springframework/ejb/config/package-info.java
+++ b/spring-context/src/main/java/org/springframework/ejb/config/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Support package for EJB/J2EE-related configuration,
+ * Support package for EJB/Java EE-related configuration,
  * with XML schema being the primary configuration format.
  */
 package org.springframework.ejb.config;

--- a/spring-context/src/main/java/org/springframework/jndi/JndiLocatorDelegate.java
+++ b/spring-context/src/main/java/org/springframework/jndi/JndiLocatorDelegate.java
@@ -76,7 +76,7 @@ public class JndiLocatorDelegate extends JndiLocatorSupport {
 	}
 
 	/**
-	 * Check whether a default JNDI environment, as in a J2EE environment,
+	 * Check whether a default JNDI environment, as in a Java EE environment,
 	 * is available on this JVM.
 	 * @return {@code true} if a default InitialContext can be used,
 	 * {@code false} if not

--- a/spring-context/src/main/java/org/springframework/jndi/JndiLocatorSupport.java
+++ b/spring-context/src/main/java/org/springframework/jndi/JndiLocatorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
  * bean properties.
  *
  * <p>JNDI names may or may not include the "java:comp/env/" prefix expected
- * by J2EE applications when accessing a locally mapped (ENC - Environmental
+ * by Java EE applications when accessing a locally mapped (ENC - Environmental
  * Naming Context) resource. If it doesn't, the "java:comp/env/" prefix will
  * be prepended if the "resourceRef" property is true (the default is
  * <strong>false</strong>) and no other scheme (e.g. "java:") is given.
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  */
 public abstract class JndiLocatorSupport extends JndiAccessor {
 
-	/** JNDI prefix used in a J2EE container */
+	/** JNDI prefix used in a Java EE container */
 	public static final String CONTAINER_PREFIX = "java:comp/env/";
 
 
@@ -47,7 +47,7 @@ public abstract class JndiLocatorSupport extends JndiAccessor {
 
 
 	/**
-	 * Set whether the lookup occurs in a J2EE container, i.e. if the prefix
+	 * Set whether the lookup occurs in a Java EE container, i.e. if the prefix
 	 * "java:comp/env/" needs to be added if the JNDI name doesn't already
 	 * contain it. Default is "false".
 	 * <p>Note: Will only get applied if no other scheme (e.g. "java:") is given.
@@ -57,7 +57,7 @@ public abstract class JndiLocatorSupport extends JndiAccessor {
 	}
 
 	/**
-	 * Return whether the lookup occurs in a J2EE container.
+	 * Return whether the lookup occurs in a Java EE container.
 	 */
 	public boolean isResourceRef() {
 		return this.resourceRef;

--- a/spring-context/src/main/java/org/springframework/jndi/JndiObjectLocator.java
+++ b/spring-context/src/main/java/org/springframework/jndi/JndiObjectLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.util.StringUtils;
  * providing configurable lookup of a specific JNDI resource.
  *
  * <p>Exposes a {@link #setJndiName "jndiName"} property. This may or may not
- * include the "java:comp/env/" prefix expected by J2EE applications when
+ * include the "java:comp/env/" prefix expected by Java EE applications when
  * accessing a locally mapped (Environmental Naming Context) resource. If it
  * doesn't, the "java:comp/env/" prefix will be prepended if the "resourceRef"
  * property is true (the default is <strong>false</strong>) and no other scheme

--- a/spring-context/src/main/java/org/springframework/jndi/support/SimpleJndiBeanFactory.java
+++ b/spring-context/src/main/java/org/springframework/jndi/support/SimpleJndiBeanFactory.java
@@ -40,7 +40,7 @@ import org.springframework.jndi.TypeMismatchNamingException;
  * the {@link org.springframework.beans.factory.ListableBeanFactory} interface.
  *
  * <p>This factory resolves given bean names as JNDI names within the
- * J2EE application's "java:comp/env/" namespace. It caches the resolved
+ * Java EE application's "java:comp/env/" namespace. It caches the resolved
  * types for all obtained objects, and optionally also caches shareable
  * objects (if they are explicitly marked as
  * {@link #addShareableResource shareable resource}.

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/DefaultManagedAwareThreadFactory.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/DefaultManagedAwareThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class DefaultManagedAwareThreadFactory extends CustomizableThreadFactory 
 	}
 
 	/**
-	 * Set whether the lookup occurs in a J2EE container, i.e. if the prefix
+	 * Set whether the lookup occurs in a Java EE container, i.e. if the prefix
 	 * "java:comp/env/" needs to be added if the JNDI name doesn't already
 	 * contain it. PersistenceAnnotationBeanPostProcessor's default is "true".
 	 * @see org.springframework.jndi.JndiLocatorSupport#setResourceRef

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/DefaultManagedTaskExecutor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/DefaultManagedTaskExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class DefaultManagedTaskExecutor extends ConcurrentTaskExecutor implement
 	}
 
 	/**
-	 * Set whether the lookup occurs in a J2EE container, i.e. if the prefix
+	 * Set whether the lookup occurs in a Java EE container, i.e. if the prefix
 	 * "java:comp/env/" needs to be added if the JNDI name doesn't already
 	 * contain it. PersistenceAnnotationBeanPostProcessor's default is "true".
 	 * @see org.springframework.jndi.JndiLocatorSupport#setResourceRef

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/DefaultManagedTaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/DefaultManagedTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class DefaultManagedTaskScheduler extends ConcurrentTaskScheduler impleme
 	}
 
 	/**
-	 * Set whether the lookup occurs in a J2EE container, i.e. if the prefix
+	 * Set whether the lookup occurs in a Java EE container, i.e. if the prefix
 	 * "java:comp/env/" needs to be added if the JNDI name doesn't already
 	 * contain it. PersistenceAnnotationBeanPostProcessor's default is "true".
 	 * @see org.springframework.jndi.JndiLocatorSupport#setResourceRef

--- a/spring-context/src/main/java/org/springframework/stereotype/Repository.java
+++ b/spring-context/src/main/java/org/springframework/stereotype/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * Domain-Driven Design (Evans, 2003) as "a mechanism for encapsulating storage,
  * retrieval, and search behavior which emulates a collection of objects".
  *
- * <p>Teams implementing traditional J2EE patterns such as "Data Access Object"
+ * <p>Teams implementing traditional Java EE patterns such as "Data Access Object"
  * may also apply this stereotype to DAO classes, though care should be taken to
  * understand the distinction between Data Access Object and DDD-style repositories
  * before doing so. This annotation is a general-purpose stereotype and individual teams

--- a/spring-context/src/test/java/org/springframework/tests/mock/jndi/SimpleNamingContextBuilder.java
+++ b/spring-context/src/test/java/org/springframework/tests/mock/jndi/SimpleNamingContextBuilder.java
@@ -35,7 +35,7 @@ import org.springframework.util.ClassUtils;
  * configure JNDI appropriately, so that {@code new InitialContext()}
  * will expose the required objects. Also usable for standalone applications,
  * e.g. for binding a JDBC DataSource to a well-known JNDI location, to be
- * able to use traditional J2EE data access code outside of a J2EE container.
+ * able to use traditional Java EE data access code outside of a Java EE container.
  *
  * <p>There are various choices for DataSource implementations:
  * <ul>

--- a/spring-context/src/test/java/org/springframework/tests/mock/jndi/package-info.java
+++ b/spring-context/src/test/java/org/springframework/tests/mock/jndi/package-info.java
@@ -19,7 +19,7 @@
  *
  * <p>Useful for setting up a simple JNDI environment for test suites
  * or standalone applications. If e.g. JDBC DataSources get bound to the
- * same JNDI names as within a J2EE container, both application code and
+ * same JNDI names as within a Java EE container, both application code and
  * configuration can me reused without changes.
  */
 package org.springframework.tests.mock.jndi;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceTransactionManager.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,14 +47,14 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  *
  * <p>Application code is required to retrieve the JDBC Connection via
  * {@link DataSourceUtils#getConnection(DataSource)} instead of a standard
- * J2EE-style {@link DataSource#getConnection()} call. Spring classes such as
+ * Java EE-style {@link DataSource#getConnection()} call. Spring classes such as
  * {@link org.springframework.jdbc.core.JdbcTemplate} use this strategy implicitly.
  * If not used in combination with this transaction manager, the
  * {@link DataSourceUtils} lookup strategy behaves exactly like the native
  * DataSource lookup; it can thus be used in a portable fashion.
  *
  * <p>Alternatively, you can allow application code to work with the standard
- * J2EE-style lookup pattern {@link DataSource#getConnection()}, for example for
+ * Java EE-style lookup pattern {@link DataSource#getConnection()}, for example for
  * legacy code that is not aware of Spring at all. In that case, define a
  * {@link TransactionAwareDataSourceProxy} for your target DataSource, and pass
  * that proxy DataSource to your DAOs, which will automatically participate in

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DriverManagerDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DriverManagerDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.springframework.util.ClassUtils;
  * connection pool, implementing the same standard interface, but creating new
  * Connections on every call.
  *
- * <p>Useful for test or standalone environments outside of a J2EE container, either
+ * <p>Useful for test or standalone environments outside of a Java EE container, either
  * as a DataSource bean in a corresponding ApplicationContext or in conjunction with
  * a simple JNDI environment. Pool-assuming {@code Connection.close()} calls will
  * simply close the Connection, so any DataSource-aware persistence code should work.
@@ -44,7 +44,7 @@ import org.springframework.util.ClassUtils;
  * loading issues with the JDBC DriverManager that be resolved through direct Driver
  * usage (which is exactly what SimpleDriverDataSource does).</b>
  *
- * <p>In a J2EE container, it is recommended to use a JNDI DataSource provided by
+ * <p>In a Java EE container, it is recommended to use a JNDI DataSource provided by
  * the container. Such a DataSource can be exposed as a DataSource bean in a Spring
  * ApplicationContext via {@link org.springframework.jndi.JndiObjectFactoryBean},
  * for seamless switching to and from a local DataSource bean like this class.
@@ -52,7 +52,7 @@ import org.springframework.util.ClassUtils;
  * {@link org.springframework.mock.jndi.SimpleNamingContextBuilder}, or switch the
  * bean definition to a local DataSource (which is simpler and thus recommended).
  *
- * <p>If you need a "real" connection pool outside of a J2EE container, consider
+ * <p>If you need a "real" connection pool outside of a Java EE container, consider
  * <a href="http://commons.apache.org/proper/commons-dbcp">Apache Commons DBCP</a>
  * or <a href="http://sourceforge.net/projects/c3p0">C3P0</a>.
  * Commons DBCP's BasicDataSource and C3P0's ComboPooledDataSource are full

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/LazyConnectionDataSourceProxy.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/LazyConnectionDataSourceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ import org.springframework.core.Constants;
  * without paying a performance penalty if no actual data access happens.
  *
  * <p>This DataSource proxy gives you behavior analogous to JTA and a
- * transactional JNDI DataSource (as provided by the J2EE server), even
+ * transactional JNDI DataSource (as provided by the Java EE server), even
  * with a local transaction strategy like DataSourceTransactionManager or
  * HibernateTransactionManager. It does not add value with Spring's
  * JtaTransactionManager as transaction strategy.

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/SimpleDriverDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/SimpleDriverDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,12 @@ import org.springframework.util.Assert;
  * connection pool, implementing the same standard interface, but creating new
  * Connections on every call.
  *
- * <p>In a J2EE container, it is recommended to use a JNDI DataSource provided by
+ * <p>In a Java EE container, it is recommended to use a JNDI DataSource provided by
  * the container. Such a DataSource can be exposed as a DataSource bean in a Spring
  * ApplicationContext via {@link org.springframework.jndi.JndiObjectFactoryBean},
  * for seamless switching to and from a local DataSource bean like this class.
  *
- * <p>If you need a "real" connection pool outside of a J2EE container, consider
+ * <p>If you need a "real" connection pool outside of a Java EE container, consider
  * <a href="http://commons.apache.org/proper/commons-dbcp">Apache Commons DBCP</a>
  * or <a href="http://sourceforge.net/projects/c3p0">C3P0</a>.
  * Commons DBCP's BasicDataSource and C3P0's ComboPooledDataSource are full

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/TransactionAwareDataSourceProxy.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/TransactionAwareDataSourceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.util.Assert;
 /**
  * Proxy for a target JDBC {@link javax.sql.DataSource}, adding awareness of
  * Spring-managed transactions. Similar to a transactional JNDI DataSource
- * as provided by a J2EE server.
+ * as provided by a Java EE server.
  *
  * <p>Data access code that should remain unaware of Spring's data access support
  * can work with this proxy to seamlessly participate in Spring-managed transactions.
@@ -51,7 +51,7 @@ import org.springframework.util.Assert;
  * Connection. If not within a transaction, normal DataSource behavior applies.
  *
  * <p>This proxy allows data access code to work with the plain JDBC API and still
- * participate in Spring-managed transactions, similar to JDBC code in a J2EE/JTA
+ * participate in Spring-managed transactions, similar to JDBC code in a Java EE/JTA
  * environment. However, if possible, use Spring's DataSourceUtils, JdbcTemplate or
  * JDBC operation objects to get transaction participation even without a proxy for
  * the target DataSource, avoiding the need to define such a proxy in the first place.

--- a/spring-jms/src/main/java/org/springframework/jms/connection/JmsTransactionManager.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/JmsTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,12 +50,12 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  *
  * <p>Application code is required to retrieve the transactional JMS Session via
  * {@link ConnectionFactoryUtils#getTransactionalSession} instead of a standard
- * J2EE-style {@link ConnectionFactory#createConnection()} call with subsequent
+ * Java EE-style {@link ConnectionFactory#createConnection()} call with subsequent
  * Session creation. Spring's {@link org.springframework.jms.core.JmsTemplate}
  * will autodetect a thread-bound Session and automatically participate in it.
  *
  * <p>Alternatively, you can allow application code to work with the standard
- * J2EE-style lookup pattern on a ConnectionFactory, for example for legacy code
+ * Java EE-style lookup pattern on a ConnectionFactory, for example for legacy code
  * that is not aware of Spring at all. In that case, define a
  * {@link TransactionAwareConnectionFactoryProxy} for your target ConnectionFactory,
  * which will automatically participate in Spring-managed transactions.

--- a/spring-jms/src/main/resources/org/springframework/jms/config/spring-jms.xsd
+++ b/spring-jms/src/main/resources/org/springframework/jms/config/spring-jms.xsd
@@ -180,7 +180,7 @@
 	A reference to the DestinationResolver strategy for resolving destination names.
 	Default is a DynamicDestinationResolver, using the JMS provider's queue/topic
 	name resolution. Alternatively, specify a reference to a JndiDestinationResolver
-	(typically in a J2EE environment).
+	(typically in a Java EE environment).
 					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -262,7 +262,7 @@
 	The cache level for JMS resources: "none", "connection", "session", "consumer"
 	or "auto". By default ("auto"), the cache level will effectively be "consumer",
 	unless an external transaction manager has been specified - in which case the
-	effective default will be "none" (assuming J2EE-style transaction management
+	effective default will be "none" (assuming Java EE-style transaction management
 	where the given ConnectionFactory is an XA-aware pool).
 					]]></xsd:documentation>
 				</xsd:annotation>
@@ -437,7 +437,7 @@
 					<xsd:documentation><![CDATA[
 	A reference to the DestinationResolver strategy for resolving destination names.
 	Default is to pass in the destination name Strings into the JCA ActivationSpec as-is.
-	Alternatively, specify a reference to a JndiDestinationResolver (typically in a J2EE
+	Alternatively, specify a reference to a JndiDestinationResolver (typically in a Java EE
 	environment, in particular if the server insists on receiving Destination objects).
 					]]></xsd:documentation>
 					<xsd:appinfo>

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/support/PersistenceAnnotationBeanPostProcessor.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/support/PersistenceAnnotationBeanPostProcessor.java
@@ -209,7 +209,7 @@ public class PersistenceAnnotationBeanPostProcessor
 	}
 
 	/**
-	 * Set whether the lookup occurs in a J2EE container, i.e. if the prefix
+	 * Set whether the lookup occurs in a Java EE container, i.e. if the prefix
 	 * "java:comp/env/" needs to be added if the JNDI name doesn't already
 	 * contain it. PersistenceAnnotationBeanPostProcessor's default is "true".
 	 * @see org.springframework.jndi.JndiLocatorSupport#setResourceRef

--- a/spring-test/src/main/java/org/springframework/mock/jndi/SimpleNamingContextBuilder.java
+++ b/spring-test/src/main/java/org/springframework/mock/jndi/SimpleNamingContextBuilder.java
@@ -37,7 +37,7 @@ import org.springframework.util.ReflectionUtils;
  * configure JNDI appropriately, so that {@code new InitialContext()}
  * will expose the required objects. Also usable for standalone applications,
  * e.g. for binding a JDBC DataSource to a well-known JNDI location, to be
- * able to use traditional J2EE data access code outside of a J2EE container.
+ * able to use traditional Java EE data access code outside of a Java EE container.
  *
  * <p>There are various choices for DataSource implementations:
  * <ul>

--- a/spring-tx/src/main/java/org/springframework/jca/cci/connection/CciLocalTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/jca/cci/connection/CciLocalTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,14 +40,14 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  *
  * <p>Application code is required to retrieve the CCI Connection via
  * {@link ConnectionFactoryUtils#getConnection(ConnectionFactory)} instead of a standard
- * J2EE-style {@link ConnectionFactory#getConnection()} call. Spring classes such as
+ * Java EE-style {@link ConnectionFactory#getConnection()} call. Spring classes such as
  * {@link org.springframework.jca.cci.core.CciTemplate} use this strategy implicitly.
  * If not used in combination with this transaction manager, the
  * {@link ConnectionFactoryUtils} lookup strategy behaves exactly like the native
  * DataSource lookup; it can thus be used in a portable fashion.
  *
  * <p>Alternatively, you can allow application code to work with the standard
- * J2EE lookup pattern {@link ConnectionFactory#getConnection()}, for example
+ * Java EE lookup pattern {@link ConnectionFactory#getConnection()}, for example
  * for legacy code that is not aware of Spring at all. In that case, define a
  * {@link TransactionAwareConnectionFactoryProxy} for your target ConnectionFactory,
  * which will automatically participate in Spring-managed transactions.

--- a/spring-tx/src/main/java/org/springframework/jca/cci/connection/TransactionAwareConnectionFactoryProxy.java
+++ b/spring-tx/src/main/java/org/springframework/jca/cci/connection/TransactionAwareConnectionFactoryProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import javax.resource.cci.ConnectionFactory;
 /**
  * Proxy for a target CCI {@link javax.resource.cci.ConnectionFactory}, adding
  * awareness of Spring-managed transactions. Similar to a transactional JNDI
- * ConnectionFactory as provided by a J2EE server.
+ * ConnectionFactory as provided by a Java EE server.
  *
  * <p>Data access code that should remain unaware of Spring's data access support
  * can work with this proxy to seamlessly participate in Spring-managed transactions.
@@ -47,7 +47,7 @@ import javax.resource.cci.ConnectionFactory;
  * Connection. If not within a transaction, normal ConnectionFactory behavior applies.
  *
  * <p>This proxy allows data access code to work with the plain JCA CCI API and still
- * participate in Spring-managed transactions, similar to CCI code in a J2EE/JTA
+ * participate in Spring-managed transactions, similar to CCI code in a Java EE/JTA
  * environment. However, if possible, use Spring's ConnectionFactoryUtils, CciTemplate or
  * CCI operation objects to get transaction participation even without a proxy for
  * the target ConnectionFactory, avoiding the need to define such a proxy in the first place.

--- a/spring-tx/src/main/java/org/springframework/jca/context/SpringContextResourceAdapter.java
+++ b/spring-tx/src/main/java/org/springframework/jca/context/SpringContextResourceAdapter.java
@@ -64,7 +64,7 @@ import org.springframework.util.StringUtils;
  * to such components.
  *
  * <p>This ResourceAdapter is to be defined in a "META-INF/ra.xml" file
- * within a J2EE ".rar" deployment unit like as follows:
+ * within a Java EE ".rar" deployment unit like as follows:
  *
  * <pre class="code">
  * &lt;?xml version="1.0" encoding="UTF-8"?&gt;

--- a/spring-tx/src/main/java/org/springframework/jca/support/LocalConnectionFactoryBean.java
+++ b/spring-tx/src/main/java/org/springframework/jca/support/LocalConnectionFactoryBean.java
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.InitializingBean;
  * a local JCA connection factory in "non-managed" mode (as defined by the
  * Java Connector Architecture specification). This is a direct alternative
  * to a {@link org.springframework.jndi.JndiObjectFactoryBean} definition that
- * obtains a connection factory handle from a J2EE server's naming environment.
+ * obtains a connection factory handle from a Java EE server's naming environment.
  *
  * <p>The type of the connection factory is dependent on the actual connector:
  * the connector can either expose its native API (such as a JDBC
@@ -45,7 +45,7 @@ import org.springframework.beans.factory.InitializingBean;
  *
  * <p><b>NOTE:</b> In non-managed mode, a connector is not deployed on an
  * application server, or more specificially not interacting with an application
- * server. Consequently, it cannot use a J2EE server's system contracts:
+ * server. Consequently, it cannot use a Java EE server's system contracts:
  * connection management, transaction management, and security management.
  * A custom ConnectionManager implementation has to be used for applying those
  * services in conjunction with a standalone transaction coordinator etc.

--- a/spring-tx/src/main/java/org/springframework/jca/work/WorkManagerTaskExecutor.java
+++ b/spring-tx/src/main/java/org/springframework/jca/work/WorkManagerTaskExecutor.java
@@ -58,7 +58,7 @@ import org.springframework.util.concurrent.ListenableFutureTask;
  * <p>This adapter is also capable of obtaining a JCA WorkManager from JNDI.
  * This is for example appropriate on the Geronimo application server, where
  * WorkManager GBeans (e.g. Geronimo's default "DefaultWorkManager" GBean)
- * can be linked into the J2EE environment through "gbean-ref" entries
+ * can be linked into the Java EE environment through "gbean-ref" entries
  * in the {@code geronimo-web.xml} deployment descriptor.
  *
  * @author Juergen Hoeller

--- a/spring-web/src/main/java/org/springframework/remoting/jaxws/LocalJaxWsServiceFactoryBean.java
+++ b/spring-web/src/main/java/org/springframework/remoting/jaxws/LocalJaxWsServiceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.InitializingBean;
  * Uses {@link LocalJaxWsServiceFactory}'s facilities underneath.
  *
  * <p>Alternatively, JAX-WS Service references can be looked up
- * in the JNDI environment of the J2EE container.
+ * in the JNDI environment of the Java EE container.
  *
  * @author Juergen Hoeller
  * @since 2.5


### PR DESCRIPTION
String with version 5 the name of Java Platform, Enterprise Edition
changed from J2EE to Java EE. However a lot of the documentation still
uses the term J2EE.

This commit includes the following changes:
- replace J2EE with Java EE where appropriate

This is not a blind search and replace. The following occurrences
remain unchanged:
- references to old J2EE releases, most notably 1.3 and 1.4.
- references to "Expert One-On-One J2EE Design and Development"
- references to "Core J2EE patterns"
- XML namespaces
- package names

I did sign and agree to the CLA.

Issue: SPR-14811
