### PR TITLE
SPR-9019 - Clarify docs for usage of @Configurable objects

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/config/SpringConfiguredBeanDefinitionParser.java
+++ b/spring-aop/src/main/java/org/springframework/aop/config/SpringConfiguredBeanDefinitionParser.java
@@ -58,7 +58,8 @@ class SpringConfiguredBeanDefinitionParser implements BeanDefinitionParser {
 			def.setFactoryMethodName("aspectOf");
 			def.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			def.setSource(parserContext.extractSource(element));
-			parserContext.registerBeanComponent(new BeanComponentDefinition(def, BEAN_CONFIGURER_ASPECT_BEAN_NAME));
+			parserContext.registerBeanComponent(new BeanComponentDefinition(def, BEAN_CONFIGURER_ASPECT_BEAN_NAME,
+					new String[]{BEAN_CONFIGURER_ASPECT_CLASS_NAME}));
 		}
 		return null;
 	}

--- a/spring-aspects/src/main/java/org/springframework/context/annotation/aspectj/SpringConfiguredConfiguration.java
+++ b/spring-aspects/src/main/java/org/springframework/context/annotation/aspectj/SpringConfiguredConfiguration.java
@@ -42,7 +42,10 @@ public class SpringConfiguredConfiguration {
 	public static final String BEAN_CONFIGURER_ASPECT_BEAN_NAME =
 			"org.springframework.context.config.internalBeanConfigurerAspect";
 
-	@Bean(name = BEAN_CONFIGURER_ASPECT_BEAN_NAME)
+	private static final String BEAN_CONFIGURER_ASPECT_CLASS_NAME =
+			"org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect";
+
+	@Bean(name = {BEAN_CONFIGURER_ASPECT_BEAN_NAME, BEAN_CONFIGURER_ASPECT_CLASS_NAME})
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	public AnnotationBeanConfigurerAspect beanConfigurerAspect() {
 		return AnnotationBeanConfigurerAspect.aspectOf();

--- a/spring-aspects/src/test/java/org/springframework/beans/factory/aspectj/AnnotationBeanConfigurerAspectTest.java
+++ b/spring-aspects/src/test/java/org/springframework/beans/factory/aspectj/AnnotationBeanConfigurerAspectTest.java
@@ -1,0 +1,74 @@
+package org.springframework.beans.factory.aspectj;
+
+import org.junit.Test;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
+import org.springframework.context.weaving.LoadTimeWeaverAware;
+import org.springframework.instrument.classloading.LoadTimeWeaver;
+
+import static org.junit.Assert.assertNotNull;
+
+public class AnnotationBeanConfigurerAspectTest {
+	@Test
+	public void injection() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class)) {
+			final MyLoadTimeWeaverAware myLoadTimeWeaverAware = context.getBean(MyLoadTimeWeaverAware.class);
+			final MyConfiguredBean myConfiguredBean = myLoadTimeWeaverAware.getMyConfiguredBean();
+			assertNotNull(myConfiguredBean);
+			final Foo foo = myConfiguredBean.getFoo();
+			assertNotNull(foo);
+		}
+	}
+
+	@Configuration
+	@EnableSpringConfigured
+	static class Config {
+		@Bean
+		@DependsOn("org.springframework.beans.factory.aspectj.AnnotationBeanConfigurerAspect")
+		public MyLoadTimeWeaverAware myLoadTimeWeaverAware() {
+			return new MyLoadTimeWeaverAware();
+		}
+
+		@Bean
+		public Foo foo() {
+			return new Foo();
+		}
+	}
+
+	@Configurable
+	static class MyConfiguredBean {
+		@Autowired
+		private Foo foo;
+
+		public Foo getFoo() {
+			return foo;
+		}
+	}
+
+	static class Foo {
+	}
+
+	static class MyLoadTimeWeaverAware implements LoadTimeWeaverAware, InitializingBean {
+		private MyConfiguredBean myConfiguredBean;
+
+		public MyConfiguredBean getMyConfiguredBean() {
+			return myConfiguredBean;
+		}
+
+		@Override
+		public void setLoadTimeWeaver(LoadTimeWeaver loadTimeWeaver) {
+			// no action, just to be visible for Spring's early initialization of LoadTimeWeaverAware
+		}
+
+		@Override
+		public void afterPropertiesSet() throws Exception {
+			this.myConfiguredBean = new MyConfiguredBean();
+		}
+	}
+}

--- a/spring-context/src/main/java/org/springframework/context/config/SpringConfiguredBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/SpringConfiguredBeanDefinitionParser.java
@@ -51,7 +51,8 @@ class SpringConfiguredBeanDefinitionParser implements BeanDefinitionParser {
 			def.setFactoryMethodName("aspectOf");
 			def.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			def.setSource(parserContext.extractSource(element));
-			parserContext.registerBeanComponent(new BeanComponentDefinition(def, BEAN_CONFIGURER_ASPECT_BEAN_NAME));
+			parserContext.registerBeanComponent(new BeanComponentDefinition(def, BEAN_CONFIGURER_ASPECT_BEAN_NAME,
+					new String[] {BEAN_CONFIGURER_ASPECT_CLASS_NAME}));
 		}
 		return null;
 	}

--- a/src/docs/asciidoc/core/core-aop.adoc
+++ b/src/docs/asciidoc/core/core-aop.adoc
@@ -2807,7 +2807,10 @@ will result in a message being issued to the debug log and no configuration of t
 object taking place. An example might be a bean in the Spring configuration that creates
 domain objects when it is initialized by Spring. In this case you can use the
 "depends-on" bean attribute to manually specify that the bean depends on the
-configuration aspect.
+configuration aspect. In general every bean implementing `LoadTimeWeaverAware` and
+internally creating instances of `@Configurable` objects should specify dependency
+on `AnnotationBeanConfigurerAspect` bean. An example might be a
+`LocalContainerEntityManagerFactoryBean` class.
 
 [source,xml,indent=0]
 [subs="verbatim,quotes"]


### PR DESCRIPTION
Hi,
I had similar issue as #13658 but with LocalContainerEntityManagerFactoryBean and Hibernate creating instances of cutom UserType classes with injected members.
I was digging around and found, that it is all about depend-on as described in docs. But problem was that there is no bean with proper name created as noted in docs. I am sending PR with added alias for aspect bean and old bean name kept, because I want to be backward compatible. I have written note into docs, to be more specific and be able to be found by google search.
Hope PR is ok for you.
Thx,
Ivos 