### PR TITLE
webmvc: AbstractEmitterSubscriber check terminated the right time

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ReactiveTypeHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ReactiveTypeHandler.java
@@ -275,6 +275,7 @@ class ReactiveTypeHandler {
 				return;
 			}
 				
+			boolean isTerminated = this.terminated;
 			Object element = this.elementRef.get();
 			if (element != null) {
 				this.elementRef.lazySet(null);
@@ -291,7 +292,7 @@ class ReactiveTypeHandler {
 				}
 			}
 			
-			if (this.terminated) {
+			if (isTerminated) {
 				this.done = true;
 				Throwable ex = this.error;
 				this.error = null;


### PR DESCRIPTION
The original version was prone to lose the final item in case of an unfortunate interleaving:

```
Drain thread                Source thread
-----------------------------------------
elementRef.get() != null
  request(1)
                            onNext(item) -> elementRef.lazySet(item)
                            onComplete() -> terminated = true;
if (terminated)
  emitter.complete()
```
The emitter is completed but the "queue" still holds the final element that will never be emitted.