### PR TITLE
SPR-15786 - Fix UriUtils.extractFileExtension() when the path fragment include '?' character

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriUtils.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Arjen Poutsma
  * @author Juergen Hoeller
+ * @author Med Belamachi
  * @since 3.0
  * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>
  */
@@ -335,9 +336,11 @@ public abstract class UriUtils {
 	 */
 	@Nullable
 	public static String extractFileExtension(String path) {
-		int end = path.indexOf('?');
+		int qIndex  = path.indexOf('?');
+		int fragIndex  = path.indexOf('#');
+		int end = (fragIndex != -1 &&  fragIndex < qIndex ? fragIndex : qIndex);
 		if (end == -1) {
-			end = path.indexOf('#');
+			end = fragIndex;
 			if (end == -1) {
 				end = path.length();
 			}

--- a/spring-web/src/test/java/org/springframework/web/util/UriUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriUtilsTests.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 /**
  * @author Arjen Poutsma
  * @author Juergen Hoeller
+ * @author Med Belamachi
  */
 public class UriUtilsTests {
 
@@ -115,6 +116,8 @@ public class UriUtilsTests {
 		assertEquals("html", UriUtils.extractFileExtension("/products/view.html#/a"));
 		assertEquals("html", UriUtils.extractFileExtension("/products/view.html#/path/a"));
 		assertEquals("html", UriUtils.extractFileExtension("/products/view.html#/path/a.do"));
+		assertEquals("html", UriUtils.extractFileExtension("/products/view.html#aaa?bbb"));
+		assertEquals("html", UriUtils.extractFileExtension("/products/view.html#aaa.xml?bbb"));
 		assertEquals("html", UriUtils.extractFileExtension("/products/view.html?param=a"));
 		assertEquals("html", UriUtils.extractFileExtension("/products/view.html?param=/path/a"));
 		assertEquals("html", UriUtils.extractFileExtension("/products/view.html?param=/path/a.do"));


### PR DESCRIPTION
Prior to this commit, the function UriUtils.extractFileExtension()  is not able to correclty parse a path uri which include a fragment path mixed by a query string.

e.g : 
- UriUtils.extractFileExtension("/xxx/yyy.json#aaa?bbb"); // => return "json#aaa" instead of "json" 
- UriUtils.extractFileExtension("/xxx/yyy.json#aaa.xml?bbb"); // => return "xml" instead of "json"

Issue: SPR-15786
ICLA: already submitted 