### PR TITLE
spring-jdbc meta data prcoessing bugfix

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericCallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericCallMetaDataProvider.java
@@ -361,14 +361,14 @@ public class GenericCallMetaDataProvider implements CallMetaDataProvider {
 						columnType == DatabaseMetaData.procedureColumnOut)) {
 					if (logger.isDebugEnabled()) {
 						logger.debug("Skipping metadata for: " + columnType + " " + procs.getInt("DATA_TYPE") +
-							" " + procs.getString("TYPE_NAME") + " " + procs.getBoolean("NULLABLE") +
+							" " + procs.getString("TYPE_NAME") + " " + procs.getShort("NULLABLE") == 1 +
 							" (probably a member of a collection)"
 						);
 					}
 				}
 				else {
 					CallParameterMetaData meta = new CallParameterMetaData(columnName, columnType,
-							procs.getInt("DATA_TYPE"), procs.getString("TYPE_NAME"), procs.getBoolean("NULLABLE")
+							procs.getInt("DATA_TYPE"), procs.getString("TYPE_NAME"), procs.getShort("NULLABLE") == 1
 					);
 					this.callParameterMetaData.add(meta);
 					if (logger.isDebugEnabled()) {


### PR DESCRIPTION
ResultSet.getBoolean doesn't describe how to handle anything other than
NULL, 0, or 1. Since the 'NULLABLE' column can return 2, meaning
unknown, the code should change to process the ResultSet with the
explicitly defined types.

Issue: SPR-15333