### PR TITLE
Build - Update Apache Licence 2.0 name and URL

### DIFF
--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -29,8 +29,8 @@ def customizePom(pom, gradleProject) {
 			}
 			licenses {
 				license {
-					name "The Apache Software License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+					name "Apache License, Version 2.0"
+					url "http://www.apache.org/licenses/LICENSE-2.0"
 					distribution "repo"
 				}
 			}


### PR DESCRIPTION
Use same Apache Licence 2.0 formal name and URL across all Spring projects.

References:
* https://www.apache.org/licenses/LICENSE-2.0#apply
* https://github.com/spring-projects/spring-data-build/blob/master/pom.xml#L42