### PR TITLE
Jackson encoder and decoder should use provided mime types

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2CodecSupport.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2CodecSupport.java
@@ -72,7 +72,8 @@ public abstract class Jackson2CodecSupport {
 	protected Jackson2CodecSupport(ObjectMapper objectMapper, MimeType... mimeTypes) {
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		this.objectMapper = objectMapper;
-		this.mimeTypes = !ObjectUtils.isEmpty(mimeTypes) ? Arrays.asList(mimeTypes) : JSON_MIME_TYPES;
+		this.mimeTypes = Collections.unmodifiableList(
+				!ObjectUtils.isEmpty(mimeTypes) ? Arrays.asList(mimeTypes) : JSON_MIME_TYPES );
 	}
 
 
@@ -110,4 +111,7 @@ public abstract class Jackson2CodecSupport {
 	@Nullable
 	protected abstract <A extends Annotation> A getAnnotation(MethodParameter parameter, Class<A> annotType);
 
+	protected List<MimeType> getMimeTypes() {
+		return mimeTypes;
+	}
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonDecoder.java
@@ -42,6 +42,6 @@ public class Jackson2JsonDecoder extends AbstractJackson2Decoder {
 
 	@Override
 	public List<MimeType> getDecodableMimeTypes() {
-		return JSON_MIME_TYPES;
+		return getMimeTypes();
 	}
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonEncoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonEncoder.java
@@ -73,6 +73,6 @@ public class Jackson2JsonEncoder extends AbstractJackson2Encoder {
 
 	@Override
 	public List<MimeType> getEncodableMimeTypes() {
-		return JSON_MIME_TYPES;
+		return getMimeTypes();
 	}
 }

--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonDecoderTests.java
@@ -16,12 +16,13 @@
 
 package org.springframework.http.codec.json;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.springframework.util.MimeType;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -61,6 +62,21 @@ public class Jackson2JsonDecoderTests extends AbstractDataBufferAllocatingTestCa
 
 		assertFalse(decoder.canDecode(forClass(String.class), null));
 		assertFalse(decoder.canDecode(forClass(Pojo.class), APPLICATION_XML));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void canDecodeWithProvidedMimeType() {
+		MimeType textJavascript = new MimeType("text", "javascript", StandardCharsets.UTF_8);
+		Jackson2JsonDecoder decoder = new Jackson2JsonDecoder(new ObjectMapper(), textJavascript);
+		assertEquals(1, decoder.getDecodableMimeTypes().size());
+		assertTrue(decoder.getDecodableMimeTypes().contains(textJavascript));
+
+		assertTrue(decoder.canDecode(forClass(Pojo.class), textJavascript));
+		assertFalse(decoder.canDecode(forClass(Pojo.class), APPLICATION_JSON));
+
+		// Validate immutability of mime types list
+		decoder.getMimeTypes().add(new MimeType("text", "ecmascript"));
+		assertEquals(1, decoder.getDecodableMimeTypes().size());
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonEncoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonEncoderTests.java
@@ -16,16 +16,20 @@
 
 package org.springframework.http.codec.json;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import static java.util.Collections.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.http.codec.json.Jackson2JsonEncoder.*;
 import static org.springframework.http.codec.json.JacksonViewBean.*;
+import org.springframework.util.MimeType;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -56,6 +60,21 @@ public class Jackson2JsonEncoderTests extends AbstractDataBufferAllocatingTestCa
 
 		// SPR-15464
 		assertTrue(this.encoder.canEncode(ResolvableType.NONE, null));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void canEncodeWithCustomMimeType() {
+		ResolvableType pojoType = ResolvableType.forClass(Pojo.class);
+		MimeType textJavascript = new MimeType("text", "javascript", StandardCharsets.UTF_8);
+		Jackson2JsonEncoder encoder = new Jackson2JsonEncoder(new ObjectMapper(), textJavascript);
+		assertEquals(1, encoder.getEncodableMimeTypes().size());
+		assertTrue(encoder.getEncodableMimeTypes().contains(textJavascript));
+
+		assertTrue(encoder.canEncode(pojoType, textJavascript));
+
+		// Validate immutability of mime types list
+		encoder.getMimeTypes().add(new MimeType("text", "ecmascript"));
+		assertEquals(1, encoder.getEncodableMimeTypes().size());
 	}
 
 	@Test


### PR DESCRIPTION
Instead of always using the default JSON mime types.

SPR-15866