### PR TITLE
Ensure the subscriber is initialized before switching the states

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/WriteResultPublisher.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/WriteResultPublisher.java
@@ -116,9 +116,9 @@ class WriteResultPublisher implements Publisher<Void> {
 			@Override
 			void subscribe(WriteResultPublisher publisher, Subscriber<? super Void> subscriber) {
 				Assert.notNull(subscriber, "Subscriber must not be null");
+				publisher.subscriber = subscriber;
 				if (publisher.changeState(this, SUBSCRIBED)) {
 					Subscription subscription = new ResponseBodyWriteResultSubscription(publisher);
-					publisher.subscriber = subscriber;
 					subscriber.onSubscribe(subscription);
 					if (publisher.publisherCompleted) {
 						publisher.publishComplete();


### PR DESCRIPTION
Fixed NPE thrown by WriteResultPublisher$State$2.publishComplete caused by a thread-safety issue

Issue: SPR-15418