### PR TITLE
SPR-15481 Fixed AnnotationUtils.getValue() operation

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
@@ -54,6 +54,7 @@ import static org.springframework.core.annotation.AnnotationUtils.*;
  * @author Sam Brannen
  * @author Chris Beams
  * @author Phillip Webb
+ * @author Oleg Zhurakousky
  */
 public class AnnotationUtilsTests {
 
@@ -1238,6 +1239,14 @@ public class AnnotationUtilsTests {
 		assertNotNull(contextConfig);
 		assertEquals("value: ", "", contextConfig.value());
 		assertEquals("location: ", "", contextConfig.location());
+	}
+	
+	@ContextConfig(value="foo", location="bar")
+	@Test(expected=AnnotationConfigurationException.class)
+	public void synthesizeAnnotationWithAttributeAliasesDifferentValues() throws Exception {
+		Method m = AnnotationUtilsTests.class.getDeclaredMethod("synthesizeAnnotationWithAttributeAliasesDifferentValues");
+		Annotation a = synthesizeAnnotation(m.getDeclaredAnnotation(ContextConfig.class));
+		getValue(a);
 	}
 
 	@Test


### PR DESCRIPTION
- Fixed AnnotationUtils.getValue() operation to ensure it re-throws AnnotationConfigurationException instead of swallowing it (as it is done in few other operations in AnnotationUtils)
- Added test
- Removed unnecessary '@SuppressWarnings("unchecked")'