### PR TITLE
SPR-12031 Support @ContextConfiguration at method level

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
@@ -731,7 +731,7 @@ public abstract class AnnotationUtils {
 	 * @see Class#isAnnotationPresent(Class)
 	 * @see Class#getDeclaredAnnotations()
 	 * @see #findAnnotationDeclaringClassForTypes(List, Class)
-	 * @see #isAnnotationDeclaredLocally(Class, Class)
+	 * @see #isAnnotationDeclaredLocally(Class, AnnotatedElement)
 	 */
 	public static Class<?> findAnnotationDeclaringClass(Class<? extends Annotation> annotationType, Class<?> clazz) {
 		Assert.notNull(annotationType, "Annotation type must not be null");
@@ -766,7 +766,7 @@ public abstract class AnnotationUtils {
 	 * @see Class#isAnnotationPresent(Class)
 	 * @see Class#getDeclaredAnnotations()
 	 * @see #findAnnotationDeclaringClass(Class, Class)
-	 * @see #isAnnotationDeclaredLocally(Class, Class)
+	 * @see #isAnnotationDeclaredLocally(Class, AnnotatedElement)
 	 */
 	public static Class<?> findAnnotationDeclaringClassForTypes(List<Class<? extends Annotation>> annotationTypes, Class<?> clazz) {
 		Assert.notEmpty(annotationTypes, "List of annotation types must not be empty");
@@ -784,33 +784,34 @@ public abstract class AnnotationUtils {
 	/**
 	 * Determine whether an annotation of the specified {@code annotationType}
 	 * is declared locally (i.e., <em>directly present</em>) on the supplied
-	 * {@code clazz}.
-	 * <p>The supplied {@link Class} may represent any type.
+	 * {@code annotatedElement}.
+	 * <p>The supplied {@link AnnotatedElement} may represents any annotated element.
 	 * <p>Meta-annotations will <em>not</em> be searched.
 	 * <p>Note: This method does <strong>not</strong> determine if the annotation
 	 * is {@linkplain java.lang.annotation.Inherited inherited}. For greater
 	 * clarity regarding inherited annotations, consider using
 	 * {@link #isAnnotationInherited(Class, Class)} instead.
 	 * @param annotationType the annotation type to look for
-	 * @param clazz the class to check for the annotation on
+	 * @param annotatedElement the element to check for the annotation on
 	 * @return {@code true} if an annotation of the specified {@code annotationType}
 	 * is <em>directly present</em>
 	 * @see java.lang.Class#getDeclaredAnnotations()
 	 * @see java.lang.Class#getDeclaredAnnotation(Class)
 	 * @see #isAnnotationInherited(Class, Class)
 	 */
-	public static boolean isAnnotationDeclaredLocally(Class<? extends Annotation> annotationType, Class<?> clazz) {
+	public static boolean isAnnotationDeclaredLocally(Class<? extends Annotation> annotationType,
+			AnnotatedElement annotatedElement) {
 		Assert.notNull(annotationType, "Annotation type must not be null");
-		Assert.notNull(clazz, "Class must not be null");
+		Assert.notNull(annotatedElement, "Annotated element must not be null");
 		try {
-			for (Annotation ann : clazz.getDeclaredAnnotations()) {
+			for (Annotation ann : annotatedElement.getDeclaredAnnotations()) {
 				if (ann.annotationType() == annotationType) {
 					return true;
 				}
 			}
 		}
 		catch (Throwable ex) {
-			handleIntrospectionFailure(clazz, ex);
+			handleIntrospectionFailure(annotatedElement, ex);
 		}
 		return false;
 	}
@@ -832,7 +833,7 @@ public abstract class AnnotationUtils {
 	 * @return {@code true} if an annotation of the specified {@code annotationType}
 	 * is <em>present</em> and <em>inherited</em>
 	 * @see Class#isAnnotationPresent(Class)
-	 * @see #isAnnotationDeclaredLocally(Class, Class)
+	 * @see #isAnnotationDeclaredLocally(Class, AnnotatedElement)
 	 */
 	public static boolean isAnnotationInherited(Class<? extends Annotation> annotationType, Class<?> clazz) {
 		Assert.notNull(annotationType, "Annotation type must not be null");

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
@@ -407,6 +407,14 @@ public class AnnotationUtilsTests {
 		assertFalse(isAnnotationDeclaredLocally(Order.class, SubNonInheritedAnnotationInterface.class));
 		assertTrue(isAnnotationDeclaredLocally(Order.class, NonInheritedAnnotationClass.class));
 		assertFalse(isAnnotationDeclaredLocally(Order.class, SubNonInheritedAnnotationClass.class));
+
+		// inherited method-level annotation; note: @Transactional is inherited
+		assertTrue(isAnnotationDeclaredLocally(Transactional.class, InheritedAnnotationClass.class.getMethod("something")));
+		assertFalse(isAnnotationDeclaredLocally(Transactional.class, SubInheritedAnnotationClass.class.getMethod("something")));
+
+		// non-inherited method-level annotation; note: @Order is not inherited
+		assertTrue(isAnnotationDeclaredLocally(Order.class, NonInheritedAnnotationInterface.class.getMethod("something")));
+		assertFalse(isAnnotationDeclaredLocally(Order.class, SubNonInheritedAnnotationInterface.class.getMethod("something")));
 	}
 
 	@Test
@@ -1719,9 +1727,13 @@ public class AnnotationUtilsTests {
 
 	@Order
 	public interface NonInheritedAnnotationInterface {
+        @Order
+        void something();
 	}
 
 	public interface SubNonInheritedAnnotationInterface extends NonInheritedAnnotationInterface {
+        @Override
+        void something();
 	}
 
 	public interface SubSubNonInheritedAnnotationInterface extends SubNonInheritedAnnotationInterface {
@@ -1735,9 +1747,17 @@ public class AnnotationUtilsTests {
 
 	@Transactional
 	public static class InheritedAnnotationClass {
+		@Transactional
+		public void something() {
+			// for test purposes
+		}
 	}
 
 	public static class SubInheritedAnnotationClass extends InheritedAnnotationClass {
+		@Override
+		public void something() {
+			// for test purposes
+		}
 	}
 
 	@Order

--- a/spring-test/src/main/java/org/springframework/test/context/ContextConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextConfiguration.java
@@ -83,7 +83,7 @@ import org.springframework.core.annotation.AliasFor;
  * @see MergedContextConfiguration
  * @see org.springframework.context.ApplicationContext
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited

--- a/spring-test/src/main/java/org/springframework/test/context/ContextConfigurationAttributes.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextConfigurationAttributes.java
@@ -16,6 +16,7 @@
 
 package org.springframework.test.context;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.apache.commons.logging.Log;
@@ -50,6 +51,8 @@ public class ContextConfigurationAttributes {
 	private static final Log logger = LogFactory.getLog(ContextConfigurationAttributes.class);
 
 	private final Class<?> declaringClass;
+
+	private final Method declaringMethod;
 
 	private Class<?>[] classes;
 
@@ -149,6 +152,14 @@ public class ContextConfigurationAttributes {
 			Class<?> declaringClass, String[] locations, Class<?>[] classes, boolean inheritLocations,
 			Class<? extends ApplicationContextInitializer<? extends ConfigurableApplicationContext>>[] initializers,
 			boolean inheritInitializers, String name, Class<? extends ContextLoader> contextLoaderClass) {
+		this(declaringClass, null, locations, classes, inheritLocations, initializers, inheritInitializers,
+				name, contextLoaderClass);
+	}
+
+	public ContextConfigurationAttributes(
+			Class<?> declaringClass, Method declaringMethod, String[] locations, Class<?>[] classes, boolean inheritLocations,
+			Class<? extends ApplicationContextInitializer<? extends ConfigurableApplicationContext>>[] initializers,
+			boolean inheritInitializers, String name, Class<? extends ContextLoader> contextLoaderClass) {
 
 		Assert.notNull(declaringClass, "declaringClass must not be null");
 		Assert.notNull(contextLoaderClass, "contextLoaderClass must not be null");
@@ -156,13 +167,14 @@ public class ContextConfigurationAttributes {
 		if (!ObjectUtils.isEmpty(locations) && !ObjectUtils.isEmpty(classes) && logger.isDebugEnabled()) {
 			logger.debug(String.format(
 					"Test class [%s] has been configured with @ContextConfiguration's 'locations' (or 'value') %s " +
-					"and 'classes' %s attributes. Most SmartContextLoader implementations support " +
-					"only one declaration of resources per @ContextConfiguration annotation.",
+							"and 'classes' %s attributes. Most SmartContextLoader implementations support " +
+							"only one declaration of resources per @ContextConfiguration annotation.",
 					declaringClass.getName(), ObjectUtils.nullSafeToString(locations),
 					ObjectUtils.nullSafeToString(classes)));
 		}
 
 		this.declaringClass = declaringClass;
+		this.declaringMethod = declaringMethod;
 		this.locations = locations;
 		this.classes = classes;
 		this.inheritLocations = inheritLocations;
@@ -181,6 +193,16 @@ public class ContextConfigurationAttributes {
 	 */
 	public Class<?> getDeclaringClass() {
 		return this.declaringClass;
+	}
+
+	/**
+	 * Get the {@linkplain Method method} that declared the
+	 * {@link ContextConfiguration @ContextConfiguration} annotation, either explicitly
+	 * or implicitly.
+	 * @return the declaring method (may be {@code null})
+	 */
+	public Method getDeclaringMethod() {
+		return this.declaringMethod;
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/ContextHierarchy.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextHierarchy.java
@@ -139,7 +139,7 @@ import java.lang.annotation.Target;
  * @see ContextConfiguration
  * @see org.springframework.context.ApplicationContext
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited

--- a/spring-test/src/main/java/org/springframework/test/context/support/DefaultTestMethodContextBootstrapper.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DefaultTestMethodContextBootstrapper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.test.context.CacheAwareContextLoaderDelegate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.ContextLoader;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestContextBootstrapper;
+import org.springframework.test.util.MetaAnnotationUtils;
+
+import java.lang.reflect.Method;
+
+import static java.lang.String.format;
+import static org.springframework.test.context.support.ContextLoaderUtils.buildContextHierarchyMap;
+import static org.springframework.test.context.support.ContextLoaderUtils.resolveContextConfigurationAttributes;
+
+/**
+ * Default implementation of the {@link TestContextBootstrapper} SPI for supplied test method.
+ * <p>Uses {@link DelegatingSmartContextLoader} as the default {@link ContextLoader}.
+ *
+ * @author Sergei Ustimenko
+ * @since 5.0
+ */
+public class DefaultTestMethodContextBootstrapper extends DefaultTestContextBootstrapper {
+	private final Log logger = LogFactory.getLog(getClass());
+
+	private final Method testMethod;
+
+	public DefaultTestMethodContextBootstrapper(Method testMethod) {
+		this.testMethod = testMethod;
+	}
+
+	/**
+	 * Build a new {@link DefaultTestContext} using the {@linkplain Method test method}.
+	 * {@link #getCacheAwareContextLoaderDelegate()}.
+	 */
+	@Override
+	public TestContext buildTestContext() {
+		return new DefaultTestContext(getBootstrapContext().getTestClass(),
+				buildMergedContextConfiguration(testMethod),
+				getCacheAwareContextLoaderDelegate());
+	}
+
+	/**
+	 * Build the {@linkplain MergedContextConfiguration merged context configuration}
+	 * for the supplied test testMethod.
+	 *
+	 * @param testMethod supplied testMethod for which to create merged context configuration
+	 *
+	 * @return the merged context configuration, never {@code null}
+	 *
+	 * @see #buildMergedContextConfiguration()
+	 * @see #buildTestContext()
+	 */
+	protected MergedContextConfiguration buildMergedContextConfiguration(Method testMethod) {
+		CacheAwareContextLoaderDelegate cacheAwareContextLoaderDelegate = getCacheAwareContextLoaderDelegate();
+
+		if (MetaAnnotationUtils.findAnnotationDescriptorForTypes(
+				testMethod, ContextConfiguration.class, ContextHierarchy.class) == null) {
+			String msg = format("Neither @ContextConfiguration nor @ContextHierarchy found for test method [%s]",
+					testMethod.getName());
+			logger.error(msg);
+			throw new IllegalStateException(msg);
+		}
+
+		if (AnnotationUtils.findAnnotation(testMethod, ContextHierarchy.class) != null) {
+			return buildMergedConfigFromHierarchyMap(() -> buildContextHierarchyMap(testMethod));
+		} else {
+			return buildMergedContextConfiguration(testMethod.getDeclaringClass(),
+					resolveContextConfigurationAttributes(testMethod), null, cacheAwareContextLoaderDelegate, true);
+		}
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/method/ContextConfigurationAppliedOnSuperMethodTest.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/method/ContextConfigurationAppliedOnSuperMethodTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration.method;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link ContextConfiguration} annotation presented on inherited methods.
+ * @author Sergei Ustimenko
+ * @since 5.0
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = ContextConfigurationOnMethodTest.TypeContext.class)
+public class ContextConfigurationAppliedOnSuperMethodTest
+		extends ContextConfigurationOnMethodTest.ContextConfigurationOnMethodParent
+		implements ContextConfigurationOnMethodTest.ContextConfigurationInterface,
+		ContextConfigurationOnMethodTest.ContextConfigurationMetaInterface {
+
+	@Autowired
+	protected String bean;
+
+	@Test
+	@Override
+	public void shouldPickUpParentBean() {
+		assertEquals("parent", bean);
+	}
+
+	@Test
+	@Override
+	public void shouldPickUpParentParentBean() {
+		assertEquals("parentParent", bean);
+	}
+
+	@Test
+	@Override
+	public void shouldPickUpMetaParent() {
+		assertEquals("metaOnParent", bean);
+	}
+
+	@Test
+	@Override
+	public void shouldPickUpMetaParentParent() {
+		assertEquals("metaOnParentParent", bean);
+	}
+
+	@Test
+	@Override
+	public void shouldPickUpConfigurationFromParentInterface() {
+		assertEquals("parentInterface", bean);
+	}
+
+	@Test
+	@Override
+	public void shouldPickUpMetaFromParentInterface() {
+		assertEquals("metaOnParentInterface", bean);
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/method/ContextConfigurationOnMethodTest.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/method/ContextConfigurationOnMethodTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration.method;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link ContextConfiguration} annotation presented on the method.
+ * @author Sergei Ustimenko
+ * @since 5.0
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = ContextConfigurationOnMethodTest.TypeContext.class)
+public class ContextConfigurationOnMethodTest {
+
+	@Autowired
+	protected String bean;
+
+	@Test
+	@ContextConfiguration(classes = MethodContext.class)
+	public void methodLevelAnnotationShouldOverrideTypeAnnotation() {
+		assertEquals("method", bean);
+	}
+
+	@Test
+	public void typeLevelAnnotationShouldInjectRightValue() {
+		assertEquals("type", bean);
+	}
+
+	// ---------------------------------------------------------------
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@ContextConfiguration(classes = MetaParentConfig.class)
+	public @interface MetaOnParent {}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@ContextConfiguration(classes = MetaParentParentConfig.class)
+	public @interface MetaOnParentParent {}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@ContextConfiguration(classes = MetaParentInterfaceConfig.class)
+	public @interface MetaOnParentInterface {}
+
+	public interface ParentContextConfigurationInterface {
+		@ContextConfiguration(classes = ContextConfigurationOnMethodTest.ParentInterfaceConfig.class)
+		void shouldPickUpConfigurationFromParentInterface();
+	}
+
+	public interface ContextConfigurationInterface extends ParentContextConfigurationInterface {}
+
+	public interface ParentContextConfigurationMetaInterface {
+		@ContextConfigurationOnMethodTest.MetaOnParentInterface
+		void shouldPickUpMetaFromParentInterface();
+	}
+
+	public interface ContextConfigurationMetaInterface extends ParentContextConfigurationMetaInterface {}
+
+	public static class TypeContext {
+		@Bean
+		public String testBean() {
+			return "type";
+		}
+	}
+
+	public static class MethodContext {
+		@Bean
+		public String testBean() {
+			return "method";
+		}
+	}
+
+	public static class ParentConfig {
+		@Bean
+		public String testBean() {
+			return "parent";
+		}
+	}
+
+	public static class ParentParentConfig {
+		@Bean
+		public String testBean() {
+			return "parentParent";
+		}
+	}
+
+	public static class MetaParentConfig {
+		@Bean
+		public String testBean() {
+			return "metaOnParent";
+		}
+	}
+
+	public static class MetaParentParentConfig {
+		@Bean
+		public String testBean() {
+			return "metaOnParentParent";
+		}
+	}
+
+	public static class ParentInterfaceConfig {
+		@Bean
+		public String testBean() {
+			return "parentInterface";
+		}
+	}
+
+	public static class MetaParentInterfaceConfig {
+		@Bean
+		public String testBean() {
+			return "metaOnParentInterface";
+		}
+	}
+
+	public static class ContextConfigurationOnMethodParentParent {
+		@ContextConfiguration(classes = ContextConfigurationOnMethodTest.ParentConfig.class)
+		public void shouldPickUpParentBean() {
+			// for test purposes
+		}
+
+		@ContextConfigurationOnMethodTest.MetaOnParent
+		public void shouldPickUpMetaParent() {
+			// for test purposes
+		}
+	}
+
+	public static class ContextConfigurationOnMethodParent extends ContextConfigurationOnMethodParentParent {
+		@ContextConfiguration(classes = ContextConfigurationOnMethodTest.ParentParentConfig.class)
+		public void shouldPickUpParentParentBean() {
+			// for test purposes
+		}
+
+		@ContextConfigurationOnMethodTest.MetaOnParentParent
+		public void shouldPickUpMetaParentParent() {
+			// for test purposes
+		}
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/method/ContextHierarchyAppliedOnSuperMethodTest.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/method/ContextHierarchyAppliedOnSuperMethodTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration.method;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link ContextHierarchy} presented on inherited methods
+ * @author Sergei Ustimenko
+ * @since 5.0
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = ContextHierarchyOnMethodTest.MainContext.class)
+public class ContextHierarchyAppliedOnSuperMethodTest
+		extends ContextHierarchyOnMethodTest.ContextHierarchyOnMethodParent
+		implements ContextHierarchyOnMethodTest.ContextHierarchyInterface,
+		ContextHierarchyOnMethodTest.ContextHierarchyMetaInterface {
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Autowired
+	private String testBean;
+
+	@Test
+	@Override
+	public void shouldLoadContextsInReverseOrderFromParentParent() {
+		assertNotNull("child ApplicationContext", applicationContext);
+		assertNotNull("parent ApplicationContext", applicationContext.getParent());
+		assertNull("grandparent ApplicationContext", applicationContext.getParent().getParent());
+		assertEquals("overridenParent", testBean);
+	}
+
+
+	@Test
+	@Override
+	public void shouldLoadContextsForMetaOnParentParent() {
+		assertNotNull("child ApplicationContext", applicationContext);
+		assertNotNull("parent ApplicationContext", applicationContext.getParent());
+		assertNull("grandparent ApplicationContext", applicationContext.getParent().getParent());
+		assertEquals("overridenMetaOnParent", testBean);
+	}
+
+	@Test
+	@Override
+	public void shouldPickUpHierarchyFromParentInterface() {
+		assertEquals("parentInterface", testBean);
+	}
+
+	@Test
+	@Override
+	public void shouldPickUpMetaHierarchyFromParentInterface() {
+		assertEquals("metaOnParentInterface", testBean);
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/method/ContextHierarchyOnMethodTest.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/method/ContextHierarchyOnMethodTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.configuration.method;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link ContextHierarchy} presented on the method-level
+ * @author Sergei Ustimenko
+ * @since 5.0
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = ContextHierarchyOnMethodTest.MainContext.class)
+public class ContextHierarchyOnMethodTest {
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Autowired
+	private String testBean;
+
+	@Test
+	@ContextHierarchy({
+			@ContextConfiguration(classes = FirstContext.class), @ContextConfiguration(classes = SecondContext.class)})
+	public void shouldLoadContextsInStraightOrder() {
+		assertEquals("second", testBean);
+	}
+
+	@Test
+	@ContextHierarchy({
+			@ContextConfiguration(classes = SecondContext.class), @ContextConfiguration(classes = FirstContext.class)})
+	public void shouldLoadContextsInReverseOrder() {
+		assertEquals("first", testBean);
+	}
+
+
+	@Test
+	@ContextHierarchy({
+			@ContextConfiguration(classes = FirstContext.class), @ContextConfiguration(classes = SecondContext.class)})
+	public void shouldCreateProperHierarchy() {
+		assertNotNull("child ApplicationContext", applicationContext);
+		assertNotNull("parent ApplicationContext", applicationContext.getParent());
+		assertNull("grandparent ApplicationContext", applicationContext.getParent().getParent());
+	}
+
+	// --------------------------------------------------------------------------
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@ContextHierarchy({@ContextConfiguration(classes = MetaOnParentContext.class)})
+	public @interface MetaOnParent {}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@ContextHierarchy({@ContextConfiguration(classes = MetaOnParentParentContext.class)})
+	public @interface MetaOnParentParent {}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@ContextHierarchy({@ContextConfiguration(classes = MetaOnParentInterfaceContext.class)})
+	public @interface MetaOnParentInterface {}
+
+	public interface ParentContextHierarchyInterface {
+		@ContextHierarchy(@ContextConfiguration(classes = ContextHierarchyOnMethodTest.ParentInterfaceContext.class))
+		void shouldPickUpHierarchyFromParentInterface();
+	}
+
+	public interface ContextHierarchyInterface extends ParentContextHierarchyInterface {}
+
+	public interface ParentContextHierarchyMetaInterface {
+		@ContextHierarchyOnMethodTest.MetaOnParentInterface
+		void shouldPickUpMetaHierarchyFromParentInterface();
+	}
+
+	public interface ContextHierarchyMetaInterface extends ParentContextHierarchyMetaInterface {}
+
+	public static class FirstContext {
+		@Bean
+		public String testBean() {
+			return "first";
+		}
+	}
+
+	public static class SecondContext {
+		@Bean
+		public String testBean() {
+			return "second";
+		}
+	}
+
+	public static class ParentLastContext {
+		@Bean
+		public String testBean() {
+			return "overridenParent";
+		}
+	}
+
+	public static class ParentParentLastContext {
+		@Bean
+		public String testBean() {
+			return "parentParent";
+		}
+	}
+
+	public static class ParentInterfaceContext {
+		@Bean
+		public String testBean() {
+			return "parentInterface";
+		}
+	}
+
+	public static class MainContext {
+		@Bean
+		public String testBean() {
+			return "main";
+		}
+	}
+
+	public static class MetaOnParentContext {
+		@Bean
+		public String testBean() {
+			return "overridenMetaOnParent";
+		}
+	}
+
+	public static class MetaOnParentParentContext {
+		@Bean
+		public String testBean() {
+			return "metaOnParentParent";
+		}
+	}
+
+	public static class MetaOnParentInterfaceContext {
+		@Bean
+		public String testBean() {
+			return "metaOnParentInterface";
+		}
+	}
+
+	public static class ContextHierarchyOnMethodParent extends ContextHierarchyOnMethodParentParent {
+		@Override
+		@ContextHierarchy({@ContextConfiguration(classes = ContextHierarchyOnMethodTest.ParentLastContext.class)})
+		public void shouldLoadContextsInReverseOrderFromParentParent() {
+			// for tes purposes
+		}
+
+		@Override
+		@ContextHierarchyOnMethodTest.MetaOnParent
+		public void shouldLoadContextsForMetaOnParentParent() {
+			// for tes purposes
+		}
+	}
+
+	public static class ContextHierarchyOnMethodParentParent {
+		@ContextHierarchy({@ContextConfiguration(classes = ContextHierarchyOnMethodTest.ParentParentLastContext.class)})
+		public void shouldLoadContextsInReverseOrderFromParentParent() {
+			// for tes purposes
+		}
+
+		@ContextHierarchyOnMethodTest.MetaOnParentParent
+		public void shouldLoadContextsForMetaOnParentParent() {
+			// for tes purposes
+		}
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/support/AbstractContextConfigurationUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/AbstractContextConfigurationUtilsTests.java
@@ -20,6 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Set;
 
@@ -39,7 +40,10 @@ import org.springframework.test.context.MergedContextConfiguration;
 import org.springframework.test.context.TestContextBootstrapper;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Abstract base class for tests involving {@link ContextLoaderUtils},
@@ -70,6 +74,18 @@ abstract class AbstractContextConfigurationUtilsTests {
 			Class<? extends ContextLoader> expectedContextLoaderClass, boolean expectedInheritLocations) {
 
 		assertEquals("declaring class", expectedDeclaringClass, attributes.getDeclaringClass());
+		assertArrayEquals("locations", expectedLocations, attributes.getLocations());
+		assertArrayEquals("classes", expectedClasses, attributes.getClasses());
+		assertEquals("inherit locations", expectedInheritLocations, attributes.isInheritLocations());
+		assertEquals("context loader", expectedContextLoaderClass, attributes.getContextLoaderClass());
+	}
+
+	void assertAttributes(ContextConfigurationAttributes attributes, Class<?> expectedDeclaringClass,
+			Method expectedDeclaringMethod, String[] expectedLocations, Class<?>[] expectedClasses,
+			Class<? extends ContextLoader> expectedContextLoaderClass, boolean expectedInheritLocations) {
+
+		assertEquals("declaring class", expectedDeclaringClass, attributes.getDeclaringClass());
+		assertEquals("declaring method", expectedDeclaringMethod, attributes.getDeclaringMethod());
 		assertArrayEquals("locations", expectedLocations, attributes.getLocations());
 		assertArrayEquals("classes", expectedClasses, attributes.getClasses());
 		assertEquals("inherit locations", expectedInheritLocations, attributes.isInheritLocations());
@@ -129,14 +145,14 @@ abstract class AbstractContextConfigurationUtilsTests {
 	@ContextConfiguration("/foo.xml")
 	@ActiveProfiles(profiles = "foo")
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	public static @interface MetaLocationsFooConfig {
 	}
 
 	@ContextConfiguration
 	@ActiveProfiles
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	public static @interface MetaLocationsFooConfigWithOverrides {
 
 		String[] locations() default "/foo.xml";
@@ -147,7 +163,7 @@ abstract class AbstractContextConfigurationUtilsTests {
 	@ContextConfiguration("/bar.xml")
 	@ActiveProfiles(profiles = "bar")
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	public static @interface MetaLocationsBarConfig {
 	}
 
@@ -211,6 +227,70 @@ abstract class AbstractContextConfigurationUtilsTests {
 	@ContextConfiguration(classes = FooConfig.class, loader = GenericPropertiesContextLoader.class)
 	@ActiveProfiles("foo")
 	static class PropertiesClassesFoo {
+	}
+
+
+	static class BareMethodAnnotations {
+		@ContextConfiguration
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	static class LocationsMethodFoo {
+		@ContextConfiguration(locations = "/foo.xml", inheritLocations = false)
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	static class ClassesMethodFoo {
+		@ContextConfiguration(classes = FooConfig.class, inheritLocations = false)
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	static class LocationsMethodBar extends LocationsMethodFoo {
+		@ContextConfiguration(locations = "/bar.xml", inheritLocations = true, loader = AnnotationConfigContextLoader.class)
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	static class ClassesMethodBar extends ClassesMethodFoo {
+		@ContextConfiguration(classes = BarConfig.class, inheritLocations = true, loader = AnnotationConfigContextLoader.class)
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	static class MetaLocationsMethodFoo {
+		@MetaLocationsFooConfig
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	static class MetaLocationsMethodBar extends MetaLocationsMethodFoo {
+		@MetaLocationsBarConfig
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	static class MetaLocationsMethodFooWithOverrides {
+		@MetaLocationsFooConfigWithOverrides
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	static class MetaLocationsMethodFooWithOverriddenAttributes {
+		@MetaLocationsFooConfigWithOverrides(locations = {"foo1.xml", "foo2.xml"}, profiles = {"foo1", "foo2"})
+		public void something() {
+			// for test purposes
+		}
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/context/support/ContextLoaderUtilsConfigurationAttributesOnMethodTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/ContextLoaderUtilsConfigurationAttributesOnMethodTests.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.support;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.core.annotation.AnnotationConfigurationException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextLoader;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.CombinableMatcher.either;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.context.support.ContextLoaderUtils.resolveContextConfigurationAttributes;
+
+/**
+ * Unit tests for {@link ContextLoaderUtils} involving {@link ContextConfigurationAttributes} parsed from method-level
+ * annotations.
+ *
+ * @author Sergei Ustimenko
+ * @since 5.0
+ */
+public class ContextLoaderUtilsConfigurationAttributesOnMethodTests extends AbstractContextConfigurationUtilsTests {
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+
+	private void assertLocationsMethodFooAttributes(ContextConfigurationAttributes attributes) throws Exception {
+		assertAttributes(attributes,
+				LocationsMethodFoo.class,
+				LocationsMethodFoo.class.getDeclaredMethod("something"),
+				new String[] {"/foo.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				false);
+	}
+
+	private void assertClassesMethodFooAttributes(ContextConfigurationAttributes attributes) throws Exception {
+		assertAttributes(attributes,
+				ClassesMethodFoo.class,
+				ClassesMethodFoo.class.getDeclaredMethod("something"),
+				EMPTY_STRING_ARRAY,
+				new Class<?>[] {FooConfig.class},
+				ContextLoader.class,
+				false);
+	}
+
+	private void assertLocationsMethodBarAttributes(ContextConfigurationAttributes attributes) throws Exception {
+		assertAttributes(attributes,
+				LocationsMethodBar.class,
+				LocationsMethodBar.class.getDeclaredMethod("something"),
+				new String[] {"/bar.xml"},
+				EMPTY_CLASS_ARRAY,
+				AnnotationConfigContextLoader.class,
+				true);
+	}
+
+	private void assertClassesMethodBarAttributes(ContextConfigurationAttributes attributes) throws Exception {
+		assertAttributes(attributes,
+				ClassesMethodBar.class,
+				ClassesMethodBar.class.getDeclaredMethod("something"),
+				EMPTY_STRING_ARRAY,
+				new Class<?>[] {BarConfig.class},
+				AnnotationConfigContextLoader.class,
+				true);
+	}
+
+	@Test
+	public void resolveConfigAttributesWithConflictingLocations() throws Exception {
+		exception.expect(AnnotationConfigurationException.class);
+		exception.expectMessage(containsString(ConflictingLocations.class.getName()));
+		exception.expectMessage(either(containsString("attribute 'value' and its alias 'locations'"))
+				.or(containsString("attribute 'locations' and its alias 'value'")));
+		exception.expectMessage(either(containsString("values of [{x}] and [{y}]")).or(containsString(
+				"values of [{y}] and [{x}]")));
+		exception.expectMessage(containsString("but only one is permitted"));
+		resolveContextConfigurationAttributes(ConflictingLocations.class.getDeclaredMethod("something"));
+	}
+
+	@Test
+	public void resolveConfigAttributesWithBareAnnotations() throws Exception {
+		Class<BareMethodAnnotations> testClass = BareMethodAnnotations.class;
+		Method something = testClass.getDeclaredMethod("something");
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(something);
+
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertAttributes(attributesList.get(0),
+				testClass,
+				something,
+				EMPTY_STRING_ARRAY,
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+	}
+
+	@Test
+	public void resolveConfigAttributesWithLocalAnnotationAndLocations() throws Exception {
+		List<ContextConfigurationAttributes> attributesList =
+				resolveContextConfigurationAttributes(LocationsMethodFoo.class.getDeclaredMethod("something"));
+
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertLocationsMethodFooAttributes(attributesList.get(0));
+	}
+
+	@Test
+	public void resolveConfigAttributesWithMetaAnnotationAndLocations() throws Exception {
+		Class<MetaLocationsMethodFoo> testClass = MetaLocationsMethodFoo.class;
+		Method something = testClass.getDeclaredMethod("something");
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(something);
+
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertAttributes(attributesList.get(0),
+				testClass,
+				something,
+				new String[] {"/foo.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+	}
+
+	@Test
+	public void resolveConfigAttributesWithMetaAnnotationAndLocationsAndOverrides() throws Exception {
+		Class<MetaLocationsMethodFooWithOverrides> testClass = MetaLocationsMethodFooWithOverrides.class;
+		Method something = testClass.getDeclaredMethod("something");
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(something);
+
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertAttributes(attributesList.get(0),
+				testClass,
+				something,
+				new String[] {"/foo.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+	}
+
+	@Test
+	public void resolveConfigAttributesWithMetaAnnotationAndLocationsAndOverriddenAttributes() throws Exception {
+		Class<MetaLocationsMethodFooWithOverriddenAttributes> testClass
+				= MetaLocationsMethodFooWithOverriddenAttributes.class;
+		Method something = testClass.getDeclaredMethod("something");
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(something);
+
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertAttributes(attributesList.get(0),
+				testClass,
+				something,
+				new String[] {"foo1.xml", "foo2.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+	}
+
+	@Test
+	public void resolveConfigAttributesWithMetaAnnotationAndLocationsInClassHierarchy() throws Exception {
+		Class<MetaLocationsMethodBar> testClass = MetaLocationsMethodBar.class;
+		Method something = testClass.getDeclaredMethod("something");
+		List<ContextConfigurationAttributes> attributesList = resolveContextConfigurationAttributes(something);
+
+		assertNotNull(attributesList);
+		assertEquals(2, attributesList.size());
+		assertAttributes(attributesList.get(0),
+				testClass,
+				something,
+				new String[] {"/bar.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+		assertAttributes(attributesList.get(1),
+				MetaLocationsMethodFoo.class,
+				MetaLocationsMethodFoo.class.getDeclaredMethod("something"),
+				new String[] {"/foo.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+	}
+
+	@Test
+	public void resolveConfigAttributesWithLocalAnnotationAndClasses() throws Exception {
+		List<ContextConfigurationAttributes> attributesList =
+				resolveContextConfigurationAttributes(ClassesMethodFoo.class.getDeclaredMethod("something"));
+
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+		assertClassesMethodFooAttributes(attributesList.get(0));
+	}
+
+	@Test
+	public void resolveConfigAttributesWithLocalAndInheritedAnnotationsAndLocations() throws Exception {
+		List<ContextConfigurationAttributes> attributesList =
+				resolveContextConfigurationAttributes(LocationsMethodBar.class.getDeclaredMethod("something"));
+
+		assertNotNull(attributesList);
+		assertEquals(2, attributesList.size());
+		assertLocationsMethodBarAttributes(attributesList.get(0));
+		assertLocationsMethodFooAttributes(attributesList.get(1));
+	}
+
+	@Test
+	public void resolveConfigAttributesWithLocalAndInheritedAnnotationsAndClasses() throws Exception {
+		List<ContextConfigurationAttributes> attributesList =
+				resolveContextConfigurationAttributes(ClassesMethodBar.class.getDeclaredMethod("something"));
+
+		assertNotNull(attributesList);
+		assertEquals(2, attributesList.size());
+		assertClassesMethodBarAttributes(attributesList.get(0));
+		assertClassesMethodFooAttributes(attributesList.get(1));
+	}
+
+	@Test
+	public void resolveConfigAttributesWithLocationsAndClasses() throws Exception {
+		List<ContextConfigurationAttributes> attributesList =
+				resolveContextConfigurationAttributes(LocationsAndClasses.class.getDeclaredMethod("something"));
+
+		assertNotNull(attributesList);
+		assertEquals(1, attributesList.size());
+	}
+
+
+	// -------------------------------------------------------------------------
+
+	private static class ConflictingLocations {
+		@ContextConfiguration(value = "x", locations = "y")
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class LocationsAndClasses {
+		@ContextConfiguration(locations = "x", classes = Object.class)
+		public void something() {
+			// for test purposes
+		}
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/support/ContextLoaderUtilsContextHierarchyOnMethodTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/ContextLoaderUtilsContextHierarchyOnMethodTests.java
@@ -1,0 +1,737 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.support;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.ContextLoader;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.springframework.test.context.support.ContextLoaderUtils.GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX;
+import static org.springframework.test.context.support.ContextLoaderUtils.buildContextHierarchyMap;
+import static org.springframework.test.context.support.ContextLoaderUtils.resolveContextHierarchyAttributes;
+
+/**
+ * Unit tests for {@link ContextLoaderUtils} involving context hierarchies parsed from method-level annotations.
+ *
+ * @author Sergei Ustimenko
+ * @since 5.0
+ */
+public class ContextLoaderUtilsContextHierarchyOnMethodTests extends AbstractContextConfigurationUtilsTests {
+
+	@Test(expected = IllegalStateException.class)
+	public void resolveContextHierarchyAttributesForSingleTestClassWithContextConfigurationAndContextHierarchy()
+			throws Exception {
+		resolveContextHierarchyAttributes(
+				SingleTestClassWithContextConfigurationAndContextHierarchy.class.getDeclaredMethod("something"));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void
+	resolveContextHierarchyAttributesForSingleTestClassWithContextConfigurationAndContextHierarchyOnSingleMetaAnnotation()
+			throws Exception {
+		resolveContextHierarchyAttributes(
+				SingleTestClassWithContextConfigurationAndContextHierarchyOnSingleMetaAnnotation.class.getDeclaredMethod("something"));
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForSingleTestClassWithImplicitSingleLevelContextHierarchy()
+			throws Exception {
+		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(
+				BareMethodAnnotations.class.getDeclaredMethod("something"));
+		assertEquals(1, hierarchyAttributes.size());
+		List<ContextConfigurationAttributes> configAttributesList = hierarchyAttributes.get(0);
+		assertEquals(1, configAttributesList.size());
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForSingleTestClassWithSingleLevelContextHierarchy() throws Exception {
+		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(
+				SingleTestClassWithSingleLevelContextHierarchy.class.getDeclaredMethod("something"));
+		assertEquals(1, hierarchyAttributes.size());
+		List<ContextConfigurationAttributes> configAttributesList = hierarchyAttributes.get(0);
+		assertEquals(1, configAttributesList.size());
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForSingleTestClassWithSingleLevelContextHierarchyFromMetaAnnotation()
+			throws Exception {
+		Class<SingleTestClassWithSingleLevelContextHierarchyFromMetaAnnotation> testClass
+				= SingleTestClassWithSingleLevelContextHierarchyFromMetaAnnotation.class;
+		Method something = testClass.getDeclaredMethod("something");
+		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(something);
+		assertEquals(1, hierarchyAttributes.size());
+
+		List<ContextConfigurationAttributes> configAttributesList = hierarchyAttributes.get(0);
+		assertNotNull(configAttributesList);
+		assertEquals(1, configAttributesList.size());
+		assertAttributes(configAttributesList.get(0),
+				testClass,
+				something,
+				new String[] {"A.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForSingleTestClassWithTripleLevelContextHierarchy() throws Exception {
+		Class<SingleTestClassWithTripleLevelContextHierarchy> testClass
+				= SingleTestClassWithTripleLevelContextHierarchy.class;
+		Method something = testClass.getDeclaredMethod("something");
+		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(something);
+		assertEquals(1, hierarchyAttributes.size());
+
+		List<ContextConfigurationAttributes> configAttributesList = hierarchyAttributes.get(0);
+		assertNotNull(configAttributesList);
+		assertEquals(3, configAttributesList.size());
+		assertAttributes(configAttributesList.get(0),
+				testClass,
+				something,
+				new String[] {"A.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+		assertAttributes(configAttributesList.get(1),
+				testClass,
+				something,
+				new String[] {"B.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+		assertAttributes(configAttributesList.get(2),
+				testClass,
+				something,
+				new String[] {"C.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForTestClassHierarchyWithSingleLevelContextHierarchies()
+			throws Exception {
+		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(
+				TestClass3WithSingleLevelContextHierarchy.class.getDeclaredMethod("something"));
+		assertEquals(3, hierarchyAttributes.size());
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel1 = hierarchyAttributes.get(0);
+		assertEquals(1, configAttributesListClassLevel1.size());
+		assertThat(configAttributesListClassLevel1.get(0).getLocations()[0], equalTo("one.xml"));
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel2 = hierarchyAttributes.get(1);
+		assertEquals(1, configAttributesListClassLevel2.size());
+		assertArrayEquals(new String[] {"two-A.xml", "two-B.xml"},
+				configAttributesListClassLevel2.get(0).getLocations());
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel3 = hierarchyAttributes.get(2);
+		assertEquals(1, configAttributesListClassLevel3.size());
+		assertThat(configAttributesListClassLevel3.get(0).getLocations()[0], equalTo("three.xml"));
+	}
+
+	@Test
+	public void
+	resolveContextHierarchyAttributesForTestClassHierarchyWithSingleLevelContextHierarchiesAndMetaAnnotations()
+			throws Exception {
+		Method something = TestClass3WithSingleLevelContextHierarchyFromMetaAnnotation.class.getDeclaredMethod(
+				"something");
+		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(something);
+		assertEquals(3, hierarchyAttributes.size());
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel1 = hierarchyAttributes.get(0);
+		assertEquals(1, configAttributesListClassLevel1.size());
+		assertThat(configAttributesListClassLevel1.get(0).getLocations()[0], equalTo("A.xml"));
+		assertAttributes(configAttributesListClassLevel1.get(0),
+				TestClass1WithSingleLevelContextHierarchyFromMetaAnnotation.class,
+				TestClass1WithSingleLevelContextHierarchyFromMetaAnnotation.class.getDeclaredMethod("something"),
+				new String[] {"A.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel2 = hierarchyAttributes.get(1);
+		assertEquals(1, configAttributesListClassLevel2.size());
+		assertArrayEquals(new String[] {"B-one.xml", "B-two.xml"},
+				configAttributesListClassLevel2.get(0).getLocations());
+		assertAttributes(configAttributesListClassLevel2.get(0),
+				TestClass2WithSingleLevelContextHierarchyFromMetaAnnotation.class,
+				TestClass2WithSingleLevelContextHierarchyFromMetaAnnotation.class.getDeclaredMethod("something"),
+				new String[] {"B-one.xml", "B-two.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel3 = hierarchyAttributes.get(2);
+		assertEquals(1, configAttributesListClassLevel3.size());
+		assertThat(configAttributesListClassLevel3.get(0).getLocations()[0], equalTo("C.xml"));
+		assertAttributes(configAttributesListClassLevel3.get(0),
+				TestClass3WithSingleLevelContextHierarchyFromMetaAnnotation.class,
+				something,
+				new String[] {"C.xml"},
+				EMPTY_CLASS_ARRAY,
+				ContextLoader.class,
+				true);
+	}
+
+	private void assertOneTwo(List<List<ContextConfigurationAttributes>> hierarchyAttributes) {
+		assertEquals(2, hierarchyAttributes.size());
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel1 = hierarchyAttributes.get(0);
+		List<ContextConfigurationAttributes> configAttributesListClassLevel2 = hierarchyAttributes.get(1);
+
+		assertEquals(1, configAttributesListClassLevel1.size());
+		assertThat(configAttributesListClassLevel1.get(0).getLocations()[0], equalTo("one.xml"));
+
+		assertEquals(1, configAttributesListClassLevel2.size());
+		assertThat(configAttributesListClassLevel2.get(0).getLocations()[0], equalTo("two.xml"));
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForTestClassHierarchyWithBareContextConfigurationInSuperclass()
+			throws Exception {
+		assertOneTwo(resolveContextHierarchyAttributes(
+				TestClass2WithBareContextConfigurationInSuperclass.class.getDeclaredMethod("something")));
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForTestClassHierarchyWithBareContextConfigurationInSubclass()
+			throws Exception {
+		assertOneTwo(resolveContextHierarchyAttributes(
+				TestClass2WithBareContextConfigurationInSubclass.class.getDeclaredMethod("something")));
+	}
+
+	@Test
+	public void
+	resolveContextHierarchyAttributesForTestClassHierarchyWithBareMetaContextConfigWithOverridesInSuperclass()
+			throws Exception {
+		assertOneTwo(resolveContextHierarchyAttributes(
+				TestClass2WithBareMetaContextConfigWithOverridesInSuperclass.class.getDeclaredMethod("something")));
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForTestClassHierarchyWithBareMetaContextConfigWithOverridesInSubclass()
+			throws Exception {
+		assertOneTwo(resolveContextHierarchyAttributes(
+				TestClass2WithBareMetaContextConfigWithOverridesInSubclass.class.getDeclaredMethod("something")));
+	}
+
+	@Test
+	public void resolveContextHierarchyAttributesForTestClassHierarchyWithMultiLevelContextHierarchies()
+			throws Exception {
+		List<List<ContextConfigurationAttributes>> hierarchyAttributes = resolveContextHierarchyAttributes(
+				TestClass3WithMultiLevelContextHierarchy.class.getDeclaredMethod("something"));
+		assertEquals(3, hierarchyAttributes.size());
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel1 = hierarchyAttributes.get(0);
+		assertEquals(2, configAttributesListClassLevel1.size());
+		assertThat(configAttributesListClassLevel1.get(0).getLocations()[0], equalTo("1-A.xml"));
+		assertThat(configAttributesListClassLevel1.get(1).getLocations()[0], equalTo("1-B.xml"));
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel2 = hierarchyAttributes.get(1);
+		assertEquals(2, configAttributesListClassLevel2.size());
+		assertThat(configAttributesListClassLevel2.get(0).getLocations()[0], equalTo("2-A.xml"));
+		assertThat(configAttributesListClassLevel2.get(1).getLocations()[0], equalTo("2-B.xml"));
+
+		List<ContextConfigurationAttributes> configAttributesListClassLevel3 = hierarchyAttributes.get(2);
+		assertEquals(3, configAttributesListClassLevel3.size());
+		assertThat(configAttributesListClassLevel3.get(0).getLocations()[0], equalTo("3-A.xml"));
+		assertThat(configAttributesListClassLevel3.get(1).getLocations()[0], equalTo("3-B.xml"));
+		assertThat(configAttributesListClassLevel3.get(2).getLocations()[0], equalTo("3-C.xml"));
+	}
+
+	@Test
+	public void buildContextHierarchyMapForTestClassHierarchyWithMultiLevelContextHierarchies() throws Exception {
+		Map<String, List<ContextConfigurationAttributes>> map = buildContextHierarchyMap(
+				TestClass3WithMultiLevelContextHierarchy.class.getDeclaredMethod("something"));
+
+		assertThat(map.size(), is(3));
+		assertThat(map.keySet(), hasItems("alpha", "beta", "gamma"));
+
+		List<ContextConfigurationAttributes> alphaConfig = map.get("alpha");
+		assertThat(alphaConfig.size(), is(3));
+		assertThat(alphaConfig.get(0).getLocations()[0], is("1-A.xml"));
+		assertThat(alphaConfig.get(1).getLocations()[0], is("2-A.xml"));
+		assertThat(alphaConfig.get(2).getLocations()[0], is("3-A.xml"));
+
+		List<ContextConfigurationAttributes> betaConfig = map.get("beta");
+		assertThat(betaConfig.size(), is(3));
+		assertThat(betaConfig.get(0).getLocations()[0], is("1-B.xml"));
+		assertThat(betaConfig.get(1).getLocations()[0], is("2-B.xml"));
+		assertThat(betaConfig.get(2).getLocations()[0], is("3-B.xml"));
+
+		List<ContextConfigurationAttributes> gammaConfig = map.get("gamma");
+		assertThat(gammaConfig.size(), is(1));
+		assertThat(gammaConfig.get(0).getLocations()[0], is("3-C.xml"));
+	}
+
+	@Test
+	public void buildContextHierarchyMapForTestClassHierarchyWithMultiLevelContextHierarchiesAndUnnamedConfig()
+			throws Exception {
+		Map<String, List<ContextConfigurationAttributes>> map = buildContextHierarchyMap(
+				TestClass3WithMultiLevelContextHierarchyAndUnnamedConfig.class.getDeclaredMethod("something"));
+
+		String level1 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 1;
+		String level2 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 2;
+		String level3 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 3;
+		String level4 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 4;
+		String level5 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 5;
+		String level6 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 6;
+		String level7 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 7;
+
+		assertThat(map.size(), is(7));
+		assertThat(map.keySet(), hasItems(level1, level2, level3, level4, level5, level6, level7));
+
+		List<ContextConfigurationAttributes> level1Config = map.get(level1);
+		assertThat(level1Config.size(), is(1));
+		assertThat(level1Config.get(0).getLocations()[0], is("1-A.xml"));
+
+		List<ContextConfigurationAttributes> level2Config = map.get(level2);
+		assertThat(level2Config.size(), is(1));
+		assertThat(level2Config.get(0).getLocations()[0], is("1-B.xml"));
+
+		List<ContextConfigurationAttributes> level3Config = map.get(level3);
+		assertThat(level3Config.size(), is(1));
+		assertThat(level3Config.get(0).getLocations()[0], is("2-A.xml"));
+
+		List<ContextConfigurationAttributes> level7Config = map.get(level7);
+		assertThat(level7Config.size(), is(1));
+		assertThat(level7Config.get(0).getLocations()[0], is("3-C.xml"));
+	}
+
+	@Test
+	public void buildContextHierarchyMapForTestClassHierarchyWithMultiLevelContextHierarchiesAndPartiallyNamedConfig()
+			throws Exception {
+		Map<String, List<ContextConfigurationAttributes>> map = buildContextHierarchyMap(
+				TestClass2WithMultiLevelContextHierarchyAndPartiallyNamedConfig.class.getDeclaredMethod("something"));
+
+		String level1 = "parent";
+		String level2 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 2;
+		String level3 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 3;
+
+		assertThat(map.size(), is(3));
+		assertThat(map.keySet(), hasItems(level1, level2, level3));
+		Iterator<String> levels = map.keySet().iterator();
+		assertThat(levels.next(), is(level1));
+		assertThat(levels.next(), is(level2));
+		assertThat(levels.next(), is(level3));
+
+		List<ContextConfigurationAttributes> level1Config = map.get(level1);
+		assertThat(level1Config.size(), is(2));
+		assertThat(level1Config.get(0).getLocations()[0], is("1-A.xml"));
+		assertThat(level1Config.get(1).getLocations()[0], is("2-A.xml"));
+
+		List<ContextConfigurationAttributes> level2Config = map.get(level2);
+		assertThat(level2Config.size(), is(1));
+		assertThat(level2Config.get(0).getLocations()[0], is("1-B.xml"));
+
+		List<ContextConfigurationAttributes> level3Config = map.get(level3);
+		assertThat(level3Config.size(), is(1));
+		assertThat(level3Config.get(0).getLocations()[0], is("2-C.xml"));
+	}
+
+	private void assertContextConfigEntriesAreNotUnique(Method testMethod) {
+		try {
+			buildContextHierarchyMap(testMethod);
+			fail("Should throw an IllegalStateException");
+		} catch (IllegalStateException e) {
+			String msg = String.format(
+					"The @ContextConfiguration elements configured via @ContextHierarchy on test method [%s] and its "
+							+ "supermethods must define unique contexts per hierarchy level.",
+					testMethod.getName());
+			assertEquals(msg, e.getMessage());
+		}
+	}
+
+	@Test
+	public void buildContextHierarchyMapForSingleTestClassWithMultiLevelContextHierarchyWithEmptyContextConfig()
+			throws Exception {
+		assertContextConfigEntriesAreNotUnique(
+				SingleTestClassWithMultiLevelContextHierarchyWithEmptyContextConfig.class.getDeclaredMethod("something"));
+	}
+
+	@Test
+	public void buildContextHierarchyMapForSingleTestClassWithMultiLevelContextHierarchyWithDuplicatedContextConfig()
+			throws Exception {
+		assertContextConfigEntriesAreNotUnique
+				(SingleTestClassWithMultiLevelContextHierarchyWithDuplicatedContextConfig.class.getDeclaredMethod("something"));
+	}
+
+	@Test
+	public void buildContextHierarchyForInterfaceHierarchy() throws Exception {
+		Map<String, List<ContextConfigurationAttributes>> map = buildContextHierarchyMap(
+				TestClassWithMethodAnnotatedInInterfaces.class.getDeclaredMethod("something"));
+		String level1 = "superInterface";
+		String level2 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 2;
+		String level3 = "parent";
+		String level4 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 4;
+		String level5 = GENERATED_CONTEXT_HIERARCHY_LEVEL_PREFIX + 5;
+
+		assertThat(map.size(), is(5));
+		assertThat(map.keySet(), hasItems(level1, level2, level3, level4, level5));
+		Iterator<String> levels = map.keySet().iterator();
+		assertThat(levels.next(), is(level1));
+		assertThat(levels.next(), is(level2));
+		assertThat(levels.next(), is(level3));
+		assertThat(levels.next(), is(level4));
+		assertThat(levels.next(), is(level5));
+
+		List<ContextConfigurationAttributes> level1Config = map.get(level1);
+		assertThat(level1Config.size(), is(1));
+		assertThat(level1Config.get(0).getLocations()[0], is("boo.xml"));
+
+		List<ContextConfigurationAttributes> level2Config = map.get(level2);
+		assertThat(level2Config.size(), is(1));
+		assertThat(level2Config.get(0).getLocations()[0], is("bak.xml"));
+
+		List<ContextConfigurationAttributes> level3Config = map.get(level3);
+		assertThat(level3Config.size(), is(1));
+		assertThat(level3Config.get(0).getLocations()[0], is("baz.xml"));
+
+		List<ContextConfigurationAttributes> level4Config = map.get(level4);
+		assertThat(level4Config.size(), is(1));
+		assertThat(level4Config.get(0).getLocations()[0], is("bar.xml"));
+
+		List<ContextConfigurationAttributes> level5Config = map.get(level5);
+		assertThat(level5Config.size(), is(1));
+		assertThat(level5Config.get(0).getLocations()[0], is("foo.xml"));
+	}
+
+
+	//-------------------------------------------------------------
+
+	private static class SingleTestClassWithContextConfigurationAndContextHierarchy {
+		@ContextConfiguration("foo.xml")
+		@ContextHierarchy(@ContextConfiguration("bar.xml"))
+		public void something() {
+			// for test purposes
+		}
+
+	}
+
+	private static class SingleTestClassWithContextConfigurationAndContextHierarchyOnSingleMetaAnnotation {
+		@ContextLoaderUtilsContextHierarchyTests.ContextConfigurationAndContextHierarchyOnSingleMeta
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class SingleTestClassWithSingleLevelContextHierarchy {
+		@ContextHierarchy(@ContextConfiguration("A.xml"))
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class SingleTestClassWithTripleLevelContextHierarchy {
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration("A.xml"),//
+				@ContextConfiguration("B.xml"),//
+				@ContextConfiguration("C.xml") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass1WithSingleLevelContextHierarchy {
+		@ContextHierarchy(@ContextConfiguration("one.xml"))
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass2WithSingleLevelContextHierarchy extends TestClass1WithSingleLevelContextHierarchy {
+		@ContextHierarchy(@ContextConfiguration({"two-A.xml", "two-B.xml"}))
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass3WithSingleLevelContextHierarchy extends TestClass2WithSingleLevelContextHierarchy {
+		@ContextHierarchy(@ContextConfiguration("three.xml"))
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass1WithBareContextConfigurationInSuperclass {
+		@ContextConfiguration("one.xml")
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass2WithBareContextConfigurationInSuperclass extends TestClass1WithBareContextConfigurationInSuperclass {
+		@ContextHierarchy(@ContextConfiguration("two.xml"))
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass1WithBareContextConfigurationInSubclass {
+		@ContextHierarchy(@ContextConfiguration("one.xml"))
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass2WithBareContextConfigurationInSubclass extends TestClass1WithBareContextConfigurationInSubclass {
+		@ContextConfiguration("two.xml")
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass1WithBareMetaContextConfigWithOverridesInSuperclass {
+		@ContextLoaderUtilsContextHierarchyTests.ContextConfigWithOverrides(locations = "one.xml")
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass2WithBareMetaContextConfigWithOverridesInSuperclass extends TestClass1WithBareMetaContextConfigWithOverridesInSuperclass {
+		@ContextHierarchy(@ContextConfiguration(locations = "two.xml"))
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass1WithBareMetaContextConfigWithOverridesInSubclass {
+		@ContextHierarchy(@ContextConfiguration(locations = "one.xml"))
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass2WithBareMetaContextConfigWithOverridesInSubclass extends TestClass1WithBareMetaContextConfigWithOverridesInSubclass {
+		@ContextLoaderUtilsContextHierarchyTests.ContextConfigWithOverrides(locations = "two.xml")
+		public void something() {
+			// for test purposes
+		}
+	}
+
+
+	private static class SingleTestClassWithSingleLevelContextHierarchyFromMetaAnnotation {
+		@ContextLoaderUtilsContextHierarchyTests.ContextHierarchyA
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass1WithSingleLevelContextHierarchyFromMetaAnnotation {
+		@ContextLoaderUtilsContextHierarchyTests.ContextHierarchyA
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass2WithSingleLevelContextHierarchyFromMetaAnnotation extends TestClass1WithSingleLevelContextHierarchyFromMetaAnnotation {
+		@ContextLoaderUtilsContextHierarchyTests.ContextHierarchyB
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass3WithSingleLevelContextHierarchyFromMetaAnnotation extends TestClass2WithSingleLevelContextHierarchyFromMetaAnnotation {
+		@ContextLoaderUtilsContextHierarchyTests.ContextHierarchyC
+		public void something() {
+			// for test purposes
+		}
+	}
+
+
+	private static class TestClass1WithMultiLevelContextHierarchy {
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration(locations = "1-A.xml", name = "alpha"),//
+				@ContextConfiguration(locations = "1-B.xml", name = "beta") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass2WithMultiLevelContextHierarchy extends TestClass1WithMultiLevelContextHierarchy {
+		@Override
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration(locations = "2-A.xml", name = "alpha"),//
+				@ContextConfiguration(locations = "2-B.xml", name = "beta") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClass3WithMultiLevelContextHierarchy extends TestClass2WithMultiLevelContextHierarchy {
+		@Override
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration(locations = "3-A.xml", name = "alpha"),//
+				@ContextConfiguration(locations = "3-B.xml", name = "beta"),//
+				@ContextConfiguration(locations = "3-C.xml", name = "gamma") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+
+	private static class TestClass1WithMultiLevelContextHierarchyAndUnnamedConfig {
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration(locations = "1-A.xml"),//
+				@ContextConfiguration(locations = "1-B.xml") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+
+	private static class TestClass2WithMultiLevelContextHierarchyAndUnnamedConfig extends TestClass1WithMultiLevelContextHierarchyAndUnnamedConfig {
+		@Override
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration(locations = "2-A.xml"),//
+				@ContextConfiguration(locations = "2-B.xml") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+
+	private static class TestClass3WithMultiLevelContextHierarchyAndUnnamedConfig extends TestClass2WithMultiLevelContextHierarchyAndUnnamedConfig {
+		@Override
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration(locations = "3-A.xml"),//
+				@ContextConfiguration(locations = "3-B.xml"),//
+				@ContextConfiguration(locations = "3-C.xml") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+
+	private static class TestClass1WithMultiLevelContextHierarchyAndPartiallyNamedConfig {
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration(locations = "1-A.xml", name = "parent"),//
+				@ContextConfiguration(locations = "1-B.xml") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+
+	private static class TestClass2WithMultiLevelContextHierarchyAndPartiallyNamedConfig extends TestClass1WithMultiLevelContextHierarchyAndPartiallyNamedConfig {
+		@Override
+		@ContextHierarchy({//
+				//
+				@ContextConfiguration(locations = "2-A.xml", name = "parent"),//
+				@ContextConfiguration(locations = "2-C.xml") //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+
+	private static class SingleTestClassWithMultiLevelContextHierarchyWithEmptyContextConfig {
+		@ContextHierarchy({
+				//
+				@ContextConfiguration,//
+				@ContextConfiguration //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class SingleTestClassWithMultiLevelContextHierarchyWithDuplicatedContextConfig {
+		@ContextHierarchy({
+				//
+				@ContextConfiguration("foo.xml"),//
+				@ContextConfiguration(classes = AbstractContextConfigurationUtilsTests.BarConfig.class),// duplicate!
+				@ContextConfiguration("baz.xml"),//
+				@ContextConfiguration(classes = AbstractContextConfigurationUtilsTests.BarConfig.class),// duplicate!
+				@ContextConfiguration(loader = AnnotationConfigContextLoader.class) //
+		})
+		public void something() {
+			// for test purposes
+		}
+	}
+
+	private static class TestClassWithMethodAnnotatedInInterfaces extends TestClassWithMethodAnnotatedInInterfacesParent
+			implements FirstLevelAnnotation {
+		@Override
+		public void something() {
+			//for test purposes
+		}
+	}
+
+	private interface FirstLevelAnnotation extends SecondLevelAnnotation {
+		@Override
+		@ContextHierarchy({@ContextConfiguration(value = "foo.xml")})
+		void something();
+	}
+
+	private interface SecondLevelAnnotation extends ThirdLevelAnnotation {
+		@Override
+		@ContextHierarchy({@ContextConfiguration("bar.xml")})
+		void something();
+	}
+
+	private interface ThirdLevelAnnotation {
+		@ContextHierarchy({@ContextConfiguration(value = "baz.xml", name = "parent")})
+		void something();
+	}
+
+	private static class TestClassWithMethodAnnotatedInInterfacesParent implements FirstLevelOnSuperClassInterface {
+		@Override
+		@ContextHierarchy({@ContextConfiguration(value = "bak.xml")})
+		public void something() {
+			//for test purposes
+		}
+	}
+
+	private interface FirstLevelOnSuperClassInterface {
+		@ContextHierarchy({@ContextConfiguration(value = "boo.xml", name = "superInterface")})
+		void something();
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/support/ContextLoaderUtilsContextHierarchyTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/ContextLoaderUtilsContextHierarchyTests.java
@@ -16,8 +16,10 @@
 
 package org.springframework.test.context.support;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -370,10 +372,11 @@ public class ContextLoaderUtilsContextHierarchyTests extends AbstractContextConf
 	private static class SingleTestClassWithContextConfigurationAndContextHierarchy {
 	}
 
+    @Target({ElementType.TYPE, ElementType.METHOD})
 	@ContextConfiguration("foo.xml")
 	@ContextHierarchy(@ContextConfiguration("bar.xml"))
 	@Retention(RetentionPolicy.RUNTIME)
-	private static @interface ContextConfigurationAndContextHierarchyOnSingleMeta {
+	@interface ContextConfigurationAndContextHierarchyOnSingleMeta {
 	}
 
 	@ContextConfigurationAndContextHierarchyOnSingleMeta
@@ -550,17 +553,19 @@ public class ContextLoaderUtilsContextHierarchyTests extends AbstractContextConf
 
 	@ContextHierarchy(@ContextConfiguration("A.xml"))
 	@Retention(RetentionPolicy.RUNTIME)
-	private static @interface ContextHierarchyA {
+	@interface ContextHierarchyA {
 	}
 
+    @Target({ElementType.TYPE, ElementType.METHOD})
 	@ContextHierarchy(@ContextConfiguration({ "B-one.xml", "B-two.xml" }))
 	@Retention(RetentionPolicy.RUNTIME)
-	private static @interface ContextHierarchyB {
+	@interface ContextHierarchyB {
 	}
 
+    @Target({ElementType.TYPE, ElementType.METHOD})
 	@ContextHierarchy(@ContextConfiguration("C.xml"))
 	@Retention(RetentionPolicy.RUNTIME)
-	private static @interface ContextHierarchyC {
+	@interface ContextHierarchyC {
 	}
 
 	@ContextHierarchyA
@@ -583,9 +588,10 @@ public class ContextLoaderUtilsContextHierarchyTests extends AbstractContextConf
 
 	// -------------------------------------------------------------------------
 
+    @Target({ElementType.TYPE, ElementType.METHOD})
 	@ContextConfiguration
 	@Retention(RetentionPolicy.RUNTIME)
-	private static @interface ContextConfigWithOverrides {
+	@interface ContextConfigWithOverrides {
 
 		String[] locations() default "A.xml";
 	}

--- a/spring-test/src/test/java/org/springframework/test/util/MetaAnnotationUtilsForMethod.java
+++ b/spring-test/src/test/java/org/springframework/test/util/MetaAnnotationUtilsForMethod.java
@@ -1,0 +1,720 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
+import static org.springframework.test.util.MetaAnnotationUtils.findAnnotationDescriptor;
+import static org.springframework.test.util.MetaAnnotationUtils.findAnnotationDescriptorForTypes;
+
+/**
+ * Unit tests for {@link MetaAnnotationUtils} for method-level annotations handling methods.
+ *
+ * @author Sergei Ustimenko
+ * @since 5.0
+ * @see MetaAnnotationUtilsTests
+ */
+public class MetaAnnotationUtilsForMethod {
+
+	private void assertAtComponentOnComposedAnnotation(Method method, String name,
+			Class<? extends Annotation> composedAnnotationType) {
+		assertAtComponentOnComposedAnnotation(method, method.getDeclaringClass(), name, composedAnnotationType);
+	}
+
+	private void assertAtComponentOnComposedAnnotation(Method method, Class<?> rootDeclaringClass, String name,
+			Class<? extends Annotation> composedAnnotationType) {
+		assertAtComponentOnComposedAnnotation(method, rootDeclaringClass, composedAnnotationType, name,
+				composedAnnotationType);
+	}
+
+	private void assertAtComponentOnComposedAnnotation(Method method, Class<?> rootDeclaringClass,
+			Class<?> declaringClass, String name, Class<? extends Annotation> composedAnnotationType) {
+		MetaAnnotationUtils.AnnotationDescriptor<Component> descriptor = findAnnotationDescriptor(method,
+				Component.class);
+		assertNotNull("AnnotationDescriptor should not be null", descriptor);
+		assertEquals("rootDeclaringClass", rootDeclaringClass, descriptor.getRootDeclaringClass());
+		assertEquals("declaringClass", declaringClass, descriptor.getDeclaringClass());
+		assertEquals("annotationType", Component.class, descriptor.getAnnotationType());
+		assertEquals("component name", name, descriptor.getAnnotation().value());
+		assertNotNull("composedAnnotation should not be null", descriptor.getComposedAnnotation());
+		assertEquals("composedAnnotationType", composedAnnotationType, descriptor.getComposedAnnotationType());
+	}
+
+	@Test
+	public void findAnnotationDescriptorWithNoAnnotationPresent() throws Exception {
+		assertNull(findAnnotationDescriptor(
+				NonAnnotatedInterface.class.getMethod("something"), Transactional.class));
+		assertNull(findAnnotationDescriptor(
+				NonAnnotatedClass.class.getMethod("something"), Transactional.class));
+	}
+
+	@Test
+	public void findAnnotationDescriptorWithInheritedAnnotationOnMethod() throws Exception {
+		// Note: @Transactional is inherited
+		Method inheritedAnnotationMethod = InheritedAnnotationClass.class.getMethod("something");
+
+		assertEquals(InheritedAnnotationClass.class, findAnnotationDescriptor(
+				inheritedAnnotationMethod,Transactional.class).getRootDeclaringClass());
+		assertEquals(InheritedAnnotationClass.class, findAnnotationDescriptor(
+				inheritedAnnotationMethod,Transactional.class).getDeclaringClass());
+		assertEquals(inheritedAnnotationMethod, findAnnotationDescriptor(
+				inheritedAnnotationMethod,Transactional.class).getDeclaringMethod());
+
+		assertEquals(SubInheritedAnnotationClass.class, findAnnotationDescriptor(
+				SubInheritedAnnotationClass.class.getMethod("something"), Transactional.class).getRootDeclaringClass());
+		assertEquals(InheritedAnnotationClass.class, findAnnotationDescriptor(
+				SubInheritedAnnotationClass.class.getMethod("something"), Transactional.class).getDeclaringClass());
+		assertEquals(inheritedAnnotationMethod, findAnnotationDescriptor(
+				SubInheritedAnnotationClass.class.getMethod("something"), Transactional.class).getDeclaringMethod());
+	}
+
+	@Test
+	public void findAnnotationDescriptorWithInheritedAnnotationOnInterface() throws Exception {
+		// Note: @Transactional is inherited
+		Method something = InheritedAnnotationInterface.class.getMethod("something");
+
+		Transactional rawAnnotation = something.getAnnotation(Transactional.class);
+
+		MetaAnnotationUtils.AnnotationOnMethodDescriptor<Transactional> descriptor;
+
+		descriptor = findAnnotationDescriptor(something, Transactional.class);
+		assertNotNull(descriptor);
+		assertEquals(InheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(something, descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+
+		Method somethingInSubInherited = SubInheritedAnnotationInterface.class.getMethod("something");
+		descriptor = findAnnotationDescriptor(somethingInSubInherited, Transactional.class);
+		assertNotNull(descriptor);
+		assertEquals(SubInheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+
+		Method somethingInSubSubInherited = SubSubInheritedAnnotationInterface.class.getMethod("something");
+		descriptor = findAnnotationDescriptor(somethingInSubSubInherited, Transactional.class);
+		assertNotNull(descriptor);
+		assertEquals(SubSubInheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+	}
+
+	@Test
+	public void findAnnotationDescriptorForNonInheritedAnnotationOnClass() throws Exception {
+		// Note: @Order is not inherited.
+		MetaAnnotationUtils.AnnotationOnMethodDescriptor<Order> something = findAnnotationDescriptor(
+				NonInheritedAnnotationClass.class.getMethod("something"), Order.class);
+		assertEquals(NonInheritedAnnotationClass.class, something.getRootDeclaringClass());
+		assertEquals(NonInheritedAnnotationClass.class.getMethod("something"), something.getDeclaringMethod());
+
+		MetaAnnotationUtils.AnnotationOnMethodDescriptor<Order> somethingOnSub = findAnnotationDescriptor(
+				SubNonInheritedAnnotationClass.class.getMethod("something"), Order.class);
+		assertEquals(SubNonInheritedAnnotationClass.class, somethingOnSub.getRootDeclaringClass());
+		assertEquals(NonInheritedAnnotationClass.class.getMethod("something"), somethingOnSub.getDeclaringMethod());
+	}
+
+	@Test
+	public void findAnnotationDescriptorForNonInheritedAnnotationOnInterface() throws Exception {
+		// Note: @Order is not inherited.
+		Order rawAnnotation = NonInheritedAnnotationInterface.class.getMethod("something").getAnnotation(Order.class);
+
+		MetaAnnotationUtils.AnnotationOnMethodDescriptor<Order> descriptor;
+
+		descriptor = findAnnotationDescriptor(NonInheritedAnnotationInterface.class.getMethod("something"), Order.class);
+		assertNotNull(descriptor);
+		assertEquals(NonInheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(NonInheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(NonInheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+
+		descriptor = findAnnotationDescriptor(SubNonInheritedAnnotationInterface.class.getMethod("something"), Order.class);
+		assertNotNull(descriptor);
+		assertEquals(SubNonInheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(NonInheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(NonInheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+	}
+
+	@Test
+	public void findAnnotationDescriptorWithMetaComponentAnnotation() throws Exception {
+		assertAtComponentOnComposedAnnotation(HasMetaComponentAnnotation.class.getDeclaredMethod("something"),
+				"meta1", MetaAnnotationUtilsTests.Meta1.class);
+	}
+
+	@Test
+	public void findAnnotationDescriptorWithLocalAndMetaComponentAnnotation() throws Exception {
+		Class<Transactional> annotationType = Transactional.class;
+		Method something = HasLocalAndMetaComponentAnnotation.class.getDeclaredMethod("something");
+		MetaAnnotationUtils.AnnotationOnMethodDescriptor<Transactional> descriptor = findAnnotationDescriptor(
+				something, annotationType);
+
+		assertEquals(HasLocalAndMetaComponentAnnotation.class, descriptor.getRootDeclaringClass());
+		assertEquals(annotationType, descriptor.getAnnotationType());
+		assertEquals(something, descriptor.getDeclaringMethod());
+		assertNull(descriptor.getComposedAnnotation());
+		assertNull(descriptor.getComposedAnnotationType());
+	}
+
+	@Test
+	public void findAnnotationDescriptorForInterfaceWithMetaAnnotation() throws Exception  {
+		assertAtComponentOnComposedAnnotation(InterfaceWithMetaAnnotation.class.getDeclaredMethod("something"),
+				"meta1", MetaAnnotationUtilsTests.Meta1.class);
+	}
+
+	@Test
+	public void findAnnotationDescriptorForClassWithMetaAnnotatedInterface() throws Exception {
+		Method something = ClassWithMetaAnnotatedInterface.class.getMethod("something");
+		Component rawAnnotation = findAnnotation(something, Component.class);
+
+		MetaAnnotationUtils.AnnotationOnMethodDescriptor<Component> descriptor;
+
+		descriptor = findAnnotationDescriptor(something, Component.class);
+		assertNotNull(descriptor);
+		assertEquals(ClassWithMetaAnnotatedInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(MetaAnnotationUtilsTests.Meta1.class, descriptor.getDeclaringClass());
+		assertEquals(InterfaceWithMetaAnnotation.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+		assertEquals(MetaAnnotationUtilsTests.Meta1.class, descriptor.getComposedAnnotation().annotationType());
+	}
+
+	@Test
+	public void findAnnotationDescriptorForClassWithLocalMetaAnnotationAndAnnotatedSuperclass() throws Exception {
+		Method something = MetaAnnotatedAndSuperAnnotatedContextConfigClass.class.getDeclaredMethod("something");
+		MetaAnnotationUtils.AnnotationOnMethodDescriptor<ContextConfiguration> descriptor = findAnnotationDescriptor(
+				something, ContextConfiguration.class);
+
+		assertNotNull("AnnotationDescriptor should not be null", descriptor);
+		assertEquals("rootDeclaringClass", MetaAnnotatedAndSuperAnnotatedContextConfigClass.class, descriptor.getRootDeclaringClass());
+		assertEquals("declaringClass", MetaAnnotationUtilsTests.MetaConfig.class, descriptor.getDeclaringClass());
+		assertEquals("annotationType", ContextConfiguration.class, descriptor.getAnnotationType());
+		assertEquals("method", something, descriptor.getDeclaringMethod());
+		assertNotNull("composedAnnotation should not be null", descriptor.getComposedAnnotation());
+		assertEquals("composedAnnotationType", MetaAnnotationUtilsTests.MetaConfig.class, descriptor.getComposedAnnotationType());
+
+		assertArrayEquals("configured classes", new Class[] { String.class },
+				descriptor.getAnnotationAttributes().getClassArray("classes"));
+	}
+
+	@Test
+	public void findAnnotationDescriptorForClassWithLocalMetaAnnotationAndMetaAnnotatedInterface() throws Exception {
+		assertAtComponentOnComposedAnnotation(
+				ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class.getDeclaredMethod("something"),
+				"meta2", MetaAnnotationUtilsTests.Meta2.class);
+	}
+
+	@Test
+	public void findAnnotationDescriptorForSubClassWithLocalMetaAnnotationAndMetaAnnotatedInterface() throws Exception {
+		assertAtComponentOnComposedAnnotation(
+				SubClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class.getDeclaredMethod("something"),
+				SubClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class,
+				"meta2", MetaAnnotationUtilsTests.Meta2.class);
+	}
+
+
+	@Test
+	public void findAnnotationDescriptorOnMetaMetaAnnotatedClass() throws Exception {
+		Method something = MetaMetaAnnotatedClass.class.getDeclaredMethod("something");
+		assertAtComponentOnComposedAnnotation(something, MetaMetaAnnotatedClass.class,
+				MetaAnnotationUtilsTests.Meta2.class, "meta2", MetaAnnotationUtilsTests.MetaMeta.class);
+	}
+
+	@Test
+	public void findAnnotationDescriptorOnMetaMetaMetaAnnotatedClass() throws Exception {
+		Method something = MetaMetaMetaAnnotatedClass.class.getDeclaredMethod("something");
+		assertAtComponentOnComposedAnnotation(something, MetaMetaMetaAnnotatedClass.class,
+				MetaAnnotationUtilsTests.Meta2.class, "meta2", MetaAnnotationUtilsTests.MetaMetaMeta.class);
+	}
+
+
+	@Test
+	public void findAnnotationDescriptorOnAnnotatedClassWithMissingTargetMetaAnnotation() throws Exception {
+		// InheritedAnnotationClass is NOT annotated or meta-annotated with @Component
+		MetaAnnotationUtils.AnnotationDescriptor<Component>
+				descriptor = findAnnotationDescriptor(
+						InheritedAnnotationClass.class.getDeclaredMethod("something"), Component.class);
+		assertNull("Should not find @Component on InheritedAnnotationClass", descriptor);
+	}
+
+	@Test
+	public void findAnnotationDescriptorOnMetaCycleAnnotatedClassWithMissingTargetMetaAnnotation() throws Exception {
+		MetaAnnotationUtils.AnnotationDescriptor<Component>
+				descriptor = findAnnotationDescriptor(
+						MetaCycleAnnotatedClass.class.getDeclaredMethod("something"), Component.class);
+		assertNull("Should not find @Component on MetaCycleAnnotatedClass", descriptor);
+	}
+
+	// -------------------------------------------------------------------------
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesWithNoAnnotationPresent() throws Exception {
+		assertNull(findAnnotationDescriptorForTypes(NonAnnotatedInterface.class.getDeclaredMethod("something"),
+				Transactional.class, Component.class));
+		assertNull(findAnnotationDescriptorForTypes(NonAnnotatedClass.class.getDeclaredMethod("something"),
+				Transactional.class, Order.class));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesWithInheritedAnnotationOnClass() throws Exception {
+		// Note: @Transactional is inherited
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor something = findAnnotationDescriptorForTypes(
+				InheritedAnnotationClass.class.getDeclaredMethod("something"), Transactional.class);
+		assertEquals(InheritedAnnotationClass.class, something.getRootDeclaringClass());
+		assertEquals(InheritedAnnotationClass.class, something.getDeclaringClass());
+		assertEquals(InheritedAnnotationClass.class.getDeclaredMethod("something"), something.getDeclaringMethod());
+
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor somethingOnSub = findAnnotationDescriptorForTypes(
+				SubInheritedAnnotationClass.class.getDeclaredMethod("something"), Transactional.class);
+		assertEquals(InheritedAnnotationClass.class, somethingOnSub.getDeclaringClass());
+		assertEquals(SubInheritedAnnotationClass.class, somethingOnSub.getRootDeclaringClass());
+		assertEquals(InheritedAnnotationClass.class.getDeclaredMethod("something"), somethingOnSub.getDeclaringMethod());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesWithInheritedAnnotationOnInterface() throws Exception {
+		// Note: @Transactional is inherited
+		Transactional rawAnnotation = InheritedAnnotationInterface.class.getDeclaredMethod("something")
+				.getAnnotation(Transactional.class);
+
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor descriptor;
+
+		descriptor = findAnnotationDescriptorForTypes(InheritedAnnotationInterface.class.getDeclaredMethod("something"),
+				Transactional.class);
+		assertNotNull(descriptor);
+		assertEquals(InheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+
+		descriptor = findAnnotationDescriptorForTypes(SubInheritedAnnotationInterface.class.getDeclaredMethod("something"),
+				Transactional.class);
+		assertNotNull(descriptor);
+		assertEquals(SubInheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+
+		descriptor = findAnnotationDescriptorForTypes(SubSubInheritedAnnotationInterface.class.getDeclaredMethod("something"),
+				Transactional.class);
+		assertNotNull(descriptor);
+		assertEquals(SubSubInheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(InheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesForNonInheritedAnnotationOnClass() throws Exception {
+		// Note: @Order is not inherited.
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor something = findAnnotationDescriptorForTypes(
+				NonInheritedAnnotationClass.class.getDeclaredMethod("something"), Order.class);
+		assertEquals(NonInheritedAnnotationClass.class, something.getRootDeclaringClass());
+		assertEquals(NonInheritedAnnotationClass.class, something.getDeclaringClass());
+		assertEquals(NonInheritedAnnotationClass.class.getDeclaredMethod("something"), something.getDeclaringMethod());
+
+
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor somethingOnSub = findAnnotationDescriptorForTypes(
+				SubNonInheritedAnnotationClass.class.getDeclaredMethod("something"), Order.class);
+		assertEquals(SubNonInheritedAnnotationClass.class, somethingOnSub.getRootDeclaringClass());
+		assertEquals(NonInheritedAnnotationClass.class, somethingOnSub.getDeclaringClass());
+		assertEquals(NonInheritedAnnotationClass.class.getDeclaredMethod("something"), somethingOnSub.getDeclaringMethod());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesForNonInheritedAnnotationOnInterface() throws Exception {
+		// Note: @Order is not inherited.
+		Order rawAnnotation = NonInheritedAnnotationInterface.class.getDeclaredMethod("something").getAnnotation(Order.class);
+
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor descriptor;
+
+		descriptor = findAnnotationDescriptorForTypes(
+				NonInheritedAnnotationInterface.class.getDeclaredMethod("something"), Order.class);
+		assertNotNull(descriptor);
+		assertEquals(NonInheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(NonInheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(NonInheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+
+		descriptor = findAnnotationDescriptorForTypes(
+				SubNonInheritedAnnotationInterface.class.getDeclaredMethod("something"), Order.class);
+		assertNotNull(descriptor);
+		assertEquals(SubNonInheritedAnnotationInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(NonInheritedAnnotationInterface.class, descriptor.getDeclaringClass());
+		assertEquals(NonInheritedAnnotationInterface.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesWithLocalAndMetaComponentAnnotation() throws Exception {
+		Class<Transactional> annotationType = Transactional.class;
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor descriptor = findAnnotationDescriptorForTypes(
+				HasLocalAndMetaComponentAnnotation.class.getDeclaredMethod("something"), Component.class,
+				annotationType, Order.class);
+
+		assertEquals(HasLocalAndMetaComponentAnnotation.class, descriptor.getRootDeclaringClass());
+		assertEquals(HasLocalAndMetaComponentAnnotation.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(annotationType, descriptor.getAnnotationType());
+		assertNull(descriptor.getComposedAnnotation());
+		assertNull(descriptor.getComposedAnnotationType());
+	}
+
+	private void assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(Method method, String name,
+			Class<? extends Annotation> composedAnnotationType) {
+		assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(method, method.getDeclaringClass(), name,
+				composedAnnotationType);
+	}
+
+	private void assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(Method method,
+			Class<?> rootDeclaringClass, String name, Class<? extends Annotation> composedAnnotationType) {
+		assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(method, method, rootDeclaringClass,
+				composedAnnotationType, name, composedAnnotationType);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(Method startMethod,
+			Method expectedMethod, Class<?> rootDeclaringClass, Class<?> declaringClass, String name,
+			Class<? extends Annotation> composedAnnotationType) {
+		Class<Component> annotationType = Component.class;
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor descriptor = findAnnotationDescriptorForTypes(
+				startMethod, Service.class, annotationType, Order.class, Transactional.class);
+		assertNotNull("UntypedAnnotationMethodDescriptor should not be null", descriptor);
+		assertEquals("rootDeclaringClass", rootDeclaringClass, descriptor.getRootDeclaringClass());
+		assertEquals("declaringClass", declaringClass, descriptor.getDeclaringClass());
+		assertEquals("declaringMethod", expectedMethod, descriptor.getDeclaringMethod());
+		assertEquals("annotationType", annotationType, descriptor.getAnnotationType());
+		assertEquals("component name", name, ((Component) descriptor.getAnnotation()).value());
+		assertNotNull("composedAnnotation should not be null", descriptor.getComposedAnnotation());
+		assertEquals("composedAnnotationType", composedAnnotationType, descriptor.getComposedAnnotationType());
+	}
+
+	@Test
+	public void findAnnotationDescriptorForTypesWithMetaComponentAnnotation() throws Exception {
+		assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(
+				HasMetaComponentAnnotation.class.getDeclaredMethod("something"), "meta1",
+				MetaAnnotationUtilsTests.Meta1.class);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesWithMetaAnnotationWithDefaultAttributes() throws Exception {
+		Class<?> startClass = MetaConfigWithDefaultAttributesTestCase.class;
+		Class<ContextConfiguration> annotationType = ContextConfiguration.class;
+
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor descriptor = findAnnotationDescriptorForTypes(
+				startClass.getDeclaredMethod("something"), Service.class,
+				ContextConfiguration.class, Order.class, Transactional.class);
+
+		assertNotNull(descriptor);
+		assertEquals(startClass, descriptor.getRootDeclaringClass());
+		assertEquals(MetaAnnotationUtilsTests.MetaConfig.class, descriptor.getDeclaringClass());
+		assertEquals(startClass.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(annotationType, descriptor.getAnnotationType());
+		assertArrayEquals(new Class[] {}, ((ContextConfiguration) descriptor.getAnnotation()).value());
+		assertArrayEquals(new Class[] {
+						MetaAnnotationUtilsTests.MetaConfig.DevConfig.class,
+						MetaAnnotationUtilsTests.MetaConfig.ProductionConfig.class
+		}, descriptor.getAnnotationAttributes().getClassArray("classes"));
+		assertNotNull(descriptor.getComposedAnnotation());
+		assertEquals(MetaAnnotationUtilsTests.MetaConfig.class, descriptor.getComposedAnnotationType());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesWithMetaAnnotationWithOverriddenAttributes() throws Exception {
+		Class<?> startClass = MetaConfigWithOverriddenAttributesTestCase.class;
+		Class<ContextConfiguration> annotationType = ContextConfiguration.class;
+
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor descriptor = findAnnotationDescriptorForTypes(
+				startClass.getDeclaredMethod("something"), Service.class,
+				ContextConfiguration.class, Order.class, Transactional.class);
+
+		assertNotNull(descriptor);
+		assertEquals(startClass, descriptor.getRootDeclaringClass());
+		assertEquals(MetaAnnotationUtilsTests.MetaConfig.class, descriptor.getDeclaringClass());
+		assertEquals(startClass.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(annotationType, descriptor.getAnnotationType());
+		assertArrayEquals(new Class[] {}, ((ContextConfiguration) descriptor.getAnnotation()).value());
+		assertArrayEquals(new Class[] { MetaAnnotationUtilsTests.class },
+				descriptor.getAnnotationAttributes().getClassArray("classes"));
+		assertNotNull(descriptor.getComposedAnnotation());
+		assertEquals(MetaAnnotationUtilsTests.MetaConfig.class, descriptor.getComposedAnnotationType());
+	}
+
+	@Test
+	public void findAnnotationDescriptorForTypesForInterfaceWithMetaAnnotation() throws Exception {
+		assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(
+				InterfaceWithMetaAnnotation.class.getDeclaredMethod("something"),
+				"meta1", MetaAnnotationUtilsTests.Meta1.class);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesForClassWithMetaAnnotatedInterface() throws Exception {
+		Component rawAnnotation = findAnnotation(ClassWithMetaAnnotatedInterface.class.getDeclaredMethod("something"),
+				Component.class);
+
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor descriptor;
+
+		descriptor = findAnnotationDescriptorForTypes(
+				ClassWithMetaAnnotatedInterface.class.getDeclaredMethod("something"),
+				Service.class, Component.class, Order.class, Transactional.class);
+		assertNotNull(descriptor);
+		assertEquals(ClassWithMetaAnnotatedInterface.class, descriptor.getRootDeclaringClass());
+		assertEquals(MetaAnnotationUtilsTests.Meta1.class, descriptor.getDeclaringClass());
+		assertEquals(InterfaceWithMetaAnnotation.class.getDeclaredMethod("something"), descriptor.getDeclaringMethod());
+		assertEquals(rawAnnotation, descriptor.getAnnotation());
+		assertEquals(MetaAnnotationUtilsTests.Meta1.class, descriptor.getComposedAnnotation().annotationType());
+	}
+
+	@Test
+	public void findAnnotationDescriptorForTypesForClassWithLocalMetaAnnotationAndMetaAnnotatedInterface() throws Exception {
+		assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(
+				ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class.getDeclaredMethod("something"),
+				"meta2", MetaAnnotationUtilsTests.Meta2.class);
+	}
+
+	@Test
+	public void findAnnotationDescriptorForTypesForSubClassWithLocalMetaAnnotationAndMetaAnnotatedInterface() throws Exception {
+		assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(
+				SubClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class.getDeclaredMethod("something"),
+				ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class.getDeclaredMethod("something"),
+				SubClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class,
+				MetaAnnotationUtilsTests.Meta2.class, "meta2", MetaAnnotationUtilsTests.Meta2.class);
+	}
+
+	@Test
+	public void findAnnotationDescriptorForTypesOnMetaMetaAnnotatedClass() throws Exception {
+		Class<MetaMetaAnnotatedClass> startClass = MetaMetaAnnotatedClass.class;
+		Method something = startClass.getDeclaredMethod("something");
+		assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(
+				something, something,
+				startClass, MetaAnnotationUtilsTests.Meta2.class, "meta2",
+				MetaAnnotationUtilsTests.MetaMeta.class);
+	}
+
+	@Test
+	public void findAnnotationDescriptorForTypesOnMetaMetaMetaAnnotatedClass() throws Exception {
+		Class<MetaMetaMetaAnnotatedClass> startClass = MetaMetaMetaAnnotatedClass.class;
+		Method something = startClass.getDeclaredMethod("something");
+		assertAtComponentOnComposedAnnotationForMultipleCandidateTypes(
+				something, something,
+				startClass, MetaAnnotationUtilsTests.Meta2.class, "meta2",
+				MetaAnnotationUtilsTests.MetaMetaMeta.class);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesOnAnnotatedClassWithMissingTargetMetaAnnotation() throws Exception {
+		// InheritedAnnotationClass is NOT annotated or meta-annotated with @Component,
+		// @Service, or @Order, but it is annotated with @Transactional.
+		MetaAnnotationUtils.UntypedAnnotationOnMethodDescriptor
+				descriptor = findAnnotationDescriptorForTypes(InheritedAnnotationClass.class.getDeclaredMethod("something"),
+				Service.class, Component.class, Order.class);
+		assertNull("Should not find @Component on InheritedAnnotationClass", descriptor);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAnnotationDescriptorForTypesOnMetaCycleAnnotatedClassWithMissingTargetMetaAnnotation() throws Exception {
+		MetaAnnotationUtils.UntypedAnnotationDescriptor
+				descriptor = findAnnotationDescriptorForTypes(MetaCycleAnnotatedClass.class.getDeclaredMethod("something"),
+				Service.class, Component.class, Order.class);
+		assertNull("Should not find @Component on MetaCycleAnnotatedClass", descriptor);
+	}
+
+	// -------------------------------------------------------------------------
+
+	static class HasMetaComponentAnnotation {
+		@MetaAnnotationUtilsTests.Meta1
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class HasLocalAndMetaComponentAnnotation {
+		@MetaAnnotationUtilsTests.Meta1
+		@Transactional
+		@MetaAnnotationUtilsTests.Meta2
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	interface InterfaceWithMetaAnnotation {
+		@MetaAnnotationUtilsTests.Meta1
+		void something();
+	}
+
+	static class ClassWithMetaAnnotatedInterface implements InterfaceWithMetaAnnotation {
+		@Override
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface implements InterfaceWithMetaAnnotation {
+		@Override
+		@MetaAnnotationUtilsTests.Meta2
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class SubClassWithLocalMetaAnnotationAndMetaAnnotatedInterface extends ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface {
+		@Override
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class MetaMetaAnnotatedClass {
+		@MetaAnnotationUtilsTests.MetaMeta
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class MetaMetaMetaAnnotatedClass {
+		@MetaAnnotationUtilsTests.MetaMetaMeta
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class MetaCycleAnnotatedClass {
+		@MetaAnnotationUtilsTests.MetaCycle3
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	public class MetaConfigWithDefaultAttributesTestCase {
+		@MetaAnnotationUtilsTests.MetaConfig
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	public class MetaConfigWithOverriddenAttributesTestCase {
+		@MetaAnnotationUtilsTests.MetaConfig(classes = MetaAnnotationUtilsTests.class)
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	interface InheritedAnnotationInterface {
+		@Transactional
+		void something();
+	}
+
+	interface SubInheritedAnnotationInterface extends InheritedAnnotationInterface {
+		@Override
+		void something();
+	}
+
+	interface SubSubInheritedAnnotationInterface extends SubInheritedAnnotationInterface {
+		@Override
+		void something();
+	}
+
+	interface NonInheritedAnnotationInterface {
+		@Order
+		void something();
+	}
+
+	interface SubNonInheritedAnnotationInterface extends NonInheritedAnnotationInterface {
+		@Override
+		void something();
+	}
+
+	static class NonAnnotatedClass {
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	interface NonAnnotatedInterface {
+		void something();
+	}
+
+	static class InheritedAnnotationClass {
+		@Transactional
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class SubInheritedAnnotationClass extends InheritedAnnotationClass {
+		@Override
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class NonInheritedAnnotationClass {
+		@Order
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class SubNonInheritedAnnotationClass extends NonInheritedAnnotationClass {
+		@Override
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class AnnotatedContextConfigClass {
+		@ContextConfiguration(classes = Number.class)
+		public void something(){
+			// for test purposes
+		}
+	}
+
+	static class MetaAnnotatedAndSuperAnnotatedContextConfigClass extends AnnotatedContextConfigClass {
+		@MetaAnnotationUtilsTests.MetaConfig(classes = String.class)
+		@Override
+		public void something(){
+			// for test purposes
+		}
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/util/MetaAnnotationUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/util/MetaAnnotationUtilsTests.java
@@ -491,7 +491,7 @@ public class MetaAnnotationUtilsTests {
 	@Component(value = "meta1")
 	@Order
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	@Documented
 	static @interface Meta1 {
 	}
@@ -499,21 +499,21 @@ public class MetaAnnotationUtilsTests {
 	@Component(value = "meta2")
 	@Transactional
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	@Documented
 	static @interface Meta2 {
 	}
 
 	@Meta2
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	@Documented
 	@interface MetaMeta {
 	}
 
 	@MetaMeta
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	@Documented
 	@interface MetaMetaMeta {
 	}
@@ -534,14 +534,14 @@ public class MetaAnnotationUtilsTests {
 
 	@MetaCycle2
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	@Documented
 	@interface MetaCycle3 {
 	}
 
 	@ContextConfiguration
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	@Documented
 	static @interface MetaConfig {
 


### PR DESCRIPTION
Prior Spring TestContext Framework had not supported
@ContextConfiguration annotation on the method-level.

This commit enables @ContextConfiguration and
@ContextHierarchy to be the method-level annotations.
Now TCF will emit fully configured throw-away
TestContext for the particular test method.

Issue: [SPR-12031](https://jira.spring.io/browse/SPR-12031)