### PR TITLE
 SPR-15253 - Add convenience setup methods in AbstractRoutingDataSource

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  * (but not necessarily) determined through some thread-bound transaction context.
  *
  * @author Juergen Hoeller
+ * @author Kazuki Shimizu
  * @since 2.0.1
  * @see #setTargetDataSources
  * @see #setDefaultTargetDataSource
@@ -64,6 +65,32 @@ public abstract class AbstractRoutingDataSource extends AbstractDataSource imple
 	 */
 	public void setTargetDataSources(Map<Object, Object> targetDataSources) {
 		this.targetDataSources = targetDataSources;
+	}
+
+	/**
+	 * Add a target {@link DataSource}.
+	 * @param lookupKey a lookup key
+	 * @param dataSource a target data source
+	 * @since 4.3.7
+	 */
+	public void addTargetDataSource(Object lookupKey, DataSource dataSource) {
+		if (this.targetDataSources == null) {
+			this.targetDataSources = new HashMap<>();
+		}
+		this.targetDataSources.put(lookupKey, dataSource);
+	}
+
+	/**
+	 * Add a target data source name (to be resolved via a {@link #setDataSourceLookup DataSourceLookup}).
+	 * @param lookupKey a lookup key
+	 * @param dataSourceName a target data source name
+	 * @since 4.3.7
+	 */
+	public void addTargetDataSourceName(Object lookupKey, String dataSourceName) {
+		if (this.targetDataSources == null) {
+			this.targetDataSources = new HashMap<>();
+		}
+		this.targetDataSources.put(lookupKey, dataSourceName);
 	}
 
 	/**

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSourceTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSourceTests.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.datasource.lookup;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.sql.DataSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link AbstractRoutingDataSource}.
+ * @author Kazuki Shimizu
+ * @since 4.3.7
+ */
+public class AbstractRoutingDataSourceTests {
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void setTargetDataSources() {
+		final ThreadLocal<String> lookupKey = new ThreadLocal<>();
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return lookupKey.get();
+			}
+		};
+		DataSource ds1 = new StubDataSource();
+		DataSource ds2 = new StubDataSource();
+
+		MapDataSourceLookup dataSourceLookup = new MapDataSourceLookup();
+		dataSourceLookup.addDataSource("dataSource2", ds2);
+		routingDataSource.setDataSourceLookup(dataSourceLookup);
+		
+		Map<Object, Object> targetDataSources = new HashMap<>();
+		targetDataSources.put("ds1", ds1);
+		targetDataSources.put("ds2", "dataSource2");
+		routingDataSource.setTargetDataSources(targetDataSources);
+
+		routingDataSource.afterPropertiesSet();
+
+		lookupKey.set("ds1");
+		assertThat(routingDataSource.determineTargetDataSource(), sameInstance(ds1));
+		
+		lookupKey.set("ds2");
+		assertThat(routingDataSource.determineTargetDataSource(), sameInstance(ds2));
+	}
+
+	@Test
+	public void targetDataSourcesIsNull() {
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return null;
+			}
+		};
+
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Property 'targetDataSources' is required");
+
+		routingDataSource.afterPropertiesSet();
+	}
+
+	@Test
+	public void dataSourceIsUnSupportedType() {
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return null;
+			}
+		};
+		Map<Object, Object> targetDataSources = new HashMap<>();
+		targetDataSources.put("ds1", 1);
+		routingDataSource.setTargetDataSources(targetDataSources);
+
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Illegal data source value - only [javax.sql.DataSource] and String supported: 1");
+
+		routingDataSource.afterPropertiesSet();
+	}
+
+
+
+	@Test
+	public void setDefaultTargetDataSource() {
+		final ThreadLocal<String> lookupKey = new ThreadLocal<>();
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return lookupKey.get();
+			}
+		};
+		DataSource ds = new StubDataSource();
+
+		routingDataSource.setTargetDataSources(new HashMap<>());
+		routingDataSource.setDefaultTargetDataSource(ds);
+
+		routingDataSource.afterPropertiesSet();
+
+		lookupKey.set("foo");
+		assertThat(routingDataSource.determineTargetDataSource(), sameInstance(ds));
+	}
+
+	@Test
+	public void setDefaultTargetDataSourceFallbackIsFalse() {
+		final ThreadLocal<String> lookupKey = new ThreadLocal<>();
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return lookupKey.get();
+			}
+		};
+		DataSource ds = new StubDataSource();
+
+		routingDataSource.setTargetDataSources(new HashMap<>());
+		routingDataSource.setDefaultTargetDataSource(ds);
+		routingDataSource.setLenientFallback(false);
+
+		routingDataSource.afterPropertiesSet();
+
+		exception.expect(IllegalStateException.class);
+		exception.expectMessage("Cannot determine target DataSource for lookup key [foo]");
+
+		lookupKey.set("foo");
+		routingDataSource.determineTargetDataSource();
+	}
+
+	@Test
+	public void setDefaultTargetDataSourceLookupKeyIsNullWhenFallbackIsFalse() {
+		final ThreadLocal<String> lookupKey = new ThreadLocal<>();
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return lookupKey.get();
+			}
+		};
+		DataSource ds = new StubDataSource();
+
+		routingDataSource.setTargetDataSources(new HashMap<>());
+		routingDataSource.setDefaultTargetDataSource(ds);
+		routingDataSource.setLenientFallback(false);
+
+		routingDataSource.afterPropertiesSet();
+
+		lookupKey.set(null);
+		assertThat(routingDataSource.determineTargetDataSource(), sameInstance(ds));
+	}
+
+	@Test // SPR-15253
+	public void addTargetDataSource() {
+		final ThreadLocal<String> lookupKey = new ThreadLocal<>();
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return lookupKey.get();
+			}
+		};
+		DataSource ds1 = new StubDataSource();
+		DataSource ds2 = new StubDataSource();
+		routingDataSource.addTargetDataSource("ds1", ds1);
+		routingDataSource.addTargetDataSource("ds2", ds2);
+		
+		routingDataSource.afterPropertiesSet();
+
+		lookupKey.set("ds1");
+		assertThat(routingDataSource.determineTargetDataSource(), sameInstance(ds1));
+
+		lookupKey.set("ds2");
+		assertThat(routingDataSource.determineTargetDataSource(), sameInstance(ds2));
+	}
+	
+	@Test // SPR-15253
+	public void addTargetDataSourceName() {
+		final ThreadLocal<String> lookupKey = new ThreadLocal<>();
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return lookupKey.get();
+			}
+		};
+		DataSource ds1 = new StubDataSource();
+		DataSource ds2 = new StubDataSource();
+		MapDataSourceLookup dataSourceLookup = new MapDataSourceLookup();
+		dataSourceLookup.addDataSource("dataSource1", ds1);
+		dataSourceLookup.addDataSource("dataSource2", ds2);
+		routingDataSource.setDataSourceLookup(dataSourceLookup);
+
+		routingDataSource.addTargetDataSourceName("ds1", "dataSource1");
+		routingDataSource.addTargetDataSourceName("ds2", "dataSource2");
+		
+		routingDataSource.afterPropertiesSet();
+		
+		lookupKey.set("ds1");
+		assertThat(routingDataSource.determineTargetDataSource(), sameInstance(ds1));
+		
+		lookupKey.set("ds2");
+		assertThat(routingDataSource.determineTargetDataSource(), sameInstance(ds2));
+	}
+
+	@Test
+	public void notInitialized() {
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return null;
+			}
+		};
+
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("DataSource router not initialized");
+
+		routingDataSource.determineTargetDataSource();
+	}
+
+}


### PR DESCRIPTION
I've added following methods in `AbstractRoutingDataSource`.

* `addTargetDataSource`
* `addTargetDataSourceName`

Issue: [SPR-15253](https://jira.spring.io/browse/SPR-15253)

Please review this.