### PR TITLE
SPR-15690 Add cloneBuilder method on WebClient.Builder

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
@@ -93,6 +93,11 @@ class DefaultWebClientBuilder implements WebClient.Builder {
 	}
 
 	@Override
+	public WebClient.Builder cloneBuilder() {
+		return new DefaultWebClientBuilder(this);
+	}
+
+	@Override
 	public WebClient.Builder defaultUriVariables(Map<String, ?> defaultUriVariables) {
 		this.defaultUriVariables = defaultUriVariables;
 		return this;

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -193,6 +193,11 @@ public interface WebClient {
 		Builder baseUrl(String baseUrl);
 
 		/**
+		 * Clone this {@code WebClient.Builder}
+		 */
+		Builder cloneBuilder();
+
+		/**
 		 * Configure default URI variable values that will be used when expanding
 		 * URI templates using a {@link Map}.
 		 * @param defaultUriVariables the default values to use


### PR DESCRIPTION
This commit adds a new `cloneBuilder()` method on `WebClient.Builder`;
we can now reuse the customizations of an existing builder without
sharing its state across several `WebClient` building code paths.

cc @poutsma

Issue: SPR-15690