### PR TITLE
Support date properties in Content-Disposition HTTP header

### DIFF
--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -19,6 +19,8 @@ package org.springframework.http;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
@@ -74,6 +76,26 @@ public class ContentDispositionTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void parseInvalidParameter() {
 		ContentDisposition.parse("foo;bar");
+	}
+
+	@Test
+	public void parseDates() {
+		ContentDisposition disposition = ContentDisposition
+				.parse("attachment; creation-date=\"Mon, 12 Feb 2007 10:15:30 -0500\"; modification-date=\"Tue, 13 Feb 2007 10:15:30 -0500\"; read-date=\"Wed, 14 Feb 2007 10:15:30 -0500\"");
+		assertEquals(ContentDisposition.builder("attachment")
+				.creationDate(ZonedDateTime.parse("Mon, 12 Feb 2007 10:15:30 -0500", DateTimeFormatter.RFC_1123_DATE_TIME))
+				.modificationDate(ZonedDateTime.parse("Tue, 13 Feb 2007 10:15:30 -0500", DateTimeFormatter.RFC_1123_DATE_TIME))
+				.readDate(ZonedDateTime.parse("Wed, 14 Feb 2007 10:15:30 -0500", DateTimeFormatter.RFC_1123_DATE_TIME))
+						.build(), disposition);
+	}
+
+	@Test
+	public void parseInvalidDates() {
+		ContentDisposition disposition = ContentDisposition
+				.parse("attachment; creation-date=\"-1\"; modification-date=\"-1\"; read-date=\"Wed, 14 Feb 2007 10:15:30 -0500\"");
+		assertEquals(ContentDisposition.builder("attachment")
+				.readDate(ZonedDateTime.parse("Wed, 14 Feb 2007 10:15:30 -0500", DateTimeFormatter.RFC_1123_DATE_TIME))
+				.build(), disposition);
 	}
 
 	@Test


### PR DESCRIPTION
As discussed with @rstoyanchev, before merging this PR we should choose a strategy regarding to date/time that we previously exposed with `long` like in `long HttpHeaders.getAccessControlMaxAge()`.

Should we continue to use `long` for consistency?
Should we add `Instant` based variants and deprecate `long` based ones?

Pros and cons should be discussed and the solution should be applied globally to Spring Framework API like we did for `Optional`.

cc @jhoeller 

Issue: SPR-15555