### PR TITLE
Only apply dependency-management and propdeps-maven to subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,10 +103,8 @@ configure(allprojects) { project ->
 	ext.gradleScriptDir = "${rootProject.projectDir}/gradle"
 
 	apply plugin: "propdeps"
-	apply plugin: "propdeps-maven"
 	apply plugin: "java"
 	apply plugin: "test-source-set-dependencies"
-	apply plugin: "io.spring.dependency-management"
 	apply from: "${gradleScriptDir}/ide.gradle"
 
 	// Kotlin compiler does not support JDK 9 yet, see https://youtrack.jetbrains.com/issue/KT-14988
@@ -176,16 +174,6 @@ configure(allprojects) { project ->
 		maven { url "https://repo.spring.io/libs-release" }
 		maven { url "https://repo.spring.io/milestone" }
 		maven { url "http://dl.bintray.com/kotlin/kotlin-eap-1.1" }
-	}
-
-	dependencyManagement {
-		imports {
-			mavenBom "io.projectreactor:reactor-bom:${reactorVersion}"
-		}
-		resolutionStrategy {
-			cacheChangingModulesFor 0, 'seconds'
-		}
-		applyMavenExclusions = false
 	}
 
 	dependencies {
@@ -262,6 +250,17 @@ configure(allprojects) { project ->
 configure(subprojects - project(":spring-build-src")) { subproject ->
 	apply plugin: "merge"
 	apply from: "${gradleScriptDir}/publish-maven.gradle"
+	apply plugin: "io.spring.dependency-management"
+
+	dependencyManagement {
+		imports {
+			mavenBom "io.projectreactor:reactor-bom:${reactorVersion}"
+		}
+		resolutionStrategy {
+			cacheChangingModulesFor 0, 'seconds'
+		}
+		applyMavenExclusions = false
+	}
 
 	configurations {
 		jacoco


### PR DESCRIPTION
Previously, the dependency management and propdeps-maven plugins
were being applied to all projects. The latter caused a problem with
publishing to Artifactory as the buildSrc project now had the
propdeps-maven plugin applied to it.

This commit removes the logic that was applying the propdeps-plugin
to all projects so that it's only applied to subprojects excluding
the buildSrc project. The logic that applies the dependency management
plugin has been moved to the same location. It is applied after the
propdeps-maven plugin as, otherwise, the pom customization does not
work correctly and optional dependencies are not included in
generated poms.

Issue: SPR-15167