### PR TITLE
Allow configuring separate CaffeineSpec properties per Cache name

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCache.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCache.java
@@ -31,9 +31,9 @@ import org.springframework.util.Assert;
  *
  * <p>Requires Caffeine 2.1 or higher.
  *
- * @author Ben Manes
  * @author Juergen Hoeller
  * @author Stephane Nicoll
+ * @author Ben Manes
  * @since 4.3
  */
 public class CaffeineCache extends AbstractValueAdaptingCache {

--- a/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineSupplier.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineSupplier.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.caffeine;
+
+import java.util.function.Function;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.lang.Nullable;
+
+/**
+ * Supplier for {@link Caffeine} instances, constructed from {@link com.github.benmanes.caffeine.cache.CaffeineSpec} values.
+ * Allows configuring different expiration, capacity and other caching parameters for different cache names.
+ *
+ * <p>Requires Caffeine 2.1 or higher.
+ *
+ * @author Igor Stepanov
+ * @since 5.0
+ * @see Caffeine
+ */
+public class CaffeineSupplier implements Function<String, Caffeine<Object, Object>>, EnvironmentAware {
+
+	public static final String CACHE_CAFFEINE_SPEC = "spring.cache.caffeine.spec.%s";
+
+	@Nullable
+	private Environment environment;
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+
+	@Override
+	public Caffeine<Object, Object> apply(String name) {
+		String value = this.environment.getProperty(composeKey(name));
+		if (value != null) {
+			return Caffeine.from(value);
+		}
+		return null;
+	}
+
+	protected String composeKey(String name) {
+		return String.format(CACHE_CAFFEINE_SPEC, name);
+	}
+
+}

--- a/spring-context-support/src/test/java/org/springframework/cache/caffeine/CaffeineCacheTests.java
+++ b/spring-context-support/src/test/java/org/springframework/cache/caffeine/CaffeineCacheTests.java
@@ -26,8 +26,8 @@ import org.springframework.cache.Cache;
 import static org.junit.Assert.*;
 
 /**
- * @author Ben Manes
  * @author Stephane Nicoll
+ * @author Ben Manes
  */
 public class CaffeineCacheTests extends AbstractValueAdaptingCacheTests<CaffeineCache> {
 


### PR DESCRIPTION
Hi,

I've implemented a minor improvement which we already use in our project with Spring and Guava Cache (have not migrated to Caffeine yet).

With this extension we're able to use a single simple `GuavaCacheManager`, just specifying the needed configuration through properties.

In my opinion this suites well for both Spring Framework and Spring Boot projects as allows to achieve more without implementing new code (just setting properties).