### PR TITLE
Fix SPR-16024 broken links to Message Converters

### DIFF
--- a/src/docs/asciidoc/web/webmvc.adoc
+++ b/src/docs/asciidoc/web/webmvc.adoc
@@ -1152,7 +1152,7 @@ default `HttpMessageConverters`:
 * `FormHttpMessageConverter` converts form data to/from a MultiValueMap<String, String>.
 * `SourceHttpMessageConverter` converts to/from a javax.xml.transform.Source.
 
-For more information on these converters, see <<rest-message-conversion,Message
+For more information on these converters, see <<mvc-config-message-converters,Message
 Converters>>. Also note that if using the MVC namespace or the MVC Java config, a wider
 range of message converters are registered by default. See <<mvc-config-enable>> for more information.
 
@@ -1226,7 +1226,7 @@ response stream.
 
 As with `@RequestBody`, Spring converts the returned object to a response body by using
 an `HttpMessageConverter`. For more information on these converters, see the previous
-section and <<rest-message-conversion,Message Converters>>.
+section and <<mvc-config-message-converters,Message Converters>>.
 
 [[mvc-ann-restcontroller]]
 ==== Creating REST Controllers with the @RestController annotation
@@ -1275,7 +1275,7 @@ World` to the response stream, and sets the response status code to 201 (Created
 
 As with `@RequestBody` and `@ResponseBody`, Spring uses `HttpMessageConverter` to
 convert from and to the request and response streams. For more information on these
-converters, see the previous section and <<rest-message-conversion,Message Converters>>.
+converters, see the previous section and <<mvc-config-message-converters,Message Converters>>.
 
 
 [[mvc-ann-modelattrib-methods]]


### PR DESCRIPTION
Replace wrong link #rest-message-conversion with correct link 
#mvc-config-message-converters.