### PR TITLE
Spring JDBC not correctly processing Postgresql ?| and ?& operator

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
@@ -153,8 +153,8 @@ public abstract class NamedParameterUtils {
 				}
 				if (c == '?') {
 					int j = i + 1;
-					if (j < statement.length && statement[j] == '?') {
-						// Postgres-style "??" operator should be skipped
+					if (j < statement.length && (statement[j] == '?' || statement[j] == '|' || statement[j] == '&')) {
+						// Postgres-style "??", "?|", "?&" operator should be skipped
 						i = i + 2;
 						continue;
 					}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterUtilsTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterUtilsTests.java
@@ -189,6 +189,26 @@ public class NamedParameterUtilsTests {
 		assertEquals(expectedSql, NamedParameterUtils.substituteNamedParameters(parsedSql, null));
 	}
 
+	@Test  // SPR-15382
+	public void parseSqlStatementWithPostgresAnyArrayStringsExistsOperator() throws Exception {
+		String expectedSql = "select '[\"3\", \"11\"]'::jsonb ?| '{1,3,11,12,17}'::text[]";
+		String sql = "select '[\"3\", \"11\"]'::jsonb ?| '{1,3,11,12,17}'::text[]";
+
+		ParsedSql parsedSql = NamedParameterUtils.parseSqlStatement(sql);
+		assertEquals(0, parsedSql.getTotalParameterCount());
+		assertEquals(expectedSql, NamedParameterUtils.substituteNamedParameters(parsedSql, null));
+	}
+
+	@Test  // SPR-15382
+	public void parseSqlStatementWithPostgresAllArrayStringsExistsOperator() throws Exception {
+		String expectedSql = "select '[\"3\", \"11\"]'::jsonb ?& '{1,3,11,12,17}'::text[] AND ? = 'Back in Black'";
+		String sql = "select '[\"3\", \"11\"]'::jsonb ?& '{1,3,11,12,17}'::text[] AND :album = 'Back in Black'";
+
+		ParsedSql parsedSql = NamedParameterUtils.parseSqlStatement(sql);
+		assertEquals(1, parsedSql.getTotalParameterCount());
+		assertEquals(expectedSql, NamedParameterUtils.substituteNamedParameters(parsedSql, null));
+	}
+
 	@Test  // SPR-7476
 	public void parseSqlStatementWithEscapedColon() throws Exception {
 		String expectedSql = "select '0\\:0' as a, foo from bar where baz < DATE(? 23:59:59) and baz = ?";


### PR DESCRIPTION
JIRA link https://jira.spring.io/browse/SPR-15382

Postgresql has many functional operators such as ?| and ?& (for example [https://www.postgresql.org/docs/9.5/static/functions-json.html]).

Spring JDBC processing for this case is not correct. When running the following SQL:
```
select '["3", "11"]'::jsonb ?| '{1,3,11,12,17}'::text[]
```

... I see exceptions like this:
```
class org.springframework.dao.InvalidDataAccessApiUsageException
SQL [select '["3", "11"]'::jsonb ?| '{1,3,11,12,17}'::text[]]: given 1 parameters but expected 0
```

If I use placeholders I see:
```
class org.springframework.dao.InvalidDataAccessApiUsageException
Not allowed to mix named and traditional ? placeholders. You have 1 named parameter(s) and 1 traditional placeholder(s) in statement:  ...
```