### PR TITLE
Making example easier for GenericApplicationContext.

### DIFF
--- a/src/asciidoc/core-beans.adoc
+++ b/src/asciidoc/core-beans.adoc
@@ -370,7 +370,7 @@ delegates, e.g. with `XmlBeanDefinitionReader` for XML files:
 [subs="verbatim,quotes"]
 ----
 	GenericApplicationContext context = new GenericApplicationContext();
-	new XmlBeanDefinitionReader(ctx).loadBeanDefinitions("services.xml", "daos.xml");
+	new XmlBeanDefinitionReader(context).loadBeanDefinitions("services.xml", "daos.xml");
     context.refresh();
 ----
 
@@ -380,7 +380,7 @@ Or with `GroovyBeanDefinitionReader` for Groovy files:
 [subs="verbatim,quotes"]
 ----
 	GenericApplicationContext context = new GenericApplicationContext();
-	new GroovyBeanDefinitionReader(ctx).loadBeanDefinitions("services.groovy", "daos.groovy");
+	new GroovyBeanDefinitionReader(context).loadBeanDefinitions("services.groovy", "daos.groovy");
     context.refresh();
 ----
 


### PR DESCRIPTION
This commit makes easier for understanding example of GenericApplicationContext. The beginners may get confused while reading the reference docs due to undeclared object `ctx`. Hence, I think this change is essential.