### PR TITLE
SPR-15423 ForwardedHeaderRequestWrapper should return a new StringBuffer instance on each invocation of the getRequestURL method

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java
@@ -118,7 +118,7 @@ public class ForwardedHeaderFilter extends OncePerRequestFilter {
 
 		private final String requestUri;
 
-		private final StringBuffer requestUrl;
+		private final String requestUrl;
 
 		private final Map<String, List<String>> headers;
 
@@ -137,8 +137,8 @@ public class ForwardedHeaderFilter extends OncePerRequestFilter {
 			String prefix = getForwardedPrefix(request);
 			this.contextPath = (prefix != null ? prefix : request.getContextPath());
 			this.requestUri = this.contextPath + pathHelper.getPathWithinApplication(request);
-			this.requestUrl = new StringBuffer(this.scheme + "://" + this.host +
-					(port == -1 ? "" : ":" + port) + this.requestUri);
+			this.requestUrl = this.scheme + "://" + this.host +
+					(port == -1 ? "" : ":" + port) + this.requestUri;
 			this.headers = initHeaders(request);
 		}
 
@@ -206,7 +206,7 @@ public class ForwardedHeaderFilter extends OncePerRequestFilter {
 
 		@Override
 		public StringBuffer getRequestURL() {
-			return this.requestUrl;
+			return new StringBuffer(this.requestUrl);
 		}
 
 		// Override header accessors to not expose forwarded headers

--- a/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java
@@ -118,7 +118,7 @@ public class ForwardedHeaderFilter extends OncePerRequestFilter {
 
 		private final String requestUri;
 
-		private final String requestUrl;
+		private final StringBuffer requestUrl;
 
 		private final Map<String, List<String>> headers;
 
@@ -137,8 +137,8 @@ public class ForwardedHeaderFilter extends OncePerRequestFilter {
 			String prefix = getForwardedPrefix(request);
 			this.contextPath = (prefix != null ? prefix : request.getContextPath());
 			this.requestUri = this.contextPath + pathHelper.getPathWithinApplication(request);
-			this.requestUrl = this.scheme + "://" + this.host +
-					(port == -1 ? "" : ":" + port) + this.requestUri;
+			this.requestUrl = new StringBuffer(this.scheme + "://" + this.host +
+					(port == -1 ? "" : ":" + port) + this.requestUri);
 			this.headers = initHeaders(request);
 		}
 
@@ -206,7 +206,7 @@ public class ForwardedHeaderFilter extends OncePerRequestFilter {
 
 		@Override
 		public StringBuffer getRequestURL() {
-			return new StringBuffer(this.requestUrl);
+			return this.requestUrl;
 		}
 
 		// Override header accessors to not expose forwarded headers

--- a/spring-web/src/test/java/org/springframework/web/filter/ForwardedHeaderFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/ForwardedHeaderFilterTests.java
@@ -208,6 +208,16 @@ public class ForwardedHeaderFilterTests {
 		HttpServletRequest actual = filterAndGetWrappedRequest();
 		assertEquals("http://localhost/prefix/mvc-showcase", actual.getRequestURL().toString());
 	}
+	
+	@Test
+	public void requestURLNewStringBuffer() throws Exception { 
+		this.request.addHeader(X_FORWARDED_PREFIX, "/prefix/");
+		this.request.setRequestURI("/mvc-showcase");
+
+		HttpServletRequest actual = filterAndGetWrappedRequest();
+		actual.getRequestURL().append("?key=value");
+		assertEquals("http://localhost/prefix/mvc-showcase", actual.getRequestURL().toString());
+	}
 
 	@Test
 	public void contextPathWithForwardedPrefix() throws Exception {

--- a/spring-web/src/test/java/org/springframework/web/filter/ForwardedHeaderFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/ForwardedHeaderFilterTests.java
@@ -208,16 +208,6 @@ public class ForwardedHeaderFilterTests {
 		HttpServletRequest actual = filterAndGetWrappedRequest();
 		assertEquals("http://localhost/prefix/mvc-showcase", actual.getRequestURL().toString());
 	}
-	
-	@Test
-	public void requestURLNewStringBuffer() throws Exception { 
-		this.request.addHeader(X_FORWARDED_PREFIX, "/prefix/");
-		this.request.setRequestURI("/mvc-showcase");
-
-		HttpServletRequest actual = filterAndGetWrappedRequest();
-		actual.getRequestURL().append("?key=value");
-		assertEquals("http://localhost/prefix/mvc-showcase", actual.getRequestURL().toString());
-	}
 
 	@Test
 	public void contextPathWithForwardedPrefix() throws Exception {


### PR DESCRIPTION
To be consistent with servlet containers a new StringBuffer instance should be returned each time the request.getRequestURL() method is invoked.  

https://jira.spring.io/browse/SPR-15423