### PR TITLE
SPR-13508 - Add i18n support to ScriptTemplateView

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/ResourceBundleMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/ResourceBundleMessageSource.java
@@ -26,6 +26,8 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -298,6 +300,45 @@ public class ResourceBundleMessageSource extends AbstractResourceBasedMessageSou
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Given a resource bundle basename and Locale, produces a Map containing all
+	 * messages if the resource bundle exists.
+	 *
+	 * @param basename the ResourceBundle basename to lookup.
+	 * @param locale the Locale to use.
+	 * @return a Map of messages if found.
+	 */
+	public Map<String, Object> getMessageMap(String basename, Locale locale) {
+		ResourceBundle resourceBundle = getResourceBundle(basename, locale);
+		if(resourceBundle == null) return Collections.emptyMap();
+
+		Map<String, Object> messages = new HashMap<>();
+		Enumeration<String> keys = resourceBundle.getKeys();
+
+		while(keys.hasMoreElements()) {
+			String key = keys.nextElement();
+			Object value = resourceBundle.getObject(key);
+			messages.put(key, value);
+		}
+
+		return messages;
+	}
+
+	/**
+	 * Given a Locale, produces a Map containing all messages for the first basename
+	 * in the basename set.
+	 *
+	 * @param locale the Locale to use.
+	 * @return a Map of messages if found.
+	 */
+	public Map<String, Object> getMessageMap(Locale locale) {
+		Set<String> basenames = getBasenameSet();
+		for (String basename : basenames) {
+			return getMessageMap(basename, locale);
+		}
+		return Collections.emptyMap();
 	}
 
 	/**

--- a/spring-context/src/main/java/org/springframework/context/support/ResourceBundleMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/ResourceBundleMessageSource.java
@@ -26,6 +26,8 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -298,6 +300,46 @@ public class ResourceBundleMessageSource extends AbstractResourceBasedMessageSou
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Given a resource bundle basename and Locale, produces a Map containing all
+	 * messages if the resource bundle exists.
+	 *
+	 * @param basename the ResourceBundle basename to lookup.
+	 * @param locale the Locale to use.
+	 * @return a Map of messages if found.
+	 */
+	public Map<String, Object> getMessageMap(String basename, Locale locale) {
+		ResourceBundle resourceBundle = getResourceBundle(basename, locale);
+		if(resourceBundle == null) return Collections.emptyMap();
+
+		Map<String, Object> messages = new HashMap<>();
+		Enumeration<String> keys = resourceBundle.getKeys();
+
+		while(keys.hasMoreElements()) {
+			String key = keys.nextElement();
+			Object value = resourceBundle.getObject(key);
+			messages.put(key, value);
+		}
+
+		return messages;
+	}
+
+	/**
+	 * Given a Locale, produces a Map containing all messages for the first basename
+	 * in the basename set.
+	 *
+	 * @param locale the Locale to use.
+	 * @return a Map of messages if found.
+	 */
+	public Map<String, Object> getMessageMap(Locale locale) {
+		Set<String> basenames = getBasenameSet();
+		for (String basename : basenames) {
+		    Map<String, Object> messages = getMessageMap(basename, locale);
+			if (!messages.isEmpty()) return messages;
+		}
+		return Collections.emptyMap();
 	}
 
 	/**

--- a/spring-context/src/main/java/org/springframework/context/support/ResourceBundleMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/ResourceBundleMessageSource.java
@@ -336,7 +336,8 @@ public class ResourceBundleMessageSource extends AbstractResourceBasedMessageSou
 	public Map<String, Object> getMessageMap(Locale locale) {
 		Set<String> basenames = getBasenameSet();
 		for (String basename : basenames) {
-			return getMessageMap(basename, locale);
+		    Map<String, Object> messages = getMessageMap(basename, locale);
+			if (!messages.isEmpty()) return messages;
 		}
 		return Collections.emptyMap();
 	}

--- a/spring-context/src/test/java/org/springframework/context/support/ResourceBundleMessageSourceTests.java
+++ b/spring-context/src/test/java/org/springframework/context/support/ResourceBundleMessageSourceTests.java
@@ -18,6 +18,7 @@ package org.springframework.context.support;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.ResourceBundle;
 
@@ -407,6 +408,18 @@ public class ResourceBundleMessageSourceTests {
 		MessageSourceResourceBundle rbg = new MessageSourceResourceBundle(ms, Locale.GERMAN);
 		assertEquals("nachricht2", rbg.getString("code2"));
 		assertTrue(rbg.containsKey("code2"));
+	}
+
+	@Test
+	public void testMessageSourceResourceBundleMap() {
+		ResourceBundleMessageSource ms = new ResourceBundleMessageSource();
+		ms.setBasename("org/springframework/context/support/messages");
+		Map<String, Object> englishMesages = ms.getMessageMap(Locale.ENGLISH);
+		assertTrue(englishMesages.containsKey("code1"));
+		assertEquals("message1", englishMesages.get("code1"));
+		Map<String, Object> germanMessages = ms.getMessageMap(Locale.GERMAN);
+		assertTrue(germanMessages.containsKey("code2"));
+		assertEquals("nachricht2", germanMessages.get("code2"));
 	}
 
 

--- a/spring-context/src/test/java/org/springframework/context/support/ResourceBundleMessageSourceTests.java
+++ b/spring-context/src/test/java/org/springframework/context/support/ResourceBundleMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/script/ScriptTemplateConfig.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/script/ScriptTemplateConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,5 +75,10 @@ public interface ScriptTemplateConfig {
 	 * Return the resource loader path(s) via a Spring resource location.
 	 */
 	String getResourceLoaderPath();
