### PR TITLE
PropertyEditor for java.time.Duration

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/PropertyEditorRegistrySupport.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyEditorRegistrySupport.java
@@ -56,6 +56,7 @@ import org.springframework.beans.propertyeditors.CustomBooleanEditor;
 import org.springframework.beans.propertyeditors.CustomCollectionEditor;
 import org.springframework.beans.propertyeditors.CustomMapEditor;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
+import org.springframework.beans.propertyeditors.DurationEditor;
 import org.springframework.beans.propertyeditors.FileEditor;
 import org.springframework.beans.propertyeditors.InputSourceEditor;
 import org.springframework.beans.propertyeditors.InputStreamEditor;
@@ -90,14 +91,17 @@ import org.springframework.util.ClassUtils;
 public class PropertyEditorRegistrySupport implements PropertyEditorRegistry {
 
 	private static Class<?> zoneIdClass;
+	private static Class<?> durationClass;
 
 	static {
 		try {
 			zoneIdClass = ClassUtils.forName("java.time.ZoneId", PropertyEditorRegistrySupport.class.getClassLoader());
+			durationClass = ClassUtils.forName("java.time.Duration", PropertyEditorRegistrySupport.class.getClassLoader());
 		}
 		catch (ClassNotFoundException ex) {
-			// Java 8 ZoneId class not available
+			// Java 8's time classes not available. (All or none should be present).
 			zoneIdClass = null;
+			durationClass = null;
 		}
 	}
 
@@ -224,6 +228,9 @@ public class PropertyEditorRegistrySupport implements PropertyEditorRegistry {
 		this.defaultEditors.put(UUID.class, new UUIDEditor());
 		if (zoneIdClass != null) {
 			this.defaultEditors.put(zoneIdClass, new ZoneIdEditor());
+		}
+		if (durationClass != null) {
+			this.defaultEditors.put(durationClass, new DurationEditor());
 		}
 
 		// Default instances of collection editors.

--- a/spring-beans/src/main/java/org/springframework/beans/propertyeditors/DurationEditor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/propertyeditors/DurationEditor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.propertyeditors;
+
+import java.beans.PropertyEditorSupport;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Editor for {@link java.time.Duration}, translating simple or ISO-8601 duration
+ * representation into {@code Duration} objects. Uses ISO-8601 standard for a text
+ * representation.
+ * <p>
+ * This class supports same extensions to the ISO-8601 duration representation as
+ * those supported by {@link Duration#parse(CharSequence)} method.
+ * <p>
+ * Additional, simple representation implemented by this class is of the form
+ * {@code OptionalSign Amount Space Unit} where {@code OptionalSign} is an optional
+ * sign (+, - or nothing), {@code Amount} is a number that fits into a long,
+ * {@code Space} is zero or one ASCII space ('\\u0020') and {@code Unit} is one of
+ * 'ms', 's', 'm', 'h', 'd' for milliseconds, seconds, minutes, hours and days
+ * respectively, where a day should be understood as exactly 24 hours.
+ *
+ * @author Piotr Findeisen
+ * @since 5.0.0
+ */
+public class DurationEditor extends PropertyEditorSupport {
+
+	private static final Pattern SIMPLE_REPRESENTATION = Pattern.compile(
+			"(?<sign>[+-]?)(?<amount>\\d+) ?(?<unit>ms|s|m|h|d)");
+
+	private static final Map<String, TemporalUnit> units = buildUnits();
+
+	private static Map<String, TemporalUnit> buildUnits() {
+		Map<String, TemporalUnit> units = new HashMap<>();
+		units.put("ms", ChronoUnit.MILLIS);
+		units.put("s", ChronoUnit.SECONDS);
+		units.put("m", ChronoUnit.MINUTES);
+		units.put("h", ChronoUnit.HOURS);
+		units.put("d", ChronoUnit.DAYS);
+		return Collections.unmodifiableMap(units);
+	}
+
+	@Override
+	public void setAsText(String text) throws IllegalArgumentException {
+		setValue(parseDuration(text));
+	}
+
+	/**
+	 * Converts {@code text} into {@link Duration} accepting both simple representation (number and unit) or
+	 * ISO-8601 standard.
+	 */
+	private Duration parseDuration(String text) {
+		Matcher matcher = SIMPLE_REPRESENTATION.matcher(text);
+		if (matcher.matches()) {
+			int sign = "-".equals(matcher.group("sign")) ? -1 : 1;
+			long amount = Long.parseLong(matcher.group("amount"));
+			TemporalUnit unit = units.get(matcher.group("unit"));
+
+			return Duration.of(sign * amount, unit);
+		}
+
+		return Duration.parse(text);
+	}
+
+	@Override
+	public String getAsText() {
+		Duration value = (Duration) getValue();
+		if (value == null) {
+			return null;
+		}
+		return formatDuration(value);
+	}
+
+	private String formatDuration(Duration value) {
+		return value.toString();
+	}
+
+}

--- a/spring-beans/src/test/java/org/springframework/beans/propertyeditors/DurationEditorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/propertyeditors/DurationEditorTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.propertyeditors;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Piotr Findeisen
+ */
+public class DurationEditorTests {
+
+	@Test
+	public void setSimpleFormat() {
+		// Given
+		DurationEditor editor = new DurationEditor();
+		// When
+		editor.setAsText("2 ms");
+		// Then
+		Duration duration = (Duration) editor.getValue();
+		assertEquals("The set Duration is not correct.", Duration.ofMillis(2), duration);
+	}
+
+	@Test
+	public void setSimpleFormatWithoutSpace() {
+		// Given
+		DurationEditor editor = new DurationEditor();
+		// When
+		editor.setAsText("2h");
+		// Then
+		Duration duration = (Duration) editor.getValue();
+		assertEquals("The set Duration is not correct.", Duration.ofHours(2), duration);
+	}
+
+	@Test
+	public void setSimpleFormatNegative() {
+		// Given
+		DurationEditor editor = new DurationEditor();
+		// When
+		editor.setAsText("-1d");
+		// Then
+		Duration duration = (Duration) editor.getValue();
+		assertEquals("The set Duration is not correct.", Duration.ofDays(-1), duration);
+	}
+
+	@Test
+	public void setISO8601Format() {
+		// Given
+		DurationEditor editor = new DurationEditor();
+		// When
+		editor.setAsText("PT19s");
+		// Then
+		Duration duration = (Duration) editor.getValue();
+		assertEquals("The set Duration is not correct.", Duration.ofSeconds(19), duration);
+	}
+
+	@Test
+	public void getValueAsText() {
+		// Given
+		DurationEditor editor = new DurationEditor();
+		// When
+		editor.setValue(Duration.ofSeconds(3));
+		// Then
+		assertEquals("The text version is not correct.", "PT3S", editor.getAsText());
+	}
+
+}


### PR DESCRIPTION
java.time.Duration is useful type for bean properties that represent timeouts
or other time limits. It's easily instantiatable using Java configuration and
XML configuration as well (e.g. with a SpEL). However, a property editor is
necessary to provide Duration value in a Property-based configuration override
file.

For example, this allows a bean with a definition like:

```xml
<bean id="a" class="A">
    <property name="duration" value="#{T(java.time.Duration).ofSeconds(2)}"/>
</bean>
```

to have its property reconfigured with:

```xml
<context:property-override properties-ref="p"/>

<util:properties id="p">
    <prop key="a.dur">12 s</prop>
</util:properties>
```
(where the actual properties might actually be sourced from an external configuration file.)