### PR TITLE
SPR-15900 - StringIndexOutOfBoundsException from RestTemplate.doExecute IOException handler when query string is empty

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -708,7 +708,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 		catch (IOException ex) {
 			String resource = url.toString();
 			String query = url.getRawQuery();
-			resource = (query != null ? resource.substring(0, resource.indexOf(query) - 1) : resource);
+			resource = (query != null ? resource.substring(0, resource.indexOf('?')) : resource);
 			throw new ResourceAccessException("I/O error on " + method.name() +
 					" request for \"" + resource + "\": " + ex.getMessage(), ex);
 		}

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
@@ -729,6 +729,32 @@ public class RestTemplateTests {
 					ex.getMessage());
 		}
 	}
+	
+	@Test
+	public void ioExceptionWithEmptyQueryString() throws Exception {
+		
+		String scheme = "http";	
+        String authority = "example.com";
+        String path = "/resource";
+        URI uri = new URI(scheme, authority, path, "", null); // http://example.com/resource?
+        
+		given(converter.canRead(String.class, null)).willReturn(true);
+		MediaType mediaType = new MediaType("foo", "bar");
+		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(mediaType));
+		given(requestFactory.createRequest(uri, HttpMethod.GET)).willReturn(request);
+		given(request.getHeaders()).willReturn(new HttpHeaders());
+		given(request.execute()).willThrow(new IOException("Socket failure"));
+
+		try {
+			template.getForObject(uri, String.class);
+			fail("RestClientException expected");
+		}
+		catch (ResourceAccessException ex) {
+			assertEquals("I/O error on GET request for \"http://example.com/resource\": " +
+					"Socket failure; nested exception is java.io.IOException: Socket failure",
+					ex.getMessage());
+		}
+	}
 
 	@Test
 	public void exchange() throws Exception {


### PR DESCRIPTION
The RestTemplate.doExecute IOException handler produces a StringIndexOutOfBoundsException when the URI's query string is an empty string.