### PR TITLE
Fix Javadoc for CronSequenceGenerator

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
@@ -42,7 +42,7 @@ import org.springframework.util.StringUtils;
  * <li>"0 0 * * * *" = the top of every hour of every day.</li>
  * <li>"*&#47;10 * * * * *" = every ten seconds.</li>
  * <li>"0 0 8-10 * * *" = 8, 9 and 10 o'clock of every day.</li>
- * <li>"0 * 6,19 * * *" = 6:00 AM and 7:00 PM every day.</li>
+ * <li>"0 0 6,19 * * *" = 6:00 AM and 7:00 PM every day.</li>
  * <li>"0 0/30 8-10 * * *" = 8:00, 8:30, 9:00, 9:30 and 10 o'clock every day.</li>
  * <li>"0 0 9-17 * * MON-FRI" = on the hour nine-to-five weekdays</li>
  * <li>"0 0 0 25 12 ?" = every Christmas Day at midnight</li>


### PR DESCRIPTION
- fix minute field set to * in example pattern which in fact makes execution to happen every minute of specified hours.