### PR TITLE
SPR-15066 - Allow request interceptor to add to headers set via entity

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -20,9 +20,11 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -844,7 +846,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 				HttpHeaders httpHeaders = httpRequest.getHeaders();
 				HttpHeaders requestHeaders = this.requestEntity.getHeaders();
 				if (!requestHeaders.isEmpty()) {
-					httpHeaders.putAll(requestHeaders);
+					httpHeaders.putAll(readWriteHttpHeaderMap(requestHeaders));
 				}
 				if (httpHeaders.getContentLength() < 0) {
 					httpHeaders.setContentLength(0L);
@@ -862,7 +864,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 						GenericHttpMessageConverter<Object> genericMessageConverter = (GenericHttpMessageConverter<Object>) messageConverter;
 						if (genericMessageConverter.canWrite(requestBodyType, requestBodyClass, requestContentType)) {
 							if (!requestHeaders.isEmpty()) {
-								httpRequest.getHeaders().putAll(requestHeaders);
+								httpRequest.getHeaders().putAll(readWriteHttpHeaderMap(requestHeaders));
 							}
 							if (logger.isDebugEnabled()) {
 								if (requestContentType != null) {
@@ -881,7 +883,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 					}
 					else if (messageConverter.canWrite(requestBodyClass, requestContentType)) {
 						if (!requestHeaders.isEmpty()) {
-							httpRequest.getHeaders().putAll(requestHeaders);
+							httpRequest.getHeaders().putAll(readWriteHttpHeaderMap(requestHeaders));
 						}
 						if (logger.isDebugEnabled()) {
 							if (requestContentType != null) {
@@ -906,8 +908,12 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 				throw new RestClientException(message);
 			}
 		}
-	}
 
+		private Map<String, List<String>> readWriteHttpHeaderMap(HttpHeaders httpHeaders) {
+			return httpHeaders.entrySet().stream().collect(
+					  Collectors.toMap(Map.Entry::getKey, (entry) -> new LinkedList<>(entry.getValue())));
+		}
+	}
 
 	/**
 	 * Response extractor for {@link HttpEntity}.

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
@@ -39,11 +39,14 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.util.DefaultUriTemplateHandler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -799,6 +802,33 @@ public class RestTemplateTests {
 		assertEquals("Invalid Accept header", MediaType.TEXT_PLAIN_VALUE, requestHeaders.getFirst("Accept"));
 		assertEquals("Invalid custom header", "MyValue", requestHeaders.getFirst("MyHeader"));
 		assertEquals("Invalid status code", HttpStatus.OK, result.getStatusCode());
+
+		verify(response).close();
+	}
+
+	@Test // SPR-15066
+	public void requestInterceptorCanAddHeaderValue() throws Exception {
+		ClientHttpRequestInterceptor interceptor = (request, body, execution) -> {
+			request.getHeaders().add("MyHeader", "MyInterceptorValue");
+			return execution.execute(request, body);
+		};
+		template.setInterceptors(Collections.singletonList(interceptor));
+
+		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST))
+				.willReturn(request);
+		HttpHeaders requestHeaders = new HttpHeaders();
+		given(request.getHeaders()).willReturn(requestHeaders);
+		given(request.execute()).willReturn(response);
+		given(errorHandler.hasError(response)).willReturn(false);
+		HttpStatus status = HttpStatus.OK;
+		given(response.getStatusCode()).willReturn(status);
+		given(response.getStatusText()).willReturn(status.getReasonPhrase());
+
+		HttpHeaders entityHeaders = new HttpHeaders();
+		entityHeaders.add("MyHeader", "MyEntityValue");
+		HttpEntity<Void> entity = new HttpEntity<>(null, entityHeaders);
+		template.exchange("http://example.com", HttpMethod.POST, entity, Void.class);
+		assertThat(requestHeaders.get("MyHeader"), contains("MyEntityValue", "MyInterceptorValue"));
 
 		verify(response).close();
 	}


### PR DESCRIPTION
Provide a fully mutable `HttpHeaders` to `ClientHttpRequestInterceptor`s of a `RestTemplate` when headers are set using `HttpEntity`. This avoids `UnsupportedOperationException` if both `HttpEntity` and `ClientHttpRequestInterceptor` add values for the same HTTP header.

I came upon this error while investigating a bug report in a third-party starter I maintain. The user was using a `RestTemplate` where our starter (without the user's knowledge) provided a `ClientHttpRequestInterceptor` that added an `Authorization` header. The user rather wanted to use a different authentication method and provided an `Authorization` header with a different scheme through an `HttpEntity` passed to the `RestTemplate`. I am avoiding this problem in our starter by calling `HttpHeaders#set(String, String)` instead of `#add(String, String)`.

But seeing that `HttpEntityRequestCallback` was copying over headers from the provided `HttpEntity` to another `HttpHeaders` object used for the request, I thought the intended behavior was rather to provide a fully mutable `HttpHeaders` for the remainder of the processing of the request, including any invocation of `ClientHttpRequestInterceptor`s.

On the other hand, this is a marginal use case at best, and could even be considered misuse of the API.

Issue: [SPR-15066](https://jira.spring.io/browse/SPR-15066)