### PR TITLE
Better encapsulation for CORS default permit configuration

### DIFF
--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/CorsRegistration.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/CorsRegistration.java
@@ -19,18 +19,14 @@ package org.springframework.web.reactive.config;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.springframework.http.HttpMethod;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.cors.CorsConfiguration;
 
 /**
  * Assists with the creation of a {@link CorsConfiguration} instance mapped to
  * a path pattern.
  *
- * <p>If no path pattern is specified, by default cross-origin request handling
- * is mapped to {@code "/**"}. Also by default, all origins, headers,
- * credentials and {@code GET}, {@code HEAD}, and {@code POST} methods are
- * allowed, while the max age is set to 30 minutes.
+ * <p>By default, all origins, headers, credentials and {@code GET}, {@code HEAD}, and
+ * {@code POST} methods are allowed, while the max age is set to 30 minutes.
  *
  * @author Sebastien Deleuze
  * @since 5.0
@@ -43,44 +39,84 @@ public class CorsRegistration {
 	private final CorsConfiguration config;
 
 
+	/**
+	 * Create a new {@link CorsRegistration} instance with all origins, headers, credentials
+	 * and {@code GET}, {@code HEAD}, and {@code POST} methods allowed, and the max age
+	 * set to 30 minutes on the specified path.
+	 * @param pathPattern the path where the CORS configuration should apply. Exact path
+	 * mapping URIs (such as {@code "/admin"}) are supported as well as Ant-style path
+	 * patterns (such as {@code "/admin/**"}).
+	 */
 	public CorsRegistration(String pathPattern) {
 		this.pathPattern = pathPattern;
 		// Same implicit default values as the @CrossOrigin annotation + allows simple methods
-		this.config = new CorsConfiguration();
-		this.config.setAllowedOrigins(Arrays.asList(CrossOrigin.DEFAULT_ORIGINS));
-		this.config.setAllowedMethods(Arrays.asList(HttpMethod.GET.name(),
-				HttpMethod.HEAD.name(), HttpMethod.POST.name()));
-		this.config.setAllowedHeaders(Arrays.asList(CrossOrigin.DEFAULT_ALLOWED_HEADERS));
-		this.config.setAllowCredentials(CrossOrigin.DEFAULT_ALLOW_CREDENTIALS);
-		this.config.setMaxAge(CrossOrigin.DEFAULT_MAX_AGE);
+		this.config = new CorsConfiguration().applyDefaultPermitConfiguration();
 	}
 
 
+	/**
+	 * Set the origins to allow, e.g. {@code "http://domain1.com"}.
+	 * <p>The special value {@code "*"} allows all domains.
+	 * <p>By default, all origins are allowed.
+	 */
 	public CorsRegistration allowedOrigins(String... origins) {
 		this.config.setAllowedOrigins(new ArrayList<>(Arrays.asList(origins)));
 		return this;
 	}
 
+	/**
+	 * Set the HTTP methods to allow, e.g. {@code "GET"}, {@code "POST"},
+	 * {@code "PUT"}, etc.
+	 * <p>The special value {@code "*"} allows all methods.
+	 * <p>By default, simple methods ({@code GET}, {@code HEAD}, and {@code POST}) are allowed.
+	 */
 	public CorsRegistration allowedMethods(String... methods) {
 		this.config.setAllowedMethods(new ArrayList<>(Arrays.asList(methods)));
 		return this;
 	}
 
+	/**
+	 * Set the list of headers that a pre-flight request can list as allowed
+	 * for use during an actual request.
+	 * <p>The special value {@code "*"} allows actual requests to send any
+	 * header.
+	 * <p>A header name is not required to be listed if it is one of:
+	 * {@code Cache-Control}, {@code Content-Language}, {@code Expires},
+	 * {@code Last-Modified}, or {@code Pragma}.
+	 * <p>By default, all headers are allowed.
+	 */
 	public CorsRegistration allowedHeaders(String... headers) {
 		this.config.setAllowedHeaders(new ArrayList<>(Arrays.asList(headers)));
 		return this;
 	}
 
+	/**
+	 * Set the list of response headers other than simple headers (i.e.
+	 * {@code Cache-Control}, {@code Content-Language}, {@code Content-Type},
+	 * {@code Expires}, {@code Last-Modified}, or {@code Pragma}) that an
+	 * actual response might have and can be exposed.
+	 * <p>Note that {@code "*"} is not a valid exposed header value.
+	 * <p>By default this is not set.
+	 */
 	public CorsRegistration exposedHeaders(String... headers) {
 		this.config.setExposedHeaders(new ArrayList<>(Arrays.asList(headers)));
 		return this;
 	}
 
