### PR TITLE
SPR-15504 - UriComponentsBuilder's fromHttpRequest uses server port as host port when handling the Forwarded header

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -717,7 +717,14 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 			String forwardedToUse = StringUtils.tokenizeToStringArray(forwardedHeader, ",")[0];
 			Matcher matcher = FORWARDED_HOST_PATTERN.matcher(forwardedToUse);
 			if (matcher.find()) {
-				host(matcher.group(1).trim());
+				String host = matcher.group(1).trim();
+				if (host.matches(".*:\\d+$")) {
+					host(host.substring(0, host.lastIndexOf(':')));
+					port(host.substring(host.lastIndexOf(':') + 1));
+				} else {
+					host(host);
+					port(null);
+				}
 			}
 			matcher = FORWARDED_PROTO_PATTERN.matcher(forwardedToUse);
 			if (matcher.find()) {

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -94,6 +94,8 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 
 	private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?");
 
+	private static final String HOST_ENDS_WITH_PORT_PATTERN = ".*:\\d+$";
+
 
 	private String scheme;
 
@@ -718,7 +720,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 			Matcher matcher = FORWARDED_HOST_PATTERN.matcher(forwardedToUse);
 			if (matcher.find()) {
 				String host = matcher.group(1).trim();
-				if (host.matches(".*:\\d+$")) {
+				if (host.matches(HOST_ENDS_WITH_PORT_PATTERN)) {
 					host(host.substring(0, host.lastIndexOf(':')));
 					port(host.substring(host.lastIndexOf(':') + 1));
 				} else {

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -94,8 +94,6 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 
 	private static final Pattern FORWARDED_PROTO_PATTERN = Pattern.compile("proto=\"?([^;,\"]+)\"?");
 
-	private static final String HOST_ENDS_WITH_PORT_PATTERN = ".*:\\d+$";
-
 
 	private String scheme;
 
@@ -719,12 +717,14 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 			String forwardedToUse = StringUtils.tokenizeToStringArray(forwardedHeader, ",")[0];
 			Matcher matcher = FORWARDED_HOST_PATTERN.matcher(forwardedToUse);
 			if (matcher.find()) {
-				String host = matcher.group(1).trim();
-				if (host.matches(HOST_ENDS_WITH_PORT_PATTERN)) {
-					host(host.substring(0, host.lastIndexOf(':')));
-					port(host.substring(host.lastIndexOf(':') + 1));
-				} else {
-					host(host);
+				String hostToUse = matcher.group(1).trim();
+				int portSeparatorIdx = hostToUse.lastIndexOf(":");
+				if (portSeparatorIdx > hostToUse.lastIndexOf("]")) {
+					host(hostToUse.substring(0, portSeparatorIdx));
+					port(Integer.parseInt(hostToUse.substring(portSeparatorIdx + 1)));
+				}
+				else {
+					host(hostToUse);
 					port(null);
 				}
 			}

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -791,7 +791,7 @@ public class UriComponentsBuilderTests {
 	}
 
 	@Test
-	public void fromHttpRequestForwardedHeaderWithHostPort() throws Exception {
+	public void fromHttpRequestForwardedHeaderWithHostPortAndWithoutServerPort() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Forwarded", "proto=https; host=84.198.58.199:9090");
 		request.setScheme("http");
@@ -828,7 +828,7 @@ public class UriComponentsBuilderTests {
 	}
 
 	@Test
-	public void fromHttpRequestForwardedHeaderWithoutHostPortOnHttps() throws Exception {
+	public void fromHttpRequestForwardedHeaderWithoutHostPortAndWithServerPort() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Forwarded", "proto=https; host=84.198.58.199");
 		request.setScheme("http");

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -832,6 +832,7 @@ public class UriComponentsBuilderTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Forwarded", "proto=https; host=84.198.58.199");
 		request.setScheme("http");
+		request.setServerPort(8080);
 		request.setServerName("example.com");
 		request.setRequestURI("/rest/mobile/users/1");
 

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -790,4 +790,58 @@ public class UriComponentsBuilderTests {
 		assertEquals("/rest/mobile/users/1", result.getPath());
 	}
 
+	@Test
+	public void fromHttpRequestForwardedHeaderWithHostPort() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Forwarded", "proto=https; host=84.198.58.199:9090");
+		request.setScheme("http");
+		request.setServerName("example.com");
+		request.setRequestURI("/rest/mobile/users/1");
+
+		HttpRequest httpRequest = new ServletServerHttpRequest(request);
+		UriComponents result = UriComponentsBuilder.fromHttpRequest(httpRequest).build();
+
+		assertEquals("https", result.getScheme());
+		assertEquals("84.198.58.199", result.getHost());
+		assertEquals("/rest/mobile/users/1", result.getPath());
+		assertEquals(9090, result.getPort());
+		assertEquals("https://84.198.58.199:9090/rest/mobile/users/1", result.toUriString());
+	}
+
+	@Test
+	public void fromHttpRequestForwardedHeaderWithHostPortAndServerPort() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Forwarded", "proto=https; host=84.198.58.199:9090");
+		request.setScheme("http");
+		request.setServerPort(8080);
+		request.setServerName("example.com");
+		request.setRequestURI("/rest/mobile/users/1");
+
+		HttpRequest httpRequest = new ServletServerHttpRequest(request);
+		UriComponents result = UriComponentsBuilder.fromHttpRequest(httpRequest).build();
+
+		assertEquals("https", result.getScheme());
+		assertEquals("84.198.58.199", result.getHost());
+		assertEquals("/rest/mobile/users/1", result.getPath());
+		assertEquals(9090, result.getPort());
+		assertEquals("https://84.198.58.199:9090/rest/mobile/users/1", result.toUriString());
+	}
+
+	@Test
+	public void fromHttpRequestForwardedHeaderWithoutHostPortOnHttps() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Forwarded", "proto=https; host=84.198.58.199");
+		request.setScheme("http");
+		request.setServerName("example.com");
+		request.setRequestURI("/rest/mobile/users/1");
+
+		HttpRequest httpRequest = new ServletServerHttpRequest(request);
+		UriComponents result = UriComponentsBuilder.fromHttpRequest(httpRequest).build();
+
+		assertEquals("https", result.getScheme());
+		assertEquals("84.198.58.199", result.getHost());
+		assertEquals("/rest/mobile/users/1", result.getPath());
+		assertEquals(-1, result.getPort());
+		assertEquals("https://84.198.58.199/rest/mobile/users/1", result.toUriString());
+	}
 }


### PR DESCRIPTION
The UriComponentsBuilder's adaptFromForwardedHeaders method doesn't handle the host port of the Forwarded header correctly, which means that the URI generated through the fromHttpRequest method will append the server port to the host (of the Forwarded header), instead of just using the port (if any) defined in the host part of the Forwarded header.
This pull request will try to parse the port of the host of the Forwarded header, and configure the builder accordingly.
According to the RFC https://tools.ietf.org/html/rfc7239#section-5.3 and https://tools.ietf.org/html/rfc7230#section-5.4 the host part of the Forwarded header "provides the host and port information from the target URI", and as such should be handled in the adaptFromForwardedHeaders method.