### PR TITLE
Update reactive tests according to latest reactor-test changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -396,7 +396,7 @@ project("spring-core") {
 		optional "io.reactivex.rxjava2:rxjava:${rxjava2Version}"
 		optional "io.reactivex:rxjava-reactive-streams:${rxjavaAdapterVersion}"
 		optional("io.netty:netty-buffer:${nettyVersion}")
-		testCompile("io.projectreactor.addons:reactor-test:1.0.0.BUILD-SNAPSHOT")
+		testCompile("io.projectreactor.addons:reactor-test:3.0.3.BUILD-SNAPSHOT")
 		testCompile("javax.xml.bind:jaxb-api:${jaxbVersion}")
 		testCompile("org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}")
 		testCompile("org.xmlunit:xmlunit-matchers:${xmlunitVersion}")
@@ -777,7 +777,7 @@ project("spring-web") {
 		optional("javax.xml.ws:jaxws-api:${jaxwsVersion}")
 		optional("javax.mail:javax.mail-api:${javamailVersion}")
 		testCompile(project(":spring-context-support"))  // for JafMediaTypeFactory
-		testCompile("io.projectreactor.addons:reactor-test:1.0.0.BUILD-SNAPSHOT")
+		testCompile("io.projectreactor.addons:reactor-test:3.0.3.BUILD-SNAPSHOT")
 		testCompile("org.apache.taglibs:taglibs-standard-jstlel:1.2.1") {
 			exclude group: "org.apache.taglibs", module: "taglibs-standard-spec"
 		}
@@ -819,7 +819,7 @@ project("spring-web-reactive") {
 		optional("org.freemarker:freemarker:${freemarkerVersion}")
 		optional "org.apache.httpcomponents:httpclient:${httpclientVersion}"
 		optional('org.webjars:webjars-locator:0.32')
-		testCompile("io.projectreactor.addons:reactor-test:1.0.0.BUILD-SNAPSHOT")
+		testCompile("io.projectreactor.addons:reactor-test:3.0.3.BUILD-SNAPSHOT")
 		testCompile("javax.validation:validation-api:${beanvalVersion}")
 		testCompile("org.hibernate:hibernate-validator:${hibval5Version}")
 		testCompile("org.apache.tomcat:tomcat-util:${tomcatVersion}")

--- a/spring-core/src/test/java/org/springframework/core/codec/ByteArrayDecoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/ByteArrayDecoderTests.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -57,12 +57,12 @@ public class ByteArrayDecoderTests extends AbstractDataBufferAllocatingTestCase 
 		Flux<byte[]> output = this.decoder.decode(source,
 				ResolvableType.forClassWithGenerics(Publisher.class, byte[].class),
 				null, Collections.emptyMap());
-		ScriptedSubscriber
-				.<byte[]>create()
+
+		Verifier.create(output)
 				.consumeNextWith(bytes -> assertArrayEquals("foo".getBytes(), bytes))
 				.consumeNextWith(bytes -> assertArrayEquals("bar".getBytes(), bytes))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/codec/ByteArrayEncoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/ByteArrayEncoderTests.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -66,8 +66,8 @@ public class ByteArrayEncoderTests extends AbstractDataBufferAllocatingTestCase 
 		Flux<DataBuffer> output = this.encoder.encode(source, this.bufferFactory,
 				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class),
 				null, Collections.emptyMap());
-		ScriptedSubscriber
-				.<DataBuffer>create()
+
+		Verifier.create(output)
 				.consumeNextWith(b -> {
 					byte[] buf = new byte[3];
 					b.read(buf);
@@ -79,7 +79,7 @@ public class ByteArrayEncoderTests extends AbstractDataBufferAllocatingTestCase 
 					assertArrayEquals(barBytes, buf);
 				})
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/codec/ByteBufferDecoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/ByteBufferDecoderTests.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -58,9 +58,9 @@ public class ByteBufferDecoderTests extends AbstractDataBufferAllocatingTestCase
 				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class),
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber.<ByteBuffer>create()
+		Verifier.create(output)
 				.expectNext(ByteBuffer.wrap("foo".getBytes()), ByteBuffer.wrap("bar".getBytes()))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 }

--- a/spring-core/src/test/java/org/springframework/core/codec/ByteBufferEncoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/ByteBufferEncoderTests.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -67,7 +67,7 @@ public class ByteBufferEncoderTests extends AbstractDataBufferAllocatingTestCase
 		Flux<DataBuffer> output = this.encoder.encode(source, this.bufferFactory,
 				ResolvableType.forClassWithGenerics(Publisher.class, ByteBuffer.class),
 				null, Collections.emptyMap());
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(output)
 				.consumeNextWith(b -> {
 					byte[] buf = new byte[3];
 					b.read(buf);
@@ -79,7 +79,7 @@ public class ByteBufferEncoderTests extends AbstractDataBufferAllocatingTestCase
 					assertArrayEquals(barBytes, buf);
 				})
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/codec/CharSequenceEncoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/CharSequenceEncoderTests.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -65,10 +65,10 @@ public class CharSequenceEncoderTests extends AbstractDataBufferAllocatingTestCa
 		Flux<String> stringFlux = Flux.just("foo");
 		Flux<DataBuffer> output = Flux.from(
 				this.encoder.encode(stringFlux, this.bufferFactory, null, null, Collections.emptyMap()));
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(output)
 				.consumeNextWith(stringConsumer("foo"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -76,10 +76,10 @@ public class CharSequenceEncoderTests extends AbstractDataBufferAllocatingTestCa
 		Flux<StringBuilder> stringBuilderFlux = Flux.just(new StringBuilder("foo"));
 		Flux<DataBuffer> output = Flux.from(
 				this.encoder.encode(stringBuilderFlux, this.bufferFactory, null, null, Collections.emptyMap()));
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(output)
 				.consumeNextWith(stringConsumer("foo"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/codec/ResourceDecoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/ResourceDecoderTests.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 
 import org.junit.Test;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.ByteArrayResource;
@@ -64,7 +64,7 @@ public class ResourceDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<Resource> result = this.decoder
 				.decode(source, ResolvableType.forClass(Resource.class), null, Collections.emptyMap());
 
-		ScriptedSubscriber.<Resource>create()
+		Verifier.create(result)
 				.consumeNextWith(resource -> {
 					try {
 						byte[] bytes = StreamUtils.copyToByteArray(resource.getInputStream());
@@ -75,7 +75,7 @@ public class ResourceDecoderTests extends AbstractDataBufferAllocatingTestCase {
 					}
 				})
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/codec/ResourceEncoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/ResourceEncoderTests.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.ByteArrayResource;
@@ -64,11 +64,10 @@ public class ResourceEncoderTests extends AbstractDataBufferAllocatingTestCase {
 				ResolvableType.forClass(Resource.class),
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(output)
 				.consumeNextWith(stringConsumer(s))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/codec/ResourceRegionEncoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/ResourceRegionEncoderTests.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.ByteArrayResource;
@@ -81,10 +81,10 @@ public class ResourceRegionEncoderTests extends AbstractDataBufferAllocatingTest
 				ResolvableType.forClass(ResourceRegion.class), MimeTypeUtils.APPLICATION_OCTET_STREAM
 				, Collections.emptyMap());
 
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(result)
 				.consumeNextWith(stringConsumer("Spring"))
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 	@Test
@@ -111,7 +111,7 @@ public class ResourceRegionEncoderTests extends AbstractDataBufferAllocatingTest
 					return previous;
 				});
 
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(reduced)
 				.consumeNextWith(buf -> {
 					String content = DataBufferTestUtils.dumpString(buf, StandardCharsets.UTF_8);
 					String[] ranges = StringUtils.tokenizeToStringArray(content, "\r\n",
@@ -138,7 +138,7 @@ public class ResourceRegionEncoderTests extends AbstractDataBufferAllocatingTest
 					assertArrayEquals(expected, ranges);
 				})
 				.expectComplete()
-				.verify(reduced);
+				.verify();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/codec/StringDecoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/StringDecoderTests.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -61,10 +61,11 @@ public class StringDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<DataBuffer> source = Flux.just(stringBuffer("foo"), stringBuffer("bar"), stringBuffer("baz"));
 		Flux<String> output = this.decoder.decode(source, ResolvableType.forClass(String.class),
 				null, Collections.emptyMap());
-		ScriptedSubscriber
-				.<String>create()
+
+		Verifier.create(output)
 				.expectNext("foo", "bar", "baz")
-				.expectComplete().verify(output);
+				.expectComplete()
+				.verify();
 
 	}
 
@@ -75,10 +76,11 @@ public class StringDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<DataBuffer> source = Flux.just(fooBar, baz);
 		Flux<String> output = decoder.decode(source, ResolvableType.forClass(String.class),
 				null, Collections.emptyMap());
-		ScriptedSubscriber
-				.<String>create()
+
+		Verifier.create(output)
 				.expectNext("\n", "foo\r", "\n", "bar\r", "\n", "baz")
-				.expectComplete().verify(output);
+				.expectComplete()
+				.verify();
 
 	}
 
@@ -88,10 +90,10 @@ public class StringDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<String> output = this.decoder.decode(source, ResolvableType.forClass(String.class),
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(output)
 				.expectNextCount(0)
-				.expectComplete().verify(output);
+				.expectComplete()
+				.verify();
 
 	}
 
@@ -101,10 +103,9 @@ public class StringDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<String> output = this.decoder.decode(source,
 				ResolvableType.forClass(String.class), null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(output)
 				.expectNext("")
-				.expectComplete().verify(output);
+				.expectComplete().verify();
 
 	}
 
@@ -115,11 +116,10 @@ public class StringDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Mono<String> output = this.decoder.decodeToMono(source,
 				ResolvableType.forClass(String.class), null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(output)
 				.expectNext("foobarbaz")
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -128,11 +128,10 @@ public class StringDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Mono<String> output = this.decoder.decodeToMono(source,
 				ResolvableType.forClass(String.class), null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(output)
 				.expectNextCount(0)
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/io/buffer/DataBufferUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/buffer/DataBufferUtilsTests.java
@@ -24,7 +24,7 @@ import java.nio.file.StandardOpenOption;
 
 import org.junit.Test;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import static org.junit.Assert.assertFalse;
 
@@ -39,13 +39,13 @@ public class DataBufferUtilsTests extends AbstractDataBufferAllocatingTestCase {
 		FileChannel channel = FileChannel.open(Paths.get(uri), StandardOpenOption.READ);
 		Flux<DataBuffer> flux = DataBufferUtils.read(channel, this.bufferFactory, 3);
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(flux)
 				.consumeNextWith(stringConsumer("foo"))
 				.consumeNextWith(stringConsumer("bar"))
 				.consumeNextWith(stringConsumer("baz"))
 				.consumeNextWith(stringConsumer("qux"))
-				.expectComplete().verify(flux);
+				.expectComplete()
+				.verify();
 
 		assertFalse(channel.isOpen());
 	}
@@ -56,12 +56,12 @@ public class DataBufferUtilsTests extends AbstractDataBufferAllocatingTestCase {
 		FileChannel channel = FileChannel.open(Paths.get(uri), StandardOpenOption.READ);
 		Flux<DataBuffer> flux = DataBufferUtils.read(channel, this.bufferFactory, 5);
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(flux)
 				.consumeNextWith(stringConsumer("fooba"))
 				.consumeNextWith(stringConsumer("rbazq"))
 				.consumeNextWith(stringConsumer("ux"))
-				.expectComplete().verify(flux);
+				.expectComplete()
+				.verify();
 
 		assertFalse(channel.isOpen());
 	}
@@ -71,13 +71,13 @@ public class DataBufferUtilsTests extends AbstractDataBufferAllocatingTestCase {
 		InputStream is = DataBufferUtilsTests.class.getResourceAsStream("DataBufferUtilsTests.txt");
 		Flux<DataBuffer> flux = DataBufferUtils.read(is, this.bufferFactory, 3);
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(flux)
 				.consumeNextWith(stringConsumer("foo"))
 				.consumeNextWith(stringConsumer("bar"))
 				.consumeNextWith(stringConsumer("baz"))
 				.consumeNextWith(stringConsumer("qux"))
-				.expectComplete().verify(flux);
+				.expectComplete()
+				.verify();
 	}
 
 	@Test
@@ -88,11 +88,10 @@ public class DataBufferUtilsTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<DataBuffer> flux = Flux.just(foo, bar, baz);
 		Flux<DataBuffer> result = DataBufferUtils.takeUntilByteCount(flux, 5L);
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(result)
 				.consumeNextWith(stringConsumer("foo"))
 				.consumeNextWith(stringConsumer("ba"))
-				.expectComplete().verify(result);
+				.expectComplete().verify();
 
 		release(baz);
 	}
@@ -105,11 +104,11 @@ public class DataBufferUtilsTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<DataBuffer> flux = Flux.just(foo, bar, baz);
 		Flux<DataBuffer> result = DataBufferUtils.skipUntilByteCount(flux, 5L);
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(result)
 				.consumeNextWith(stringConsumer("r"))
 				.consumeNextWith(stringConsumer("baz"))
-				.expectComplete().verify(result);
+				.expectComplete()
+				.verify();
 	}
 
 	@Test
@@ -120,10 +119,10 @@ public class DataBufferUtilsTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<DataBuffer> flux = Flux.just(foo, bar, baz);
 		Flux<DataBuffer> result = DataBufferUtils.skipUntilByteCount(flux, 9L);
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(result)
 				.expectNextCount(0)
-				.expectComplete().verify(result);
+				.expectComplete()
+				.verify();
 	}
 
 }

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/DispatcherHandlerErrorTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/DispatcherHandlerErrorTests.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -99,13 +99,13 @@ public class DispatcherHandlerErrorTests {
 		this.request.setUri("/does-not-exist");
 		Mono<Void> publisher = this.dispatcherHandler.handle(this.exchange);
 
-		ScriptedSubscriber.<Void>create()
+		Verifier.create(publisher)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(ResponseStatusException.class));
 					assertThat(error.getMessage(),
 							is("Request failure [status: 404, reason: \"No matching handler\"]"));
 				})
