### PR TITLE
HttpOnly Cookie Result Matcher

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/CookieResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/CookieResultMatchers.java
@@ -198,4 +198,14 @@ public class CookieResultMatchers {
 		};
 	}
 
+	/**
+	 * Assert whether the cookie must be httpOnly.
+	 */
+	public ResultMatcher httpOnly(final String name, final boolean httpOnly) {
+		return result -> {
+			Cookie cookie = result.getResponse().getCookie(name);
+			assertEquals("Response cookie httpOnly", httpOnly, cookie.isHttpOnly());
+		};
+	}
+
 }

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resultmatchers/CookieAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resultmatchers/CookieAssertionTests.java
@@ -46,7 +46,7 @@ public class CookieAssertionTests {
 	public void setup() {
 		CookieLocaleResolver localeResolver = new CookieLocaleResolver();
 		localeResolver.setCookieDomain("domain");
-
+		localeResolver.setCookieHttpOnly(true);
 		this.mockMvc = standaloneSetup(new SimpleController())
 				.addInterceptors(new LocaleChangeInterceptor())
 				.setLocaleResolver(localeResolver)
@@ -62,7 +62,7 @@ public class CookieAssertionTests {
 
 	@Test
 	public void testNotExists() throws Exception {
-		this.mockMvc.perform(get("/")).andExpect(cookie().doesNotExist("unknowCookie"));
+		this.mockMvc.perform(get("/")).andExpect(cookie().doesNotExist("unknownCookie"));
 	}
 
 	@Test
@@ -101,6 +101,10 @@ public class CookieAssertionTests {
 		this.mockMvc.perform(get("/")).andExpect(cookie().secure(COOKIE_NAME, false));
 	}
 
+	@Test
+	public void testHttpOnly() throws Exception {
+		this.mockMvc.perform(get("/")).andExpect(cookie().httpOnly(COOKIE_NAME, true));
+	}
 
 	@Controller
 	private static class SimpleController {


### PR DESCRIPTION
# Added a httpOnly cookie ResultMatcher in spring test web [SPR-15488](https://jira.spring.io/browse/SPR-15488)

Also, FIxed a small typo in a String var ("unknowCookie" to "unknownCookie")

Basically it allows us to do the following:

```
@Test 
public void someTest(){
    ....
    Cookie cookie = result.getResponse().getCookie(name);
    assertEquals("Response cookie httpOnly", httpOnly, cookie.isHttpOnly());
}

```
