### PR TITLE
Fix WebJarsResourceResolver multiple matches

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/WebJarsResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/WebJarsResourceResolver.java
@@ -105,7 +105,7 @@ public class WebJarsResourceResolver extends AbstractResourceResolver {
 			if (endOffset != -1) {
 				String webjar = path.substring(startOffset, endOffset);
 				String partialPath = path.substring(endOffset);
-				String webJarPath = webJarAssetLocator.getFullPath(webjar, partialPath);
+				String webJarPath = webJarAssetLocator.getFullPathExact(webjar, partialPath);
 				return webJarPath.substring(WEBJARS_LOCATION_LENGTH);
 			}
 		}


### PR DESCRIPTION
Using WebJarAssetLocator.getFullPathExact instead of WebJarAssetLocator.getFullPath avoid
multiple matches in case of multiple files with the same name in the same webjar.

Refer to this issue for details https://github.com/webjars/webjars-locator/issues/90