### PR TITLE
SPR-14995 - Add some new matchers for query parameters into MockRestRequestMatchers

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/match/MockRestRequestMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/match/MockRestRequestMatchers.java
@@ -18,6 +18,7 @@ package org.springframework.test.web.client.match;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import javax.xml.xpath.XPathExpressionException;
@@ -31,7 +32,11 @@ import org.springframework.test.util.AssertionErrors;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.RequestMatcher;
 import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.*;
 import static org.springframework.test.util.AssertionErrors.*;
 
@@ -153,9 +158,75 @@ public abstract class MockRestRequestMatchers {
 	}
 
 	private static void assertHeaderValueCount(final String name, HttpHeaders headers, int expectedCount) {
-		List<String> actualValues = headers.get(name);
-		AssertionErrors.assertTrue("Expected header <" + name + ">", actualValues != null);
-		AssertionErrors.assertTrue("Expected header <" + name + "> to have at least <" + expectedCount +
+		assertMultiValueMapCount("header", name, headers, expectedCount);
+	}
+
+
+	/**
+	 * Assert request query parameter values with the given Hamcrest matcher.
+	 */
+	@SafeVarargs
+	public static RequestMatcher queryParameter(final String name, final Matcher<? super String>... matchers) {
+		return queryParameter(name, UTF_8, matchers);
+	}
+
+	/**
+	 * Assert request query parameter values with the given Hamcrest matcher.
+	 */
+	@SafeVarargs
+	public static RequestMatcher queryParameter(final String name, final Charset charset,
+												final Matcher<? super String>... matchers) {
+		return new RequestMatcher() {
+			@Override
+			public void match(ClientHttpRequest request) {
+				MultiValueMap<String, String> queryParameters = getQueryParameters(request.getURI().toString(), charset);
+				assertQueryParameterValueCount(name, queryParameters, matchers.length);
+				for (int i = 0 ; i < matchers.length; i++) {
+					assertThat("Request query parameter", queryParameters.get(name).get(i), matchers[i]);
+				}
+			}
+		};
+	}
+
+	/**
+	 * Assert request query parameter values.
+	 */
+	public static RequestMatcher queryParameter(final String name, final String... expectedValues) {
+		return queryParameter(name, UTF_8, expectedValues);
+	}
+
+	/**
+	 * Assert request query parameter values.
+	 */
+	public static RequestMatcher queryParameter(final String name, final Charset charset, final String... expectedValues) {
+		return new RequestMatcher() {
+			@Override
+			public void match(ClientHttpRequest request) {
+				MultiValueMap<String, String> queryParameters = getQueryParameters(request.getURI().toString(), charset);
+				assertQueryParameterValueCount(name, queryParameters, expectedValues.length);
+				for (int i = 0 ; i < expectedValues.length; i++) {
+					assertEquals("Request query parameter + [" + name + "]",
+							expectedValues[i], queryParameters.get(name).get(i));
+				}
+			}
+		};
+	}
+
+	private static MultiValueMap<String, String> getQueryParameters(String uri, Charset charset) {
+		String decodeUri = UriUtils.decode(uri, charset);
+		MultiValueMap<String, String> queryParameters = UriComponentsBuilder.fromUriString(decodeUri)
+				.build().getQueryParams();
+		return queryParameters;
+	}
+
+	private static void assertQueryParameterValueCount(final String name, MultiValueMap<String, String> queryParameters, int expectedCount) {
+		assertMultiValueMapCount("query parameter", name, queryParameters, expectedCount);
+	}
+
+	private static void assertMultiValueMapCount(String type, final String name, MultiValueMap<String, String> multiValueMap, int expectedCount) {
+		List<String> actualValues = multiValueMap.get(name);
+		assertTrue("Expected " + type + " <" + name + ">", actualValues != null);
+		assertTrue("Expected " + type + " <" + name + "> to have at least <" + expectedCount +
 				"> values but found " + actualValues, expectedCount <= actualValues.size());
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/web/client/match/MockRestRequestMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/match/MockRestRequestMatchersTests.java
@@ -16,15 +16,20 @@
 
 package org.springframework.test.web.client.match;
 
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.test.web.client.RequestMatcher;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
 import java.net.URI;
 import java.util.Arrays;
 
-import org.junit.Test;
-
-import org.springframework.http.HttpMethod;
-import org.springframework.mock.http.client.MockClientHttpRequest;
-
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 /**
  * Unit tests for {@link MockRestRequestMatchers}.
@@ -127,6 +132,76 @@ public class MockRestRequestMatchersTests {
 		this.request.getHeaders().put("foo", Arrays.asList("bar"));
 
 		MockRestRequestMatchers.header("foo", "bar", "baz").match(this.request);
+	}
+
+	@Test
+	public void queryParameter() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+		RequestMatcher requestMatcher = MockRestRequestMatchers.queryParameter("foo", "bar", "baz");
+		assertThat("Factory method did not create any request matcher", requestMatcher, notNullValue());
+		requestMatcher.match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void queryParameterMissing() throws Exception {
+		this.request.setURI(UriComponentsBuilder
+				.fromUriString("http://foo.com")
+				.path("/bar")
+				.build().encode()
+				.toUri());
+
+		MockRestRequestMatchers.queryParameter("foo", "bar").match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void queryParameterMissingValue() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+		MockRestRequestMatchers.queryParameter("foo", "bad").match(this.request);
+	}
+
+	@Test
+	public void queryParameterContains() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+        RequestMatcher requestMatcher = MockRestRequestMatchers.queryParameter("foo", containsString("ba"));
+        assertThat("Factory method did not create any request matcher", requestMatcher, notNullValue());
+        requestMatcher.match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void queryParameterContainsWithMissingValue() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+		MockRestRequestMatchers.queryParameter("foo", containsString("bx")).match(this.request);
+	}
+
+	@Test
+	public void queryParameters() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar", "baz"));
+
+        RequestMatcher requestMatcher = MockRestRequestMatchers.queryParameter("foo", "bar", "baz");
+        assertThat("Factory method did not create any request matcher", requestMatcher, notNullValue());
+        requestMatcher.match(this.request);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void queryParametersWithMissingValue() throws Exception {
+		this.request.setURI(createUriWithQueryParameters("foo", "bar"));
+
+		MockRestRequestMatchers.queryParameter("foo", "bar", "baz").match(this.request);
+	}
+
+
+	private URI createUriWithQueryParameters(String key, String ... values) {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.put(key, Arrays.asList(values));
+		return UriComponentsBuilder
+				.fromUriString("http://foo.com")
+				.path("/bar")
+				.queryParams(params)
+				.build().encode().toUri();
 	}
 
 }


### PR DESCRIPTION
Hello,
as I have seen there isn't any request matcher for query parameters in the project spring-test.
I'd like to use it in the project spring-cloud-contract and imho the place of these code pieces are here.
If you have the same feelings please merge this pull request. :)
The factory methods for query parameters also support charset for URI decoding or use the default one (UTF_8)

Thanks.