### PR TITLE
SPR-14925: Return 5xx HTTP status for invalid target types with Jackson

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/HttpMessageConversionException.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/HttpMessageConversionException.java
@@ -17,15 +17,21 @@
 package org.springframework.http.converter;
 
 import org.springframework.core.NestedRuntimeException;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
 
 /**
  * Thrown by {@link HttpMessageConverter} implementations when a conversion attempt fails.
  *
  * @author Arjen Poutsma
+ * @author Sebastien Deleuze
  * @since 3.0
  */
 @SuppressWarnings("serial")
 public class HttpMessageConversionException extends NestedRuntimeException {
+
+	private final HttpStatus errorStatus;
 
 	/**
 	 * Create a new HttpMessageConversionException.
@@ -33,6 +39,7 @@ public class HttpMessageConversionException extends NestedRuntimeException {
 	 */
 	public HttpMessageConversionException(String msg) {
 		super(msg);
+		this.errorStatus = null;
 	}
 
 	/**
@@ -42,6 +49,25 @@ public class HttpMessageConversionException extends NestedRuntimeException {
 	 */
 	public HttpMessageConversionException(String msg, Throwable cause) {
 		super(msg, cause);
+		this.errorStatus = null;
 	}
 
+	/**
+	 * Create a new HttpMessageConversionException.
+	 * @since 5.0
+	 * @param msg the detail message
+	 * @param cause the root cause (if any)
+	 * @param errorStatus the HTTP error status related to this exception
+	 */
+	public HttpMessageConversionException(String msg, Throwable cause, HttpStatus errorStatus) {
+		super(msg, cause);
+		this.errorStatus = errorStatus;
+	}
+
+	/**
+	 * Return the HTTP error status related to this exception if any.
+	 */
+	public Optional<HttpStatus> getErrorStatus() {
+		return Optional.ofNullable(errorStatus);
+	}
 }

--- a/spring-web/src/main/java/org/springframework/http/converter/HttpMessageNotReadableException.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/HttpMessageNotReadableException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.http.converter;
 
+import org.springframework.http.HttpStatus;
+
 /**
  * Thrown by {@link HttpMessageConverter} implementations when the
  * {@link HttpMessageConverter#read} method fails.
@@ -41,6 +43,17 @@ public class HttpMessageNotReadableException extends HttpMessageConversionExcept
 	 */
 	public HttpMessageNotReadableException(String msg, Throwable cause) {
 		super(msg, cause);
+	}
+
+	/**
+	 * Create a new HttpMessageNotReadableException.
+	 * @since 5.0
+	 * @param msg the detail message
+	 * @param cause the root cause (if any)
+	 * @param errorStatus the HTTP error status related to this exception
+	 */
+	public HttpMessageNotReadableException(String msg, Throwable cause, HttpStatus errorStatus) {
+		super(msg, cause, errorStatus);
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -36,12 +36,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.AbstractGenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -234,6 +236,9 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 				}
 			}
 			return this.objectMapper.readValue(inputMessage.getBody(), javaType);
+		}
+		catch (InvalidDefinitionException ex) {
+			throw new HttpMessageNotReadableException("Could not read document: " + ex.getMessage(), ex, HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		catch (IOException ex) {
 			throw new HttpMessageNotReadableException("Could not read document: " + ex.getMessage(), ex);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
@@ -27,6 +27,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.ConversionNotSupportedException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
@@ -354,7 +355,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 		if (logger.isWarnEnabled()) {
 			logger.warn("Failed to read HTTP message: " + ex);
 		}
-		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		response.sendError(ex.getErrorStatus().orElse(HttpStatus.BAD_REQUEST).value());
 		return new ModelAndView();
 	}
 


### PR DESCRIPTION
InvalidDefinitionException has been introduced in Jackson 2.9 to be
able to differentiate invalid data sent from the client (should still
generate a 4xx HTTP status code) from server side errors like beans with
no default constructor (should generate a 5xx HTTP status code).

Could you have a look and say me if you are ok @poutsma ?