### PR TITLE
WebJarsResourceResolver: multiple matches fix

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/WebJarsResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/WebJarsResourceResolver.java
@@ -104,8 +104,11 @@ public class WebJarsResourceResolver extends AbstractResourceResolver {
 			int endOffset = path.indexOf("/", 1);
 			if (endOffset != -1) {
 				String webjar = path.substring(startOffset, endOffset);
-				String partialPath = path.substring(endOffset);
-				String webJarPath = webJarAssetLocator.getFullPath(webjar, partialPath);
+				String partialPath = path.substring(endOffset + 1);
+				String webJarPath = webJarAssetLocator.getFullPathExact(webjar, partialPath);
+				if (webJarPath == null) {
+					throw new IllegalArgumentException();
+				}
 				return webJarPath.substring(WEBJARS_LOCATION_LENGTH);
 			}
 		}


### PR DESCRIPTION
Using WebJarAssetLocator.getFullPathExact instead of WebJarAssetLocator.getFullPath avoid
multiple matches in case of multiple files with the same name in the same webjar.

Refer to this issue for details https://github.com/webjars/webjars-locator/issues/90