### PR TITLE
SPR-14988: @GetMapping method annotation uses consumes attribute from @RequestMapping class annotation

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/GetMapping.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/GetMapping.java
@@ -31,9 +31,6 @@ import org.springframework.core.annotation.AliasFor;
  * <p>Specifically, {@code @GetMapping} is a <em>composed annotation</em> that
  * acts as a shortcut for {@code @RequestMapping(method = RequestMethod.GET)}.
  *
- * <h5>Difference between {@code @GetMapping} &amp; {@code @RequestMapping}</h5>
- * <p>{@code @GetMapping} does not support the {@link RequestMapping#consumes consumes}
- * attribute of {@code @RequestMapping}.
  *
  * @author Sam Brannen
  * @since 4.3
@@ -78,6 +75,13 @@ public @interface GetMapping {
 	 */
 	@AliasFor(annotation = RequestMapping.class)
 	String[] headers() default {};
+
+	/**
+	 * Alias for {@link RequestMapping#consumes}.
+	 * @since 4.3.5
+	 */
+	@AliasFor(annotation = RequestMapping.class)
+	String[] consumes() default {};
 
 	/**
 	 * Alias for {@link RequestMapping#produces}.

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMappingTests.java
@@ -22,6 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -145,6 +146,17 @@ public class RequestMappingHandlerMappingTests {
 			info.getProducesCondition().getProducibleMediaTypes().iterator().next().toString());
 	}
 
+	/**
+	 * SPR-14988: Add consumes() attribute to @GetMapping annotation
+	 */
+	@Test
+	public void getMappingOverridesConsumesFromTypeLevelAnnotation() throws Exception {
+		RequestMappingInfo requestMappingInfo = assertComposedAnnotationMapping(RequestMethod.GET);
+
+		assertArrayEquals(new MediaType[]{MediaType.ALL},
+				new ArrayList<MediaType>(requestMappingInfo.getConsumesCondition().getConsumableMediaTypes()).toArray());
+	}
+
 	@Test
 	public void getMapping() throws Exception {
 		assertComposedAnnotationMapping(RequestMethod.GET);
@@ -199,6 +211,7 @@ public class RequestMappingHandlerMappingTests {
 
 
 	@Controller
+	@RequestMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
 	static class ComposedAnnotationController {
 
 		@RequestMapping
@@ -209,7 +222,7 @@ public class RequestMappingHandlerMappingTests {
 		public void postJson() {
 		}
 
-		@GetMapping("/get")
+		@GetMapping(value = "/get", consumes = MediaType.ALL_VALUE)
 		public void get() {
 		}
 


### PR DESCRIPTION
[SPR-14988: @GetMapping method annotation uses consumes attribute from @RequestMapping class annotation](https://jira.spring.io/browse/SPR-14988)

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.
