### PR TITLE
webmvc: fix AbstractEmitterSubscriber

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ReactiveTypeHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ReactiveTypeHandler.java
@@ -221,7 +221,7 @@ class ReactiveTypeHandler {
 				if (logger.isDebugEnabled()) {
 					logger.debug("Connection timed out for " + this.emitter);
 				}
-				this.subscription.cancel();
+				terminate();
 				this.emitter.complete();
 			});
 			subscription.request(1);


### PR DESCRIPTION
@smaldini brought this class to my attention and asked me to verify it. There were a couple of problems with the `AbstractEmitterSubscriber`:

- Using a shared queue for items, error and completion signals. The problem with this is that if the user is in the business of processing `Exception`s as values, the logic may treat it as an error even if it came through `onNext`.
- Since `onError` and `onComplete` are at most once events, there is no need to queue them up but could be simply saved in a field and read out in the emission side.
- Now that the terminal events have their own fields, the queue can be simplified to an `AtomicReference` because this class requests items one-by-one.
- It is unclear where the `onTimeout` body would trigger in respect to the regular signals, thus calling `emitter` directly from it is likely violating the serialization requirement of the emitter. The code now pretends to call `onComplete` which gets properly serialized with respect to any other signal.
- In the handler method, if the `send` method crashed, the exception was not forwarded to the emitter for some reason. I assume the error should be reported since the source is otherwise cancelled and won't send any new item/signal.
- Changed the `executing` to a linearizing atomic counter because the original CAS+Set based trampolining is generally hard to verify on not losing request for scheduling.

I also kept the one-by-one nature and the rescheduling logic assuming the intent was not to "cannibalize" the executor if there was plenty of source items available and behave "fairly" with other tasks running on the same executor.