### PR TITLE
fix class name in javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/ResourceAccessException.java
+++ b/spring-web/src/main/java/org/springframework/web/client/ResourceAccessException.java
@@ -30,7 +30,7 @@ public class ResourceAccessException extends RestClientException {
 
 
 	/**
-	 * Construct a new {@code HttpIOException} with the given message.
+	 * Construct a new {@code ResourceAccessException} with the given message.
 	 * @param msg the message
 	 */
 	public ResourceAccessException(String msg) {
@@ -38,7 +38,7 @@ public class ResourceAccessException extends RestClientException {
 	}
 
 	/**
-	 * Construct a new {@code HttpIOException} with the given message and {@link IOException}.
+	 * Construct a new {@code ResourceAccessException} with the given message and {@link IOException}.
 	 * @param msg the message
 	 * @param ex the {@code IOException}
 	 */


### PR DESCRIPTION
appeared after renaming in commit 760cab8fea4710dc6bf207a3d7d38244518894cf