+
+	/**
+	 * Return the resource bundle basename for use in i18n.
+	 */
+	String getResourceBundleBasename();
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/script/ScriptTemplateConfigurer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/script/ScriptTemplateConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,8 @@ public class ScriptTemplateConfigurer implements ScriptTemplateConfig {
 	private Charset charset;
 
 	private String resourceLoaderPath;
+
+	private String resourceBundleBasename;
 
 
 	/**
@@ -222,4 +224,16 @@ public class ScriptTemplateConfigurer implements ScriptTemplateConfig {
 		return this.resourceLoaderPath;
 	}
 
+	/**
+	 * Set the resource bundle basename for i18n.
+	 * @param resourceBundleBasename the resource bundle basename.
+	 */
+	public void setResourceBundleBasename(String resourceBundleBasename) {
+		this.resourceBundleBasename = resourceBundleBasename;
+	}
+
+	@Override
+	public String getResourceBundleBasename() {
+		return this.resourceBundleBasename;
+	}
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/script/ScriptTemplateViewTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/script/ScriptTemplateViewTests.java
@@ -209,7 +209,7 @@ public class ScriptTemplateViewTests {
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		Map<String, Object> model = new HashMap<>();
 		InvocableScriptEngine engine = mock(InvocableScriptEngine.class);
-		when(engine.invokeFunction(any(), any(), any(), any())).thenReturn("foo");
+		when(engine.invokeFunction(any(), any(), any(), any(), any())).thenReturn("foo");
 		this.view.setEngine(engine);
 		this.view.setRenderFunction("render");
 		this.view.setApplicationContext(this.wac);

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/jruby/render.rb
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/jruby/render.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 require 'java'
 
 # Renders an ERB template against a hashmap of variables.
-def render(template, variables, url)
+def render(template, variables, url, messages)
   context = OpenStruct.new(variables).instance_eval do
     variables.each do |k, v|
       instance_variable_set(k, v) if k[0] == '@'

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/jython/render.py
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/jython/render.py
@@ -1,5 +1,5 @@
 from string import Template
 
-def render(template, model, url):
+def render(template, model, url, messages):
 	s = Template(template)
 	return s.substitute(model)

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/messages_en.properties
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/messages_en.properties
@@ -1,0 +1,2 @@
+title=Hello Spring!
+body=This is the body

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/messages_fr.properties
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/messages_fr.properties
@@ -1,0 +1,2 @@
+title=Bonjour Spring!
+body=Voici le corps de la page

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/nashorn/render.js
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/script/nashorn/render.js
@@ -5,3 +5,7 @@ function render(template, model) {
 function renderWithUrl(template, model, url) {
     return template.replace("{{title}}", "Check url parameter").replace("{{body}}", url);
 }
+
+function renderWithMessages(template, model, url, messages) {
+    return template.replace("{{title}}", messages.title).replace("{{body}}", messages.body);
+}


### PR DESCRIPTION
The current `ScriptTemplateView` does not provide support for internationalization using a message resource bundle on the classpath.  This PR allows configuring a resource bundle basename on the `ScriptTemplateConfigurer` and then load that resource bundle at render time using the `HttpServletRequest` locale.

Two new methods have been added to `ResourceBundleMessageSource` allowing to return a `ResourceBundle` as a `Map` for a given basename and locale, or simply for a given locale.  The resulting map can then be passed to the render function from `ScriptTemplateView` where it can be used to replace message placeholders in the template.

Issue: SPR-13508

I have signed the CLA.