### PR TITLE
Polish CollectionFactoryTests

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/CollectionFactoryTests.java
+++ b/spring-core/src/test/java/org/springframework/core/CollectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.*;
 import static org.springframework.core.CollectionFactory.*;
 
@@ -165,7 +166,7 @@ public class CollectionFactoryTests {
 	@Test
 	public void createApproximateCollectionFromEmptyHashSet() {
 		Collection<String> set = createApproximateCollection(new HashSet<String>(), 2);
-		assertThat(set.size(), is(0));
+		assertThat(set, is(empty()));
 	}
 
 	@Test
@@ -173,19 +174,19 @@ public class CollectionFactoryTests {
 		HashSet<String> hashSet = new HashSet<>();
 		hashSet.add("foo");
 		Collection<String> set = createApproximateCollection(hashSet, 2);
-		assertThat(set.size(), is(0));
+		assertThat(set, is(empty()));
 	}
 
 	@Test
 	public void createApproximateCollectionFromEmptyEnumSet() {
 		Collection<Color> colors = createApproximateCollection(EnumSet.noneOf(Color.class), 2);
-		assertThat(colors.size(), is(0));
+		assertThat(colors, is(empty()));
 	}
 
 	@Test
 	public void createApproximateCollectionFromNonEmptyEnumSet() {
 		Collection<Color> colors = createApproximateCollection(EnumSet.of(Color.BLUE), 2);
-		assertThat(colors.size(), is(0));
+		assertThat(colors, is(empty()));
 	}
 
 	@Test


### PR DESCRIPTION
Use `is(empty())` to test empty collections.