### PR TITLE
Introduce JSON streaming support

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -138,6 +138,18 @@ public class MediaType extends MimeType implements Serializable {
 	public final static String APPLICATION_RSS_XML_VALUE = "application/rss+xml";
 
 	/**
+	 * Public constant media type for {@code application/stream+json}.
+	 * @since 5.0
+	 */
+	public final static MediaType APPLICATION_STREAM_JSON;
+
+	/**
+	 * A String equivalent of {@link MediaType#APPLICATION_STREAM_JSON}.
+	 * @since 5.0
+	 */
+	public final static String APPLICATION_STREAM_JSON_VALUE = "application/stream+json";
+
+	/**
 	 * Public constant media type for {@code application/xhtml+xml}.
 	 */
 	public final static MediaType APPLICATION_XHTML_XML;
@@ -292,6 +304,7 @@ public class MediaType extends MimeType implements Serializable {
 		APPLICATION_PROBLEM_JSON = valueOf(APPLICATION_PROBLEM_JSON_VALUE);
 		APPLICATION_PROBLEM_XML = valueOf(APPLICATION_PROBLEM_XML_VALUE);
 		APPLICATION_RSS_XML = valueOf(APPLICATION_RSS_XML_VALUE);
+		APPLICATION_STREAM_JSON = valueOf(APPLICATION_STREAM_JSON_VALUE);
 		APPLICATION_XHTML_XML = valueOf(APPLICATION_XHTML_XML_VALUE);
 		APPLICATION_XML = valueOf(APPLICATION_XML_VALUE);
 		IMAGE_GIF = valueOf(IMAGE_GIF_VALUE);


### PR DESCRIPTION
This commit introduces JSON streaming support which
consists of serializing HTTP request with
`application/stream+json` media type as line delimited JSON.

It also optimize `Flux` serialization for `application/json` by
using `flux.collectList()` and a single Jackson invocation
instead of one call per element previous strategy.
This change result in a x4 throughput improvement
for collection with a lot of small elements.

Issues: [SPR-15095](https://jira.spring.io/browse/SPR-15095), [SPR-15104](https://jira.spring.io/browse/SPR-15104)