### PR TITLE
SPR-16027: Remove possible Servlet instance leak

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/ServletWrappingController.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/ServletWrappingController.java
@@ -148,6 +148,9 @@ public class ServletWrappingController extends AbstractController
 		if (this.servletName == null) {
 			this.servletName = this.beanName;
 		}
+		if (this.servletInstance != null) {
+			this.servletInstance.destroy();
+		}
 		this.servletInstance = ReflectionUtils.accessibleConstructor(this.servletClass).newInstance();
 		this.servletInstance.init(new DelegatingServletConfig());
 	}


### PR DESCRIPTION
This happens for example from JolokiaMvcEndpoint in spring-boot-actuator 1.5.7 where ``@ConfigurationProperties`` triggers two calls to ``afterPropertiesSet()`` thus resulting in a duplicate AgentServlet that is initialized but never destroyed.