-				.verify(publisher);
+				.verify();
 	}
 
 	@Test
@@ -113,12 +113,12 @@ public class DispatcherHandlerErrorTests {
 		this.request.setUri("/unknown-argument-type");
 		Mono<Void> publisher = this.dispatcherHandler.handle(this.exchange);
 
-		ScriptedSubscriber.<Void>create()
+		Verifier.create(publisher)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(IllegalStateException.class));
 					assertThat(error.getMessage(), startsWith("No resolver for argument [0]"));
 				})
-				.verify(publisher);
+				.verify();
 	}
 
 	@Test
@@ -126,11 +126,11 @@ public class DispatcherHandlerErrorTests {
 		this.request.setUri("/error-signal");
 		Mono<Void> publisher = this.dispatcherHandler.handle(this.exchange);
 
-		ScriptedSubscriber.<Void>create()
+		Verifier.create(publisher)
 				.consumeErrorWith(error -> {
 					assertSame(EXCEPTION, error);
 				})
-				.verify(publisher);
+				.verify();
 	}
 
 	@Test
@@ -138,11 +138,11 @@ public class DispatcherHandlerErrorTests {
 		this.request.setUri("/raise-exception");
 		Mono<Void> publisher = this.dispatcherHandler.handle(this.exchange);
 
-		ScriptedSubscriber.<Void>create()
+		Verifier.<Void>create(publisher)
 				.consumeErrorWith(error -> {
 					assertSame(EXCEPTION, error);
 				})
-				.verify(publisher);
+				.verify();
 	}
 
 	@Test
@@ -150,12 +150,12 @@ public class DispatcherHandlerErrorTests {
 		this.request.setUri("/unknown-return-type");
 		Mono<Void> publisher = this.dispatcherHandler.handle(this.exchange);
 
-		ScriptedSubscriber.<Void>create()
+		Verifier.create(publisher)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(IllegalStateException.class));
 					assertThat(error.getMessage(), startsWith("No HandlerResultHandler"));
 				})
-				.verify(publisher);
+				.verify();
 	}
 
 	@Test
@@ -163,11 +163,11 @@ public class DispatcherHandlerErrorTests {
 		this.request.setUri("/request-body").setHeader("Accept", "application/json").setBody("body");
 		Mono<Void> publisher = this.dispatcherHandler.handle(this.exchange);
 
-		ScriptedSubscriber.<Void>create()
+		Verifier.create(publisher)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(NotAcceptableStatusException.class));
 				})
-				.verify(publisher);
+				.verify();
 	}
 
 	@Test
@@ -175,12 +175,12 @@ public class DispatcherHandlerErrorTests {
 		this.request.setUri("/request-body").setBody(Mono.error(EXCEPTION));
 		Mono<Void> publisher = this.dispatcherHandler.handle(this.exchange);
 
-		ScriptedSubscriber.<Void>create()
+		Verifier.create(publisher)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(ServerWebInputException.class));
 					assertSame(EXCEPTION, error.getCause());
 				})
