### PR TITLE
Fix Javadoc in UriComponentsBuilder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -239,8 +239,8 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	 * be parsed unambiguously. Such values should be substituted for URI
 	 * variables to enable correct parsing:
 	 * <pre class="code">
-	 * String uriString = &quot;/hotels/42?filter={value}&quot;;
-	 * UriComponentsBuilder.fromUriString(uriString).buildAndExpand(&quot;hot&amp;cold&quot;);
+	 * String urlString = &quot;https://example.com/hotels/42?filter={value}&quot;;
+	 * UriComponentsBuilder.fromHttpUrl(urlString).buildAndExpand(&quot;hot&amp;cold&quot;);
 	 * </pre>
 	 * @param httpUrl the source URI
 	 * @return the URI components of the URI


### PR DESCRIPTION
The Javadoc for `UriComponentsBuilder.fromHttpUrl` contains an example that uses the wrong method.

If not paying attention, like me, this might lead you to believe that `fromHttpUrl` could be used with relative URIs, when in fact this leads to a `java.lang.IllegalArgumentException: ... is not a valid HTTP URL`.

This PR alters the Javadoc example to demonstrate correct use of the method.

I'm sure this is an Obvious Fix but I've signed the CLA anyway.