### PR TITLE
Fix AbstractJackson2Encoder#canEncode and make writer type resolution more consistent

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Encoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Encoder.java
@@ -79,9 +79,8 @@ public abstract class AbstractJackson2Encoder extends Jackson2CodecSupport imple
 	@Override
 	public boolean canEncode(ResolvableType elementType, @Nullable MimeType mimeType) {
 		Class<?> clazz = elementType.resolve(Object.class);
-		return (Object.class == clazz) ||
-				!String.class.isAssignableFrom(elementType.resolve(clazz)) &&
-						getObjectMapper().canSerialize(clazz) && supportsMimeType(mimeType);
+		return supportsMimeType(mimeType) && (Object.class == clazz ||
+				(!String.class.isAssignableFrom(elementType.resolve(clazz)) && getObjectMapper().canSerialize(clazz)));
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonEncoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonEncoderTests.java
@@ -61,6 +61,9 @@ public class Jackson2JsonEncoderTests extends AbstractDataBufferAllocatingTestCa
 
 		// SPR-15464
 		assertTrue(this.encoder.canEncode(ResolvableType.NONE, null));
+
+		// SPR-15910
+		assertFalse(this.encoder.canEncode(ResolvableType.forClass(Object.class), APPLICATION_OCTET_STREAM));
 	}
 
 	@Test // SPR-15866

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageWriterResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageWriterResultHandler.java
@@ -97,11 +97,11 @@ public abstract class AbstractMessageWriterResultHandler extends HandlerResultHa
 		if (adapter != null) {
 			publisher = adapter.toPublisher(body);
 			ResolvableType genericType = bodyType.getGeneric(0);
-			elementType = getElementType(adapter, genericType);
+			elementType = getElementType(genericType, adapter);
 		}
 		else {
 			publisher = Mono.justOrEmpty(body);
-			elementType = (bodyClass == null && body != null ? ResolvableType.forInstance(body) : bodyType);
+			elementType = getElementType(bodyType, null);
 		}
 
 		if (void.class == elementType.getRawClass() || Void.class == elementType.getRawClass()) {
@@ -128,11 +128,11 @@ public abstract class AbstractMessageWriterResultHandler extends HandlerResultHa
 		return Mono.error(new NotAcceptableStatusException(getProducibleMediaTypes(elementType)));
 	}
 
-	private ResolvableType getElementType(ReactiveAdapter adapter, ResolvableType genericType) {
-		if (adapter.isNoValue()) {
+	private ResolvableType getElementType(ResolvableType genericType, @Nullable ReactiveAdapter adapter) {
+		if (adapter != null && adapter.isNoValue()) {
 			return ResolvableType.forClass(Void.class);
 		}
-		else if (genericType != ResolvableType.NONE) {
+		else if (genericType != ResolvableType.NONE && genericType.resolve() != null) {
 			return genericType;
 		}
 		else {

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandlerTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandlerTests.java
@@ -195,9 +195,6 @@ public class ResponseEntityResultHandlerTests {
 		MethodParameter returnType = on(TestController.class).resolveReturnType(entity(String.class));
 		testHandle(returnValue, returnType);
 
-		returnType = on(TestController.class).resolveReturnType(Object.class);
-		testHandle(returnValue, returnType);
-
 		returnValue = Mono.just(ok("abc"));
 		returnType = on(TestController.class).resolveReturnType(Mono.class, entity(String.class));
 		testHandle(returnValue, returnType);
@@ -304,7 +301,7 @@ public class ResponseEntityResultHandlerTests {
 		this.resultHandler.handleResult(exchange, result).block(Duration.ofSeconds(5));
 
 		assertEquals(HttpStatus.OK, exchange.getResponse().getStatusCode());
-		assertResponseBody(exchange, "body");
+		assertResponseBody(exchange, "\"body\"");
 	}
 
 	@Test // SPR-14877


### PR DESCRIPTION
This PR contains 2 commits intended to address [SPR-15910](https://jira.spring.io/browse/SPR-15910) raised by @wilkinsona. The type resolution consistency change is a significant (but really needed IMO) one that I would like to validate with @wilkinsona, @rstoyanchev, @poutsma and @bclozel.

The details of this change are in the 2nd commit message log and reproduced bellow:

> Before this commit, Spring WebFlux used both the declared
> return value type and the concrete object type in writers,
> in a similar fashion than Spring MVC.
> 
> But this can lead to inconsistent behaviors, for example between
> type resolution of a return value that requires an adapter
> (declared return value type is used) and one that does not
> (concrete return value type is used) or between ? and Object handling.
> 
> After this commit, only declared type (via return value type for
> annotation-based programming model or ParameterizedTypeReference for
> the functional API) is used in order to provide a consistent and
> predictable behavior.
> 
> The asynchronous nature of WebFlux, type erasure and providing
> error-prone SPI are also reasons that motivates this change.
> 
> Concretely that means that handler methods declaring an Object return
> value type and returning a String or Resource value won't be handled
> anymore by respectively by CharSequenceEncoder and ResourceEncoder.
> These handler methods need to declare explicitly the return value type.
> 
> For use cases that requires Spring MVC dynamic type resolution based
> on the concrete return value type, using the functional API which allows
> programmatic type resolution is the recommended way to use with WebFlux.

Thanks in advance for your feedbacks.