### PR TITLE
Remove "chin" in admonition blocks of reference documentation.

### DIFF
--- a/src/docs/asciidoc/stylesheets/spring.css
+++ b/src/docs/asciidoc/stylesheets/spring.css
@@ -383,7 +383,7 @@ table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-w
 
 table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-size: inherit; }
 
-.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; }
+.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; margin-bottom: 0; }
 .admonitionblock > table td.icon { text-align: center; width: 80px; }
 .admonitionblock > table td.icon img { max-width: initial; }
 .admonitionblock > table td.icon .title { font-weight: bold; font-family: Montserrat, sans-serif; text-transform: uppercase; }


### PR DESCRIPTION
Without the change proposed, admonition blocks carry quite a "chin" that looks heavy.

Before:

<img width="827" alt="bildschirmfoto 2017-09-08 um 15 50 29" src="https://user-images.githubusercontent.com/128577/30215271-c8ebdafc-94af-11e7-8abc-6260254033a7.PNG">

After:

<img width="825" alt="bildschirmfoto 2017-09-08 um 15 50 39" src="https://user-images.githubusercontent.com/128577/30215275-cd79570c-94af-11e7-8738-cbf803950a0e.PNG">
