### PR TITLE
MimeType should use last `+` to delimit suffix

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeType.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeType.java
@@ -320,13 +320,13 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 			}
 			if (this.isWildcardSubtype()) {
 				// wildcard with suffix, e.g. application/*+xml
-				int thisPlusIdx = getSubtype().indexOf('+');
+				int thisPlusIdx = getSubtype().lastIndexOf('+');
 				if (thisPlusIdx == -1) {
 					return true;
 				}
 				else {
 					// application/*+xml includes application/soap+xml
-					int otherPlusIdx = other.getSubtype().indexOf('+');
+					int otherPlusIdx = other.getSubtype().lastIndexOf('+');
 					if (otherPlusIdx != -1) {
 						String thisSubtypeNoSuffix = getSubtype().substring(0, thisPlusIdx);
 						String thisSubtypeSuffix = getSubtype().substring(thisPlusIdx + 1);
@@ -364,8 +364,8 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 			// wildcard with suffix? e.g. application/*+xml
 			if (this.isWildcardSubtype() || other.isWildcardSubtype()) {
 
-				int thisPlusIdx = getSubtype().indexOf('+');
-				int otherPlusIdx = other.getSubtype().indexOf('+');
+				int thisPlusIdx = getSubtype().lastIndexOf('+');
+				int otherPlusIdx = other.getSubtype().lastIndexOf('+');
 
 				if (thisPlusIdx == -1 && otherPlusIdx == -1) {
 					return true;

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -327,4 +327,20 @@ public class MimeTypeTests {
 		assertEquals(m2, m1);
 	}
 
+	/**
+	 * SPR-15795
+	 */
+	@Test
+	public void includesAndIsCompatibleWithUseLastPlusSymbolForSyntaxSuffix() {
+		MimeType m1 = new MimeType("application", "*+json");
+		MimeType m2 = new MimeType("application", "x.y+z+json");
+
+		assertTrue(m1.includes(m2));
+		assertFalse(m2.includes(m1));
+
+		assertTrue(m1.isCompatibleWith(m2));
+		assertTrue(m2.isCompatibleWith(m1));
+	}
+
+
 }


### PR DESCRIPTION
According to the [RFC][1], multiple `+` symbols are allowed in a media type. The _last_ one should always be used to delimit the structured syntax suffix.  

The `MimeType` class was using the first `+` rather than the last, so media types with multiple `+` symbols failed to be included in the correct type matchers.  

Issue: [SPR-15795][2] 
CLA: Signed.  

[1]: https://trac.tools.ietf.org/html/draft-ietf-appsawg-media-type-regs-14#section-4.2 
[2]: https://jira.spring.io/browse/SPR-15795