### PR TITLE
Specify the HandlerMapping#order in the websocket example

### DIFF
--- a/src/docs/asciidoc/web/web-flux.adoc
+++ b/src/docs/asciidoc/web/web-flux.adoc
@@ -238,6 +238,7 @@ public HandlerMapping webSocketMapping() {
 	map.put("/bar", new BarWebSocketHandler());
 
 	SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
+	mapping.setOrder(10);
 	mapping.setUrlMap(map);
 	return mapping;
 }


### PR DESCRIPTION
The order value has to be specified for the HandlerMapping
so that it will be ordered before the one that serves the static resources.