### PR TITLE
SPR-15850 - Support groovy markup template in WebFlux

### DIFF
--- a/spring-webflux/spring-webflux.gradle
+++ b/spring-webflux/spring-webflux.gradle
@@ -25,6 +25,7 @@ dependencies {
 	optional("com.fasterxml.jackson.core:jackson-databind:${jackson2Version}")
 	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jackson2Version}")
 	optional("org.freemarker:freemarker:${freemarkerVersion}")
+	optional("org.codehaus.groovy:groovy-all:${groovyVersion}")
 	optional("org.apache.httpcomponents:httpclient:${httpclientVersion}") {
 		exclude group: "commons-logging", module: "commons-logging"
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/ViewResolverRegistry.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/ViewResolverRegistry.java
@@ -32,6 +32,8 @@ import org.springframework.web.reactive.result.view.View;
 import org.springframework.web.reactive.result.view.ViewResolver;
 import org.springframework.web.reactive.result.view.freemarker.FreeMarkerConfigurer;
 import org.springframework.web.reactive.result.view.freemarker.FreeMarkerViewResolver;
+import org.springframework.web.reactive.result.view.groovy.GroovyMarkupConfigurer;
+import org.springframework.web.reactive.result.view.groovy.GroovyMarkupViewResolver;
 
 /**
  * Assist with the configuration of a chain of {@link ViewResolver}'s supporting
@@ -42,6 +44,7 @@ import org.springframework.web.reactive.result.view.freemarker.FreeMarkerViewRes
  * JSON, XML, etc.
  *
  * @author Rossen Stoyanchev
+ * @author Jason Yu
  * @since 5.0
  */
 public class ViewResolverRegistry {
@@ -75,6 +78,27 @@ public class ViewResolverRegistry {
 					"This bean may be given any name.");
 		}
 		FreeMarkerRegistration registration = new FreeMarkerRegistration();
+		UrlBasedViewResolver resolver = registration.getViewResolver();
+		if (this.applicationContext != null) {
+			resolver.setApplicationContext(this.applicationContext);
+		}
+		this.viewResolvers.add(resolver);
+		return registration;
+	}
+
+	/**
+	 * Register a {@code GroovyMarkupViewResolver} with a ".tpl" suffix.
+	 * <p><strong>Note</strong> that you must also configure GroovyTemplate by
+	 * adding a {@link GroovyMarkupConfigurer} bean.
+	 */
+	public UrlBasedViewResolverRegistration groovyMarkup() {
+		if (!checkBeanOfType(GroovyMarkupConfigurer.class)) {
+			throw new BeanInitializationException("In addition to a GroovyMarker view resolver " +
+					"there must also be a single GroovyMarkupConfig bean in this web application context " +
+					"(or its parent): GroovyMarkupConfigurer is the usual implementation. " +
+					"This bean may be given any name.");
+		}
+		GroovyMarkupRegistration registration = new GroovyMarkupRegistration();
 		UrlBasedViewResolver resolver = registration.getViewResolver();
 		if (this.applicationContext != null) {
 			resolver.setApplicationContext(this.applicationContext);
@@ -147,6 +171,14 @@ public class ViewResolverRegistry {
 		public FreeMarkerRegistration() {
 			super(new FreeMarkerViewResolver());
 			getViewResolver().setSuffix(".ftl");
+		}
+	}
+
+	private static class GroovyMarkupRegistration extends UrlBasedViewResolverRegistration {
+
+		public GroovyMarkupRegistration() {
+			super(new GroovyMarkupViewResolver());
+			getViewResolver().setSuffix(".tpl");
 		}
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupConfig.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.view.groovy;
+
+import groovy.text.markup.MarkupTemplateEngine;
+
+/**
+ * Interface to be implemented by objects that configure and manage a Groovy
+ * {@link MarkupTemplateEngine} for automatic lookup in a web environment.
+ * Detected and used by {@link GroovyMarkupView}.
+ *
+ * @author Jason Yu
+ * @since 5.0
+ */
+public interface GroovyMarkupConfig {
+
+	/**
+	 * Return the Groovy {@link MarkupTemplateEngine} for the current
+	 * web application context. May be unique to one servlet, or shared
+	 * in the root context.
+	 * @return the Groovy MarkupTemplateEngine engine
+	 */
+	MarkupTemplateEngine getTemplateEngine();
+}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupConfigurer.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupConfigurer.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.view.groovy;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import groovy.text.markup.MarkupTemplateEngine;
+import groovy.text.markup.TemplateConfiguration;
+import groovy.text.markup.TemplateResolver;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.core.io.Resource;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * An extension of Groovy's {@link groovy.text.markup.TemplateConfiguration} and
+ * an implementation of Spring WebFlux's {@link GroovyMarkupConfig} for creating
+ * a {@code MarkupTemplateEngine} for use in a web application. The most basic
+ * way to configure this class is to set the "resourceLoaderPath". For example:
+ *
+ * <pre class="code">
+ *
+ * // Add the following to an &#64;Configuration class
+ *
+ * &#64;Bean
+ * public GroovyMarkupConfig groovyMarkupConfigurer() {
+ *     GroovyMarkupConfigurer configurer = new GroovyMarkupConfigurer();
+ *     configurer.setResourceLoaderPath("classpath:/WEB-INF/groovymarkup/");
+ *     return configurer;
+ * }
+ * </pre>
+ *
+ * By default this bean will create a {@link MarkupTemplateEngine} with:
+ * <ul>
+ * <li>a parent ClassLoader for loading Groovy templates with their references
+ * <li>the default configuration in the base class {@link TemplateConfiguration}
+ * <li>a {@link groovy.text.markup.TemplateResolver} for resolving template files
+ * </ul>
+ *
+ * You can provide the {@link MarkupTemplateEngine} instance directly to this bean
+ * in which case all other properties will not be effectively ignored.
+ *
+ * <p>This bean must be included in the application context of any application
+ * using the Spring WebFlux {@link GroovyMarkupView} for rendering. It exists purely
+ * for the purpose of configuring Groovy's Markup templates. It is not meant to be
+ * referenced by application components directly. It implements GroovyMarkupConfig
+ * to be found by GroovyMarkupView without depending on a bean name. Each
+ * DispatcherServlet can define its own GroovyMarkupConfigurer if desired.
+ *
+ * <p>Note that resource caching is enabled by default in {@link MarkupTemplateEngine}.
+ * Use the {@link #setCacheTemplates(boolean)} to configure that as necessary.
+ *
+ * <p>Spring's Groovy Markup template support requires Groovy 2.3.1 or higher.
+ *
+ * @author Jason Yu
+ * @since 5.0
+ * @see GroovyMarkupView
+ * @see <a href="http://groovy-lang.org/templating.html#_the_markuptemplateengine">
+ *     Groovy Markup Template engine documentation</a>
+ */
+public class GroovyMarkupConfigurer extends TemplateConfiguration
+		implements GroovyMarkupConfig, ApplicationContextAware, InitializingBean {
+
+	private String resourceLoaderPath = "classpath:";
+
+	@Nullable
+	private MarkupTemplateEngine templateEngine;
+
+	@Nullable
+	private ApplicationContext applicationContext;
+
+	/**
+	 * Set the Groovy Markup Template resource loader path(s) via a Spring resource
+	 * location. Accepts multiple locations as a comma-separated list of paths.
+	 * Standard URLs like "file:" and "classpath:" and pseudo URLs are supported
+	 * as understood by Spring's {@link org.springframework.core.io.ResourceLoader}.
+	 * Relative paths are allowed when running in an ApplicationContext.
+	 *
+	 */
+	public void setResourceLoaderPath(String resourceLoaderPath) {
+		this.resourceLoaderPath = resourceLoaderPath;
+	}
+
+	public String getResourceLoaderPath() {
+		return resourceLoaderPath;
+	}
+
+	/**
+	 * Set a pre-configured MarkupTemplateEngine to use for the Groovy Markup
+	 * Template web configuration.
+	 * <p>Note that this engine instance has to be manually configured, since all
+	 * other bean properties of this configurer will be ignored.
+	 */
+	public void setTemplateEngine(MarkupTemplateEngine templateEngine) {
+		this.templateEngine = templateEngine;
+	}
+
+	@Override
+	public MarkupTemplateEngine getTemplateEngine() {
+		Assert.state(this.templateEngine != null, "No MarkupTemplateEngine set");
+		return this.templateEngine;
+	}
+
+	protected ApplicationContext getApplicationContext() {
+		Assert.state(this.applicationContext != null, "No ApplicationContext set");
+		return this.applicationContext;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if (this.templateEngine == null) {
+			this.templateEngine = createTemplateEngine();
+		}
+	}
+
+	protected MarkupTemplateEngine createTemplateEngine() throws IOException {
+		if (this.templateEngine == null) {
+			ClassLoader templateClassLoader = createTemplateClassLoader();
+			this.templateEngine = new MarkupTemplateEngine(templateClassLoader, this, new LocaleTemplateResolver());
+		}
+		return this.templateEngine;
+	}
+
+	/**
+	 * Create a parent ClassLoader for Groovy to use as parent ClassLoader
+	 * when loading and compiling templates.
+	 */
+	protected ClassLoader createTemplateClassLoader() throws IOException {
+		String[] paths = StringUtils.commaDelimitedListToStringArray(getResourceLoaderPath());
+		List<URL> urls = new ArrayList<>();
+		for (String path: paths) {
+			Resource[] resources = getApplicationContext().getResources(path);
+			if (resources.length > 0) {
+				for (Resource resource : resources) {
+					if (resource.exists()) {
+						urls.add(resource.getURL());
+					}
+				}
+			}
+		}
+		ClassLoader classLoader = getApplicationContext().getClassLoader();
+		Assert.state(classLoader != null, "No ClassLoader");
+		return (urls.size() > 0 ? new URLClassLoader(urls.toArray(new URL[urls.size()]), classLoader) : classLoader);
+	}
+
+	/**
+	 * Resolve a template from the given template path.
+	 * <p>The default implementation uses the Locale associated with the current request,
+	 * as obtained through {@link org.springframework.context.i18n.LocaleContextHolder LocaleContextHolder},
+	 * to find the template file. Effectively the locale configured at the engine level is ignored.
+	 * @see LocaleContextHolder
+	 */
+	protected URL resolveTemplate(ClassLoader classLoader, String templatePath) throws IOException {
+		MarkupTemplateEngine.TemplateResource resource = MarkupTemplateEngine.TemplateResource.parse(templatePath);
+		Locale locale = LocaleContextHolder.getLocale();
+		URL url = classLoader.getResource(resource.withLocale(locale.toString().replace("-", "_")).toString());
+		if (url == null) {
+			url = classLoader.getResource(resource.withLocale(locale.getLanguage()).toString());
+		}
+		if (url == null) {
+			url = classLoader.getResource(resource.withLocale(null).toString());
+		}
+		if (url == null) {
+			throw new IOException("Unable to load template:" + templatePath);
+		}
+		return url;
+	}
+
+	/**
+	 * Custom {@link TemplateResolver template resolver} that simply delegates to
+	 * {@link #resolveTemplate(ClassLoader, String)}..
+	 */
+	private class LocaleTemplateResolver implements TemplateResolver {
+
+		@Nullable
+		private ClassLoader classLoader;
+
+		@Override
+		public void configure(ClassLoader templateClassLoader, TemplateConfiguration configuration) {
+			this.classLoader = templateClassLoader;
+		}
+
+		@Override
+		public URL resolveTemplate(String templatePath) throws IOException {
+			Assert.state(this.classLoader != null, "No template Classloader available");
+			return GroovyMarkupConfigurer.this.resolveTemplate(this.classLoader, templatePath);
+		}
+	}
+}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupView.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupView.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.view.groovy;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import groovy.text.Template;
+import groovy.text.markup.MarkupTemplateEngine;
+import org.springframework.web.util.NestedServletException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContextException;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeType;
+import org.springframework.web.reactive.result.view.AbstractUrlBasedView;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * An {@link AbstractUrlBasedView} subclass based on Groovy XML/XHTML markup templates.
+ *
+ * <p>Spring's Groovy Markup Template support requires Groovy 2.3.1 and higher.
+ *
+ * @author Jason Yu
+ * @since 5.0
+ * @see GroovyMarkupViewResolver
+ * @see GroovyMarkupConfigurer
+ * @see <a href="http://groovy-lang.org/templating.html#_the_markuptemplateengine">
+ * Groovy Markup Template engine documentation</a>
+ */
+public class GroovyMarkupView extends AbstractUrlBasedView {
+
+	@Nullable
+	private MarkupTemplateEngine engine;
+
+	/**
+	 * Set the MarkupTemplateEngine to use in this view.
+	 * <p>If not set, the engine is auto-detected by looking up a single
+	 * {@link GroovyMarkupConfig} bean in the web application context and using
+	 * it to obtain the configured {@code MarkupTemplateEngine} instance.
+	 * @see GroovyMarkupConfig
+	 */
+	public void setTemplateEngine(MarkupTemplateEngine templateEngine) {
+		this.engine = templateEngine;
+	}
+
+	/**
+	 * Autodetect a MarkupTemplateEngine via the ApplicationContext.
+	 * Called if a MarkupTemplateEngine has not been manually configured.
+	 */
+	protected MarkupTemplateEngine autodetectMarkupTemplateEngine() throws BeansException {
+		try {
+			return BeanFactoryUtils
+					.beanOfTypeIncludingAncestors(
+							obtainApplicationContext(),
+							GroovyMarkupConfig.class, true, false)
+					.getTemplateEngine();
+		}
+		catch (NoSuchBeanDefinitionException e) {
+			throw new ApplicationContextException("Expected a single GroovyMarkupConfig bean in the current " +
+					"Servlet web application context or the parent root context: GroovyMarkupConfigurer is " +
+					"the usual implementation. This bean may have any name.", e);
+		}
+	}
+
+	/**
+	 * Invoked at startup.
+	 * If no {@link #setTemplateEngine(MarkupTemplateEngine) templateEngine} has
+	 * been manually set, this method looks up a {@link GroovyMarkupConfig} bean
+	 * by type and uses it to obtain the Groovy Markup template engine.
+	 * @see GroovyMarkupConfig
+	 * @see #setTemplateEngine(groovy.text.markup.MarkupTemplateEngine)
+	 */
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		super.afterPropertiesSet();
+		if (this.engine == null) {
+			setTemplateEngine(autodetectMarkupTemplateEngine());
+		}
+	}
+
+	@Override
+	public boolean checkResourceExists(Locale locale) throws Exception {
+		Assert.state(this.engine != null, "No MarkupTemplateEngine set");
+		try {
+			this.engine.resolveTemplate(getUrl());
+		}
+		catch (IOException e) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	protected Mono<Void> renderInternal(
+			Map<String, Object> renderAttributes,
+			@Nullable MediaType contentType,
+			ServerWebExchange exchange) {
+
+		String url = getUrl();
+		Assert.state(url != null, "'url' not set");
+		Assert.state(this.engine != null, "No MarkupTemplateEngine set");
+
+		DataBuffer dataBuffer = exchange.getResponse().bufferFactory().allocateBuffer();
+		try {
+			Template template = this.engine.createTemplateByPath(url);
+			Charset charset = getCharset(contentType);
+			Writer writer = new OutputStreamWriter(dataBuffer.asOutputStream(), charset);
+			template.make(renderAttributes).writeTo(new BufferedWriter(writer));
+		}
+		catch (IOException e) {
+			String message = "Could not load Groovy template for URL : " + getUrl();
+			return Mono.error(new IllegalStateException(message, e));
+		}
+		catch (ClassNotFoundException e) {
+			Throwable cause = (e.getCause() != null ? e.getCause() : e);
+			return Mono.error(new NestedServletException(
+				"Could not find class while rendering Groovy Markup view with name '" +
+				getUrl() + "':" + e.getMessage() + "'", cause));
+		}
+		catch (Throwable e) {
+			return Mono.error(e);
+		}
+		return exchange.getResponse().writeWith(Flux.just(dataBuffer));
+	}
+
+	/**
+	 * Transform {@code MediaType} to {@code Charset}. If {@code MediaType} is null, then get
+	 * default charset from {@code AbstractView} class.
+	 */
+	private Charset getCharset(@Nullable MediaType mediaType) {
+		return Optional.ofNullable(mediaType).map(MimeType::getCharset).orElse(getDefaultCharset());
+	}
+}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupViewResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupViewResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.web.servlet.view.groovy;
+package org.springframework.web.reactive.result.view.groovy;
 
-import java.util.Locale;
-
-import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
+import org.springframework.web.reactive.result.view.UrlBasedViewResolver;
 
 /**
- * Convenience subclass of {@link AbstractTemplateViewResolver} that supports
+ * Convenience subclass of {@link UrlBasedViewResolver} that supports
  * {@link GroovyMarkupView} (i.e. Groovy XML/XHTML markup templates) and
  * custom subclasses of it.
  *
@@ -32,11 +30,11 @@ import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
  * existence of the specified template resources and only return a non-null
  * View object if a template is actually found.
  *
- * @author Brian Clozel
- * @since 4.1
+ * @author Jason Yu
+ * @since 5.0
  * @see GroovyMarkupConfigurer
  */
-public class GroovyMarkupViewResolver extends AbstractTemplateViewResolver {
+public class GroovyMarkupViewResolver extends UrlBasedViewResolver {
 
 	/**
 	 * Sets the default {@link #setViewClass view class} to {@link #requiredViewClass}:
@@ -51,26 +49,16 @@ public class GroovyMarkupViewResolver extends AbstractTemplateViewResolver {
 	 * and {@link #setSuffix suffix} as constructor arguments.
 	 * @param prefix the prefix that gets prepended to view names when building a URL
 	 * @param suffix the suffix that gets appended to view names when building a URL
-	 * @since 4.3
+	 * @since 5.0
 	 */
 	public GroovyMarkupViewResolver(String prefix, String suffix) {
-		this();
+		setViewClass(requiredViewClass());
 		setPrefix(prefix);
 		setSuffix(suffix);
 	}
-
 
 	@Override
 	protected Class<?> requiredViewClass() {
 		return GroovyMarkupView.class;
 	}
-
-	/**
-	 * This resolver supports i18n, so cache keys should contain the locale.
-	 */
-	@Override
-	protected Object getCacheKey(String viewName, Locale locale) {
-		return viewName + '_' + locale;
-	}
-
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/package-info.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/groovy/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Support classes for the integration of
+ * <a href="http://docs.groovy-lang.org/docs/next/html/documentation/template-engines.html#_the_markuptemplateengine">
+ * Groovy Templates</a> as Spring web view technology.
+ * Contains a View implementation for Groovy templates.
+ */
+@NonNullApi
+package org.springframework.web.reactive.result.view.groovy;
+
+import org.springframework.lang.NonNullApi;
+

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/config/ViewResolverRegistryTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/config/ViewResolverRegistryTests.java
@@ -25,6 +25,7 @@ import org.springframework.web.reactive.result.view.HttpMessageWriterView;
 import org.springframework.web.reactive.result.view.UrlBasedViewResolver;
 import org.springframework.web.reactive.result.view.View;
 import org.springframework.web.reactive.result.view.freemarker.FreeMarkerConfigurer;
+import org.springframework.web.reactive.result.view.groovy.GroovyMarkupConfigurer;
 
 import static org.junit.Assert.*;
 
@@ -32,6 +33,7 @@ import static org.junit.Assert.*;
  * Unit tests for {@link ViewResolverRegistry}.
  *
  * @author Rossen Stoyanchev
+ * @author Jason Yu
  */
 public class ViewResolverRegistryTests {
 
@@ -42,6 +44,7 @@ public class ViewResolverRegistryTests {
 	public void setup() {
 		StaticWebApplicationContext context = new StaticWebApplicationContext();
 		context.registerSingleton("freeMarkerConfigurer", FreeMarkerConfigurer.class);
+		context.registerSingleton("groovyMarkupConfigurer", GroovyMarkupConfigurer.class);
 		this.registry = new ViewResolverRegistry(context);
 	}
 
@@ -56,6 +59,14 @@ public class ViewResolverRegistryTests {
 		assertFalse(this.registry.hasRegistrations());
 
 		this.registry.freeMarker();
+		assertTrue(this.registry.hasRegistrations());
+	}
+
+	@Test
+	public void hasGroovyMarkupRegistrations() {
+		assertFalse(this.registry.hasRegistrations());
+
+		this.registry.groovyMarkup();
 		assertTrue(this.registry.hasRegistrations());
 	}
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupConfigurerTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupConfigurerTests.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.view.groovy;
+
+import groovy.text.markup.MarkupTemplateEngine;
+import groovy.text.markup.TemplateConfiguration;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Locale;
+
+
+import groovy.text.TemplateEngine;
+
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.StaticApplicationContext;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for
+ * {@link org.springframework.web.reactive.result.view.groovy.GroovyMarkupConfigurer}.
+ *
+ * @author Jason Yu
+ */
+public class GroovyMarkupConfigurerTests {
+
+	private static final String RESOURCE_LOADER_PATH = "classpath:org/springframework/web/reactive/result/view/groovy/";
+
+	private static final String TEMPLATE_PREFIX = "org/springframework/web/reactive/result/view/groovy/";
+
+	private StaticApplicationContext applicationContext;
+
+	private GroovyMarkupConfigurer configurer;
+
+	@Before
+	public void setUp() throws Exception {
+		this.applicationContext = new StaticApplicationContext();
+		this.configurer = new GroovyMarkupConfigurer();
+		this.configurer.setResourceLoaderPath(RESOURCE_LOADER_PATH);
+	}
+
+	@Test
+	public void defaultTemplateEngine() throws Exception {
+		this.configurer.setApplicationContext(this.applicationContext);
+		this.configurer.afterPropertiesSet();
+
+		TemplateEngine engine = this.configurer.getTemplateEngine();
+		assertNotNull(engine);
+		assertEquals(MarkupTemplateEngine.class, engine.getClass());
+
+		MarkupTemplateEngine markupEngine = (MarkupTemplateEngine)engine;
+		TemplateConfiguration configuration = markupEngine.getTemplateConfiguration();
+		assertNotNull(configuration);
+		assertEquals(GroovyMarkupConfigurer.class, configuration.getClass());
+	}
+
+	@Test
+	public void customTemplateEngine() throws Exception {
+		this.configurer.setApplicationContext(this.applicationContext);
+		this.configurer.setTemplateEngine(new TestTemplateEngine());
+		this.configurer.afterPropertiesSet();
+
+		TemplateEngine engine = this.configurer.getTemplateEngine();
+		assertNotNull(engine);
+		assertEquals(TestTemplateEngine.class, engine.getClass());
+	}
+
+	@Test
+	public void customTemplateConfiguration() throws Exception {
+		this.configurer.setApplicationContext(this.applicationContext);
+		this.configurer.setCacheTemplates(false);
+		this.configurer.afterPropertiesSet();
+
+		TemplateEngine engine = this.configurer.getTemplateEngine();
+		assertNotNull(engine);
+		assertEquals(MarkupTemplateEngine.class, engine.getClass());
+
+		MarkupTemplateEngine markupEngine = (MarkupTemplateEngine) engine;
+		TemplateConfiguration configuration = markupEngine.getTemplateConfiguration();
+		assertNotNull(configuration);
+		assertFalse(configuration.isCacheTemplates());
+	}
+
+	@Test
+	public void parentLoader() throws Exception {
+
+		this.configurer.setApplicationContext(this.applicationContext);
+
+		ClassLoader classLoader = this.configurer.createTemplateClassLoader();
+		assertNotNull(classLoader);
+		URLClassLoader urlClassLoader = (URLClassLoader) classLoader;
+		assertThat(Arrays.asList(urlClassLoader.getURLs()), Matchers.hasSize(1));
+		assertThat(Arrays.asList(urlClassLoader.getURLs()).get(0).toString(),
+				   Matchers.endsWith("org/springframework/web/reactive/result/view/groovy/"));
+
+		this.configurer.setResourceLoaderPath(RESOURCE_LOADER_PATH + ",classpath:org/springframework/web/reactive/result/view/");
+		classLoader = this.configurer.createTemplateClassLoader();
+		assertNotNull(classLoader);
+		urlClassLoader = (URLClassLoader) classLoader;
+		assertThat(Arrays.asList(urlClassLoader.getURLs()), Matchers.hasSize(2));
+		assertThat(Arrays.asList(urlClassLoader.getURLs()).get(0).toString(),
+				   Matchers.endsWith("org/springframework/web/reactive/result/view/groovy/"));
+		assertThat(Arrays.asList(urlClassLoader.getURLs()).get(1).toString(),
+				   Matchers.endsWith("org/springframework/web/reactive/result/view/"));
+	}
+
+	private class TestTemplateEngine extends MarkupTemplateEngine {
+
+		public TestTemplateEngine() {
+			super(new TemplateConfiguration());
+		}
+	}
+
+	@Test
+	public void resolveSampleTemplate() throws Exception {
+		URL url = this.configurer.resolveTemplate(getClass().getClassLoader(), TEMPLATE_PREFIX + "test.tpl");
+		assertNotNull(url);
+	}
+
+	@Test
+	public void resolveI18nFullLocale() throws Exception {
+		LocaleContextHolder.setLocale(Locale.GERMANY);
+		URL url = this.configurer.resolveTemplate(getClass().getClassLoader(), TEMPLATE_PREFIX + "i18n.tpl");
+		assertNotNull(url);
+		assertThat(url.getPath(), Matchers.containsString("i18n_de_DE.tpl"));
+	}
+
+	@Test
+	public void resolveI18nPartialLocale() throws Exception {
+		LocaleContextHolder.setLocale(Locale.FRANCE);
+		URL url = this.configurer.resolveTemplate(getClass().getClassLoader(), TEMPLATE_PREFIX + "i18n.tpl");
+		assertNotNull(url);
+		assertThat(url.getPath(), Matchers.containsString("i18n_fr.tpl"));
+	}
+
+	@Test
+	public void resolveI18nDefaultLocale() throws Exception {
+		LocaleContextHolder.setLocale(Locale.US);
+		URL url = this.configurer.resolveTemplate(getClass().getClassLoader(), TEMPLATE_PREFIX + "i18n.tpl");
+		assertNotNull(url);
+		assertThat(url.getPath(), Matchers.containsString("i18n.tpl"));
+	}
+
+	@Test(expected = IOException.class)
+	public void failMissingTemplate() throws Exception {
+		LocaleContextHolder.setLocale(Locale.US);
+		this.configurer.resolveTemplate(getClass().getClassLoader(), TEMPLATE_PREFIX + "missing.tpl");
+		fail();
+	}
+}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupViewResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupViewResolverTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.view.groovy;
+
+import org.junit.Test;
+
+import org.springframework.beans.DirectFieldAccessor;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for
+ * {@link org.springframework.web.reactive.result.view.groovy.GroovyMarkupViewResolverTests}.
+ *
+ * @author Jason Yu
+ */
+public class GroovyMarkupViewResolverTests {
+
+	@Test
+	public void viewClass() throws Exception {
+		GroovyMarkupViewResolver resolver = new GroovyMarkupViewResolver();
+		assertEquals(GroovyMarkupView.class, resolver.requiredViewClass());
+		DirectFieldAccessor viewAccessor = new DirectFieldAccessor(resolver);
+		Class viewClass = (Class) viewAccessor.getPropertyValue("viewClass");
+		assertEquals(GroovyMarkupView.class, viewClass);
+	}
+}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupViewTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/groovy/GroovyMarkupViewTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.view.groovy;
+
+import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import groovy.text.Template;
+import groovy.text.TemplateEngine;
+import groovy.text.markup.MarkupTemplateEngine;
+import groovy.text.markup.TemplateConfiguration;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.context.ApplicationContextException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.mock.http.server.reactive.test.MockServerHttpRequest;
+import org.springframework.mock.http.server.reactive.test.MockServerWebExchange;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * @author Jason Yu
+ */
+public class GroovyMarkupViewTests {
+
+	private static final String RESOURCE_LOADER_PATH = "classpath*:org/springframework/web/reactive/result/view/groovy/";
+
+	private GenericApplicationContext context;
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Before
+	public void setUp() throws Exception {
+		this.context = new GenericApplicationContext();
+		this.context.refresh();
+	}
+
+
+	@Test
+	public void missingGroovyMarkupConfig() throws Exception {
+		this.exception.expect(ApplicationContextException.class);
+		this.exception.expectMessage("Expected a single GroovyMarkupConfig bean in");
+
+		GroovyMarkupView view = new GroovyMarkupView();
+		view.setApplicationContext(this.context);
+		view.setUrl("sampleView");
+		view.afterPropertiesSet();
+		fail();
+	}
+
+	@Test
+	public void customTemplateEngine() throws Exception {
+		GroovyMarkupView view = new GroovyMarkupView();
+		view.setTemplateEngine(new TestTemplateEngine());
+		view.setApplicationContext(this.context);
+
+		DirectFieldAccessor accessor = new DirectFieldAccessor(view);
+		TemplateEngine engine = (TemplateEngine)accessor.getPropertyValue("engine");
+		assertNotNull(engine);
+		assertEquals(TestTemplateEngine.class, engine.getClass());
+	}
+
+	@Test
+	public void checkResource() throws Exception {
+		GroovyMarkupView view = createViewWithUrl("test.tpl");
+		assertTrue(view.checkResourceExists(Locale.US));
+	}
+
+	@Test
+	public void checkMissingResource() throws Exception {
+		GroovyMarkupView view = createViewWithUrl("missing.tpl");
+		assertFalse(view.checkResourceExists(Locale.US));
+	}
+
+	@Test
+	public void checkI18nResource() throws Exception {
+		GroovyMarkupView view = createViewWithUrl("i18n.tpl");
+		assertTrue(view.checkResourceExists(Locale.FRENCH));
+	}
+
+	@Test
+	public void checkI18nResourceMissingLocale() throws Exception {
+		GroovyMarkupView view = createViewWithUrl("i18n.tpl");
+		assertTrue(view.checkResourceExists(Locale.CHINESE));
+	}
+
+	@Test
+	public void renderMarkupTemplate() throws Exception {
+		Map<String, Object> model = new HashMap<>();
+		model.put("name", "Spring");
+		MockServerWebExchange exchange = renderViewWithModel("test.tpl", model, Locale.US);
+		DataBuffer buf = exchange.getResponse().getBody().blockFirst();
+		assertThat(asString(buf), Matchers.containsString("<h1>Hello Spring</h1>"));
+	}
+
+	@Test
+	public void renderI18nTemplate() throws Exception {
+		Map<String, Object> model = new HashMap<>();
+		model.put("name", "Spring");
+		MockServerWebExchange exchange = renderViewWithModel("i18n.tpl", model, Locale.FRANCE);
+		DataBuffer buf = exchange.getResponse().getBody().blockFirst();
+		assertEquals("<p>Bonjour Spring</p>", asString(buf));
+
+		exchange = renderViewWithModel("i18n.tpl", model, Locale.GERMANY);
+		buf = exchange.getResponse().getBody().blockFirst();
+		assertEquals("<p>Include German</p><p>Hallo Spring</p>", asString(buf));
+
+		exchange = renderViewWithModel("i18n.tpl", model, new Locale("es"));
+		buf = exchange.getResponse().getBody().blockFirst();
+		assertEquals("<p>Include Default</p><p>Hola Spring</p>", asString(buf));
+	}
+
+	@Test
+	public void renderLayoutTemplate() throws Exception {
+		Map<String, Object> model = new HashMap<>();
+		MockServerWebExchange exchange = renderViewWithModel("content.tpl", model, Locale.US);
+		DataBuffer buf = exchange.getResponse().getBody().blockFirst();
+		assertEquals("<html><head><title>Layout example</title></head><body><p>This is the body</p></body></html>",
+					 asString(buf));
+	}
+
+	private GroovyMarkupView createViewWithUrl(String viewUrl) throws Exception {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.register(GroovyMarkupConfiguration.class);
+		ctx.refresh();
+
+		GroovyMarkupView view = new GroovyMarkupView();
+		view.setUrl(viewUrl);
+		view.setApplicationContext(ctx);
+		view.afterPropertiesSet();
+		return view;
+	}
+
+	private MockServerWebExchange renderViewWithModel(
+			String viewUrl, Map<String, Object> model, Locale locale) throws Exception {
+		GroovyMarkupView view = createViewWithUrl(viewUrl);
+		MockServerWebExchange exchange = MockServerHttpRequest.get("/path")
+				.acceptLanguageAsLocales(locale).toExchange();
+		LocaleContextHolder.setLocale(locale);
+		view.render(model, null, exchange).block(Duration.ofSeconds(5));
+		return exchange;
+	}
+
+	private static String asString(DataBuffer dataBuffer) {
+		ByteBuffer byteBuffer = dataBuffer.asByteBuffer();
+		final byte[] bytes = new byte[byteBuffer.remaining()];
+		byteBuffer.get(bytes);
+		return new String(bytes, StandardCharsets.UTF_8);
+	}
+
+	public class TestTemplateEngine extends MarkupTemplateEngine {
+
+		public TestTemplateEngine() {
+			super(new TemplateConfiguration());
+		}
+
+		@Override
+		public Template createTemplate(Reader reader) {
+			return null;
+		}
+	}
+
+	@Configuration
+	static class GroovyMarkupConfiguration {
+
+		@Bean
+		public GroovyMarkupConfig groovyMarkupConfigurer() {
+			GroovyMarkupConfigurer configurer = new GroovyMarkupConfigurer();
+			configurer.setResourceLoaderPath(RESOURCE_LOADER_PATH);
+			return configurer;
+		}
+	}
+}

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/content.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/content.tpl
@@ -1,0 +1,3 @@
+layout 'layout-main.tpl',
+    title: 'Layout example',
+    bodyContents: contents { p('This is the body') }

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/i18n.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/i18n.tpl
@@ -1,0 +1,1 @@
+p('Hello Spring')

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/i18n_de_DE.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/i18n_de_DE.tpl
@@ -1,0 +1,2 @@
+include template: 'includes/include.tpl'
+p('Hallo Spring')

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/i18n_es.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/i18n_es.tpl
@@ -1,0 +1,2 @@
+include template: 'includes/include.tpl'
+p('Hola Spring')

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/i18n_fr.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/i18n_fr.tpl
@@ -1,0 +1,1 @@
+p('Bonjour Spring')

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/includes/include.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/includes/include.tpl
@@ -1,0 +1,1 @@
+p('Include Default')

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/includes/include_de_DE.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/includes/include_de_DE.tpl
@@ -1,0 +1,1 @@
+p('Include German')

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/layout-main.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/layout-main.tpl
@@ -1,0 +1,8 @@
+html {
+    head {
+        title(title)
+    }
+    body {
+        bodyContents()
+    }
+}

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/test.tpl
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/result/view/groovy/test.tpl
@@ -1,0 +1,13 @@
+yieldUnescaped '<!DOCTYPE html>'
+html {
+    head {
+        meta('http-equiv':'"Content-Type", content="text/html; charset=utf-8"')
+        title('Spring Framework Groovy Template Support')
+    }
+    body {
+        div(class:'test') {
+			h1("Hello $name")
+			p("Groovy Templates")
+        }
+    }
+}


### PR DESCRIPTION
 - Migrate groovy markup template implementation from webmvc to webflux.
 - Migrate groovy markup template tests from webmvc to webflux.
 - Add groovy markup view solver to view resolver registry.

Issue: SPR-15850