### PR TITLE
SPR-15119: Add Kotlin array-like addAttribute to Model and ModelMap  

### DIFF
--- a/spring-context/src/main/kotlin/org/springframework/ui/ModelExtension.kt
+++ b/spring-context/src/main/kotlin/org/springframework/ui/ModelExtension.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2017 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ui
+
+/**
+ * Extension for [Model] providing idiomatic Kotlin API
+ *
+ * @author Mario Arias
+ * @since 5.0
+ */
+object ModelExtension {
+
+	/** Array like setter for [Model]
+	 *
+	 * ```kotlin
+	 * model["firstName"] = "Mario"
+	 * ```
+	 *
+	 * @see Model.addAttribute
+	 */
+	operator fun Model.set(attributeName: String, attributeValue: Any) {
+		this.addAttribute(attributeName, attributeValue)
+	}
+}

--- a/spring-context/src/main/kotlin/org/springframework/ui/ModelMapExtension.kt
+++ b/spring-context/src/main/kotlin/org/springframework/ui/ModelMapExtension.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2017 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ui
+
+/**
+ * Extension for [ModelMap] providing idiomatic Kotlin API
+ *
+ * @author Mario Arias
+ * @since 5.0
+ */
+object ModelMapExtension {
+
+	/** Array like setter for [ModelMap]
+	 *
+	 * ```kotlin
+	 * model["firstName"] = "Mario"
+	 * ```
+	 *
+	 * @see ModelMap.addAttribute
+	 */
+	operator fun ModelMap.set(attributeName: String, attributeValue: Any) {
+		this.addAttribute(attributeName, attributeValue)
+	}
+}

--- a/spring-context/src/test/kotlin/org/springframework/ui/ModelExtensionTests.kt
+++ b/spring-context/src/test/kotlin/org/springframework/ui/ModelExtensionTests.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2017 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.springframework.ui.ModelExtension.set
+
+
+class ModelExtensionTests {
+
+	@Test
+	fun setAttribute() {
+		val model:Model = ConcurrentModel()
+		model["foo"] = "bing"
+		assertTrue(model.containsAttribute("foo"))
+		assertEquals("bing", model.asMap()["foo"])
+	}
+}

--- a/spring-context/src/test/kotlin/org/springframework/ui/ModelMapExtensionTests.kt
+++ b/spring-context/src/test/kotlin/org/springframework/ui/ModelMapExtensionTests.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2017 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.springframework.ui.ModelMapExtension.set
+
+
+class ModelMapExtensionTests {
+
+	@Test
+	fun setAttribute() {
+		val model = ModelMap()
+		model["foo"] = "bing"
+		assertTrue(model.containsAttribute("foo"))
+		assertEquals("bing", model["foo"])
+	}
+}


### PR DESCRIPTION
Add idiomatic Kotlin `addAAttribute` to Model and ModelMap (cc @sdeleuze)

```kotlin
// orginal code
model.addAttribute("firstName", firstName)
//kotlin idiomatic code
model["firstName"] = firstName
```