### PR TITLE
Introduce mime/media types for application/rss+xml

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -103,6 +103,16 @@ public abstract class MimeTypeUtils {
 	public final static String APPLICATION_OCTET_STREAM_VALUE = "application/octet-stream";
 
 	/**
+	 * Public constant mime type for {@code application/rss+xml}.
+	 */
+	public final static MimeType APPLICATION_RSS_XML;
+
+	/**
+	 * A String equivalent of {@link MimeTypeUtils#APPLICATION_RSS_XML}.
+	 */
+	public final static String APPLICATION_RSS_XML_VALUE = "application/rss+xml";
+
+	/**
 	 * Public constant mime type for {@code application/xhtml+xml}.
 	 *  */
 	public final static MimeType APPLICATION_XHTML_XML;
@@ -199,6 +209,7 @@ public abstract class MimeTypeUtils {
 		APPLICATION_FORM_URLENCODED = MimeType.valueOf(APPLICATION_FORM_URLENCODED_VALUE);
 		APPLICATION_JSON = MimeType.valueOf(APPLICATION_JSON_VALUE);
 		APPLICATION_OCTET_STREAM = MimeType.valueOf(APPLICATION_OCTET_STREAM_VALUE);
+		APPLICATION_RSS_XML = MimeType.valueOf(APPLICATION_RSS_XML_VALUE);
 		APPLICATION_XHTML_XML = MimeType.valueOf(APPLICATION_XHTML_XML_VALUE);
 		APPLICATION_XML = MimeType.valueOf(APPLICATION_XML_VALUE);
 		IMAGE_GIF = MimeType.valueOf(IMAGE_GIF_VALUE);

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -125,6 +125,16 @@ public class MediaType extends MimeType implements Serializable {
 	public final static String APPLICATION_PDF_VALUE = "application/pdf";
 
 	/**
+	 * Public constant media type for {@code application/rss+xml}.
+	 */
+	public final static MediaType APPLICATION_RSS_XML;
+
+	/**
+	 * A String equivalent of {@link MediaType#APPLICATION_RSS_XML}.
+	 */
+	public final static String APPLICATION_RSS_XML_VALUE = "application/rss+xml";
+
+	/**
 	 * Public constant media type for {@code application/xhtml+xml}.
 	 */
 	public final static MediaType APPLICATION_XHTML_XML;
@@ -249,6 +259,7 @@ public class MediaType extends MimeType implements Serializable {
 		APPLICATION_JSON_UTF8 = valueOf(APPLICATION_JSON_UTF8_VALUE);
 		APPLICATION_OCTET_STREAM = valueOf(APPLICATION_OCTET_STREAM_VALUE);
 		APPLICATION_PDF = valueOf(APPLICATION_PDF_VALUE);
+		APPLICATION_RSS_XML = valueOf(APPLICATION_RSS_XML_VALUE);
 		APPLICATION_XHTML_XML = valueOf(APPLICATION_XHTML_XML_VALUE);
 		APPLICATION_XML = valueOf(APPLICATION_XML_VALUE);
 		IMAGE_GIF = valueOf(IMAGE_GIF_VALUE);

--- a/spring-web/src/main/java/org/springframework/http/converter/feed/RssChannelHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/feed/RssChannelHttpMessageConverter.java
@@ -38,7 +38,7 @@ import org.springframework.http.MediaType;
 public class RssChannelHttpMessageConverter extends AbstractWireFeedHttpMessageConverter<Channel> {
 
 	public RssChannelHttpMessageConverter() {
-		super(new MediaType("application", "rss+xml"));
+		super(MediaType.APPLICATION_RSS_XML);
 	}
 
 	@Override

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParser.java
@@ -433,7 +433,7 @@ class AnnotationDrivenBeanDefinitionParser implements BeanDefinitionParser {
 		Properties props = new Properties();
 		if (romePresent) {
 			props.put("atom", MediaType.APPLICATION_ATOM_XML_VALUE);
-			props.put("rss", "application/rss+xml");
+			props.put("rss", MediaType.APPLICATION_RSS_XML_VALUE);
 		}
 		if (jaxb2Present || jackson2XmlPresent) {
 			props.put("xml", MediaType.APPLICATION_XML_VALUE);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -385,7 +385,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 		Map<String, MediaType> map = new HashMap<>(4);
 		if (romePresent) {
 			map.put("atom", MediaType.APPLICATION_ATOM_XML);
-			map.put("rss", MediaType.valueOf("application/rss+xml"));
+			map.put("rss", MediaType.APPLICATION_RSS_XML);
 		}
 		if (jaxb2Present || jackson2XmlPresent) {
 			map.put("xml", MediaType.APPLICATION_XML);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/feed/AbstractRssFeedView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/feed/AbstractRssFeedView.java
@@ -24,6 +24,8 @@ import javax.servlet.http.HttpServletResponse;
 import com.rometools.rome.feed.rss.Channel;
 import com.rometools.rome.feed.rss.Item;
 
+import org.springframework.util.MimeTypeUtils;
+
 /**
  * Abstract superclass for RSS Feed views, using the
  * <a href="https://github.com/rometools/rome">ROME</a> package.
@@ -46,7 +48,7 @@ import com.rometools.rome.feed.rss.Item;
 public abstract class AbstractRssFeedView extends AbstractFeedView<Channel> {
 
 	public AbstractRssFeedView() {
-		setContentType("application/rss+xml");
+		setContentType(MimeTypeUtils.APPLICATION_RSS_XML_VALUE);
 	}
 
 	/**


### PR DESCRIPTION
`MimeTypeUtils` and `MediaType` have constants for Atom but not for RSS. It'd be useful to have constants for both.

Issue: SPR-15109

Submitted ICLA.