### PR TITLE
SPR-15075 - Remove String#toCharArray from ScriptUtils

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -178,9 +178,8 @@ public abstract class ScriptUtils {
 		boolean inSingleQuote = false;
 		boolean inDoubleQuote = false;
 		boolean inEscape = false;
-		char[] content = script.toCharArray();
 		for (int i = 0; i < script.length(); i++) {
-			char c = content[i];
+			char c = script.charAt(i);
 			if (inEscape) {
 				inEscape = false;
 				sb.append(c);
@@ -342,9 +341,8 @@ public abstract class ScriptUtils {
 	 */
 	public static boolean containsSqlScriptDelimiters(String script, String delim) {
 		boolean inLiteral = false;
-		char[] content = script.toCharArray();
 		for (int i = 0; i < script.length(); i++) {
-			if (content[i] == '\'') {
+			if (script.charAt(i) == '\'') {
 				inLiteral = !inLiteral;
 			}
 			if (!inLiteral && script.startsWith(delim, i)) {


### PR DESCRIPTION
ScriptUtils contains two calls to String#toCharArray for the sole
purpose to iterating over all chars in a String. Not only is this
unnecessary and can be replaced with String#charAt it also causes
additional allocator and heap pressure because String#toCharArray
rather than returning the backing array (which is gone in Java 9)
creates a copy.

This commit contains the following changes:

 - remove String#toCharArray from ScriptUtils and replace with
   String#charAt

Issue: SPR-15075