### PR TITLE
SPR-15537 - Logging exception in ExceptionWebSocketHandlerDecorator.

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/handler/ExceptionWebSocketHandlerDecorator.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/handler/ExceptionWebSocketHandlerDecorator.java
@@ -94,7 +94,7 @@ public class ExceptionWebSocketHandlerDecorator extends WebSocketHandlerDecorato
 				session.close(CloseStatus.SERVER_ERROR);
 			}
 			catch (Throwable ex) {
-				// ignore
+				logger.error("Error for " + this, ex);
 			}
 		}
 	}


### PR DESCRIPTION
Hello,
I am working on an app which includes a module of spring-websocket. I did some changes in the code and I was having some hibernate exception in the back, but the exception is not getting printed/logged. I found out this while debugging the code. In this class "ExceptionWebSocketHandlerDecorator" in this public static method "tryCloseWithError", exception handling is there but logging is missing.