+	/**
+	 * Configure how long, in seconds, the response from a pre-flight request
+	 * can be cached by clients.
+	 * <p>By default, this is set to 1800 seconds (30 minutes).
+	 */
 	public CorsRegistration maxAge(long maxAge) {
 		this.config.setMaxAge(maxAge);
 		return this;
 	}
 
+	/**
+	 * Whether user credentials are supported.
+	 * <p>By default, this is set to {@code true} (i.e. user credentials are supported).
+	 */
 	public CorsRegistration allowCredentials(boolean allowCredentials) {
 		this.config.setAllowCredentials(allowCredentials);
 		return this;

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMapping.java
@@ -18,7 +18,6 @@ package org.springframework.web.reactive.result.method.annotation;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Set;
 
 import org.springframework.context.EmbeddedValueResolverAware;
@@ -294,25 +293,12 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 		updateCorsConfig(config, typeAnnotation);
 		updateCorsConfig(config, methodAnnotation);
 
-		if (CollectionUtils.isEmpty(config.getAllowedOrigins())) {
-			config.setAllowedOrigins(Arrays.asList(CrossOrigin.DEFAULT_ORIGINS));
-		}
 		if (CollectionUtils.isEmpty(config.getAllowedMethods())) {
 			for (RequestMethod allowedMethod : mappingInfo.getMethodsCondition().getMethods()) {
 				config.addAllowedMethod(allowedMethod.name());
 			}
 		}
-		if (CollectionUtils.isEmpty(config.getAllowedHeaders())) {
-			config.setAllowedHeaders(Arrays.asList(CrossOrigin.DEFAULT_ALLOWED_HEADERS));
-		}
-		if (config.getAllowCredentials() == null) {
-			config.setAllowCredentials(CrossOrigin.DEFAULT_ALLOW_CREDENTIALS);
-		}
-		if (config.getMaxAge() == null) {
-			config.setMaxAge(CrossOrigin.DEFAULT_MAX_AGE);
-		}
-
-		return config;
+		return config.applyDefaultPermitConfiguration();
 	}
 
 	private void updateCorsConfig(CorsConfiguration config, CrossOrigin annotation) {

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/CrossOrigin.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/CrossOrigin.java
@@ -23,11 +23,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.web.cors.CorsConfiguration;
 
 /**
  * Marks the annotated method or type as permitting cross origin requests.
  *
- * <p>By default, all origins and headers are permitted.
+ * <p>By default, all origins, headers are permitted, credentials are allowed and the
+ * maximum age is set to 30 minutes.
  *
  * <p><b>NOTE:</b> {@code @CrossOrigin} is processed if an appropriate
  * {@code HandlerMapping}-{@code HandlerAdapter} pair is configured such as the
@@ -44,12 +46,28 @@ import org.springframework.core.annotation.AliasFor;
 @Documented
 public @interface CrossOrigin {
 
+	/**
+	 * @deprecated as of Spring 5.0, in favor of using {@link CorsConfiguration#applyDefaultPermitConfiguration}
+	 */
+	@Deprecated
 	String[] DEFAULT_ORIGINS = { "*" };
 
+	/**
+	 * @deprecated as of Spring 5.0, in favor of using {@link CorsConfiguration#applyDefaultPermitConfiguration}
+	 */
+	@Deprecated
 	String[] DEFAULT_ALLOWED_HEADERS = { "*" };
 
+	/**
+	 * @deprecated as of Spring 5.0, in favor of using {@link CorsConfiguration#applyDefaultPermitConfiguration}
+	 */
+	@Deprecated
 	boolean DEFAULT_ALLOW_CREDENTIALS = true;
 
+	/**
+	 * @deprecated as of Spring 5.0, in favor of using {@link CorsConfiguration#applyDefaultPermitConfiguration}
+	 */
+	@Deprecated
 	long DEFAULT_MAX_AGE = 1800;
 
 

--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.web.cors;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -71,7 +72,9 @@ public class CorsConfiguration {
 
 
 	/**
-	 * Construct a new, empty {@code CorsConfiguration} instance.
+	 * Construct a new {@code CorsConfiguration} instance with nothing allowed by default
+	 * but {@code "GET"} and {@code "HEAD"} methods.
+	 * @see #applyDefaultPermitConfiguration()
 	 */
 	public CorsConfiguration() {
 	}
@@ -90,6 +93,36 @@ public class CorsConfiguration {
 		this.maxAge = other.maxAge;
 	}
 
+	/**
+	 * Apply the following default permit configuration only for properties that has not
+	 * been defined:
+	 * <ul>
+	 *     <li>All origins are allowed</li>
+	 *     <li>Simple methods ({@code GET}, {@code HEAD} and {@code POST}) are allowed</li>
+	 *     <li>All headers are allowed</li>
+	 *     <li>Credentials are allowed</li>
+	 *     <li>Max age is set to 1800 seconds (30 minutes)</li>
+	 * </ul>
+	 */
+	public CorsConfiguration applyDefaultPermitConfiguration() {
+		if (this.allowedOrigins == null) {
+			this.addAllowedOrigin(ALL);
+		}
+		if (this.allowedMethods == null) {
+			this.setAllowedMethods(Arrays.asList(HttpMethod.GET.name(),
+					HttpMethod.HEAD.name(), HttpMethod.POST.name()));
+		}
+		if (this.allowedHeaders == null) {
+			this.addAllowedHeader(ALL);
+		}
+		if (this.allowCredentials == null) {
+			this.setAllowCredentials(true);
+		}
+		if (this.maxAge == null) {
+			this.setMaxAge(1800L);
+		}
+		return this;
+	}
 
 	/**
 	 * Combine the supplied {@code CorsConfiguration} with this one.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/CorsBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/CorsBeanDefinitionParser.java
@@ -26,7 +26,6 @@ import org.w3c.dom.Element;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.http.HttpMethod;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 import org.springframework.web.cors.CorsConfiguration;
@@ -42,18 +41,6 @@ import org.springframework.web.cors.CorsConfiguration;
  */
 public class CorsBeanDefinitionParser implements BeanDefinitionParser {
 
-	private static final List<String> DEFAULT_ALLOWED_ORIGINS = Arrays.asList("*");
-
-	private static final List<String> DEFAULT_ALLOWED_METHODS =
-			Arrays.asList(HttpMethod.GET.name(), HttpMethod.HEAD.name(), HttpMethod.POST.name());
-
-	private static final List<String> DEFAULT_ALLOWED_HEADERS = Arrays.asList("*");
-
-	private static final boolean DEFAULT_ALLOW_CREDENTIALS = true;
-
-	private static final long DEFAULT_MAX_AGE = 1600;
-
-
 	@Override
 	public BeanDefinition parse(Element element, ParserContext parserContext) {
 
@@ -61,12 +48,7 @@ public class CorsBeanDefinitionParser implements BeanDefinitionParser {
 		List<Element> mappings = DomUtils.getChildElementsByTagName(element, "mapping");
 
 		if (mappings.isEmpty()) {
-			CorsConfiguration config = new CorsConfiguration();
-			config.setAllowedOrigins(DEFAULT_ALLOWED_ORIGINS);
-			config.setAllowedMethods(DEFAULT_ALLOWED_METHODS);
-			config.setAllowedHeaders(DEFAULT_ALLOWED_HEADERS);
-			config.setAllowCredentials(DEFAULT_ALLOW_CREDENTIALS);
-			config.setMaxAge(DEFAULT_MAX_AGE);
+			CorsConfiguration config = new CorsConfiguration().applyDefaultPermitConfiguration();
 			corsConfigurations.put("/**", config);
 		}
 		else {
@@ -76,22 +58,13 @@ public class CorsBeanDefinitionParser implements BeanDefinitionParser {
 					String[] allowedOrigins = StringUtils.tokenizeToStringArray(mapping.getAttribute("allowed-origins"), ",");
 					config.setAllowedOrigins(Arrays.asList(allowedOrigins));
 				}
-				else {
-					config.setAllowedOrigins(DEFAULT_ALLOWED_ORIGINS);
-				}
 				if (mapping.hasAttribute("allowed-methods")) {
 					String[] allowedMethods = StringUtils.tokenizeToStringArray(mapping.getAttribute("allowed-methods"), ",");
 					config.setAllowedMethods(Arrays.asList(allowedMethods));
 				}
-				else {
-					config.setAllowedMethods(DEFAULT_ALLOWED_METHODS);
-				}
 				if (mapping.hasAttribute("allowed-headers")) {
 					String[] allowedHeaders = StringUtils.tokenizeToStringArray(mapping.getAttribute("allowed-headers"), ",");
 					config.setAllowedHeaders(Arrays.asList(allowedHeaders));
-				}
-				else {
-					config.setAllowedHeaders(DEFAULT_ALLOWED_HEADERS);
 				}
 				if (mapping.hasAttribute("exposed-headers")) {
 					String[] exposedHeaders = StringUtils.tokenizeToStringArray(mapping.getAttribute("exposed-headers"), ",");
@@ -100,16 +73,10 @@ public class CorsBeanDefinitionParser implements BeanDefinitionParser {
 				if (mapping.hasAttribute("allow-credentials")) {
 					config.setAllowCredentials(Boolean.parseBoolean(mapping.getAttribute("allow-credentials")));
 				}
-				else {
-					config.setAllowCredentials(DEFAULT_ALLOW_CREDENTIALS);
-				}
 				if (mapping.hasAttribute("max-age")) {
 					config.setMaxAge(Long.parseLong(mapping.getAttribute("max-age")));
 				}
-				else {
-					config.setMaxAge(DEFAULT_MAX_AGE);
-				}
-				corsConfigurations.put(mapping.getAttribute("path"), config);
+				corsConfigurations.put(mapping.getAttribute("path"), config.applyDefaultPermitConfiguration());
 			}
 		}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/CorsRegistration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/CorsRegistration.java
@@ -19,20 +19,14 @@ package org.springframework.web.servlet.config.annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.springframework.http.HttpMethod;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.cors.CorsConfiguration;
 
 /**
- * {@code CorsRegistration} assists with the creation of a
- * {@link CorsConfiguration} instance mapped to a path pattern.
+ * {@code CorsRegistration} assists with the creation of a {@link CorsConfiguration}
+ * instance mapped to a path pattern.
  *
- * <p>If no path pattern is specified, cross-origin request handling is
- * mapped to {@code "/**"}.
- *
- * <p>By default, all origins, all headers, credentials and {@code GET},
- * {@code HEAD}, and {@code POST} methods are allowed, and the max age is
- * set to 30 minutes.
+ * <p>By default, all origins, headers, credentials and {@code GET}, {@code HEAD}, and
+ * {@code POST} methods are allowed, and the max age is set to 30 minutes.
  *
  * @author Sebastien Deleuze
  * @author Sam Brannen
@@ -47,43 +41,84 @@ public class CorsRegistration {
 	private final CorsConfiguration config;
 
 
+	/**
+	 * Create a new {@link CorsRegistration} instance with all origins, headers, credentials
+	 * and {@code GET}, {@code HEAD}, and {@code POST} methods allowed, and the max age
+	 * set to 30 minutes on the specified path.
+	 * @param pathPattern the path where the CORS configuration should apply. Exact path
+	 * mapping URIs (such as {@code "/admin"}) are supported as well as Ant-style path
+	 * patterns (such as {@code "/admin/**"}).
+	 */
 	public CorsRegistration(String pathPattern) {
 		this.pathPattern = pathPattern;
 		// Same implicit default values as the @CrossOrigin annotation + allows simple methods
-		this.config = new CorsConfiguration();
-		this.config.setAllowedOrigins(Arrays.asList(CrossOrigin.DEFAULT_ORIGINS));
-		this.config.setAllowedMethods(Arrays.asList(HttpMethod.GET.name(),
-				HttpMethod.HEAD.name(), HttpMethod.POST.name()));
-		this.config.setAllowedHeaders(Arrays.asList(CrossOrigin.DEFAULT_ALLOWED_HEADERS));
-		this.config.setAllowCredentials(CrossOrigin.DEFAULT_ALLOW_CREDENTIALS);
-		this.config.setMaxAge(CrossOrigin.DEFAULT_MAX_AGE);
+		this.config = new CorsConfiguration().applyDefaultPermitConfiguration();
 	}
 
+	/**
+	 * Set the origins to allow, e.g. {@code "http://domain1.com"}.
+	 * <p>The special value {@code "*"} allows all domains.
+	 * <p>By default, all origins are allowed.
+	 */
 	public CorsRegistration allowedOrigins(String... origins) {
 		this.config.setAllowedOrigins(new ArrayList<>(Arrays.asList(origins)));
 		return this;
 	}
 
+
+	/**
+	 * Set the HTTP methods to allow, e.g. {@code "GET"}, {@code "POST"},
+	 * {@code "PUT"}, etc.
+	 * <p>The special value {@code "*"} allows all methods.
+	 * <p>By default, simple methods ({@code GET}, {@code HEAD}, and {@code POST}) are allowed.
+	 */
 	public CorsRegistration allowedMethods(String... methods) {
 		this.config.setAllowedMethods(new ArrayList<>(Arrays.asList(methods)));
 		return this;
 	}
 
+	/**
+	 * Set the list of headers that a pre-flight request can list as allowed
+	 * for use during an actual request.
+	 * <p>The special value {@code "*"} allows actual requests to send any
+	 * header.
+	 * <p>A header name is not required to be listed if it is one of:
+	 * {@code Cache-Control}, {@code Content-Language}, {@code Expires},
+	 * {@code Last-Modified}, or {@code Pragma}.
+	 * <p>By default, all headers are allowed.
+	 */
 	public CorsRegistration allowedHeaders(String... headers) {
 		this.config.setAllowedHeaders(new ArrayList<>(Arrays.asList(headers)));
 		return this;
 	}
 
+	/**
+	 * Set the list of response headers other than simple headers (i.e.
+	 * {@code Cache-Control}, {@code Content-Language}, {@code Content-Type},
+	 * {@code Expires}, {@code Last-Modified}, or {@code Pragma}) that an
+	 * actual response might have and can be exposed.
+	 * <p>Note that {@code "*"} is not a valid exposed header value.
+	 * <p>By default this is not set.
+	 */
 	public CorsRegistration exposedHeaders(String... headers) {
 		this.config.setExposedHeaders(new ArrayList<>(Arrays.asList(headers)));
 		return this;
 	}
 
+	/**
+	 * Configure how long, in seconds, the response from a pre-flight request
+	 * can be cached by clients.
+	 * <p>By default, this is set to 1800 seconds (30 minutes).
+	 */
 	public CorsRegistration maxAge(long maxAge) {
 		this.config.setMaxAge(maxAge);
 		return this;
 	}
 
+	/**
+	 * Whether user credentials are supported.
+	 * <p>By default, this is set to {@code true} (i.e. user credentials are supported).
+	 */
 	public CorsRegistration allowCredentials(boolean allowCredentials) {
 		this.config.setAllowCredentials(allowCredentials);
 		return this;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
@@ -18,7 +18,6 @@ package org.springframework.web.servlet.mvc.method.annotation;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
@@ -305,24 +304,12 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 		updateCorsConfig(config, typeAnnotation);
 		updateCorsConfig(config, methodAnnotation);
 
-		if (CollectionUtils.isEmpty(config.getAllowedOrigins())) {
-			config.setAllowedOrigins(Arrays.asList(CrossOrigin.DEFAULT_ORIGINS));
-		}
 		if (CollectionUtils.isEmpty(config.getAllowedMethods())) {
 			for (RequestMethod allowedMethod : mappingInfo.getMethodsCondition().getMethods()) {
 				config.addAllowedMethod(allowedMethod.name());
 			}
 		}
-		if (CollectionUtils.isEmpty(config.getAllowedHeaders())) {
-			config.setAllowedHeaders(Arrays.asList(CrossOrigin.DEFAULT_ALLOWED_HEADERS));
-		}
-		if (config.getAllowCredentials() == null) {
-			config.setAllowCredentials(CrossOrigin.DEFAULT_ALLOW_CREDENTIALS);
-		}
-		if (config.getMaxAge() == null) {
-			config.setMaxAge(CrossOrigin.DEFAULT_MAX_AGE);
-		}
-		return config;
+		return config.applyDefaultPermitConfiguration();
 	}
 
 	private void updateCorsConfig(CorsConfiguration config, CrossOrigin annotation) {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/MvcNamespaceTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/MvcNamespaceTests.java
@@ -882,7 +882,7 @@ public class MvcNamespaceTests {
 			assertArrayEquals(new String[]{"*"}, config.getAllowedHeaders().toArray());
 			assertNull(config.getExposedHeaders());
 			assertTrue(config.getAllowCredentials());
-			assertEquals(new Long(1600), config.getMaxAge());
+			assertEquals(new Long(1800), config.getMaxAge());
 		}
 	}
 
@@ -912,7 +912,7 @@ public class MvcNamespaceTests {
 			assertArrayEquals(new String[]{"*"}, config.getAllowedHeaders().toArray());
 			assertNull(config.getExposedHeaders());
 			assertTrue(config.getAllowCredentials());
-			assertEquals(new Long(1600), config.getMaxAge());
+			assertEquals(new Long(1800), config.getMaxAge());
 		}
 	}
 


### PR DESCRIPTION
This PR allows better encapsulation for CORS user-level configuration, and improve the `CorsRegistration` Javadoc as discussed in [SPR-14798](https://jira.spring.io/browse/SPR-14798).

I did not implement the `CorsConfiguration #PERMIT_ALL_CORS_CONFIGURATION` proposal because the properties won't be immutable, so I chose the previous proposal using `applyDefaultPermitConfiguration()` method name instead of `initEmptyToPermitAll()`.

I chose this name because this is not totally a permit all strategy, not all methods are allowed and it also set `allowCredentials` and `maxAge` to defaults that make sense for most users.
