### PR TITLE
add value predicate support in BeanUtils.copyProperties()

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.*;
  * @author Juergen Hoeller
  * @author Rob Harrop
  * @author Chris Beams
+ * @author Eko Kurniawan Khannedy
  * @since 19.05.2003
  */
 public class BeanUtilsTests {

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -21,6 +21,7 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Test;
 
@@ -275,6 +276,42 @@ public class BeanUtilsTests {
 		}
 	}
 
+	@Test
+	public void testCopyPropertiesWithValuePredicate1() throws Exception {
+		Configuration target = new Configuration("Original", "Original", "Original");
+		Configuration source = new Configuration("Foo", "Bar", null);
+
+		BeanUtils.copyProperties(source, target, Objects::nonNull);
+
+		assertEquals("Foo", target.getFoo());
+		assertEquals("Bar", target.getBar());
+		assertEquals("Original", target.getFooBar());
+	}
+
+	@Test
+	public void testCopyPropertiesWithValuePredicate2() throws Exception {
+		Configuration target = new Configuration("Original", "Original", "Original");
+		Configuration source = new Configuration("Foo", "Bar", null);
+
+		BeanUtils.copyProperties(source, target, Configuration.class, Objects::nonNull);
+
+		assertEquals("Foo", target.getFoo());
+		assertEquals("Bar", target.getBar());
+		assertEquals("Original", target.getFooBar());
+	}
+
+	@Test
+	public void testCopyPropertiesWithValuePredicate3() throws Exception {
+		Configuration target = new Configuration("Original", "Original", "Original");
+		Configuration source = new Configuration("Foo", "Bar", null);
+
+		BeanUtils.copyProperties(source, target, Objects::nonNull, "bar");
+
+		assertEquals("Foo", target.getFoo());
+		assertEquals("Original", target.getBar());
+		assertEquals("Original", target.getFooBar());
+	}
+
 	private void assertSignatureEquals(Method desiredMethod, String signature) {
 		assertEquals(desiredMethod, BeanUtils.resolveSignature(signature, MethodSignatureBean.class));
 	}
@@ -442,6 +479,48 @@ public class BeanUtilsTests {
 		@Override
 		public void setValue(String aValue) {
 			value = aValue;
+		}
+	}
+
+	private static class Configuration {
+
+		private String foo;
+
+		private String bar;
+
+		private String fooBar;
+
+		public Configuration(String foo, String bar, String fooBar) {
+			this.foo = foo;
+			this.bar = bar;
+			this.fooBar = fooBar;
+		}
+
+		public Configuration() {
+		}
+
+		public String getFoo() {
+			return foo;
+		}
+
+		public void setFoo(String foo) {
+			this.foo = foo;
+		}
+
+		public String getBar() {
+			return bar;
+		}
+
+		public void setBar(String bar) {
+			this.bar = bar;
+		}
+
+		public String getFooBar() {
+			return fooBar;
+		}
+
+		public void setFooBar(String fooBar) {
+			this.fooBar = fooBar;
 		}
 	}
 


### PR DESCRIPTION
In my project, I have some ugly code to merge 2 properties object like this 

```java
Configuration global = ...
Configuration config = ...

Configuration mergeConfig = new Configuration()
BeanUtils.copyProperties(mergeConfig, global);

if(config.getFoo() != null){
   mergeConfig.setFoo(config.getFoo());
}

if(config.getBar() != null){
   mergeConfig.setBar(config.getBar());
}

if(config.getXxx() != null){
   mergeConfig.setXxx(config.getXxx());
}
```

My code only make sure that I only override non null values. This is very ugly because I need to check null in all of attributes.

This pull request is to add Predicate support for BeanUtils.copyProperties, so I can merge properties easily.

```java

Configuration global= ...
Configuration config = ...

Configuration mergeConfig = new Configuration();
BeanProperties.copyProperties(mergeConfig, global);
BeanProperties.copyProperties(mergeConfig, config, Object::nonNull)

```


