### PR TITLE
Minor Javadoc typo fix: form -> from

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/HttpMessageConverter.java
@@ -57,7 +57,7 @@ public interface HttpMessageConverter<T> {
 	List<MediaType> getSupportedMediaTypes();
 
 	/**
-	 * Read an object of the given type form the given input message, and returns it.
+	 * Read an object of the given type from the given input message, and returns it.
 	 * @param clazz the type of object to return. This type must have previously been passed to the
 	 * {@link #canRead canRead} method of this interface, which must have returned {@code true}.
 	 * @param inputMessage the HTTP input message to read from


### PR DESCRIPTION
The method takes in an `HttpInputMessage inputMessage`, so I don't think the intent of the comment was to _form_ an input message.