### PR TITLE
SPR-14990 - Update JdbcUtils to improve enum support

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcUtils.java
@@ -131,7 +131,7 @@ public abstract class JdbcUtils {
 	 * @see #getResultSetValue(ResultSet, int)
 	 */
 	public static Object getResultSetValue(ResultSet rs, int index, Class<?> requiredType) throws SQLException {
-		if (requiredType == null) {
+		if (requiredType == null || requiredType.isEnum()) {
 			return getResultSetValue(rs, index);
 		}
 


### PR DESCRIPTION
Since we have StringToEnumConverter and IntegerToEnumConverter in shared DefaultConversionService, BeanPropertyRowMapper supports Enum now, but there is a little problem with jdbc 4.1 rs.getObject(index,type), if type is Enum it will always return null, actually we need String or Integer here, use rs.getObject(index) is fine.