### PR TITLE
SPR-15254 RestTemplate with MockMvcClientHttpRequestFactory double encodes URIs

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/MockMvcClientHttpRequestFactory.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/MockMvcClientHttpRequestFactory.java
@@ -60,7 +60,7 @@ public class MockMvcClientHttpRequestFactory implements ClientHttpRequestFactory
 			@Override
 			public ClientHttpResponse executeInternal() throws IOException {
 				try {
-					MockHttpServletRequestBuilder requestBuilder = request(httpMethod, uri.toString());
+					MockHttpServletRequestBuilder requestBuilder = request(httpMethod, uri);
 					requestBuilder.content(getBodyAsBytes());
 					requestBuilder.headers(getHeaders());
 					MvcResult mvcResult = MockMvcClientHttpRequestFactory.this.mockMvc.perform(requestBuilder).andReturn();


### PR DESCRIPTION
SPR-15254 RestTemplate with MockMvcClientHttpRequestFactory double encodes URIs

Using an URI with an email address as a request parameter with a RestTemplate method causes the @ to be double encoded. It should be encoded as %40, but will eventually end up as %2540. The reason is that the MockMvcClientHttpRequestFactory will run .toString() on the URI before passing it over to the MockMvc request builder. The MockMvc request builder assumes that Strings are unencoded, and will (re-) encode the URI. Passing it as an URI to the MockMvc builder will skip that encoding step.
