### PR TITLE
Add preferred content type configurer method

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationManagerFactoryBean.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationManagerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,8 +224,8 @@ public class ContentNegotiationManagerFactoryBean
 	 * <p>By default this is not set.
 	 * @see #setDefaultContentTypeStrategy
 	 */
-	public void setDefaultContentType(MediaType contentType) {
-		this.defaultNegotiationStrategy = new FixedContentNegotiationStrategy(contentType);
+	public void setDefaultContentType(List<MediaType> contentTypes) {
+		this.defaultNegotiationStrategy = new FixedContentNegotiationStrategy(contentTypes);
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/accept/FixedContentNegotiationStrategy.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/FixedContentNegotiationStrategy.java
@@ -16,12 +16,11 @@
 
 package org.springframework.web.accept;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.http.MediaType;
 import org.springframework.web.context.request.NativeWebRequest;
 
@@ -35,23 +34,36 @@ public class FixedContentNegotiationStrategy implements ContentNegotiationStrate
 
 	private static final Log logger = LogFactory.getLog(FixedContentNegotiationStrategy.class);
 
-	private final List<MediaType> contentType;
+	private final List<MediaType> contentTypes;
 
 
 	/**
 	 * Create an instance with the given content type.
 	 */
-	public FixedContentNegotiationStrategy(MediaType contentType) {
-		this.contentType = Collections.singletonList(contentType);
+	public FixedContentNegotiationStrategy(MediaType... contentTypes) {
+		this.contentTypes = Arrays.asList(contentTypes);
+	}
+	
+	/**
+	 * Create an instance with the given content type.
+	 * 
+	 * <p>
+	 * List is ordered in the same manner as a "quality" parameter on incoming requests.
+	 * If destinations which do not support any of the media types provided are present,
+	 * end the list with {@link MediaType#ALL} to allow standard media type determination
+	 */
+	public FixedContentNegotiationStrategy(List<MediaType> contentTypes) {
+		this.contentTypes = contentTypes;
 	}
 
 
 	@Override
 	public List<MediaType> resolveMediaTypes(NativeWebRequest request) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("Requested media types: " + this.contentType);
+			logger.debug("Requested media types: " + this.contentTypes);
 		}
-		return this.contentType;
+		
+		return this.contentTypes;
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/web/accept/ContentNegotiationManagerFactoryBeanTests.java
+++ b/spring-web/src/test/java/org/springframework/web/accept/ContentNegotiationManagerFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.springframework.web.accept;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.mock.web.test.MockServletContext;
@@ -175,10 +175,10 @@ public class ContentNegotiationManagerFactoryBeanTests {
 
 		assertEquals(Collections.<MediaType>emptyList(), manager.resolveMediaTypes(this.webRequest));
 	}
-
+	
 	@Test
 	public void setDefaultContentType() throws Exception {
-		this.factoryBean.setDefaultContentType(MediaType.APPLICATION_JSON);
+		this.factoryBean.setDefaultContentType(Arrays.asList(MediaType.APPLICATION_JSON));
 		this.factoryBean.afterPropertiesSet();
 		ContentNegotiationManager manager = this.factoryBean.getObject();
 
@@ -188,6 +188,21 @@ public class ContentNegotiationManagerFactoryBeanTests {
 		// SPR-10513
 		this.servletRequest.addHeader("Accept", MediaType.ALL_VALUE);
 		assertEquals(Collections.singletonList(MediaType.APPLICATION_JSON),
+				manager.resolveMediaTypes(this.webRequest));
+	}
+	
+	@Test
+	public void setMultipleDefaultContentTypess() throws Exception {
+		this.factoryBean.setDefaultContentType(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.ALL));
+		this.factoryBean.afterPropertiesSet();
+		ContentNegotiationManager manager = this.factoryBean.getObject();
+
+		assertEquals(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.ALL),
+				manager.resolveMediaTypes(this.webRequest));
+
+		// SPR-15367
+		this.servletRequest.addHeader("Accept", MediaType.ALL_VALUE);
+		assertEquals(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.ALL),
 				manager.resolveMediaTypes(this.webRequest));
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/ContentNegotiationConfigurer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/ContentNegotiationConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package org.springframework.web.servlet.config.annotation;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.servlet.ServletContext;
 
 import org.springframework.http.MediaType;
@@ -209,11 +211,18 @@ public class ContentNegotiationConfigurer {
 
 	/**
 	 * Set the default content type to use when no content type is requested.
-	 * <p>By default this is not set.
+	 * <p>
+	 * Media types are ordered in the same manner as a "quality" parameter on incoming
+	 * requests. If destinations which do not support any of the media types provided are
+	 * present, end the list with {@link MediaType#ALL} to allow standard media type
+	 * determination
+	 * <p>
+	 * By default this is not set.
+	 * 
 	 * @see #defaultContentTypeStrategy
 	 */
-	public ContentNegotiationConfigurer defaultContentType(MediaType defaultContentType) {
-		this.factory.setDefaultContentType(defaultContentType);
+	public ContentNegotiationConfigurer defaultContentType(MediaType... defaultContentTypes) {
+		this.factory.setDefaultContentType(Arrays.asList(defaultContentTypes));
 		return this;
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/ContentNegotiationConfigurerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/ContentNegotiationConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.test.MockHttpServletRequest;
 import org.springframework.web.accept.ContentNegotiationManager;
@@ -110,6 +109,14 @@ public class ContentNegotiationConfigurerTests {
 		ContentNegotiationManager manager = this.configurer.getContentNegotiationManager();
 
 		assertEquals(Arrays.asList(MediaType.APPLICATION_JSON), manager.resolveMediaTypes(this.webRequest));
+	}
+	
+	@Test
+	public void setMultipleDefaultContentTypes() throws Exception {
+		this.configurer.defaultContentType(MediaType.APPLICATION_JSON, MediaType.ALL);
+		ContentNegotiationManager manager = this.configurer.getContentNegotiationManager();
+
+		assertEquals(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.ALL), manager.resolveMediaTypes(this.webRequest));
 	}
 
 	@Test


### PR DESCRIPTION
Applications which support end points with a variety of content types often want to specify a default set of content types to "prefer" when a client does not request a specific content type. Such a list would replicate a set of default content types with "quality" parameters (such as those used in accept headers) for requests which accept all (*/*) content types.

The existing functionality to set the default content type will cause any end point which does not support the specified default to return a 406 status code when "*/*" (or nothing) is provided in an Accept header - however, based on the documentation, it appears this is intended. For this reason, this PR adds a new method to the configurer, as opposed to enhancing the defaultContentType method.

I proposed this addition/enhancement in JIRA issue [SPR-15367](https://jira.spring.io/browse/SPR-15367)
I have also submitted ICLA per the contribution guidelines