### PR TITLE
Support URI with https scheme and port for SSL client use with Netty

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/Netty4ClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/Netty4ClientHttpRequestFactory.java
@@ -51,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
  * @author Brian Clozel
+ * @author Mark Paluch
  * @since 4.1.2
  */
 public class Netty4ClientHttpRequestFactory implements ClientHttpRequestFactory,
@@ -174,8 +175,7 @@ public class Netty4ClientHttpRequestFactory implements ClientHttpRequestFactory,
 	}
 
 	private Bootstrap getBootstrap(URI uri) {
-		boolean isSecure = (uri.getPort() == 443 ||
-				(uri.getPort() == -1 && "https".equalsIgnoreCase(uri.getScheme())));
+		boolean isSecure = (uri.getPort() == 443 || "https".equalsIgnoreCase(uri.getScheme()));
 		if (isSecure) {
 			if (this.sslBootstrap == null) {
 				this.sslBootstrap = buildBootstrap(true);


### PR DESCRIPTION
Do not check on non-specified port when scheme is https. Enables SSL for https URIs with a specified port.

Issue: SPR-14889