### PR TITLE
Fix SPR-15136 - Exception if no RequestDataValueProcessor is present

### DIFF
--- a/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/view/AbstractView.java
+++ b/spring-web-reactive/src/main/java/org/springframework/web/reactive/result/view/AbstractView.java
@@ -191,11 +191,12 @@ public abstract class AbstractView implements View, ApplicationContextAware {
 	 * <p>The default implementation looks in the {@link #getApplicationContext()
 	 * Spring configuration} for a {@code RequestDataValueProcessor} bean with
 	 * the name {@link #REQUEST_DATA_VALUE_PROCESSOR_BEAN_NAME}.
+	 * @return the RequestDataValueProcessor, or null if there is none at the application context.
 	 */
 	protected RequestDataValueProcessor getRequestDataValueProcessor() {
-		if (getApplicationContext() != null) {
-			String beanName = REQUEST_DATA_VALUE_PROCESSOR_BEAN_NAME;
-			return getApplicationContext().getBean(beanName, RequestDataValueProcessor.class);
+		ApplicationContext appCtx = getApplicationContext();
+		if (appCtx != null && appCtx.containsBean(REQUEST_DATA_VALUE_PROCESSOR_BEAN_NAME)) {
+			return appCtx.getBean(REQUEST_DATA_VALUE_PROCESSOR_BEAN_NAME, RequestDataValueProcessor.class);
 		}
 		return null;
 	}


### PR DESCRIPTION
This modifications fix the way the reactive AbstractView retrieves the
RequestDataValueProcessor bean, correctly returning null if there
is no bean of such type at the Application Context.

This avoids an exception at the reactive RedirectView (which extends
AbstractView) when trying to post-process the URL generated for 
redirection, when no RequestDataValueProcessor exists.