### PR TITLE
SPR-15892 - Url parameter based version strategy support

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/UrlParameterFixedVersionStrategy.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/UrlParameterFixedVersionStrategy.java
@@ -1,0 +1,35 @@
+package org.springframework.web.servlet.resource;
+
+import org.springframework.core.io.Resource;
+
+/**
+ * A {@code VersionStrategy} that relies on a fixed version applied as a request
+ * parameter
+ *
+ * <p>This is useful for example when {@link ContentVersionStrategy} cannot be
+ * used such as when using JavaScript and css module loaders which are in charge of
+ * loading the JavaScript and css resources and need to know their relative paths.
+ *
+ * @author Zsolt Fatér
+ * @see VersionResourceResolver
+ */
+public class UrlParameterFixedVersionStrategy extends AbstractVersionStrategy {
+
+    private final String version;
+
+    public UrlParameterFixedVersionStrategy(String version) {
+        super(new UrlParameterVersionStrategy());
+        this.version = version;
+    }
+
+	public UrlParameterFixedVersionStrategy(String version, String attributeName) {
+		super(new UrlParameterVersionStrategy(attributeName));
+		this.version = version;
+	}
+
+    @Override
+    public String getResourceVersion(Resource resource) {
+        return this.version;
+    }
+
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/AbstractVersionStrategyUrlParameterVersionStrategyTest.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/AbstractVersionStrategyUrlParameterVersionStrategyTest.java
@@ -1,0 +1,74 @@
+package org.springframework.web.servlet.resource;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AbstractVersionStrategy.UrlParameterVersionStrategy}.
+ *
+ * @author Zsolt Fatér
+ */
+public class AbstractVersionStrategyUrlParameterVersionStrategyTest {
+
+	private static final String VERSION = "1.0.0";
+	private static final String VERSION_ATTRIBUTE = "v=" + VERSION;
+	private static final String JSESSIONID = ";jsessionid=123456";
+	private static final String OTHER_ATTRIBUTE = "other=other";
+
+	private static final String ADD_URL_SIMPLE = "http://localhost/project/css/test.css";
+	private static final String EXPECTED_ADD_URL_SIMPLE = ADD_URL_SIMPLE + "?" + VERSION_ATTRIBUTE;
+	private static final String ADD_URL_JSESSION = ADD_URL_SIMPLE + JSESSIONID;
+	private static final String EXPECTED_ADD_URL_JSESSION = ADD_URL_SIMPLE + "?" + VERSION_ATTRIBUTE + JSESSIONID;
+	private static final String ADD_URL_OTHER = ADD_URL_SIMPLE + "?" + OTHER_ATTRIBUTE;
+	private static final String EXPECTED_ADD_URL_OTHER = ADD_URL_OTHER + "&" + VERSION_ATTRIBUTE;
+	private static final String ADD_URL_OTHER_JSESSION = ADD_URL_SIMPLE + "?" + OTHER_ATTRIBUTE + JSESSIONID;
+	private static final String EXPECTED_ADD_URL_OTHER_JSESSION = ADD_URL_OTHER + "&" + VERSION_ATTRIBUTE + JSESSIONID;
+	private static final String ADD_URL_OTHER_OTHER = ADD_URL_SIMPLE + "?" + OTHER_ATTRIBUTE + "&" + OTHER_ATTRIBUTE;
+	private static final String EXPECTED_ADD_URL_OTHER_OTHER = ADD_URL_OTHER_OTHER + "&" + VERSION_ATTRIBUTE;
+	private static final String ADD_URL_OTHER_OTHER_JSESSION = ADD_URL_OTHER_OTHER + JSESSIONID;
+	private static final String EXPECTED_ADD_URL_OTHER_OTHER_JSESSION = ADD_URL_OTHER_OTHER + "&" + VERSION_ATTRIBUTE + JSESSIONID;
+
+	private static final String EXTRACT_URL = ADD_URL_OTHER + "&" + VERSION_ATTRIBUTE + "&" + OTHER_ATTRIBUTE;
+	private static final String EXTRACT_URL_JSESSION = EXTRACT_URL + JSESSIONID;
+
+	private static final String REMOVE_URL_VERSION_OTHER = EXPECTED_ADD_URL_SIMPLE + "&" + OTHER_ATTRIBUTE;
+	private static final String REMOVE_URL_VERSION_OTHER_JSESSION = REMOVE_URL_VERSION_OTHER + JSESSIONID;
+	private static final String REMOVE_URL_OTHER_VERSION_OTHER = EXPECTED_ADD_URL_OTHER + "&" + OTHER_ATTRIBUTE;
+	private static final String REMOVE_URL_OTHER_VERSION_OTHER_JSESSION = REMOVE_URL_OTHER_VERSION_OTHER + JSESSIONID;
+
+	private static final AbstractVersionStrategy.UrlParameterVersionStrategy URL_PARAMETER_VERSION_STRATEGY = new AbstractVersionStrategy.UrlParameterVersionStrategy();
+
+	@Test
+	public void addTest() {
+		Assert.assertEquals(EXPECTED_ADD_URL_SIMPLE, URL_PARAMETER_VERSION_STRATEGY.addVersion(ADD_URL_SIMPLE, VERSION));
+		Assert.assertEquals(EXPECTED_ADD_URL_JSESSION, URL_PARAMETER_VERSION_STRATEGY.addVersion(ADD_URL_JSESSION, VERSION));
+		Assert.assertEquals(EXPECTED_ADD_URL_OTHER, URL_PARAMETER_VERSION_STRATEGY.addVersion(ADD_URL_OTHER, VERSION));
+		Assert.assertEquals(EXPECTED_ADD_URL_OTHER_JSESSION, URL_PARAMETER_VERSION_STRATEGY.addVersion(ADD_URL_OTHER_JSESSION, VERSION));
+		Assert.assertEquals(EXPECTED_ADD_URL_OTHER_OTHER, URL_PARAMETER_VERSION_STRATEGY.addVersion(ADD_URL_OTHER_OTHER, VERSION));
+		Assert.assertEquals(EXPECTED_ADD_URL_OTHER_OTHER_JSESSION, URL_PARAMETER_VERSION_STRATEGY.addVersion(ADD_URL_OTHER_OTHER_JSESSION, VERSION));
+	}
+
+	@Test
+	public void extractTest() {
+		Assert.assertNull(URL_PARAMETER_VERSION_STRATEGY.extractVersion(ADD_URL_SIMPLE));
+		Assert.assertEquals(VERSION, URL_PARAMETER_VERSION_STRATEGY.extractVersion(EXPECTED_ADD_URL_SIMPLE));
+		Assert.assertEquals(VERSION, URL_PARAMETER_VERSION_STRATEGY.extractVersion(EXPECTED_ADD_URL_JSESSION));
+		Assert.assertEquals(VERSION, URL_PARAMETER_VERSION_STRATEGY.extractVersion(EXPECTED_ADD_URL_OTHER));
+		Assert.assertEquals(VERSION, URL_PARAMETER_VERSION_STRATEGY.extractVersion(EXPECTED_ADD_URL_OTHER_JSESSION));
+		Assert.assertEquals(VERSION, URL_PARAMETER_VERSION_STRATEGY.extractVersion(EXTRACT_URL));
+		Assert.assertEquals(VERSION, URL_PARAMETER_VERSION_STRATEGY.extractVersion(EXTRACT_URL_JSESSION));
+	}
+
+	@Test
+	public void removeTest() {
+		Assert.assertEquals(ADD_URL_SIMPLE, URL_PARAMETER_VERSION_STRATEGY.removeVersion(ADD_URL_SIMPLE, VERSION));
+		Assert.assertEquals(ADD_URL_SIMPLE, URL_PARAMETER_VERSION_STRATEGY.removeVersion(EXPECTED_ADD_URL_SIMPLE, VERSION));
+		Assert.assertEquals(ADD_URL_JSESSION, URL_PARAMETER_VERSION_STRATEGY.removeVersion(EXPECTED_ADD_URL_JSESSION, VERSION));
+		Assert.assertEquals(ADD_URL_OTHER, URL_PARAMETER_VERSION_STRATEGY.removeVersion(EXPECTED_ADD_URL_OTHER, VERSION));
+		Assert.assertEquals(ADD_URL_OTHER_JSESSION, URL_PARAMETER_VERSION_STRATEGY.removeVersion(EXPECTED_ADD_URL_OTHER_JSESSION, VERSION));
+		Assert.assertEquals(ADD_URL_OTHER, URL_PARAMETER_VERSION_STRATEGY.removeVersion(REMOVE_URL_VERSION_OTHER, VERSION));
+		Assert.assertEquals(ADD_URL_OTHER_JSESSION, URL_PARAMETER_VERSION_STRATEGY.removeVersion(REMOVE_URL_VERSION_OTHER_JSESSION, VERSION));
+		Assert.assertEquals(ADD_URL_OTHER_OTHER, URL_PARAMETER_VERSION_STRATEGY.removeVersion(REMOVE_URL_OTHER_VERSION_OTHER, VERSION));
+		Assert.assertEquals(ADD_URL_OTHER_OTHER_JSESSION, URL_PARAMETER_VERSION_STRATEGY.removeVersion(REMOVE_URL_OTHER_VERSION_OTHER_JSESSION, VERSION));
+	}
+}


