### PR TITLE
Add more static builder methods to ResponseEntity

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -61,6 +61,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Arjen Poutsma
  * @author Brian Clozel
+ * @author Theodoros Ntakouris
  * @since 3.0.2
  * @see #getStatusCode()
  */
@@ -234,6 +235,15 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	}
 
 	/**
+	 * Create a builder with the status set to {@linkplain HttpStatus#CREATED CREATED}.
+	 * @return the created builder
+	 * @since 5.0
+	 */
+	public static BodyBuilder created() {
+		return status(HttpStatus.CREATED);
+	}
+
+	/**
 	 * Create a new builder with a {@linkplain HttpStatus#CREATED CREATED} status
 	 * and a location header set to the given URI.
 	 * @param location the location URI
@@ -255,6 +265,17 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	}
 
 	/**
+	 * A shortcut for creating a {@code ResponseEntity} with the given body and
+	 * the status set to {@linkplain HttpStatus#ACCEPTED ACCEPTED}.
+	 * @return the created {@code ResponseEntity}
+	 * @since 5.0
+	 */
+	public static <T> ResponseEntity<T> accepted(T body) {
+		BodyBuilder builder = accepted();
+		return builder.body(body);
+	}
+
+	/**
 	 * Create a builder with a {@linkplain HttpStatus#NO_CONTENT NO_CONTENT} status.
 	 * @return the created builder
 	 * @since 4.1
@@ -270,6 +291,17 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	 */
 	public static BodyBuilder badRequest() {
 		return status(HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * A shortcut for creating a {@code ResponseEntity} with the given body and
+	 * the status set to {@linkplain HttpStatus#BAD_REQUEST BAD_REQUEST}.
+	 * @return the created {@code ResponseEntity}
+	 * @since 5.0
+	 */
+	public static <T> ResponseEntity<T> badRequest(T body) {
+		BodyBuilder builder = badRequest();
+		return builder.body(body);
 	}
 
 	/**
@@ -291,6 +323,111 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 		return status(HttpStatus.UNPROCESSABLE_ENTITY);
 	}
 
+	/**
+	 * A shortcut for creating a {@code ResponseEntity} with the given body and
+	 * the status set to {@linkplain HttpStatus#UNPROCESSABLE_ENTITY UNPROCESSABLE_ENTITY}.
+	 * @return the created {@code ResponseEntity}
+	 * @since 5.0
+	 */
+	public static <T> ResponseEntity<T> unprocessableEntity(T body) {
+		BodyBuilder builder = unprocessableEntity();
+		return builder.body(body);
+	}
+
+	/**
+	 * Create a builder with an
+	 * {@linkplain HttpStatus#INTERNAL_SERVER_ERROR INTERNAL_SERVER_ERROR} status.
+	 * @return the created builder
+	 * @since 5.0
+	 */
+	public static BodyBuilder serverError(){return status(HttpStatus.INTERNAL_SERVER_ERROR);}
+
+	/**
+	 * A shortcut for creating a {@code ResponseEntity} with the given body and
+	 * the status set to {@linkplain HttpStatus#INTERNAL_SERVER_ERROR INTERNAL_SERVER_ERROR}.
+	 * @return the created {@code ResponseEntity}
+	 * @since 5.0
+	 */
+	public static <T> ResponseEntity<T> serverError(T body) {
+		BodyBuilder builder = serverError();
+		return builder.body(body);
+	}
+
+	/**
+	 * Create a builder with an
+	 * {@linkplain HttpStatus#UNAUTHORIZED UNAUTHORIZED} status.
+	 * @return the created builder
+	 * @since 5.0
+	 */
+	public static BodyBuilder unauthorized(){return status(HttpStatus.UNAUTHORIZED);}
+
+	/**
+	 * A shortcut for creating a {@code ResponseEntity} with the given body and
+	 * the status set to {@linkplain HttpStatus#UNAUTHORIZED UNAUTHORIZED}.
+	 * @return the created {@code ResponseEntity}
+	 * @since 5.0
+	 */
+	public static <T> ResponseEntity<T> unauthorized(T body) {
+		BodyBuilder builder = unauthorized();
+		return builder.body(body);
+	}
+
+	/**
+	 * Create a builder with an
+	 * {@linkplain HttpStatus#NOT_IMPLEMENTED NOT_IMPLEMENTED} status.
+	 * @return the created builder
+	 * @since 5.0
+	 */
+	public static BodyBuilder notImplemented(){return status(HttpStatus.NOT_IMPLEMENTED);}
+
+	/**
+	 * A shortcut for creating a {@code ResponseEntity} with the given body and
+	 * the status set to {@linkplain HttpStatus#NOT_IMPLEMENTED NOT_IMPLEMENTED}.
+	 * @return the created {@code ResponseEntity}
+	 * @since 5.0
+	 */
+	public static <T> ResponseEntity<T> notImplemented(T body) {
+		BodyBuilder builder = notImplemented();
+		return builder.body(body);
+	}
+
+	/**
+	 * Create a builder with an
+	 * {@linkplain HttpStatus#FORBIDDEN FORBIDDEN} status.
+	 * @return the created builder
+	 * @since 5.0
+	 */
+	public static BodyBuilder forbidden(){return status(HttpStatus.FORBIDDEN);}
+
+	/**
+	 * A shortcut for creating a {@code ResponseEntity} with the given body and
+	 * the status set to {@linkplain HttpStatus#FORBIDDEN FORBIDDEN}.
+	 * @return the created {@code ResponseEntity}
+	 * @since 5.0
+	 */
+	public static <T> ResponseEntity<T> forbidden(T body) {
+		BodyBuilder builder = forbidden();
+		return builder.body(body);
+	}
+
+	/**
+	 * Create a builder with an
+	 * {@linkplain HttpStatus#SERVICE_UNAVAILABLE SERVICE_UNAVAILABLE} status.
+	 * @return the created builder
+	 * @since 5.0
+	 */
+	public static BodyBuilder serviceUnavailable(){return status(HttpStatus.SERVICE_UNAVAILABLE);}
+
+	/**
+	 * A shortcut for creating a {@code ResponseEntity} with the given body and
+	 * the status set to {@linkplain HttpStatus#SERVICE_UNAVAILABLE SERVICE_UNAVAILABLE}.
+	 * @return the created {@code ResponseEntity}
+	 * @since 5.0
+	 */
+	public static <T> ResponseEntity<T> serviceUnavailable(T body) {
+		BodyBuilder builder = serviceUnavailable();
+		return builder.body(body);
+	}
 
 	/**
 	 * Defines a builder that adds headers to the response entity.

--- a/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.*;
  * @author Arjen Poutsma
  * @author Marcel Overdijk
  * @author Kazuki Shimizu
+ * @author Theodoros Ntakouris
  */
 public class ResponseEntityTests {
 
@@ -73,6 +74,15 @@ public class ResponseEntityTests {
 	}
 
 	@Test
+	public void createdNoBody() throws URISyntaxException {
+		ResponseEntity<Void> responseEntity = ResponseEntity.created().build();
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode());
+		assertNull(responseEntity.getBody());
+	}
+
+	@Test
 	public void createdLocation() throws URISyntaxException {
 		URI location = new URI("location");
 		ResponseEntity<Void> responseEntity = ResponseEntity.created(location).build();
@@ -96,6 +106,16 @@ public class ResponseEntityTests {
 		assertNull(responseEntity.getBody());
 	}
 
+	@Test
+	public void accepted() throws URISyntaxException {
+		Integer entity = 42;
+		ResponseEntity<Integer> responseEntity = ResponseEntity.accepted(entity);
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.ACCEPTED, responseEntity.getStatusCode());
+		assertEquals(entity, responseEntity.getBody());
+	}
+
 	@Test // SPR-14939
 	public void acceptedNoBodyWithAlternativeBodyType() throws URISyntaxException {
 		ResponseEntity<String> responseEntity = ResponseEntity.accepted().build();
@@ -106,7 +126,7 @@ public class ResponseEntityTests {
 	}
 
 	@Test
-	public void noContent() throws URISyntaxException {
+	public void noContentNoBody() throws URISyntaxException {
 		ResponseEntity<Void> responseEntity = ResponseEntity.noContent().build();
 
 		assertNotNull(responseEntity);
@@ -115,7 +135,7 @@ public class ResponseEntityTests {
 	}
 
 	@Test
-	public void badRequest() throws URISyntaxException {
+	public void badRequestNoBody() throws URISyntaxException {
 		ResponseEntity<Void> responseEntity = ResponseEntity.badRequest().build();
 
 		assertNotNull(responseEntity);
@@ -124,7 +144,17 @@ public class ResponseEntityTests {
 	}
 
 	@Test
-	public void notFound() throws URISyntaxException {
+	public void badRequest() throws URISyntaxException {
+		Integer entity = 42;
+		ResponseEntity<Integer> responseEntity = ResponseEntity.badRequest(entity);
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
+		assertEquals(entity, responseEntity.getBody());
+	}
+
+	@Test
+	public void notFoundNoBody() throws URISyntaxException {
 		ResponseEntity<Void> responseEntity = ResponseEntity.notFound().build();
 
 		assertNotNull(responseEntity);
@@ -134,11 +164,107 @@ public class ResponseEntityTests {
 
 	@Test
 	public void unprocessableEntity() throws URISyntaxException {
-		ResponseEntity<String> responseEntity = ResponseEntity.unprocessableEntity().body("error");
+		String entity = "error";
+		ResponseEntity<String> responseEntity = ResponseEntity.unprocessableEntity(entity);
 
 		assertNotNull(responseEntity);
 		assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, responseEntity.getStatusCode());
-		assertEquals("error", responseEntity.getBody());
+		assertEquals(entity, responseEntity.getBody());
+	}
+
+	@Test
+	public void serverErrorNoBody() throws URISyntaxException{
+		ResponseEntity<Void> responseEntity = ResponseEntity.serverError().build();
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
+		assertNull(responseEntity.getBody());
+	}
+
+	@Test
+	public void serverError() throws URISyntaxException{
+		Integer entity = 42;
+		ResponseEntity<Integer> responseEntity = ResponseEntity.serverError(entity);
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
+		assertEquals(entity, responseEntity.getBody());
+	}
+
+	@Test
+	public void unauthorizedNoBody() throws URISyntaxException{
+		ResponseEntity<Void> responseEntity = ResponseEntity.unauthorized().build();
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.UNAUTHORIZED, responseEntity.getStatusCode());
+		assertNull(responseEntity.getBody());
+	}
+
+	@Test
+	public void unauthorized() throws URISyntaxException{
+		Integer entity = 42;
+		ResponseEntity<Integer> responseEntity = ResponseEntity.unauthorized(entity);
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.UNAUTHORIZED, responseEntity.getStatusCode());
+		assertEquals(entity, responseEntity.getBody());
+	}
+
+	@Test
+	public void notImplementedNoBody() throws URISyntaxException{
+		ResponseEntity<Void> responseEntity = ResponseEntity.notImplemented().build();
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.NOT_IMPLEMENTED, responseEntity.getStatusCode());
+		assertNull(responseEntity.getBody());
+	}
+
+	@Test
+	public void notImplemented() throws URISyntaxException{
+		Integer entity = 42;
+		ResponseEntity<Integer> responseEntity = ResponseEntity.notImplemented(entity);
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.NOT_IMPLEMENTED, responseEntity.getStatusCode());
+		assertEquals(entity, responseEntity.getBody());
+	}
+
+	@Test
+	public void forbiddenNoBody() throws URISyntaxException{
+		ResponseEntity<Void> responseEntity = ResponseEntity.forbidden().build();
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
+		assertNull(responseEntity.getBody());
+	}
+
+	@Test
+	public void forbidden() throws URISyntaxException{
+		Integer entity = 42;
+		ResponseEntity<Integer> responseEntity = ResponseEntity.forbidden(entity);
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
+		assertEquals(entity, responseEntity.getBody());
+	}
+
+	@Test
+	public void serviceUnavailableNoBody() throws URISyntaxException{
+		ResponseEntity<Void> responseEntity = ResponseEntity.serviceUnavailable().build();
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.SERVICE_UNAVAILABLE, responseEntity.getStatusCode());
+		assertNull(responseEntity.getBody());
+	}
+
+	@Test
+	public void serviceUnavailable() throws URISyntaxException{
+		Integer entity = 42;
+		ResponseEntity<Integer> responseEntity = ResponseEntity.serviceUnavailable(entity);
+
+		assertNotNull(responseEntity);
+		assertEquals(HttpStatus.SERVICE_UNAVAILABLE, responseEntity.getStatusCode());
+		assertEquals(entity, responseEntity.getBody());
 	}
 
 	@Test


### PR DESCRIPTION
I added a couple more static helper methods that either produce a BodyBuilder or a ResponseEntity with specified body. I find myself typing .build() or 'manually' constructing such response entities frequently, thus I made these changes. Some unit tests were added as well as changed (prefixed with 'NoBody') in order to fit the new changes & be understood better by just reading the method name.

* I've signed the CLA