### PR TITLE
SPR-15543: Fix duplicate subscriptionId for destination-sessionId key

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/DefaultSubscriptionRegistry.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/DefaultSubscriptionRegistry.java
@@ -292,8 +292,10 @@ public class DefaultSubscriptionRegistry extends AbstractSubscriptionRegistry {
 					String cachedDestination = entry.getKey();
 					if (getPathMatcher().match(destination, cachedDestination)) {
 						LinkedMultiValueMap<String, String> subs = entry.getValue();
-						subs.add(sessionId, subsId);
-						this.accessCache.put(cachedDestination, subs.deepCopy());
+						if (!subs.containsKey(sessionId) || !subs.get(sessionId).contains(subsId)) {
+							subs.add(sessionId, subsId);
+							this.accessCache.put(cachedDestination, subs.deepCopy());
+						}
 					}
 				}
 			}


### PR DESCRIPTION
DefaultSubscriptionRegistry's destinationCache accessCache contains duplicate subscriptionId for destination - sessionId key if findSubscriptions is called after addSubscription and before updateAfterNewSubscription.

The change includes checking for existing subsId in updateAfterNewSubscription method before adding subsId value to sessionId key. (Set implementation to avoid duplication can be considered or other better solutions are appreciated).

Issue: SPR-15492

I have submitted CLA.