### PR TITLE
SPR-15411: Avoid query parameters in filename

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/UrlResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/UrlResource.java
@@ -244,7 +244,7 @@ public class UrlResource extends AbstractFileResolvingResource {
 	 */
 	@Override
 	public String getFilename() {
-		return new File(this.url.getFile()).getName();
+		return new File(this.url.getPath()).getName();
 	}
 
 	/**


### PR DESCRIPTION
The URL.getFile() javadocs say :
Gets the file name of this URL. The returned file portion will be the same as getPath(), plus the concatenation of the value of getQuery(), if any. If there is no query portion, this method and getPath() will return identical results.

This causes a bug in Spring boot when specifying --spring.config.location=http://host/group/repo/raw/branch/config.yml?private_token=NyAq4wDit3hmJ7UZPyMU because ".yml?private_token=NyAq4wDit3hmJ7UZPyMU" is not a supported extension.

My workaround until this gets fixed is to use --spring.config.location=http://host/group/repo/raw/branch/config.yml?private_token=NyAq4wDit3hmJ7UZPyMU&fake_param=whatever.yml

https://jira.spring.io/browse/SPR-15411