### PR TITLE
SPR-15819 - URI variables with MockRestRequestMatchers requestTo

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/match/MockRestRequestMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/match/MockRestRequestMatchers.java
@@ -87,6 +87,18 @@ public abstract class MockRestRequestMatchers {
 	}
 
 	/**
+	 * Assert the request URI string.
+	 * @param expectedUri the expected URI
+	 * @param uriVars zero or more URI variables to populate the expected URI
+	 * @return the request matcher
+	 */
+	public static RequestMatcher requestToUriTemplate(final String expectedUri, final Object... uriVars) {
+		Assert.notNull(expectedUri, "'uri' must not be null");
+		String uri = UriComponentsBuilder.fromUriString(expectedUri).buildAndExpand(uriVars).encode().toString();
+		return request -> assertEquals("Request URI", uri, request.getURI().toString());
+	}
+
+	/**
 	 * Expect a request to the given URI.
 	 * @param uri the expected URI
 	 * @return the request matcher

--- a/spring-test/src/test/java/org/springframework/test/web/client/match/MockRestRequestMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/match/MockRestRequestMatchersTests.java
@@ -45,6 +45,13 @@ public class MockRestRequestMatchersTests {
 		MockRestRequestMatchers.requestTo("http://foo.com/bar").match(this.request);
 	}
 
+	@Test // SPR-15819
+	public void requestToUriTemplate() throws Exception {
+		this.request.setURI(new URI("http://foo.com/bar"));
+
+		MockRestRequestMatchers.requestToUriTemplate("http://foo.com/{bar}", "bar").match(this.request);
+	}
+
 	@Test(expected = AssertionError.class)
 	public void requestToNoMatch() throws Exception {
 		this.request.setURI(new URI("http://foo.com/bar"));


### PR DESCRIPTION
Adds ability to use URI variables with `MockRestRequestMatchers`'s `requestTo`