### PR TITLE
Make the signature of ReactiveHttpOutputMessage#writeAndFlush(…) more flexible

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpResponse.java
@@ -52,7 +52,7 @@ public class MockServerHttpResponse implements ServerHttpResponse {
 
 	private Publisher<DataBuffer> body;
 
-	private Publisher<Publisher<DataBuffer>> bodyWithFlushes;
+	private Publisher<? extends Publisher<DataBuffer>> bodyWithFlushes;
 
 	private DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
 
@@ -81,7 +81,7 @@ public class MockServerHttpResponse implements ServerHttpResponse {
 		return this.body;
 	}
 
-	public Publisher<Publisher<DataBuffer>> getBodyWithFlush() {
+	public Publisher<? extends Publisher<DataBuffer>> getBodyWithFlush() {
 		return this.bodyWithFlushes;
 	}
 
@@ -92,7 +92,7 @@ public class MockServerHttpResponse implements ServerHttpResponse {
 	}
 
 	@Override
-	public Mono<Void> writeAndFlushWith(Publisher<Publisher<DataBuffer>> body) {
+	public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<DataBuffer>> body) {
 		this.bodyWithFlushes = body;
 		return Flux.from(this.bodyWithFlushes).then();
 	}

--- a/spring-web/src/main/java/org/springframework/http/ReactiveHttpOutputMessage.java
+++ b/spring-web/src/main/java/org/springframework/http/ReactiveHttpOutputMessage.java
@@ -64,7 +64,7 @@ public interface ReactiveHttpOutputMessage extends HttpMessage {
 	 * @param body the body content publisher
 	 * @return a {@link Mono} that indicates completion or error
 	 */
-	Mono<Void> writeAndFlushWith(Publisher<Publisher<DataBuffer>> body);
+	Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<DataBuffer>> body);
 
 	/**
 	 * Indicate that message handling is complete, allowing for any cleanup or

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
@@ -80,7 +80,7 @@ public class ReactorClientHttpRequest extends AbstractClientHttpRequest {
 	}
 
 	@Override
-	public Mono<Void> writeAndFlushWith(Publisher<Publisher<DataBuffer>> body) {
+	public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<DataBuffer>> body) {
 		Publisher<Publisher<ByteBuf>> byteBufs = Flux.from(body).
 				map(ReactorClientHttpRequest::toByteBufs);
 		return applyBeforeCommit().then(this.httpRequest

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractListenerServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractListenerServerHttpResponse.java
@@ -48,7 +48,7 @@ public abstract class AbstractListenerServerHttpResponse extends AbstractServerH
 	}
 
 	@Override
-	protected final Mono<Void> writeAndFlushWithInternal(Publisher<Publisher<DataBuffer>> body) {
+	protected final Mono<Void> writeAndFlushWithInternal(Publisher<? extends Publisher<DataBuffer>> body) {
 		if (this.writeCalled.compareAndSet(false, true)) {
 			Processor<Publisher<DataBuffer>, Void> bodyProcessor = createBodyFlushProcessor();
 			return Mono.from(subscriber -> {

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractServerHttpResponse.java
@@ -131,7 +131,7 @@ public abstract class AbstractServerHttpResponse implements ServerHttpResponse {
 	}
 
 	@Override
-	public final Mono<Void> writeAndFlushWith(Publisher<Publisher<DataBuffer>> body) {
+	public final Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<DataBuffer>> body) {
 		return new ChannelSendOperator<>(body,
 				writePublisher -> doCommit(() -> writeAndFlushWithInternal(writePublisher)));
 	}
@@ -193,7 +193,7 @@ public abstract class AbstractServerHttpResponse implements ServerHttpResponse {
 	 * each {@code Publisher<DataBuffer>}.
 	 * @param body the publisher to write and flush with
 	 */
-	protected abstract Mono<Void> writeAndFlushWithInternal(Publisher<Publisher<DataBuffer>> body);
+	protected abstract Mono<Void> writeAndFlushWithInternal(Publisher<? extends Publisher<DataBuffer>> body);
 
 	/**
 	 * Implement this method to write the status code to the underlying response.

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpResponse.java
@@ -76,7 +76,7 @@ public class ReactorServerHttpResponse extends AbstractServerHttpResponse
 	}
 
 	@Override
-	protected Mono<Void> writeAndFlushWithInternal(Publisher<Publisher<DataBuffer>> publisher) {
+	protected Mono<Void> writeAndFlushWithInternal(Publisher<? extends Publisher<DataBuffer>> publisher) {
 		Publisher<Publisher<ByteBuf>> body = Flux.from(publisher)
 				.map(ReactorServerHttpResponse::toByteBufs);
 		return this.response.sendGroups(body);

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/RxNettyServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/RxNettyServerHttpResponse.java
@@ -80,7 +80,7 @@ public class RxNettyServerHttpResponse extends AbstractServerHttpResponse {
 
 	@Override
 	protected Mono<Void> writeAndFlushWithInternal(
-			Publisher<Publisher<DataBuffer>> body) {
+			Publisher<? extends Publisher<DataBuffer>> body) {
 		Flux<ByteBuf> bodyWithFlushSignals = Flux.from(body).
 				flatMap(publisher -> Flux.from(publisher).
 						map(NettyDataBufferFactory::toByteBuf).

--- a/spring-web/src/test/java/org/springframework/http/codec/ServerSentEventHttpMessageWriterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/ServerSentEventHttpMessageWriterTests.java
@@ -72,7 +72,7 @@ public class ServerSentEventHttpMessageWriterTests extends AbstractDataBufferAll
 		messageWriter.write(source, ResolvableType.forClass(ServerSentEvent.class),
 				new MediaType("text", "event-stream"), outputMessage, Collections.emptyMap());
 
-		Publisher<Publisher<DataBuffer>> result = Flux.from(outputMessage.getBodyWithFlush());
+		Publisher<? extends Publisher<DataBuffer>> result = Flux.from(outputMessage.getBodyWithFlush());
 		StepVerifier.create(result)
 				.consumeNextWith(sseConsumer("id:c42\n" + "event:foo\n" + "retry:123\n" +
 						":bla\n:bla bla\n:bla bla bla\n" + "data:bar\n"))
@@ -87,7 +87,7 @@ public class ServerSentEventHttpMessageWriterTests extends AbstractDataBufferAll
 		messageWriter.write(source, ResolvableType.forClass(String.class),
 				new MediaType("text", "event-stream"), outputMessage, Collections.emptyMap());
 
-		Publisher<Publisher<DataBuffer>> result = outputMessage.getBodyWithFlush();
+		Publisher<? extends Publisher<DataBuffer>> result = outputMessage.getBodyWithFlush();
 		StepVerifier.create(result)
 				.consumeNextWith(sseConsumer("data:foo\n"))
 				.consumeNextWith(sseConsumer("data:bar\n"))
@@ -102,7 +102,7 @@ public class ServerSentEventHttpMessageWriterTests extends AbstractDataBufferAll
 		messageWriter.write(source, ResolvableType.forClass(String.class),
 				new MediaType("text", "event-stream"), outputMessage, Collections.emptyMap());
 
-		Publisher<Publisher<DataBuffer>> result = outputMessage.getBodyWithFlush();
+		Publisher<? extends Publisher<DataBuffer>> result = outputMessage.getBodyWithFlush();
 		StepVerifier.create(result)
 				.consumeNextWith(sseConsumer("data:foo\ndata:bar\n"))
 				.consumeNextWith(sseConsumer("data:foo\ndata:baz\n"))
@@ -118,7 +118,7 @@ public class ServerSentEventHttpMessageWriterTests extends AbstractDataBufferAll
 		messageWriter.write(source, ResolvableType.forClass(Pojo.class),
 				new MediaType("text", "event-stream"), outputMessage, Collections.emptyMap());
 
-		Publisher<Publisher<DataBuffer>> result = outputMessage.getBodyWithFlush();
+		Publisher<? extends Publisher<DataBuffer>> result = outputMessage.getBodyWithFlush();
 		StepVerifier.create(result)
 				.consumeNextWith(sseConsumer("data:", "{\"foo\":\"foofoo\",\"bar\":\"barbar\"}", "\n"))
 				.consumeNextWith(sseConsumer("data:", "{\"foo\":\"foofoofoo\",\"bar\":\"barbarbar\"}", "\n"))

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/ServerHttpResponseTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/ServerHttpResponseTests.java
@@ -166,7 +166,7 @@ public class ServerHttpResponseTests {
 
 		@Override
 		protected Mono<Void> writeAndFlushWithInternal(
-				Publisher<Publisher<DataBuffer>> body) {
+				Publisher<? extends Publisher<DataBuffer>> body) {
 			return Mono.error(new UnsupportedOperationException());
 		}
 	}

--- a/spring-web/src/test/java/org/springframework/mock/http/server/reactive/test/MockServerHttpResponse.java
+++ b/spring-web/src/test/java/org/springframework/mock/http/server/reactive/test/MockServerHttpResponse.java
@@ -51,7 +51,7 @@ public class MockServerHttpResponse implements ServerHttpResponse {
 
 	private Publisher<DataBuffer> body;
 
-	private Publisher<Publisher<DataBuffer>> bodyWithFlushes;
+	private Publisher<? extends Publisher<DataBuffer>> bodyWithFlushes;
 
 	private DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
 
@@ -81,7 +81,7 @@ public class MockServerHttpResponse implements ServerHttpResponse {
 		return this.body;
 	}
 
-	public Publisher<Publisher<DataBuffer>> getBodyWithFlush() {
+	public Publisher<? extends Publisher<DataBuffer>> getBodyWithFlush() {
 		return this.bodyWithFlushes;
 	}
 
@@ -92,7 +92,7 @@ public class MockServerHttpResponse implements ServerHttpResponse {
 	}
 
 	@Override
-	public Mono<Void> writeAndFlushWith(Publisher<Publisher<DataBuffer>> body) {
+	public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<DataBuffer>> body) {
 		this.bodyWithFlushes = body;
 		return Flux.from(this.bodyWithFlushes).then();
 	}

--- a/spring-web/src/test/java/org/springframework/web/client/reactive/test/MockClientHttpRequest.java
+++ b/spring-web/src/test/java/org/springframework/web/client/reactive/test/MockClientHttpRequest.java
@@ -43,7 +43,7 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest {
 
 	private Publisher<DataBuffer> body;
 
-	private Publisher<Publisher<DataBuffer>> bodyWithFlushes;
+	private Publisher<? extends Publisher<DataBuffer>> bodyWithFlushes;
 
 
 	public MockClientHttpRequest() {
@@ -96,7 +96,7 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest {
 	}
 
 	@Override
-	public Mono<Void> writeAndFlushWith(Publisher<Publisher<DataBuffer>> body) {
+	public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<DataBuffer>> body) {
 		this.bodyWithFlushes = body;
 		return applyBeforeCommit().then(Flux.from(this.bodyWithFlushes).then());
 	}
@@ -105,7 +105,7 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest {
 		return body;
 	}
 
-	public Publisher<Publisher<DataBuffer>> getBodyWithFlush() {
+	public Publisher<? extends Publisher<DataBuffer>> getBodyWithFlush() {
 		return bodyWithFlushes;
 	}
 


### PR DESCRIPTION
This solves [SPR-14952](https://jira.spring.io/browse/SPR-14952) by applying the suggested solution and cascading the change through the interface hierarchy (and clients).

Original signature of `ReactiveHttpOutputMessage#writeAndFlushWith(…)`:

```java
Mono<Void> writeAndFlushWith(Publisher<Publisher<DataBuffer>> body);
```

Modified signature:

```java
Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<DataBuffer>> body);
```

Which makes this method callable with `Flux<Flux<DataBuffer>>` objects as arguments. Which is what is obtained for example by means of calling `Flux#window(…)`:

```java
final Flux<DataBuffer> dataStream = ...;
// Flux<T>#window(...) returns Flux<Flux<T>>
exchange.getResponse().writeAndFlushWith(dataStream.window(3));
```
