### PR TITLE
Timeout Overrides in Messaging Templates

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/core/GenericMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/core/GenericMessagingTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,36 +40,50 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Rossen Stoyanchev
+ * @author Gary Russell
  * @since 4.0
  */
 public class GenericMessagingTemplate extends AbstractDestinationResolvingMessagingTemplate<MessageChannel>
 		implements BeanFactoryAware {
 
+	public static final String DEFAULT_SEND_TIMEOUT_HEADER = "sendTimeout";
+
+	public static final String DEFAULT_RECEIVE_TIMEOUT_HEADER = "receiveTimeout";
+
 	private volatile long sendTimeout = -1;
 
 	private volatile long receiveTimeout = -1;
+
+	private String sendTimeoutHeader = DEFAULT_SEND_TIMEOUT_HEADER;
+
+	private String receiveTimeoutHeader = DEFAULT_RECEIVE_TIMEOUT_HEADER;
 
 	private volatile boolean throwExceptionOnLateReply = false;
 
 
 	/**
-	 * Configure the timeout value to use for send operations.
+	 * Configure the default timeout value to use for send operations.
+	 * May be overridden for individual messages.
 	 * @param sendTimeout the send timeout in milliseconds
+	 * @see #setSendTimeoutHeader(String)
 	 */
 	public void setSendTimeout(long sendTimeout) {
 		this.sendTimeout = sendTimeout;
 	}
 
 	/**
-	 * Return the configured send operation timeout value.
+	 * Return the configured default send operation timeout value.
 	 */
 	public long getSendTimeout() {
 		return this.sendTimeout;
 	}
 
 	/**
-	 * Configure the timeout value to use for receive operations.
+	 * Configure the default timeout value to use for receive operations.
+	 * May be overridden for individual messages when using sendAndReceive
+	 * operations.
 	 * @param receiveTimeout the receive timeout in milliseconds
+	 * @see #setReceiveTimeoutHeader(String)
 	 */
 	public void setReceiveTimeout(long receiveTimeout) {
 		this.receiveTimeout = receiveTimeout;
@@ -80,6 +94,47 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 	 */
 	public long getReceiveTimeout() {
 		return this.receiveTimeout;
+	}
+
+
+	/**
+	 * Set the name of the header used to determine the send timeout (if present).
+	 * Default {@value #DEFAULT_SEND_TIMEOUT_HEADER}.
+	 * The header is removed before sending the message to avoid propagation.
+	 * @param sendTimeoutHeader the sendTimeoutHeader to set
+	 * @since 5.0
+	 */
+	public void setSendTimeoutHeader(String sendTimeoutHeader) {
+		Assert.notNull(sendTimeoutHeader, "'sendTimeoutHeader' cannot be null");
+		this.sendTimeoutHeader = sendTimeoutHeader;
+	}
+
+	/**
+	 * @return the configured sendTimeoutHeader.
+	 * @since 5.0
+	 */
+	public String getSendTimeoutHeader() {
+		return sendTimeoutHeader;
+	}
+
+	/**
+	 * Set the name of the header used to determine the send timeout (if present).
+	 * Default {@value #DEFAULT_RECEIVE_TIMEOUT_HEADER}.
+	 * The header is removed before sending the message to avoid propagation.
+	 * @param receiveTimeoutHeader the receiveTimeoutHeader to set
+	 * @since 5.0
+	 */
+	public void setReceiveTimeoutHeader(String receiveTimeoutHeader) {
+		Assert.notNull(receiveTimeoutHeader, "'receiveTimeoutHeader' cannot be null");
+		this.receiveTimeoutHeader = receiveTimeoutHeader;
+	}
+
+	/**
+	 * @return the configured receiveTimeoutHeader
+	 * @since 5.0
+	 */
+	public String getReceiveTimeoutHeader() {
+		return receiveTimeoutHeader;
 	}
 
 	/**
@@ -101,18 +156,30 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 		setDestinationResolver(new BeanFactoryMessageChannelDestinationResolver(beanFactory));
 	}
 
-
 	@Override
 	protected final void doSend(MessageChannel channel, Message<?> message) {
+		doSend(channel, message, sendTimeout(message));
+	}
+
+	protected final void doSend(MessageChannel channel, Message<?> message, long timeout) {
 		Assert.notNull(channel, "MessageChannel is required");
 
+		Message<?> messageToSend = message;
 		MessageHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, MessageHeaderAccessor.class);
 		if (accessor != null && accessor.isMutable()) {
+			accessor.removeHeader(this.sendTimeoutHeader);
+			accessor.removeHeader(this.receiveTimeoutHeader);
 			accessor.setImmutable();
 		}
+		else if (message.getHeaders().containsKey(this.sendTimeoutHeader)
+				|| message.getHeaders().containsKey(this.receiveTimeoutHeader)) {
+			messageToSend = MessageBuilder.fromMessage(message)
+					.setHeader(this.sendTimeoutHeader, null)
+					.setHeader(this.receiveTimeoutHeader, null)
+					.build();
+		}
 
-		long timeout = this.sendTimeout;
-		boolean sent = (timeout >= 0 ? channel.send(message, timeout) : channel.send(message));
+		boolean sent = (timeout >= 0 ? channel.send(messageToSend, timeout) : channel.send(messageToSend));
 
 		if (!sent) {
 			throw new MessageDeliveryException(message,
@@ -122,10 +189,13 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 
 	@Override
 	protected final Message<?> doReceive(MessageChannel channel) {
+		return doReceive(channel, this.receiveTimeout);
+	}
+
+	protected final Message<?> doReceive(MessageChannel channel, long timeout) {
 		Assert.notNull(channel, "MessageChannel is required");
 		Assert.state(channel instanceof PollableChannel, "A PollableChannel is required to receive messages");
 
-		long timeout = this.receiveTimeout;
 		Message<?> message = (timeout >= 0 ?
 				((PollableChannel) channel).receive(timeout) : ((PollableChannel) channel).receive());
 
@@ -142,20 +212,25 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 		Object originalReplyChannelHeader = requestMessage.getHeaders().getReplyChannel();
 		Object originalErrorChannelHeader = requestMessage.getHeaders().getErrorChannel();
 
-		TemporaryReplyChannel tempReplyChannel = new TemporaryReplyChannel();
-		requestMessage = MessageBuilder.fromMessage(requestMessage).setReplyChannel(tempReplyChannel).
-				setErrorChannel(tempReplyChannel).build();
+		long sendTimeout = sendTimeout(requestMessage);
+		long receiveTimeout = receiveTimeout(requestMessage);
+
+		TemporaryReplyChannel tempReplyChannel = new TemporaryReplyChannel(this.throwExceptionOnLateReply);
+		requestMessage = MessageBuilder.fromMessage(requestMessage).setReplyChannel(tempReplyChannel)
+				.setHeader(this.sendTimeoutHeader, null)
+				.setHeader(this.receiveTimeoutHeader, null)
+				.setErrorChannel(tempReplyChannel).build();
 
 		try {
-			doSend(channel, requestMessage);
+			doSend(channel, requestMessage, sendTimeout);
 		}
 		catch (RuntimeException ex) {
 			tempReplyChannel.setSendFailed(true);
 			throw ex;
 		}
 
-		Message<?> replyMessage = this.doReceive(tempReplyChannel);
-		if (replyMessage != null) {
+		Message<?> replyMessage = this.doReceive(tempReplyChannel, receiveTimeout);
+		if (replyMessage != null && (originalReplyChannelHeader!= null || originalErrorChannelHeader != null)) {
 			replyMessage = MessageBuilder.fromMessage(replyMessage)
 					.setHeader(MessageHeaders.REPLY_CHANNEL, originalReplyChannelHeader)
 					.setHeader(MessageHeaders.ERROR_CHANNEL, originalErrorChannelHeader)
@@ -165,15 +240,38 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 		return replyMessage;
 	}
 
+	private long sendTimeout(Message<?> requestMessage) {
+		Long sendTimeout = headerToLong(requestMessage.getHeaders().get(this.sendTimeoutHeader));
+		return sendTimeout == null ? this.sendTimeout : sendTimeout;
+	}
+
+	private long receiveTimeout(Message<?> requestMessage) {
+		Long receiveTimeout = headerToLong(requestMessage.getHeaders().get(this.receiveTimeoutHeader));
+		return receiveTimeout == null ? this.receiveTimeout : receiveTimeout;
+	}
+
+	private Long headerToLong(Object headerValue) {
+		if (headerValue instanceof Number) {
+			return ((Number) headerValue).longValue();
+		}
+		else if(headerValue instanceof String) {
+			return Long.parseLong((String) headerValue);
+		}
+		else {
+			return null;
+		}
+	}
 
 	/**
 	 * A temporary channel for receiving a single reply message.
 	 */
-	private class TemporaryReplyChannel implements PollableChannel {
+	private static final class TemporaryReplyChannel implements PollableChannel {
 
 		private final Log logger = LogFactory.getLog(TemporaryReplyChannel.class);
 
 		private final CountDownLatch replyLatch = new CountDownLatch(1);
+
+		private final boolean throwExceptionOnLateReply;
 
 		private volatile Message<?> replyMessage;
 
@@ -182,6 +280,10 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 		private volatile boolean hasTimedOut;
 
 		private volatile boolean hasSendFailed;
+
+		TemporaryReplyChannel(boolean throwExceptionOnLateReply) {
+			this.throwExceptionOnLateReply = throwExceptionOnLateReply;
+		}
 
 		public void setSendFailed(boolean hasSendError) {
 			this.hasSendFailed = hasSendError;
@@ -195,12 +297,12 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 		@Override
 		public Message<?> receive(long timeout) {
 			try {
-				if (GenericMessagingTemplate.this.receiveTimeout < 0) {
+				if (timeout < 0) {
 					this.replyLatch.await();
 					this.hasReceived = true;
 				}
 				else {
-					if (this.replyLatch.await(GenericMessagingTemplate.this.receiveTimeout, TimeUnit.MILLISECONDS)) {
+					if (this.replyLatch.await(timeout, TimeUnit.MILLISECONDS)) {
 						this.hasReceived = true;
 					}
 					else {
@@ -241,7 +343,7 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 				if (logger.isWarnEnabled()) {
 					logger.warn(errorDescription + ":" + message);
 				}
-				if (GenericMessagingTemplate.this.throwExceptionOnLateReply) {
+				if (this.throwExceptionOnLateReply) {
 					throw new MessageDeliveryException(message, errorDescription);
 				}
 			}

--- a/spring-messaging/src/test/java/org/springframework/messaging/core/GenericMessagingTemplateTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/core/GenericMessagingTemplateTests.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageDeliveryException;
@@ -70,10 +69,9 @@ public class GenericMessagingTemplateTests {
 	@Test
 	public void sendWithTimeout() {
 		SubscribableChannel channel = mock(SubscribableChannel.class);
+		final AtomicReference<Message<?>> sent = new AtomicReference<>();
 		doAnswer(invocation -> {
-			Message<?> sent = invocation.getArgument(0);
-			assertFalse(sent.getHeaders().containsKey(GenericMessagingTemplate.DEFAULT_SEND_TIMEOUT_HEADER));
-			assertFalse(sent.getHeaders().containsKey(GenericMessagingTemplate.DEFAULT_RECEIVE_TIMEOUT_HEADER));
+			sent.set(invocation.getArgument(0));
 			return true;
 		}).when(channel).send(any(Message.class), eq(30_000L));
 		Message<?> message = MessageBuilder.withPayload("request")
@@ -82,15 +80,17 @@ public class GenericMessagingTemplateTests {
 				.build();
 		this.template.send(channel, message);
 		verify(channel).send(any(Message.class), eq(30_000L));
+		assertNotNull(sent.get());
+		assertFalse(sent.get().getHeaders().containsKey(GenericMessagingTemplate.DEFAULT_SEND_TIMEOUT_HEADER));
+		assertFalse(sent.get().getHeaders().containsKey(GenericMessagingTemplate.DEFAULT_RECEIVE_TIMEOUT_HEADER));
 	}
 
 	@Test
 	public void sendWithTimeoutMutable() {
 		SubscribableChannel channel = mock(SubscribableChannel.class);
+		final AtomicReference<Message<?>> sent = new AtomicReference<>();
 		doAnswer(invocation -> {
-			Message<?> sent = invocation.getArgument(0);
-			assertFalse(sent.getHeaders().containsKey(GenericMessagingTemplate.DEFAULT_SEND_TIMEOUT_HEADER));
-			assertFalse(sent.getHeaders().containsKey(GenericMessagingTemplate.DEFAULT_RECEIVE_TIMEOUT_HEADER));
+			sent.set(invocation.getArgument(0));
 			return true;
 		}).when(channel).send(any(Message.class), eq(30_000L));
 		MessageHeaderAccessor accessor = new MessageHeaderAccessor();
@@ -99,6 +99,9 @@ public class GenericMessagingTemplateTests {
 		accessor.setHeader(GenericMessagingTemplate.DEFAULT_SEND_TIMEOUT_HEADER, 30_000L);
 		this.template.send(channel, message);
 		verify(channel).send(any(Message.class), eq(30_000L));
+		assertNotNull(sent.get());
+		assertFalse(sent.get().getHeaders().containsKey(GenericMessagingTemplate.DEFAULT_SEND_TIMEOUT_HEADER));
+		assertFalse(sent.get().getHeaders().containsKey(GenericMessagingTemplate.DEFAULT_RECEIVE_TIMEOUT_HEADER));
 	}
 
 	@Test


### PR DESCRIPTION
Issue: SPR-15591

Provide a mechanism to override the configured send and receive timeouts in the
GenericMessagingTemplate.

- overload `doReceive()` to take a receive timeout argument
- for `sendAndReceive()` methods examine message headers for these timeout values
  - remove headers to avoid propagation
  - avoid the unconditional rebuild of the reply message if the original headers weren't present
- also remove headers from simple `send()` operations
- change javadocs for the setters to indicate they are now defaults
- add properties to allow the user to override the header names used
- change `TemporaryReplyChannel` to use the `send` argument and change it to static
  - add package-protected ctor to avoid the compiler creating a synthetic ctor for access