### PR TITLE
Add a Kotlin RouterFunction implementation

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/RouterFunctionExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/RouterFunctionExtensions.kt
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono
  * Provide a routing DSL for [RouterFunctions] and [RouterFunction] in order to be able to
  * write idiomatic Kotlin code as below:
  *
- * * ```kotlin
+ * ```kotlin
  * fun route(request: ServerRequest) = route(request) {
  * 		accept(TEXT_HTML).apply {
  * 			(GET("/user/") or GET("/users/")) { findAllView() }
@@ -46,7 +46,7 @@ class RouterDsl {
 	}
 
 	fun GET(pattern: String, f: (ServerRequest) -> Mono<ServerResponse>) {
-		routes += RouterFunctions.route(RequestPredicates.GET(pattern), HandlerFunction { f(it) } )
+		routes += RouterFunctions.route(RequestPredicates.GET(pattern), HandlerFunction { f(it) })
 	}
 
 	fun HEAD(pattern: String, f: (ServerRequest) -> Mono<ServerResponse>) {
@@ -81,7 +81,7 @@ class RouterDsl {
 		routes += RouterFunctions.route(RequestPredicates.contentType(mediaType), HandlerFunction { f(it) })
 	}
 
-	fun headers(headerPredicate: (ServerRequest.Headers)->Boolean, f: (ServerRequest) -> Mono<ServerResponse>) {
+	fun headers(headerPredicate: (ServerRequest.Headers) -> Boolean, f: (ServerRequest) -> Mono<ServerResponse>) {
 		routes += RouterFunctions.route(RequestPredicates.headers(headerPredicate), HandlerFunction { f(it) })
 	}
 
@@ -94,13 +94,12 @@ class RouterDsl {
 	}
 
 	fun resources(path: String, location: Resource) {
-		routes +=  RouterFunctions.resources(path, location)
+		routes += RouterFunctions.resources(path, location)
 	}
 
 	fun resources(lookupFunction: (ServerRequest) -> Mono<Resource>) {
-		routes +=  RouterFunctions.resources(lookupFunction)
+		routes += RouterFunctions.resources(lookupFunction)
 	}
-
 
 	@Suppress("UNCHECKED_CAST")
 	fun router(): RouterFunction<ServerResponse> {
@@ -119,5 +118,27 @@ class RouterDsl {
 		}
 		return allRoutes
 	}
+
+}
+
+/**
+ * Abstract subclass of [RouterFunction] for Kotlin [RouterDsl]
+ * Request mappings can be written in the body of the controller
+ *
+ * ```kotlin
+ * class SampleController : KotlinRouterFunction({
+ *     GET("/super") { req ->
+ *         ServerResponse.ok().body(fromObject("super!!!"))
+ *     }
+ * })
+ * ```
+ *
+ * @since 5.0
+ * @author Sebastien Deleuze
+ * @author Yevhenii Melnyk
+ */
+abstract class KotlinRouterFunction(val routes: RouterDsl.() -> Unit) : RouterFunction<ServerResponse> {
+
+	override fun route(request: ServerRequest): Mono<HandlerFunction<ServerResponse>> = route(request, routes)
 
 }

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/KotlinRouterFunctionTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/KotlinRouterFunctionTests.kt
@@ -1,0 +1,143 @@
+package org.springframework.web.reactive.function.server
+
+import org.junit.Test
+import org.springframework.core.io.ClassPathResource
+import org.springframework.http.HttpHeaders.ACCEPT
+import org.springframework.http.HttpHeaders.CONTENT_TYPE
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpMethod.PATCH
+import org.springframework.http.HttpMethod.POST
+import org.springframework.http.MediaType.*
+import org.springframework.web.reactive.function.server.MockServerRequest.builder
+import org.springframework.web.reactive.function.server.RequestPredicates.*
+import org.springframework.web.reactive.function.server.ServerResponse.ok
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.net.URI
+
+class KotlinRouterFunctionTests {
+
+	@Test
+	fun header() {
+		val request = builder().header("bar", "bar").build()
+		StepVerifier.create(FooController().route(request))
+				.expectNextCount(1)
+				.verifyComplete()
+	}
+
+	@Test
+	fun accept() {
+		val request = builder().header(ACCEPT, APPLICATION_ATOM_XML_VALUE).build()
+		StepVerifier.create(FooController().route(request))
+				.expectNextCount(1)
+				.verifyComplete()
+	}
+
+	@Test
+	fun acceptAndPOST() {
+		val request = builder().method(POST).uri(URI("/api/foo/")).header(ACCEPT, APPLICATION_JSON_VALUE).build()
+		StepVerifier.create(FooController().route(request))
+				.expectNextCount(1)
+				.verifyComplete()
+	}
+
+	@Test
+	fun contentType() {
+		val request = builder().header(CONTENT_TYPE, APPLICATION_OCTET_STREAM_VALUE).build()
+		StepVerifier.create(FooController().route(request))
+				.expectNextCount(1)
+				.verifyComplete()
+	}
+
+	@Test
+	fun resourceByPath() {
+		val request = builder().uri(URI("/org/springframework/web/reactive/function/response.txt")).build()
+		StepVerifier.create(FooController().route(request))
+				.expectNextCount(1)
+				.verifyComplete()
+	}
+
+	@Test
+	fun method() {
+		val request = builder().method(PATCH).build()
+		StepVerifier.create(FooController().route(request))
+				.expectNextCount(1)
+				.verifyComplete()
+	}
+
+	@Test
+	fun path() {
+		val request = builder().uri(URI("/baz")).build()
+		StepVerifier.create(FooController().route(request))
+				.expectNextCount(1)
+				.verifyComplete()
+	}
+
+	@Test
+	fun resource() {
+		val request = builder().uri(URI("/response.txt")).build()
+		StepVerifier.create(FooController().route(request))
+				.expectNextCount(1)
+				.verifyComplete()
+	}
+
+	@Test
+	fun noRoute() {
+		val request = builder()
+				.uri(URI("/bar"))
+				.header(ACCEPT, APPLICATION_PDF_VALUE)
+				.header(CONTENT_TYPE, APPLICATION_PDF_VALUE)
+				.build()
+		StepVerifier.create(FooController().route(request))
+				.verifyComplete()
+	}
+
+	class FooController : KotlinRouterFunction({
+
+		(GET("/foo/") or GET("/foos/")) { req ->
+			handle(req)
+		}
+
+		accept(APPLICATION_JSON).apply {
+			POST("/api/foo/", ::handle)
+			PUT("/api/foo/", ::handle)
+			DELETE("/api/foo/", ::handle)
+		}
+
+		accept(APPLICATION_ATOM_XML, ::handle)
+
+		contentType(APPLICATION_OCTET_STREAM) {
+			ok().build()
+		}
+
+		method(HttpMethod.PATCH) { req ->
+			handle(req)
+		}
+
+		headers({ it.accept().contains(APPLICATION_JSON) }).apply {
+			GET("/api/foo/", ::handle)
+		}
+
+		headers({ it.header("bar").isNotEmpty() }, ::handle)
+
+		resources("/org/springframework/web/reactive/function/**",
+				ClassPathResource("/org/springframework/web/reactive/function/response.txt"))
+
+		resources {
+			if (it.path() == "/response.txt") {
+				Mono.just(ClassPathResource("/org/springframework/web/reactive/function/response.txt"))
+			}
+			else {
+				Mono.empty()
+			}
+		}
+
+		path("/baz") { req ->
+			handle(req)
+		}
+
+	})
+}
+
+private fun handle(req: ServerRequest) = ok().build()
+


### PR DESCRIPTION
The reason for this PR is to give opportunity to create functional controllers in Kotlin without implementing `RouterFunction.route` function but writing mappings inside the controller.
Insired by [Twitter Finatra](https://github.com/twitter/finatra/blob/develop/examples/hello-world/src/main/scala/com/twitter/hello/HelloWorldController.scala) "server as a function principle" and [Spek](http://spekframework.org/)  - Kotlin testing framework.

Sample controller can look like this:
```kotlin
class SampleController : KotlinRouterFunction({
    GET("/super") { req ->
        ServerResponse.ok().body(fromObject("super!!!"))
    }
})
```