### PR TITLE
Add Vertx support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ configure(allprojects) { project ->
 	ext.xmlunitVersion         = "2.2.1"
 	ext.xnioVersion            = "3.4.1.Final"
 	ext.xstreamVersion         = "1.4.9"
+	ext.vertxVersion		   = "3.3.3"
 
 	ext.gradleScriptDir = "${rootProject.projectDir}/gradle"
 
@@ -745,6 +746,8 @@ project("spring-web") {
 		optional("io.reactivex:rxjava:${rxjavaVersion}")
 		optional "io.reactivex.rxjava2:rxjava:${rxjava2Version}"
 		optional("io.reactivex:rxjava-reactive-streams:${rxjavaAdapterVersion}")
+		provided("io.vertx:vertx-codegen:${vertxVersion}")
+		optional("io.vertx:vertx-core:${vertxVersion}")
 		optional("io.undertow:undertow-core:${undertowVersion}")
 		optional("org.jboss.xnio:xnio-api:${xnioVersion}")
 		optional("io.netty:netty-buffer:${nettyVersion}")  // temporarily for JsonObjectDecoder
@@ -828,6 +831,8 @@ project("spring-web-reactive") {
 		}
 		optional("io.reactivex:rxjava:${rxjavaVersion}")
 		optional("io.reactivex:rxjava-reactive-streams:${rxjavaAdapterVersion}")
+		provided("io.vertx:vertx-codegen:${vertxVersion}")
+		optional("io.vertx:vertx-core:${vertxVersion}")
 		testCompile("io.projectreactor.addons:reactor-test:${reactorCoreVersion}")
 		testCompile("javax.validation:validation-api:${beanvalVersion}")
 		testCompile("org.hibernate:hibernate-validator:${hibval5Version}")

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/VertxHttpHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/VertxHttpHandlerAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server.reactive;
+
+
+import java.util.function.Function;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.http.HttpServerRequest;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.io.buffer.NettyDataBufferFactory;
+
+/**
+ * Adapt {@link HttpHandler} using Vertx.
+ *
+ * @author Yevhenii Melnyk
+ * @since 5.0
+ */
+public class VertxHttpHandlerAdapter extends HttpHandlerAdapterSupport implements Function<HttpServerRequest, Mono<Void>> {
+
+
+	public VertxHttpHandlerAdapter(HttpHandler httpHandler) {
+		super(httpHandler);
+	}
+
+
+	@Override
+	public Mono<Void> apply(HttpServerRequest serverRequest) {
+		NettyDataBufferFactory bufferFactory = new NettyDataBufferFactory(ByteBufAllocator.DEFAULT);
+		VertxServerHttpRequest request = new VertxServerHttpRequest(serverRequest, bufferFactory);
+		VertxServerHttpResponse response = new VertxServerHttpResponse(serverRequest.response(), bufferFactory);
+		return getHttpHandler().handle(request, response)
+				.otherwise(ex -> {
+					logger.error("Could not complete request", ex);
+					serverRequest.response().setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+					serverRequest.response().end();
+					return Mono.empty();
+				})
+				.doOnSuccess(v -> {
+					if (!serverRequest.response().ended()) {
+						serverRequest.response().end();
+					}
+					logger.debug("Successfully completed request");
+				});
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/VertxServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/VertxServerHttpRequest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server.reactive;
+
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.SocketAddress;
+import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Flux;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.NettyDataBufferFactory;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static io.vertx.core.http.HttpHeaders.COOKIE;
+
+/**
+ * Adapt {@link ServerHttpRequest} to the Vertx {@link HttpServerRequest}.
+ *
+ * @author Yevhenii Melnyk
+ * @since 5.0
+ */
+public class VertxServerHttpRequest extends AbstractServerHttpRequest {
+
+
+	private final NettyDataBufferFactory bufferFactory;
+
+	private final HttpServerRequest request;
+
+
+	public VertxServerHttpRequest(HttpServerRequest request, NettyDataBufferFactory bufferFactory) {
+		super(initUri(request), initHeaders(request));
+		Assert.notNull(request, "'HttpServerRequest' must not be null.");
+		this.request = request;
+		this.bufferFactory = bufferFactory;
+	}
+
+	private static URI initUri(HttpServerRequest request) {
+		Assert.notNull(request, "Vertx 'httpServerRequest' must not be null");
+		try {
+			URI uri = new URI(request.uri());
+			SocketAddress remoteAddress = request.remoteAddress();
+			return new URI(
+					uri.getScheme(),
+					uri.getUserInfo(),
+					(remoteAddress != null ? remoteAddress.host() : null),
+					(remoteAddress != null ? remoteAddress.port() : -1),
+					uri.getPath(),
+					uri.getQuery(),
+					uri.getFragment());
+		}
+		catch (URISyntaxException ex) {
+			throw new IllegalStateException("Could not get URI: " + ex.getMessage(), ex);
+		}
+	}
+
+	private static HttpHeaders initHeaders(HttpServerRequest request) {
+		Assert.notNull(request, "Vertx 'httpServerRequest' must not be null");
+		HttpHeaders headers = new HttpHeaders();
+		for (String name : request.headers().names()) {
+			headers.put(name, request.headers().getAll(name));
+		}
+		return headers;
+	}
+
+	@Override
+	protected MultiValueMap<String, HttpCookie> initCookies() {
+		String cookieHeader = request.headers().get(COOKIE);
+		MultiValueMap<String, HttpCookie> cookies = new LinkedMultiValueMap<>();
+		if (cookieHeader != null) {
+			Set<Cookie> nettyCookies = ServerCookieDecoder.STRICT.decode(cookieHeader);
+			for (Cookie cookie : nettyCookies) {
+				HttpCookie httpCookie = new HttpCookie(cookie.name(), cookie.value());
+				cookies.add(cookie.name(), httpCookie);
+			}
+		}
+		return cookies;
+	}
+
+	@Override
+	public HttpMethod getMethod() {
+		return HttpMethod.valueOf(request.method().name());
+	}
+
+	@Override
+	public Flux<DataBuffer> getBody() {
+		EmitterProcessor<Buffer> stream = EmitterProcessor.<Buffer>create().connect();
+		request.handler(stream::onNext);
+		request.endHandler(e -> stream.onComplete());
+		return stream.map(buffer -> bufferFactory.wrap(buffer.getByteBuf()));
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/VertxServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/VertxServerHttpResponse.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server.reactive;
+
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerResponse;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.NettyDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.util.Assert;
+
+import static io.vertx.core.http.HttpHeaders.SET_COOKIE;
+import static java.util.function.Function.identity;
+
+/**
+ * Adapt {@link ServerHttpResponse} to the Vertx {@link HttpServerResponse}.
+ *
+ * @author Yevhenii Melnyk
+ * @since 5.0
+ */
+public class VertxServerHttpResponse extends AbstractServerHttpResponse {
+
+	private final HttpServerResponse response;
+
+	public VertxServerHttpResponse(HttpServerResponse response, DataBufferFactory dataBufferFactory) {
+		super(dataBufferFactory);
+		Assert.notNull(response, "'HttpServerResponse' must not be null.");
+		this.response = response;
+	}
+
+	@Override
+	protected Mono<Void> writeWithInternal(Publisher<? extends DataBuffer> publisher) {
+		return toBuffers(publisher)
+				.doOnNext(response::write)
+				.doOnComplete(response::end)
+				.then();
+	}
+
+	private static Flux<Buffer> toBuffers(Publisher<? extends DataBuffer> dataBuffers) {
+		return Flux.from(dataBuffers).map(b -> Buffer.buffer(NettyDataBufferFactory.toByteBuf(b)));
+	}
+
+	@Override
+	protected Mono<Void> writeAndFlushWithInternal(Publisher<? extends Publisher<? extends DataBuffer>> publisher) {
+		// Vertx response flushes data when the internal buffer is full, so just flatten the stream
+		return writeWithInternal(Flux.from(publisher).flatMap(identity()));
+	}
+
+	@Override
+	protected void applyStatusCode() {
+		HttpStatus statusCode = getStatusCode();
+		if (statusCode != null) {
+			response.setStatusCode(statusCode.value());
+		}
+	}
+
+	@Override
+	protected void applyHeaders() {
+		HttpHeaders headers = getHeaders();
+		if (!headers.containsKey(HttpHeaders.CONTENT_LENGTH)) {
+			response.setChunked(true);
+		}
+		for (String name : headers.keySet()) {
+			for (String value : headers.get(name)) {
+				response.putHeader(name, value);
+			}
+		}
+	}
+
+	@Override
+	protected void applyCookies() {
+		for (String name : getCookies().keySet()) {
+			for (ResponseCookie httpCookie : getCookies().get(name)) {
+				Cookie nettyCookie = new DefaultCookie(name, httpCookie.getValue());
+				if (!httpCookie.getMaxAge().isNegative()) {
+					nettyCookie.setMaxAge(httpCookie.getMaxAge().getSeconds());
+				}
+				httpCookie.getDomain().ifPresent(nettyCookie::setDomain);
+				httpCookie.getPath().ifPresent(nettyCookie::setPath);
+				nettyCookie.setSecure(httpCookie.isSecure());
+				nettyCookie.setHttpOnly(httpCookie.isHttpOnly());
+				response.headers()
+						.add(SET_COOKIE, ServerCookieEncoder.STRICT.encode(nettyCookie));
+			}
+		}
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/AbstractHttpHandlerIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/AbstractHttpHandlerIntegrationTests.java
@@ -29,6 +29,7 @@ import org.springframework.http.server.reactive.bootstrap.ReactorHttpServer;
 import org.springframework.http.server.reactive.bootstrap.RxNettyHttpServer;
 import org.springframework.http.server.reactive.bootstrap.TomcatHttpServer;
 import org.springframework.http.server.reactive.bootstrap.UndertowHttpServer;
+import org.springframework.http.server.reactive.bootstrap.VertxHttpServer;
 import org.springframework.util.SocketUtils;
 
 
@@ -49,7 +50,8 @@ public abstract class AbstractHttpHandlerIntegrationTests {
 				{new RxNettyHttpServer()},
 				{new ReactorHttpServer()},
 				{new TomcatHttpServer(base.getAbsolutePath())},
-				{new UndertowHttpServer()}
+				{new UndertowHttpServer()},
+				{new VertxHttpServer()}
 		};
 	}
 
@@ -61,6 +63,7 @@ public abstract class AbstractHttpHandlerIntegrationTests {
 		this.server.setHandler(createHttpHandler());
 		this.server.afterPropertiesSet();
 		this.server.start();
+		waitForServerCondition(true);
 	}
 
 	protected abstract HttpHandler createHttpHandler();
@@ -68,6 +71,14 @@ public abstract class AbstractHttpHandlerIntegrationTests {
 	@After
 	public void tearDown() throws Exception {
 		this.server.stop();
+		waitForServerCondition(false);
+	}
+
+	// Vertx server deploys asynchronously
+	private void waitForServerCondition(Boolean isRunning) throws InterruptedException {
+		while (!isRunning.equals(server.isRunning())) {
+			Thread.sleep(50);
+		}
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/bootstrap/VertxHttpServer.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/bootstrap/VertxHttpServer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server.reactive.bootstrap;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Vertx;
+
+import org.springframework.http.server.reactive.VertxHttpHandlerAdapter;
+
+/**
+ * @author Yevhenii Melnyk
+ */
+public class VertxHttpServer extends HttpServerSupport implements HttpServer {
+
+
+	private Vertx vertx;
+
+	private VertxHttpHandlerAdapter handler;
+
+	private AtomicBoolean running = new AtomicBoolean();
+
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		vertx = Vertx.vertx();
+		handler = new VertxHttpHandlerAdapter(getHttpHandler());
+	}
+
+	@Override
+	public void start() {
+		if (!running.get()) {
+			vertx.deployVerticle(new ReactiveVerticle(), res -> {
+				if (res.succeeded()) {
+					running.set(true);
+				}
+			});
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (running.get()) {
+			vertx.close(res -> {
+				if (res.succeeded()) {
+					running.set(false);
+				}
+			});
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return running.get();
+	}
+
+
+	private class ReactiveVerticle extends AbstractVerticle {
+		@Override
+		public void start() throws Exception {
+			vertx.createHttpServer().
+					requestHandler(request -> handler.apply(request).subscribe())
+					.listen(getPort(), getHost());
+		}
+	}
+
+}


### PR DESCRIPTION
This commit adds Vert.x integration that includes Vert.x-based implementations of ServerHttpRequest and ServerHttpResponse as well as an adapter from the Vert.x HttpServerRequest to the HttpHandler contracts.

I'm interested in feedback if implementation of spring reactive using Vert.x is reasonable task. 