### PR TITLE
SPR-15018 - Construct RowMapper using the impl hook

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1177,7 +1177,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 					else {
 						if (!this.skipUndeclaredResults) {
 							String rsName = RETURN_RESULT_SET_PREFIX + (rsIndex + 1);
-							SqlReturnResultSet undeclaredRsParam = new SqlReturnResultSet(rsName, new ColumnMapRowMapper());
+							SqlReturnResultSet undeclaredRsParam = new SqlReturnResultSet(rsName, getColumnMapRowMapper());
 							if (logger.isDebugEnabled()) {
 								logger.debug("Added default SqlReturnResultSet parameter named '" + rsName + "'");
 							}
@@ -1242,7 +1242,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 						}
 						else {
 							String rsName = outParam.getName();
-							SqlReturnResultSet rsParam = new SqlReturnResultSet(rsName, new ColumnMapRowMapper());
+							SqlReturnResultSet rsParam = new SqlReturnResultSet(rsName, getColumnMapRowMapper());
 							returnedResults.putAll(processResultSet((ResultSet) out, rsParam));
 							if (logger.isDebugEnabled()) {
 								logger.debug("Added default SqlReturnResultSet parameter named '" + rsName + "'");


### PR DESCRIPTION
Call getColumnRowMapper() to create the row mapper; prevents requirement to override extractReturnedResults().

We have large result sets that are affected by the inefficiency of the LinkedCaseInsensitiveMap returned by the ColumnMapRowMapper.  The problem can be fixed if we can just override getColumnMapRowMapper().  But We are forced to override extractReturnedResults()
because it's constructing a ColumnMapRowMapper directly instead of calling getColumnMapRowMapper().