### PR DESCRIPTION
Prefix based version path strategy has a problem with css.

If css include any relative url, the server can not resolve relative url, because it has two version prefix in the url.

**Example**

The version: 1.0.0

The css url: http://localhost/application/1.0.0/css/test.css

Original css content
```
body {
    background-image: url("img/picture.jpg");
    background-size: cover;
}
```
Modified css content
```
body {
    background-image: url("1.0.0/img/picture.jpg");
    background-size: cover;
}
```
The picture.jpg url will be: http://localhost/application/1.0.0/css/1.0.0/img/picture.jpg but the expected is http://locahost/application/1.0.0/css/img/picture.jpg

**Solution**

We was make the UrlParameterFixedVersrionStrategy class.

The css url: http://localhost/application/css/test.css?v=1.0.0

Modified css content
```
body {
    background-image: url("img/picture.jpg?v=1.0.0");
    background-size: cover;
}
```
the picture.jpg url: http://localhost/application/css/img/picture.jpg?v=1.0.0

MvcConfig example
```
import org.springframework.context.annotation.ComponentScan;
import org.springframework.context.annotation.Configuration;
import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
import org.springframework.web.servlet.resource.AbstractVersionStrategy;
import org.springframework.web.servlet.resource.UrlParameterFixedVersionStrategy;
import org.springframework.web.servlet.resource.VersionResourceResolver;

@Configuration
@ComponentScan({"test.controller"})
public class MvcConfig extends WebMvcConfigurerAdapter {

    @Override
    public void addResourceHandlers(ResourceHandlerRegistry registry) {
        AbstractVersionStrategy fixedVersionStrategy = new UrlParameterFixedVersionStrategy("1.0.0");
        VersionResourceResolver versionResourceResolver = new VersionResourceResolver()
                .addVersionStrategy(fixedVersionStrategy, "/**");

        registry.addResourceHandler("/**")
                .addResourceLocations("classpath:/other-resources/")
                .resourceChain(true)
                .addResolver(versionResourceResolver);
    }

}
```