### PR TITLE
SPR-15505 - Use original query string of forwarded request

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractFlashMapManager.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/AbstractFlashMapManager.java
@@ -167,13 +167,14 @@ public abstract class AbstractFlashMapManager implements FlashMapManager {
 	 */
 	protected boolean isFlashMapForRequest(FlashMap flashMap, HttpServletRequest request) {
 		String expectedPath = flashMap.getTargetRequestPath();
+		String requestUri = getUrlPathHelper().getOriginatingRequestUri(request);
 		if (expectedPath != null) {
-			String requestUri = getUrlPathHelper().getOriginatingRequestUri(request);
 			if (!requestUri.equals(expectedPath) && !requestUri.equals(expectedPath + "/")) {
 				return false;
 			}
 		}
-		UriComponents uriComponents = ServletUriComponentsBuilder.fromRequest(request).build();
+		String queryString = getUrlPathHelper().getOriginatingQueryString(request);
+		UriComponents uriComponents = ServletUriComponentsBuilder.fromUriString(requestUri).query(queryString).build();
 		MultiValueMap<String, String> actualParams = uriComponents.getQueryParams();
 		MultiValueMap<String, String> expectedParams = flashMap.getTargetRequestParams();
 		for (String expectedName : expectedParams.keySet()) {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/support/FlashMapManagerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/support/FlashMapManagerTests.java
@@ -318,6 +318,26 @@ public class FlashMapManagerTests {
 		assertEquals("value", flashMap.get("key"));
 	}
 
+	// SPR-15505
+
+	@Test
+	public void retrieveAndUpdateMatchByOriginatingPathAndQueryString() {
+		FlashMap flashMap = new FlashMap();
+		flashMap.put("key", "value");
+		flashMap.setTargetRequestPath("/accounts");
+		flashMap.addTargetRequestParam("a", "b");
+
+		this.flashMapManager.setFlashMaps(Arrays.asList(flashMap));
+
+		this.request.setAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE, "/accounts");
+		this.request.setAttribute(WebUtils.FORWARD_QUERY_STRING_ATTRIBUTE, "a=b");
+		this.request.setRequestURI("/mvc/accounts");
+		this.request.setQueryString("x=y");
+		FlashMap inputFlashMap = this.flashMapManager.retrieveAndUpdate(this.request, this.response);
+
+		assertEquals(flashMap, inputFlashMap);
+		assertEquals("Input FlashMap should have been removed", 0, this.flashMapManager.getFlashMaps().size());
+	}
 
 	private static class TestFlashMapManager extends AbstractFlashMapManager {
 


### PR DESCRIPTION
This pull request solves the problem happening when FlashMaps are used in conjunction with forwarded requests with differing query parameters. The AbstractFlashMapManager has used the originating URI but the query string of the forwarded request. That resulted to FlashMap not being matched even when both originating URI and query string matched the FlashMap attributes. The originating query string is now used to match the forwarded request.

This is my first pull request to Spring project so I hope I followed all the guidelines correctly. I've submitted the ICLA. 

Issue: SPR-15505