### PR TITLE
SPR-7582 - Rebuild Advisor chain when interceptor list is updated in ProxyFactoryBean

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -391,6 +391,11 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 		return this.advisors;
 	}
 
+	protected void clearAdvisors() {
+		this.advisors.clear();
+		updateAdvisorArray();
+		adviceChanged();
+	}
 
 	@Override
 	public void addAdvice(Advice advice) throws AopConfigException {

--- a/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactoryBean.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactoryBean.java
@@ -163,6 +163,7 @@ public class ProxyFactoryBean extends ProxyCreatorSupport
 	 */
 	public void setInterceptorNames(String... interceptorNames) {
 		this.interceptorNames = interceptorNames;
+		initializeAdvisorChain();
 	}
 
 	/**
@@ -248,7 +249,9 @@ public class ProxyFactoryBean extends ProxyCreatorSupport
 	 */
 	@Override
 	public Object getObject() throws BeansException {
-		initializeAdvisorChain();
+		if (!this.advisorChainInitialized) {
+			initializeAdvisorChain();
+		}
 		if (isSingleton()) {
 			return getSingletonInstance();
 		}
@@ -430,9 +433,7 @@ public class ProxyFactoryBean extends ProxyCreatorSupport
 	 * are unaffected by such changes.
 	 */
 	private synchronized void initializeAdvisorChain() throws AopConfigException, BeansException {
-		if (this.advisorChainInitialized) {
-			return;
-		}
+		clearAdvisors();
 
 		if (!ObjectUtils.isEmpty(this.interceptorNames)) {
 			if (this.beanFactory == null) {


### PR DESCRIPTION
When getObject() on ProxyFactoryBean is called it might not be
fully initialized yet, leading to an exception. This is fine, but
the empty Advisor chain is never rebuilt, not even after initialization
has finished. This leads to 'no-op' proxies which don't do anything.

Issue: SPR-7582