### PR TITLE
Revert Incorrect MessagingTemplate Change

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/core/GenericMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/core/GenericMessagingTemplate.java
@@ -230,7 +230,7 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 		}
 
 		Message<?> replyMessage = this.doReceive(tempReplyChannel, receiveTimeout);
-		if (replyMessage != null && (originalReplyChannelHeader!= null || originalErrorChannelHeader != null)) {
+		if (replyMessage != null) {
 			replyMessage = MessageBuilder.fromMessage(replyMessage)
 					.setHeader(MessageHeaders.REPLY_CHANNEL, originalReplyChannelHeader)
 					.setHeader(MessageHeaders.ERROR_CHANNEL, originalErrorChannelHeader)


### PR DESCRIPTION
Issue: SPR-15991

The change to "optimize" the template by not rebuilding the reply message
when the original header channels was null was incorrect.

We need to null out those headers if they were originally null.