### PR TITLE
SPR-14555

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -3355,7 +3355,7 @@ public class DefaultListableBeanFactoryTests {
 
 		private MapBean(Map<EnumMapping,EnumMappedBean> beanMap) {this.beanMap = beanMap;}
 
-		Map<EnumMapping,EnumMappedBean> getBeanMap() {
+		public Map<EnumMapping,EnumMappedBean> getBeanMap() {
 			return beanMap;
 		}
 	}


### PR DESCRIPTION
Resolve map of dependencies by keying on an enum value instead of bean name.
This is more a proof of concept than a complete implementation, as I believe there are many ways to go about this.

I chose the route to just leave resolving beans by type in place, and remap the keys by searching a method on the value type that returns the expected key type.
If multiple methods have the return type, this throws an exception.
If multiple beans resolve to the same key, this throws an exception.

Very open to suggestions and guidance towards a complete solution.