### PR TITLE
[Documentation] Updated URI Template reference links

### DIFF
--- a/src/asciidoc/web-mvc.adoc
+++ b/src/asciidoc/web-mvc.adoc
@@ -771,9 +771,8 @@ __URI templates__ can be used for convenient access to selected parts of a URL i
 `@RequestMapping` method.
 
 A URI Template is a URI-like string, containing one or more variable names. When you
-substitute values for these variables, the template becomes a URI. The
-http://bitworking.org/projects/URI-Templates/[proposed RFC] for URI Templates defines
-how a URI is parameterized. For example, the URI Template
+substitute values for these variables, the template becomes a URI. https://tools.ietf.org/html/rfc6570[RFC 6570] for
+https://github.com/uri-templates/[URI Templates] defines how a URI is parameterized. For example, the URI Template
 `http://www.example.com/users/{userId}` contains the variable __userId__. Assigning the
 value __fred__ to the variable yields `http://www.example.com/users/fred`.
 


### PR DESCRIPTION
Updated link to URI Template reference - the existing link no longer works/exists.  Instead I've linked to the RFC and related GitHub repository.