### PR TITLE
Print session attributes in PrintingResultHandler in Spring MVC Test

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/MockMvcResultHandlers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/MockMvcResultHandlers.java
@@ -108,7 +108,7 @@ public abstract class MockMvcResultHandlers {
 					if (value != null && value.getClass().isArray()) {
 						value = CollectionUtils.arrayToList(value);
 					}
-					writer.println(String.format("%17s = %s", label, value));
+					writer.println(String.format("%18s = %s", label, value));
 				}
 			});
 		}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/PrintingResultHandler.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/PrintingResultHandler.java
@@ -17,10 +17,12 @@
 package org.springframework.test.web.servlet.result;
 
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.http.HttpHeaders;
@@ -114,6 +116,23 @@ public class PrintingResultHandler implements ResultHandler {
 		this.printer.printValue("Parameters", getParamsMultiValueMap(request));
 		this.printer.printValue("Headers", getRequestHeaders(request));
 		this.printer.printValue("Body", body);
+		this.printer.printValue("Session attributes", getSessionAttributes(request));
+	}
+
+	protected static Map<String, Object> getSessionAttributes(MockHttpServletRequest request) {
+		Map<String, Object> sessionAttributes = new HashMap<>();
+		HttpSession session = request.getSession();
+		if (session != null) {
+			Enumeration<String> sessionAttributesNames = session.getAttributeNames();
+			while (sessionAttributesNames.hasMoreElements()) {
+				String sessionAttributeName = sessionAttributesNames.nextElement();
+				Object sessionAttribute = session.getAttribute(sessionAttributeName);
+				if (sessionAttribute != null) {
+					sessionAttributes.put(sessionAttributeName, sessionAttribute);
+				}
+			}
+		}
+		return sessionAttributes;
 	}
 
 	protected final HttpHeaders getRequestHeaders(MockHttpServletRequest request) {

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/result/PrintingResultHandlerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/result/PrintingResultHandlerTests.java
@@ -73,6 +73,8 @@ public class PrintingResultHandlerTests {
 		String palindrome = "ablE was I ere I saw Elba";
 		byte[] bytes = palindrome.getBytes("UTF-16");
 		this.request.setContent(bytes);
+		this.request.getSession().setAttribute("jsessionId", "1A530690283A13B04199A42E5D530454");
+		this.request.getSession().setAttribute("userId", "jdoe");
 
 		this.handler.handle(this.mvcResult);
 
@@ -82,11 +84,16 @@ public class PrintingResultHandlerTests {
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("param", "paramValue");
 
+		Map<String, Object> sessionAttributes = new HashMap<>();
+		sessionAttributes.put("jsessionId", "1A530690283A13B04199A42E5D530454");
+		sessionAttributes.put("userId", "jdoe");
+
 		assertValue("MockHttpServletRequest", "HTTP Method", this.request.getMethod());
 		assertValue("MockHttpServletRequest", "Request URI", this.request.getRequestURI());
 		assertValue("MockHttpServletRequest", "Parameters", params);
 		assertValue("MockHttpServletRequest", "Headers", headers);
 		assertValue("MockHttpServletRequest", "Body", palindrome);
+		assertValue("MockHttpServletRequest", "Session attributes", sessionAttributes);
 	}
 
 	@Test

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resulthandlers/PrintingResultHandlerSmokeTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resulthandlers/PrintingResultHandlerSmokeTests.java
@@ -19,6 +19,7 @@ package org.springframework.test.web.servlet.samples.standalone.resulthandlers;
 import java.io.StringWriter;
 
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Ignore;
@@ -56,7 +57,10 @@ public class PrintingResultHandlerSmokeTests {
 
 		standaloneSetup(new SimpleController())
 			.build()
-			.perform(get("/").content("Hello Request".getBytes()))
+			.perform(get("/")
+					.content("Hello Request".getBytes())
+					.sessionAttr("jsessionId", "1A530690283A13B04199A42E5D530454")
+					.sessionAttr("userId", "jdoe"))
 			.andDo(log())
 			.andDo(print())
 			.andDo(print(System.err))

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resulthandlers/PrintingResultHandlerSmokeTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resulthandlers/PrintingResultHandlerSmokeTests.java
@@ -19,7 +19,6 @@ package org.springframework.test.web.servlet.samples.standalone.resulthandlers;
 import java.io.StringWriter;
 
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Ignore;


### PR DESCRIPTION
Print session attributes in PrintingResultHandler in Spring MVC Test when print result handler is enabled.
Update unit and smoke tests accordingly.

JIRA issue: https://jira.spring.io/browse/SPR-15189