### PR TITLE
Modify from return method 'requiredSingleResult' to 'singleResult' in in NamedParameterJdbcTemplate`s queryForObject

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
@@ -210,7 +210,7 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 			throws DataAccessException {
 
 		List<T> results = getJdbcOperations().query(getPreparedStatementCreator(sql, paramSource), rowMapper);
-		return DataAccessUtils.requiredSingleResult(results);
+		return DataAccessUtils.singleResult(results);
 	}
 
 	@Override


### PR DESCRIPTION
in DataAccessUtils.java,
```
public static <T> T singleResult(@Nullable Collection<T> results) throws IncorrectResultSizeDataAccessException {
		int size = (results != null ? results.size() : 0);
		if (size == 0) {
			return null;
		}
		if (results.size() > 1) {
			throw new IncorrectResultSizeDataAccessException(1, size);
		}
		return results.iterator().next();
	}
```
	public static <T> T requiredSingleResult(@Nullable Collection<T> results) throws IncorrectResultSizeDataAccessException {
		int size = (results != null ? results.size() : 0);
		if (size == 0) {
			throw new EmptyResultDataAccessException(1);
		}
		if (results.size() > 1) {
			throw new IncorrectResultSizeDataAccessException(1, size);
		}
		return results.iterator().next();
	}`

when result`s size is 0,
singleReust method return null  and requiredSingleResult method throw 'EmptyResultDataAccessException'.

In NamedParameterJdbcTemplate\`s queryForObject method use DataAccessUtils`s requiredSingleResult method.

This means developer using queryForObject in NamedParameterJdbcTemplate additionally accepts and handles EmptyResultDataAccessException when result size of query is 0.

I think Handling process when result size is 0 is not  Jdbctemplate\`s role or DAO`s role
so, NamedParmeterJdbcTemplate should return null when result size is 0.

