### PR TITLE
SPR-15218 - Add logging to processPropertySource() (Obvious Fix)

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
@@ -419,13 +419,21 @@ class ConfigurationClassParser {
 			}
 			catch (IllegalArgumentException ex) {
 				// from resolveRequiredPlaceholders
-				if (!ignoreResourceNotFound) {
+				if (ignoreResourceNotFound) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Failed to process property source from [" + location + "]", ex);
+					}
+				} else {
 					throw ex;
 				}
 			}
 			catch (FileNotFoundException ex) {
 				// from ResourcePropertySource constructor
-				if (!ignoreResourceNotFound) {
+				if (ignoreResourceNotFound) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Failed to process property source from [" + location + "]", ex);
+					}
+				} else {
 					throw ex;
 				}
 			}


### PR DESCRIPTION
This change set amends ConfigurationClassParser.processPropertySource() to log a message at debug level when a PropertySource with ignoreResourceNotFound = true cannot be loaded for any reason.

Detailed justification for this change, including a link to an illustrative project, may be found on the JIRA:

https://jira.spring.io/browse/SPR-15218

I believe this qualifies as an "obvious fix" which does not require a CLA signature according to the following document:

https://cla.pivotal.io/about#obvious-fixes