### PR TITLE
SPR-15683 Avoid NullPointerException if cron expression is null

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
@@ -261,7 +261,9 @@ public class CronSequenceGenerator {
 	 */
 	private void parse(String expression) throws IllegalArgumentException {
 		String[] fields = StringUtils.tokenizeToStringArray(expression, " ");
-		if (!areValidCronFields(fields)) {
+		if (fields == null) {
+			throw new IllegalArgumentException("Cron expression must not be null");
+		} else if (!areValidCronFields(fields)) {
 			throw new IllegalArgumentException(String.format(
 					"Cron expression must consist of 6 fields (found %d in \"%s\")", fields.length, expression));
 		}


### PR DESCRIPTION
When you pass a null cron expression to the constructor of ```CronTrigger```, it creates a ```CronSequenceGenerator``` instance which calls the ```parse()``` method from its constructor.
Inside this method the cron expression is first tokenized by ```StringUtils.tokenizeToStringArray()``` (which will return null if the cron expression is null) and put into the ```fields``` variable. Then, if the content of ```fields``` is considered invalid (null or not having the right number of elements), an ```IllegalArgumentException``` is thrown.
But as we are using ```fields.count```'s value to create the message of the exception, we get a ```NullPointerException``` (with no message) instead when ```fields``` is null.

These changes let the ```parse()``` method throw an ```IllegalArgumentException``` with a message when ```fields``` is null.