### PR TITLE
Ignore HTML references > MAX_REFERENCE_SIZE in HtmlCharacterEntityDecoder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityDecoder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityDecoder.java
@@ -71,7 +71,7 @@ class HtmlCharacterEntityDecoder {
 			boolean isPotentialReference =
 					nextPotentialReferencePosition != -1
 					&& nextSemicolonPosition != -1
-					&& nextPotentialReferencePosition - nextSemicolonPosition < MAX_REFERENCE_SIZE;
+					&& nextSemicolonPosition - nextPotentialReferencePosition < MAX_REFERENCE_SIZE;
 
 			if (isPotentialReference) {
 				break;


### PR DESCRIPTION
Hello, I think that there's something incorrect when I read the code.
Although this is not a severe problem, the code just worked all fine.
But I just want to get it right, and improve a little on performance :D