### PR TITLE
Avoid use of double constructor of BigDecimal

### DIFF
--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateQueryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,8 +197,8 @@ public class JdbcTemplateQueryTests {
 	public void testQueryForObjectWithBigDecimal() throws Exception {
 		String sql = "SELECT AGE FROM CUSTMR WHERE ID = 3";
 		given(this.resultSet.next()).willReturn(true, false);
-		given(this.resultSet.getBigDecimal(1)).willReturn(new BigDecimal(22.5));
-		assertEquals(new BigDecimal(22.5), this.template.queryForObject(sql, BigDecimal.class));
+		given(this.resultSet.getBigDecimal(1)).willReturn(new BigDecimal("22.5"));
+		assertEquals(new BigDecimal("22.5"), this.template.queryForObject(sql, BigDecimal.class));
 		verify(this.resultSet).close();
 		verify(this.statement).close();
 	}


### PR DESCRIPTION
Codacy warns about an Error Prone [1] use of the double constructor of
BigDecimal in tests. The reason given is that it is a source of
precision loss if the number does not have an exact double
representation. The recommendation is to use the String constructor of
BigDecimal instead as it does not require using a lossy argument.

This commit contains the following changes:

 - replace usage of the double constructor of BigDecimal with the
   String constructor of BigDecimal in JdbcTemplateQueryTests
 - update the copyright year

 [1] http://errorprone.info/bugpattern/BigDecimalLiteralDouble

Issue: SPR-15077