### PR TITLE
Add "data:" prefix for multi-line SSE data field with Jackson

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageWriter.java
@@ -19,6 +19,7 @@ package org.springframework.http.codec;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,6 +48,16 @@ import org.springframework.util.MimeTypeUtils;
  * @since 5.0
  */
 public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Object> {
+
+	/**
+	 * Server-Sent Events hint expecting a {@link Boolean} value which when set to true
+	 * will adapt the content in order to comply with Server-Sent Events recommendation.
+	 * For example, it will append "data:" after each line break with data encoders
+	 * supporting it.
+	 * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events W3C recommendation</a>
+	 */
+	public static final String SSE_CONTENT_HINT = ServerSentEventHttpMessageWriter.class.getName() + ".sseContent";
+
 
 	private final List<Encoder<?>> dataEncoders;
 
@@ -87,6 +98,8 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 	private Flux<Publisher<DataBuffer>> encode(Publisher<?> inputStream, DataBufferFactory bufferFactory,
 			ResolvableType type, Map<String, Object> hints) {
 
+		Map<String, Object> hintsWithSse = new HashMap<>(hints);
+		hintsWithSse.put(SSE_CONTENT_HINT, true);
 		return Flux.from(inputStream)
 				.map(o -> toSseEvent(o, type))
 				.map(sse -> {
@@ -107,7 +120,7 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 									return Flux.empty();
 								}
 								else {
-									return applyEncoder(data, bufferFactory, hints);
+									return applyEncoder(data, bufferFactory, hintsWithSse);
 								}
 							}).orElse(Flux.empty());
 

--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -27,11 +27,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -69,22 +72,29 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 
 	private Boolean prettyPrint;
 
+	private PrettyPrinter ssePrettyPrinter;
+
 
 	protected AbstractJackson2HttpMessageConverter(ObjectMapper objectMapper) {
-		this.objectMapper = objectMapper;
-		setDefaultCharset(DEFAULT_CHARSET);
+		init(objectMapper);
 	}
 
 	protected AbstractJackson2HttpMessageConverter(ObjectMapper objectMapper, MediaType supportedMediaType) {
 		super(supportedMediaType);
-		this.objectMapper = objectMapper;
-		setDefaultCharset(DEFAULT_CHARSET);
+		init(objectMapper);
 	}
 
 	protected AbstractJackson2HttpMessageConverter(ObjectMapper objectMapper, MediaType... supportedMediaTypes) {
 		super(supportedMediaTypes);
+		init(objectMapper);
+	}
+
+	protected void init(ObjectMapper objectMapper) {
 		this.objectMapper = objectMapper;
 		setDefaultCharset(DEFAULT_CHARSET);
+		DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+		prettyPrinter.indentObjectsWith(new DefaultIndenter("  ", "\ndata:"));
+		this.ssePrettyPrinter = prettyPrinter;
 	}
 
 
@@ -234,7 +244,8 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 	protected void writeInternal(Object object, Type type, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException {
 
-		JsonEncoding encoding = getJsonEncoding(outputMessage.getHeaders().getContentType());
+		MediaType contentType = outputMessage.getHeaders().getContentType();
+		JsonEncoding encoding = getJsonEncoding(contentType);
 		JsonGenerator generator = this.objectMapper.getFactory().createGenerator(outputMessage.getBody(), encoding);
 		try {
 			writePrefix(generator, object);
@@ -264,6 +275,11 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 			}
 			if (javaType != null && javaType.isContainerType()) {
 				objectWriter = objectWriter.forType(javaType);
+			}
+			SerializationConfig config = objectWriter.getConfig();
+			if (contentType != null && contentType.isCompatibleWith(MediaType.TEXT_EVENT_STREAM) &&
+					config.isEnabled(SerializationFeature.INDENT_OUTPUT)) {
+				objectWriter = objectWriter.with(this.ssePrettyPrinter);
 			}
 			objectWriter.writeValue(generator, value);
 

--- a/spring-web/src/test/java/org/springframework/http/converter/json/MappingJackson2HttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/MappingJackson2HttpMessageConverterTests.java
@@ -224,6 +224,20 @@ public class MappingJackson2HttpMessageConverterTests {
 	}
 
 	@Test
+	public void prettyPrintWithSse() throws Exception {
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+		outputMessage.getHeaders().setContentType(MediaType.TEXT_EVENT_STREAM);
+		PrettyPrintBean bean = new PrettyPrintBean();
+		bean.setName("Jason");
+
+		this.converter.setPrettyPrint(true);
+		this.converter.writeInternal(bean, null, outputMessage);
+		String result = outputMessage.getBodyAsString(StandardCharsets.UTF_8);
+
+		assertEquals("{\ndata:  \"name\" : \"Jason\"\ndata:}", result);
+	}
+
+	@Test
 	public void prefixJson() throws Exception {
 		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
 		this.converter.setPrefixJson(true);


### PR DESCRIPTION
@rstoyanchev Based on the Jackson `PrettyPrinter` based trick with discussed + Jackson capabilities to specify such `PrettyPrinter` at `ObjectWriter` level, I think I ended up with a pretty good solution in the sense it is not intrusive and it does not lead to performance penalty. Could you say me if that's fine for you?

Also could you confirm that we should apply that to `4.3.x` branch as well?

Issue: SPR-14899