### PR TITLE
SPR-15763 - Unnecessary assertion in setExceptionMessage of CustomizableTraceInterceptor

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/interceptor/CustomizableTraceInterceptor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/interceptor/CustomizableTraceInterceptor.java
@@ -230,8 +230,6 @@ public class CustomizableTraceInterceptor extends AbstractTraceInterceptor {
 		checkForInvalidPlaceholders(exceptionMessage);
 		Assert.doesNotContain(exceptionMessage, PLACEHOLDER_RETURN_VALUE,
 				"exceptionMessage cannot contain placeholder [" + PLACEHOLDER_RETURN_VALUE + "]");
-		Assert.doesNotContain(exceptionMessage, PLACEHOLDER_INVOCATION_TIME,
-				"exceptionMessage cannot contain placeholder [" + PLACEHOLDER_INVOCATION_TIME + "]");
 		this.exceptionMessage = exceptionMessage;
 	}
 


### PR DESCRIPTION
CustomizableTraceInterceptor used to not calculate the invocation time when an exception occurred.  Because of that, INVOCATION_TIME was not valid in the exception message.  However, that bug was fixed, but the prohibition on the INVOCATION_TIME placeholder was not removed from the setExceptionMessage() for the CustomizableTraceInterceptor.  As such, I just removed this assertion.  The tests looked like they ignored checking this.