### PR TITLE
Deprecate AsyncRestTemplate and simply access to request/response object in Web[Test]Client

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/http/client/MockAsyncClientHttpRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/client/MockAsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,21 +20,22 @@ import java.io.IOException;
 import java.net.URI;
 
 import org.springframework.http.HttpMethod;
-import org.springframework.http.client.AsyncClientHttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * An extension of {@link MockClientHttpRequest} that also implements
- * {@link AsyncClientHttpRequest} by wrapping the response in a
+ * {@link org.springframework.http.client.AsyncClientHttpRequest} by wrapping the response in a
  * {@link SettableListenableFuture}.
  *
  * @author Rossen Stoyanchev
  * @author Sam Brannen
  * @since 4.1
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
-public class MockAsyncClientHttpRequest extends MockClientHttpRequest implements AsyncClientHttpRequest {
+@Deprecated
+public class MockAsyncClientHttpRequest extends MockClientHttpRequest implements org.springframework.http.client.AsyncClientHttpRequest {
 
 	public MockAsyncClientHttpRequest() {
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/client/MockRestServiceServer.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/MockRestServiceServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,10 @@ import java.io.IOException;
 import java.net.URI;
 
 import org.springframework.http.HttpMethod;
-import org.springframework.http.client.AsyncClientHttpRequest;
-import org.springframework.http.client.AsyncClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.mock.http.client.MockAsyncClientHttpRequest;
 import org.springframework.util.Assert;
-import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.support.RestGatewaySupport;
 
@@ -65,6 +61,7 @@ import org.springframework.web.client.support.RestGatewaySupport;
  * @author Rossen Stoyanchev
  * @since 3.2
  */
+@SuppressWarnings("deprecation")
 public class MockRestServiceServer {
 
 	private final RequestExpectationManager expectationManager;
@@ -139,7 +136,7 @@ public class MockRestServiceServer {
 	 * to reply to the given {@code AsyncRestTemplate}.
 	 * @since 4.3
 	 */
-	public static MockRestServiceServerBuilder bindTo(AsyncRestTemplate asyncRestTemplate) {
+	public static MockRestServiceServerBuilder bindTo(org.springframework.web.client.AsyncRestTemplate asyncRestTemplate) {
 		return new DefaultBuilder(asyncRestTemplate);
 	}
 
@@ -168,7 +165,7 @@ public class MockRestServiceServer {
 	 * @param asyncRestTemplate the AsyncRestTemplate to set up for mock testing
 	 * @return the created mock server
 	 */
-	public static MockRestServiceServer createServer(AsyncRestTemplate asyncRestTemplate) {
+	public static MockRestServiceServer createServer(org.springframework.web.client.AsyncRestTemplate asyncRestTemplate) {
 		return bindTo(asyncRestTemplate).build();
 	}
 
@@ -215,7 +212,7 @@ public class MockRestServiceServer {
 
 		private final RestTemplate restTemplate;
 
-		private final AsyncRestTemplate asyncRestTemplate;
+		private final org.springframework.web.client.AsyncRestTemplate asyncRestTemplate;
 
 		private boolean ignoreExpectOrder;
 
@@ -225,7 +222,7 @@ public class MockRestServiceServer {
 			this.asyncRestTemplate = null;
 		}
 
-		public DefaultBuilder(AsyncRestTemplate asyncRestTemplate) {
+		public DefaultBuilder(org.springframework.web.client.AsyncRestTemplate asyncRestTemplate) {
 			Assert.notNull(asyncRestTemplate, "AsyncRestTemplate must not be null");
 			this.restTemplate = null;
 			this.asyncRestTemplate = asyncRestTemplate;
@@ -266,7 +263,8 @@ public class MockRestServiceServer {
 	 * Mock ClientHttpRequestFactory that creates requests by iterating
 	 * over the list of expected {@link DefaultRequestExpectation}'s.
 	 */
-	private class MockClientHttpRequestFactory implements ClientHttpRequestFactory, AsyncClientHttpRequestFactory {
+	@SuppressWarnings("deprecation")
+	private class MockClientHttpRequestFactory implements ClientHttpRequestFactory, org.springframework.http.client.AsyncClientHttpRequestFactory {
 
 		@Override
 		public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
@@ -274,15 +272,15 @@ public class MockRestServiceServer {
 		}
 
 		@Override
-		public AsyncClientHttpRequest createAsyncRequest(URI uri, HttpMethod httpMethod) {
+		public org.springframework.http.client.AsyncClientHttpRequest createAsyncRequest(URI uri, HttpMethod httpMethod) {
 			return createRequestInternal(uri, httpMethod);
 		}
 
-		private MockAsyncClientHttpRequest createRequestInternal(URI uri, HttpMethod method) {
+		private org.springframework.mock.http.client.MockAsyncClientHttpRequest createRequestInternal(URI uri, HttpMethod method) {
 			Assert.notNull(uri, "'uri' must not be null");
 			Assert.notNull(method, "'httpMethod' must not be null");
 
-			return new MockAsyncClientHttpRequest(method, uri) {
+			return new org.springframework.mock.http.client.MockAsyncClientHttpRequest(method, uri) {
 
 				@Override
 				protected ClientHttpResponse executeInternal() throws IOException {

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ClientHttpRequest;
@@ -97,42 +98,43 @@ class DefaultWebTestClient implements WebTestClient {
 
 
 	@Override
-	public UriSpec get() {
-		return toUriSpec(WebClient::get);
+	public UriSpec<RequestHeadersSpec<?>> get() {
+		return toUriSpec(wc -> wc.method(HttpMethod.GET));
 	}
 
 	@Override
-	public UriSpec head() {
-		return toUriSpec(WebClient::head);
+	public UriSpec<RequestHeadersSpec<?>> head() {
+		return toUriSpec(wc -> wc.method(HttpMethod.HEAD));
 	}
 
 	@Override
-	public UriSpec post() {
-		return toUriSpec(WebClient::post);
+	public UriSpec<RequestBodySpec> post() {
+		return toUriSpec(wc -> wc.method(HttpMethod.POST));
 	}
 
 	@Override
-	public UriSpec put() {
-		return toUriSpec(WebClient::put);
+	public UriSpec<RequestBodySpec> put() {
+		return toUriSpec(wc -> wc.method(HttpMethod.PUT));
 	}
 
 	@Override
-	public UriSpec patch() {
-		return toUriSpec(WebClient::patch);
+	public UriSpec<RequestBodySpec> patch() {
+		return toUriSpec(wc -> wc.method(HttpMethod.PATCH));
 	}
 
 	@Override
-	public UriSpec delete() {
-		return toUriSpec(WebClient::delete);
+	public UriSpec<RequestHeadersSpec<?>> delete() {
+		return toUriSpec(wc -> wc.method(HttpMethod.DELETE));
 	}
 
 	@Override
-	public UriSpec options() {
-		return toUriSpec(WebClient::options);
+	public UriSpec<RequestHeadersSpec<?>> options() {
+		return toUriSpec(wc -> wc.method(HttpMethod.OPTIONS));
 	}
 
-	private UriSpec toUriSpec(Function<WebClient, WebClient.UriSpec> function) {
-		return new DefaultUriSpec(function.apply(this.webClient));
+	@SuppressWarnings("unchecked")
+	private <S extends RequestHeadersSpec<?>> UriSpec<S> toUriSpec(Function<WebClient, WebClient.UriSpec<WebClient.RequestBodySpec>> function) {
+		return new DefaultUriSpec<>(function.apply(this.webClient));
 	}
 
 
@@ -156,123 +158,133 @@ class DefaultWebTestClient implements WebTestClient {
 	}
 
 
-	private class DefaultUriSpec implements UriSpec {
+	@SuppressWarnings("unchecked")
+	private class DefaultUriSpec<S extends RequestHeadersSpec<?>> implements
+			UriSpec<S> {
 
-		private final WebClient.UriSpec uriSpec;
+		private final WebClient.UriSpec<WebClient.RequestBodySpec> uriSpec;
 
 
-		DefaultUriSpec(WebClient.UriSpec spec) {
+		DefaultUriSpec(WebClient.UriSpec<WebClient.RequestBodySpec> spec) {
 			this.uriSpec = spec;
 		}
 
 		@Override
-		public HeaderSpec uri(URI uri) {
-			return new DefaultHeaderSpec(this.uriSpec.uri(uri));
+		public S uri(URI uri) {
+			return (S) new DefaultRequestBodySpec(this.uriSpec.uri(uri));
 		}
 
 		@Override
-		public HeaderSpec uri(String uriTemplate, Object... uriVariables) {
-			return new DefaultHeaderSpec(this.uriSpec.uri(uriTemplate, uriVariables));
+		public S uri(String uriTemplate, Object... uriVariables) {
+			return (S) new DefaultRequestBodySpec(this.uriSpec.uri(uriTemplate, uriVariables));
 		}
 
 		@Override
-		public HeaderSpec uri(String uriTemplate, Map<String, ?> uriVariables) {
-			return new DefaultHeaderSpec(this.uriSpec.uri(uriTemplate, uriVariables));
+		public S uri(String uriTemplate, Map<String, ?> uriVariables) {
+			return (S) new DefaultRequestBodySpec(this.uriSpec.uri(uriTemplate, uriVariables));
 		}
 
 		@Override
-		public HeaderSpec uri(Function<UriBuilder, URI> uriBuilder) {
-			return new DefaultHeaderSpec(this.uriSpec.uri(uriBuilder));
+		public S uri(Function<UriBuilder, URI> uriBuilder) {
+			return (S) new DefaultRequestBodySpec(this.uriSpec.uri(uriBuilder));
 		}
 	}
 
-	private class DefaultHeaderSpec implements WebTestClient.HeaderSpec {
+	private class DefaultRequestBodySpec implements RequestBodySpec {
 
-		private final WebClient.HeaderSpec headerSpec;
+		private final WebClient.RequestBodySpec bodySpec;
 
 		private final String requestId;
 
 
-		DefaultHeaderSpec(WebClient.HeaderSpec spec) {
-			this.headerSpec = spec;
+		DefaultRequestBodySpec(WebClient.RequestBodySpec spec) {
+			this.bodySpec = spec;
 			this.requestId = String.valueOf(requestIndex.incrementAndGet());
-			this.headerSpec.header(WiretapConnector.REQUEST_ID_HEADER_NAME, this.requestId);
+			this.bodySpec.header(WiretapConnector.REQUEST_ID_HEADER_NAME, this.requestId);
 		}
 
 
 		@Override
-		public DefaultHeaderSpec header(String headerName, String... headerValues) {
-			this.headerSpec.header(headerName, headerValues);
+		public RequestBodySpec header(String headerName, String... headerValues) {
+			this.bodySpec.header(headerName, headerValues);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec headers(HttpHeaders headers) {
-			this.headerSpec.headers(headers);
+		public RequestBodySpec headers(HttpHeaders headers) {
+			this.bodySpec.headers(headers);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec accept(MediaType... acceptableMediaTypes) {
-			this.headerSpec.accept(acceptableMediaTypes);
+		public RequestBodySpec accept(MediaType... acceptableMediaTypes) {
+			this.bodySpec.accept(acceptableMediaTypes);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec acceptCharset(Charset... acceptableCharsets) {
-			this.headerSpec.acceptCharset(acceptableCharsets);
+		public RequestBodySpec acceptCharset(Charset... acceptableCharsets) {
+			this.bodySpec.acceptCharset(acceptableCharsets);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec contentType(MediaType contentType) {
-			this.headerSpec.contentType(contentType);
+		public RequestBodySpec contentType(MediaType contentType) {
+			this.bodySpec.contentType(contentType);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec contentLength(long contentLength) {
-			this.headerSpec.contentLength(contentLength);
+		public RequestBodySpec contentLength(long contentLength) {
+			this.bodySpec.contentLength(contentLength);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec cookie(String name, String value) {
-			this.headerSpec.cookie(name, value);
+		public RequestBodySpec cookie(String name, String value) {
+			this.bodySpec.cookie(name, value);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec cookies(MultiValueMap<String, String> cookies) {
-			this.headerSpec.cookies(cookies);
+		public RequestBodySpec cookies(MultiValueMap<String, String> cookies) {
+			this.bodySpec.cookies(cookies);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec ifModifiedSince(ZonedDateTime ifModifiedSince) {
-			this.headerSpec.ifModifiedSince(ifModifiedSince);
+		public RequestBodySpec ifModifiedSince(ZonedDateTime ifModifiedSince) {
+			this.bodySpec.ifModifiedSince(ifModifiedSince);
 			return this;
 		}
 
 		@Override
-		public DefaultHeaderSpec ifNoneMatch(String... ifNoneMatches) {
-			this.headerSpec.ifNoneMatch(ifNoneMatches);
+		public RequestBodySpec ifNoneMatch(String... ifNoneMatches) {
+			this.bodySpec.ifNoneMatch(ifNoneMatches);
 			return this;
 		}
 
 		@Override
 		public ResponseSpec exchange() {
-			return toResponseSpec(this.headerSpec.exchange());
+			return toResponseSpec(this.bodySpec.exchange());
 		}
 
 		@Override
-		public <T> ResponseSpec exchange(BodyInserter<T, ? super ClientHttpRequest> inserter) {
-			return toResponseSpec(this.headerSpec.exchange(inserter));
+		public <T> RequestHeadersSpec<?> body(BodyInserter<T, ? super ClientHttpRequest> inserter) {
+			this.bodySpec.body(inserter);
+			return this;
 		}
 
 		@Override
-		public <T, S extends Publisher<T>> ResponseSpec exchange(S publisher, Class<T> elementClass) {
-			return toResponseSpec(this.headerSpec.exchange(publisher, elementClass));
+		public <T, S extends Publisher<T>> RequestHeadersSpec<?> body(S publisher, Class<T> elementClass) {
+			this.bodySpec.body(publisher, elementClass);
+			return this;
+		}
+
+		@Override
+		public <T> RequestHeadersSpec<?> body(T body) {
+			this.bodySpec.body(body);
+			return this;
 		}
 
 		private DefaultResponseSpec toResponseSpec(Mono<ClientResponse> mono) {

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -78,43 +78,43 @@ public interface WebTestClient {
 	 * Prepare an HTTP GET request.
 	 * @return a spec for specifying the target URL
 	 */
-	UriSpec get();
+	UriSpec<RequestHeadersSpec<?>> get();
 
 	/**
 	 * Prepare an HTTP HEAD request.
 	 * @return a spec for specifying the target URL
 	 */
-	UriSpec head();
+	UriSpec<RequestHeadersSpec<?>> head();
 
 	/**
 	 * Prepare an HTTP POST request.
 	 * @return a spec for specifying the target URL
 	 */
-	UriSpec post();
+	UriSpec<RequestBodySpec> post();
 
 	/**
 	 * Prepare an HTTP PUT request.
 	 * @return a spec for specifying the target URL
 	 */
-	UriSpec put();
+	UriSpec<RequestBodySpec> put();
 
 	/**
 	 * Prepare an HTTP PATCH request.
 	 * @return a spec for specifying the target URL
 	 */
-	UriSpec patch();
+	UriSpec<RequestBodySpec> patch();
 
 	/**
 	 * Prepare an HTTP DELETE request.
 	 * @return a spec for specifying the target URL
 	 */
-	UriSpec delete();
+	UriSpec<RequestHeadersSpec<?>> delete();
 
 	/**
 	 * Prepare an HTTP OPTIONS request.
 	 * @return a spec for specifying the target URL
 	 */
-	UriSpec options();
+	UriSpec<RequestHeadersSpec<?>> options();
 
 
 	/**
@@ -327,13 +327,13 @@ public interface WebTestClient {
 	/**
 	 * Specification for providing the URI of a request.
 	 */
-	interface UriSpec {
+	interface UriSpec<S extends RequestHeadersSpec<?>> {
 
 		/**
 		 * Specify the URI using an absolute, fully constructed {@link URI}.
 		 * @return spec to add headers or perform the exchange
 		 */
-		HeaderSpec uri(URI uri);
+		S uri(URI uri);
 
 		/**
 		 * Specify the URI for the request using a URI template and URI variables.
@@ -341,7 +341,7 @@ public interface WebTestClient {
 		 * with a base URI) it will be used to expand the URI template.
 		 * @return spec to add headers or perform the exchange
 		 */
-		HeaderSpec uri(String uri, Object... uriVariables);
+		S uri(String uri, Object... uriVariables);
 
 		/**
 		 * Specify the URI for the request using a URI template and URI variables.
@@ -349,21 +349,21 @@ public interface WebTestClient {
 		 * with a base URI) it will be used to expand the URI template.
 		 * @return spec to add headers or perform the exchange
 		 */
-		HeaderSpec uri(String uri, Map<String, ?> uriVariables);
+		S uri(String uri, Map<String, ?> uriVariables);
 
 		/**
 		 * Build the URI for the request with a {@link UriBuilder} obtained
 		 * through the {@link UriBuilderFactory} configured for this client.
 		 * @return spec to add headers or perform the exchange
 		 */
-		HeaderSpec uri(Function<UriBuilder, URI> uriFunction);
+		S uri(Function<UriBuilder, URI> uriFunction);
 
 	}
 
 	/**
 	 * Specification for adding request headers and performing an exchange.
 	 */
-	interface HeaderSpec {
+	interface RequestHeadersSpec<S extends RequestHeadersSpec<S>> {
 
 		/**
 		 * Set the list of acceptable {@linkplain MediaType media types}, as
@@ -371,7 +371,7 @@ public interface WebTestClient {
 		 * @param acceptableMediaTypes the acceptable media types
 		 * @return the same instance
 		 */
-		HeaderSpec accept(MediaType... acceptableMediaTypes);
+		S accept(MediaType... acceptableMediaTypes);
 
 		/**
 		 * Set the list of acceptable {@linkplain Charset charsets}, as specified
@@ -379,25 +379,7 @@ public interface WebTestClient {
 		 * @param acceptableCharsets the acceptable charsets
 		 * @return the same instance
 		 */
-		HeaderSpec acceptCharset(Charset... acceptableCharsets);
-
-		/**
-		 * Set the length of the body in bytes, as specified by the
-		 * {@code Content-Length} header.
-		 * @param contentLength the content length
-		 * @return the same instance
-		 * @see HttpHeaders#setContentLength(long)
-		 */
-		HeaderSpec contentLength(long contentLength);
-
-		/**
-		 * Set the {@linkplain MediaType media type} of the body, as specified
-		 * by the {@code Content-Type} header.
-		 * @param contentType the content type
-		 * @return the same instance
-		 * @see HttpHeaders#setContentType(MediaType)
-		 */
-		HeaderSpec contentType(MediaType contentType);
+		S acceptCharset(Charset... acceptableCharsets);
 
 		/**
 		 * Add a cookie with the given name and value.
@@ -405,7 +387,7 @@ public interface WebTestClient {
 		 * @param value the cookie value
 		 * @return the same instance
 		 */
-		HeaderSpec cookie(String name, String value);
+		S cookie(String name, String value);
 
 		/**
 		 * Copy the given cookies into the entity's cookies map.
@@ -413,7 +395,7 @@ public interface WebTestClient {
 		 * @param cookies the existing cookies to copy from
 		 * @return the same instance
 		 */
-		HeaderSpec cookies(MultiValueMap<String, String> cookies);
+		S cookies(MultiValueMap<String, String> cookies);
 
 		/**
 		 * Set the value of the {@code If-Modified-Since} header.
@@ -422,14 +404,14 @@ public interface WebTestClient {
 		 * @param ifModifiedSince the new value of the header
 		 * @return the same instance
 		 */
-		HeaderSpec ifModifiedSince(ZonedDateTime ifModifiedSince);
+		S ifModifiedSince(ZonedDateTime ifModifiedSince);
 
 		/**
 		 * Set the values of the {@code If-None-Match} header.
 		 * @param ifNoneMatches the new value of the header
 		 * @return the same instance
 		 */
-		HeaderSpec ifNoneMatch(String... ifNoneMatches);
+		S ifNoneMatch(String... ifNoneMatches);
 
 		/**
 		 * Add the given, single header value under the given name.
@@ -437,14 +419,14 @@ public interface WebTestClient {
 		 * @param headerValues the header value(s)
 		 * @return the same instance
 		 */
-		HeaderSpec header(String headerName, String... headerValues);
+		S header(String headerName, String... headerValues);
 
 		/**
 		 * Copy the given headers into the entity's headers map.
 		 * @param headers the existing headers to copy from
 		 * @return the same instance
 		 */
-		HeaderSpec headers(HttpHeaders headers);
+		S headers(HttpHeaders headers);
 
 		/**
 		 * Perform the exchange without a request body.
@@ -452,26 +434,55 @@ public interface WebTestClient {
 		 */
 		ResponseSpec exchange();
 
+	}
+
+	interface RequestBodySpec extends RequestHeadersSpec<RequestBodySpec> {
 		/**
-		 * Perform the exchange with the body for the request populated using
-		 * a {@link BodyInserter}.
+		 * Set the length of the body in bytes, as specified by the
+		 * {@code Content-Length} header.
+		 * @param contentLength the content length
+		 * @return the same instance
+		 * @see HttpHeaders#setContentLength(long)
+		 */
+		RequestBodySpec contentLength(long contentLength);
+
+		/**
+		 * Set the {@linkplain MediaType media type} of the body, as specified
+		 * by the {@code Content-Type} header.
+		 * @param contentType the content type
+		 * @return the same instance
+		 * @see HttpHeaders#setContentType(MediaType)
+		 */
+		RequestBodySpec contentType(MediaType contentType);
+
+		/**
+		 * Set the body of the request to the given {@code BodyInserter}.
 		 * @param inserter the inserter
 		 * @param <T> the body type, or the the element type (for a stream)
 		 * @return spec for decoding the response
 		 * @see org.springframework.web.reactive.function.BodyInserters
 		 */
-		<T> ResponseSpec exchange(BodyInserter<T, ? super ClientHttpRequest> inserter);
+		<T> RequestHeadersSpec<?> body(BodyInserter<T, ? super ClientHttpRequest> inserter);
 
 		/**
-		 * Perform the exchange and use the given {@code Publisher} for the
-		 * request body.
+		 * Set the body of the request to the given {@code Publisher}.
 		 * @param publisher the request body data
 		 * @param elementClass the class of elements contained in the publisher
 		 * @param <T> the type of the elements contained in the publisher
 		 * @param <S> the type of the {@code Publisher}
 		 * @return spec for decoding the response
 		 */
-		<T, S extends Publisher<T>> ResponseSpec exchange(S publisher, Class<T> elementClass);
+		<T, S extends Publisher<T>> RequestHeadersSpec<?> body(S publisher, Class<T> elementClass);
+
+		/**
+		 * Set the body of the request to the given {@code Object} and
+		 * perform the request.
+		 * @param body the {@code Object} to write to the request
+		 * @param <T> the type contained in the body
+		 * @return a {@code Mono} with the response
+		 */
+		<T> RequestHeadersSpec<?> body(T body);
+
 	}
 
 	/**

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/ResponseEntityTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/ResponseEntityTests.java
@@ -41,7 +41,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.hamcrest.CoreMatchers.endsWith;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.springframework.http.MediaType.TEXT_EVENT_STREAM;
 
 /**
@@ -115,7 +115,8 @@ public class ResponseEntityTests {
 	@Test
 	public void postEntity() throws Exception {
 		this.client.post().uri("/persons")
-				.exchange(Mono.just(new Person("John")), Person.class)
+				.body(Mono.just(new Person("John")), Person.class)
+				.exchange()
 				.expectStatus().isCreated()
 				.expectHeader().valueEquals("location", "/persons/John")
 				.expectBody().isEmpty();

--- a/spring-web/src/main/java/org/springframework/http/client/AbstractAsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/AbstractAsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ import org.springframework.util.concurrent.ListenableFuture;
  *
  * @author Arjen Poutsma
  * @since 4.0
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.http.client.reactive.AbstractClientHttpRequest}
  */
+@Deprecated
 abstract class AbstractAsyncClientHttpRequest implements AsyncClientHttpRequest {
 
 	private final HttpHeaders headers = new HttpHeaders();

--- a/spring-web/src/main/java/org/springframework/http/client/AbstractBufferingAsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/AbstractBufferingAsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ import org.springframework.util.concurrent.ListenableFuture;
  *
  * @author Arjen Poutsma
  * @since 4.0
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 abstract class AbstractBufferingAsyncClientHttpRequest extends AbstractAsyncClientHttpRequest {
 
 	private ByteArrayOutputStream bufferedOutput = new ByteArrayOutputStream(1024);

--- a/spring-web/src/main/java/org/springframework/http/client/AsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/AsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @author Arjen Poutsma
  * @since 4.0
  * @see AsyncClientHttpRequestFactory#createAsyncRequest
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.web.reactive.function.client.ClientRequest}
  */
+@Deprecated
 public interface AsyncClientHttpRequest extends HttpRequest, HttpOutputMessage {
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/client/AsyncClientHttpRequestExecution.java
+++ b/spring-web/src/main/java/org/springframework/http/client/AsyncClientHttpRequestExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,17 +31,19 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @author Rossen Stoyanchev
  * @since 4.3
  * @see AsyncClientHttpRequestInterceptor
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.web.reactive.function.client.ExchangeFilterFunction}
  */
+@Deprecated
 public interface AsyncClientHttpRequestExecution {
 
-    /**
-     * Resume the request execution by invoking the next interceptor in the chain
-     * or executing the request to the remote service.
-     * @param request the HTTP request, containing the HTTP method and headers
-     * @param body the body of the request
-     * @return a corresponding future handle
-     * @throws IOException in case of I/O errors
-     */
-    ListenableFuture<ClientHttpResponse> executeAsync(HttpRequest request, byte[] body) throws IOException;
+	/**
+	 * Resume the request execution by invoking the next interceptor in the chain
+	 * or executing the request to the remote service.
+	 * @param request the HTTP request, containing the HTTP method and headers
+	 * @param body the body of the request
+	 * @return a corresponding future handle
+	 * @throws IOException in case of I/O errors
+	 */
+	ListenableFuture<ClientHttpResponse> executeAsync(HttpRequest request, byte[] body) throws IOException;
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/AsyncClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/AsyncClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ import org.springframework.http.HttpMethod;
  *
  * @author Arjen Poutsma
  * @since 4.0
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.http.client.reactive.ClientHttpConnector}
  */
+@Deprecated
 public interface AsyncClientHttpRequestFactory {
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/client/AsyncClientHttpRequestInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/http/client/AsyncClientHttpRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.http.client;
 import java.io.IOException;
 
 import org.springframework.http.HttpRequest;
-import org.springframework.http.client.support.InterceptingAsyncHttpAccessor;
 import org.springframework.util.concurrent.ListenableFuture;
 
 /**
@@ -36,8 +35,10 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @author Rossen Stoyanchev
  * @since 4.3
  * @see org.springframework.web.client.AsyncRestTemplate
- * @see InterceptingAsyncHttpAccessor
+ * @see org.springframework.http.client.support.InterceptingAsyncHttpAccessor
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.web.reactive.function.client.ExchangeFilterFunction}
  */
+@Deprecated
 public interface AsyncClientHttpRequestInterceptor {
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,9 @@ import org.springframework.util.concurrent.SuccessCallback;
  * @author Arjen Poutsma
  * @since 4.0
  * @see HttpComponentsClientHttpRequestFactory#createRequest
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 final class HttpComponentsAsyncClientHttpRequest extends AbstractBufferingAsyncClientHttpRequest {
 
 	private final HttpAsyncClient httpClient;

--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ import org.springframework.util.Assert;
  * @author Stephane Nicoll
  * @since 4.0
  * @see HttpAsyncClient
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 public class HttpComponentsAsyncClientHttpRequestFactory extends HttpComponentsClientHttpRequestFactory
 		implements AsyncClientHttpRequestFactory, InitializingBean {
 

--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,9 @@ import org.springframework.util.StreamUtils;
  * @author Arjen Poutsma
  * @since 4.0
  * @see HttpComponentsAsyncClientHttpRequest#executeAsync()
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 final class HttpComponentsAsyncClientHttpResponse extends AbstractClientHttpResponse {
 
 	private final HttpResponse httpResponse;

--- a/spring-web/src/main/java/org/springframework/http/client/InterceptingAsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/InterceptingAsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,84 +34,86 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @author Jakub Narloch
  * @author Rossen Stoyanchev
  * @see InterceptingAsyncClientHttpRequestFactory
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 class InterceptingAsyncClientHttpRequest extends AbstractBufferingAsyncClientHttpRequest {
 
-    private AsyncClientHttpRequestFactory requestFactory;
+	private AsyncClientHttpRequestFactory requestFactory;
 
-    private List<AsyncClientHttpRequestInterceptor> interceptors;
+	private List<AsyncClientHttpRequestInterceptor> interceptors;
 
-    private URI uri;
+	private URI uri;
 
-    private HttpMethod httpMethod;
-
-
-    /**
-     * Creates new instance of {@link InterceptingAsyncClientHttpRequest}.
-     *
-     * @param requestFactory the async request factory
-     * @param interceptors   the list of interceptors
-     * @param uri            the request URI
-     * @param httpMethod     the HTTP method
-     */
-    public InterceptingAsyncClientHttpRequest(AsyncClientHttpRequestFactory requestFactory,
-            List<AsyncClientHttpRequestInterceptor> interceptors, URI uri, HttpMethod httpMethod) {
-
-        this.requestFactory = requestFactory;
-        this.interceptors = interceptors;
-        this.uri = uri;
-        this.httpMethod = httpMethod;
-    }
+	private HttpMethod httpMethod;
 
 
-    @Override
-    protected ListenableFuture<ClientHttpResponse> executeInternal(HttpHeaders headers, byte[] body)
-            throws IOException {
+	/**
+	 * Creates new instance of {@link InterceptingAsyncClientHttpRequest}.
+	 *
+	 * @param requestFactory the async request factory
+	 * @param interceptors   the list of interceptors
+	 * @param uri            the request URI
+	 * @param httpMethod     the HTTP method
+	 */
+	public InterceptingAsyncClientHttpRequest(AsyncClientHttpRequestFactory requestFactory,
+			List<AsyncClientHttpRequestInterceptor> interceptors, URI uri, HttpMethod httpMethod) {
 
-        return new AsyncRequestExecution().executeAsync(this, body);
-    }
-
-    @Override
-    public HttpMethod getMethod() {
-        return httpMethod;
-    }
-
-    @Override
-    public URI getURI() {
-        return uri;
-    }
+		this.requestFactory = requestFactory;
+		this.interceptors = interceptors;
+		this.uri = uri;
+		this.httpMethod = httpMethod;
+	}
 
 
-    private class AsyncRequestExecution implements AsyncClientHttpRequestExecution {
+	@Override
+	protected ListenableFuture<ClientHttpResponse> executeInternal(HttpHeaders headers, byte[] body)
+			throws IOException {
 
-        private Iterator<AsyncClientHttpRequestInterceptor> iterator;
+		return new AsyncRequestExecution().executeAsync(this, body);
+	}
 
-        public AsyncRequestExecution() {
-            this.iterator = interceptors.iterator();
-        }
+	@Override
+	public HttpMethod getMethod() {
+		return httpMethod;
+	}
 
-        @Override
-        public ListenableFuture<ClientHttpResponse> executeAsync(HttpRequest request, byte[] body)
-                throws IOException {
+	@Override
+	public URI getURI() {
+		return uri;
+	}
 
-            if (this.iterator.hasNext()) {
-                AsyncClientHttpRequestInterceptor interceptor = this.iterator.next();
-                return interceptor.intercept(request, body, this);
-            }
-            else {
-                URI theUri = request.getURI();
-                HttpMethod theMethod = request.getMethod();
-                HttpHeaders theHeaders = request.getHeaders();
 
-                AsyncClientHttpRequest delegate = requestFactory.createAsyncRequest(theUri, theMethod);
-                delegate.getHeaders().putAll(theHeaders);
-                if (body.length > 0) {
-                    StreamUtils.copy(body, delegate.getBody());
-                }
+	private class AsyncRequestExecution implements AsyncClientHttpRequestExecution {
 
-                return delegate.executeAsync();
-            }
-        }
-    }
+		private Iterator<AsyncClientHttpRequestInterceptor> iterator;
+
+		public AsyncRequestExecution() {
+			this.iterator = interceptors.iterator();
+		}
+
+		@Override
+		public ListenableFuture<ClientHttpResponse> executeAsync(HttpRequest request, byte[] body)
+				throws IOException {
+
+			if (this.iterator.hasNext()) {
+				AsyncClientHttpRequestInterceptor interceptor = this.iterator.next();
+				return interceptor.intercept(request, body, this);
+			}
+			else {
+				URI theUri = request.getURI();
+				HttpMethod theMethod = request.getMethod();
+				HttpHeaders theHeaders = request.getHeaders();
+
+				AsyncClientHttpRequest delegate = requestFactory.createAsyncRequest(theUri, theMethod);
+				delegate.getHeaders().putAll(theHeaders);
+				if (body.length > 0) {
+					StreamUtils.copy(body, delegate.getBody());
+				}
+
+				return delegate.executeAsync();
+			}
+		}
+	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/InterceptingAsyncClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/InterceptingAsyncClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ import org.springframework.http.HttpMethod;
  * @author Jakub Narloch
  * @since 4.3
  * @see InterceptingAsyncClientHttpRequest
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 public class InterceptingAsyncClientHttpRequestFactory implements AsyncClientHttpRequestFactory {
 
 	private AsyncClientHttpRequestFactory delegate;

--- a/spring-web/src/main/java/org/springframework/http/client/Netty4ClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/Netty4ClientHttpRequest.java
@@ -50,7 +50,9 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @author Rossen Stoyanchev
  * @author Brian Clozel
  * @since 4.1.2
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.http.client.reactive.ReactorClientHttpConnector}
  */
+@Deprecated
 class Netty4ClientHttpRequest extends AbstractAsyncClientHttpRequest implements ClientHttpRequest {
 
 	private final Bootstrap bootstrap;

--- a/spring-web/src/main/java/org/springframework/http/client/Netty4ClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/Netty4ClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,9 @@ import org.springframework.util.Assert;
  * @author Brian Clozel
  * @author Mark Paluch
  * @since 4.1.2
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.http.client.reactive.ReactorClientHttpConnector}
  */
+@Deprecated
 public class Netty4ClientHttpRequestFactory implements ClientHttpRequestFactory,
 		AsyncClientHttpRequestFactory, InitializingBean, DisposableBean {
 

--- a/spring-web/src/main/java/org/springframework/http/client/Netty4ClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/Netty4ClientHttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ import org.springframework.util.Assert;
  *
  * @author Arjen Poutsma
  * @since 4.1.2
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.http.client.reactive.ReactorClientHttpConnector}
  */
+@Deprecated
 class Netty4ClientHttpResponse extends AbstractClientHttpResponse {
 
 	private final ChannelHandlerContext context;

--- a/spring-web/src/main/java/org/springframework/http/client/OkHttp3AsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/OkHttp3AsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,9 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @author Arjen Poutsma
  * @author Roy Clarkson
  * @since 4.3
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 class OkHttp3AsyncClientHttpRequest extends AbstractBufferingAsyncClientHttpRequest {
 
 	private final OkHttpClient client;

--- a/spring-web/src/main/java/org/springframework/http/client/OkHttp3ClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/OkHttp3ClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Roy Clarkson
  * @since 4.3
  */
+@SuppressWarnings("deprecation")
 public class OkHttp3ClientHttpRequestFactory
 		implements ClientHttpRequestFactory, AsyncClientHttpRequestFactory, DisposableBean {
 

--- a/spring-web/src/main/java/org/springframework/http/client/SimpleBufferingAsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleBufferingAsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,9 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @author Arjen Poutsma
  * @since 3.0
  * @see org.springframework.http.client.SimpleClientHttpRequestFactory#createRequest
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 final class SimpleBufferingAsyncClientHttpRequest extends AbstractBufferingAsyncClientHttpRequest {
 
 	private final HttpURLConnection connection;

--- a/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * @see java.net.HttpURLConnection
  * @see HttpComponentsClientHttpRequestFactory
  */
+@SuppressWarnings("deprecation")
 public class SimpleClientHttpRequestFactory implements ClientHttpRequestFactory, AsyncClientHttpRequestFactory {
 
 	private static final int DEFAULT_CHUNK_SIZE = 4096;

--- a/spring-web/src/main/java/org/springframework/http/client/SimpleStreamingAsyncClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleStreamingAsyncClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,9 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @author Arjen Poutsma
  * @since 3.0
  * @see org.springframework.http.client.SimpleClientHttpRequestFactory#createRequest
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 final class SimpleStreamingAsyncClientHttpRequest extends AbstractAsyncClientHttpRequest {
 
 	private final HttpURLConnection connection;

--- a/spring-web/src/main/java/org/springframework/http/client/support/AsyncHttpAccessor.java
+++ b/spring-web/src/main/java/org/springframework/http/client/support/AsyncHttpAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,14 +23,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.http.HttpMethod;
-import org.springframework.http.client.AsyncClientHttpRequest;
-import org.springframework.http.client.AsyncClientHttpRequestFactory;
 import org.springframework.util.Assert;
 
 /**
  * Base class for {@link org.springframework.web.client.AsyncRestTemplate}
  * and other HTTP accessing gateway helpers, defining common properties
- * such as the {@link AsyncClientHttpRequestFactory} to operate on.
+ * such as the {@link org.springframework.http.client.AsyncClientHttpRequestFactory} to operate on.
  *
  * <p>Not intended to be used directly. See
  * {@link org.springframework.web.client.AsyncRestTemplate}.
@@ -38,19 +36,21 @@ import org.springframework.util.Assert;
  * @author Arjen Poutsma
  * @since 4.0
  * @see org.springframework.web.client.AsyncRestTemplate
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 public class AsyncHttpAccessor {
 
 	/** Logger available to subclasses. */
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	private AsyncClientHttpRequestFactory asyncRequestFactory;
+	private org.springframework.http.client.AsyncClientHttpRequestFactory asyncRequestFactory;
 
 	/**
 	 * Set the request factory that this accessor uses for obtaining {@link
 	 * org.springframework.http.client.ClientHttpRequest HttpRequests}.
 	 */
-	public void setAsyncRequestFactory(AsyncClientHttpRequestFactory asyncRequestFactory) {
+	public void setAsyncRequestFactory(org.springframework.http.client.AsyncClientHttpRequestFactory asyncRequestFactory) {
 		Assert.notNull(asyncRequestFactory, "'asyncRequestFactory' must not be null");
 		this.asyncRequestFactory = asyncRequestFactory;
 	}
@@ -59,21 +59,21 @@ public class AsyncHttpAccessor {
 	 * Return the request factory that this accessor uses for obtaining {@link
 	 * org.springframework.http.client.ClientHttpRequest HttpRequests}.
 	 */
-	public AsyncClientHttpRequestFactory getAsyncRequestFactory() {
+	public org.springframework.http.client.AsyncClientHttpRequestFactory getAsyncRequestFactory() {
 		return this.asyncRequestFactory;
 	}
 
 	/**
-	 * Create a new {@link AsyncClientHttpRequest} via this template's {@link
-	 * AsyncClientHttpRequestFactory}.
+	 * Create a new {@link org.springframework.http.client.AsyncClientHttpRequest} via this template's
+	 * {@link org.springframework.http.client.AsyncClientHttpRequestFactory}.
 	 * @param url the URL to connect to
 	 * @param method the HTTP method to execute (GET, POST, etc.)
 	 * @return the created request
 	 * @throws IOException in case of I/O errors
 	 */
-	protected AsyncClientHttpRequest createAsyncRequest(URI url, HttpMethod method)
+	protected org.springframework.http.client.AsyncClientHttpRequest createAsyncRequest(URI url, HttpMethod method)
 			throws IOException {
-		AsyncClientHttpRequest request = getAsyncRequestFactory().createAsyncRequest(url, method);
+		org.springframework.http.client.AsyncClientHttpRequest request = getAsyncRequestFactory().createAsyncRequest(url, method);
 		if (logger.isDebugEnabled()) {
 			logger.debug("Created asynchronous " + method.name() + " request for \"" + url + "\"");
 		}

--- a/spring-web/src/main/java/org/springframework/http/client/support/InterceptingAsyncHttpAccessor.java
+++ b/spring-web/src/main/java/org/springframework/http/client/support/InterceptingAsyncHttpAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,6 @@ package org.springframework.http.client.support;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.http.client.AsyncClientHttpRequestFactory;
-import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
-import org.springframework.http.client.InterceptingAsyncClientHttpRequestFactory;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -31,38 +28,40 @@ import org.springframework.util.CollectionUtils;
  * @author Jakub Narloch
  * @author Rossen Stoyanchev
  * @since 4.3
+ * @deprecated as of Spring 5.0, with no direct replacement
  */
+@Deprecated
 public abstract class InterceptingAsyncHttpAccessor extends AsyncHttpAccessor {
 
-    private List<AsyncClientHttpRequestInterceptor> interceptors =
+	private List<org.springframework.http.client.AsyncClientHttpRequestInterceptor> interceptors =
 			new ArrayList<>();
 
 
-    /**
-     * Set the request interceptors that this accessor should use.
-     * @param interceptors the list of interceptors
-     */
-    public void setInterceptors(List<AsyncClientHttpRequestInterceptor> interceptors) {
-        this.interceptors = interceptors;
-    }
+	/**
+	 * Set the request interceptors that this accessor should use.
+	 * @param interceptors the list of interceptors
+	 */
+	public void setInterceptors(List<org.springframework.http.client.AsyncClientHttpRequestInterceptor> interceptors) {
+		this.interceptors = interceptors;
+	}
 
-    /**
-     * Return the request interceptor that this accessor uses.
-     */
-    public List<AsyncClientHttpRequestInterceptor> getInterceptors() {
-        return this.interceptors;
-    }
+	/**
+	 * Return the request interceptor that this accessor uses.
+	 */
+	public List<org.springframework.http.client.AsyncClientHttpRequestInterceptor> getInterceptors() {
+		return this.interceptors;
+	}
 
 
-    @Override
-    public AsyncClientHttpRequestFactory getAsyncRequestFactory() {
-        AsyncClientHttpRequestFactory delegate = super.getAsyncRequestFactory();
-        if (!CollectionUtils.isEmpty(getInterceptors())) {
-            return new InterceptingAsyncClientHttpRequestFactory(delegate, getInterceptors());
-        }
-        else {
-            return delegate;
-        }
-    }
+	@Override
+	public org.springframework.http.client.AsyncClientHttpRequestFactory getAsyncRequestFactory() {
+		org.springframework.http.client.AsyncClientHttpRequestFactory delegate = super.getAsyncRequestFactory();
+		if (!CollectionUtils.isEmpty(getInterceptors())) {
+			return new org.springframework.http.client.InterceptingAsyncClientHttpRequestFactory(delegate, getInterceptors());
+		}
+		else {
+			return delegate;
+		}
+	}
 
 }

--- a/spring-web/src/main/java/org/springframework/web/client/AsyncRequestCallback.java
+++ b/spring-web/src/main/java/org/springframework/web/client/AsyncRequestCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,8 @@ package org.springframework.web.client;
 
 import java.io.IOException;
 
-import org.springframework.http.client.AsyncClientHttpRequest;
-
 /**
- * Callback interface for code that operates on an {@link AsyncClientHttpRequest}. Allows
+ * Callback interface for code that operates on an {@link org.springframework.http.client.AsyncClientHttpRequest}. Allows
  * to manipulate the request headers, and write to the request body.
  *
  * <p>Used internally by the {@link AsyncRestTemplate}, but also useful for application code.
@@ -29,8 +27,10 @@ import org.springframework.http.client.AsyncClientHttpRequest;
  * @author Arjen Poutsma
  * @see org.springframework.web.client.AsyncRestTemplate#execute
  * @since 4.0
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.web.reactive.function.client.ExchangeFilterFunction}
  */
 @FunctionalInterface
+@Deprecated
 public interface AsyncRequestCallback {
 
 	/**
@@ -40,6 +40,6 @@ public interface AsyncRequestCallback {
 	 * @param request the active HTTP request
 	 * @throws java.io.IOException in case of I/O errors
 	 */
-	void doWithRequest(AsyncClientHttpRequest request) throws IOException;
+	void doWithRequest(org.springframework.http.client.AsyncClientHttpRequest request) throws IOException;
 
 }

--- a/spring-web/src/main/java/org/springframework/web/client/AsyncRestOperations.java
+++ b/spring-web/src/main/java/org/springframework/web/client/AsyncRestOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,9 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @since 4.0
  * @see AsyncRestTemplate
  * @see RestOperations
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.web.reactive.function.client.WebClient}
  */
+@Deprecated
 public interface AsyncRestOperations {
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/client/AsyncRestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/AsyncRestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,13 +33,10 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.AsyncClientHttpRequest;
-import org.springframework.http.client.AsyncClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.http.client.support.InterceptingAsyncHttpAccessor;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
@@ -59,15 +56,17 @@ import org.springframework.web.util.UriTemplateHandler;
  * <p><strong>Note:</strong> by default {@code AsyncRestTemplate} relies on
  * standard JDK facilities to establish HTTP connections. You can switch to use
  * a different HTTP library such as Apache HttpComponents, Netty, and OkHttp by
- * using a constructor accepting an {@link AsyncClientHttpRequestFactory}.
+ * using a constructor accepting an {@link org.springframework.http.client.AsyncClientHttpRequestFactory}.
  *
  * <p>For more information, please refer to the {@link RestTemplate} API documentation.
  *
  * @author Arjen Poutsma
  * @since 4.0
  * @see RestTemplate
+ * @deprecated as of Spring 5.0, in favor of {@link org.springframework.web.reactive.function.client.WebClient}
  */
-public class AsyncRestTemplate extends InterceptingAsyncHttpAccessor implements AsyncRestOperations {
+@Deprecated
+public class AsyncRestTemplate extends org.springframework.http.client.support.InterceptingAsyncHttpAccessor implements AsyncRestOperations {
 
 	private final RestTemplate syncTemplate;
 
@@ -97,14 +96,14 @@ public class AsyncRestTemplate extends InterceptingAsyncHttpAccessor implements 
 
 	/**
 	 * Create a new instance of the {@code AsyncRestTemplate} using the given
-	 * {@link AsyncClientHttpRequestFactory}.
+	 * {@link org.springframework.http.client.AsyncClientHttpRequestFactory}.
 	 * <p>This constructor will cast the given asynchronous
 	 * {@code AsyncClientHttpRequestFactory} to a {@link ClientHttpRequestFactory}. Since
 	 * all implementations of {@code ClientHttpRequestFactory} provided in Spring also
 	 * implement {@code AsyncClientHttpRequestFactory}, this should not result in a
 	 * {@code ClassCastException}.
 	 */
-	public AsyncRestTemplate(AsyncClientHttpRequestFactory asyncRequestFactory) {
+	public AsyncRestTemplate(org.springframework.http.client.AsyncClientHttpRequestFactory asyncRequestFactory) {
 		this(asyncRequestFactory, (ClientHttpRequestFactory) asyncRequestFactory);
 	}
 
@@ -115,18 +114,18 @@ public class AsyncRestTemplate extends InterceptingAsyncHttpAccessor implements 
 	 * @param syncRequestFactory the synchronous request factory
 	 */
 	public AsyncRestTemplate(
-			AsyncClientHttpRequestFactory asyncRequestFactory, ClientHttpRequestFactory syncRequestFactory) {
+			org.springframework.http.client.AsyncClientHttpRequestFactory asyncRequestFactory, ClientHttpRequestFactory syncRequestFactory) {
 
 		this(asyncRequestFactory, new RestTemplate(syncRequestFactory));
 	}
 
 	/**
 	 * Create a new instance of the {@code AsyncRestTemplate} using the given
-	 * {@link AsyncClientHttpRequestFactory} and synchronous {@link RestTemplate}.
+	 * {@link org.springframework.http.client.AsyncClientHttpRequestFactory} and synchronous {@link RestTemplate}.
 	 * @param requestFactory the asynchronous request factory to use
 	 * @param restTemplate the synchronous template to use
 	 */
-	public AsyncRestTemplate(AsyncClientHttpRequestFactory requestFactory, RestTemplate restTemplate) {
+	public AsyncRestTemplate(org.springframework.http.client.AsyncClientHttpRequestFactory requestFactory, RestTemplate restTemplate) {
 		Assert.notNull(restTemplate, "RestTemplate must not be null");
 		this.syncTemplate = restTemplate;
 		setAsyncRequestFactory(requestFactory);
@@ -505,7 +504,7 @@ public class AsyncRestTemplate extends InterceptingAsyncHttpAccessor implements 
 		Assert.notNull(url, "'url' must not be null");
 		Assert.notNull(method, "'method' must not be null");
 		try {
-			AsyncClientHttpRequest request = createAsyncRequest(url, method);
+			org.springframework.http.client.AsyncClientHttpRequest request = createAsyncRequest(url, method);
 			if (requestCallback != null) {
 				requestCallback.doWithRequest(request);
 			}
@@ -647,7 +646,7 @@ public class AsyncRestTemplate extends InterceptingAsyncHttpAccessor implements 
 		}
 
 		@Override
-		public void doWithRequest(final AsyncClientHttpRequest request) throws IOException {
+		public void doWithRequest(final org.springframework.http.client.AsyncClientHttpRequest request) throws IOException {
 			if (this.adaptee != null) {
 				this.adaptee.doWithRequest(new ClientHttpRequest() {
 					@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientResponse.java
@@ -27,6 +27,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ClientHttpResponse;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyExtractor;
@@ -87,6 +88,14 @@ public interface ClientResponse {
 	 * 4xx or 5xx
 	 */
 	<T> Flux<T> bodyToFlux(Class<? extends T> elementClass);
+
+	/**
+	 * Converts this {@code ClientResponse} into a {@code ResponseEntity}.
+	 * @param responseClass the type of response contained in the {@code ResponseEntity}
+	 * @param <T> the response type
+	 * @return a mono containing the response entity
+	 */
+	<T> Mono<ResponseEntity<T>> toResponseEntity(Class<T> responseClass);
 
 
 	/**

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientResponse.java
@@ -33,6 +33,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ClientHttpResponse;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.util.MultiValueMap;
@@ -100,6 +101,11 @@ class DefaultClientResponse implements ClientResponse {
 		return bodyToPublisher(BodyExtractors.toFlux(elementClass), Flux::error);
 	}
 
+	@Override
+	public <T> Mono<ResponseEntity<T>> toResponseEntity(Class<T> responseClass) {
+		return bodyToMono(responseClass)
+				.map(t -> new ResponseEntity<>(t, headers().asHttpHeaders(), statusCode()));
+	}
 
 	private <T extends Publisher<?>> T bodyToPublisher(
 			BodyExtractor<T, ? super ClientHttpResponse> extractor,

--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
@@ -1,13 +1,29 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.web.reactive.function.client
 
 import org.reactivestreams.Publisher
 
 /**
- * Extension for [WebClient.HeaderSpec.exchange] providing a variant without explicit class
+ * Extension for [WebClient.RequestHeadersSpec.exchangePublisher] providing a variant without explicit class
  * parameter thanks to Kotlin reified type parameters.
  *
  * @author Sebastien Deleuze
  * @since 5.0
  */
-inline fun <reified T : Any, S : Publisher<T>> WebClient.HeaderSpec.exchange(publisher: S) =
-        exchange(publisher, T::class.java)
+inline fun <reified T : Any, S : Publisher<T>> WebClient.RequestBodySpec.body(publisher: S) =
+        body(publisher, T::class.java)


### PR DESCRIPTION
Please read the individual commit messages for more information.

@rstoyanchev Can this be merged?