### PR TITLE
Make getters and setters null-safety consistent

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJExpressionPointcutAdvisor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJExpressionPointcutAdvisor.java
@@ -34,7 +34,7 @@ public class AspectJExpressionPointcutAdvisor extends AbstractGenericPointcutAdv
 	private final AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
 
 
-	public void setExpression(String expression) {
+	public void setExpression(@Nullable String expression) {
 		this.pointcut.setExpression(expression);
 	}
 
@@ -43,7 +43,7 @@ public class AspectJExpressionPointcutAdvisor extends AbstractGenericPointcutAdv
 		return this.pointcut.getExpression();
 	}
 
-	public void setLocation(String location) {
+	public void setLocation(@Nullable String location) {
 		this.pointcut.setLocation(location);
 	}
 

--- a/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/AbstractAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/AbstractAutoProxyCreator.java
@@ -203,7 +203,7 @@ public abstract class AbstractAutoProxyCreator extends ProxyProcessorSupport
 	}
 
 	@Override
-	public void setBeanFactory(BeanFactory beanFactory) {
+	public void setBeanFactory(@Nullable BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
 	}
 

--- a/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/DefaultAdvisorAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/DefaultAdvisorAutoProxyCreator.java
@@ -70,7 +70,7 @@ public class DefaultAdvisorAutoProxyCreator extends AbstractAdvisorAutoProxyCrea
 	 * references. Default value is the bean name of this object + a dot.
 	 * @param advisorBeanNamePrefix the exclusion prefix
 	 */
-	public void setAdvisorBeanNamePrefix(String advisorBeanNamePrefix) {
+	public void setAdvisorBeanNamePrefix(@Nullable String advisorBeanNamePrefix) {
 		this.advisorBeanNamePrefix = advisorBeanNamePrefix;
 	}
 

--- a/spring-aop/src/main/java/org/springframework/aop/support/AbstractBeanFactoryPointcutAdvisor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/AbstractBeanFactoryPointcutAdvisor.java
@@ -63,7 +63,7 @@ public abstract class AbstractBeanFactoryPointcutAdvisor extends AbstractPointcu
 	 * of the advisor.
 	 * @see #getAdvice()
 	 */
-	public void setAdviceBeanName(String adviceBeanName) {
+	public void setAdviceBeanName(@Nullable String adviceBeanName) {
 		this.adviceBeanName = adviceBeanName;
 	}
 

--- a/spring-aop/src/main/java/org/springframework/aop/support/AbstractExpressionPointcut.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/AbstractExpressionPointcut.java
@@ -43,7 +43,7 @@ public abstract class AbstractExpressionPointcut implements ExpressionPointcut, 
 	/**
 	 * Set the location for debugging.
 	 */
-	public void setLocation(String location) {
+	public void setLocation(@Nullable String location) {
 		this.location = location;
 	}
 
@@ -58,7 +58,7 @@ public abstract class AbstractExpressionPointcut implements ExpressionPointcut, 
 		return this.location;
 	}
 
-	public void setExpression(String expression) {
+	public void setExpression(@Nullable String expression) {
 		this.expression = expression;
 		try {
 			onSetExpression(expression);
@@ -82,7 +82,7 @@ public abstract class AbstractExpressionPointcut implements ExpressionPointcut, 
 	 * @throws IllegalArgumentException if the expression is invalid
 	 * @see #setExpression
 	 */
-	protected void onSetExpression(String expression) throws IllegalArgumentException {
+	protected void onSetExpression(@Nullable String expression) throws IllegalArgumentException {
 	}
 
 	/**

--- a/spring-beans/src/main/java/org/springframework/beans/ExtendedBeanInfo.java
+++ b/spring-beans/src/main/java/org/springframework/beans/ExtendedBeanInfo.java
@@ -292,7 +292,7 @@ class ExtendedBeanInfo implements BeanInfo {
 		}
 
 		@Override
-		public void setReadMethod(Method readMethod) {
+		public void setReadMethod(@Nullable Method readMethod) {
 			this.readMethod = readMethod;
 		}
 
@@ -303,7 +303,7 @@ class ExtendedBeanInfo implements BeanInfo {
 		}
 
 		@Override
-		public void setWriteMethod(Method writeMethod) {
+		public void setWriteMethod(@Nullable Method writeMethod) {
 			this.writeMethod = writeMethod;
 		}
 
@@ -327,7 +327,7 @@ class ExtendedBeanInfo implements BeanInfo {
 		}
 
 		@Override
-		public void setPropertyEditorClass(Class<?> propertyEditorClass) {
+		public void setPropertyEditorClass(@Nullable Class<?> propertyEditorClass) {
 			this.propertyEditorClass = propertyEditorClass;
 		}
 
@@ -399,7 +399,7 @@ class ExtendedBeanInfo implements BeanInfo {
 		}
 
 		@Override
-		public void setReadMethod(Method readMethod) {
+		public void setReadMethod(@Nullable Method readMethod) {
 			this.readMethod = readMethod;
 		}
 
@@ -410,7 +410,7 @@ class ExtendedBeanInfo implements BeanInfo {
 		}
 
 		@Override
-		public void setWriteMethod(Method writeMethod) {
+		public void setWriteMethod(@Nullable Method writeMethod) {
 			this.writeMethod = writeMethod;
 		}
 
@@ -434,7 +434,7 @@ class ExtendedBeanInfo implements BeanInfo {
 		}
 
 		@Override
-		public void setIndexedReadMethod(Method indexedReadMethod) throws IntrospectionException {
+		public void setIndexedReadMethod(@Nullable Method indexedReadMethod) throws IntrospectionException {
 			this.indexedReadMethod = indexedReadMethod;
 		}
 
@@ -445,7 +445,7 @@ class ExtendedBeanInfo implements BeanInfo {
 		}
 
 		@Override
-		public void setIndexedWriteMethod(Method indexedWriteMethod) throws IntrospectionException {
+		public void setIndexedWriteMethod(@Nullable Method indexedWriteMethod) throws IntrospectionException {
 			this.indexedWriteMethod = indexedWriteMethod;
 		}
 
@@ -470,7 +470,7 @@ class ExtendedBeanInfo implements BeanInfo {
 		}
 
 		@Override
-		public void setPropertyEditorClass(Class<?> propertyEditorClass) {
+		public void setPropertyEditorClass(@Nullable Class<?> propertyEditorClass) {
 			this.propertyEditorClass = propertyEditorClass;
 		}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/AbstractFactoryBean.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/AbstractFactoryBean.java
@@ -101,7 +101,7 @@ public abstract class AbstractFactoryBean<T>
 	}
 
 	@Override
-	public void setBeanFactory(BeanFactory beanFactory) {
+	public void setBeanFactory(@Nullable BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/BeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/BeanDefinition.java
@@ -148,7 +148,7 @@ public interface BeanDefinition extends AttributeAccessor, BeanMetadataElement {
 	 * Set the names of the beans that this bean depends on being initialized.
 	 * The bean factory will guarantee that these beans get initialized first.
 	 */
-	void setDependsOn(String... dependsOn);
+	void setDependsOn(@Nullable String... dependsOn);
 
 	/**
 	 * Return the bean names that this bean depends on.

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/ConstructorArgumentValues.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/ConstructorArgumentValues.java
@@ -554,8 +554,8 @@ public class ConstructorArgumentValues {
 		 * Set the converted value of the constructor argument,
 		 * after processed type conversion.
 		 */
-		public synchronized void setConvertedValue(Object value) {
-			this.converted = true;
+		public synchronized void setConvertedValue(@Nullable Object value) {
+			this.converted = (value != null);
 			this.convertedValue = value;
 		}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/FieldRetrievingFactoryBean.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/FieldRetrievingFactoryBean.java
@@ -87,7 +87,7 @@ public class FieldRetrievingFactoryBean
 	 * @see #setTargetObject
 	 * @see #setTargetField
 	 */
-	public void setTargetClass(Class<?> targetClass) {
+	public void setTargetClass(@Nullable Class<?> targetClass) {
 		this.targetClass = targetClass;
 	}
 
@@ -106,7 +106,7 @@ public class FieldRetrievingFactoryBean
 	 * @see #setTargetClass
 	 * @see #setTargetField
 	 */
-	public void setTargetObject(Object targetObject) {
+	public void setTargetObject(@Nullable Object targetObject) {
 		this.targetObject = targetObject;
 	}
 
@@ -125,7 +125,7 @@ public class FieldRetrievingFactoryBean
 	 * @see #setTargetClass
 	 * @see #setTargetObject
 	 */
-	public void setTargetField(String targetField) {
+	public void setTargetField(@Nullable String targetField) {
 		this.targetField = StringUtils.trimAllWhitespace(targetField);
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/TypedStringValue.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/TypedStringValue.java
@@ -126,8 +126,7 @@ public class TypedStringValue implements BeanMetadataElement {
 	/**
 	 * Specify the type to convert to.
 	 */
-	public void setTargetTypeName(String targetTypeName) {
-		Assert.notNull(targetTypeName, "'targetTypeName' must not be null");
+	public void setTargetTypeName(@Nullable String targetTypeName) {
 		this.targetType = targetTypeName;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/serviceloader/AbstractServiceLoaderBasedFactoryBean.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/serviceloader/AbstractServiceLoaderBasedFactoryBean.java
@@ -45,7 +45,7 @@ public abstract class AbstractServiceLoaderBasedFactoryBean extends AbstractFact
 	/**
 	 * Specify the desired service type (typically the service's public API).
 	 */
-	public void setServiceType(Class<?> serviceType) {
+	public void setServiceType(@Nullable Class<?> serviceType) {
 		this.serviceType = serviceType;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinitionReader.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinitionReader.java
@@ -122,7 +122,7 @@ public abstract class AbstractBeanDefinitionReader implements EnvironmentCapable
 	 * @see org.springframework.core.io.support.ResourcePatternResolver
 	 * @see org.springframework.core.io.support.PathMatchingResourcePatternResolver
 	 */
-	public void setResourceLoader(ResourceLoader resourceLoader) {
+	public void setResourceLoader(@Nullable ResourceLoader resourceLoader) {
 		this.resourceLoader = resourceLoader;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -268,7 +268,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 	 * @see org.springframework.core.OrderComparator
 	 * @see org.springframework.core.annotation.AnnotationAwareOrderComparator
 	 */
-	public void setDependencyComparator(Comparator<Object> dependencyComparator) {
+	public void setDependencyComparator(@Nullable Comparator<Object> dependencyComparator) {
 		this.dependencyComparator = dependencyComparator;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/ManagedMap.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/ManagedMap.java
@@ -71,7 +71,7 @@ public class ManagedMap<K, V> extends LinkedHashMap<K, V> implements Mergeable, 
 	/**
 	 * Set the default key type name (class name) to be used for this map.
 	 */
-	public void setKeyTypeName(String keyTypeName) {
+	public void setKeyTypeName(@Nullable String keyTypeName) {
 		this.keyTypeName = keyTypeName;
 	}
 
@@ -86,7 +86,7 @@ public class ManagedMap<K, V> extends LinkedHashMap<K, V> implements Mergeable, 
 	/**
 	 * Set the default value type name (class name) to be used for this map.
 	 */
-	public void setValueTypeName(String valueTypeName) {
+	public void setValueTypeName(@Nullable String valueTypeName) {
 		this.valueTypeName = valueTypeName;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/ManagedSet.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/ManagedSet.java
@@ -68,7 +68,7 @@ public class ManagedSet<E> extends LinkedHashSet<E> implements Mergeable, BeanMe
 	/**
 	 * Set the default element type name (class name) to be used for this set.
 	 */
-	public void setElementTypeName(String elementTypeName) {
+	public void setElementTypeName(@Nullable String elementTypeName) {
 		this.elementTypeName = elementTypeName;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
@@ -257,7 +257,7 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 	/**
 	 * Register a target definition that is being decorated by this bean definition.
 	 */
-	public void setDecoratedDefinition(BeanDefinitionHolder decoratedDefinition) {
+	public void setDecoratedDefinition(@Nullable BeanDefinitionHolder decoratedDefinition) {
 		this.decoratedDefinition = decoratedDefinition;
 	}
 
@@ -276,7 +276,7 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 	 * @see #setTargetType(ResolvableType)
 	 * @see #getResolvedFactoryMethod()
 	 */
-	public void setQualifiedElement(AnnotatedElement qualifiedElement) {
+	public void setQualifiedElement(@Nullable AnnotatedElement qualifiedElement) {
 		this.qualifiedElement = qualifiedElement;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/support/ArgumentConvertingMethodInvoker.java
+++ b/spring-beans/src/main/java/org/springframework/beans/support/ArgumentConvertingMethodInvoker.java
@@ -55,9 +55,9 @@ public class ArgumentConvertingMethodInvoker extends MethodInvoker {
 	 * @see org.springframework.beans.SimpleTypeConverter
 	 * @see org.springframework.beans.BeanWrapperImpl
 	 */
-	public void setTypeConverter(TypeConverter typeConverter) {
+	public void setTypeConverter(@Nullable TypeConverter typeConverter) {
 		this.typeConverter = typeConverter;
-		this.useDefaultConverter = false;
+		this.useDefaultConverter = (typeConverter == null);
 	}
 
 	/**

--- a/spring-context-support/src/main/java/org/springframework/cache/ehcache/EhCacheCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/ehcache/EhCacheCacheManager.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  */
 public class EhCacheCacheManager extends AbstractTransactionSupportingCacheManager {
 
+	@Nullable
 	private net.sf.ehcache.CacheManager cacheManager;
 
 
@@ -59,7 +60,7 @@ public class EhCacheCacheManager extends AbstractTransactionSupportingCacheManag
 	/**
 	 * Set the backing EhCache {@link net.sf.ehcache.CacheManager}.
 	 */
-	public void setCacheManager(net.sf.ehcache.CacheManager cacheManager) {
+	public void setCacheManager(@Nullable net.sf.ehcache.CacheManager cacheManager) {
 		this.cacheManager = cacheManager;
 	}
 

--- a/spring-context-support/src/main/java/org/springframework/cache/jcache/JCacheCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/jcache/JCacheCacheManager.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  */
 public class JCacheCacheManager extends AbstractTransactionSupportingCacheManager {
 
+	@Nullable
 	private javax.cache.CacheManager cacheManager;
 
 	private boolean allowNullValues = true;
@@ -62,7 +63,7 @@ public class JCacheCacheManager extends AbstractTransactionSupportingCacheManage
 	/**
 	 * Set the backing JCache {@link javax.cache.CacheManager}.
 	 */
-	public void setCacheManager(javax.cache.CacheManager cacheManager) {
+	public void setCacheManager(@Nullable javax.cache.CacheManager cacheManager) {
 		this.cacheManager = cacheManager;
 	}
 

--- a/spring-context-support/src/main/java/org/springframework/cache/jcache/interceptor/DefaultJCacheOperationSource.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/jcache/interceptor/DefaultJCacheOperationSource.java
@@ -63,7 +63,7 @@ public class DefaultJCacheOperationSource extends AnnotationJCacheOperationSourc
 	 * Set the default {@link CacheManager} to use to lookup cache by name. Only mandatory
 	 * if the {@linkplain CacheResolver cache resolvers} have not been set.
 	 */
-	public void setCacheManager(CacheManager cacheManager) {
+	public void setCacheManager(@Nullable CacheManager cacheManager) {
 		this.cacheManager = cacheManager;
 	}
 
@@ -79,7 +79,7 @@ public class DefaultJCacheOperationSource extends AnnotationJCacheOperationSourc
 	 * Set the {@link CacheResolver} to resolve regular caches. If none is set, a default
 	 * implementation using the specified cache manager will be used.
 	 */
-	public void setCacheResolver(CacheResolver cacheResolver) {
+	public void setCacheResolver(@Nullable CacheResolver cacheResolver) {
 		this.cacheResolver = cacheResolver;
 	}
 
@@ -95,7 +95,7 @@ public class DefaultJCacheOperationSource extends AnnotationJCacheOperationSourc
 	 * Set the {@link CacheResolver} to resolve exception caches. If none is set, a default
 	 * implementation using the specified cache manager will be used.
 	 */
-	public void setExceptionCacheResolver(CacheResolver exceptionCacheResolver) {
+	public void setExceptionCacheResolver(@Nullable CacheResolver exceptionCacheResolver) {
 		this.exceptionCacheResolver = exceptionCacheResolver;
 	}
 
@@ -112,7 +112,7 @@ public class DefaultJCacheOperationSource extends AnnotationJCacheOperationSourc
 	 * honoring the JSR-107 {@link javax.cache.annotation.CacheKey} and
 	 * {@link javax.cache.annotation.CacheValue} will be used.
 	 */
-	public void setKeyGenerator(KeyGenerator keyGenerator) {
+	public void setKeyGenerator(@Nullable KeyGenerator keyGenerator) {
 		this.keyGenerator = keyGenerator;
 	}
 

--- a/spring-context-support/src/main/java/org/springframework/mail/SimpleMailMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/SimpleMailMessage.java
@@ -98,7 +98,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 
 
 	@Override
-	public void setFrom(String from) {
+	public void setFrom(@Nullable String from) {
 		this.from = from;
 	}
 
@@ -108,7 +108,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	}
 
 	@Override
-	public void setReplyTo(String replyTo) {
+	public void setReplyTo(@Nullable String replyTo) {
 		this.replyTo = replyTo;
 	}
 
@@ -118,12 +118,12 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	}
 
 	@Override
-	public void setTo(String to) {
+	public void setTo(@Nullable String to) {
 		this.to = new String[] {to};
 	}
 
 	@Override
-	public void setTo(String[] to) {
+	public void setTo(@Nullable String[] to) {
 		this.to = to;
 	}
 
@@ -133,12 +133,12 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	}
 
 	@Override
-	public void setCc(String cc) {
+	public void setCc(@Nullable String cc) {
 		this.cc = new String[] {cc};
 	}
 
 	@Override
-	public void setCc(String[] cc) {
+	public void setCc(@Nullable String[] cc) {
 		this.cc = cc;
 	}
 
@@ -148,12 +148,12 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	}
 
 	@Override
-	public void setBcc(String bcc) {
+	public void setBcc(@Nullable String bcc) {
 		this.bcc = new String[] {bcc};
 	}
 
 	@Override
-	public void setBcc(String[] bcc) {
+	public void setBcc(@Nullable String[] bcc) {
 		this.bcc = bcc;
 	}
 
@@ -163,7 +163,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	}
 
 	@Override
-	public void setSentDate(Date sentDate) {
+	public void setSentDate(@Nullable Date sentDate) {
 		this.sentDate = sentDate;
 	}
 
@@ -173,7 +173,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	}
 
 	@Override
-	public void setSubject(String subject) {
+	public void setSubject(@Nullable String subject) {
 		this.subject = subject;
 	}
 
@@ -183,7 +183,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	}
 
 	@Override
-	public void setText(String text) {
+	public void setText(@Nullable String text) {
 		this.text = text;
 	}
 

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderImpl.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderImpl.java
@@ -99,6 +99,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	@Nullable
 	private String defaultEncoding;
 
+	@Nullable
 	private FileTypeMap defaultFileTypeMap;
 
 
@@ -165,7 +166,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	/**
 	 * Set the mail protocol. Default is "smtp".
 	 */
-	public void setProtocol(String protocol) {
+	public void setProtocol(@Nullable String protocol) {
 		this.protocol = protocol;
 	}
 
@@ -181,7 +182,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	 * Set the mail server host, typically an SMTP host.
 	 * <p>Default is the default host of the underlying JavaMail Session.
 	 */
-	public void setHost(String host) {
+	public void setHost(@Nullable String host) {
 		this.host = host;
 	}
 
@@ -220,7 +221,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	 * @see #setSession
 	 * @see #setPassword
 	 */
-	public void setUsername(String username) {
+	public void setUsername(@Nullable String username) {
 		this.username = username;
 	}
 
@@ -243,7 +244,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	 * @see #setSession
 	 * @see #setUsername
 	 */
-	public void setPassword(String password) {
+	public void setPassword(@Nullable String password) {
 		this.password = password;
 	}
 
@@ -260,7 +261,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	 * created by this instance.
 	 * <p>Such an encoding will be auto-detected by {@link MimeMessageHelper}.
 	 */
-	public void setDefaultEncoding(String defaultEncoding) {
+	public void setDefaultEncoding(@Nullable String defaultEncoding) {
 		this.defaultEncoding = defaultEncoding;
 	}
 
@@ -286,7 +287,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	 * {@code mime.types} file contained in the Spring jar).
 	 * @see MimeMessageHelper#setFileTypeMap
 	 */
-	public void setDefaultFileTypeMap(FileTypeMap defaultFileTypeMap) {
+	public void setDefaultFileTypeMap(@Nullable FileTypeMap defaultFileTypeMap) {
 		this.defaultFileTypeMap = defaultFileTypeMap;
 	}
 

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
@@ -86,12 +86,15 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 
 	private final CacheOperationExpressionEvaluator evaluator = new CacheOperationExpressionEvaluator();
 
+	@Nullable
 	private CacheOperationSource cacheOperationSource;
 
 	private KeyGenerator keyGenerator = new SimpleKeyGenerator();
 
+	@Nullable
 	private CacheResolver cacheResolver;
 
+	@Nullable
 	private BeanFactory beanFactory;
 
 	private boolean initialized = false;
@@ -150,8 +153,7 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 	 * @see #setCacheManager(org.springframework.cache.CacheManager)
 	 * @see SimpleCacheResolver
 	 */
-	public void setCacheResolver(CacheResolver cacheResolver) {
-		Assert.notNull(cacheResolver, "CacheResolver must not be null");
+	public void setCacheResolver(@Nullable CacheResolver cacheResolver) {
 		this.cacheResolver = cacheResolver;
 	}
 

--- a/spring-context/src/main/java/org/springframework/context/ApplicationEventPublisherAware.java
+++ b/spring-context/src/main/java/org/springframework/context/ApplicationEventPublisherAware.java
@@ -17,6 +17,7 @@
 package org.springframework.context;
 
 import org.springframework.beans.factory.Aware;
+import org.springframework.lang.Nullable;
 
 /**
  * Interface to be implemented by any object that wishes to be notified
@@ -37,6 +38,6 @@ public interface ApplicationEventPublisherAware extends Aware {
 	 * Invoked before ApplicationContextAware's setApplicationContext.
 	 * @param applicationEventPublisher event publisher to be used by this object
 	 */
-	void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher);
+	void setApplicationEventPublisher(@Nullable ApplicationEventPublisher applicationEventPublisher);
 
 }

--- a/spring-context/src/main/java/org/springframework/context/event/EventPublicationInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/context/event/EventPublicationInterceptor.java
@@ -81,7 +81,7 @@ public class EventPublicationInterceptor
 	}
 
 	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+	public void setApplicationEventPublisher(@Nullable ApplicationEventPublisher applicationEventPublisher) {
 		this.applicationEventPublisher = applicationEventPublisher;
 	}
 

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -262,9 +262,8 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 	 * Typically done during initialization of concrete context implementations.
 	 * <p>Default is the object id of the context instance.
 	 */
-	public void setDisplayName(String displayName) {
-		Assert.hasLength(displayName, "Display name must not be empty");
-		this.displayName = displayName;
+	public void setDisplayName(@Nullable String displayName) {
+		this.displayName = (displayName != null ? displayName : ObjectUtils.identityToString(this));
 	}
 
 	/**

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractMessageSource.java
@@ -90,7 +90,7 @@ public abstract class AbstractMessageSource extends MessageSourceSupport impleme
 	 * <p>May also link to an externally defined Properties object, e.g. defined
 	 * through a {@link org.springframework.beans.factory.config.PropertiesFactoryBean}.
 	 */
-	public void setCommonMessages(Properties commonMessages) {
+	public void setCommonMessages(@Nullable Properties commonMessages) {
 		this.commonMessages = commonMessages;
 	}
 

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractResourceBasedMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractResourceBasedMessageSource.java
@@ -119,7 +119,7 @@ public abstract class AbstractResourceBasedMessageSource extends AbstractMessage
 	 * <p>Only applies to classic properties files, not to XML files.
 	 * @param defaultEncoding the default charset
 	 */
-	public void setDefaultEncoding(String defaultEncoding) {
+	public void setDefaultEncoding(@Nullable String defaultEncoding) {
 		this.defaultEncoding = defaultEncoding;
 	}
 

--- a/spring-context/src/main/java/org/springframework/ejb/access/LocalStatelessSessionProxyFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/ejb/access/LocalStatelessSessionProxyFactoryBean.java
@@ -70,7 +70,7 @@ public class LocalStatelessSessionProxyFactoryBean extends LocalSlsbInvokerInter
 	 * Using a business methods interface is a best practice when implementing EJBs.
 	 * @param businessInterface set the business interface of the EJB
 	 */
-	public void setBusinessInterface(Class<?> businessInterface) {
+	public void setBusinessInterface(@Nullable Class<?> businessInterface) {
 		this.businessInterface = businessInterface;
 	}
 

--- a/spring-context/src/main/java/org/springframework/ejb/access/SimpleRemoteStatelessSessionProxyFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/ejb/access/SimpleRemoteStatelessSessionProxyFactoryBean.java
@@ -84,7 +84,7 @@ public class SimpleRemoteStatelessSessionProxyFactoryBean extends SimpleRemoteSl
 	 * converted to Spring's generic RemoteAccessException.
 	 * @param businessInterface the business interface of the EJB
 	 */
-	public void setBusinessInterface(Class<?> businessInterface) {
+	public void setBusinessInterface(@Nullable Class<?> businessInterface) {
 		this.businessInterface = businessInterface;
 	}
 

--- a/spring-context/src/main/java/org/springframework/format/datetime/joda/JodaTimeContext.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/joda/JodaTimeContext.java
@@ -49,7 +49,7 @@ public class JodaTimeContext {
 	/**
 	 * Set the user's chronology (calendar system).
 	 */
-	public void setChronology(Chronology chronology) {
+	public void setChronology(@Nullable Chronology chronology) {
 		this.chronology = chronology;
 	}
 
@@ -69,7 +69,7 @@ public class JodaTimeContext {
 	 * @see org.springframework.context.i18n.LocaleContextHolder#getTimeZone()
 	 * @see org.springframework.context.i18n.LocaleContextHolder#setLocaleContext
 	 */
-	public void setTimeZone(DateTimeZone timeZone) {
+	public void setTimeZone(@Nullable DateTimeZone timeZone) {
 		this.timeZone = timeZone;
 	}
 

--- a/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeContext.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeContext.java
@@ -47,7 +47,7 @@ public class DateTimeContext {
 	/**
 	 * Set the user's chronology (calendar system).
 	 */
-	public void setChronology(Chronology chronology) {
+	public void setChronology(@Nullable Chronology chronology) {
 		this.chronology = chronology;
 	}
 
@@ -67,7 +67,7 @@ public class DateTimeContext {
 	 * @see org.springframework.context.i18n.LocaleContextHolder#getTimeZone()
 	 * @see org.springframework.context.i18n.LocaleContextHolder#setLocaleContext
 	 */
-	public void setTimeZone(ZoneId timeZone) {
+	public void setTimeZone(@Nullable ZoneId timeZone) {
 		this.timeZone = timeZone;
 	}
 

--- a/spring-context/src/main/java/org/springframework/jmx/access/MBeanClientInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/jmx/access/MBeanClientInterceptor.java
@@ -158,7 +158,7 @@ public class MBeanClientInterceptor
 	 * Specify the environment for the JMX connector.
 	 * @see javax.management.remote.JMXConnectorFactory#connect(javax.management.remote.JMXServiceURL, java.util.Map)
 	 */
-	public void setEnvironment(Map<String, ?> environment) {
+	public void setEnvironment(@Nullable Map<String, ?> environment) {
 		this.environment = environment;
 	}
 
@@ -229,7 +229,7 @@ public class MBeanClientInterceptor
 	 * setters and getters for MBean attributes and conventional Java methods
 	 * for MBean operations.
 	 */
-	public void setManagementInterface(Class<?> managementInterface) {
+	public void setManagementInterface(@Nullable Class<?> managementInterface) {
 		this.managementInterface = managementInterface;
 	}
 

--- a/spring-context/src/main/java/org/springframework/jmx/access/NotificationListenerRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/jmx/access/NotificationListenerRegistrar.java
@@ -82,7 +82,7 @@ public class NotificationListenerRegistrar extends NotificationListenerHolder
 	 * Specify the environment for the JMX connector.
 	 * @see javax.management.remote.JMXConnectorFactory#connect(javax.management.remote.JMXServiceURL, java.util.Map)
 	 */
-	public void setEnvironment(Map<String, ?> environment) {
+	public void setEnvironment(@Nullable Map<String, ?> environment) {
 		this.environment = environment;
 	}
 

--- a/spring-context/src/main/java/org/springframework/jmx/export/assembler/AbstractReflectiveMBeanInfoAssembler.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/assembler/AbstractReflectiveMBeanInfoAssembler.java
@@ -172,6 +172,7 @@ public abstract class AbstractReflectiveMBeanInfoAssembler extends AbstractMBean
 	/**
 	 * Default value for the JMX field "currencyTimeLimit".
 	 */
+	@Nullable
 	private Integer defaultCurrencyTimeLimit;
 
 	/**
@@ -181,6 +182,7 @@ public abstract class AbstractReflectiveMBeanInfoAssembler extends AbstractMBean
 
 	private boolean exposeClassDescriptor = false;
 
+	@Nullable
 	private ParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
 
 
@@ -204,7 +206,7 @@ public abstract class AbstractReflectiveMBeanInfoAssembler extends AbstractMBean
 	 * @see org.springframework.jmx.export.metadata.AbstractJmxAttribute#setCurrencyTimeLimit
 	 * @see #applyCurrencyTimeLimit(javax.management.Descriptor, int)
 	 */
-	public void setDefaultCurrencyTimeLimit(Integer defaultCurrencyTimeLimit) {
+	public void setDefaultCurrencyTimeLimit(@Nullable Integer defaultCurrencyTimeLimit) {
 		this.defaultCurrencyTimeLimit = defaultCurrencyTimeLimit;
 	}
 
@@ -266,7 +268,7 @@ public abstract class AbstractReflectiveMBeanInfoAssembler extends AbstractMBean
 	 * names if needed (e.g. for parameter names of MBean operation methods).
 	 * <p>Default is a {@link DefaultParameterNameDiscoverer}.
 	 */
-	public void setParameterNameDiscoverer(ParameterNameDiscoverer parameterNameDiscoverer) {
+	public void setParameterNameDiscoverer(@Nullable ParameterNameDiscoverer parameterNameDiscoverer) {
 		this.parameterNameDiscoverer = parameterNameDiscoverer;
 	}
 

--- a/spring-context/src/main/java/org/springframework/jmx/export/metadata/ManagedNotification.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/metadata/ManagedNotification.java
@@ -27,10 +27,13 @@ import org.springframework.util.StringUtils;
  */
 public class ManagedNotification {
 
+	@Nullable
 	private String[] notificationTypes;
 
+	@Nullable
 	private String name;
 
+	@Nullable
 	private String description;
 
 
@@ -45,7 +48,7 @@ public class ManagedNotification {
 	/**
 	 * Set a list of notification types.
 	 */
-	public void setNotificationTypes(String... notificationTypes) {
+	public void setNotificationTypes(@Nullable String... notificationTypes) {
 		this.notificationTypes = notificationTypes;
 	}
 
@@ -60,13 +63,14 @@ public class ManagedNotification {
 	/**
 	 * Set the name of this notification.
 	 */
-	public void setName(String name) {
+	public void setName(@Nullable String name) {
 		this.name = name;
 	}
 
 	/**
 	 * Return the name of this notification.
 	 */
+	@Nullable
 	public String getName() {
 		return this.name;
 	}
@@ -74,7 +78,7 @@ public class ManagedNotification {
 	/**
 	 * Set a description for this notification.
 	 */
-	public void setDescription(String description) {
+	public void setDescription(@Nullable String description) {
 		this.description = description;
 	}
 

--- a/spring-context/src/main/java/org/springframework/jmx/support/MBeanRegistrationSupport.java
+++ b/spring-context/src/main/java/org/springframework/jmx/support/MBeanRegistrationSupport.java
@@ -96,7 +96,7 @@ public class MBeanRegistrationSupport {
 	 * be registered. The {@code MBeanExporter} will attempt to locate an
 	 * existing {@code MBeanServer} if none is supplied.
 	 */
-	public void setServer(MBeanServer server) {
+	public void setServer(@Nullable MBeanServer server) {
 		this.server = server;
 	}
 

--- a/spring-context/src/main/java/org/springframework/jndi/JndiObjectLocator.java
+++ b/spring-context/src/main/java/org/springframework/jndi/JndiObjectLocator.java
@@ -62,7 +62,7 @@ public abstract class JndiObjectLocator extends JndiLocatorSupport implements In
 	 * @param jndiName the JNDI name to look up
 	 * @see #setResourceRef
 	 */
-	public void setJndiName(String jndiName) {
+	public void setJndiName(@Nullable String jndiName) {
 		this.jndiName = jndiName;
 	}
 

--- a/spring-context/src/main/java/org/springframework/remoting/support/RemoteInvocation.java
+++ b/spring-context/src/main/java/org/springframework/remoting/support/RemoteInvocation.java
@@ -181,7 +181,7 @@ public class RemoteInvocation implements Serializable {
 	 * @see #addAttribute
 	 * @see #getAttribute
 	 */
-	public void setAttributes(Map<String, Serializable> attributes) {
+	public void setAttributes(@Nullable Map<String, Serializable> attributes) {
 		this.attributes = attributes;
 	}
 

--- a/spring-context/src/main/java/org/springframework/remoting/support/RemoteInvocationResult.java
+++ b/spring-context/src/main/java/org/springframework/remoting/support/RemoteInvocationResult.java
@@ -41,8 +41,10 @@ public class RemoteInvocationResult implements Serializable {
 	private static final long serialVersionUID = 2138555143707773549L;
 
 
+	@Nullable
 	private Object value;
 
+	@Nullable
 	private Throwable exception;
 
 
@@ -81,7 +83,7 @@ public class RemoteInvocationResult implements Serializable {
 	 * Use {@link #RemoteInvocationResult(Object)} otherwise.
 	 * @see #RemoteInvocationResult()
 	 */
-	public void setValue(Object value) {
+	public void setValue(@Nullable Object value) {
 		this.value = value;
 	}
 
@@ -102,7 +104,7 @@ public class RemoteInvocationResult implements Serializable {
 	 * Use {@link #RemoteInvocationResult(Throwable)} otherwise.
 	 * @see #RemoteInvocationResult()
 	 */
-	public void setException(Throwable exception) {
+	public void setException(@Nullable Throwable exception) {
 		this.exception = exception;
 	}
 

--- a/spring-context/src/main/java/org/springframework/scheduling/config/ScheduledTaskRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/config/ScheduledTaskRegistrar.java
@@ -92,9 +92,8 @@ public class ScheduledTaskRegistrar implements InitializingBean, DisposableBean 
 	 * {@link java.util.concurrent.ScheduledExecutorService} to be wrapped as a
 	 * {@code TaskScheduler}.
 	 */
-	public void setScheduler(Object scheduler) {
-		Assert.notNull(scheduler, "Scheduler object must not be null");
-		if (scheduler instanceof TaskScheduler) {
+	public void setScheduler(@Nullable Object scheduler) {
+		if ((scheduler instanceof TaskScheduler) || (scheduler == null)) {
 			this.taskScheduler = (TaskScheduler) scheduler;
 		}
 		else if (scheduler instanceof ScheduledExecutorService) {

--- a/spring-context/src/main/java/org/springframework/validation/DataBinder.java
+++ b/spring-context/src/main/java/org/springframework/validation/DataBinder.java
@@ -424,7 +424,7 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 * @see #setDisallowedFields
 	 * @see #isAllowed(String)
 	 */
-	public void setAllowedFields(String... allowedFields) {
+	public void setAllowedFields(@Nullable String... allowedFields) {
 		this.allowedFields = PropertyAccessorUtils.canonicalPropertyNames(allowedFields);
 	}
 
@@ -448,7 +448,7 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 * @see #setAllowedFields
 	 * @see #isAllowed(String)
 	 */
-	public void setDisallowedFields(String... disallowedFields) {
+	public void setDisallowedFields(@Nullable String... disallowedFields) {
 		this.disallowedFields = PropertyAccessorUtils.canonicalPropertyNames(disallowedFields);
 	}
 
@@ -471,7 +471,7 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 * @see #setBindingErrorProcessor
 	 * @see DefaultBindingErrorProcessor#MISSING_FIELD_ERROR_CODE
 	 */
-	public void setRequiredFields(String... requiredFields) {
+	public void setRequiredFields(@Nullable String... requiredFields) {
 		this.requiredFields = PropertyAccessorUtils.canonicalPropertyNames(requiredFields);
 		if (logger.isDebugEnabled()) {
 			logger.debug("DataBinder requires binding of required fields [" +
@@ -526,14 +526,18 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 * @see #addValidators(Validator...)
 	 * @see #replaceValidators(Validator...)
 	 */
-	public void setValidator(Validator validator) {
+	public void setValidator(@Nullable Validator validator) {
 		assertValidators(validator);
 		this.validators.clear();
-		this.validators.add(validator);
+		if (validator != null) {
+			this.validators.add(validator);
+		}
 	}
 
-	private void assertValidators(Validator... validators) {
-		Assert.notNull(validators, "Validators required");
+	private void assertValidators(@Nullable Validator... validators) {
+		if (validators == null) {
+			return;
+		}
 		for (Validator validator : validators) {
 			if (validator != null && (getTarget() != null && !validator.supports(getTarget().getClass()))) {
 				throw new IllegalStateException("Invalid target for Validator [" + validator + "]: " + getTarget());
@@ -546,9 +550,11 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 * @see #setValidator(Validator)
 	 * @see #replaceValidators(Validator...)
 	 */
-	public void addValidators(Validator... validators) {
+	public void addValidators(@Nullable Validator... validators) {
 		assertValidators(validators);
-		this.validators.addAll(Arrays.asList(validators));
+		if (validators != null) {
+			this.validators.addAll(Arrays.asList(validators));
+		}
 	}
 
 	/**
@@ -559,7 +565,9 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	public void replaceValidators(Validator... validators) {
 		assertValidators(validators);
 		this.validators.clear();
-		this.validators.addAll(Arrays.asList(validators));
+		if (validators != null) {
+			this.validators.addAll(Arrays.asList(validators));
+		}
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/core/convert/support/ConvertingPropertyEditorAdapter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/ConvertingPropertyEditorAdapter.java
@@ -56,7 +56,7 @@ public class ConvertingPropertyEditorAdapter extends PropertyEditorSupport {
 
 
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
+	public void setAsText(@Nullable String text) throws IllegalArgumentException {
 		setValue(this.conversionService.convert(text, TypeDescriptor.valueOf(String.class), this.targetDescriptor));
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
+++ b/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
@@ -103,7 +103,7 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator implement
 	 * @see #setThreadNamePrefix
 	 * @see #setThreadPriority
 	 */
-	public void setThreadFactory(ThreadFactory threadFactory) {
+	public void setThreadFactory(@Nullable ThreadFactory threadFactory) {
 		this.threadFactory = threadFactory;
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
@@ -430,7 +430,7 @@ public abstract class CollectionUtils {
 		}
 
 		@Override
-		public void set(K key, V value) {
+		public void set(K key, @Nullable V value) {
 			List<V> values = new LinkedList<>();
 			values.add(value);
 			this.map.put(key, values);

--- a/spring-core/src/main/java/org/springframework/util/CustomizableThreadCreator.java
+++ b/spring-core/src/main/java/org/springframework/util/CustomizableThreadCreator.java
@@ -127,7 +127,7 @@ public class CustomizableThreadCreator implements Serializable {
 	 * Specify the thread group that threads should be created in.
 	 * @see #setThreadGroupName
 	 */
-	public void setThreadGroup(ThreadGroup threadGroup) {
+	public void setThreadGroup(@Nullable ThreadGroup threadGroup) {
 		this.threadGroup = threadGroup;
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/LinkedMultiValueMap.java
+++ b/spring-core/src/main/java/org/springframework/util/LinkedMultiValueMap.java
@@ -101,7 +101,7 @@ public class LinkedMultiValueMap<K, V> implements MultiValueMap<K, V>, Serializa
 	}
 
 	@Override
-	public void set(K key, V value) {
+	public void set(K key, @Nullable V value) {
 		List<V> values = new LinkedList<>();
 		values.add(value);
 		this.targetMap.put(key, values);

--- a/spring-core/src/main/java/org/springframework/util/MethodInvoker.java
+++ b/spring-core/src/main/java/org/springframework/util/MethodInvoker.java
@@ -65,7 +65,7 @@ public class MethodInvoker {
 	 * @see #setTargetObject
 	 * @see #setTargetMethod
 	 */
-	public void setTargetClass(Class<?> targetClass) {
+	public void setTargetClass(@Nullable Class<?> targetClass) {
 		this.targetClass = targetClass;
 	}
 
@@ -106,7 +106,7 @@ public class MethodInvoker {
 	 * @see #setTargetClass
 	 * @see #setTargetObject
 	 */
-	public void setTargetMethod(String targetMethod) {
+	public void setTargetMethod(@Nullable String targetMethod) {
 		this.targetMethod = targetMethod;
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/MultiValueMap.java
+++ b/spring-core/src/main/java/org/springframework/util/MultiValueMap.java
@@ -64,7 +64,7 @@ public interface MultiValueMap<K, V> extends Map<K, List<V>> {
 	 * @param key the key
 	 * @param value the value to set
 	 */
-	void set(K key, V value);
+	void set(K key, @Nullable V value);
 
 	/**
 	 * Set the given values under.

--- a/spring-core/src/main/java/org/springframework/util/xml/AbstractXMLReader.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/AbstractXMLReader.java
@@ -41,19 +41,24 @@ import org.springframework.lang.Nullable;
  */
 abstract class AbstractXMLReader implements XMLReader {
 
+	@Nullable
 	private DTDHandler dtdHandler;
 
+	@Nullable
 	private ContentHandler contentHandler;
 
+	@Nullable
 	private EntityResolver entityResolver;
 
+	@Nullable
 	private ErrorHandler errorHandler;
 
+	@Nullable
 	private LexicalHandler lexicalHandler;
 
 
 	@Override
-	public void setContentHandler(ContentHandler contentHandler) {
+	public void setContentHandler(@Nullable ContentHandler contentHandler) {
 		this.contentHandler = contentHandler;
 	}
 
@@ -64,7 +69,7 @@ abstract class AbstractXMLReader implements XMLReader {
 	}
 
 	@Override
-	public void setDTDHandler(DTDHandler dtdHandler) {
+	public void setDTDHandler(@Nullable DTDHandler dtdHandler) {
 		this.dtdHandler = dtdHandler;
 	}
 
@@ -75,7 +80,7 @@ abstract class AbstractXMLReader implements XMLReader {
 	}
 
 	@Override
-	public void setEntityResolver(EntityResolver entityResolver) {
+	public void setEntityResolver(@Nullable EntityResolver entityResolver) {
 		this.entityResolver = entityResolver;
 	}
 
@@ -86,7 +91,7 @@ abstract class AbstractXMLReader implements XMLReader {
 	}
 
 	@Override
-	public void setErrorHandler(ErrorHandler errorHandler) {
+	public void setErrorHandler(@Nullable ErrorHandler errorHandler) {
 		this.errorHandler = errorHandler;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -143,7 +143,7 @@ public class CallMetaDataContext {
 	/**
 	 * Specify the name of the procedure.
 	 */
-	public void setProcedureName(String procedureName) {
+	public void setProcedureName(@Nullable String procedureName) {
 		this.procedureName = procedureName;
 	}
 
@@ -158,7 +158,7 @@ public class CallMetaDataContext {
 	/**
 	 * Specify the name of the catalog.
 	 */
-	public void setCatalogName(String catalogName) {
+	public void setCatalogName(@Nullable String catalogName) {
 		this.catalogName = catalogName;
 	}
 
@@ -173,7 +173,7 @@ public class CallMetaDataContext {
 	/**
 	 * Secify the name of the schema.
 	 */
-	public void setSchemaName(String schemaName) {
+	public void setSchemaName(@Nullable String schemaName) {
 		this.schemaName = schemaName;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -75,7 +75,7 @@ public class TableMetaDataContext {
 	/**
 	 * Set the name of the table for this context.
 	 */
-	public void setTableName(String tableName) {
+	public void setTableName(@Nullable String tableName) {
 		this.tableName = tableName;
 	}
 
@@ -90,7 +90,7 @@ public class TableMetaDataContext {
 	/**
 	 * Set the name of the catalog for this context.
 	 */
-	public void setCatalogName(String catalogName) {
+	public void setCatalogName(@Nullable String catalogName) {
 		this.catalogName = catalogName;
 	}
 
@@ -105,7 +105,7 @@ public class TableMetaDataContext {
 	/**
 	 * Set the name of the schema for this context.
 	 */
-	public void setSchemaName(String schemaName) {
+	public void setSchemaName(@Nullable String schemaName) {
 		this.schemaName = schemaName;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
@@ -108,7 +108,7 @@ public abstract class AbstractJdbcCall {
 	/**
 	 * Set the name of the stored procedure.
 	 */
-	public void setProcedureName(String procedureName) {
+	public void setProcedureName(@Nullable String procedureName) {
 		this.callMetaDataContext.setProcedureName(procedureName);
 	}
 
@@ -137,7 +137,7 @@ public abstract class AbstractJdbcCall {
 	/**
 	 * Set the catalog name to use.
 	 */
-	public void setCatalogName(String catalogName) {
+	public void setCatalogName(@Nullable String catalogName) {
 		this.callMetaDataContext.setCatalogName(catalogName);
 	}
 
@@ -152,7 +152,7 @@ public abstract class AbstractJdbcCall {
 	/**
 	 * Set the schema name to use.
 	 */
-	public void setSchemaName(String schemaName) {
+	public void setSchemaName(@Nullable String schemaName) {
 		this.callMetaDataContext.setSchemaName(schemaName);
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
@@ -119,7 +119,7 @@ public abstract class AbstractJdbcInsert {
 	/**
 	 * Set the name of the table for this insert.
 	 */
-	public void setTableName(String tableName) {
+	public void setTableName(@Nullable String tableName) {
 		checkIfConfigurationModificationIsAllowed();
 		this.tableMetaDataContext.setTableName(tableName);
 	}
@@ -135,7 +135,7 @@ public abstract class AbstractJdbcInsert {
 	/**
 	 * Set the name of the schema for this insert.
 	 */
-	public void setSchemaName(String schemaName) {
+	public void setSchemaName(@Nullable String schemaName) {
 		checkIfConfigurationModificationIsAllowed();
 		this.tableMetaDataContext.setSchemaName(schemaName);
 	}
@@ -151,7 +151,7 @@ public abstract class AbstractJdbcInsert {
 	/**
 	 * Set the name of the catalog for this insert.
 	 */
-	public void setCatalogName(String catalogName) {
+	public void setCatalogName(@Nullable String catalogName) {
 		checkIfConfigurationModificationIsAllowed();
 		this.tableMetaDataContext.setCatalogName(catalogName);
 	}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/JdbcDaoSupport.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/JdbcDaoSupport.java
@@ -84,7 +84,7 @@ public abstract class JdbcDaoSupport extends DaoSupport {
 	 * Set the JdbcTemplate for this DAO explicitly,
 	 * as an alternative to specifying a DataSource.
 	 */
-	public final void setJdbcTemplate(JdbcTemplate jdbcTemplate) {
+	public final void setJdbcTemplate(@Nullable JdbcTemplate jdbcTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
 		initTemplateConfig();
 	}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/AbstractDriverBasedDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/AbstractDriverBasedDataSource.java
@@ -57,7 +57,7 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * Set the JDBC URL to use for connecting through the Driver.
 	 * @see java.sql.Driver#connect(String, java.util.Properties)
 	 */
-	public void setUrl(String url) {
+	public void setUrl(@Nullable String url) {
 		Assert.hasText(url, "Property 'url' must not be empty");
 		this.url = url.trim();
 	}
@@ -74,7 +74,7 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * Set the JDBC username to use for connecting through the Driver.
 	 * @see java.sql.Driver#connect(String, java.util.Properties)
 	 */
-	public void setUsername(String username) {
+	public void setUsername(@Nullable String username) {
 		this.username = username;
 	}
 
@@ -90,7 +90,7 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * Set the JDBC password to use for connecting through the Driver.
 	 * @see java.sql.Driver#connect(String, java.util.Properties)
 	 */
-	public void setPassword(String password) {
+	public void setPassword(@Nullable String password) {
 		this.password = password;
 	}
 
@@ -107,7 +107,7 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * @since 4.3.2
 	 * @see Connection#setCatalog
 	 */
-	public void setCatalog(String catalog) {
+	public void setCatalog(@Nullable String catalog) {
 		this.catalog = catalog;
 	}
 
@@ -125,7 +125,7 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * @since 4.3.2
 	 * @see Connection#setSchema
 	 */
-	public void setSchema(String schema) {
+	public void setSchema(@Nullable String schema) {
 		this.schema = schema;
 	}
 
@@ -146,7 +146,7 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * DataSource will override the corresponding connection properties.
 	 * @see java.sql.Driver#connect(String, java.util.Properties)
 	 */
-	public void setConnectionProperties(Properties connectionProperties) {
+	public void setConnectionProperties(@Nullable Properties connectionProperties) {
 		this.connectionProperties = connectionProperties;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceTransactionManager.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DataSourceTransactionManager.java
@@ -155,8 +155,8 @@ public class DataSourceTransactionManager extends AbstractPlatformTransactionMan
 	 * @see TransactionAwareDataSourceProxy
 	 * @see org.springframework.transaction.jta.JtaTransactionManager
 	 */
-	public void setDataSource(DataSource dataSource) {
-		if (dataSource instanceof TransactionAwareDataSourceProxy) {
+	public void setDataSource(@Nullable DataSource dataSource) {
+		if (dataSource != null && dataSource instanceof TransactionAwareDataSourceProxy) {
 			// If we got a TransactionAwareDataSourceProxy, we need to perform transactions
 			// for its underlying target DataSource, else data access code won't see
 			// properly exposed transactions (i.e. transactions for the target DataSource).

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DelegatingDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DelegatingDataSource.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  */
 public class DelegatingDataSource implements DataSource, InitializingBean {
 
+	@Nullable
 	private DataSource targetDataSource;
 
 
@@ -62,8 +63,7 @@ public class DelegatingDataSource implements DataSource, InitializingBean {
 	/**
 	 * Set the target DataSource that this DataSource should delegate to.
 	 */
-	public void setTargetDataSource(DataSource targetDataSource) {
-		Assert.notNull(targetDataSource, "'targetDataSource' must not be null");
+	public void setTargetDataSource(@Nullable DataSource targetDataSource) {
 		this.targetDataSource = targetDataSource;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/AbstractFallbackSQLExceptionTranslator.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/AbstractFallbackSQLExceptionTranslator.java
@@ -38,6 +38,7 @@ public abstract class AbstractFallbackSQLExceptionTranslator implements SQLExcep
 	/** Logger available to subclasses */
 	protected final Log logger = LogFactory.getLog(getClass());
 
+	@Nullable
 	private SQLExceptionTranslator fallbackTranslator;
 
 
@@ -45,7 +46,7 @@ public abstract class AbstractFallbackSQLExceptionTranslator implements SQLExcep
 	 * Override the default SQL state fallback translator
 	 * (typically a {@link SQLStateSQLExceptionTranslator}).
 	 */
-	public void setFallbackTranslator(SQLExceptionTranslator fallback) {
+	public void setFallbackTranslator(@Nullable SQLExceptionTranslator fallback) {
 		this.fallbackTranslator = fallback;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/CustomSQLErrorCodesTranslation.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/CustomSQLErrorCodesTranslation.java
@@ -53,8 +53,8 @@ public class CustomSQLErrorCodesTranslation {
 	/**
 	 * Set the exception class for the specified error codes.
 	 */
-	public void setExceptionClass(Class<?> exceptionClass) {
-		if (!DataAccessException.class.isAssignableFrom(exceptionClass)) {
+	public void setExceptionClass(@Nullable Class<?> exceptionClass) {
+		if (exceptionClass != null && !DataAccessException.class.isAssignableFrom(exceptionClass)) {
 			throw new IllegalArgumentException("Invalid exception class [" + exceptionClass +
 					"]: needs to be a subclass of [org.springframework.dao.DataAccessException]");
 		}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcAccessor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcAccessor.java
@@ -54,7 +54,7 @@ public abstract class JdbcAccessor implements InitializingBean {
 	/**
 	 * Set the JDBC DataSource to obtain connections from.
 	 */
-	public void setDataSource(DataSource dataSource) {
+	public void setDataSource(@Nullable DataSource dataSource) {
 		this.dataSource = dataSource;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLErrorCodeSQLExceptionTranslator.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLErrorCodeSQLExceptionTranslator.java
@@ -152,7 +152,7 @@ public class SQLErrorCodeSQLExceptionTranslator extends AbstractFallbackSQLExcep
 	 * Set custom error codes to be used for translation.
 	 * @param sec custom error codes to use
 	 */
-	public void setSqlErrorCodes(SQLErrorCodes sec) {
+	public void setSqlErrorCodes(@Nullable SQLErrorCodes sec) {
 		this.sqlErrorCodes = sec;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLErrorCodes.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLErrorCodes.java
@@ -71,7 +71,7 @@ public class SQLErrorCodes {
 	 * Set this property if the database name contains spaces,
 	 * in which case we can not use the bean name for lookup.
 	 */
-	public void setDatabaseProductName(String databaseProductName) {
+	public void setDatabaseProductName(@Nullable String databaseProductName) {
 		this.databaseProductNames = new String[] {databaseProductName};
 	}
 
@@ -85,7 +85,7 @@ public class SQLErrorCodes {
 	 * Set this property to specify multiple database names that contains spaces,
 	 * in which case we can not use bean names for lookup.
 	 */
-	public void setDatabaseProductNames(String... databaseProductNames) {
+	public void setDatabaseProductNames(@Nullable String... databaseProductNames) {
 		this.databaseProductNames = databaseProductNames;
 	}
 
@@ -210,7 +210,7 @@ public class SQLErrorCodes {
 		}
 	}
 
-	public void setCustomSqlExceptionTranslator(SQLExceptionTranslator customSqlExceptionTranslator) {
+	public void setCustomSqlExceptionTranslator(@Nullable SQLExceptionTranslator customSqlExceptionTranslator) {
 		this.customSqlExceptionTranslator = customSqlExceptionTranslator;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/config/JmsListenerEndpointRegistrar.java
+++ b/spring-jms/src/main/java/org/springframework/jms/config/JmsListenerEndpointRegistrar.java
@@ -63,7 +63,7 @@ public class JmsListenerEndpointRegistrar implements BeanFactoryAware, Initializ
 	/**
 	 * Set the {@link JmsListenerEndpointRegistry} instance to use.
 	 */
-	public void setEndpointRegistry(JmsListenerEndpointRegistry endpointRegistry) {
+	public void setEndpointRegistry(@Nullable JmsListenerEndpointRegistry endpointRegistry) {
 		this.endpointRegistry = endpointRegistry;
 	}
 
@@ -84,7 +84,7 @@ public class JmsListenerEndpointRegistrar implements BeanFactoryAware, Initializ
 	 * or to customize conversion and validation support. See
 	 * {@link DefaultMessageHandlerMethodFactory} javadoc for more details.
 	 */
-	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory messageHandlerMethodFactory) {
+	public void setMessageHandlerMethodFactory(@Nullable MessageHandlerMethodFactory messageHandlerMethodFactory) {
 		this.messageHandlerMethodFactory = messageHandlerMethodFactory;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/config/MethodJmsListenerEndpoint.java
+++ b/spring-jms/src/main/java/org/springframework/jms/config/MethodJmsListenerEndpoint.java
@@ -68,7 +68,7 @@ public class MethodJmsListenerEndpoint extends AbstractJmsListenerEndpoint imple
 	/**
 	 * Set the actual bean instance to invoke this endpoint method on.
 	 */
-	public void setBean(Object bean) {
+	public void setBean(@Nullable Object bean) {
 		this.bean = bean;
 	}
 
@@ -80,7 +80,7 @@ public class MethodJmsListenerEndpoint extends AbstractJmsListenerEndpoint imple
 	/**
 	 * Set the method to invoke for processing a message managed by this endpoint.
 	 */
-	public void setMethod(Method method) {
+	public void setMethod(@Nullable Method method) {
 		this.method = method;
 	}
 
@@ -95,7 +95,7 @@ public class MethodJmsListenerEndpoint extends AbstractJmsListenerEndpoint imple
 	 * (if annotated itself, that is, if not just annotated in an interface).
 	 * @since 4.2.3
 	 */
-	public void setMostSpecificMethod(Method mostSpecificMethod) {
+	public void setMostSpecificMethod(@Nullable Method mostSpecificMethod) {
 		this.mostSpecificMethod = mostSpecificMethod;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/config/SimpleJmsListenerEndpoint.java
+++ b/spring-jms/src/main/java/org/springframework/jms/config/SimpleJmsListenerEndpoint.java
@@ -39,7 +39,7 @@ public class SimpleJmsListenerEndpoint extends AbstractJmsListenerEndpoint {
 	 * Set the {@link MessageListener} to invoke when a message matching
 	 * the endpoint is received.
 	 */
-	public void setMessageListener(MessageListener messageListener) {
+	public void setMessageListener(@Nullable MessageListener messageListener) {
 		this.messageListener = messageListener;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/connection/DelegatingConnectionFactory.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/DelegatingConnectionFactory.java
@@ -55,6 +55,7 @@ import org.springframework.util.Assert;
 public class DelegatingConnectionFactory
 		implements SmartConnectionFactory, QueueConnectionFactory, TopicConnectionFactory, InitializingBean {
 
+	@Nullable
 	private ConnectionFactory targetConnectionFactory;
 
 	private boolean shouldStopConnections = false;
@@ -63,8 +64,7 @@ public class DelegatingConnectionFactory
 	/**
 	 * Set the target ConnectionFactory that this ConnectionFactory should delegate to.
 	 */
-	public void setTargetConnectionFactory(ConnectionFactory targetConnectionFactory) {
-		Assert.notNull(targetConnectionFactory, "'targetConnectionFactory' must not be null");
+	public void setTargetConnectionFactory(@Nullable ConnectionFactory targetConnectionFactory) {
 		this.targetConnectionFactory = targetConnectionFactory;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/connection/JmsTransactionManager.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/JmsTransactionManager.java
@@ -127,8 +127,8 @@ public class JmsTransactionManager extends AbstractPlatformTransactionManager
 	/**
 	 * Set the JMS ConnectionFactory that this instance should manage transactions for.
 	 */
-	public void setConnectionFactory(ConnectionFactory cf) {
-		if (cf instanceof TransactionAwareConnectionFactoryProxy) {
+	public void setConnectionFactory(@Nullable ConnectionFactory cf) {
+		if (cf != null && cf instanceof TransactionAwareConnectionFactoryProxy) {
 			// If we got a TransactionAwareConnectionFactoryProxy, we need to perform transactions
 			// for its underlying target ConnectionFactory, else JMS access code won't see
 			// properly exposed transactions (i.e. transactions for the target ConnectionFactory).

--- a/spring-jms/src/main/java/org/springframework/jms/connection/SingleConnectionFactory.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/SingleConnectionFactory.java
@@ -143,7 +143,7 @@ public class SingleConnectionFactory implements ConnectionFactory, QueueConnecti
 	 * Set the target ConnectionFactory which will be used to lazily
 	 * create a single Connection.
 	 */
-	public void setTargetConnectionFactory(ConnectionFactory targetConnectionFactory) {
+	public void setTargetConnectionFactory(@Nullable ConnectionFactory targetConnectionFactory) {
 		this.targetConnectionFactory = targetConnectionFactory;
 	}
 
@@ -151,7 +151,7 @@ public class SingleConnectionFactory implements ConnectionFactory, QueueConnecti
 	 * Return the target ConnectionFactory which will be used to lazily
 	 * create a single Connection, if any.
 	 */
-	@org.springframework.lang.Nullable
+	@Nullable
 	public ConnectionFactory getTargetConnectionFactory() {
 		return this.targetConnectionFactory;
 	}
@@ -165,7 +165,7 @@ public class SingleConnectionFactory implements ConnectionFactory, QueueConnecti
 	 * @see javax.jms.Connection#setClientID
 	 * @see #setTargetConnectionFactory
 	 */
-	public void setClientId(String clientId) {
+	public void setClientId(@Nullable String clientId) {
 		this.clientId = clientId;
 	}
 
@@ -173,7 +173,7 @@ public class SingleConnectionFactory implements ConnectionFactory, QueueConnecti
 	 * Return a JMS client ID for the single Connection created and exposed
 	 * by this ConnectionFactory, if any.
 	 */
-	@org.springframework.lang.Nullable
+	@Nullable
 	protected String getClientId() {
 		return this.clientId;
 	}
@@ -183,7 +183,7 @@ public class SingleConnectionFactory implements ConnectionFactory, QueueConnecti
 	 * registered with the single Connection created by this factory.
 	 * @see #setReconnectOnException
 	 */
-	public void setExceptionListener(ExceptionListener exceptionListener) {
+	public void setExceptionListener(@Nullable ExceptionListener exceptionListener) {
 		this.exceptionListener = exceptionListener;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/connection/TransactionAwareConnectionFactoryProxy.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/TransactionAwareConnectionFactoryProxy.java
@@ -81,6 +81,7 @@ public class TransactionAwareConnectionFactoryProxy
 
 	private boolean synchedLocalTransactionAllowed = false;
 
+	@Nullable
 	private ConnectionFactory targetConnectionFactory;
 
 
@@ -102,8 +103,7 @@ public class TransactionAwareConnectionFactoryProxy
 	/**
 	 * Set the target ConnectionFactory that this ConnectionFactory should delegate to.
 	 */
-	public final void setTargetConnectionFactory(ConnectionFactory targetConnectionFactory) {
-		Assert.notNull(targetConnectionFactory, "'targetConnectionFactory' must not be null");
+	public final void setTargetConnectionFactory(@Nullable ConnectionFactory targetConnectionFactory) {
 		this.targetConnectionFactory = targetConnectionFactory;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/core/JmsMessagingTemplate.java
+++ b/spring-jms/src/main/java/org/springframework/jms/core/JmsMessagingTemplate.java
@@ -106,7 +106,7 @@ public class JmsMessagingTemplate extends AbstractMessagingTemplate<Destination>
 	/**
 	 * Set the {@link JmsTemplate} to use.
 	 */
-	public void setJmsTemplate(JmsTemplate jmsTemplate) {
+	public void setJmsTemplate(@Nullable JmsTemplate jmsTemplate) {
 		this.jmsTemplate = jmsTemplate;
 	}
 
@@ -147,7 +147,7 @@ public class JmsMessagingTemplate extends AbstractMessagingTemplate<Destination>
 	 * without a destination argument will raise an exception if invoked.
 	 * @see #setDefaultDestination(Object)
 	 */
-	public void setDefaultDestinationName(String defaultDestinationName) {
+	public void setDefaultDestinationName(@Nullable String defaultDestinationName) {
 		this.defaultDestinationName = defaultDestinationName;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/core/JmsTemplate.java
+++ b/spring-jms/src/main/java/org/springframework/jms/core/JmsTemplate.java
@@ -92,6 +92,7 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 	private final JmsTemplateResourceFactory transactionalResourceFactory = new JmsTemplateResourceFactory();
 
 
+	@Nullable
 	private Object defaultDestination;
 
 	private MessageConverter messageConverter;
@@ -161,7 +162,7 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 	 * @see #convertAndSend(Object, MessagePostProcessor)
 	 * @see #setDefaultDestinationName(String)
 	 */
-	public void setDefaultDestination(Destination destination) {
+	public void setDefaultDestination(@Nullable Destination destination) {
 		this.defaultDestination = destination;
 	}
 
@@ -195,7 +196,7 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 	 * @see #setDestinationResolver
 	 * @see #setDefaultDestination(javax.jms.Destination)
 	 */
-	public void setDefaultDestinationName(String destinationName) {
+	public void setDefaultDestinationName(@Nullable String destinationName) {
 		this.defaultDestination = destinationName;
 	}
 
@@ -234,7 +235,6 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 	/**
 	 * Return the message converter for this template.
 	 */
-	@Nullable
 	public MessageConverter getMessageConverter() {
 		return this.messageConverter;
 	}

--- a/spring-jms/src/main/java/org/springframework/jms/core/support/JmsGatewaySupport.java
+++ b/spring-jms/src/main/java/org/springframework/jms/core/support/JmsGatewaySupport.java
@@ -84,7 +84,7 @@ public abstract class JmsGatewaySupport implements InitializingBean {
 	 * Set the JmsTemplate for the gateway.
 	 * @see #setConnectionFactory(javax.jms.ConnectionFactory)
 	 */
-	public final void setJmsTemplate(JmsTemplate jmsTemplate) {
+	public final void setJmsTemplate(@Nullable JmsTemplate jmsTemplate) {
 		this.jmsTemplate = jmsTemplate;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/listener/AbstractJmsListeningContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/AbstractJmsListeningContainer.java
@@ -96,7 +96,7 @@ public abstract class AbstractJmsListeningContainer extends JmsDestinationAccess
 	 * @see javax.jms.Connection#setClientID
 	 * @see #setConnectionFactory
 	 */
-	public void setClientId(String clientId) {
+	public void setClientId(@Nullable String clientId) {
 		this.clientId = clientId;
 	}
 
@@ -143,7 +143,7 @@ public abstract class AbstractJmsListeningContainer extends JmsDestinationAccess
 	}
 
 	@Override
-	public void setBeanName(String beanName) {
+	public void setBeanName(@Nullable String beanName) {
 		this.beanName = beanName;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/listener/AbstractMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/AbstractMessageListenerContainer.java
@@ -196,8 +196,7 @@ public abstract class AbstractMessageListenerContainer extends AbstractJmsListen
 	 * CACHE_CONSUMER). However, this is considered advanced usage; use it with care!
 	 * @see #setDestinationName(String)
 	 */
-	public void setDestination(Destination destination) {
-		Assert.notNull(destination, "'destination' must not be null");
+	public void setDestination(@Nullable Destination destination) {
 		this.destination = destination;
 		if (destination instanceof Topic && !(destination instanceof Queue)) {
 			// Clearly a Topic: let's set the "pubSubDomain" flag accordingly.
@@ -226,8 +225,7 @@ public abstract class AbstractMessageListenerContainer extends AbstractJmsListen
 	 * CACHE_CONSUMER). However, this is considered advanced usage; use it with care!
 	 * @see #setDestination(javax.jms.Destination)
 	 */
-	public void setDestinationName(String destinationName) {
-		Assert.notNull(destinationName, "'destinationName' must not be null");
+	public void setDestinationName(@Nullable String destinationName) {
 		this.destination = destinationName;
 	}
 
@@ -286,10 +284,10 @@ public abstract class AbstractMessageListenerContainer extends AbstractJmsListen
 	 * @see javax.jms.MessageListener
 	 * @see SessionAwareMessageListener
 	 */
-	public void setMessageListener(Object messageListener) {
+	public void setMessageListener(@Nullable Object messageListener) {
 		checkMessageListener(messageListener);
 		this.messageListener = messageListener;
-		if (this.subscriptionName == null) {
+		if (messageListener != null && this.subscriptionName == null) {
 			this.subscriptionName = getDefaultSubscriptionName(messageListener);
 		}
 	}
@@ -313,8 +311,8 @@ public abstract class AbstractMessageListenerContainer extends AbstractJmsListen
 	 * @see javax.jms.MessageListener
 	 * @see SessionAwareMessageListener
 	 */
-	protected void checkMessageListener(Object messageListener) {
-		if (!(messageListener instanceof MessageListener ||
+	protected void checkMessageListener(@Nullable Object messageListener) {
+		if (messageListener != null && !(messageListener instanceof MessageListener ||
 				messageListener instanceof SessionAwareMessageListener)) {
 			throw new IllegalArgumentException(
 					"Message listener needs to be of type [" + MessageListener.class.getName() +
@@ -408,7 +406,7 @@ public abstract class AbstractMessageListenerContainer extends AbstractJmsListen
 	 * @see #setClientId
 	 * @see #setMessageListener
 	 */
-	public void setSubscriptionName(String subscriptionName) {
+	public void setSubscriptionName(@Nullable String subscriptionName) {
 		this.subscriptionName = subscriptionName;
 	}
 
@@ -435,9 +433,9 @@ public abstract class AbstractMessageListenerContainer extends AbstractJmsListen
 	 * @see #setClientId
 	 * @see #setMessageListener
 	 */
-	public void setDurableSubscriptionName(String durableSubscriptionName) {
+	public void setDurableSubscriptionName(@Nullable String durableSubscriptionName) {
 		this.subscriptionName = durableSubscriptionName;
-		this.subscriptionDurable = true;
+		this.subscriptionDurable = (durableSubscriptionName != null);
 	}
 
 	/**
@@ -529,7 +527,7 @@ public abstract class AbstractMessageListenerContainer extends AbstractJmsListen
 	 * Set the JMS ExceptionListener to notify in case of a JMSException thrown
 	 * by the registered message listener or the invocation infrastructure.
 	 */
-	public void setExceptionListener(ExceptionListener exceptionListener) {
+	public void setExceptionListener(@Nullable ExceptionListener exceptionListener) {
 		this.exceptionListener = exceptionListener;
 	}
 
@@ -548,7 +546,7 @@ public abstract class AbstractMessageListenerContainer extends AbstractJmsListen
 	 * <p>By default, there will be <b>no</b> ErrorHandler so that error-level
 	 * logging is the only result.
 	 */
-	public void setErrorHandler(ErrorHandler errorHandler) {
+	public void setErrorHandler(@Nullable ErrorHandler errorHandler) {
 		this.errorHandler = errorHandler;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
@@ -123,7 +123,7 @@ public abstract class AbstractPollingMessageListenerContainer extends AbstractMe
 	 * @see org.springframework.transaction.jta.JtaTransactionManager
 	 * @see org.springframework.jms.connection.JmsTransactionManager
 	 */
-	public void setTransactionManager(PlatformTransactionManager transactionManager) {
+	public void setTransactionManager(@Nullable PlatformTransactionManager transactionManager) {
 		this.transactionManager = transactionManager;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/adapter/AbstractAdaptableMessageListener.java
@@ -142,7 +142,7 @@ public abstract class AbstractAdaptableMessageListener
 	 * {@link javax.jms.TextMessage TextMessages} and
 	 * {@link javax.jms.ObjectMessage ObjectMessages}.
 	 */
-	public void setMessageConverter(MessageConverter messageConverter) {
+	public void setMessageConverter(@Nullable MessageConverter messageConverter) {
 		this.messageConverter = messageConverter;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/JmsActivationSpecConfig.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/JmsActivationSpecConfig.java
@@ -78,7 +78,7 @@ public class JmsActivationSpecConfig {
 	private MessageConverter messageConverter;
 
 
-	public void setDestinationName(String destinationName) {
+	public void setDestinationName(@Nullable String destinationName) {
 		this.destinationName = destinationName;
 	}
 
@@ -108,7 +108,7 @@ public class JmsActivationSpecConfig {
 		}
 	}
 
-	public void setReplyQosSettings(QosSettings replyQosSettings) {
+	public void setReplyQosSettings(@Nullable QosSettings replyQosSettings) {
 		this.replyQosSettings = replyQosSettings;
 	}
 
@@ -139,7 +139,7 @@ public class JmsActivationSpecConfig {
 		return this.subscriptionShared;
 	}
 
-	public void setSubscriptionName(String subscriptionName) {
+	public void setSubscriptionName(@Nullable String subscriptionName) {
 		this.subscriptionName = subscriptionName;
 	}
 
@@ -148,9 +148,9 @@ public class JmsActivationSpecConfig {
 		return this.subscriptionName;
 	}
 
-	public void setDurableSubscriptionName(String durableSubscriptionName) {
+	public void setDurableSubscriptionName(@Nullable String durableSubscriptionName) {
 		this.subscriptionName = durableSubscriptionName;
-		this.subscriptionDurable = true;
+		this.subscriptionDurable = (durableSubscriptionName != null);
 	}
 
 	@Nullable
@@ -158,7 +158,7 @@ public class JmsActivationSpecConfig {
 		return (this.subscriptionDurable ? this.subscriptionName : null);
 	}
 
-	public void setClientId(String clientId) {
+	public void setClientId(@Nullable String clientId) {
 		this.clientId = clientId;
 	}
 
@@ -167,7 +167,7 @@ public class JmsActivationSpecConfig {
 		return this.clientId;
 	}
 
-	public void setMessageSelector(String messageSelector) {
+	public void setMessageSelector(@Nullable String messageSelector) {
 		this.messageSelector = messageSelector;
 	}
 
@@ -274,7 +274,7 @@ public class JmsActivationSpecConfig {
 	 * Set the {@link MessageConverter} strategy for converting JMS Messages.
 	 * @param messageConverter the message converter to use
 	 */
-	public void setMessageConverter(MessageConverter messageConverter) {
+	public void setMessageConverter(@Nullable MessageConverter messageConverter) {
 		this.messageConverter = messageConverter;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/JmsMessageEndpointManager.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/JmsMessageEndpointManager.java
@@ -138,7 +138,7 @@ public class JmsMessageEndpointManager extends GenericMessageEndpointManager
 	 * <p>This config object will be turned into a concrete JCA 1.5 ActivationSpec
 	 * object through a {@link #setActivationSpecFactory JmsActivationSpecFactory}.
 	 */
-	public void setActivationSpecConfig(JmsActivationSpecConfig activationSpecConfig) {
+	public void setActivationSpecConfig(@Nullable JmsActivationSpecConfig activationSpecConfig) {
 		this.activationSpecConfig = activationSpecConfig;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/StandardJmsActivationSpecFactory.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/StandardJmsActivationSpecFactory.java
@@ -90,7 +90,7 @@ public class StandardJmsActivationSpecFactory implements JmsActivationSpecFactor
 	 * or {@link org.springframework.jms.support.destination.BeanFactoryDestinationResolver}
 	 * but not {@link org.springframework.jms.support.destination.DynamicDestinationResolver}.
 	 */
-	public void setDestinationResolver(DestinationResolver destinationResolver) {
+	public void setDestinationResolver(@Nullable DestinationResolver destinationResolver) {
 		this.destinationResolver = destinationResolver;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/remoting/JmsInvokerClientInterceptor.java
+++ b/spring-jms/src/main/java/org/springframework/jms/remoting/JmsInvokerClientInterceptor.java
@@ -92,7 +92,7 @@ public class JmsInvokerClientInterceptor implements MethodInterceptor, Initializ
 	/**
 	 * Set the QueueConnectionFactory to use for obtaining JMS QueueConnections.
 	 */
-	public void setConnectionFactory(ConnectionFactory connectionFactory) {
+	public void setConnectionFactory(@Nullable ConnectionFactory connectionFactory) {
 		this.connectionFactory = connectionFactory;
 	}
 

--- a/spring-jms/src/main/java/org/springframework/jms/support/JmsAccessor.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/JmsAccessor.java
@@ -54,6 +54,7 @@ public abstract class JmsAccessor implements InitializingBean {
 	/** Logger available to subclasses */
 	protected final Log logger = LogFactory.getLog(getClass());
 
+	@Nullable
 	private ConnectionFactory connectionFactory;
 
 	private boolean sessionTransacted = false;
@@ -64,7 +65,7 @@ public abstract class JmsAccessor implements InitializingBean {
 	/**
 	 * Set the ConnectionFactory to use for obtaining JMS {@link Connection Connections}.
 	 */
-	public void setConnectionFactory(ConnectionFactory connectionFactory) {
+	public void setConnectionFactory(@Nullable ConnectionFactory connectionFactory) {
 		this.connectionFactory = connectionFactory;
 	}
 

--- a/spring-jms/src/test/java/org/springframework/jms/listener/AbstractMessageListenerContainerTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/listener/AbstractMessageListenerContainerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.jms.listener;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -28,10 +29,10 @@ public abstract class AbstractMessageListenerContainerTests {
 
 	protected abstract AbstractMessageListenerContainer getContainer();
 
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testSettingMessageListenerToANullType() throws Exception {
+	
+	public void testSettingMessageListenerToANullType() {
 		getContainer().setMessageListener(null);
+		Assert.assertNull(getContainer().getMessageListener());
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/spring-messaging/src/main/java/org/springframework/messaging/converter/MarshallingMessageConverter.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/converter/MarshallingMessageConverter.java
@@ -92,7 +92,7 @@ public class MarshallingMessageConverter extends AbstractMessageConverter {
 	/**
 	 * Set the {@link Marshaller} to be used by this message converter.
 	 */
-	public void setMarshaller(Marshaller marshaller) {
+	public void setMarshaller(@Nullable Marshaller marshaller) {
 		this.marshaller = marshaller;
 	}
 
@@ -107,7 +107,7 @@ public class MarshallingMessageConverter extends AbstractMessageConverter {
 	/**
 	 * Set the {@link Unmarshaller} to be used by this message converter.
 	 */
-	public void setUnmarshaller(Unmarshaller unmarshaller) {
+	public void setUnmarshaller(@Nullable Unmarshaller unmarshaller) {
 		this.unmarshaller = unmarshaller;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/core/AbstractDestinationResolvingMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/core/AbstractDestinationResolvingMessagingTemplate.java
@@ -51,8 +51,7 @@ public abstract class AbstractDestinationResolvingMessagingTemplate<D> extends A
 	 * require resolving a destination name will raise an {@link IllegalArgumentException}.
 	 * @param destinationResolver the destination resolver to use
 	 */
-	public void setDestinationResolver(DestinationResolver<D> destinationResolver) {
-		Assert.notNull(destinationResolver, "'destinationResolver' is required");
+	public void setDestinationResolver(@Nullable DestinationResolver<D> destinationResolver) {
 		this.destinationResolver = destinationResolver;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/core/AbstractMessageSendingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/core/AbstractMessageSendingTemplate.java
@@ -63,7 +63,7 @@ public abstract class AbstractMessageSendingTemplate<D> implements MessageSendin
 	 * a destination argument. If a default destination is not configured, send methods
 	 * without a destination argument will raise an exception if invoked.
 	 */
-	public void setDefaultDestination(D defaultDestination) {
+	public void setDefaultDestination(@Nullable D defaultDestination) {
 		this.defaultDestination = defaultDestination;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/AbstractMethodMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/AbstractMethodMessageHandler.java
@@ -96,6 +96,7 @@ public abstract class AbstractMethodMessageHandler<T>
 	private final HandlerMethodReturnValueHandlerComposite returnValueHandlers =
 			new HandlerMethodReturnValueHandlerComposite();
 
+	@Nullable
 	private ApplicationContext applicationContext;
 
 	private final Map<T, HandlerMethod> handlerMethods = new LinkedHashMap<>(64);
@@ -211,7 +212,7 @@ public abstract class AbstractMethodMessageHandler<T>
 	}
 
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) {
+	public void setApplicationContext(@Nullable ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessageHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessageHeaderAccessor.java
@@ -121,8 +121,7 @@ public class SimpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
 		return (SimpMessageType) getHeader(MESSAGE_TYPE_HEADER);
 	}
 
-	public void setDestination(String destination) {
-		Assert.notNull(destination, "Destination must not be null");
+	public void setDestination(@Nullable String destination) {
 		setHeader(DESTINATION_HEADER, destination);
 	}
 
@@ -155,7 +154,7 @@ public class SimpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
 	/**
 	 * A static alternative for access to the session attributes header.
 	 */
-	public void setSessionAttributes(Map<String, Object> attributes) {
+	public void setSessionAttributes(@Nullable Map<String, Object> attributes) {
 		setHeader(SESSION_ATTRIBUTES, attributes);
 	}
 
@@ -168,7 +167,7 @@ public class SimpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
 		return (Map<String, Object>) getHeader(SESSION_ATTRIBUTES);
 	}
 
-	public void setUser(Principal principal) {
+	public void setUser(@Nullable Principal principal) {
 		setHeader(USER_HEADER, principal);
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
@@ -111,7 +111,7 @@ public class SimpMessagingTemplate extends AbstractMessageSendingTemplate<String
 	 * messages created through the {@code SimpMessagingTemplate}.
 	 * <p>By default, this property is not set.
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandler.java
@@ -121,7 +121,7 @@ public class SendToMethodReturnValueHandler implements HandlerMethodReturnValueH
 	 * messages sent to the client outbound channel.
 	 * <p>By default this property is not set.
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SimpAnnotationMethodMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SimpAnnotationMethodMessageHandler.java
@@ -234,7 +234,7 @@ public class SimpAnnotationMethodMessageHandler extends AbstractMethodMessageHan
 	 * @see org.springframework.validation.annotation.Validated
 	 * @see PayloadArgumentResolver
 	 */
-	public void setValidator(Validator validator) {
+	public void setValidator(@Nullable Validator validator) {
 		this.validator = validator;
 	}
 
@@ -249,7 +249,7 @@ public class SimpAnnotationMethodMessageHandler extends AbstractMethodMessageHan
 	 * that send messages from controller return values.
 	 * <p>By default, this property is not set.
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SubscriptionMethodReturnValueHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SubscriptionMethodReturnValueHandler.java
@@ -63,6 +63,7 @@ public class SubscriptionMethodReturnValueHandler implements HandlerMethodReturn
 
 	private final MessageSendingOperations<String> messagingTemplate;
 
+	@Nullable
 	private MessageHeaderInitializer headerInitializer;
 
 
@@ -82,7 +83,7 @@ public class SubscriptionMethodReturnValueHandler implements HandlerMethodReturn
 	 * messages sent to the client outbound channel.
 	 * <p>By default this property is not set.
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/AbstractBrokerMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/AbstractBrokerMessageHandler.java
@@ -129,7 +129,7 @@ public abstract class AbstractBrokerMessageHandler
 	}
 
 	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+	public void setApplicationEventPublisher(@Nullable ApplicationEventPublisher publisher) {
 		this.eventPublisher = publisher;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/SimpleBrokerMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/SimpleBrokerMessageHandler.java
@@ -157,10 +157,9 @@ public class SimpleBrokerMessageHandler extends AbstractBrokerMessageHandler {
 	 * <p>By default this is not set.
 	 * @since 4.2
 	 */
-	public void setTaskScheduler(TaskScheduler taskScheduler) {
-		Assert.notNull(taskScheduler, "TaskScheduler must not be null");
+	public void setTaskScheduler(@Nullable TaskScheduler taskScheduler) {
 		this.taskScheduler = taskScheduler;
-		if (this.heartbeatValue == null) {
+		if (taskScheduler != null && this.heartbeatValue == null) {
 			this.heartbeatValue = new long[] {10000, 10000};
 		}
 	}
@@ -183,8 +182,8 @@ public class SimpleBrokerMessageHandler extends AbstractBrokerMessageHandler {
 	 * (in milliseconds).
 	 * @since 4.2
 	 */
-	public void setHeartbeatValue(long[] heartbeat) {
-		if (heartbeat.length != 2 || heartbeat[0] < 0 || heartbeat[1] < 0) {
+	public void setHeartbeatValue(@Nullable long[] heartbeat) {
+		if (heartbeat != null && (heartbeat.length != 2 || heartbeat[0] < 0 || heartbeat[1] < 0)) {
 			throw new IllegalArgumentException("Invalid heart-beat: " + Arrays.toString(heartbeat));
 		}
 		this.heartbeatValue = heartbeat;
@@ -205,7 +204,7 @@ public class SimpleBrokerMessageHandler extends AbstractBrokerMessageHandler {
 	 * <p>By default this property is not set.
 	 * @since 4.1
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/config/AbstractMessageBrokerConfiguration.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/config/AbstractMessageBrokerConfiguration.java
@@ -112,7 +112,7 @@ public abstract class AbstractMessageBrokerConfiguration implements ApplicationC
 
 
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) {
+	public void setApplicationContext(@Nullable ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
@@ -325,7 +325,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 	 * providing the cloud-based STOMP service.
 	 * <p>By default this property is not set.
 	 */
-	public void setVirtualHost(String virtualHost) {
+	public void setVirtualHost(@Nullable String virtualHost) {
 		this.virtualHost = virtualHost;
 	}
 
@@ -341,7 +341,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 	 * Configure a TCP client for managing TCP connections to the STOMP broker.
 	 * <p>By default {@link ReactorNettyTcpClient} is used.
 	 */
-	public void setTcpClient(TcpOperations<byte[]> tcpClient) {
+	public void setTcpClient(@Nullable TcpOperations<byte[]> tcpClient) {
 		this.tcpClient = tcpClient;
 	}
 
@@ -361,7 +361,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 	 * are sent to the client outbound message channel.
 	 * <p>By default this property is not set.
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompClientSupport.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompClientSupport.java
@@ -43,6 +43,7 @@ public abstract class StompClientSupport {
 
 	private MessageConverter messageConverter = new SimpleMessageConverter();
 
+	@Nullable
 	private TaskScheduler taskScheduler;
 
 	private long[] defaultHeartbeat = new long[] {10000, 10000};
@@ -76,7 +77,7 @@ public abstract class StompClientSupport {
 	 * Receipts however, if needed, do require a TaskScheduler to be configured.
 	 * <p>By default, this is not set.
 	 */
-	public void setTaskScheduler(TaskScheduler taskScheduler) {
+	public void setTaskScheduler(@Nullable TaskScheduler taskScheduler) {
 		this.taskScheduler = taskScheduler;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
@@ -61,7 +61,7 @@ public class StompDecoder {
 	 * Configure a {@link MessageHeaderInitializer} to apply to the headers of
 	 * {@link Message}s from decoded STOMP frames.
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaderAccessor.java
@@ -246,7 +246,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return (rawValue != null ? StringUtils.commaDelimitedListToSet(rawValue) : Collections.emptySet());
 	}
 
-	public void setHost(String host) {
+	public void setHost(@Nullable String host) {
 		setNativeHeader(STOMP_HOST_HEADER, host);
 	}
 
@@ -302,7 +302,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		setNativeHeader(STOMP_HEARTBEAT_HEADER, cx + "," + cy);
 	}
 
-	public void setAck(String ack) {
+	public void setAck(@Nullable String ack) {
 		setNativeHeader(STOMP_ACK_HEADER, ack);
 	}
 
@@ -311,7 +311,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return getFirstNativeHeader(STOMP_ACK_HEADER);
 	}
 
-	public void setNack(String nack) {
+	public void setNack(@Nullable String nack) {
 		setNativeHeader(STOMP_NACK_HEADER, nack);
 	}
 
@@ -320,7 +320,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return getFirstNativeHeader(STOMP_NACK_HEADER);
 	}
 
-	public void setLogin(String login) {
+	public void setLogin(@Nullable String login) {
 		setNativeHeader(STOMP_LOGIN_HEADER, login);
 	}
 
@@ -329,7 +329,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return getFirstNativeHeader(STOMP_LOGIN_HEADER);
 	}
 
-	public void setPasscode(String passcode) {
+	public void setPasscode(@Nullable String passcode) {
 		setNativeHeader(STOMP_PASSCODE_HEADER, passcode);
 		protectPasscode();
 	}
@@ -351,7 +351,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return (credentials != null ? credentials.passcode : null);
 	}
 
-	public void setReceiptId(String receiptId) {
+	public void setReceiptId(@Nullable String receiptId) {
 		setNativeHeader(STOMP_RECEIPT_ID_HEADER, receiptId);
 	}
 
@@ -360,7 +360,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return getFirstNativeHeader(STOMP_RECEIPT_ID_HEADER);
 	}
 
-	public void setReceipt(String receiptId) {
+	public void setReceipt(@Nullable String receiptId) {
 		setNativeHeader(STOMP_RECEIPT_HEADER, receiptId);
 	}
 
@@ -374,7 +374,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return getFirstNativeHeader(STOMP_MESSAGE_HEADER);
 	}
 
-	public void setMessage(String content) {
+	public void setMessage(@Nullable String content) {
 		setNativeHeader(STOMP_MESSAGE_HEADER, content);
 	}
 
@@ -383,7 +383,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return getFirstNativeHeader(STOMP_MESSAGE_ID_HEADER);
 	}
 
-	public void setMessageId(String id) {
+	public void setMessageId(@Nullable String id) {
 		setNativeHeader(STOMP_MESSAGE_ID_HEADER, id);
 	}
 
@@ -392,7 +392,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 		return getFirstNativeHeader(STOMP_VERSION_HEADER);
 	}
 
-	public void setVersion(String version) {
+	public void setVersion(@Nullable String version) {
 		setNativeHeader(STOMP_VERSION_HEADER, version);
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaders.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaders.java
@@ -126,10 +126,15 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the content-type header.
 	 * Applies to the SEND, MESSAGE, and ERROR frames.
 	 */
-	public void setContentType(MimeType mimeType) {
-		Assert.isTrue(!mimeType.isWildcardType(), "'Content-Type' cannot contain wildcard type '*'");
-		Assert.isTrue(!mimeType.isWildcardSubtype(), "'Content-Type' cannot contain wildcard subtype '*'");
-		set(CONTENT_TYPE, mimeType.toString());
+	public void setContentType(@Nullable MimeType mimeType) {
+		if (mimeType != null) {
+			Assert.isTrue(!mimeType.isWildcardType(), "'Content-Type' cannot contain wildcard type '*'");
+			Assert.isTrue(!mimeType.isWildcardSubtype(), "'Content-Type' cannot contain wildcard subtype '*'");
+			set(CONTENT_TYPE, mimeType.toString());
+		}
+		else {
+			set(CONTENT_TYPE, null);
+		}
 	}
 
 	/**
@@ -161,7 +166,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the receipt header.
 	 * Applies to any client frame other than CONNECT.
 	 */
-	public void setReceipt(String receipt) {
+	public void setReceipt(@Nullable String receipt) {
 		set(RECEIPT, receipt);
 	}
 
@@ -177,7 +182,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the host header.
 	 * Applies to the CONNECT frame.
 	 */
-	public void setHost(String host) {
+	public void setHost(@Nullable String host) {
 		set(HOST, host);
 	}
 
@@ -193,7 +198,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the login header.
 	 * Applies to the CONNECT frame.
 	 */
-	public void setLogin(String login) {
+	public void setLogin(@Nullable String login) {
 		set(LOGIN, login);
 	}
 
@@ -209,7 +214,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the passcode header.
 	 * Applies to the CONNECT frame.
 	 */
-	public void setPasscode(String passcode) {
+	public void setPasscode(@Nullable String passcode) {
 		set(PASSCODE, passcode);
 	}
 
@@ -263,7 +268,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the session header.
 	 * Applies to the CONNECTED frame.
 	 */
-	public void setSession(String session) {
+	public void setSession(@Nullable String session) {
 		set(SESSION, session);
 	}
 
@@ -279,7 +284,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the server header.
 	 * Applies to the CONNECTED frame.
 	 */
-	public void setServer(String server) {
+	public void setServer(@Nullable String server) {
 		set(SERVER, server);
 	}
 
@@ -295,7 +300,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	/**
 	 * Set the destination header.
 	 */
-	public void setDestination(String destination) {
+	public void setDestination(@Nullable String destination) {
 		set(DESTINATION, destination);
 	}
 
@@ -312,7 +317,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the id header.
 	 * Applies to the SUBSCR0BE, UNSUBSCRIBE, and ACK or NACK frames.
 	 */
-	public void setId(String id) {
+	public void setId(@Nullable String id) {
 		set(ID, id);
 	}
 
@@ -328,7 +333,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the ack header to one of "auto", "client", or "client-individual".
 	 * Applies to the SUBSCRIBE and MESSAGE frames.
 	 */
-	public void setAck(String ack) {
+	public void setAck(@Nullable String ack) {
 		set(ACK, ack);
 	}
 
@@ -344,7 +349,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the login header.
 	 * Applies to the MESSAGE frame.
 	 */
-	public void setSubscription(String subscription) {
+	public void setSubscription(@Nullable String subscription) {
 		set(SUBSCRIPTION, subscription);
 	}
 
@@ -360,7 +365,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the message-id header.
 	 * Applies to the MESSAGE frame.
 	 */
-	public void setMessageId(String messageId) {
+	public void setMessageId(@Nullable String messageId) {
 		set(MESSAGE_ID, messageId);
 	}
 
@@ -376,7 +381,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * Set the receipt-id header.
 	 * Applies to the RECEIPT frame.
 	 */
-	public void setReceiptId(String receiptId) {
+	public void setReceiptId(@Nullable String receiptId) {
 		set(RECEIPT_ID, receiptId);
 	}
 
@@ -433,7 +438,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	 * @see #add(String, String)
 	 */
 	@Override
-	public void set(String headerName, String headerValue) {
+	public void set(String headerName, @Nullable String headerValue) {
 		List<String> headerValues = new LinkedList<>();
 		headerValues.add(headerValue);
 		headers.put(headerName, headerValues);

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationMessageHandler.java
@@ -108,7 +108,7 @@ public class UserDestinationMessageHandler implements MessageHandler, SmartLifec
 	 * <p>By default this is not set.
 	 * @param destination the target destination.
 	 */
-	public void setBroadcastDestination(String destination) {
+	public void setBroadcastDestination(@Nullable String destination) {
 		this.broadcastHandler = (StringUtils.hasText(destination) ?
 				new BroadcastHandler(this.messagingTemplate, destination) : null);
 	}
@@ -134,7 +134,7 @@ public class UserDestinationMessageHandler implements MessageHandler, SmartLifec
 	 * headers of resolved target messages.
 	 * <p>By default this is not set.
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/support/IdTimestampMessageHeaderInitializer.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/IdTimestampMessageHeaderInitializer.java
@@ -43,7 +43,7 @@ public class IdTimestampMessageHeaderInitializer implements MessageHeaderInitial
 	 * IdGenerator of {@link org.springframework.messaging.MessageHeaders} is used.
 	 * <p>To have no id's generated at all, see {@link #setDisableIdGeneration()}.
 	 */
-	public void setIdGenerator(IdGenerator idGenerator) {
+	public void setIdGenerator(@Nullable IdGenerator idGenerator) {
 		this.idGenerator = idGenerator;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate5/HibernateTemplate.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate5/HibernateTemplate.java
@@ -105,8 +105,10 @@ public class HibernateTemplate implements HibernateOperations, InitializingBean 
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
+	@Nullable
 	private SessionFactory sessionFactory;
 
+	@Nullable
 	private String[] filterNames;
 
 	private boolean exposeNativeSession = false;
@@ -115,6 +117,7 @@ public class HibernateTemplate implements HibernateOperations, InitializingBean 
 
 	private boolean cacheQueries = false;
 
+	@Nullable
 	private String queryCacheRegion;
 
 	private int fetchSize = 0;
@@ -142,7 +145,7 @@ public class HibernateTemplate implements HibernateOperations, InitializingBean 
 	 * Set the Hibernate SessionFactory that should be used to create
 	 * Hibernate Sessions.
 	 */
-	public void setSessionFactory(SessionFactory sessionFactory) {
+	public void setSessionFactory(@Nullable  SessionFactory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}
 
@@ -177,7 +180,7 @@ public class HibernateTemplate implements HibernateOperations, InitializingBean 
 	 * @see #enableFilters(Session)
 	 * @see Session#enableFilter(String)
 	 */
-	public void setFilterNames(String... filterNames) {
+	public void setFilterNames(@Nullable  String... filterNames) {
 		this.filterNames = filterNames;
 	}
 
@@ -267,7 +270,7 @@ public class HibernateTemplate implements HibernateOperations, InitializingBean 
 	 * @see org.hibernate.Query#setCacheRegion
 	 * @see Criteria#setCacheRegion
 	 */
-	public void setQueryCacheRegion(String queryCacheRegion) {
+	public void setQueryCacheRegion(@Nullable String queryCacheRegion) {
 		this.queryCacheRegion = queryCacheRegion;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate5/HibernateTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate5/HibernateTransactionManager.java
@@ -156,7 +156,7 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 	/**
 	 * Set the SessionFactory that this instance should manage transactions for.
 	 */
-	public void setSessionFactory(SessionFactory sessionFactory) {
+	public void setSessionFactory(@Nullable SessionFactory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}
 
@@ -202,8 +202,8 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 	 * @see DataSourceUtils
 	 * @see org.springframework.jdbc.core.JdbcTemplate
 	 */
-	public void setDataSource(DataSource dataSource) {
-		if (dataSource instanceof TransactionAwareDataSourceProxy) {
+	public void setDataSource(@Nullable DataSource dataSource) {
+		if (dataSource != null && dataSource instanceof TransactionAwareDataSourceProxy) {
 			// If we got a TransactionAwareDataSourceProxy, we need to perform transactions
 			// for its underlying target DataSource, else data access code won't see
 			// properly exposed transactions (i.e. transactions for the target DataSource).
@@ -319,7 +319,7 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 	 * HibernateTransactionManager.
 	 * @see LocalSessionFactoryBean#setEntityInterceptor
 	 */
-	public void setEntityInterceptor(Interceptor entityInterceptor) {
+	public void setEntityInterceptor(@Nullable Interceptor entityInterceptor) {
 		this.entityInterceptor = entityInterceptor;
 	}
 
@@ -837,7 +837,7 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 			return this.newSession;
 		}
 
-		public void setPreviousHoldability(Integer previousHoldability) {
+		public void setPreviousHoldability(@Nullable Integer previousHoldability) {
 			this.previousHoldability = previousHoldability;
 		}
 

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate5/SessionHolder.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate5/SessionHolder.java
@@ -57,7 +57,7 @@ public class SessionHolder extends ResourceHolderSupport {
 		return this.session;
 	}
 
-	public void setTransaction(Transaction transaction) {
+	public void setTransaction(@Nullable Transaction transaction) {
 		this.transaction = transaction;
 	}
 
@@ -66,7 +66,7 @@ public class SessionHolder extends ResourceHolderSupport {
 		return this.transaction;
 	}
 
-	public void setPreviousFlushMode(FlushMode previousFlushMode) {
+	public void setPreviousFlushMode(@Nullable FlushMode previousFlushMode) {
 		this.previousFlushMode = previousFlushMode;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate5/support/HibernateDaoSupport.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate5/support/HibernateDaoSupport.java
@@ -97,7 +97,7 @@ public abstract class HibernateDaoSupport extends DaoSupport {
 	 * as an alternative to specifying a SessionFactory.
 	 * @see #setSessionFactory
 	 */
-	public final void setHibernateTemplate(HibernateTemplate hibernateTemplate) {
+	public final void setHibernateTemplate(@Nullable HibernateTemplate hibernateTemplate) {
 		this.hibernateTemplate = hibernateTemplate;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/hibernate5/support/OpenSessionInterceptor.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate5/support/OpenSessionInterceptor.java
@@ -50,13 +50,14 @@ import org.springframework.util.Assert;
  */
 public class OpenSessionInterceptor implements MethodInterceptor, InitializingBean {
 
+	@Nullable
 	private SessionFactory sessionFactory;
 
 
 	/**
 	 * Set the Hibernate SessionFactory that should be used to create Hibernate Sessions.
 	 */
-	public void setSessionFactory(SessionFactory sessionFactory) {
+	public void setSessionFactory(@Nullable SessionFactory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/AbstractEntityManagerFactoryBean.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/AbstractEntityManagerFactoryBean.java
@@ -271,7 +271,7 @@ public abstract class AbstractEntityManagerFactoryBean implements
 	 * such as persistence provider class and JpaDialect, unless locally
 	 * overridden in this FactoryBean.
 	 */
-	public void setJpaVendorAdapter(JpaVendorAdapter jpaVendorAdapter) {
+	public void setJpaVendorAdapter(@Nullable JpaVendorAdapter jpaVendorAdapter) {
 		this.jpaVendorAdapter = jpaVendorAdapter;
 	}
 
@@ -296,7 +296,7 @@ public abstract class AbstractEntityManagerFactoryBean implements
 	 * in init methods of related beans, even for metadata introspection purposes.
 	 * @since 4.3
 	 */
-	public void setBootstrapExecutor(AsyncTaskExecutor bootstrapExecutor) {
+	public void setBootstrapExecutor(@Nullable AsyncTaskExecutor bootstrapExecutor) {
 		this.bootstrapExecutor = bootstrapExecutor;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryAccessor.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryAccessor.java
@@ -46,8 +46,10 @@ public abstract class EntityManagerFactoryAccessor implements BeanFactoryAware {
 	/** Logger available to subclasses */
 	protected final Log logger = LogFactory.getLog(getClass());
 
+	@Nullable
 	private EntityManagerFactory entityManagerFactory;
 
+	@Nullable
 	private String persistenceUnitName;
 
 	private final Map<String, Object> jpaPropertyMap = new HashMap<>();
@@ -59,7 +61,7 @@ public abstract class EntityManagerFactoryAccessor implements BeanFactoryAware {
 	 * @see javax.persistence.EntityManagerFactory#createEntityManager()
 	 * @see javax.persistence.EntityManagerFactory#createEntityManager(java.util.Map)
 	 */
-	public void setEntityManagerFactory(EntityManagerFactory emf) {
+	public void setEntityManagerFactory(@Nullable EntityManagerFactory emf) {
 		this.entityManagerFactory = emf;
 	}
 
@@ -92,7 +94,7 @@ public abstract class EntityManagerFactoryAccessor implements BeanFactoryAware {
 	 * be retrieved through finding a single unique bean of type EntityManagerFactory.
 	 * @see #setEntityManagerFactory
 	 */
-	public void setPersistenceUnitName(String persistenceUnitName) {
+	public void setPersistenceUnitName(@Nullable String persistenceUnitName) {
 		this.persistenceUnitName = persistenceUnitName;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerHolder.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerHolder.java
@@ -63,7 +63,7 @@ public class EntityManagerHolder extends ResourceHolderSupport {
 		return this.transactionActive;
 	}
 
-	protected void setSavepointManager(SavepointManager savepointManager) {
+	protected void setSavepointManager(@Nullable SavepointManager savepointManager) {
 		this.savepointManager = savepointManager;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
@@ -154,7 +154,7 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 	 * single unique bean of type EntityManagerFactory in the containing BeanFactory.
 	 * @see #setPersistenceUnitName
 	 */
-	public void setEntityManagerFactory(EntityManagerFactory emf) {
+	public void setEntityManagerFactory(@Nullable EntityManagerFactory emf) {
 		this.entityManagerFactory = emf;
 	}
 
@@ -186,7 +186,7 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 	 * be retrieved by finding a single unique bean of type EntityManagerFactory.
 	 * @see #setEntityManagerFactory
 	 */
-	public void setPersistenceUnitName(String persistenceUnitName) {
+	public void setPersistenceUnitName(@Nullable String persistenceUnitName) {
 		this.persistenceUnitName = persistenceUnitName;
 	}
 
@@ -254,8 +254,8 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 	 * @see org.springframework.jdbc.datasource.DataSourceUtils
 	 * @see org.springframework.jdbc.core.JdbcTemplate
 	 */
-	public void setDataSource(DataSource dataSource) {
-		if (dataSource instanceof TransactionAwareDataSourceProxy) {
+	public void setDataSource(@Nullable DataSource dataSource) {
+		if (dataSource != null && dataSource instanceof TransactionAwareDataSourceProxy) {
 			// If we got a TransactionAwareDataSourceProxy, we need to perform transactions
 			// for its underlying target DataSource, else data access code won't see
 			// properly exposed transactions (i.e. transactions for the target DataSource).

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/persistenceunit/DefaultPersistenceUnitManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/persistenceunit/DefaultPersistenceUnitManager.java
@@ -339,7 +339,7 @@ public class DefaultPersistenceUnitManager
 	 * none has been registered before.
 	 * @see javax.persistence.spi.PersistenceUnitInfo#getNonJtaDataSource()
 	 */
-	public void setDefaultDataSource(DataSource defaultDataSource) {
+	public void setDefaultDataSource(@Nullable DataSource defaultDataSource) {
 		this.defaultDataSource = defaultDataSource;
 	}
 
@@ -361,7 +361,7 @@ public class DefaultPersistenceUnitManager
 	 * none has been registered before.
 	 * @see javax.persistence.spi.PersistenceUnitInfo#getJtaDataSource()
 	 */
-	public void setDefaultJtaDataSource(DataSource defaultJtaDataSource) {
+	public void setDefaultJtaDataSource(@Nullable DataSource defaultJtaDataSource) {
 		this.defaultJtaDataSource = defaultJtaDataSource;
 	}
 
@@ -380,7 +380,7 @@ public class DefaultPersistenceUnitManager
 	 * <p>Such post-processors can, for example, register further entity classes and
 	 * jar files, in addition to the metadata read from {@code persistence.xml}.
 	 */
-	public void setPersistenceUnitPostProcessors(PersistenceUnitPostProcessor... postProcessors) {
+	public void setPersistenceUnitPostProcessors(@Nullable PersistenceUnitPostProcessor... postProcessors) {
 		this.persistenceUnitPostProcessors = postProcessors;
 	}
 
@@ -412,7 +412,7 @@ public class DefaultPersistenceUnitManager
 	 * @see org.springframework.instrument.classloading.ReflectiveLoadTimeWeaver
 	 */
 	@Override
-	public void setLoadTimeWeaver(LoadTimeWeaver loadTimeWeaver) {
+	public void setLoadTimeWeaver(@Nullable LoadTimeWeaver loadTimeWeaver) {
 		this.loadTimeWeaver = loadTimeWeaver;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/persistenceunit/MutablePersistenceUnitInfo.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/persistenceunit/MutablePersistenceUnitInfo.java
@@ -85,7 +85,7 @@ public class MutablePersistenceUnitInfo implements SmartPersistenceUnitInfo {
 	private String persistenceProviderPackageName;
 
 
-	public void setPersistenceUnitName(String persistenceUnitName) {
+	public void setPersistenceUnitName(@Nullable String persistenceUnitName) {
 		this.persistenceUnitName = persistenceUnitName;
 	}
 
@@ -95,7 +95,7 @@ public class MutablePersistenceUnitInfo implements SmartPersistenceUnitInfo {
 		return this.persistenceUnitName;
 	}
 
-	public void setPersistenceProviderClassName(String persistenceProviderClassName) {
+	public void setPersistenceProviderClassName(@Nullable String persistenceProviderClassName) {
 		this.persistenceProviderClassName = persistenceProviderClassName;
 	}
 
@@ -120,7 +120,7 @@ public class MutablePersistenceUnitInfo implements SmartPersistenceUnitInfo {
 		}
 	}
 
-	public void setJtaDataSource(DataSource jtaDataSource) {
+	public void setJtaDataSource(@Nullable DataSource jtaDataSource) {
 		this.jtaDataSource = jtaDataSource;
 	}
 
@@ -130,7 +130,7 @@ public class MutablePersistenceUnitInfo implements SmartPersistenceUnitInfo {
 		return this.jtaDataSource;
 	}
 
-	public void setNonJtaDataSource(DataSource nonJtaDataSource) {
+	public void setNonJtaDataSource(@Nullable DataSource nonJtaDataSource) {
 		this.nonJtaDataSource = nonJtaDataSource;
 	}
 
@@ -251,7 +251,7 @@ public class MutablePersistenceUnitInfo implements SmartPersistenceUnitInfo {
 	}
 
 	@Override
-	public void setPersistenceProviderPackageName(String persistenceProviderPackageName) {
+	public void setPersistenceProviderPackageName(@Nullable String persistenceProviderPackageName) {
 		this.persistenceProviderPackageName = persistenceProviderPackageName;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/support/OpenEntityManagerInViewFilter.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/support/OpenEntityManagerInViewFilter.java
@@ -92,7 +92,7 @@ public class OpenEntityManagerInViewFilter extends OncePerRequestFilter {
 	 * @see #setPersistenceUnitName
 	 * @see #DEFAULT_ENTITY_MANAGER_FACTORY_BEAN_NAME
 	 */
-	public void setEntityManagerFactoryBeanName(String entityManagerFactoryBeanName) {
+	public void setEntityManagerFactoryBeanName(@Nullable String entityManagerFactoryBeanName) {
 		this.entityManagerFactoryBeanName = entityManagerFactoryBeanName;
 	}
 
@@ -115,7 +115,7 @@ public class OpenEntityManagerInViewFilter extends OncePerRequestFilter {
 	 * @see #setEntityManagerFactoryBeanName
 	 * @see #DEFAULT_ENTITY_MANAGER_FACTORY_BEAN_NAME
 	 */
-	public void setPersistenceUnitName(String persistenceUnitName) {
+	public void setPersistenceUnitName(@Nullable String persistenceUnitName) {
 		this.persistenceUnitName = persistenceUnitName;
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/AbstractJpaVendorAdapter.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/AbstractJpaVendorAdapter.java
@@ -47,7 +47,7 @@ public abstract class AbstractJpaVendorAdapter implements JpaVendorAdapter {
 	 * Specify the target database to operate on, as a value of the {@code Database} enum:
 	 * DB2, DERBY, H2, HSQL, INFORMIX, MYSQL, ORACLE, POSTGRESQL, SQL_SERVER, SYBASE
 	 */
-	public void setDatabase(Database database) {
+	public void setDatabase(@Nullable Database database) {
 		this.database = database;
 	}
 
@@ -63,7 +63,7 @@ public abstract class AbstractJpaVendorAdapter implements JpaVendorAdapter {
 	 * Specify the name of the target database to operate on.
 	 * The supported values are vendor-dependent platform identifiers.
 	 */
-	public void setDatabasePlatform(String databasePlatform) {
+	public void setDatabasePlatform(@Nullable String databasePlatform) {
 		this.databasePlatform = databasePlatform;
 	}
 

--- a/spring-oxm/src/main/java/org/springframework/oxm/jaxb/Jaxb2Marshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/jaxb/Jaxb2Marshaller.java
@@ -210,8 +210,7 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 	 * <p>Setting either this property, {@link #setClassesToBeBound "classesToBeBound"}
 	 * or {@link #setPackagesToScan "packagesToScan"} is required.
 	 */
-	public void setContextPath(String contextPath) {
-		Assert.hasText(contextPath, "'contextPath' must not be null");
+	public void setContextPath(@Nullable String contextPath) {
 		this.contextPath = contextPath;
 	}
 
@@ -228,8 +227,7 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 	 * <p>Setting either this property, {@link #setContextPath "contextPath"}
 	 * or {@link #setPackagesToScan "packagesToScan"} is required.
 	 */
-	public void setClassesToBeBound(Class<?>... classesToBeBound) {
-		Assert.notEmpty(classesToBeBound, "'classesToBeBound' must not be empty");
+	public void setClassesToBeBound(@Nullable Class<?>... classesToBeBound) {
 		this.classesToBeBound = classesToBeBound;
 	}
 
@@ -248,7 +246,7 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 	 * <p>Setting either this property, {@link #setContextPath "contextPath"}
 	 * or {@link #setClassesToBeBound "classesToBeBound"} is required.
 	 */
-	public void setPackagesToScan(String... packagesToScan) {
+	public void setPackagesToScan(@Nullable String... packagesToScan) {
 		this.packagesToScan = packagesToScan;
 	}
 

--- a/spring-oxm/src/main/java/org/springframework/oxm/support/MarshallingSource.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/support/MarshallingSource.java
@@ -108,14 +108,19 @@ public class MarshallingSource extends SAXSource {
 
 		private final Object content;
 
+		@Nullable
 		private DTDHandler dtdHandler;
 
+		@Nullable
 		private ContentHandler contentHandler;
 
+		@Nullable
 		private EntityResolver entityResolver;
 
+		@Nullable
 		private ErrorHandler errorHandler;
 
+		@Nullable
 		private LexicalHandler lexicalHandler;
 
 		private MarshallingXMLReader(Marshaller marshaller, Object content) {
@@ -126,7 +131,7 @@ public class MarshallingSource extends SAXSource {
 		}
 
 		@Override
-		public void setContentHandler(ContentHandler contentHandler) {
+		public void setContentHandler(@Nullable ContentHandler contentHandler) {
 			this.contentHandler = contentHandler;
 		}
 
@@ -137,7 +142,7 @@ public class MarshallingSource extends SAXSource {
 		}
 
 		@Override
-		public void setDTDHandler(DTDHandler dtdHandler) {
+		public void setDTDHandler(@Nullable DTDHandler dtdHandler) {
 			this.dtdHandler = dtdHandler;
 		}
 
@@ -148,7 +153,7 @@ public class MarshallingSource extends SAXSource {
 		}
 
 		@Override
-		public void setEntityResolver(EntityResolver entityResolver) {
+		public void setEntityResolver(@Nullable EntityResolver entityResolver) {
 			this.entityResolver = entityResolver;
 		}
 
@@ -159,7 +164,7 @@ public class MarshallingSource extends SAXSource {
 		}
 
 		@Override
-		public void setErrorHandler(ErrorHandler errorHandler) {
+		public void setErrorHandler(@Nullable ErrorHandler errorHandler) {
 			this.errorHandler = errorHandler;
 		}
 
@@ -169,6 +174,7 @@ public class MarshallingSource extends SAXSource {
 			return this.errorHandler;
 		}
 
+		@Nullable
 		protected LexicalHandler getLexicalHandler() {
 			return this.lexicalHandler;
 		}
@@ -184,6 +190,7 @@ public class MarshallingSource extends SAXSource {
 		}
 
 		@Override
+		@Nullable
 		public Object getProperty(String name) throws SAXNotRecognizedException {
 			if ("http://xml.org/sax/properties/lexical-handler".equals(name)) {
 				return lexicalHandler;

--- a/spring-test/src/main/java/org/springframework/mock/web/HeaderValueHolder.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/HeaderValueHolder.java
@@ -39,9 +39,11 @@ class HeaderValueHolder {
 	private final List<Object> values = new LinkedList<>();
 
 
-	public void setValue(Object value) {
+	public void setValue(@Nullable Object value) {
 		this.values.clear();
-		this.values.add(value);
+		if (value != null) {
+			this.values.add(value);
+		}
 	}
 
 	public void addValue(Object value) {

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -917,7 +917,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		return this.asyncSupported;
 	}
 
-	public void setAsyncContext(MockAsyncContext asyncContext) {
+	public void setAsyncContext(@Nullable MockAsyncContext asyncContext) {
 		this.asyncContext = asyncContext;
 	}
 
@@ -941,7 +941,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	// HttpServletRequest interface
 	// ---------------------------------------------------------------------
 
-	public void setAuthType(String authType) {
+	public void setAuthType(@Nullable String authType) {
 		this.authType = authType;
 	}
 
@@ -1102,7 +1102,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		}
 	}
 
-	public void setMethod(String method) {
+	public void setMethod(@Nullable String method) {
 		this.method = method;
 	}
 
@@ -1167,7 +1167,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 				((MockServletContext) this.servletContext).getDeclaredRoles().contains(role)));
 	}
 
-	public void setUserPrincipal(Principal userPrincipal) {
+	public void setUserPrincipal(@Nullable Principal userPrincipal) {
 		this.userPrincipal = userPrincipal;
 	}
 
@@ -1177,7 +1177,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		return this.userPrincipal;
 	}
 
-	public void setRequestedSessionId(String requestedSessionId) {
+	public void setRequestedSessionId(@Nullable String requestedSessionId) {
 		this.requestedSessionId = requestedSessionId;
 	}
 
@@ -1187,7 +1187,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		return this.requestedSessionId;
 	}
 
-	public void setRequestURI(String requestURI) {
+	public void setRequestURI(@Nullable String requestURI) {
 		this.requestURI = requestURI;
 	}
 

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -642,7 +642,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 	// Methods for MockRequestDispatcher
 	//---------------------------------------------------------------------
 
-	public void setForwardedUrl(String forwardedUrl) {
+	public void setForwardedUrl(@Nullable String forwardedUrl) {
 		this.forwardedUrl = forwardedUrl;
 	}
 

--- a/spring-test/src/main/java/org/springframework/mock/web/MockServletContext.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockServletContext.java
@@ -582,7 +582,7 @@ public class MockServletContext implements ServletContext {
 	}
 
 	// @Override - but only against Servlet 4.0
-	public void setRequestCharacterEncoding(String requestCharacterEncoding) {
+	public void setRequestCharacterEncoding(@Nullable String requestCharacterEncoding) {
 		this.requestCharacterEncoding = requestCharacterEncoding;
 	}
 
@@ -593,7 +593,7 @@ public class MockServletContext implements ServletContext {
 	}
 
 	// @Override - but only against Servlet 4.0
-	public void setResponseCharacterEncoding(String responseCharacterEncoding) {
+	public void setResponseCharacterEncoding(@Nullable String responseCharacterEncoding) {
 		this.responseCharacterEncoding = responseCharacterEncoding;
 	}
 

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/DefaultMvcResult.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/DefaultMvcResult.java
@@ -76,7 +76,7 @@ class DefaultMvcResult implements MvcResult {
 		return this.mockResponse;
 	}
 
-	public void setHandler(Object handler) {
+	public void setHandler(@Nullable Object handler) {
 		this.handler = handler;
 	}
 

--- a/spring-tx/src/main/java/org/springframework/jca/cci/connection/CciLocalTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/jca/cci/connection/CciLocalTransactionManager.java
@@ -92,7 +92,7 @@ public class CciLocalTransactionManager extends AbstractPlatformTransactionManag
 	 * Set the CCI ConnectionFactory that this instance should manage local
 	 * transactions for.
 	 */
-	public void setConnectionFactory(ConnectionFactory cf) {
+	public void setConnectionFactory(@Nullable ConnectionFactory cf) {
 		if (cf instanceof TransactionAwareConnectionFactoryProxy) {
 			// If we got a TransactionAwareConnectionFactoryProxy, we need to perform transactions
 			// for its underlying target ConnectionFactory, else JMS access code won't see

--- a/spring-tx/src/main/java/org/springframework/jca/cci/connection/DelegatingConnectionFactory.java
+++ b/spring-tx/src/main/java/org/springframework/jca/cci/connection/DelegatingConnectionFactory.java
@@ -44,13 +44,14 @@ import org.springframework.util.Assert;
 @SuppressWarnings("serial")
 public class DelegatingConnectionFactory implements ConnectionFactory, InitializingBean {
 
+	@Nullable
 	private ConnectionFactory targetConnectionFactory;
 
 
 	/**
 	 * Set the target ConnectionFactory that this ConnectionFactory should delegate to.
 	 */
-	public void setTargetConnectionFactory(ConnectionFactory targetConnectionFactory) {
+	public void setTargetConnectionFactory(@Nullable ConnectionFactory targetConnectionFactory) {
 		this.targetConnectionFactory = targetConnectionFactory;
 	}
 

--- a/spring-tx/src/main/java/org/springframework/jca/cci/core/CciTemplate.java
+++ b/spring-tx/src/main/java/org/springframework/jca/cci/core/CciTemplate.java
@@ -119,7 +119,7 @@ public class CciTemplate implements CciOperations {
 	/**
 	 * Set the CCI ConnectionFactory to obtain Connections from.
 	 */
-	public void setConnectionFactory(ConnectionFactory connectionFactory) {
+	public void setConnectionFactory(@Nullable ConnectionFactory connectionFactory) {
 		this.connectionFactory = connectionFactory;
 	}
 
@@ -141,7 +141,7 @@ public class CciTemplate implements CciOperations {
 	 * Set the CCI ConnectionSpec that this template instance is
 	 * supposed to obtain Connections for.
 	 */
-	public void setConnectionSpec(ConnectionSpec connectionSpec) {
+	public void setConnectionSpec(@Nullable ConnectionSpec connectionSpec) {
 		this.connectionSpec = connectionSpec;
 	}
 
@@ -165,7 +165,7 @@ public class CciTemplate implements CciOperations {
 	 * @see javax.resource.cci.Interaction#execute(javax.resource.cci.InteractionSpec, Record)
 	 * @see javax.resource.cci.Interaction#execute(javax.resource.cci.InteractionSpec, Record, Record)
 	 */
-	public void setOutputRecordCreator(RecordCreator creator) {
+	public void setOutputRecordCreator(@Nullable RecordCreator creator) {
 		this.outputRecordCreator = creator;
 	}
 

--- a/spring-tx/src/main/java/org/springframework/jca/cci/object/EisOperation.java
+++ b/spring-tx/src/main/java/org/springframework/jca/cci/object/EisOperation.java
@@ -71,7 +71,7 @@ public abstract class EisOperation implements InitializingBean {
 	/**
 	 * Set the CCI InteractionSpec for this operation.
 	 */
-	public void setInteractionSpec(InteractionSpec interactionSpec) {
+	public void setInteractionSpec(@Nullable InteractionSpec interactionSpec) {
 		this.interactionSpec = interactionSpec;
 	}
 

--- a/spring-tx/src/main/java/org/springframework/jca/endpoint/GenericMessageEndpointManager.java
+++ b/spring-tx/src/main/java/org/springframework/jca/endpoint/GenericMessageEndpointManager.java
@@ -148,10 +148,13 @@ import org.springframework.util.Assert;
  */
 public class GenericMessageEndpointManager implements SmartLifecycle, InitializingBean, DisposableBean {
 
+	@Nullable
 	private ResourceAdapter resourceAdapter;
 
+	@Nullable
 	private MessageEndpointFactory messageEndpointFactory;
 
+	@Nullable
 	private ActivationSpec activationSpec;
 
 	private boolean autoStartup = true;
@@ -166,7 +169,7 @@ public class GenericMessageEndpointManager implements SmartLifecycle, Initializi
 	/**
 	 * Set the JCA ResourceAdapter to manage endpoints for.
 	 */
-	public void setResourceAdapter(ResourceAdapter resourceAdapter) {
+	public void setResourceAdapter(@Nullable ResourceAdapter resourceAdapter) {
 		this.resourceAdapter = resourceAdapter;
 	}
 
@@ -186,7 +189,7 @@ public class GenericMessageEndpointManager implements SmartLifecycle, Initializi
 	 * with different {@link #setActivationSpec ActivationSpec} objects applied.
 	 * @see GenericMessageEndpointFactory#setMessageListener
 	 */
-	public void setMessageEndpointFactory(MessageEndpointFactory messageEndpointFactory) {
+	public void setMessageEndpointFactory(@Nullable MessageEndpointFactory messageEndpointFactory) {
 		this.messageEndpointFactory = messageEndpointFactory;
 	}
 
@@ -203,7 +206,7 @@ public class GenericMessageEndpointManager implements SmartLifecycle, Initializi
 	 * <p>Note that this ActivationSpec instance should not be shared
 	 * across multiple ResourceAdapter instances.
 	 */
-	public void setActivationSpec(ActivationSpec activationSpec) {
+	public void setActivationSpec(@Nullable ActivationSpec activationSpec) {
 		this.activationSpec = activationSpec;
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/DefaultTransactionAttribute.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/DefaultTransactionAttribute.java
@@ -100,7 +100,7 @@ public class DefaultTransactionAttribute extends DefaultTransactionDefinition im
 	 * e.g. indicating where the attribute is applying.
 	 * @since 4.3.4
 	 */
-	public void setDescriptor(String descriptor) {
+	public void setDescriptor(@Nullable String descriptor) {
 		this.descriptor = descriptor;
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
@@ -148,7 +148,7 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 	/**
 	 * Specify the name of the default transaction manager bean.
 	 */
-	public void setTransactionManagerBeanName(String transactionManagerBeanName) {
+	public void setTransactionManagerBeanName(@Nullable String transactionManagerBeanName) {
 		this.transactionManagerBeanName = transactionManagerBeanName;
 	}
 
@@ -167,7 +167,7 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 	 * default transaction manager bean has not been specified.
 	 * @see #setTransactionManagerBeanName
 	 */
-	public void setTransactionManager(PlatformTransactionManager transactionManager) {
+	public void setTransactionManager(@Nullable PlatformTransactionManager transactionManager) {
 		this.transactionManager = transactionManager;
 	}
 
@@ -218,7 +218,7 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 	 * @see NameMatchTransactionAttributeSource
 	 * @see org.springframework.transaction.annotation.AnnotationTransactionAttributeSource
 	 */
-	public void setTransactionAttributeSource(TransactionAttributeSource transactionAttributeSource) {
+	public void setTransactionAttributeSource(@Nullable TransactionAttributeSource transactionAttributeSource) {
 		this.transactionAttributeSource = transactionAttributeSource;
 	}
 
@@ -234,7 +234,7 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 	 * Set the BeanFactory to use for retrieving PlatformTransactionManager beans.
 	 */
 	@Override
-	public void setBeanFactory(BeanFactory beanFactory) {
+	public void setBeanFactory(@Nullable BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/jta/JtaTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/jta/JtaTransactionManager.java
@@ -249,7 +249,7 @@ public class JtaTransactionManager extends AbstractPlatformTransactionManager
 	 * Creates a JndiTemplate with the given environment settings.
 	 * @see #setJndiTemplate
 	 */
-	public void setJndiEnvironment(Properties jndiEnvironment) {
+	public void setJndiEnvironment(@Nullable Properties jndiEnvironment) {
 		this.jndiTemplate = new JndiTemplate(jndiEnvironment);
 	}
 
@@ -269,7 +269,7 @@ public class JtaTransactionManager extends AbstractPlatformTransactionManager
 	 * @see #setUserTransactionName
 	 * @see #setAutodetectUserTransaction
 	 */
-	public void setUserTransaction(UserTransaction userTransaction) {
+	public void setUserTransaction(@Nullable UserTransaction userTransaction) {
 		this.userTransaction = userTransaction;
 	}
 
@@ -333,7 +333,7 @@ public class JtaTransactionManager extends AbstractPlatformTransactionManager
 	 * @see #setTransactionManagerName
 	 * @see #setAutodetectTransactionManager
 	 */
-	public void setTransactionManager(TransactionManager transactionManager) {
+	public void setTransactionManager(@Nullable TransactionManager transactionManager) {
 		this.transactionManager = transactionManager;
 	}
 
@@ -386,7 +386,7 @@ public class JtaTransactionManager extends AbstractPlatformTransactionManager
 	 * @see #setTransactionSynchronizationRegistryName
 	 * @see #setAutodetectTransactionSynchronizationRegistry
 	 */
-	public void setTransactionSynchronizationRegistry(TransactionSynchronizationRegistry transactionSynchronizationRegistry) {
+	public void setTransactionSynchronizationRegistry(@Nullable TransactionSynchronizationRegistry transactionSynchronizationRegistry) {
 		this.transactionSynchronizationRegistry = transactionSynchronizationRegistry;
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/support/TransactionTemplate.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/TransactionTemplate.java
@@ -105,7 +105,7 @@ public class TransactionTemplate extends DefaultTransactionDefinition
 	/**
 	 * Set the transaction management strategy to be used.
 	 */
-	public void setTransactionManager(PlatformTransactionManager transactionManager) {
+	public void setTransactionManager(@Nullable PlatformTransactionManager transactionManager) {
 		this.transactionManager = transactionManager;
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -555,7 +555,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the (new) value of the {@code Access-Control-Allow-Origin} response header.
 	 */
-	public void setAccessControlAllowOrigin(String allowedOrigin) {
+	public void setAccessControlAllowOrigin(@Nullable String allowedOrigin) {
 		set(ACCESS_CONTROL_ALLOW_ORIGIN, allowedOrigin);
 	}
 
@@ -614,8 +614,8 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the (new) value of the {@code Access-Control-Request-Method} request header.
 	 */
-	public void setAccessControlRequestMethod(HttpMethod requestMethod) {
-		set(ACCESS_CONTROL_REQUEST_METHOD, requestMethod.name());
+	public void setAccessControlRequestMethod(@Nullable HttpMethod requestMethod) {
+		set(ACCESS_CONTROL_REQUEST_METHOD, (requestMethod != null ? requestMethod.name() : null));
 	}
 
 	/**
@@ -705,7 +705,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the (new) value of the {@code Cache-Control} header.
 	 */
-	public void setCacheControl(String cacheControl) {
+	public void setCacheControl(@Nullable String cacheControl) {
 		set(CACHE_CONTROL, cacheControl);
 	}
 
@@ -811,9 +811,8 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 * to set multiple content languages.</p>
 	 * @since 5.0
 	 */
-	public void setContentLanguage(Locale locale) {
-		Assert.notNull(locale, "'locale' must not be null");
-		set(CONTENT_LANGUAGE, locale.toLanguageTag());
+	public void setContentLanguage(@Nullable Locale locale) {
+		set(CONTENT_LANGUAGE, (locale != null ? locale.toLanguageTag() : null));
 	}
 
 	/**
@@ -855,10 +854,15 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 * Set the {@linkplain MediaType media type} of the body,
 	 * as specified by the {@code Content-Type} header.
 	 */
-	public void setContentType(MediaType mediaType) {
-		Assert.isTrue(!mediaType.isWildcardType(), "'Content-Type' cannot contain wildcard type '*'");
-		Assert.isTrue(!mediaType.isWildcardSubtype(), "'Content-Type' cannot contain wildcard subtype '*'");
-		set(CONTENT_TYPE, mediaType.toString());
+	public void setContentType(@Nullable MediaType mediaType) {
+		if (mediaType != null) {
+			Assert.isTrue(!mediaType.isWildcardType(), "'Content-Type' cannot contain wildcard type '*'");
+			Assert.isTrue(!mediaType.isWildcardSubtype(), "'Content-Type' cannot contain wildcard subtype '*'");
+			set(CONTENT_TYPE, mediaType.toString());
+		}
+		else {
+			set(CONTENT_TYPE, null);
+		}
 	}
 
 	/**
@@ -896,10 +900,12 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the (new) entity tag of the body, as specified by the {@code ETag} header.
 	 */
-	public void setETag(String etag) {
-		Assert.isTrue(etag.startsWith("\"") || etag.startsWith("W/"),
-				"Invalid ETag: does not start with W/ or \"");
-		Assert.isTrue(etag.endsWith("\""), "Invalid ETag: does not end with \"");
+	public void setETag(@Nullable String etag) {
+		if (etag != null) {
+			Assert.isTrue(etag.startsWith("\"") || etag.startsWith("W/"),
+					"Invalid ETag: does not start with W/ or \"");
+			Assert.isTrue(etag.endsWith("\""), "Invalid ETag: does not end with \"");
+		}
 		set(ETAG, etag);
 	}
 
@@ -939,10 +945,15 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 * {@linkplain InetSocketAddress#getHostString() hostname}.
 	 * @since 5.0
 	 */
-	public void setHost(InetSocketAddress host) {
-		String value = (host.getPort() != 0 ?
-				String.format("%s:%d", host.getHostString(), host.getPort()) : host.getHostString());
-		set(HOST, value);
+	public void setHost(@Nullable InetSocketAddress host) {
+		if (host != null) {
+			String value = (host.getPort() != 0 ?
+					String.format("%s:%d", host.getHostString(), host.getPort()) : host.getHostString());
+			set(HOST, value);
+		}
+		else {
+			set(HOST, null);
+		}
 	}
 
 	/**
@@ -1086,8 +1097,8 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 * Set the (new) location of a resource,
 	 * as specified by the {@code Location} header.
 	 */
-	public void setLocation(URI location) {
-		set(LOCATION, location.toASCIIString());
+	public void setLocation(@Nullable URI location) {
+		set(LOCATION, (location != null ? location.toASCIIString() : null));
 	}
 
 	/**
@@ -1104,7 +1115,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the (new) value of the {@code Origin} header.
 	 */
-	public void setOrigin(String origin) {
+	public void setOrigin(@Nullable String origin) {
 		set(ORIGIN, origin);
 	}
 
@@ -1119,7 +1130,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the (new) value of the {@code Pragma} header.
 	 */
-	public void setPragma(String pragma) {
+	public void setPragma(@Nullable String pragma) {
 		set(PRAGMA, pragma);
 	}
 
@@ -1151,7 +1162,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the (new) value of the {@code Upgrade} header.
 	 */
-	public void setUpgrade(String upgrade) {
+	public void setUpgrade(@Nullable String upgrade) {
 		set(UPGRADE, upgrade);
 	}
 
@@ -1428,7 +1439,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 * @see #add(String, String)
 	 */
 	@Override
-	public void set(String headerName, String headerValue) {
+	public void set(String headerName, @Nullable String headerValue) {
 		List<String> headerValues = new LinkedList<>();
 		headerValues.add(headerValue);
 		this.headers.put(headerName, headerValues);

--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsAsyncClientHttpRequestFactory.java
@@ -117,8 +117,7 @@ public class HttpComponentsAsyncClientHttpRequestFactory extends HttpComponentsC
 	 * @since 4.3.10
 	 * @see #setHttpClient(HttpClient)
 	 */
-	public void setAsyncClient(HttpAsyncClient asyncClient) {
-		Assert.notNull(asyncClient, "HttpAsyncClient must not be null");
+	public void setAsyncClient(@Nullable HttpAsyncClient asyncClient) {
 		this.asyncClient = asyncClient;
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactory.java
@@ -90,8 +90,7 @@ public class HttpComponentsClientHttpRequestFactory implements ClientHttpRequest
 	 * Set the {@code HttpClient} used for
 	 * {@linkplain #createRequest(URI, HttpMethod) synchronous execution}.
 	 */
-	public void setHttpClient(HttpClient httpClient) {
-		Assert.notNull(httpClient, "HttpClient must not be null");
+	public void setHttpClient(@Nullable HttpClient httpClient) {
 		this.httpClient = httpClient;
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/codec/AbstractCodecConfigurer.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/AbstractCodecConfigurer.java
@@ -138,7 +138,7 @@ abstract class AbstractCodecConfigurer implements CodecConfigurer {
 		/**
 		 * Access to custom codecs for sub-classes, e.g. for multipart writers.
 		 */
-		public void setCustomCodecs(DefaultCustomCodecs customCodecs) {
+		public void setCustomCodecs(@Nullable DefaultCustomCodecs customCodecs) {
 			this.customCodecs = customCodecs;
 		}
 

--- a/spring-web/src/main/java/org/springframework/http/converter/AbstractHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/AbstractHttpMessageConverter.java
@@ -110,7 +110,7 @@ public abstract class AbstractHttpMessageConverter<T> implements HttpMessageConv
 	 * Set the default character set, if any.
 	 * @since 4.3
 	 */
-	public void setDefaultCharset(Charset defaultCharset) {
+	public void setDefaultCharset(@Nullable Charset defaultCharset) {
 		this.defaultCharset = defaultCharset;
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/converter/BufferedImageHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/BufferedImageHttpMessageConverter.java
@@ -99,12 +99,13 @@ public class BufferedImageHttpMessageConverter implements HttpMessageConverter<B
 	 * Sets the default {@code Content-Type} to be used for writing.
 	 * @throws IllegalArgumentException if the given content type is not supported by the Java Image I/O API
 	 */
-	public void setDefaultContentType(MediaType defaultContentType) {
-		Assert.notNull(defaultContentType, "'contentType' must not be null");
-		Iterator<ImageWriter> imageWriters = ImageIO.getImageWritersByMIMEType(defaultContentType.toString());
-		if (!imageWriters.hasNext()) {
-			throw new IllegalArgumentException(
-					"Content-Type [" + defaultContentType + "] is not supported by the Java Image I/O API");
+	public void setDefaultContentType(@Nullable MediaType defaultContentType) {
+		if (defaultContentType!= null) {
+			Iterator<ImageWriter> imageWriters = ImageIO.getImageWritersByMIMEType(defaultContentType.toString());
+			if (!imageWriters.hasNext()) {
+				throw new IllegalArgumentException(
+						"Content-Type [" + defaultContentType + "] is not supported by the Java Image I/O API");
+			}
 		}
 
 		this.defaultContentType = defaultContentType;

--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -93,6 +93,7 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 	}
 
 	protected void init(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		this.objectMapper = objectMapper;
 		setDefaultCharset(DEFAULT_CHARSET);
 		DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
@@ -121,7 +122,6 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 	/**
 	 * Return the underlying {@code ObjectMapper} for this view.
 	 */
-	@Nullable
 	public ObjectMapper getObjectMapper() {
 		return this.objectMapper;
 	}

--- a/spring-web/src/main/java/org/springframework/http/converter/json/MappingJacksonInputMessage.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/MappingJacksonInputMessage.java
@@ -61,7 +61,7 @@ public class MappingJacksonInputMessage implements HttpInputMessage {
 		return this.headers;
 	}
 
-	public void setDeserializationView(Class<?> deserializationView) {
+	public void setDeserializationView(@Nullable Class<?> deserializationView) {
 		this.deserializationView = deserializationView;
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/converter/json/MappingJacksonValue.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/MappingJacksonValue.java
@@ -39,10 +39,13 @@ public class MappingJacksonValue {
 
 	private Object value;
 
+	@Nullable
 	private Class<?> serializationView;
 
+	@Nullable
 	private FilterProvider filters;
 
+	@Nullable
 	private String jsonpFunction;
 
 
@@ -74,7 +77,7 @@ public class MappingJacksonValue {
 	 * @see com.fasterxml.jackson.databind.ObjectMapper#writerWithView(Class)
 	 * @see com.fasterxml.jackson.annotation.JsonView
 	 */
-	public void setSerializationView(Class<?> serializationView) {
+	public void setSerializationView(@Nullable Class<?> serializationView) {
 		this.serializationView = serializationView;
 	}
 
@@ -95,7 +98,7 @@ public class MappingJacksonValue {
 	 * @see com.fasterxml.jackson.annotation.JsonFilter
 	 * @see Jackson2ObjectMapperBuilder#filters(FilterProvider)
 	 */
-	public void setFilters(FilterProvider filters) {
+	public void setFilters(@Nullable FilterProvider filters) {
 		this.filters = filters;
 	}
 
@@ -113,7 +116,7 @@ public class MappingJacksonValue {
 	/**
 	 * Set the name of the JSONP function name.
 	 */
-	public void setJsonpFunction(String functionName) {
+	public void setJsonpFunction(@Nullable String functionName) {
 		this.jsonpFunction = functionName;
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractServerHttpResponse.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 
 /**
  * Base class for {@link ServerHttpResponse} implementations.
@@ -91,11 +92,10 @@ public abstract class AbstractServerHttpResponse implements ServerHttpResponse {
 	}
 
 	@Override
-	public boolean setStatusCode(HttpStatus statusCode) {
-		Assert.notNull(statusCode, "Status code must not be null");
+	public boolean setStatusCode(@Nullable HttpStatus statusCode) {
 		if (this.state.get() == State.COMMITTED) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("Can't set the status " + statusCode.toString() +
+				logger.debug("Can't set the status " + (statusCode != null ? statusCode.toString() : "null") +
 						" because the HTTP response has already been committed");
 			}
 			return false;

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpResponse.java
@@ -39,7 +39,7 @@ public interface ServerHttpResponse extends ReactiveHttpOutputMessage {
 	 * @return {@code false} if the status code has not been set because the HTTP response
 	 * is already committed, {@code true} if it has been set correctly.
 	 */
-	boolean setStatusCode(HttpStatus status);
+	boolean setStatusCode(@Nullable HttpStatus status);
 
 	/**
 	 * Return the HTTP status code or {@code null} if not set.

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpResponseDecorator.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpResponseDecorator.java
@@ -26,6 +26,7 @@ import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.MultiValueMap;
 
@@ -55,7 +56,7 @@ public class ServerHttpResponseDecorator implements ServerHttpResponse {
 	// ServerHttpResponse delegation methods...
 
 	@Override
-	public boolean setStatusCode(HttpStatus status) {
+	public boolean setStatusCode(@Nullable HttpStatus status) {
 		return getDelegate().setStatusCode(status);
 	}
 

--- a/spring-web/src/main/java/org/springframework/remoting/httpinvoker/HttpInvokerClientInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/remoting/httpinvoker/HttpInvokerClientInterceptor.java
@@ -92,7 +92,7 @@ public class HttpInvokerClientInterceptor extends RemoteInvocationBasedAccessor
 	 * @see org.springframework.remoting.rmi.CodebaseAwareObjectInputStream
 	 * @see java.rmi.server.RMIClassLoader
 	 */
-	public void setCodebaseUrl(String codebaseUrl) {
+	public void setCodebaseUrl(@Nullable String codebaseUrl) {
 		this.codebaseUrl = codebaseUrl;
 	}
 

--- a/spring-web/src/main/java/org/springframework/remoting/jaxws/JaxWsPortClientInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/remoting/jaxws/JaxWsPortClientInterceptor.java
@@ -119,7 +119,7 @@ public class JaxWsPortClientInterceptor extends LocalJaxWsServiceFactory
 	 * @see #setServiceName
 	 * @see org.springframework.jndi.JndiObjectFactoryBean
 	 */
-	public void setJaxWsService(Service jaxWsService) {
+	public void setJaxWsService(@Nullable Service jaxWsService) {
 		this.jaxWsService = jaxWsService;
 	}
 
@@ -135,7 +135,7 @@ public class JaxWsPortClientInterceptor extends LocalJaxWsServiceFactory
 	 * Set the name of the port.
 	 * Corresponds to the "wsdl:port" name.
 	 */
-	public void setPortName(String portName) {
+	public void setPortName(@Nullable String portName) {
 		this.portName = portName;
 	}
 
@@ -151,7 +151,7 @@ public class JaxWsPortClientInterceptor extends LocalJaxWsServiceFactory
 	 * Set the username to specify on the stub.
 	 * @see javax.xml.ws.BindingProvider#USERNAME_PROPERTY
 	 */
-	public void setUsername(String username) {
+	public void setUsername(@Nullable String username) {
 		this.username = username;
 	}
 
@@ -167,7 +167,7 @@ public class JaxWsPortClientInterceptor extends LocalJaxWsServiceFactory
 	 * Set the password to specify on the stub.
 	 * @see javax.xml.ws.BindingProvider#PASSWORD_PROPERTY
 	 */
-	public void setPassword(String password) {
+	public void setPassword(@Nullable String password) {
 		this.password = password;
 	}
 
@@ -183,7 +183,7 @@ public class JaxWsPortClientInterceptor extends LocalJaxWsServiceFactory
 	 * Set the endpoint address to specify on the stub.
 	 * @see javax.xml.ws.BindingProvider#ENDPOINT_ADDRESS_PROPERTY
 	 */
-	public void setEndpointAddress(String endpointAddress) {
+	public void setEndpointAddress(@Nullable String endpointAddress) {
 		this.endpointAddress = endpointAddress;
 	}
 
@@ -229,7 +229,7 @@ public class JaxWsPortClientInterceptor extends LocalJaxWsServiceFactory
 	 * Set the SOAP action URI to specify on the stub.
 	 * @see javax.xml.ws.BindingProvider#SOAPACTION_URI_PROPERTY
 	 */
-	public void setSoapActionUri(String soapActionUri) {
+	public void setSoapActionUri(@Nullable String soapActionUri) {
 		this.soapActionUri = soapActionUri;
 	}
 
@@ -289,9 +289,10 @@ public class JaxWsPortClientInterceptor extends LocalJaxWsServiceFactory
 	/**
 	 * Set the interface of the service that this factory should create a proxy for.
 	 */
-	public void setServiceInterface(Class<?> serviceInterface) {
-		Assert.notNull(serviceInterface, "'serviceInterface' must not be null");
-		Assert.isTrue(serviceInterface.isInterface(), "'serviceInterface' must be an interface");
+	public void setServiceInterface(@Nullable Class<?> serviceInterface) {
+		if (serviceInterface != null) {
+			Assert.isTrue(serviceInterface.isInterface(), "'serviceInterface' must be an interface");
+		}
 		this.serviceInterface = serviceInterface;
 	}
 
@@ -318,7 +319,7 @@ public class JaxWsPortClientInterceptor extends LocalJaxWsServiceFactory
 	 * building a client proxy in the {@link JaxWsPortProxyFactoryBean} subclass.
 	 */
 	@Override
-	public void setBeanClassLoader(ClassLoader classLoader) {
+	public void setBeanClassLoader(@Nullable ClassLoader classLoader) {
 		this.beanClassLoader = classLoader;
 	}
 

--- a/spring-web/src/main/java/org/springframework/remoting/jaxws/LocalJaxWsServiceFactory.java
+++ b/spring-web/src/main/java/org/springframework/remoting/jaxws/LocalJaxWsServiceFactory.java
@@ -67,7 +67,7 @@ public class LocalJaxWsServiceFactory {
 	 * Set the URL of the WSDL document that describes the service.
 	 * @see #setWsdlDocumentResource(Resource)
 	 */
-	public void setWsdlDocumentUrl(URL wsdlDocumentUrl) {
+	public void setWsdlDocumentUrl(@Nullable URL wsdlDocumentUrl) {
 		this.wsdlDocumentUrl = wsdlDocumentUrl;
 	}
 
@@ -109,7 +109,7 @@ public class LocalJaxWsServiceFactory {
 	 * Set the name of the service to look up.
 	 * Corresponds to the "wsdl:service" name.
 	 */
-	public void setServiceName(String serviceName) {
+	public void setServiceName(@Nullable String serviceName) {
 		this.serviceName = serviceName;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/bind/WebDataBinder.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/WebDataBinder.java
@@ -131,7 +131,6 @@ public class WebDataBinder extends DataBinder {
 	/**
 	 * Return the prefix for parameters that mark potentially empty fields.
 	 */
-	@Nullable
 	public String getFieldMarkerPrefix() {
 		return this.fieldMarkerPrefix;
 	}
@@ -157,7 +156,6 @@ public class WebDataBinder extends DataBinder {
 	/**
 	 * Return the prefix for parameters that mark default fields.
 	 */
-	@Nullable
 	public String getFieldDefaultPrefix() {
 		return this.fieldDefaultPrefix;
 	}

--- a/spring-web/src/main/java/org/springframework/web/bind/support/ConfigurableWebBindingInitializer.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/support/ConfigurableWebBindingInitializer.java
@@ -106,7 +106,7 @@ public class ConfigurableWebBindingInitializer implements WebBindingInitializer 
 	 * the data binder.
 	 * @see org.springframework.validation.DataBinder#setMessageCodesResolver
 	 */
-	public final void setMessageCodesResolver(MessageCodesResolver messageCodesResolver) {
+	public final void setMessageCodesResolver(@Nullable MessageCodesResolver messageCodesResolver) {
 		this.messageCodesResolver = messageCodesResolver;
 	}
 
@@ -125,7 +125,7 @@ public class ConfigurableWebBindingInitializer implements WebBindingInitializer 
 	 * of the data binder.
 	 * @see org.springframework.validation.DataBinder#setBindingErrorProcessor
 	 */
-	public final void setBindingErrorProcessor(BindingErrorProcessor bindingErrorProcessor) {
+	public final void setBindingErrorProcessor(@Nullable BindingErrorProcessor bindingErrorProcessor) {
 		this.bindingErrorProcessor = bindingErrorProcessor;
 	}
 
@@ -140,7 +140,7 @@ public class ConfigurableWebBindingInitializer implements WebBindingInitializer 
 	/**
 	 * Set the Validator to apply after each binding step.
 	 */
-	public final void setValidator(Validator validator) {
+	public final void setValidator(@Nullable Validator validator) {
 		this.validator = validator;
 	}
 
@@ -156,7 +156,7 @@ public class ConfigurableWebBindingInitializer implements WebBindingInitializer 
 	 * Specify a ConversionService which will apply to every DataBinder.
 	 * @since 3.0
 	 */
-	public final void setConversionService(ConversionService conversionService) {
+	public final void setConversionService(@Nullable ConversionService conversionService) {
 		this.conversionService = conversionService;
 	}
 
@@ -178,7 +178,7 @@ public class ConfigurableWebBindingInitializer implements WebBindingInitializer 
 	/**
 	 * Specify multiple PropertyEditorRegistrars to be applied to every DataBinder.
 	 */
-	public final void setPropertyEditorRegistrars(PropertyEditorRegistrar[] propertyEditorRegistrars) {
+	public final void setPropertyEditorRegistrars(@Nullable PropertyEditorRegistrar[] propertyEditorRegistrars) {
 		this.propertyEditorRegistrars = propertyEditorRegistrars;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/context/ConfigurableWebApplicationContext.java
+++ b/spring-web/src/main/java/org/springframework/web/context/ConfigurableWebApplicationContext.java
@@ -58,14 +58,14 @@ public interface ConfigurableWebApplicationContext extends WebApplicationContext
 	 * called after the setting of all configuration properties.
 	 * @see #refresh()
 	 */
-	void setServletContext(ServletContext servletContext);
+	void setServletContext(@Nullable ServletContext servletContext);
 
 	/**
 	 * Set the ServletConfig for this web application context.
 	 * Only called for a WebApplicationContext that belongs to a specific Servlet.
 	 * @see #refresh()
 	 */
-	void setServletConfig(ServletConfig servletConfig);
+	void setServletConfig(@Nullable ServletConfig servletConfig);
 
 	/**
 	 * Return the ServletConfig for this web application context, if any.
@@ -78,7 +78,7 @@ public interface ConfigurableWebApplicationContext extends WebApplicationContext
 	 * to be used for building a default context config location.
 	 * The root web application context does not have a namespace.
 	 */
-	void setNamespace(String namespace);
+	void setNamespace(@Nullable String namespace);
 
 	/**
 	 * Return the namespace for this web application context, if any.

--- a/spring-web/src/main/java/org/springframework/web/context/support/AbstractRefreshableWebApplicationContext.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/AbstractRefreshableWebApplicationContext.java
@@ -104,7 +104,7 @@ public abstract class AbstractRefreshableWebApplicationContext extends AbstractR
 
 
 	@Override
-	public void setServletContext(ServletContext servletContext) {
+	public void setServletContext(@Nullable ServletContext servletContext) {
 		this.servletContext = servletContext;
 	}
 
@@ -115,7 +115,7 @@ public abstract class AbstractRefreshableWebApplicationContext extends AbstractR
 	}
 
 	@Override
-	public void setServletConfig(ServletConfig servletConfig) {
+	public void setServletConfig(@Nullable ServletConfig servletConfig) {
 		this.servletConfig = servletConfig;
 		if (this.servletContext == null) {
 			setServletContext(servletConfig.getServletContext());
@@ -129,9 +129,9 @@ public abstract class AbstractRefreshableWebApplicationContext extends AbstractR
 	}
 
 	@Override
-	public void setNamespace(String namespace) {
+	public void setNamespace(@Nullable String namespace) {
 		this.namespace = namespace;
-		setDisplayName("WebApplicationContext for namespace '" + namespace + "'");
+		setDisplayName(namespace != null ? "WebApplicationContext for namespace '" + namespace + "'" : null);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/web/context/support/AnnotationConfigWebApplicationContext.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/AnnotationConfigWebApplicationContext.java
@@ -84,8 +84,10 @@ import org.springframework.web.context.ContextLoader;
 public class AnnotationConfigWebApplicationContext extends AbstractRefreshableWebApplicationContext
 		implements AnnotationConfigRegistry {
 
+	@Nullable
 	private BeanNameGenerator beanNameGenerator;
 
+	@Nullable
 	private ScopeMetadataResolver scopeMetadataResolver;
 
 	private final Set<Class<?>> annotatedClasses = new LinkedHashSet<>();
@@ -100,7 +102,7 @@ public class AnnotationConfigWebApplicationContext extends AbstractRefreshableWe
 	 * @see AnnotatedBeanDefinitionReader#setBeanNameGenerator
 	 * @see ClassPathBeanDefinitionScanner#setBeanNameGenerator
 	 */
-	public void setBeanNameGenerator(BeanNameGenerator beanNameGenerator) {
+	public void setBeanNameGenerator(@Nullable BeanNameGenerator beanNameGenerator) {
 		this.beanNameGenerator = beanNameGenerator;
 	}
 
@@ -120,7 +122,7 @@ public class AnnotationConfigWebApplicationContext extends AbstractRefreshableWe
 	 * @see AnnotatedBeanDefinitionReader#setScopeMetadataResolver
 	 * @see ClassPathBeanDefinitionScanner#setScopeMetadataResolver
 	 */
-	public void setScopeMetadataResolver(ScopeMetadataResolver scopeMetadataResolver) {
+	public void setScopeMetadataResolver(@Nullable ScopeMetadataResolver scopeMetadataResolver) {
 		this.scopeMetadataResolver = scopeMetadataResolver;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/context/support/GenericWebApplicationContext.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/GenericWebApplicationContext.java
@@ -208,7 +208,7 @@ public class GenericWebApplicationContext extends GenericApplicationContext
 	// ---------------------------------------------------------------------
 
 	@Override
-	public void setServletConfig(ServletConfig servletConfig) {
+	public void setServletConfig(@Nullable ServletConfig servletConfig) {
 		// no-op
 	}
 
@@ -219,7 +219,7 @@ public class GenericWebApplicationContext extends GenericApplicationContext
 	}
 
 	@Override
-	public void setNamespace(String namespace) {
+	public void setNamespace(@Nullable String namespace) {
 		// no-op
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/context/support/StaticWebApplicationContext.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/StaticWebApplicationContext.java
@@ -80,7 +80,7 @@ public class StaticWebApplicationContext extends StaticApplicationContext
 	 * Set the ServletContext that this WebApplicationContext runs in.
 	 */
 	@Override
-	public void setServletContext(ServletContext servletContext) {
+	public void setServletContext(@Nullable ServletContext servletContext) {
 		this.servletContext = servletContext;
 	}
 
@@ -91,7 +91,7 @@ public class StaticWebApplicationContext extends StaticApplicationContext
 	}
 
 	@Override
-	public void setServletConfig(ServletConfig servletConfig) {
+	public void setServletConfig(@Nullable ServletConfig servletConfig) {
 		this.servletConfig = servletConfig;
 		if (this.servletContext == null) {
 			this.servletContext = servletConfig.getServletContext();
@@ -105,9 +105,9 @@ public class StaticWebApplicationContext extends StaticApplicationContext
 	}
 
 	@Override
-	public void setNamespace(String namespace) {
+	public void setNamespace(@Nullable String namespace) {
 		this.namespace = namespace;
-		setDisplayName("WebApplicationContext for namespace '" + namespace + "'");
+		setDisplayName(namespace != null ? "WebApplicationContext for namespace '" + namespace + "'" : null);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -278,7 +278,7 @@ public class CorsConfiguration {
 	 * Whether user credentials are supported.
 	 * <p>By default this is not set (i.e. user credentials are not supported).
 	 */
-	public void setAllowCredentials(Boolean allowCredentials) {
+	public void setAllowCredentials(@Nullable Boolean allowCredentials) {
 		this.allowCredentials = allowCredentials;
 	}
 
@@ -296,7 +296,7 @@ public class CorsConfiguration {
 	 * can be cached by clients.
 	 * <p>By default this is not set.
 	 */
-	public void setMaxAge(Long maxAge) {
+	public void setMaxAge(@Nullable Long maxAge) {
 		this.maxAge = maxAge;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/filter/CharacterEncodingFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/CharacterEncodingFilter.java
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  */
 public class CharacterEncodingFilter extends OncePerRequestFilter {
 
+	@Nullable
 	private String encoding;
 
 	private boolean forceRequestEncoding = false;
@@ -110,7 +111,7 @@ public class CharacterEncodingFilter extends OncePerRequestFilter {
 	 * (and whether it will be applied as default response encoding as well)
 	 * depends on the {@link #setForceEncoding "forceEncoding"} flag.
 	 */
-	public void setEncoding(String encoding) {
+	public void setEncoding(@Nullable String encoding) {
 		this.encoding = encoding;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/filter/DelegatingFilterProxy.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/DelegatingFilterProxy.java
@@ -174,7 +174,7 @@ public class DelegatingFilterProxy extends GenericFilterBean {
 	 * Set the name of the ServletContext attribute which should be used to retrieve the
 	 * {@link WebApplicationContext} from which to load the delegate {@link Filter} bean.
 	 */
-	public void setContextAttribute(String contextAttribute) {
+	public void setContextAttribute(@Nullable String contextAttribute) {
 		this.contextAttribute = contextAttribute;
 	}
 
@@ -193,7 +193,7 @@ public class DelegatingFilterProxy extends GenericFilterBean {
 	 * <p>By default, the {@code filter-name} as specified for the
 	 * DelegatingFilterProxy in {@code web.xml} will be used.
 	 */
-	public void setTargetBeanName(String targetBeanName) {
+	public void setTargetBeanName(@Nullable String targetBeanName) {
 		this.targetBeanName = targetBeanName;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/jsf/DecoratingNavigationHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/jsf/DecoratingNavigationHandler.java
@@ -39,6 +39,7 @@ import org.springframework.lang.Nullable;
  */
 public abstract class DecoratingNavigationHandler extends NavigationHandler {
 
+	@Nullable
 	private NavigationHandler decoratedNavigationHandler;
 
 

--- a/spring-web/src/main/java/org/springframework/web/server/i18n/AcceptHeaderLocaleContextResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/server/i18n/AcceptHeaderLocaleContextResolver.java
@@ -70,7 +70,7 @@ public class AcceptHeaderLocaleContextResolver implements LocaleContextResolver 
 	 * have an "Accept-Language" header (not set by default).
 	 * @param defaultLocale the default locale to use
 	 */
-	public void setDefaultLocale(Locale defaultLocale) {
+	public void setDefaultLocale(@Nullable Locale defaultLocale) {
 		this.defaultLocale = defaultLocale;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/util/CookieGenerator.java
+++ b/spring-web/src/main/java/org/springframework/web/util/CookieGenerator.java
@@ -50,12 +50,15 @@ public class CookieGenerator {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
+	@Nullable
 	private String cookieName;
 
+	@Nullable
 	private String cookieDomain;
 
 	private String cookiePath = DEFAULT_COOKIE_PATH;
 
+	@Nullable 
 	private Integer cookieMaxAge;
 
 	private boolean cookieSecure = false;
@@ -67,13 +70,14 @@ public class CookieGenerator {
 	 * Use the given name for cookies created by this generator.
 	 * @see javax.servlet.http.Cookie#getName()
 	 */
-	public void setCookieName(String cookieName) {
+	public void setCookieName(@Nullable String cookieName) {
 		this.cookieName = cookieName;
 	}
 
 	/**
 	 * Return the given name for cookies created by this generator.
 	 */
+	@Nullable
 	public String getCookieName() {
 		return this.cookieName;
 	}
@@ -83,7 +87,7 @@ public class CookieGenerator {
 	 * The cookie is only visible to servers in this domain.
 	 * @see javax.servlet.http.Cookie#setDomain
 	 */
-	public void setCookieDomain(String cookieDomain) {
+	public void setCookieDomain(@Nullable String cookieDomain) {
 		this.cookieDomain = cookieDomain;
 	}
 
@@ -118,7 +122,7 @@ public class CookieGenerator {
 	 * default.
 	 * @see javax.servlet.http.Cookie#setMaxAge
 	 */
-	public void setCookieMaxAge(Integer cookieMaxAge) {
+	public void setCookieMaxAge(@Nullable Integer cookieMaxAge) {
 		this.cookieMaxAge = cookieMaxAge;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurationSupport.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurationSupport.java
@@ -90,7 +90,7 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 
 
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) {
+	public void setApplicationContext(@Nullable ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/PathResourceResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/PathResourceResolver.java
@@ -43,6 +43,7 @@ import org.springframework.web.server.ServerWebExchange;
  */
 public class PathResourceResolver extends AbstractResourceResolver {
 
+	@Nullable
 	private Resource[] allowedLocations;
 
 
@@ -61,7 +62,7 @@ public class PathResourceResolver extends AbstractResourceResolver {
 	 * to match its list of locations.
 	 * @param locations the list of allowed locations
 	 */
-	public void setAllowedLocations(Resource... locations) {
+	public void setAllowedLocations(@Nullable Resource... locations) {
 		this.allowedLocations = locations;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceTransformerSupport.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceTransformerSupport.java
@@ -35,6 +35,7 @@ import org.springframework.web.server.ServerWebExchange;
  */
 public abstract class ResourceTransformerSupport implements ResourceTransformer {
 
+	@Nullable
 	private ResourceUrlProvider resourceUrlProvider;
 
 
@@ -45,7 +46,7 @@ public abstract class ResourceTransformerSupport implements ResourceTransformer 
 	 * relative links.
 	 * @param resourceUrlProvider the URL provider to use
 	 */
-	public void setResourceUrlProvider(ResourceUrlProvider resourceUrlProvider) {
+	public void setResourceUrlProvider(@Nullable ResourceUrlProvider resourceUrlProvider) {
 		this.resourceUrlProvider = resourceUrlProvider;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -95,8 +95,10 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 
 	private final List<ResourceTransformer> resourceTransformers = new ArrayList<>(4);
 
+	@Nullable
 	private CacheControl cacheControl;
 
+	@Nullable
 	private ResourceHttpMessageWriter resourceHttpMessageWriter;
 
 
@@ -160,7 +162,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 	 * Set the {@link org.springframework.http.CacheControl} instance to build
 	 * the Cache-Control HTTP response header.
 	 */
-	public void setCacheControl(CacheControl cacheControl) {
+	public void setCacheControl(@Nullable CacheControl cacheControl) {
 		this.cacheControl = cacheControl;
 	}
 
@@ -177,7 +179,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 	 * Configure the {@link ResourceHttpMessageWriter} to use.
 	 * <p>By default a {@link ResourceHttpMessageWriter} will be configured.
 	 */
-	public void setResourceHttpMessageWriter(ResourceHttpMessageWriter httpMessageWriter) {
+	public void setResourceHttpMessageWriter(@Nullable ResourceHttpMessageWriter httpMessageWriter) {
 		this.resourceHttpMessageWriter = httpMessageWriter;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerAdapter.java
@@ -76,7 +76,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Application
 	 * Configure HTTP message readers to de-serialize the request body with.
 	 * <p>By default this is set to {@link ServerCodecConfigurer} with defaults.
 	 */
-	public void setMessageCodecConfigurer(ServerCodecConfigurer configurer) {
+	public void setMessageCodecConfigurer(@Nullable ServerCodecConfigurer configurer) {
 		this.messageCodecConfigurer = configurer;
 	}
 
@@ -92,7 +92,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Application
 	 * Provide a WebBindingInitializer with "global" initialization to apply
 	 * to every DataBinder instance.
 	 */
-	public void setWebBindingInitializer(WebBindingInitializer webBindingInitializer) {
+	public void setWebBindingInitializer(@Nullable WebBindingInitializer webBindingInitializer) {
 		this.webBindingInitializer = webBindingInitializer;
 	}
 
@@ -107,8 +107,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Application
 	/**
 	 * Configure resolvers for controller method arguments.
 	 */
-	public void setArgumentResolverConfigurer(ArgumentResolverConfigurer configurer) {
-		Assert.notNull(configurer, "ArgumentResolverConfigurer is required");
+	public void setArgumentResolverConfigurer(@Nullable ArgumentResolverConfigurer configurer) {
 		this.argumentResolverConfigurer = configurer;
 	}
 
@@ -125,7 +124,7 @@ public class RequestMappingHandlerAdapter implements HandlerAdapter, Application
 	 * <p>By default this is an instance of {@link ReactiveAdapterRegistry} with
 	 * default settings.
 	 */
-	public void setReactiveAdapterRegistry(ReactiveAdapterRegistry registry) {
+	public void setReactiveAdapterRegistry(@Nullable ReactiveAdapterRegistry registry) {
 		this.reactiveAdapterRegistry = registry;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/AbstractUrlBasedView.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/AbstractUrlBasedView.java
@@ -30,6 +30,7 @@ import org.springframework.lang.Nullable;
  */
 public abstract class AbstractUrlBasedView extends AbstractView implements InitializingBean {
 
+	@Nullable
 	private String url;
 
 
@@ -51,7 +52,7 @@ public abstract class AbstractUrlBasedView extends AbstractView implements Initi
 	 * Set the URL of the resource that this view wraps.
 	 * The URL must be appropriate for the concrete View implementation.
 	 */
-	public void setUrl(String url) {
+	public void setUrl(@Nullable String url) {
 		this.url = url;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/AbstractView.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/AbstractView.java
@@ -134,7 +134,7 @@ public abstract class AbstractView implements View, ApplicationContextAware {
 	}
 
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) {
+	public void setApplicationContext(@Nullable ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/RedirectView.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/RedirectView.java
@@ -111,9 +111,10 @@ public class RedirectView extends AbstractUrlBasedView {
 	 * {@link HttpStatus#TEMPORARY_REDIRECT} or
 	 * {@link HttpStatus#PERMANENT_REDIRECT}.
 	 */
-	public void setStatusCode(HttpStatus statusCode) {
-		Assert.notNull(statusCode, "HttpStatus must not be null");
-		Assert.isTrue(statusCode.is3xxRedirection(), "Must be a redirection (3xx status code)");
+	public void setStatusCode(@Nullable HttpStatus statusCode) {
+		if (statusCode != null) {
+			Assert.isTrue(statusCode.is3xxRedirection(), "Must be a redirection (3xx status code)");
+		}
 		this.statusCode = statusCode;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/UrlBasedViewResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/UrlBasedViewResolver.java
@@ -73,18 +73,22 @@ public class UrlBasedViewResolver extends ViewResolverSupport
 	public static final String REDIRECT_URL_PREFIX = "redirect:";
 
 
+	@Nullable
 	private Class<?> viewClass;
 
 	private String prefix = "";
 
 	private String suffix = "";
 
+	@Nullable
 	private String[] viewNames;
 
 	private Function<String, RedirectView> redirectViewProvider = RedirectView::new;
 
+	@Nullable
 	private String requestContextAttribute;
 
+	@Nullable
 	private ApplicationContext applicationContext;
 
 
@@ -93,8 +97,8 @@ public class UrlBasedViewResolver extends ViewResolverSupport
 	 * @param viewClass a class that is assignable to the required view class
 	 * which by default is AbstractUrlBasedView
 	 */
-	public void setViewClass(Class<?> viewClass) {
-		if (!requiredViewClass().isAssignableFrom(viewClass)) {
+	public void setViewClass(@Nullable Class<?> viewClass) {
+		if (viewClass != null && !requiredViewClass().isAssignableFrom(viewClass)) {
 			String name = viewClass.getName();
 			throw new IllegalArgumentException("Given view class [" + name + "] " +
 					"is not of type [" + requiredViewClass().getName() + "]");
@@ -153,7 +157,7 @@ public class UrlBasedViewResolver extends ViewResolverSupport
 	 * 'my*', '*Report' and '*Repo*' will all match the view name 'myReport'.
 	 * @see #canHandle
 	 */
-	public void setViewNames(String... viewNames) {
+	public void setViewNames(@Nullable String... viewNames) {
 		this.viewNames = viewNames;
 	}
 
@@ -179,7 +183,7 @@ public class UrlBasedViewResolver extends ViewResolverSupport
 	 * @param requestContextAttribute name of the RequestContext attribute
 	 * @see AbstractView#setRequestContextAttribute
 	 */
-	public void setRequestContextAttribute(String requestContextAttribute) {
+	public void setRequestContextAttribute(@Nullable String requestContextAttribute) {
 		this.requestContextAttribute = requestContextAttribute;
 	}
 
@@ -200,7 +204,7 @@ public class UrlBasedViewResolver extends ViewResolverSupport
 	 * @see #applyLifecycleMethods
 	 */
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) {
+	public void setApplicationContext(@Nullable ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/freemarker/FreeMarkerView.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/freemarker/FreeMarkerView.java
@@ -67,8 +67,10 @@ import org.springframework.web.server.ServerWebExchange;
  */
 public class FreeMarkerView extends AbstractUrlBasedView {
 
+	@Nullable
 	private Configuration configuration;
 
+	@Nullable
 	private String encoding;
 
 
@@ -78,7 +80,7 @@ public class FreeMarkerView extends AbstractUrlBasedView {
 	 * {@link FreeMarkerConfig} is expected in the Spring application context
 	 * which is used to obtain the FreeMarker configuration.
 	 */
-	public void setConfiguration(Configuration configuration) {
+	public void setConfiguration(@Nullable Configuration configuration) {
 		this.configuration = configuration;
 	}
 
@@ -109,7 +111,7 @@ public class FreeMarkerView extends AbstractUrlBasedView {
 	 * encoding in the FreeMarker Configuration rather than per template if all
 	 * your templates share a common encoding.
 	 */
-	public void setEncoding(String encoding) {
+	public void setEncoding(@Nullable String encoding) {
 		this.encoding = encoding;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/FrameworkServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/FrameworkServlet.java
@@ -285,7 +285,7 @@ public abstract class FrameworkServlet extends HttpServletBean implements Applic
 	 * Set the name of the ServletContext attribute which should be used to retrieve the
 	 * {@link WebApplicationContext} that this servlet is supposed to use.
 	 */
-	public void setContextAttribute(String contextAttribute) {
+	public void setContextAttribute(@Nullable String contextAttribute) {
 		this.contextAttribute = contextAttribute;
 	}
 
@@ -322,7 +322,7 @@ public abstract class FrameworkServlet extends HttpServletBean implements Applic
 	 * Specify a custom WebApplicationContext id,
 	 * to be used as serialization id for the underlying BeanFactory.
 	 */
-	public void setContextId(String contextId) {
+	public void setContextId(@Nullable String contextId) {
 		this.contextId = contextId;
 	}
 
@@ -355,7 +355,7 @@ public abstract class FrameworkServlet extends HttpServletBean implements Applic
 	 * location built from the namespace. This location string can consist of
 	 * multiple locations separated by any number of commas and spaces.
 	 */
-	public void setContextConfigLocation(String contextConfigLocation) {
+	public void setContextConfigLocation(@Nullable String contextConfigLocation) {
 		this.contextConfigLocation = contextConfigLocation;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/ModelAndView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/ModelAndView.java
@@ -264,7 +264,7 @@ public class ModelAndView {
 	 * <p>The response status is set just prior to View rendering.
 	 * @since 4.3
 	 */
-	public void setStatus(HttpStatus status) {
+	public void setStatus(@Nullable HttpStatus status) {
 		this.status = status;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -229,7 +229,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	 * Set the Spring {@link ApplicationContext}, e.g. for resource loading.
 	 */
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) {
+	public void setApplicationContext(@Nullable ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 
@@ -247,7 +247,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	 * looking up file extensions, etc.
 	 */
 	@Override
-	public void setServletContext(ServletContext servletContext) {
+	public void setServletContext(@Nullable ServletContext servletContext) {
 		this.servletContext = servletContext;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
@@ -104,7 +104,7 @@ public abstract class AbstractHandlerMapping extends WebApplicationObjectSupport
 	 * This handler will be returned if no specific mapping was found.
 	 * <p>Default is {@code null}, indicating no default handler.
 	 */
-	public void setDefaultHandler(Object defaultHandler) {
+	public void setDefaultHandler(@Nullable Object defaultHandler) {
 		this.defaultHandler = defaultHandler;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
@@ -54,6 +54,7 @@ import org.springframework.web.servlet.HandlerExecutionChain;
  */
 public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping implements MatchableHandlerMapping {
 
+	@Nullable
 	private Object rootHandler;
 
 	private boolean useTrailingSlashMatch = false;
@@ -68,7 +69,7 @@ public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping i
 	 * the handler to be registered for the root path ("/").
 	 * <p>Default is {@code null}, indicating no root handler.
 	 */
-	public void setRootHandler(Object rootHandler) {
+	public void setRootHandler(@Nullable Object rootHandler) {
 		this.rootHandler = rootHandler;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/MappedInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/MappedInterceptor.java
@@ -109,7 +109,7 @@ public final class MappedInterceptor implements HandlerInterceptor {
 	 * PathMatcher implementations that support mapping metadata other than the
 	 * Ant-style path patterns supported by default.
 	 */
-	public void setPathMatcher(PathMatcher pathMatcher) {
+	public void setPathMatcher(@Nullable PathMatcher pathMatcher) {
 		this.pathMatcher = pathMatcher;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleContextResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleContextResolver.java
@@ -39,13 +39,14 @@ import org.springframework.web.servlet.LocaleContextResolver;
  */
 public abstract class AbstractLocaleContextResolver extends AbstractLocaleResolver implements LocaleContextResolver {
 
+	@Nullable
 	private TimeZone defaultTimeZone;
 
 
 	/**
 	 * Set a default TimeZone that this resolver will return if no other time zone found.
 	 */
-	public void setDefaultTimeZone(TimeZone defaultTimeZone) {
+	public void setDefaultTimeZone(@Nullable TimeZone defaultTimeZone) {
 		this.defaultTimeZone = defaultTimeZone;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleResolver.java
@@ -31,13 +31,14 @@ import org.springframework.web.servlet.LocaleResolver;
  */
 public abstract class AbstractLocaleResolver implements LocaleResolver {
 
+	@Nullable
 	private Locale defaultLocale;
 
 
 	/**
 	 * Set a default Locale that this resolver will return if no other locale found.
 	 */
-	public void setDefaultLocale(Locale defaultLocale) {
+	public void setDefaultLocale(@Nullable Locale defaultLocale) {
 		this.defaultLocale = defaultLocale;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
@@ -43,6 +43,7 @@ public class AcceptHeaderLocaleResolver implements LocaleResolver {
 
 	private final List<Locale> supportedLocales = new ArrayList<>(4);
 
+	@Nullable
 	private Locale defaultLocale;
 
 
@@ -77,7 +78,7 @@ public class AcceptHeaderLocaleResolver implements LocaleResolver {
 	 * @param defaultLocale the default locale to use
 	 * @since 4.3
 	 */
-	public void setDefaultLocale(Locale defaultLocale) {
+	public void setDefaultLocale(@Nullable Locale defaultLocale) {
 		this.defaultLocale = defaultLocale;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieLocaleResolver.java
@@ -127,7 +127,7 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 	/**
 	 * Set a fixed Locale that this resolver will return if no cookie found.
 	 */
-	public void setDefaultLocale(Locale defaultLocale) {
+	public void setDefaultLocale(@Nullable Locale defaultLocale) {
 		this.defaultLocale = defaultLocale;
 	}
 
@@ -144,7 +144,7 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 	 * Set a fixed TimeZone that this resolver will return if no cookie found.
 	 * @since 4.0
 	 */
-	public void setDefaultTimeZone(TimeZone defaultTimeZone) {
+	public void setDefaultTimeZone(@Nullable TimeZone defaultTimeZone) {
 		this.defaultTimeZone = defaultTimeZone;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/ParameterizableViewController.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/ParameterizableViewController.java
@@ -38,8 +38,10 @@ import org.springframework.web.servlet.support.RequestContextUtils;
  */
 public class ParameterizableViewController extends AbstractController {
 
+	@Nullable
 	private Object view;
 
+	@Nullable
 	private HttpStatus statusCode;
 
 	private boolean statusOnly;
@@ -55,7 +57,7 @@ public class ParameterizableViewController extends AbstractController {
 	 * DispatcherServlet via a ViewResolver. Will override any pre-existing
 	 * view name or View.
 	 */
-	public void setViewName(String viewName) {
+	public void setViewName(@Nullable String viewName) {
 		this.view = viewName;
 	}
 
@@ -98,7 +100,7 @@ public class ParameterizableViewController extends AbstractController {
 	 * fully handled within the controller.
 	 * @since 4.1
 	 */
-	public void setStatusCode(HttpStatus statusCode) {
+	public void setStatusCode(@Nullable HttpStatus statusCode) {
 		this.statusCode = statusCode;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
@@ -534,7 +534,7 @@ public final class RequestMappingInfo implements RequestCondition<RequestMapping
 		 * <p>By default this is not set.
 		 * @since 4.2.8
 		 */
-		public void setUrlPathHelper(UrlPathHelper urlPathHelper) {
+		public void setUrlPathHelper(@Nullable UrlPathHelper urlPathHelper) {
 			this.urlPathHelper = urlPathHelper;
 		}
 
@@ -550,7 +550,7 @@ public final class RequestMappingInfo implements RequestCondition<RequestMapping
 		 * Set a custom PathMatcher to use for the PatternsRequestCondition.
 		 * <p>By default this is not set.
 		 */
-		public void setPathMatcher(PathMatcher pathMatcher) {
+		public void setPathMatcher(@Nullable PathMatcher pathMatcher) {
 			this.pathMatcher = pathMatcher;
 		}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
@@ -120,7 +120,7 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 	 * after built-in ones. To override the built-in support for argument
 	 * resolution use {@link #setArgumentResolvers} instead.
 	 */
-	public void setCustomArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+	public void setCustomArgumentResolvers(@Nullable List<HandlerMethodArgumentResolver> argumentResolvers) {
 		this.customArgumentResolvers= argumentResolvers;
 	}
 
@@ -160,7 +160,7 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 	 * ordered after built-in ones. To override the built-in support for
 	 * return value handling use {@link #setReturnValueHandlers}.
 	 */
-	public void setCustomReturnValueHandlers(List<HandlerMethodReturnValueHandler> returnValueHandlers) {
+	public void setCustomReturnValueHandlers(@Nullable List<HandlerMethodReturnValueHandler> returnValueHandlers) {
 		this.customReturnValueHandlers = returnValueHandlers;
 	}
 
@@ -239,7 +239,7 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 	}
 
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) {
+	public void setApplicationContext(@Nullable ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ModelAndViewMethodReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ModelAndViewMethodReturnValueHandler.java
@@ -44,6 +44,7 @@ import org.springframework.web.servlet.View;
  */
 public class ModelAndViewMethodReturnValueHandler implements HandlerMethodReturnValueHandler {
 
+	@Nullable
 	private String[] redirectPatterns;
 
 
@@ -56,7 +57,7 @@ public class ModelAndViewMethodReturnValueHandler implements HandlerMethodReturn
 	 * prefix as well.
 	 * @since 4.1
 	 */
-	public void setRedirectPatterns(String... redirectPatterns) {
+	public void setRedirectPatterns(@Nullable String... redirectPatterns) {
 		this.redirectPatterns = redirectPatterns;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -196,7 +196,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 	 * after built-in ones. To override the built-in support for argument
 	 * resolution use {@link #setArgumentResolvers} instead.
 	 */
-	public void setCustomArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+	public void setCustomArgumentResolvers(@Nullable List<HandlerMethodArgumentResolver> argumentResolvers) {
 		this.customArgumentResolvers = argumentResolvers;
 	}
 
@@ -258,7 +258,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 	 * ordered after built-in ones. To override the built-in support for
 	 * return value handling use {@link #setReturnValueHandlers}.
 	 */
-	public void setCustomReturnValueHandlers(List<HandlerMethodReturnValueHandler> returnValueHandlers) {
+	public void setCustomReturnValueHandlers(@Nullable List<HandlerMethodReturnValueHandler> returnValueHandlers) {
 		this.customReturnValueHandlers = returnValueHandlers;
 	}
 
@@ -307,7 +307,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 	 * the return type and controller method information and can be ordered
 	 * freely relative to other return value handlers.
 	 */
-	public void setModelAndViewResolvers(List<ModelAndViewResolver> modelAndViewResolvers) {
+	public void setModelAndViewResolvers(@Nullable List<ModelAndViewResolver> modelAndViewResolvers) {
 		this.modelAndViewResolvers = modelAndViewResolvers;
 	}
 
@@ -369,7 +369,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 	 * Provide a WebBindingInitializer with "global" initialization to apply
 	 * to every DataBinder instance.
 	 */
-	public void setWebBindingInitializer(WebBindingInitializer webBindingInitializer) {
+	public void setWebBindingInitializer(@Nullable WebBindingInitializer webBindingInitializer) {
 		this.webBindingInitializer = webBindingInitializer;
 	}
 
@@ -524,8 +524,11 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 	 * in method argument default values.
 	 */
 	@Override
-	public void setBeanFactory(BeanFactory beanFactory) {
-		if (beanFactory instanceof ConfigurableBeanFactory) {
+	public void setBeanFactory(@Nullable BeanFactory beanFactory) {
+		if (beanFactory == null) {
+			this.beanFactory = null;
+		}
+		else if (beanFactory instanceof ConfigurableBeanFactory) {
 			this.beanFactory = (ConfigurableBeanFactory) beanFactory;
 		}
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ViewNameMethodReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ViewNameMethodReturnValueHandler.java
@@ -44,6 +44,7 @@ import org.springframework.web.servlet.RequestToViewNameTranslator;
  */
 public class ViewNameMethodReturnValueHandler implements HandlerMethodReturnValueHandler {
 
+	@Nullable
 	private String[] redirectPatterns;
 
 
@@ -56,7 +57,7 @@ public class ViewNameMethodReturnValueHandler implements HandlerMethodReturnValu
 	 * prefix as well.
 	 * @since 4.1
 	 */
-	public void setRedirectPatterns(String... redirectPatterns) {
+	public void setRedirectPatterns(@Nullable String... redirectPatterns) {
 		this.redirectPatterns = redirectPatterns;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
@@ -43,6 +43,7 @@ import org.springframework.web.context.support.ServletContextResource;
  */
 public class PathResourceResolver extends AbstractResourceResolver {
 
+	@Nullable
 	private Resource[] allowedLocations;
 
 
@@ -63,7 +64,7 @@ public class PathResourceResolver extends AbstractResourceResolver {
 	 * @since 4.1.2
 	 * @see ResourceHttpRequestHandler#initAllowedLocations()
 	 */
-	public void setAllowedLocations(Resource... locations) {
+	public void setAllowedLocations(@Nullable Resource... locations) {
 		this.allowedLocations = locations;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -181,7 +181,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	 * <p>By default a {@link ResourceHttpMessageConverter} will be configured.
 	 * @since 4.3
 	 */
-	public void setResourceHttpMessageConverter(ResourceHttpMessageConverter messageConverter) {
+	public void setResourceHttpMessageConverter(@Nullable ResourceHttpMessageConverter messageConverter) {
 		this.resourceHttpMessageConverter = messageConverter;
 	}
 
@@ -199,7 +199,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	 * <p>By default a {@link ResourceRegionHttpMessageConverter} will be configured.
 	 * @since 4.3
 	 */
-	public void setResourceRegionHttpMessageConverter(ResourceRegionHttpMessageConverter messageConverter) {
+	public void setResourceRegionHttpMessageConverter(@Nullable ResourceRegionHttpMessageConverter messageConverter) {
 		this.resourceRegionHttpMessageConverter = messageConverter;
 	}
 
@@ -219,7 +219,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	 * @param contentNegotiationManager the manager in use
 	 * @since 4.3
 	 */
-	public void setContentNegotiationManager(ContentNegotiationManager contentNegotiationManager) {
+	public void setContentNegotiationManager(@Nullable ContentNegotiationManager contentNegotiationManager) {
 		this.contentNegotiationManager = contentNegotiationManager;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceTransformerSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceTransformerSupport.java
@@ -45,7 +45,7 @@ public abstract class ResourceTransformerSupport implements ResourceTransformer 
 	 * This is required only for links expressed as full paths and not for
 	 * relative links.
 	 */
-	public void setResourceUrlProvider(ResourceUrlProvider resourceUrlProvider) {
+	public void setResourceUrlProvider(@Nullable ResourceUrlProvider resourceUrlProvider) {
 		this.resourceUrlProvider = resourceUrlProvider;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/WebContentGenerator.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/WebContentGenerator.java
@@ -151,7 +151,7 @@ public abstract class WebContentGenerator extends WebApplicationObjectSupport {
 	 * <p>Default is GET, HEAD and POST for simple form controller types;
 	 * unrestricted for general controllers and interceptors.
 	 */
-	public final void setSupportedMethods(String... methods) {
+	public final void setSupportedMethods(@Nullable String... methods) {
 		if (!ObjectUtils.isEmpty(methods)) {
 			this.supportedMethods = new LinkedHashSet<>(Arrays.asList(methods));
 		}
@@ -223,7 +223,7 @@ public abstract class WebContentGenerator extends WebApplicationObjectSupport {
 	 * the Cache-Control HTTP response header.
 	 * @since 4.2
 	 */
-	public final void setCacheControl(CacheControl cacheControl) {
+	public final void setCacheControl(@Nullable CacheControl cacheControl) {
 		this.cacheControl = cacheControl;
 	}
 
@@ -269,7 +269,7 @@ public abstract class WebContentGenerator extends WebApplicationObjectSupport {
 	 * @param varyByRequestHeaders one or more request header names
 	 * @since 4.3
 	 */
-	public final void setVaryByRequestHeaders(String... varyByRequestHeaders) {
+	public final void setVaryByRequestHeaders(@Nullable String... varyByRequestHeaders) {
 		this.varyByRequestHeaders = varyByRequestHeaders;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/Param.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/Param.java
@@ -41,7 +41,7 @@ public class Param {
 	/**
 	 * Set the raw name of the parameter
 	 */
-	public void setName(String name) {
+	public void setName(@Nullable String name) {
 		this.name = name;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/AbstractUrlBasedView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/AbstractUrlBasedView.java
@@ -53,7 +53,7 @@ public abstract class AbstractUrlBasedView extends AbstractView implements Initi
 	 * Set the URL of the resource that this view wraps.
 	 * The URL must be appropriate for the concrete View implementation.
 	 */
-	public void setUrl(String url) {
+	public void setUrl(@Nullable String url) {
 		this.url = url;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/AbstractView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/AbstractView.java
@@ -83,6 +83,7 @@ public abstract class AbstractView extends WebApplicationObjectSupport implement
 
 	@Nullable
 	private Set<String> exposedContextBeanNames;
+	
 	@Nullable
 	private String beanName;
 
@@ -278,7 +279,7 @@ public abstract class AbstractView extends WebApplicationObjectSupport implement
 	 * <p>Framework code must call this when constructing views.
 	 */
 	@Override
-	public void setBeanName(String beanName) {
+	public void setBeanName(@Nullable String beanName) {
 		this.beanName = beanName;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/ContentNegotiatingViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/ContentNegotiatingViewResolver.java
@@ -110,7 +110,7 @@ public class ContentNegotiatingViewResolver extends WebApplicationObjectSupport
 	 * applying a {@link org.springframework.web.accept.HeaderContentNegotiationStrategy}.
 	 * @see ContentNegotiationManager#ContentNegotiationManager()
 	 */
-	public void setContentNegotiationManager(ContentNegotiationManager contentNegotiationManager) {
+	public void setContentNegotiationManager(@Nullable ContentNegotiationManager contentNegotiationManager) {
 		this.contentNegotiationManager = contentNegotiationManager;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/RedirectView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/RedirectView.java
@@ -265,7 +265,7 @@ public class RedirectView extends AbstractUrlBasedView implements SmartView {
 	 * @param hosts one or more application hosts
 	 * @since 4.3
 	 */
-	public void setHosts(String... hosts) {
+	public void setHosts(@Nullable String... hosts) {
 		this.hosts = hosts;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/UrlBasedViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/UrlBasedViewResolver.java
@@ -146,8 +146,8 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 	 * (by default, AbstractUrlBasedView)
 	 * @see AbstractUrlBasedView
 	 */
-	public void setViewClass(Class<?> viewClass) {
-		if (!requiredViewClass().isAssignableFrom(viewClass)) {
+	public void setViewClass(@Nullable Class<?> viewClass) {
+		if (viewClass != null && !requiredViewClass().isAssignableFrom(viewClass)) {
 			throw new IllegalArgumentException("Given view class [" + viewClass.getName() +
 					"] is not of type [" + requiredViewClass().getName() + "]");
 		}
@@ -204,7 +204,7 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 	 * <p>May be ignored by view classes if the view itself is assumed
 	 * to set the content type, e.g. in case of JSPs.
 	 */
-	public void setContentType(String contentType) {
+	public void setContentType(@Nullable String contentType) {
 		this.contentType = contentType;
 	}
 
@@ -276,7 +276,7 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 	 * @param redirectHosts one or more application hosts
 	 * @since 4.3
 	 */
-	public void setRedirectHosts(String... redirectHosts) {
+	public void setRedirectHosts(@Nullable String... redirectHosts) {
 		this.redirectHosts = redirectHosts;
 	}
 
@@ -294,7 +294,7 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 	 * @param requestContextAttribute name of the RequestContext attribute
 	 * @see AbstractView#setRequestContextAttribute
 	 */
-	public void setRequestContextAttribute(String requestContextAttribute) {
+	public void setRequestContextAttribute(@Nullable String requestContextAttribute) {
 		this.requestContextAttribute = requestContextAttribute;
 	}
 
@@ -393,7 +393,7 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 	 * attributes.
 	 * @see AbstractView#setExposedContextBeanNames
 	 */
-	public void setExposedContextBeanNames(String... exposedContextBeanNames) {
+	public void setExposedContextBeanNames(@Nullable String... exposedContextBeanNames) {
 		this.exposedContextBeanNames = exposedContextBeanNames;
 	}
 
@@ -409,7 +409,7 @@ public class UrlBasedViewResolver extends AbstractCachingViewResolver implements
 	 * view name 'myReport'.
 	 * @see #canHandle
 	 */
-	public void setViewNames(String... viewNames) {
+	public void setViewNames(@Nullable String... viewNames) {
 		this.viewNames = viewNames;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/freemarker/FreeMarkerView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/freemarker/FreeMarkerView.java
@@ -106,7 +106,7 @@ public class FreeMarkerView extends AbstractTemplateView {
 	 * <p>Specify the encoding in the FreeMarker Configuration rather than per
 	 * template if all your templates share a common encoding.
 	 */
-	public void setEncoding(String encoding) {
+	public void setEncoding(@Nullable String encoding) {
 		this.encoding = encoding;
 	}
 
@@ -127,7 +127,7 @@ public class FreeMarkerView extends AbstractTemplateView {
 	 * in terms of memory and initial CPU usage. In production it is recommended that you use
 	 * a {@link FreeMarkerConfig} which exposes a single shared {@link TaglibFactory}.
 	 */
-	public void setConfiguration(Configuration configuration) {
+	public void setConfiguration(@Nullable Configuration configuration) {
 		this.configuration = configuration;
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
@@ -142,7 +142,7 @@ public class MappingJackson2JsonView extends AbstractJackson2View {
 	 * Set the attributes in the model that should be rendered by this view.
 	 * When set, all other model attributes will be ignored.
 	 */
-	public void setModelKeys(Set<String> modelKeys) {
+	public void setModelKeys(@Nullable Set<String> modelKeys) {
 		this.modelKeys = modelKeys;
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketHttpHeaders.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketHttpHeaders.java
@@ -87,7 +87,7 @@ public class WebSocketHttpHeaders extends HttpHeaders {
 	 * Sets the (new) value of the {@code Sec-WebSocket-Accept} header.
 	 * @param secWebSocketAccept the value of the header
 	 */
-	public void setSecWebSocketAccept(String secWebSocketAccept) {
+	public void setSecWebSocketAccept(@Nullable String secWebSocketAccept) {
 		set(SEC_WEBSOCKET_ACCEPT, secWebSocketAccept);
 	}
 
@@ -134,7 +134,7 @@ public class WebSocketHttpHeaders extends HttpHeaders {
 	 * Sets the (new) value of the {@code Sec-WebSocket-Key} header.
 	 * @param secWebSocketKey the value of the header
 	 */
-	public void setSecWebSocketKey(String secWebSocketKey) {
+	public void setSecWebSocketKey(@Nullable String secWebSocketKey) {
 		set(SEC_WEBSOCKET_KEY, secWebSocketKey);
 	}
 
@@ -184,7 +184,7 @@ public class WebSocketHttpHeaders extends HttpHeaders {
 	 * Sets the (new) value of the {@code Sec-WebSocket-Version} header.
 	 * @param secWebSocketVersion the value of the header
 	 */
-	public void setSecWebSocketVersion(String secWebSocketVersion) {
+	public void setSecWebSocketVersion(@Nullable String secWebSocketVersion) {
 		set(SEC_WEBSOCKET_VERSION, secWebSocketVersion);
 	}
 
@@ -232,7 +232,7 @@ public class WebSocketHttpHeaders extends HttpHeaders {
 	 * @see #add(String, String)
 	 */
 	@Override
-	public void set(String headerName, String headerValue) {
+	public void set(String headerName, @Nullable String headerValue) {
 		this.headers.set(headerName, headerValue);
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/WebSocketConnectionManager.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/WebSocketConnectionManager.java
@@ -86,7 +86,7 @@ public class WebSocketConnectionManager extends ConnectionManagerSupport {
 	/**
 	 * Set the origin to use.
 	 */
-	public void setOrigin(String origin) {
+	public void setOrigin(@Nullable String origin) {
 		this.headers.setOrigin(origin);
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/AbstractWebSocketHandlerRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/AbstractWebSocketHandlerRegistration.java
@@ -84,7 +84,7 @@ public abstract class AbstractWebSocketHandlerRegistration<M> implements WebSock
 	}
 
 	@Override
-	public WebSocketHandlerRegistration setHandshakeHandler(HandshakeHandler handshakeHandler) {
+	public WebSocketHandlerRegistration setHandshakeHandler(@Nullable HandshakeHandler handshakeHandler) {
 		this.handshakeHandler = handshakeHandler;
 		return this;
 	}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/ServletWebSocketHandlerRegistry.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/ServletWebSocketHandlerRegistry.java
@@ -92,7 +92,7 @@ public class ServletWebSocketHandlerRegistry implements WebSocketHandlerRegistry
 	 * Set the UrlPathHelper to configure on the {@code SimpleUrlHandlerMapping}
 	 * used to map handshake requests.
 	 */
-	public void setUrlPathHelper(UrlPathHelper urlPathHelper) {
+	public void setUrlPathHelper(@Nullable UrlPathHelper urlPathHelper) {
 		this.urlPathHelper = urlPathHelper;
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompEndpointRegistry.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompEndpointRegistry.java
@@ -125,7 +125,7 @@ public class WebMvcStompEndpointRegistry implements StompEndpointRegistry {
 	 * used to map handshake requests.
 	 */
 	@Override
-	public void setUrlPathHelper(UrlPathHelper urlPathHelper) {
+	public void setUrlPathHelper(@Nullable UrlPathHelper urlPathHelper) {
 		this.urlPathHelper = urlPathHelper;
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java
@@ -176,7 +176,7 @@ public class StompSubProtocolHandler implements SubProtocolHandler, ApplicationE
 	 * client inbound channel.
 	 * <p>By default this property is not set.
 	 */
-	public void setHeaderInitializer(MessageHeaderInitializer headerInitializer) {
+	public void setHeaderInitializer(@Nullable MessageHeaderInitializer headerInitializer) {
 		this.headerInitializer = headerInitializer;
 		this.stompDecoder.setHeaderInitializer(headerInitializer);
 	}
@@ -195,7 +195,7 @@ public class StompSubProtocolHandler implements SubProtocolHandler, ApplicationE
 	}
 
 	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+	public void setApplicationEventPublisher(@Nullable ApplicationEventPublisher applicationEventPublisher) {
 		this.eventPublisher = applicationEventPublisher;
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/SubProtocolWebSocketHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/SubProtocolWebSocketHandler.java
@@ -172,7 +172,7 @@ public class SubProtocolWebSocketHandler
 	 * sub-protocol.
 	 * @param defaultProtocolHandler the default handler
 	 */
-	public void setDefaultProtocolHandler(SubProtocolHandler defaultProtocolHandler) {
+	public void setDefaultProtocolHandler(@Nullable SubProtocolHandler defaultProtocolHandler) {
 		this.defaultProtocolHandler = defaultProtocolHandler;
 		if (this.protocolHandlerLookup.isEmpty()) {
 			setProtocolHandlers(Collections.singletonList(defaultProtocolHandler));

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/standard/ServerEndpointExporter.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/standard/ServerEndpointExporter.java
@@ -76,7 +76,7 @@ public class ServerEndpointExporter extends WebApplicationObjectSupport
 	 * Set the JSR-356 {@link ServerContainer} to use for endpoint registration.
 	 * If not set, the container is going to be retrieved via the {@code ServletContext}.
 	 */
-	public void setServerContainer(ServerContainer serverContainer) {
+	public void setServerContainer(@Nullable ServerContainer serverContainer) {
 		this.serverContainer = serverContainer;
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/SockJsClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/SockJsClient.java
@@ -134,7 +134,7 @@ public class SockJsClient implements WebSocketClient, Lifecycle {
 	 *
 	 * @param httpHeaderNames HTTP header names
 	 */
-	public void setHttpHeaderNames(String... httpHeaderNames) {
+	public void setHttpHeaderNames(@Nullable String... httpHeaderNames) {
 		this.httpHeaderNames = httpHeaderNames;
 	}
 


### PR DESCRIPTION
This commit ensures that null-safety is consistent between
getters and setters in order to be able to provide beans
with properties with a common type when type safety is
taken in account like with Kotlin.

It also adds a few missing property-level @Nullable
annotations.

Issue: SPR-15540