### PR TITLE
Fix broken RequestMappingHandlerAdapter setter

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -430,7 +430,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 	 */
 	public void setReactiveRegistry(ReactiveAdapterRegistry reactiveRegistry) {
 		Assert.notNull(reactiveRegistry, "ReactiveAdapterRegistry is required");
-		this.reactiveRegistry = this.reactiveRegistry;
+		this.reactiveRegistry = reactiveRegistry;
 	}
 
 	/**


### PR DESCRIPTION
RequestMappingHandlerAdapter.setReactiveRegistry() doesn't actually set the value appropriately.

FYI: I found this using lgtm.com

https://lgtm.com/projects/g/spring-projects/spring-framework/alerts/?mode=list