-				.verify(publisher);
+				.verify();
 	}
 
 	@Test

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/config/ResourceHandlerRegistryTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/config/ResourceHandlerRegistryTests.java
@@ -24,7 +24,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.context.support.GenericApplicationContext;
@@ -100,11 +100,11 @@ public class ResourceHandlerRegistryTests {
 		ResourceWebHandler handler = getHandler("/resources/**");
 		handler.handle(this.exchange).blockMillis(5000);
 
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(this.response.getBody())
 				.consumeNextWith(buf -> assertEquals("test stylesheet content",
 						DataBufferTestUtils.dumpString(buf, StandardCharsets.UTF_8)))
 				.expectComplete()
-				.verify(this.response.getBody());
+				.verify();
 	}
 
 	@Test

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/function/SseHandlerFunctionIntegrationTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/function/SseHandlerFunctionIntegrationTests.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -74,11 +74,11 @@ public class SseHandlerFunctionIntegrationTests
 				.map(s -> (s.replace("\n", "")))
 				.take(2);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("data:foo 0")
 				.expectNext("data:foo 1")
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(5));
+				.verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -97,10 +97,10 @@ public class SseHandlerFunctionIntegrationTests
 				.takeUntil(s -> s.endsWith("foo 1\"}"))
 				.reduce((s1, s2) -> s1 + s2);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("data:{\"name\":\"foo 0\"}data:{\"name\":\"foo 1\"}")
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(5));
+				.verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -118,11 +118,11 @@ public class SseHandlerFunctionIntegrationTests
 				.map(s -> s.replace("\n", ""))
 				.take(2);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("id:0:bardata:foo")
 				.expectNext("id:1:bardata:foo")
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(5));
+				.verify(Duration.ofSeconds(5));
 	}
 
 	private static class SseHandler {

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/resource/ResourceWebHandlerTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/resource/ResourceWebHandlerTests.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -527,10 +527,10 @@ public class ResourceWebHandlerTests {
 		this.request.addHeader("Range", "bytes= foo bar");
 		this.exchange.getAttributes().put(PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "foo.txt");
 
-		ScriptedSubscriber.create()
+		Verifier.create(this.handler.handle(this.exchange))
 				.expectNextCount(0)
 				.expectComplete()
-				.verify(this.handler.handle(this.exchange));
+				.verify();
 
 		assertEquals(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE, this.response.getStatusCode());
 		assertEquals("bytes", this.response.getHeaders().getFirst("Accept-Ranges"));
@@ -555,7 +555,7 @@ public class ResourceWebHandlerTests {
 					return previous;
 				});
 
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(reduced)
 				.consumeNextWith(buf -> {
 					String content = DataBufferTestUtils.dumpString(buf, StandardCharsets.UTF_8);
 					String[] ranges = StringUtils.tokenizeToStringArray(content, "\r\n", false, true);
@@ -576,7 +576,7 @@ public class ResourceWebHandlerTests {
 					assertEquals("t.", ranges[11]);
 				})
 				.expectComplete()
-				.verify(reduced);
+				.verify();
 	}
 
 	@Test  // SPR-14005
@@ -598,11 +598,11 @@ public class ResourceWebHandlerTests {
 	}
 
 	private void assertResponseBody(String responseBody) {
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(this.response.getBody())
 				.consumeNextWith(buf -> assertEquals(responseBody,
 						DataBufferTestUtils.dumpString(buf, StandardCharsets.UTF_8)))
 				.expectComplete()
-				.verify(this.response.getBody());
+				.verify();
 	}
 
 }

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/HandlerMethodMappingTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/HandlerMethodMappingTests.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -100,7 +100,7 @@ public class HandlerMethodMappingTests {
 		this.mapping.registerMapping("/fo?", this.handler, this.method2);
 		Mono<Object> result = this.mapping.getHandler(createExchange(HttpMethod.GET, "/foo"));
 
-		ScriptedSubscriber.create().expectError(IllegalStateException.class).verify(result);
+		Verifier.create(result).expectError(IllegalStateException.class).verify();
 	}
 
 	@Test

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/InvocableHandlerMethodTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/InvocableHandlerMethodTests.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.http.server.reactive.test.MockServerHttpRequest;
@@ -92,13 +92,14 @@ public class InvocableHandlerMethodTests {
 		InvocableHandlerMethod hm = handlerMethod("singleArg");
 		Mono<HandlerResult> mono = hm.invoke(this.exchange, new BindingContext());
 
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(IllegalStateException.class));
 					assertThat(error.getMessage(), is("No resolver for argument [0] of type [java.lang.String] " +
 							"on method [" + hm.getMethod().toGenericString() + "]"));
 				})
-				.verify(mono);
+				.verify();
 	}
 
 	@Test
@@ -107,12 +108,13 @@ public class InvocableHandlerMethodTests {
 		addResolver(hm, Mono.error(new UnsupportedMediaTypeStatusException("boo")));
 		Mono<HandlerResult> mono = hm.invoke(this.exchange, new BindingContext());
 
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(UnsupportedMediaTypeStatusException.class));
 					assertThat(error.getMessage(), is("Request failure [status: 415, reason: \"boo\"]"));
 				})
-				.verify(mono);
+				.verify();
 	}
 
 	@Test
@@ -121,14 +123,15 @@ public class InvocableHandlerMethodTests {
 		addResolver(hm, Mono.just(1));
 		Mono<HandlerResult> mono = hm.invoke(this.exchange, new BindingContext());
 
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(IllegalStateException.class));
 					assertThat(error.getMessage(), is("Failed to invoke controller with resolved arguments: " +
 							"[0][type=java.lang.Integer][value=1] " +
 							"on method [" + hm.getMethod().toGenericString() + "]"));
 				})
-				.verify(mono);
+				.verify();
 	}
 
 	@Test
@@ -136,12 +139,13 @@ public class InvocableHandlerMethodTests {
 		InvocableHandlerMethod hm = handlerMethod("exceptionMethod");
 		Mono<HandlerResult> mono = hm.invoke(this.exchange, new BindingContext());
 
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.consumeErrorWith(error -> {
 					assertThat(error, instanceOf(IllegalStateException.class));
 					assertThat(error.getMessage(), is("boo"));
 				})
-				.verify(mono);
+				.verify();
 	}
 
 
@@ -158,14 +162,14 @@ public class InvocableHandlerMethodTests {
 	}
 
 	private void assertHandlerResultValue(Mono<HandlerResult> mono, String expected) {
-		ScriptedSubscriber.<HandlerResult>create()
+		Verifier.create(mono)
 				.consumeNextWith(result -> {
 					Optional<?> optional = result.getReturnValue();
 					assertTrue(optional.isPresent());
 					assertEquals(expected, optional.get());
 				})
 				.expectComplete()
-				.verify(mono);
+				.verify();
 	}
 
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMappingTests.java
@@ -29,7 +29,7 @@ import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -164,9 +164,9 @@ public class RequestMappingInfoHandlerMappingTests {
 		this.handlerMapping.registerHandler(new UserController());
 		Mono<Object> mono = this.handlerMapping.getHandler(exchange);
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(mono)
 				.expectError(NotAcceptableStatusException.class)
-				.verify(mono);
+				.verify();
 	}
 
 	@Test // SPR-8462
