### PR TITLE
Fix sample code for bean definition using functional style on web-flux.adoc

### DIFF
--- a/src/docs/asciidoc/web/web-flux.adoc
+++ b/src/docs/asciidoc/web/web-flux.adoc
@@ -326,9 +326,10 @@ For the **functional programming model** bootstrap as follows:
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
-ApplicationContext context = new AnnotationConfigApplicationContext(); // (1)
+AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(); // (1)
 context.registerBean(FooBean.class, () -> new FooBeanImpl()); // (2)
 context.registerBean(BarBean.class); // (3)
+context.refresh();
 
 HttpHandler handler = WebHttpHandlerBuilder
 		.webHandler(RouterFunctions.toHttpHandler(...))


### PR DESCRIPTION
I've fixed wrong sample code for bean definition using functional style.

* The `registerBean` does not exist  on the `ApplicationContext`
* `AnnotationConfigApplicationContext` instance generated by default constructor is need calling the `refresh` method

Please review this.