### PR TITLE
Add some new matchers for query parameters into MockRestRequestMatchers

### DIFF
--- a/spring-test/src/test/java/org/springframework/test/web/client/match/MockRestRequestMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/match/MockRestRequestMatchersTests.java
@@ -16,18 +16,20 @@
 
 package org.springframework.test.web.client.match;
 
-import java.net.URI;
-import java.util.Arrays;
-
 import org.junit.Test;
-
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.test.web.client.RequestMatcher;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import static org.hamcrest.Matchers.*;
+import java.net.URI;
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 /**
  * Unit tests for {@link MockRestRequestMatchers}.
@@ -136,7 +138,9 @@ public class MockRestRequestMatchersTests {
 	public void queryParameter() throws Exception {
 		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
 
-		MockRestRequestMatchers.queryParameter("foo", "bar", "baz").match(this.request);
+		RequestMatcher requestMatcher = MockRestRequestMatchers.queryParameter("foo", "bar", "baz");
+		assertThat("Factory method did not create any request matcher", requestMatcher, notNullValue());
+		requestMatcher.match(this.request);
 	}
 
 	@Test(expected = AssertionError.class)
@@ -161,7 +165,9 @@ public class MockRestRequestMatchersTests {
 	public void queryParameterContains() throws Exception {
 		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
 
-		MockRestRequestMatchers.queryParameter("foo", containsString("ba")).match(this.request);
+        RequestMatcher requestMatcher = MockRestRequestMatchers.queryParameter("foo", containsString("ba"));
+        assertThat("Factory method did not create any request matcher", requestMatcher, notNullValue());
+        requestMatcher.match(this.request);
 	}
 
 	@Test(expected = AssertionError.class)
@@ -175,7 +181,9 @@ public class MockRestRequestMatchersTests {
 	public void queryParameters() throws Exception {
 		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
 
-		MockRestRequestMatchers.queryParameter("foo", "bar", "baz").match(this.request);
+        RequestMatcher requestMatcher = MockRestRequestMatchers.queryParameter("foo", "bar", "baz");
+        assertThat("Factory method did not create any request matcher", requestMatcher, notNullValue());
+        requestMatcher.match(this.request);
 	}
 
 	@Test(expected = AssertionError.class)

--- a/spring-test/src/test/java/org/springframework/test/web/client/match/MockRestRequestMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/match/MockRestRequestMatchersTests.java
@@ -23,6 +23,9 @@ import org.junit.Test;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.hamcrest.Matchers.*;
 
@@ -127,6 +130,70 @@ public class MockRestRequestMatchersTests {
 		this.request.getHeaders().put("foo", Arrays.asList("bar"));
 
 		MockRestRequestMatchers.header("foo", "bar", "baz").match(this.request);
+	}
+
+	@Test
+	public void queryParameter() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+		MockRestRequestMatchers.queryParameter("foo", "bar", "baz").match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void queryParameterMissing() throws Exception {
+		this.request.setURI(UriComponentsBuilder
+				.fromUriString("http://foo.com")
+				.path("/bar")
+				.build().encode()
+				.toUri());
+
+		MockRestRequestMatchers.queryParameter("foo", "bar").match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void queryParameterMissingValue() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+		MockRestRequestMatchers.queryParameter("foo", "bad").match(this.request);
+	}
+
+	@Test
+	public void queryParameterContains() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+		MockRestRequestMatchers.queryParameter("foo", containsString("ba")).match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void queryParameterContainsWithMissingValue() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+		MockRestRequestMatchers.queryParameter("foo", containsString("bx")).match(this.request);
+	}
+
+	@Test
+	public void queryParameters() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+		MockRestRequestMatchers.queryParameter("foo", "bar", "baz").match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void queryParametersWithMissingValue() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar"));
+
+		MockRestRequestMatchers.queryParameter("foo", "bar", "baz").match(this.request);
+	}
+
+
+	private URI createUriWithQueryParameters(String key, String ... values) {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.put(key, Arrays.asList(values));
+		return UriComponentsBuilder
+				.fromUriString("http://foo.com")
+				.path("/bar")
+				.queryParams(params)
+				.build().encode().toUri();
 	}
 
 }


### PR DESCRIPTION
Hello,
as I have seen there isn't any request matcher for query parameters in the project spring-test.
I'd like to use it in the project spring-cloud-contract and imho the place of these code pieces are here.
If you have the same feelings please merge this pull request. :)

Thanks.