### PR TITLE
ChannelFutureMono renamed to FutureMono

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/tcp/reactor/ReactorNettyTcpClient.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/tcp/reactor/ReactorNettyTcpClient.java
@@ -31,7 +31,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoProcessor;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.ipc.netty.ChannelFutureMono;
+import reactor.ipc.netty.FutureMono;
 import reactor.ipc.netty.NettyContext;
 import reactor.ipc.netty.NettyInbound;
 import reactor.ipc.netty.NettyOutbound;
@@ -164,7 +164,7 @@ public class ReactorNettyTcpClient<P> implements TcpOperations<P> {
 
 		this.stopping = true;
 
-		Mono<Void> completion = ChannelFutureMono.from(this.group.close())
+		Mono<Void> completion = FutureMono.from(this.group.close())
 				.doAfterTerminate((x, e) -> this.scheduler.shutdown());
 
 		return new MonoToListenableFutureAdapter<>(completion);


### PR DESCRIPTION
In the latest reactor-netty there is renaming
of ChannelFutureMono class to FutureMono. Thus
build fails on the latest master.

Reference to the [changes](https://github.com/reactor/reactor-netty/commit/734996eadbf87f62593f1e4c1488c8e329d1abbc) in the reactor-netty repo.