### PR TITLE
SPR-11587: Support multiple TilesContainer per ServletContext

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/tiles3/SpringTilesContainerFactory.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/tiles3/SpringTilesContainerFactory.java
@@ -1,0 +1,127 @@
+package org.springframework.web.servlet.view.tiles3;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.servlet.jsp.JspFactory;
+
+import org.apache.tiles.TilesContainer;
+import org.apache.tiles.definition.DefinitionsFactory;
+import org.apache.tiles.definition.DefinitionsReader;
+import org.apache.tiles.definition.dao.BaseLocaleUrlDefinitionDAO;
+import org.apache.tiles.definition.dao.CachingLocaleUrlDefinitionDAO;
+import org.apache.tiles.definition.digester.DigesterDefinitionsReader;
+import org.apache.tiles.evaluator.AttributeEvaluator;
+import org.apache.tiles.evaluator.AttributeEvaluatorFactory;
+import org.apache.tiles.evaluator.BasicAttributeEvaluatorFactory;
+import org.apache.tiles.evaluator.impl.DirectAttributeEvaluator;
+import org.apache.tiles.factory.BasicTilesContainerFactory;
+import org.apache.tiles.impl.mgmt.CachingTilesContainer;
+import org.apache.tiles.locale.LocaleResolver;
+import org.apache.tiles.preparer.factory.PreparerFactory;
+import org.apache.tiles.request.ApplicationContext;
+import org.apache.tiles.request.ApplicationContextAware;
+import org.apache.tiles.request.ApplicationResource;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
+import org.springframework.web.servlet.view.tiles3.TilesConfigurer.TilesElActivator;
+
+/**
+ * @author Torsten Krah
+ */
+class SpringTilesContainerFactory extends BasicTilesContainerFactory {
+
+    private TilesConfigurer tilesConfigurer;
+
+    public SpringTilesContainerFactory(TilesConfigurer tilesConfigurer) {
+        this.tilesConfigurer = tilesConfigurer;
+    }
+
+    @Override
+    protected TilesContainer createDecoratedContainer(TilesContainer originalContainer, ApplicationContext context) {
+        return (tilesConfigurer.useMutableTilesContainer ? new CachingTilesContainer(originalContainer) : originalContainer);
+    }
+
+    @Override
+    protected List<ApplicationResource> getSources(ApplicationContext applicationContext) {
+        if (tilesConfigurer.definitions != null) {
+            List<ApplicationResource> result = new LinkedList<>();
+            for (String definition : tilesConfigurer.definitions) {
+                Collection<ApplicationResource> resources = applicationContext.getResources(definition);
+                if (resources != null) {
+                    result.addAll(resources);
+                }
+            }
+            return result;
+        } else {
+            return super.getSources(applicationContext);
+        }
+    }
+
+    @Override
+    protected BaseLocaleUrlDefinitionDAO instantiateLocaleDefinitionDao(ApplicationContext applicationContext,
+                                                                        LocaleResolver resolver) {
+        BaseLocaleUrlDefinitionDAO dao = super.instantiateLocaleDefinitionDao(applicationContext, resolver);
+        if (tilesConfigurer.checkRefresh && dao instanceof CachingLocaleUrlDefinitionDAO) {
+            ((CachingLocaleUrlDefinitionDAO) dao).setCheckRefresh(true);
+        }
+        return dao;
+    }
+
+    @Override
+    protected DefinitionsReader createDefinitionsReader(ApplicationContext context) {
+        DigesterDefinitionsReader reader = (DigesterDefinitionsReader) super.createDefinitionsReader(context);
+        reader.setValidating(tilesConfigurer.validateDefinitions);
+        return reader;
+    }
+
+    @Override
+    protected DefinitionsFactory createDefinitionsFactory(ApplicationContext applicationContext,
+                                                          LocaleResolver resolver) {
+
+        if (tilesConfigurer.definitionsFactoryClass != null) {
+            DefinitionsFactory factory = BeanUtils.instantiateClass(tilesConfigurer.definitionsFactoryClass);
+            if (factory instanceof ApplicationContextAware) {
+                ((ApplicationContextAware) factory).setApplicationContext(applicationContext);
+            }
+            BeanWrapper bw = PropertyAccessorFactory.forBeanPropertyAccess(factory);
+            if (bw.isWritableProperty("localeResolver")) {
+                bw.setPropertyValue("localeResolver", resolver);
+            }
+            if (bw.isWritableProperty("definitionDAO")) {
+                bw.setPropertyValue("definitionDAO", createLocaleDefinitionDao(applicationContext, resolver));
+            }
+            return factory;
+        } else {
+            return super.createDefinitionsFactory(applicationContext, resolver);
+        }
+    }
+
+    @Override
+    protected PreparerFactory createPreparerFactory(ApplicationContext context) {
+        if (tilesConfigurer.preparerFactoryClass != null) {
+            return BeanUtils.instantiateClass(tilesConfigurer.preparerFactoryClass);
+        } else {
+            return super.createPreparerFactory(context);
+        }
+    }
+
+    @Override
+    protected LocaleResolver createLocaleResolver(ApplicationContext context) {
+        return new SpringLocaleResolver();
+    }
+
+    @Override
+    protected AttributeEvaluatorFactory createAttributeEvaluatorFactory(ApplicationContext context,
+                                                                        LocaleResolver resolver) {
+        AttributeEvaluator evaluator;
+        if (TilesConfigurer.tilesElPresent && JspFactory.getDefaultFactory() != null) {
+            evaluator = new TilesElActivator().createEvaluator(tilesConfigurer.servletContext);
+        } else {
+            evaluator = new DirectAttributeEvaluator();
+        }
+        return new BasicAttributeEvaluatorFactory(evaluator);
+    }
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/tiles3/SpringTilesInitializer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/tiles3/SpringTilesInitializer.java
@@ -1,0 +1,30 @@
+package org.springframework.web.servlet.view.tiles3;
+
+import org.apache.tiles.factory.AbstractTilesContainerFactory;
+import org.apache.tiles.request.ApplicationContext;
+import org.apache.tiles.startup.DefaultTilesInitializer;
+
+/**
+ * @author Torsten Krah
+ */
+class SpringTilesInitializer extends DefaultTilesInitializer {
+
+    private TilesConfigurer tilesConfigurer;
+    private final String contextId;
+
+    public SpringTilesInitializer(TilesConfigurer tilesConfigurer, final String contextId) {
+        super();
+        this.tilesConfigurer = tilesConfigurer;
+        this.contextId = contextId;
+    }
+
+    @Override
+    protected AbstractTilesContainerFactory createContainerFactory(ApplicationContext context) {
+        return new SpringTilesContainerFactory(this.tilesConfigurer);
+    }
+
+    @Override
+    protected String getContainerKey(ApplicationContext applicationContext) {
+        return this.contextId;
+    }
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/tiles3/TilesView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/tiles3/TilesView.java
@@ -94,7 +94,8 @@ public class TilesView extends AbstractUrlBasedView {
 
 		this.applicationContext = ServletUtil.getApplicationContext(getServletContext());
 		if (this.renderer == null) {
-			TilesContainer container = TilesAccess.getContainer(this.applicationContext);
+			TilesContainer container = TilesAccess.getContainer(this.applicationContext,
+					getWebApplicationContext().getId());
 			this.renderer = new DefinitionRenderer(container);
 		}
 	}
@@ -129,6 +130,7 @@ public class TilesView extends AbstractUrlBasedView {
 		}
 
 		Request tilesRequest = createTilesRequest(request, response);
+        TilesAccess.setCurrentContainer(tilesRequest, getWebApplicationContext().getId());
 		this.renderer.render(getUrl(), tilesRequest);
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/tiles3/TilesConfigurerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/tiles3/TilesConfigurerTests.java
@@ -16,18 +16,21 @@
 
 package org.springframework.web.servlet.view.tiles3;
 
+import org.apache.tiles.Definition;
 import org.apache.tiles.access.TilesAccess;
 import org.apache.tiles.impl.BasicTilesContainer;
 import org.apache.tiles.request.ApplicationContext;
 import org.apache.tiles.request.Request;
 import org.apache.tiles.request.servlet.ServletRequest;
 import org.apache.tiles.request.servlet.ServletUtil;
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.mock.web.test.MockHttpServletResponse;
 import org.springframework.mock.web.test.MockServletContext;
+import org.springframework.web.context.support.StaticWebApplicationContext;
 
 import static org.junit.Assert.*;
 
@@ -41,22 +44,90 @@ public class TilesConfigurerTests {
 	@Test
 	public void simpleBootstrap() {
 		MockServletContext servletContext = new MockServletContext();
+		StaticWebApplicationContext wac = new StaticWebApplicationContext();
+		wac.setServletContext(servletContext);
+		wac.refresh();
 
 		TilesConfigurer tc = new TilesConfigurer();
 		tc.setDefinitions("/org/springframework/web/servlet/view/tiles3/tiles-definitions.xml");
 		tc.setCheckRefresh(true);
 		tc.setServletContext(servletContext);
+		tc.setApplicationContext(wac);
 		tc.afterPropertiesSet();
 
 		ApplicationContext tilesContext = ServletUtil.getApplicationContext(servletContext);
 
-		BasicTilesContainer container = (BasicTilesContainer) TilesAccess.getContainer(tilesContext);
+		BasicTilesContainer container = (BasicTilesContainer) TilesAccess.getContainer(tilesContext, wac.getId());
 		Request requestContext = new ServletRequest(container.getApplicationContext(),
 				new MockHttpServletRequest(), new MockHttpServletResponse());
-		assertNotNull(container.getDefinitionsFactory().getDefinition("test", requestContext));
+        Definition definition = container.getDefinitionsFactory().getDefinition("test", requestContext);
+        assertNotNull(definition);
+        assertEquals("/WEB-INF/tiles/test.jsp", definition.getTemplateAttribute().getValue());
 
-		tc.destroy();
+        tc.destroy();
 	}
+
+    @Test
+    public void moreThanOneContextBootstrap() {
+        MockServletContext servletContext = new MockServletContext();
+
+        StaticWebApplicationContext wac1 = new StaticWebApplicationContext();
+        wac1.setDisplayName("wac1");
+        wac1.setId("wac1");
+        wac1.setServletContext(servletContext);
+        wac1.refresh();
+
+        TilesConfigurer tc1 = new TilesConfigurer();
+        tc1.setDefinitions("/org/springframework/web/servlet/view/tiles3/tiles-definitions.xml");
+        tc1.setCheckRefresh(true);
+        tc1.setServletContext(servletContext);
+        tc1.setApplicationContext(wac1);
+        tc1.afterPropertiesSet();
+
+
+        StaticWebApplicationContext wac2 = new StaticWebApplicationContext();
+        wac2.setDisplayName("wac2");
+        wac2.setId("wac2");
+        wac2.setServletContext(servletContext);
+        wac2.refresh();
+
+        TilesConfigurer tc2 = new TilesConfigurer();
+        tc2.setDefinitions("/org/springframework/web/servlet/view/tiles3/tiles-definitions-2nd.xml");
+        tc2.setCheckRefresh(true);
+        tc2.setServletContext(servletContext);
+        tc2.setApplicationContext(wac2);
+        tc2.afterPropertiesSet();
+
+        ApplicationContext tilesContext = ServletUtil.getApplicationContext(servletContext);
+        assertNotNull(tilesContext.getApplicationScope().get(wac1.getId()));
+        assertNotNull(tilesContext.getApplicationScope().get(wac2.getId()));
+        assertNull(TilesAccess.getContainer(tilesContext));
+
+        try {
+            BasicTilesContainer container = (BasicTilesContainer) TilesAccess.getContainer(tilesContext, wac1.getId());
+            Request requestContext = new ServletRequest(container.getApplicationContext(),
+                    new MockHttpServletRequest(), new MockHttpServletResponse());
+            Definition definition = container.getDefinitionsFactory().getDefinition("test", requestContext);
+            assertNotNull(definition);
+            assertEquals("/WEB-INF/tiles/test.jsp", definition.getTemplateAttribute().getValue());
+        } finally {
+
+        }
+
+        try {
+            BasicTilesContainer container = (BasicTilesContainer) TilesAccess.getContainer(tilesContext, wac2.getId());
+            Request requestContext = new ServletRequest(container.getApplicationContext(),
+                    new MockHttpServletRequest(), new MockHttpServletResponse());
+            Definition definition = container.getDefinitionsFactory().getDefinition("test2", requestContext);
+            assertNotNull(definition);
+            assertEquals("/WEB-INF/tiles/test2.jsp", definition.getTemplateAttribute().getValue());
+        } finally {
+
+        }
+
+
+        tc1.destroy();
+    }
 
 
 	@Configuration

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/tiles3/TilesViewIntegrationTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/tiles3/TilesViewIntegrationTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.web.servlet.view.tiles3;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.tiles.definition.NoSuchDefinitionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.test.MockHttpServletRequest;
+import org.springframework.mock.web.test.MockHttpServletResponse;
+import org.springframework.mock.web.test.MockServletContext;
+import org.springframework.web.context.support.StaticWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+/**
+ * Test fixture for {@link TilesView}.
+ *
+ * @author mick semb wever
+ * @author Sebastien Deleuze
+ */
+public class TilesViewIntegrationTests {
+
+	private static final String VIEW_PATH = "test";
+
+    private static final String VIEW_PATH_2 = "test2";
+
+	private TilesView view1;
+
+    private TilesView view2;
+
+	private MockHttpServletRequest request1;
+
+	private MockHttpServletResponse response1;
+
+    private MockHttpServletRequest request2;
+
+    private MockHttpServletResponse response2;
+
+
+	@Before
+	public void setUp() throws Exception {
+		final MockServletContext servletContext = new MockServletContext();
+
+		final StaticWebApplicationContext wac1 = new StaticWebApplicationContext();
+		wac1.setDisplayName("wac1");
+		wac1.setId("wac1");
+		wac1.setServletContext(servletContext);
+		wac1.refresh();
+
+		request1 = new MockHttpServletRequest();
+		request1.setAttribute(DispatcherServlet.WEB_APPLICATION_CONTEXT_ATTRIBUTE, wac1);
+
+		response1 = new MockHttpServletResponse();
+
+        final TilesConfigurer tc1 = new TilesConfigurer();
+        tc1.setDefinitions("/org/springframework/web/servlet/view/tiles3/tiles-definitions.xml");
+        tc1.setCheckRefresh(true);
+        tc1.setServletContext(servletContext);
+        tc1.setApplicationContext(wac1);
+        tc1.afterPropertiesSet();
+
+        final StaticWebApplicationContext wac2 = new StaticWebApplicationContext();
+        wac2.setDisplayName("wac2");
+        wac2.setId("wac2");
+        wac2.setServletContext(servletContext);
+        wac2.refresh();
+
+        request2 = new MockHttpServletRequest();
+        request2.setAttribute(DispatcherServlet.WEB_APPLICATION_CONTEXT_ATTRIBUTE, wac2);
+
+        response2 = new MockHttpServletResponse();
+
+        final TilesConfigurer tc2 = new TilesConfigurer();
+        tc2.setDefinitions("/org/springframework/web/servlet/view/tiles3/tiles-definitions-2nd.xml");
+        tc2.setCheckRefresh(true);
+        tc2.setServletContext(servletContext);
+        tc2.setApplicationContext(wac2);
+        tc2.afterPropertiesSet();
+
+        view1 = new TilesView();
+		view1.setServletContext(servletContext);
+		view1.setApplicationContext(wac1);
+		view1.setUrl(VIEW_PATH);
+		view1.afterPropertiesSet();
+
+        view2 = new TilesView();
+        view2.setServletContext(servletContext);
+        view2.setApplicationContext(wac2);
+        view2.setUrl(VIEW_PATH_2);
+        view2.afterPropertiesSet();
+	}
+
+	@Test
+	public void render() throws Exception {
+		Map<String, Object> model = new HashMap<>();
+		model.put("modelAttribute", "modelValue");
+		view1.render(model, request1, response1);
+		assertEquals("modelValue", request1.getAttribute("modelAttribute"));
+        view2.render(model, request2, response2);
+        assertEquals("modelValue", request2.getAttribute("modelAttribute"));
+	}
+
+    @Test(expected = NoSuchDefinitionException.class)
+	public void renderPath1FromWac2() throws Exception {
+        Map<String, Object> model = new HashMap<>();
+        view2.setUrl(VIEW_PATH);
+        view2.render(model, request2, response2);
+    }
+
+    @Test(expected = NoSuchDefinitionException.class)
+    public void renderPath2FromWac1() throws Exception {
+        Map<String, Object> model = new HashMap<>();
+        view1.setUrl(VIEW_PATH_2);
+        view1.render(model, request1, response1);
+    }
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/tiles3/TilesViewTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/tiles3/TilesViewTests.java
@@ -15,23 +15,29 @@
  */
 package org.springframework.web.servlet.view.tiles3;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.isA;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.verify;
+
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.tiles.access.TilesAccess;
 import org.apache.tiles.request.AbstractRequest;
 import org.apache.tiles.request.Request;
 import org.apache.tiles.request.render.Renderer;
+import org.apache.tiles.request.render.StringRenderer;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.mock.web.test.MockHttpServletResponse;
 import org.springframework.mock.web.test.MockServletContext;
 import org.springframework.web.context.support.StaticWebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
-
-import static org.junit.Assert.*;
-import static org.mockito.BDDMockito.*;
 
 /**
  * Test fixture for {@link TilesView}.
@@ -66,8 +72,16 @@ public class TilesViewTests {
 
 		renderer = mock(Renderer.class);
 
-		view = new TilesView();
+        TilesConfigurer tc = new TilesConfigurer();
+        tc.setDefinitions("/org/springframework/web/servlet/view/tiles3/tiles-definitions.xml");
+        tc.setCheckRefresh(true);
+        tc.setServletContext(servletContext);
+        tc.setApplicationContext(wac);
+        tc.afterPropertiesSet();
+
+        view = new TilesView();
 		view.setServletContext(servletContext);
+		view.setApplicationContext(wac);
 		view.setRenderer(renderer);
 		view.setUrl(VIEW_PATH);
 		view.afterPropertiesSet();

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/tiles3/tiles-definitions-2nd.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/tiles3/tiles-definitions-2nd.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE tiles-definitions PUBLIC
+		"-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN"
+		"http://tiles.apache.org/dtds/tiles-config_3_0.dtd">
+
+<tiles-definitions>
+
+	<definition name="test2" template="/WEB-INF/tiles/test2.jsp"/>
+
+</tiles-definitions>


### PR DESCRIPTION
Why i did this - because Spring fails to properly support multiple TilesContainer per ServletContext because its using a "null" key mapping, multiple container in different FrameworkServlets will override each others factory. See ticket for details.

Question to be answered:

1. Should i include visibility/extension changes according to the ticket in this one or do another changeset - still tbd?
2. Are the test enhancements / naming made sufficient?

Discussion in general:

Still need to polish it to the coding guidelines - but want to get early feedback on the general refactoring 
stuf, if it fits your expectations or how todo it better.
Package visibility access on many properties is not my favourite - should i refactor those in getters or pass the needed references to each instance via construction parameters? Any other ideas?

ICLA  submitted.

Issue: SPR-11587