### PR TITLE
ApplicationContext-based HttpHandler setup

### DIFF
--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/DispatcherHandler.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/DispatcherHandler.java
@@ -36,6 +36,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebHandler;
 import org.springframework.web.server.adapter.HttpWebHandlerAdapter;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
 
 /**
  * Central dispatcher for HTTP request handlers/controllers. Dispatches to registered
@@ -170,7 +171,14 @@ public class DispatcherHandler implements WebHandler, ApplicationContextAware {
 	 * Expose a dispatcher-based {@link HttpHandler} for the given application context,
 	 * typically for direct registration with an engine adapter such as
 	 * {@link org.springframework.http.server.reactive.ServletHttpHandlerAdapter}.
-	 * @param applicationContext the application context to find the handler beans in
+	 *
+	 * <p>Delegates to {@link WebHttpHandlerBuilder#applicationContext} that
+	 * detects the target {@link DispatcherHandler} along with
+	 * {@link org.springframework.web.server.WebFilter}s, and
+	 * {@link org.springframework.web.server.WebExceptionHandler}s in the given
+	 * ApplicationContext.
+	 *
+	 * @param context the application context to find the handler beans in
 	 * @see #DispatcherHandler(ApplicationContext)
 	 * @see HttpWebHandlerAdapter
 	 * @see org.springframework.http.server.reactive.ServletHttpHandlerAdapter
@@ -178,8 +186,8 @@ public class DispatcherHandler implements WebHandler, ApplicationContextAware {
 	 * @see org.springframework.http.server.reactive.RxNettyHttpHandlerAdapter
 	 * @see org.springframework.http.server.reactive.UndertowHttpHandlerAdapter
 	 */
-	public static HttpHandler toHttpHandler(ApplicationContext applicationContext) {
-		return new HttpWebHandlerAdapter(new DispatcherHandler(applicationContext));
+	public static HttpHandler toHttpHandler(ApplicationContext context) {
+		return WebHttpHandlerBuilder.applicationContext(context).build();
 	}
 
 }

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfigurationSupport.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/config/WebReactiveConfigurationSupport.java
@@ -61,6 +61,7 @@ import org.springframework.validation.Validator;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.support.ConfigurableWebBindingInitializer;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.reactive.DispatcherHandler;
 import org.springframework.web.reactive.HandlerMapping;
 import org.springframework.web.reactive.accept.CompositeContentTypeResolver;
 import org.springframework.web.reactive.accept.RequestedContentTypeResolverBuilder;
@@ -74,6 +75,8 @@ import org.springframework.web.reactive.result.method.annotation.ResponseEntityR
 import org.springframework.web.reactive.result.view.ViewResolutionResultHandler;
 import org.springframework.web.reactive.result.view.ViewResolver;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebExceptionHandler;
+import org.springframework.web.server.handler.ResponseStatusExceptionHandler;
 
 /**
  * The main class for Spring Web Reactive configuration.
@@ -115,6 +118,16 @@ public class WebReactiveConfigurationSupport implements ApplicationContextAware 
 		return this.applicationContext;
 	}
 
+
+	@Bean
+	public DispatcherHandler webHandler() {
+		return new DispatcherHandler();
+	}
+
+	@Bean
+	public WebExceptionHandler responseStatusExceptionHandler() {
+		return new ResponseStatusExceptionHandler();
+	}
 
 	@Bean
 	public RequestMappingHandlerMapping requestMappingHandlerMapping() {

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/AbstractRequestMappingIntegrationTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/AbstractRequestMappingIntegrationTests.java
@@ -29,9 +29,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.reactive.AbstractHttpHandlerIntegrationTests;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.DispatcherHandler;
 import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
-import org.springframework.web.server.handler.ResponseStatusExceptionHandler;
 
 import static org.springframework.http.RequestEntity.get;
 import static org.springframework.http.RequestEntity.options;
@@ -53,10 +51,7 @@ public abstract class AbstractRequestMappingIntegrationTests extends AbstractHtt
 	protected HttpHandler createHttpHandler() {
 		this.restTemplate = initRestTemplate();
 		this.applicationContext = initApplicationContext();
-		return WebHttpHandlerBuilder
-				.webHandler(new DispatcherHandler(this.applicationContext))
-				.exceptionHandlers(new ResponseStatusExceptionHandler())
-				.build();
+		return WebHttpHandlerBuilder.applicationContext(this.applicationContext).build();
 	}
 
 	protected abstract ApplicationContext initApplicationContext();


### PR DESCRIPTION
This commit adds support for detecting the target WebHandler along with
WebFilters, WebExceptionHandlers, and other spring-web reactive
strategies in an ApplicationContext.

WebReactiveConfigurationSupport has @Bean factory methods for
DispatcherHandler and ResponseStatusExceptionHandler.

WebHttpHandlerBuilder has a static factory method that initializes the
builder from an ApplicationContext. This method is also used in the
DispatcherHandler#toHttpHandler(ApplicationContext) shortcut method.

Issue: SPR-14837
