### PR TITLE
Doc fix for example of GenericApplicationContext & representation of ConditionalGenericConverter

### DIFF
--- a/src/asciidoc/core-beans.adoc
+++ b/src/asciidoc/core-beans.adoc
@@ -370,7 +370,7 @@ delegates, e.g. with `XmlBeanDefinitionReader` for XML files:
 [subs="verbatim,quotes"]
 ----
 	GenericApplicationContext context = new GenericApplicationContext();
-	new XmlBeanDefinitionReader(ctx).loadBeanDefinitions("services.xml", "daos.xml");
+	new XmlBeanDefinitionReader(context).loadBeanDefinitions("services.xml", "daos.xml");
     context.refresh();
 ----
 
@@ -380,7 +380,7 @@ Or with `GroovyBeanDefinitionReader` for Groovy files:
 [subs="verbatim,quotes"]
 ----
 	GenericApplicationContext context = new GenericApplicationContext();
-	new GroovyBeanDefinitionReader(ctx).loadBeanDefinitions("services.groovy", "daos.groovy");
+	new GroovyBeanDefinitionReader(context).loadBeanDefinitions("services.groovy", "daos.groovy");
     context.refresh();
 ----
 

--- a/src/asciidoc/core-validation.adoc
+++ b/src/asciidoc/core-validation.adoc
@@ -863,10 +863,14 @@ such as a `static valueOf` method, is defined on the target class.
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
-	public interface ConditionalGenericConverter
-	        extends GenericConverter, ConditionalConverter {
+	public interface ConditionalConverter {
 
 		boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType);
+
+	}
+	
+	public interface ConditionalGenericConverter
+	        extends GenericConverter, ConditionalConverter {
 
 	}
 ----


### PR DESCRIPTION
Making easier for understanding example of GenericApplicationContext by changing undeclared object `ctx` to `context`. And, also fix for representation of ConditionalGenericConverter interface. I think these changes are essential.