### PR TITLE
SPR-14773: CssLinkResourceTransformer not working with gzipped CSS

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/GzipResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/GzipResourceResolver.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
+import java.util.zip.GZIPInputStream;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -90,7 +91,7 @@ public class GzipResourceResolver extends AbstractResourceResolver {
 		}
 
 		public InputStream getInputStream() throws IOException {
-			return this.gzipped.getInputStream();
+			return new GZIPInputStream(this.gzipped.getInputStream());
 		}
 
 		public boolean exists() {


### PR DESCRIPTION
CssLinkResourceTransformer is not working if you are using gzipped CSS
files. The links will not be modified within a CSS file, if you have a
gzipped file. The problem is that the links could not be find due to
reading the gzipped content. The gzipped file should be decompressed
first or if available the uncompressed version should be used.

Issue: SPR-14773