@@ -353,13 +353,13 @@ public class RequestMappingInfoHandlerMappingTests {
 	@SuppressWarnings("unchecked")
 	private <T> void assertError(Mono<Object> mono, final Class<T> exceptionClass, final Consumer<T> consumer)  {
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(mono)
 				.consumeErrorWith(error -> {
 					assertEquals(exceptionClass, error.getClass());
 					consumer.accept((T) error);
 
 				})
-				.verify(mono);
+				.verify();
 	}
 
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/CookieValueMethodArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/CookieValueMethodArgumentResolverTests.java
@@ -21,7 +21,7 @@ import java.lang.reflect.Method;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.MethodParameter;
@@ -119,10 +119,10 @@ public class CookieValueMethodArgumentResolverTests {
 	@Test
 	public void notFound() {
 		Mono<Object> mono = resolver.resolveArgument(this.cookieParameter, this.bindingContext, this.exchange);
-		ScriptedSubscriber.create()
+		Verifier.create(mono)
 				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(mono);
+				.verify();
 	}
 
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/HttpEntityArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/HttpEntityArgumentResolverTests.java
@@ -29,7 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 import rx.Observable;
 import rx.RxReactiveStreams;
 import rx.Single;
@@ -130,7 +130,7 @@ public class HttpEntityArgumentResolverTests {
 		ResolvableType type = httpEntityType(forClassWithGenerics(Mono.class, String.class));
 		HttpEntity<Mono<String>> entity = resolveValueWithEmptyBody(type);
 
-		ScriptedSubscriber.create().expectNextCount(0).expectComplete().verify(entity.getBody());
+		Verifier.create(entity.getBody()).expectNextCount(0).expectComplete().verify();
 	}
 
 	@Test
@@ -138,7 +138,7 @@ public class HttpEntityArgumentResolverTests {
 		ResolvableType type = httpEntityType(forClassWithGenerics(Flux.class, String.class));
 		HttpEntity<Flux<String>> entity = resolveValueWithEmptyBody(type);
 
-		ScriptedSubscriber.create().expectNextCount(0).expectComplete().verify(entity.getBody());
+		Verifier.create(entity.getBody()).expectNextCount(0).expectComplete().verify();
 	}
 
 	@Test
@@ -146,10 +146,10 @@ public class HttpEntityArgumentResolverTests {
 		ResolvableType type = httpEntityType(forClassWithGenerics(Single.class, String.class));
 		HttpEntity<Single<String>> entity = resolveValueWithEmptyBody(type);
 
-		ScriptedSubscriber
-				.create().expectNextCount(0)
+		Verifier.create(RxReactiveStreams.toPublisher(entity.getBody()))
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(RxReactiveStreams.toPublisher(entity.getBody()));
+				.verify();
 	}
 
 	@Test
@@ -157,10 +157,10 @@ public class HttpEntityArgumentResolverTests {
 		ResolvableType type = httpEntityType(forClassWithGenerics(io.reactivex.Single.class, String.class));
 		HttpEntity<io.reactivex.Single<String>> entity = resolveValueWithEmptyBody(type);
 
-		ScriptedSubscriber
-				.create().expectNextCount(0)
+		Verifier.create(entity.getBody().toFlowable())
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(entity.getBody().toFlowable());
+				.verify();
 	}
 
 	@Test
@@ -168,10 +168,10 @@ public class HttpEntityArgumentResolverTests {
 		ResolvableType type = httpEntityType(forClassWithGenerics(Maybe.class, String.class));
 		HttpEntity<Maybe<String>> entity = resolveValueWithEmptyBody(type);
 
-		ScriptedSubscriber
-				.create().expectNextCount(0)
+		Verifier.create(entity.getBody().toFlowable())
+				.expectNextCount(0)
 				.expectComplete()
-				.verify(entity.getBody().toFlowable());
+				.verify();
 	}
 
 	@Test
@@ -179,10 +179,10 @@ public class HttpEntityArgumentResolverTests {
 		ResolvableType type = httpEntityType(forClassWithGenerics(Observable.class, String.class));
 		HttpEntity<Observable<String>> entity = resolveValueWithEmptyBody(type);
 
-		ScriptedSubscriber
-				.create().expectNextCount(0)
+		Verifier.create(RxReactiveStreams.toPublisher(entity.getBody()))
+				.expectNextCount(0)
 				.expectComplete()
-				.verify(RxReactiveStreams.toPublisher(entity.getBody()));
+				.verify();
 	}
 
 	@Test
@@ -190,10 +190,10 @@ public class HttpEntityArgumentResolverTests {
 		ResolvableType type = httpEntityType(forClassWithGenerics(io.reactivex.Observable.class, String.class));
 		HttpEntity<io.reactivex.Observable<String>> entity = resolveValueWithEmptyBody(type);
 
-		ScriptedSubscriber
-				.create().expectNextCount(0)
+		Verifier.create(entity.getBody().toFlowable(BackpressureStrategy.BUFFER))
+				.expectNextCount(0)
 				.expectComplete()
-				.verify(entity.getBody().toFlowable(BackpressureStrategy.BUFFER));
+				.verify();
 	}
 
 	@Test
@@ -201,9 +201,10 @@ public class HttpEntityArgumentResolverTests {
 		ResolvableType type = httpEntityType(forClassWithGenerics(Flowable.class, String.class));
 		HttpEntity<Flowable<String>> entity = resolveValueWithEmptyBody(type);
 
-		ScriptedSubscriber
-				.create().expectNextCount(0)
-				.expectComplete().verify(entity.getBody());
+		Verifier.create(entity.getBody())
+				.expectNextCount(0)
+				.expectComplete()
+				.verify();
 	}
 
 	@Test
@@ -284,13 +285,12 @@ public class HttpEntityArgumentResolverTests {
 		HttpEntity<Flux<String>> httpEntity = resolveValue(type, body);
 
 		assertEquals(this.request.getHeaders(), httpEntity.getHeaders());
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(httpEntity.getBody())
 				.expectNext("line1\n")
 				.expectNext("line2\n")
 				.expectNext("line3\n")
 				.expectComplete()
-				.verify(httpEntity.getBody());
+				.verify();
 	}
 
 	@Test

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/MessageReaderArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/MessageReaderArgumentResolverTests.java
@@ -34,7 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 import rx.Observable;
 import rx.Single;
 
@@ -103,7 +103,7 @@ public class MessageReaderArgumentResolverTests {
 		MethodParameter param = this.testMethod.resolveParam(type);
 		Mono<Object> result = this.resolver.readBody(param, true, this.bindingContext, this.exchange);
 
-		ScriptedSubscriber.create().expectError(UnsupportedMediaTypeStatusException.class).verify(result);
+		Verifier.create(result).expectError(UnsupportedMediaTypeStatusException.class).verify();
 	}
 
 	// More extensive "empty body" tests in RequestBody- and HttpEntityArgumentResolverTests
@@ -116,7 +116,7 @@ public class MessageReaderArgumentResolverTests {
 		Mono<TestBean> result = (Mono<TestBean>) this.resolver.readBody(
 				param, true, this.bindingContext, this.exchange).block();
 
-		ScriptedSubscriber.create().expectError(ServerWebInputException.class).verify(result);
+		Verifier.create(result).expectError(ServerWebInputException.class).verify();
 	}
 
 	@Test
@@ -273,7 +273,7 @@ public class MessageReaderArgumentResolverTests {
 		MethodParameter param = this.testMethod.resolveParam(type);
 		Mono<TestBean> mono = resolveValue(param, body);
 
-		ScriptedSubscriber.create().expectNextCount(0).expectError(ServerWebInputException.class).verify(mono);
+		Verifier.create(mono).expectNextCount(0).expectError(ServerWebInputException.class).verify();
 	}
 
 	@Test @SuppressWarnings("unchecked")
@@ -283,10 +283,10 @@ public class MessageReaderArgumentResolverTests {
 		MethodParameter param = this.testMethod.resolveParam(type);
 		Flux<TestBean> flux = resolveValue(param, body);
 
-		ScriptedSubscriber.<TestBean>create()
+		Verifier.create(flux)
 				.expectNext(new TestBean("f1", "b1"))
 				.expectError(ServerWebInputException.class)
-				.verify(flux);
+				.verify();
 	}
 
 	@Test // SPR-9964

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/MessageWriterResultHandlerTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/MessageWriterResultHandlerTests.java
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 import rx.Completable;
 import rx.Observable;
 
@@ -137,7 +137,7 @@ public class MessageWriterResultHandlerTests {
 		HttpMessageWriter<?> writer = new EncoderHttpMessageWriter<>(new ByteBufferEncoder());
 		Mono<Void> mono = createResultHandler(writer).writeBody(body, returnType(type), this.exchange);
 
-		ScriptedSubscriber.create().expectError(IllegalStateException.class).verify(mono);
+		Verifier.create(mono).expectError(IllegalStateException.class).verify();
 	}
 
 	@Test  // SPR-12811
@@ -194,11 +194,11 @@ public class MessageWriterResultHandlerTests {
 	}
 
 	private void assertResponseBody(String responseBody) {
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(this.response.getBody())
 				.consumeNextWith(buf -> assertEquals(responseBody,
 						DataBufferTestUtils.dumpString(buf, StandardCharsets.UTF_8)))
 				.expectComplete()
-				.verify(this.response.getBody());
+				.verify();
 	}
 
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/PathVariableMethodArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/PathVariableMethodArgumentResolverTests.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.core.annotation.SynthesizingMethodParameter;
@@ -134,20 +134,21 @@ public class PathVariableMethodArgumentResolverTests {
 	public void handleMissingValue() throws Exception {
 		BindingContext bindingContext = new BindingContext();
 		Mono<Object> mono = this.resolver.resolveArgument(this.paramNamedString, bindingContext, this.exchange);
-		ScriptedSubscriber
-				.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.expectError(ServerErrorException.class)
-				.verify(mono);
+				.verify();
 	}
 
 	@Test
 	public void nullIfNotRequired() throws Exception {
 		BindingContext bindingContext = new BindingContext();
 		Mono<Object> mono = this.resolver.resolveArgument(this.paramNotRequired, bindingContext, this.exchange);
-		ScriptedSubscriber
-				.create().expectNextCount(0)
+		Verifier
+				.create(mono)
+				.expectNextCount(0)
 				.expectComplete()
-				.verify(mono);
+				.verify();
 	}
 
 	@Test
@@ -155,13 +156,13 @@ public class PathVariableMethodArgumentResolverTests {
 		BindingContext bindingContext = new BindingContext();
 		Mono<Object> mono = this.resolver.resolveArgument(this.paramOptional, bindingContext, this.exchange);
 
-		ScriptedSubscriber.create()
+		Verifier.create(mono)
 				.consumeNextWith(value -> {
 					assertTrue(value instanceof Optional);
 					assertFalse(((Optional) value).isPresent());
 				})
 				.expectComplete()
-				.verify(mono);
+				.verify();
 	}
 
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestAttributeMethodArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestAttributeMethodArgumentResolverTests.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.DefaultParameterNameDiscoverer;
@@ -89,9 +89,10 @@ public class RequestAttributeMethodArgumentResolverTests {
 	public void resolve() throws Exception {
 		MethodParameter param = initMethodParameter(0);
 		Mono<Object> mono = this.resolver.resolveArgument(param, new BindingContext(), this.exchange);
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(mono);
+				.verify();
 
 		Foo foo = new Foo();
 		this.exchange.getAttributes().put("foo", foo);

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestBodyArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestBodyArgumentResolverTests.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 import rx.Observable;
 import rx.RxReactiveStreams;
 import rx.Single;
@@ -126,13 +126,15 @@ public class RequestBodyArgumentResolverTests {
 	public void emptyBodyWithMono() throws Exception {
 		ResolvableType type = forClassWithGenerics(Mono.class, String.class);
 
-		ScriptedSubscriber.<Void>create().expectNextCount(0)
+		Verifier.create((Mono<Void>) resolveValueWithEmptyBody(type, true))
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify((Mono<Void>) resolveValueWithEmptyBody(type, true));
+				.verify();
 
-		ScriptedSubscriber.<Void>create().expectNextCount(0)
+		Verifier.create((Mono<Void>) resolveValueWithEmptyBody(type, false))
+				.expectNextCount(0)
 				.expectComplete()
-				.verify((Mono<Void>) resolveValueWithEmptyBody(type, false));
+				.verify();
 	}
 
 	@Test
@@ -140,13 +142,15 @@ public class RequestBodyArgumentResolverTests {
 	public void emptyBodyWithFlux() throws Exception {
 		ResolvableType type = forClassWithGenerics(Flux.class, String.class);
 
-		ScriptedSubscriber.<Void>create().expectNextCount(0)
+		Verifier.create((Flux<Void>) resolveValueWithEmptyBody(type, true))
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify((Flux<Void>) resolveValueWithEmptyBody(type, true));
+				.verify();
 
-		ScriptedSubscriber.<Void>create().expectNextCount(0)
+		Verifier.create((Flux<Void>) resolveValueWithEmptyBody(type, false))
+				.expectNextCount(0)
 				.expectComplete()
-				.verify((Flux<Void>) resolveValueWithEmptyBody(type, false));
+				.verify();
 	}
 
 	@Test
@@ -154,14 +158,16 @@ public class RequestBodyArgumentResolverTests {
 		ResolvableType type = forClassWithGenerics(Single.class, String.class);
 
 		Single<String> single = resolveValueWithEmptyBody(type, true);
-		ScriptedSubscriber.<String>create().expectNextCount(0)
+		Verifier.create(RxReactiveStreams.toPublisher(single))
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(RxReactiveStreams.toPublisher(single));
+				.verify();
 
 		single = resolveValueWithEmptyBody(type, false);
-		ScriptedSubscriber.<String>create().expectNextCount(0)
+		Verifier.create(RxReactiveStreams.toPublisher(single))
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(RxReactiveStreams.toPublisher(single));
+				.verify();
 	}
 
 	@Test
@@ -169,14 +175,16 @@ public class RequestBodyArgumentResolverTests {
 		ResolvableType type = forClassWithGenerics(Maybe.class, String.class);
 
 		Maybe<String> maybe = resolveValueWithEmptyBody(type, true);
-		ScriptedSubscriber.<String>create().expectNextCount(0)
+		Verifier.create(maybe.toFlowable())
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(maybe.toFlowable());
+				.verify();
 
 		maybe = resolveValueWithEmptyBody(type, false);
-		ScriptedSubscriber.<String>create().expectNextCount(0)
+		Verifier.create(maybe.toFlowable())
+				.expectNextCount(0)
 				.expectComplete()
-				.verify(maybe.toFlowable());
+				.verify();
 	}
 
 	@Test
@@ -184,14 +192,16 @@ public class RequestBodyArgumentResolverTests {
 		ResolvableType type = forClassWithGenerics(Observable.class, String.class);
 
 		Observable<String> observable = resolveValueWithEmptyBody(type, true);
-		ScriptedSubscriber.<String>create().expectNextCount(0)
+		Verifier.create(RxReactiveStreams.toPublisher(observable))
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(RxReactiveStreams.toPublisher(observable));
+				.verify();
 
 		observable = resolveValueWithEmptyBody(type, false);
-		ScriptedSubscriber.<String>create().expectNextCount(0)
+		Verifier.create(RxReactiveStreams.toPublisher(observable))
+				.expectNextCount(0)
 				.expectComplete()
-				.verify(RxReactiveStreams.toPublisher(observable));
+				.verify();
 	}
 
 	@Test

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestHeaderMethodArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestHeaderMethodArgumentResolverTests.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.MethodParameter;
@@ -203,9 +203,10 @@ public class RequestHeaderMethodArgumentResolverTests {
 		Mono<Object> mono = resolver.resolveArgument(
 				this.paramNamedValueStringArray, this.bindingContext, this.exchange);
 
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(mono);
+				.verify();
 	}
 
 	@Test

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestParamMethodArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestParamMethodArgumentResolverTests.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
@@ -159,9 +159,10 @@ public class RequestParamMethodArgumentResolverTests {
 		Mono<Object> mono = this.resolver.resolveArgument(
 				this.paramNamedStringArray, this.bindingContext, this.exchange);
 
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.expectError(ServerWebInputException.class)
-				.verify(mono);
+				.verify();
 	}
 
 	@Test

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandlerTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandlerTests.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 import rx.Completable;
 import rx.Single;
 
@@ -291,11 +291,11 @@ public class ResponseEntityResultHandlerTests {
 	}
 
 	private void assertResponseBody(String responseBody) {
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(this.response.getBody())
 				.consumeNextWith(buf -> assertEquals(responseBody,
 						DataBufferTestUtils.dumpString(buf, StandardCharsets.UTF_8)))
 				.expectComplete()
-				.verify(this.response.getBody());
+				.verify();
 	}
 
 	private void assertConditionalResponse(HttpStatus status, String body, String etag, Instant lastModified) throws Exception {

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/SessionAttributeMethodArgumentResolverTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/SessionAttributeMethodArgumentResolverTests.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.DefaultParameterNameDiscoverer;
@@ -96,7 +96,7 @@ public class SessionAttributeMethodArgumentResolverTests {
 	public void resolve() throws Exception {
 		MethodParameter param = initMethodParameter(0);
 		Mono<Object> mono = this.resolver.resolveArgument(param, new BindingContext(), this.exchange);
-		ScriptedSubscriber.create().expectError(ServerWebInputException.class).verify(mono);
+		Verifier.create(mono).expectError(ServerWebInputException.class).verify();
 
 		Foo foo = new Foo();
 		when(this.session.getAttribute("foo")).thenReturn(Optional.of(foo));

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/SseIntegrationTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/method/annotation/SseIntegrationTests.java
@@ -32,7 +32,7 @@ import org.springframework.http.codec.BodyExtractors;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.http.server.reactive.AbstractHttpHandlerIntegrationTests;
 import org.springframework.http.server.reactive.HttpHandler;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.reactive.ClientRequest;
@@ -87,11 +87,11 @@ public class SseIntegrationTests extends AbstractHttpHandlerIntegrationTests {
 				.map(s -> (s.replace("\n", "")))
 				.take(2);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("data:foo 0")
 				.expectNext("data:foo 1")
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(5L));
+				.verify(Duration.ofSeconds(5L));
 	}
 	@Test
 	public void sseAsPerson() throws Exception {
@@ -109,10 +109,10 @@ public class SseIntegrationTests extends AbstractHttpHandlerIntegrationTests {
 				.takeUntil(s -> s.endsWith("foo 1\"}"))
 				.reduce((s1, s2) -> s1 + s2);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("data:{\"name\":\"foo 0\"}data:{\"name\":\"foo 1\"}")
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(5L));
+				.verify(Duration.ofSeconds(5L));
 	}
 
 	@Test
@@ -129,11 +129,11 @@ public class SseIntegrationTests extends AbstractHttpHandlerIntegrationTests {
 				.map(s -> s.replace("\n", ""))
 				.take(2);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("id:0:bardata:foo")
 				.expectNext("id:1:bardata:foo")
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(5L));
+				.verify(Duration.ofSeconds(5L));
 	}
 
 	@Test
@@ -151,11 +151,11 @@ public class SseIntegrationTests extends AbstractHttpHandlerIntegrationTests {
 				.map(s -> s.replace("\n", ""))
 				.take(2);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("id:0:bardata:foo")
 				.expectNext("id:1:bardata:foo")
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(5L));
+				.verify(Duration.ofSeconds(5L));
 	}
 
 	@RestController

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/view/HttpMessageWriterViewTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/view/HttpMessageWriterViewTests.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.codec.CharSequenceEncoder;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -155,12 +155,12 @@ public class HttpMessageWriterViewTests {
 
 		this.view.render(this.model, MediaType.APPLICATION_JSON, exchange);
 
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(response.getBody())
 				.consumeNextWith( buf -> assertEquals("{\"foo\":\"f\",\"bar\":\"b\"}",
 						DataBufferTestUtils.dumpString(buf, StandardCharsets.UTF_8))
 				)
 				.expectComplete()
-				.verify(response.getBody());
+				.verify();
 	}
 
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/view/ViewResolutionResultHandlerTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/view/ViewResolutionResultHandlerTests.java
@@ -31,7 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 import rx.Completable;
 import rx.Single;
 
@@ -204,9 +204,10 @@ public class ViewResolutionResultHandlerTests {
 		this.request.setUri("/path");
 		Mono<Void> mono = createResultHandler().handleResult(this.exchange, handlerResult);
 
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.expectErrorWith(err -> err.getMessage().equals("Could not resolve view with name 'account'."))
-				.verify(mono);
+				.verify();
 	}
 
 	@Test
@@ -239,9 +240,10 @@ public class ViewResolutionResultHandlerTests {
 
 		ViewResolutionResultHandler resultHandler = createResultHandler(new TestViewResolver("account"));
 		Mono<Void> mono = resultHandler.handleResult(this.exchange, handlerResult);
-		ScriptedSubscriber.create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.expectError(NotAcceptableStatusException.class)
-				.verify(mono);
+				.verify();
 	}
 
 
@@ -291,11 +293,11 @@ public class ViewResolutionResultHandlerTests {
 	}
 
 	private void assertResponseBody(String responseBody) {
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(this.response.getBody())
 				.consumeNextWith(buf -> assertEquals(responseBody,
 						DataBufferTestUtils.dumpString(buf, StandardCharsets.UTF_8)))
 				.expectComplete()
-				.verify(this.response.getBody());
+				.verify();
 	}
 
 

--- a/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/view/freemarker/FreeMarkerViewTests.java
+++ b/spring-web-reactive/src/test/java/org/springframework/web/reactive/result/view/freemarker/FreeMarkerViewTests.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.context.ApplicationContextException;
 import org.springframework.context.support.GenericApplicationContext;
@@ -123,12 +123,12 @@ public class FreeMarkerViewTests {
 		model.addAttribute("hello", "hi FreeMarker");
 		view.render(model, null, this.exchange);
 
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(this.response.getBody())
 				.consumeNextWith(buf -> {
 					assertEquals("<html><body>hi FreeMarker</body></html>", asString(buf));
 				})
 				.expectComplete()
-				.verify(this.response.getBody());
+				.verify();
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/http/codec/BodyExtractorsTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/BodyExtractorsTests.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.codec.ByteBufferDecoder;
 import org.springframework.core.codec.StringDecoder;
@@ -80,10 +80,10 @@ public class BodyExtractorsTests {
 
 		Mono<String> result = extractor.extract(request, this.context);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("foo")
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 	@Test
@@ -100,10 +100,10 @@ public class BodyExtractorsTests {
 
 		Flux<String> result = extractor.extract(request, this.context);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("foo")
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 	@Test
@@ -127,9 +127,9 @@ public class BodyExtractorsTests {
 		};
 
 		Flux<String> result = extractor.extract(request, emptyContext);
-		ScriptedSubscriber.create()
+		Verifier.create(result)
 				.expectError(UnsupportedMediaTypeException.class)
-				.verify(result);
+				.verify();
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/codec/BodyInsertersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/BodyInsertersTests.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.codec.ByteBufferEncoder;
 import org.springframework.core.codec.CharSequenceEncoder;
@@ -85,14 +85,14 @@ public class BodyInsertersTests {
 
 		MockServerHttpResponse response = new MockServerHttpResponse();
 		Mono<Void> result = inserter.insert(response, this.context);
-		ScriptedSubscriber.create().expectComplete().verify(result);
+		Verifier.create(result).expectComplete().verify();
 
 		ByteBuffer byteBuffer = ByteBuffer.wrap(body.getBytes(UTF_8));
 		DataBuffer buffer = new DefaultDataBufferFactory().wrap(byteBuffer);
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(response.getBody())
 				.expectNext(buffer)
 				.expectComplete()
-				.verify(response.getBody());
+				.verify();
 	}
 
 	@Test
@@ -104,14 +104,14 @@ public class BodyInsertersTests {
 
 		MockServerHttpResponse response = new MockServerHttpResponse();
 		Mono<Void> result = inserter.insert(response, this.context);
-		ScriptedSubscriber.create().expectComplete().verify(result);
+		Verifier.create(result).expectComplete().verify();
 
 		ByteBuffer byteBuffer = ByteBuffer.wrap("foo".getBytes(UTF_8));
 		DataBuffer buffer = new DefaultDataBufferFactory().wrap(byteBuffer);
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(response.getBody())
 				.expectNext(buffer)
 				.expectComplete()
-				.verify(response.getBody());
+				.verify();
 	}
 
 	@Test
@@ -123,18 +123,18 @@ public class BodyInsertersTests {
 
 		MockServerHttpResponse response = new MockServerHttpResponse();
 		Mono<Void> result = inserter.insert(response, this.context);
-		ScriptedSubscriber.create().expectComplete().verify(result);
+		Verifier.create(result).expectComplete().verify();
 
 		byte[] expectedBytes = Files.readAllBytes(body.getFile().toPath());
 
-		ScriptedSubscriber.<DataBuffer>create()
+		Verifier.create(response.getBody())
 				.consumeNextWith(dataBuffer -> {
 					byte[] resultBytes = new byte[dataBuffer.readableByteCount()];
 					dataBuffer.read(resultBytes);
 					assertArrayEquals(expectedBytes, resultBytes);
 				})
 				.expectComplete()
-				.verify(response.getBody());
+				.verify();
 	}
 
 	@Test
@@ -148,7 +148,7 @@ public class BodyInsertersTests {
 
 		MockServerHttpResponse response = new MockServerHttpResponse();
 		Mono<Void> result = inserter.insert(response, this.context);
-		ScriptedSubscriber.create().expectNextCount(0).expectComplete().verify(result);
+		Verifier.create(result).expectNextCount(0).expectComplete().verify();
 	}
 
 	@Test
@@ -161,7 +161,7 @@ public class BodyInsertersTests {
 
 		MockServerHttpResponse response = new MockServerHttpResponse();
 		Mono<Void> result = inserter.insert(response, this.context);
-		ScriptedSubscriber.create().expectNextCount(0).expectComplete().verify(result);
+		Verifier.create(result).expectNextCount(0).expectComplete().verify();
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/codec/EncoderHttpMessageWriterTest.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/EncoderHttpMessageWriterTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.ByteBufferEncoder;
@@ -68,10 +68,10 @@ public class EncoderHttpMessageWriterTest {
 				MediaType.APPLICATION_OCTET_STREAM, this.response, Collections.emptyMap());
 
 		assertThat(this.response.getHeaders().getContentType(), is(MediaType.APPLICATION_OCTET_STREAM));
-		ScriptedSubscriber.<String>create()
+		Verifier.create(this.response.getBodyAsString())
 				.expectNext(payload)
 				.expectComplete()
-				.verify(this.response.getBodyAsString());
+				.verify();
 	}
 
 	@NotNull

--- a/spring-web/src/test/java/org/springframework/http/codec/ResourceHttpMessageWriterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/ResourceHttpMessageWriterTests.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.ByteArrayResource;
@@ -73,22 +73,20 @@ public class ResourceHttpMessageWriterTests {
 		Mono<Void> mono = this.writer.write(Mono.just(resource), null,
 				ResolvableType.forClass(Resource.class),
 				MediaType.TEXT_PLAIN, this.request, this.response, Collections.emptyMap());
-		ScriptedSubscriber
-				.<Void>create()
+		Verifier.create(mono)
 				.expectNextCount(0)
 				.expectComplete()
-				.verify(mono);
+				.verify();
 
 		assertThat(this.response.getHeaders().getContentType(), is(MediaType.TEXT_PLAIN));
 		assertThat(this.response.getHeaders().getContentLength(), is(39L));
 		assertThat(this.response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES), is("bytes"));
 
 		Mono<String> result = this.response.getBodyAsString();
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectNext("Spring Framework test resource content.")
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 	@Test
@@ -96,11 +94,10 @@ public class ResourceHttpMessageWriterTests {
 		this.request.getHeaders().setRange(Collections.singletonList(HttpRange.createByteRange(0, 5)));
 		Mono<Void> mono = this.writer.write(Mono.just(resource), null, ResolvableType.forClass(Resource.class),
 				MediaType.TEXT_PLAIN, this.request, this.response, Collections.emptyMap());
-		ScriptedSubscriber
-				.<Void>create()
+		Verifier.create(mono)
 				.expectNextCount(0)
 				.expectComplete()
-				.verify(mono);
+				.verify();
 
 		assertThat(this.response.getHeaders().getContentType(), is(MediaType.TEXT_PLAIN));
 		assertThat(this.response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE), is("bytes 0-5/39"));
@@ -108,11 +105,10 @@ public class ResourceHttpMessageWriterTests {
 		assertThat(this.response.getHeaders().getContentLength(), is(6L));
 
 		Mono<String> result = this.response.getBodyAsString();
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectNext("Spring")
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 	@Test
@@ -121,11 +117,10 @@ public class ResourceHttpMessageWriterTests {
 
 		Mono<Void> mono = this.writer.write(Mono.just(resource), null, ResolvableType.forClass(Resource.class),
 				MediaType.TEXT_PLAIN, this.request, this.response, Collections.emptyMap());
-		ScriptedSubscriber
-				.<Void>create()
+		Verifier.create(mono)
 				.expectNextCount(0)
 				.expectComplete()
-				.verify(mono);
+				.verify();
 
 		assertThat(this.response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES), is("bytes"));
 		assertThat(this.response.getStatusCode(), is(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE));

--- a/spring-web/src/test/java/org/springframework/http/codec/ResourceRegionHttpMessageWriterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/ResourceRegionHttpMessageWriterTests.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.ByteArrayResource;
@@ -85,14 +85,14 @@ public class ResourceRegionHttpMessageWriterTests {
 
 		Mono<Void> mono = this.writer.write(Mono.just(region), ResolvableType.forClass(ResourceRegion.class),
 				MediaType.TEXT_PLAIN, this.response, Collections.emptyMap());
-		ScriptedSubscriber.<Void>create().expectComplete().verify(mono);
+		Verifier.create(mono).expectComplete().verify();
 
 		assertThat(this.response.getHeaders().getContentType(), is(MediaType.TEXT_PLAIN));
 		assertThat(this.response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE), is("bytes 0-5/39"));
 		assertThat(this.response.getHeaders().getContentLength(), is(6L));
 
 		Mono<String> result = response.getBodyAsString();
-		ScriptedSubscriber.<String>create().expectNext("Spring").expectComplete().verify(result);
+		Verifier.create(result).expectNext("Spring").expectComplete().verify();
 	}
 
 	@Test
@@ -109,15 +109,14 @@ public class ResourceRegionHttpMessageWriterTests {
 
 		Mono<Void> mono = this.writer.write(regions, ResolvableType.forClass(ResourceRegion.class),
 				MediaType.TEXT_PLAIN, this.response, hints);
-		ScriptedSubscriber.<Void>create().expectComplete().verify(mono);
+		Verifier.create(mono).expectComplete().verify();
 
 		HttpHeaders headers = this.response.getHeaders();
 		assertThat(headers.getContentType().toString(), startsWith("multipart/byteranges;boundary=" + boundary));
 
 		Mono<String> result = response.getBodyAsString();
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.consumeNextWith(content -> {
 					String[] ranges = StringUtils
 							.tokenizeToStringArray(content, "\r\n", false, true);
@@ -143,7 +142,7 @@ public class ResourceRegionHttpMessageWriterTests {
 					assertArrayEquals(expected, ranges);
 				})
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonDecoderTests.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -61,10 +61,10 @@ public class Jackson2JsonDecoderTests extends AbstractDataBufferAllocatingTestCa
 		Flux<Object> flux = new Jackson2JsonDecoder().decode(source, elementType, null,
 				Collections.emptyMap());
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(flux)
 				.expectNext(new Pojo("foofoo", "barbar"))
 				.expectComplete()
-				.verify(flux);
+				.verify();
 	}
 
 	@Test
@@ -76,10 +76,10 @@ public class Jackson2JsonDecoderTests extends AbstractDataBufferAllocatingTestCa
 		Mono<Object> mono = new Jackson2JsonDecoder().decodeToMono(source, elementType,
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(mono)
 				.expectNext(Arrays.asList(new Pojo("f1", "b1"), new Pojo("f2", "b2")))
 				.expectComplete()
-				.verify(mono);
+				.verify();
 	}
 
 	@Test
@@ -91,11 +91,11 @@ public class Jackson2JsonDecoderTests extends AbstractDataBufferAllocatingTestCa
 		Flux<Object> flux = new Jackson2JsonDecoder().decode(source, elementType, null,
 				Collections.emptyMap());
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(flux)
 				.expectNext(new Pojo("f1", "b1"))
 				.expectNext(new Pojo("f2", "b2"))
 				.expectComplete()
-				.verify(flux);
+				.verify();
 	}
 
 	@Test
@@ -107,14 +107,14 @@ public class Jackson2JsonDecoderTests extends AbstractDataBufferAllocatingTestCa
 		Flux<JacksonViewBean> flux = new Jackson2JsonDecoder()
 				.decode(source, elementType, null, hints).cast(JacksonViewBean.class);
 
-		ScriptedSubscriber.<JacksonViewBean>create()
+		Verifier.create(flux)
 				.consumeNextWith(b -> {
 					assertTrue(b.getWithView1().equals("with"));
 					assertNull(b.getWithView2());
 					assertNull(b.getWithoutView());
 				})
 				.expectComplete()
-				.verify(flux);
+				.verify();
 	}
 
 	@Test
@@ -124,10 +124,10 @@ public class Jackson2JsonDecoderTests extends AbstractDataBufferAllocatingTestCa
 		Mono<Object> mono = new Jackson2JsonDecoder().decodeToMono(source, elementType,
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber.
-				<Object>create().expectNextCount(0)
+		Verifier.create(mono)
+				.expectNextCount(0)
 				.expectComplete()
-				.verify(mono);
+				.verify();
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonEncoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonEncoderTests.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -65,8 +65,7 @@ public class Jackson2JsonEncoderTests extends AbstractDataBufferAllocatingTestCa
 		ResolvableType type = ResolvableType.forClass(Pojo.class);
 		Flux<DataBuffer> output = this.encoder.encode(source, this.bufferFactory, type, null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(output)
 				.consumeNextWith(stringConsumer("["))
 				.consumeNextWith(stringConsumer("{\"foo\":\"foo\",\"bar\":\"bar\"}"))
 				.consumeNextWith(stringConsumer(","))
@@ -75,7 +74,7 @@ public class Jackson2JsonEncoderTests extends AbstractDataBufferAllocatingTestCa
 				.consumeNextWith(stringConsumer("{\"foo\":\"foofoofoo\",\"bar\":\"barbarbar\"}"))
 				.consumeNextWith(stringConsumer("]"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -84,15 +83,14 @@ public class Jackson2JsonEncoderTests extends AbstractDataBufferAllocatingTestCa
 		ResolvableType type = ResolvableType.forClass(ParentClass.class);
 		Flux<DataBuffer> output = this.encoder.encode(source, this.bufferFactory, type, null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(output)
 				.consumeNextWith(stringConsumer("["))
 				.consumeNextWith(stringConsumer("{\"type\":\"foo\"}"))
 				.consumeNextWith(stringConsumer(","))
 				.consumeNextWith(stringConsumer("{\"type\":\"bar\"}"))
 				.consumeNextWith(stringConsumer("]"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -106,11 +104,10 @@ public class Jackson2JsonEncoderTests extends AbstractDataBufferAllocatingTestCa
 		Map<String, Object> hints = Collections.singletonMap(Jackson2JsonEncoder.JSON_VIEW_HINT, MyJacksonView1.class);
 		Flux<DataBuffer> output = this.encoder.encode(Mono.just(bean), this.bufferFactory, type, null, hints);
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(output)
 				.consumeNextWith(stringConsumer("{\"withView1\":\"with\"}"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/http/codec/json/JsonObjectDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/JsonObjectDecoderTests.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 
 import org.junit.Test;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -38,10 +38,10 @@ public class JsonObjectDecoderTests extends AbstractDataBufferAllocatingTestCase
 				Flux.just(stringBuffer("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}"));
 		Flux<String> output =
 				decoder.decode(source, null, null, Collections.emptyMap()).map(JsonObjectDecoderTests::toString);
-		ScriptedSubscriber.<String>create()
+		Verifier.create(output)
 				.expectNext("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}")
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -51,10 +51,10 @@ public class JsonObjectDecoderTests extends AbstractDataBufferAllocatingTestCase
 				stringBuffer(", \"bar\": \"barbar\"}"));
 		Flux<String> output =
 				decoder.decode(source, null, null, Collections.emptyMap()).map(JsonObjectDecoderTests::toString);
-		ScriptedSubscriber.<String>create()
+		Verifier.create(output)
 				.expectNext("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}")
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -65,19 +65,19 @@ public class JsonObjectDecoderTests extends AbstractDataBufferAllocatingTestCase
 				"[{\"foo\": \"foofoo\", \"bar\": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]"));
 		Flux<String> output =
 				decoder.decode(source, null, null, Collections.emptyMap()).map(JsonObjectDecoderTests::toString);
-		ScriptedSubscriber.<String>create()
+		Verifier.create(output)
 				.expectNext("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}")
 				.expectNext("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}")
 				.expectComplete()
-				.verify(output);
+				.verify();
 
 		source = Flux.just(stringBuffer("[{\"foo\": \"bar\"},{\"foo\": \"baz\"}]"));
 		output = decoder.decode(source, null, null, Collections.emptyMap()).map(JsonObjectDecoderTests::toString);
-		ScriptedSubscriber.<String>create()
+		Verifier.create(output)
 				.expectNext("{\"foo\": \"bar\"}")
 				.expectNext("{\"foo\": \"baz\"}")
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -89,11 +89,11 @@ public class JsonObjectDecoderTests extends AbstractDataBufferAllocatingTestCase
 						": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]"));
 		Flux<String> output =
 				decoder.decode(source, null, null, Collections.emptyMap()).map(JsonObjectDecoderTests::toString);
-		ScriptedSubscriber.<String>create()
+		Verifier.create(output)
 				.expectNext("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}")
 				.expectNext("{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}")
 				.expectComplete()
-				.verify(output);
+				.verify();
 
 		source = Flux.just(
 				stringBuffer("[{\"foo\": \""),
@@ -101,11 +101,11 @@ public class JsonObjectDecoderTests extends AbstractDataBufferAllocatingTestCase
 				stringBuffer("o\": \"baz\"}"),
 				stringBuffer("]"));
 		output = decoder.decode(source, null, null, Collections.emptyMap()).map(JsonObjectDecoderTests::toString);
-		ScriptedSubscriber.<String>create()
+		Verifier.create(output)
 				.expectNext("{\"foo\": \"bar\"}")
 				.expectNext("{\"foo\": \"baz\"}")
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/http/codec/xml/Jaxb2XmlDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/xml/Jaxb2XmlDecoderTests.java
@@ -23,7 +23,7 @@ import javax.xml.stream.events.XMLEvent;
 
 import org.junit.Test;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -91,7 +91,7 @@ public class Jaxb2XmlDecoderTests extends AbstractDataBufferAllocatingTestCase {
 				.decode(Flux.just(stringBuffer(POJO_ROOT)), null, null, Collections.emptyMap());
 		Flux<List<XMLEvent>> result = this.decoder.split(xmlEvents, new QName("pojo"));
 
-		ScriptedSubscriber.<List<XMLEvent>>create()
+		Verifier.create(result)
 				.consumeNextWith(events -> {
 					assertEquals(8, events.size());
 					assertStartElement(events.get(0), "pojo");
@@ -104,7 +104,7 @@ public class Jaxb2XmlDecoderTests extends AbstractDataBufferAllocatingTestCase {
 					assertEndElement(events.get(7), "pojo");
 				})
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 	@Test
@@ -114,7 +114,7 @@ public class Jaxb2XmlDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<List<XMLEvent>> result = this.decoder.split(xmlEvents, new QName("pojo"));
 
 
-		ScriptedSubscriber.<List<XMLEvent>>create()
+		Verifier.create(result)
 				.consumeNextWith(events -> {
 					assertEquals(8, events.size());
 					assertStartElement(events.get(0), "pojo");
@@ -138,7 +138,7 @@ public class Jaxb2XmlDecoderTests extends AbstractDataBufferAllocatingTestCase {
 					assertEndElement(events.get(7), "pojo");
 				})
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 	private static void assertStartElement(XMLEvent event, String expectedLocalName) {
@@ -162,10 +162,10 @@ public class Jaxb2XmlDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<Object> output = this.decoder.decode(source, ResolvableType.forClass(Pojo.class),
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(output)
 				.expectNext(new Pojo("foofoo", "barbar"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -174,10 +174,10 @@ public class Jaxb2XmlDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<Object> output = this.decoder.decode(source, ResolvableType.forClass(TypePojo.class),
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(output)
 				.expectNext(new TypePojo("foofoo", "barbar"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -186,11 +186,11 @@ public class Jaxb2XmlDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<Object> output = this.decoder.decode(source, ResolvableType.forClass(Pojo.class),
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(output)
 				.expectNext(new Pojo("foo", "bar"))
 				.expectNext(new Pojo("foofoo", "barbar"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test
@@ -199,11 +199,11 @@ public class Jaxb2XmlDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<Object> output = this.decoder.decode(source, ResolvableType.forClass(TypePojo.class),
 				null, Collections.emptyMap());
 
-		ScriptedSubscriber.<Object>create()
+		Verifier.create(output)
 				.expectNext(new TypePojo("foo", "bar"))
 				.expectNext(new TypePojo("foofoo", "barbar"))
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/http/codec/xml/Jaxb2XmlEncoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/xml/Jaxb2XmlEncoderTests.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 
 import org.junit.Test;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
@@ -69,8 +69,7 @@ public class Jaxb2XmlEncoderTests extends AbstractDataBufferAllocatingTestCase {
 				ResolvableType.forClass(Pojo.class),
 				MediaType.APPLICATION_XML, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<DataBuffer>create()
+		Verifier.create(output)
 				.consumeNextWith(dataBuffer -> {
 					try {
 						String s = DataBufferTestUtils
@@ -83,7 +82,7 @@ public class Jaxb2XmlEncoderTests extends AbstractDataBufferAllocatingTestCase {
 					}
 				})
 				.expectComplete()
-				.verify(output);
+				.verify();
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/codec/xml/XmlEventDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/xml/XmlEventDecoderTests.java
@@ -21,7 +21,7 @@ import javax.xml.stream.events.XMLEvent;
 
 import org.junit.Test;
 import reactor.core.publisher.Flux;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
 
@@ -47,8 +47,7 @@ public class XmlEventDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<XMLEvent> events =
 				this.decoder.decode(Flux.just(stringBuffer(XML)), null, null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<XMLEvent>create()
+		Verifier.create(events)
 				.consumeNextWith(e -> assertTrue(e.isStartDocument()))
 				.consumeNextWith(e -> assertStartElement(e, "pojo"))
 				.consumeNextWith(e -> assertStartElement(e, "foo"))
@@ -59,7 +58,7 @@ public class XmlEventDecoderTests extends AbstractDataBufferAllocatingTestCase {
 				.consumeNextWith(e -> assertEndElement(e, "bar"))
 				.consumeNextWith(e -> assertEndElement(e, "pojo"))
 				.expectComplete()
-				.verify(events);
+				.verify();
 	}
 
 	@Test
@@ -69,8 +68,7 @@ public class XmlEventDecoderTests extends AbstractDataBufferAllocatingTestCase {
 		Flux<XMLEvent> events =
 				this.decoder.decode(Flux.just(stringBuffer(XML)), null, null, Collections.emptyMap());
 
-		ScriptedSubscriber
-				.<XMLEvent>create()
+		Verifier.create(events)
 				.consumeNextWith(e -> assertTrue(e.isStartDocument()))
 				.consumeNextWith(e -> assertStartElement(e, "pojo"))
 				.consumeNextWith(e -> assertStartElement(e, "foo"))
@@ -82,7 +80,7 @@ public class XmlEventDecoderTests extends AbstractDataBufferAllocatingTestCase {
 				.consumeNextWith(e -> assertEndElement(e, "pojo"))
 				.consumeNextWith(e -> assertTrue(e.isEndDocument()))
 				.expectComplete()
-				.verify(events);
+				.verify();
 	}
 
 	private static void assertStartElement(XMLEvent event, String expectedLocalName) {

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/FlushingIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/FlushingIntegrationTests.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -56,10 +56,10 @@ public class FlushingIntegrationTests extends AbstractHttpHandlerIntegrationTest
 				.takeUntil(s -> s.endsWith("data1"))
 				.reduce((s1, s2) -> s1 + s2);
 
-		ScriptedSubscriber.<String>create()
+		Verifier.create(result)
 				.expectNext("data0data1")
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(5L));
+				.verify(Duration.ofSeconds(5L));
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/web/client/reactive/ExchangeFilterFunctionsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/reactive/ExchangeFilterFunctionsTests.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -97,10 +97,10 @@ public class ExchangeFilterFunctionsTests {
 
 		Mono<ClientResponse> result = standardErrors.filter(request, exchange);
 
-		ScriptedSubscriber.<ClientResponse>create()
+		Verifier.create(result)
 				.expectNext(response)
 				.expectComplete()
-				.verify(result);
+				.verify();
 	}
 
 	@Test
@@ -114,9 +114,9 @@ public class ExchangeFilterFunctionsTests {
 
 		Mono<ClientResponse> result = standardErrors.filter(request, exchange);
 
-		ScriptedSubscriber.<ClientResponse>create()
+		Verifier.create(result)
 				.expectError(WebClientException.class)
-				.verify(result);
+				.verify();
 	}
 
 	@Test
@@ -131,9 +131,9 @@ public class ExchangeFilterFunctionsTests {
 
 		Mono<ClientResponse> result = errorPredicate.filter(request, exchange);
 
-		ScriptedSubscriber.<ClientResponse>create()
+		Verifier.create(result)
 				.expectError(WebClientException.class)
-				.verify(result);
+				.verify();
 	}
 
 
@@ -148,9 +148,9 @@ public class ExchangeFilterFunctionsTests {
 
 		Mono<ClientResponse> result = errorMapper.filter(request, exchange);
 
-		ScriptedSubscriber.<ClientResponse>create()
+		Verifier.create(result)
 				.expectError(IllegalStateException.class)
-				.verify(result);
+				.verify();
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/web/client/reactive/WebClientIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/reactive/WebClientIntegrationTests.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -70,14 +70,14 @@ public class WebClientIntegrationTests {
 				.exchange(request)
 				.map(response -> response.headers().asHttpHeaders());
 
-		ScriptedSubscriber.<HttpHeaders>create()
+		Verifier.create(result)
 				.consumeNextWith(
 						httpHeaders -> {
 							assertEquals(MediaType.TEXT_PLAIN, httpHeaders.getContentType());
 							assertEquals(13L, httpHeaders.getContentLength());
 						})
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -98,11 +98,10 @@ public class WebClientIntegrationTests {
 				.exchange(request)
 				.then(response -> response.body(toMono(String.class)));
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectNext("Hello Spring!")
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -121,11 +120,10 @@ public class WebClientIntegrationTests {
 		Mono<String> result = this.webClient
 				.retrieveMono(request, String.class);
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectNext("Hello Spring!")
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -143,11 +141,10 @@ public class WebClientIntegrationTests {
 		Flux<String> result = this.webClient
 				.retrieveFlux(request, String.class);
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectNext("Hello Spring!")
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -170,11 +167,10 @@ public class WebClientIntegrationTests {
 				.exchange(request)
 				.then(response -> response.body(toMono(String.class)));
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectNext(content)
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -196,11 +192,10 @@ public class WebClientIntegrationTests {
 				.exchange(request)
 				.then(response -> response.body(toMono(Pojo.class)));
 
-		ScriptedSubscriber
-				.<Pojo>create()
+		Verifier.create(result)
 				.consumeNextWith(p -> assertEquals("barbar", p.getBar()))
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -222,12 +217,11 @@ public class WebClientIntegrationTests {
 				.exchange(request)
 				.flatMap(response -> response.body(toFlux(Pojo.class)));
 
-		ScriptedSubscriber
-				.<Pojo>create()
+		Verifier.create(result)
 				.consumeNextWith(p -> assertThat(p.getBar(), Matchers.is("bar1")))
 				.consumeNextWith(p -> assertThat(p.getBar(), Matchers.is("bar2")))
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -252,11 +246,10 @@ public class WebClientIntegrationTests {
 				.exchange(request)
 				.then(response -> response.body(BodyExtractors.toMono(Pojo.class)));
 
-		ScriptedSubscriber
-				.<Pojo>create()
+		Verifier.create(result)
 				.consumeNextWith(p -> assertEquals("BARBAR", p.getBar()))
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -281,11 +274,10 @@ public class WebClientIntegrationTests {
 				.exchange(request)
 				.then(response -> response.body(toMono(String.class)));
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectNext("test")
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -304,13 +296,12 @@ public class WebClientIntegrationTests {
 		Mono<ClientResponse> result = this.webClient
 				.exchange(request);
 
-		ScriptedSubscriber
-				.<ClientResponse>create()
+		Verifier.create(result)
 				.consumeNextWith(response -> {
 					assertEquals(HttpStatus.NOT_FOUND, response.statusCode());
 				})
 				.expectComplete()
-				.verify(result, Duration.ofSeconds(3));
+				.verify(Duration.ofSeconds(3));
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -329,10 +320,9 @@ public class WebClientIntegrationTests {
 		Mono<String> result = this.webClient
 				.retrieveMono(request, String.class);
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectError(WebClientException.class)
-				.verify(result, Duration.ofSeconds(3));
+				.verify(Duration.ofSeconds(3));
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -351,10 +341,9 @@ public class WebClientIntegrationTests {
 		Mono<String> result = this.webClient
 				.retrieveMono(request, String.class);
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectError(WebClientException.class)
-				.verify(result, Duration.ofSeconds(3));
+				.verify(Duration.ofSeconds(3));
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());
@@ -380,11 +369,10 @@ public class WebClientIntegrationTests {
 		Mono<String> result = filteredClient.exchange(request)
 				.then(response -> response.body(toMono(String.class)));
 
-		ScriptedSubscriber
-				.<String>create()
+		Verifier.create(result)
 				.expectNext("Hello Spring!")
 				.expectComplete()
-				.verify(result);
+				.verify();
 
 		RecordedRequest recordedRequest = server.takeRequest();
 		assertEquals(1, server.getRequestCount());

--- a/spring-web/src/test/java/org/springframework/web/server/handler/ResponseStatusExceptionHandlerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/handler/ResponseStatusExceptionHandlerTests.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
-import reactor.test.subscriber.ScriptedSubscriber;
+import reactor.test.subscriber.Verifier;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -72,10 +72,9 @@ public class ResponseStatusExceptionHandlerTests {
 		Throwable expected = new IllegalStateException();
 		Mono<Void> mono = this.handler.handle(this.exchange, expected);
 
-		ScriptedSubscriber
-				.<Void>create()
+		Verifier.create(mono)
 				.consumeErrorWith(actual -> assertSame(expected, actual))
-				.verify(mono);
+				.verify();
 	}
 
 }


### PR DESCRIPTION
To be merged in master when https://github.com/reactor/reactor-addons/pull/31 will be merged.

These changes discussed in detail this afternoon with @smaldini provide many improvements:
 - Generics are finally automatically resolved
 - The new `create(Publisher<T>)` is consistent with the new `create(Supplier<Publisher<T>>)` added by Stéphane for the time based assertions
 - Shorter name very handy to use with indentation Verifier (same length than 2 tabs or 8 characters)