### PR TITLE
Import format fix according to Code Style

### DIFF
--- a/src/idea/spring-framework.xml
+++ b/src/idea/spring-framework.xml
@@ -13,7 +13,7 @@
 		</value>
 	</option>
 	<option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50"/>
-	<option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1"/>
+	<option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50"/>
 	<option name="IMPORT_LAYOUT_TABLE">
 		<value>
 			<package name="" withSubpackages="true" static="true"/>


### PR DESCRIPTION
Fix for IntelliJ IDEA import format rules according to current [Spring Framework Code Style](https://github.com/spring-projects/spring-integration/wiki/Spring-Integration-Framework-Code-Style)
