### PR TITLE
CollectionToObjectConverter - Refactor with Collection#isEmpty()

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/CollectionToObjectConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/CollectionToObjectConverter.java
@@ -57,7 +57,7 @@ final class CollectionToObjectConverter implements ConditionalGenericConverter {
 			return source;
 		}
 		Collection<?> sourceCollection = (Collection<?>) source;
-		if (sourceCollection.size() == 0) {
+		if (sourceCollection.isEmpty()) {
 			return null;
 		}
 		Object firstElement = sourceCollection.iterator().next();

--- a/spring-core/src/main/java/org/springframework/core/convert/support/CollectionToObjectConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/CollectionToObjectConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replace `sourceCollection.size() == 0` by `sourceCollection.isEmpty()` in class `CollectionToObjectConverter`.