### PR TITLE
SPR-14953: Provide shortcut methods for routing

### DIFF
--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/function/RouterFunction.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/function/RouterFunction.java
@@ -18,6 +18,8 @@ package org.springframework.web.reactive.function;
 
 import java.util.Optional;
 
+import static org.springframework.web.reactive.function.RequestPredicates.*;
+
 /**
  * Represents a function that routes to a {@linkplain HandlerFunction handler function}.
  *
@@ -86,6 +88,41 @@ public interface RouterFunction<T> {
 	default <S> RouterFunction<?> andRoute(RequestPredicate predicate,
 			HandlerFunction<S> handlerFunction) {
 		return and(RouterFunctions.route(predicate, handlerFunction));
+	}
+
+	/**
+	 * Shortcut for {@link #andRoute(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#GET(String)}.
+	 */
+	default <S> RouterFunction<?> andRouteGet(String pattern, HandlerFunction<S> handlerFunction) {
+		return andRoute(GET(pattern), handlerFunction);
+	}
+
+	/**
+	 * Shortcut for {@link #andRoute(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#POST(String)}.
+	 */
+	default <S> RouterFunction<?> andRoutePost(String pattern, HandlerFunction<S> handlerFunction) {
+		return andRoute(POST(pattern), handlerFunction);
+	}
+
+	/**
+	 * Shortcut for {@link #andRoute(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#PUT(String)}.
+	 */
+	default <S> RouterFunction<?> andRoutePut(String pattern, HandlerFunction<S> handlerFunction) {
+		return andRoute(PUT(pattern), handlerFunction);
+	}
+
+	/**
+	 * Shortcut for {@link #andRoute(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#PATCH(String)}.
+	 */
+	default <S> RouterFunction<?> andRoutePatch(String pattern, HandlerFunction<S> handlerFunction) {
+		return andRoute(PATCH(pattern), handlerFunction);
+	}
+
+	/**
+	 * Shortcut for {@link #andRoute(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#DELETE(String)}.
+	 */
+	default <S> RouterFunction<?> andRouteDelete(String pattern, HandlerFunction<S> handlerFunction) {
+		return andRoute(DELETE(pattern), handlerFunction);
 	}
 
 	/**

--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/function/RouterFunctions.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/function/RouterFunctions.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static org.springframework.web.reactive.function.RequestPredicates.*;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.io.Resource;
@@ -74,12 +75,52 @@ public abstract class RouterFunctions {
 	 * @return a router function that routes to {@code handlerFunction} if
 	 * {@code predicate} evaluates to {@code true}
 	 * @see RequestPredicates
+	 * @see #routeGet(String, HandlerFunction)
+	 * @see #routePost(String, HandlerFunction)
+	 * @see #routePut(String, HandlerFunction)
+	 * @see #routePatch(String, HandlerFunction)
+	 * @see #routeDelete(String, HandlerFunction)
 	 */
 	public static <T> RouterFunction<T> route(RequestPredicate predicate, HandlerFunction<T> handlerFunction) {
 		Assert.notNull(predicate, "'predicate' must not be null");
 		Assert.notNull(handlerFunction, "'handlerFunction' must not be null");
 
 		return request -> predicate.test(request) ? Optional.of(handlerFunction) : Optional.empty();
+	}
+
+	/**
+	 * Shortcut for {@link #route(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#GET(String)}.
+	 */
+	public static <T> RouterFunction<T> routeGet(String pattern, HandlerFunction<T> handlerFunction) {
+		return route(GET(pattern), handlerFunction);
+	}
+
+	/**
+	 * Shortcut for {@link #route(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#POST(String)}.
+	 */
+	public static <T> RouterFunction<T> routePost(String pattern, HandlerFunction<T> handlerFunction) {
+		return route(POST(pattern), handlerFunction);
+	}
+
+	/**
+	 * Shortcut for {@link #route(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#PUT(String)}.
+	 */
+	public static <T> RouterFunction<T> routePut(String pattern, HandlerFunction<T> handlerFunction) {
+		return route(PUT(pattern), handlerFunction);
+	}
+
+	/**
+	 * Shortcut for {@link #route(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#PATCH(String)}.
+	 */
+	public static <T> RouterFunction<T> routePatch(String pattern, HandlerFunction<T> handlerFunction) {
+		return route(PATCH(pattern), handlerFunction);
+	}
+
+	/**
+	 * Shortcut for {@link #route(RequestPredicate, HandlerFunction)} + {@link RequestPredicates#DELETE(String)}.
+	 */
+	public static <T> RouterFunction<T> routeDelete(String pattern, HandlerFunction<T> handlerFunction) {
+		return route(DELETE(pattern), handlerFunction);
 	}
 
 	/**


### PR DESCRIPTION
This PR make the route declaration shorter and more readable, for example for Reactor website:

Instead of:
```java
private static RouterFunction<?> routes() {
	return route(GET("/docs/api/**"), request ->
			status(FOUND).location(URI.create(request.path().replace("/docs/", "/old/"))).build())
		.andRoute(GET("/docs/reference/**"), request ->
			status(FOUND).location(URI.create(request.path().replace("/docs/", "/old/"))).build())
		.andRoute(GET("/docs/raw/**"), request ->
			status(FOUND).location(URI.create(request.path().replace("/docs/", "/old/"))).build())
		.andRoute(GET("/docs/{dir}/api"), request ->
			status(FOUND).location(URI.create(request.path().replace("api", "release"))).build())
		.andRoute(GET("/core/docs/reference/**"), request ->
			status(FOUND).location(URI.create("https://github.com/reactor/reactor-core/blob/master/README.md")).build())
		.andRoute(GET("/core/docs/api/**"), request ->
			status(FOUND).location(URI.create(request.path().replace("/core/docs/","/docs/core/release/"))).build())
		.andRoute(GET("/netty/docs/api/**"), request ->
			status(FOUND).location(URI.create(request.path().replace("/netty/docs/","/docs/netty/release/"))).build())
		.andRoute(GET("/ipc/docs/api/**"), request ->
			status(FOUND).location(URI.create(request.path().replace("/ipc/docs/", "/docs/ipc/release/"))).build())
		.andRoute(GET("/ext/docs/api/**/test/**"), request ->
			status(FOUND).location(URI.create(request.path().replace("/ext/docs/", "/docs/test/release/"))).build())
		.andRoute(GET("/ext/docs/api/**/adapter/**"), request ->
			status(FOUND).location(URI.create(request.path().replace("/ext/docs/", "/docs/adapter/release/"))).build())
		.and(resources("/**", new ClassPathResource("static/")))
		;
}
```

We can write:
```java
private static RouterFunction<?> routes() {
	return routeGet("/docs/api/**", request ->
			status(FOUND).location(URI.create(request.path().replace("/docs/", "/old/"))).build())
		.andRouteGet("/docs/reference/**", request ->
			status(FOUND).location(URI.create(request.path().replace("/docs/", "/old/"))).build())
		.andRouteGet("/docs/raw/**", request ->
			status(FOUND).location(URI.create(request.path().replace("/docs/", "/old/"))).build())
		.andRouteGet("/docs/{dir}/api", request ->
			status(FOUND).location(URI.create(request.path().replace("api", "release"))).build())
		.andRouteGet("/core/docs/reference/**", request ->
			status(FOUND).location(URI.create("https://github.com/reactor/reactor-core/blob/master/README.md")).build())
		.andRouteGet("/core/docs/api/**", request ->
			status(FOUND).location(URI.create(request.path().replace("/core/docs/","/docs/core/release/"))).build())
		.andRouteGet("/netty/docs/api/**", request ->
			status(FOUND).location(URI.create(request.path().replace("/netty/docs/","/docs/netty/release/"))).build())
		.andRouteGet("/ipc/docs/api/**", request ->
			status(FOUND).location(URI.create(request.path().replace("/ipc/docs/", "/docs/ipc/release/"))).build())
		.andRouteGet("/ext/docs/api/**/test/**", request ->
			status(FOUND).location(URI.create(request.path().replace("/ext/docs/", "/docs/test/release/"))).build())
		.andRouteGet("/ext/docs/api/**/adapter/**", request ->
			status(FOUND).location(URI.create(request.path().replace("/ext/docs/", "/docs/adapter/release/"))).build())
		.and(resources("/**", new ClassPathResource("static/")))
		;
}
```

Also in Kotlin it provides for free a workaround for a limitation that forces to specify the lambda type, so instead of writing:
```kotlin
route(GET("/"), HandlerFunction { ok().body(fromObject("Hello Mix-IT!")) })
.andRoute(GET("/user/{id}"), HandlerFunction { req -> ok().body(fromObject(User(req.pathVariable("id").toLong(), "Robert"))) })
```
We can write:
```kotlin
routeGet("/", { ok().body(fromObject("Hello Mix-IT!")) })
.andRouteGet("/user/{id}", { req -> ok().body(fromObject(User(req.pathVariable("id").toLong(), "Robert"))) })
```