### PR TITLE
SPR-15140: @RequestParam injects a raw undecoded string for reactive HTTP requests

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractServerHttpRequest.java
@@ -16,7 +16,10 @@
 
 package org.springframework.http.server.reactive;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -77,6 +80,22 @@ public abstract class AbstractServerHttpRequest implements ServerHttpRequest {
 	}
 
 	/**
+	 * A method for decoding name and value string in a name-value pair.
+	 * <p>Note that the plus sign "+" is converted into a space character " ".</p>
+	 * @param encodedString the string to be decoded
+	 * @return the decoded string
+	 * @see java.net.URLDecoder#decode(String, String)
+	 */
+	private static String decodeQueryParam(final String encodedString) {
+		try {
+			return URLDecoder.decode(encodedString, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+			// StandardCharsets are guaranteed to be available on every implementation of the Java platform, so this should never happen.
+			throw new IllegalStateException(e);
+		}
+	}
+
+	/**
 	 * A method for parsing of the query into name-value pairs. The return
 	 * value is turned into an immutable map and cached.
 	 *
@@ -94,7 +113,8 @@ public abstract class AbstractServerHttpRequest implements ServerHttpRequest {
 				String eq = matcher.group(2);
 				String value = matcher.group(3);
 				value = (value != null ? value : (StringUtils.hasLength(eq) ? "" : null));
-				queryParams.add(name, value);
+				queryParams.add(decodeQueryParam(name),
+						value != null ? decodeQueryParam(value) : null);
 			}
 		}
 		return queryParams;

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/ServerHttpRequestTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/ServerHttpRequestTests.java
@@ -65,6 +65,13 @@ public class ServerHttpRequestTests {
 	}
 
 	@Test
+	public void queryParamsWithUrlEncodedValue() throws Exception {
+		MultiValueMap<String, String> params = createHttpRequest("/path?a=%20%2B+%C3%A0").getQueryParams();
+		assertEquals(1, params.size());
+		assertEquals(Collections.singletonList(" + \u00e0"), params.get("a"));
+	}
+
+	@Test
 	public void queryParamsWithEmptyValue() throws Exception {
 		MultiValueMap<String, String> params = createHttpRequest("/path?a=").getQueryParams();
 		assertEquals(1, params.size());


### PR DESCRIPTION
When using spring-web-reactive, %-encoded strings were injected as-is into @RequestParam variables, which does not coincide with spring-webmvc behaviour.

Example: 

```java
@ResponseBody
@GetMapping("/search")
public String search(@RequestParam("q") String q) {
    return q;
}
```
```bash
curl -s 'http://localhost:8080/search?q=%20%2B+%C3%A0'
```

Spring Web Reactive: `%20%2B+%C3%A0`
Spring Web MVC: `(space)+ à`

(`(space)` is a space character, GitHub seems to remove leading whitespaces...)

---

The cause is that `AbstractServerHttpRequest.getQueryParams()` is returning undecoded name-value pairs, while the interface method `ServerHttpRequest.getQueryParams()` specifies (in javadoc) to return *decoded* ones.

This commit fixed the `AbstractServerHttpRequest` implementation to correctly return
decoded name-value pairs and added an unit test.

https://jira.spring.io/browse/SPR-15140

(I have signed the CLA.)