### PR TITLE
SPR-15492 - Improve servlet request parameter name handling

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -579,6 +579,12 @@ public abstract class WebUtils {
 	 * Maps single values to String and multiple values to String array.
 	 * <p>For example, with a prefix of "spring_", "spring_param1" and
 	 * "spring_param2" result in a Map with "param1" and "param2" as keys.
+	 * <p>Parameter names using square brackets such as, "items[0][id]"
+	 * and "items[0]['tags'][]" will be converted to "items[0].id" and
+	 * "items[0].tags" respectively, so those parameters can be bound to
+	 * a model attribute object through
+	 * {@link org.springframework.web.bind.ServletRequestParameterPropertyValues}
+	 * and {@link org.springframework.web.bind.ServletRequestDataBinder}.
 	 * @param request HTTP request in which to look for parameters
 	 * @param prefix the beginning of parameter names
 	 * (if this is null or the empty string, all parameters will match)
@@ -604,14 +610,27 @@ public abstract class WebUtils {
 					// Do nothing, no values found at all.
 				}
 				else if (values.length > 1) {
-					params.put(unprefixed, values);
+					params.put(convertSquareBracketToDot(unprefixed), values);
 				}
 				else {
-					params.put(unprefixed, values[0]);
+					params.put(convertSquareBracketToDot(unprefixed), values[0]);
 				}
 			}
 		}
 		return params;
+	}
+
+	private static String convertSquareBracketToDot(String paramName) {
+		return paramName
+				.replaceAll("\\['", "[")
+				.replaceAll("']", "]")
+				.replaceAll("\\[\"", "[")
+				.replaceAll("\"]", "]")
+				.replaceAll("\\[]", "")
+				.replaceAll("\\[(\\d+)]", "!#%@$1%@#!")
+				.replaceAll("\\[", ".")
+				.replaceAll("]", "")
+				.replaceAll("!#%@(\\d+)%@#!", "[$1]");
 	}
 
 	/**

--- a/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/WebUtilsTests.java
@@ -56,6 +56,48 @@ public class WebUtilsTests {
 	}
 
 	@Test
+	public void convertSquareBracketToDot() {
+		String[] strArr = new String[] {"123", "abc"};
+
+		Map<String, Object> params = new HashMap<>();
+		params.put("k1", "simpleKey");
+		params.put("33", "numberKey");
+		params.put("level1dot.level2", "dot");
+		params.put("level1[level2]", "squareBracket");
+		params.put("34[22]", "NumberKeyWithSquareBracket1");
+		params.put("35[3b][22]", "NumberKeyWithSquareBracket2");
+		params.put("level1-dot[level-2]", "dash");
+		params.put("level1arr[]", strArr);
+		params.put("level1[level2_arr][]", strArr);
+		params.put("level1arr[0]['level2']", "level2-SingleQuote");
+		params.put("level1arr[0][level2arr][]", strArr);
+		params.put("level1arr[0][level2][\"level3\"]", "level3-DoubleQuote");
+		params.put("level1arr[0][\"level2\"]['level3arr'][0][level4]", "level4-of-nestedArray");
+		params.put("level1arr[0][level2][\"level3arr\"][0][level4arr][]", strArr);
+		params.put("`~!@#$%^&*()-_=+\\|[{'\";:}][<,>/?]", "special");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameters(params);
+		Map<String, Object> paramMap = WebUtils.getParametersStartingWith(request, "");
+
+		assertEquals("simpleKey", paramMap.get("k1"));
+		assertEquals("numberKey", paramMap.get("33"));
+		assertEquals("dot", paramMap.get("level1dot.level2"));
+		assertEquals("squareBracket", paramMap.get("level1.level2"));
+		assertEquals("NumberKeyWithSquareBracket1", paramMap.get("34[22]"));
+		assertEquals("NumberKeyWithSquareBracket2", paramMap.get("35.3b[22]"));
+		assertEquals("dash", paramMap.get("level1-dot.level-2"));
+		assertEquals(strArr, paramMap.get("level1arr"));
+		assertEquals(strArr, paramMap.get("level1.level2_arr"));
+		assertEquals("level2-SingleQuote", paramMap.get("level1arr[0].level2"));
+		assertEquals(strArr, paramMap.get("level1arr[0].level2arr"));
+		assertEquals("level3-DoubleQuote", paramMap.get("level1arr[0].level2.level3"));
+		assertEquals("level4-of-nestedArray", paramMap.get("level1arr[0].level2.level3arr[0].level4"));
+		assertEquals(strArr, paramMap.get("level1arr[0].level2.level3arr[0].level4arr"));
+		assertEquals("special", paramMap.get("`~!@#$%^&*()-_=+\\|.{'\";:}.<,>/?"));
+	}
+
+	@Test
 	public void parseMatrixVariablesString() {
 		MultiValueMap<String, String> variables;
 


### PR DESCRIPTION
Parameters whose names are including square brackets
such as "items[0][id]" and "items[0][tags][]" produce
org.springframework.beans.InvalidPropertyException
when binding to a model object

This commit improves the WebUtils class by adding simple
regular expressions, so those parameters can be bound
to a model object without unnecessary exception

Issue: SPR-15492