### PR TITLE
Fix ProtobufJavaUtilSupport not flushing output stream.

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverter.java
@@ -356,7 +356,9 @@ public class ProtobufHttpMessageConverter extends AbstractHttpMessageConverter<M
 				throws IOException {
 
 			if (contentType.isCompatibleWith(APPLICATION_JSON)) {
-				this.printer.appendTo(message, new OutputStreamWriter(output, charset));
+				final OutputStreamWriter writer = new OutputStreamWriter(output, charset);
+				this.printer.appendTo(message, writer);
+				writer.flush();
 			}
 			else {
 				throw new IOException("protobuf-java-util does not support " + contentType + " format");


### PR DESCRIPTION
Flush stream once we have finished printing the protobuf object to json.

We were having a problem with empty responses, and tracked it down to here.

@bclozel You seemed to have implemented the protobuf v3 converter. Can you look over it quickly?