### PR TITLE
Update SimpleApplicationEventMulticaster.java

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/event/SimpleApplicationEventMulticaster.java
+++ b/spring-context/src/main/java/org/springframework/context/event/SimpleApplicationEventMulticaster.java
@@ -130,8 +130,8 @@ public class SimpleApplicationEventMulticaster extends AbstractApplicationEventM
 	@Override
 	public void multicastEvent(final ApplicationEvent event, @Nullable ResolvableType eventType) {
 		ResolvableType type = (eventType != null ? eventType : resolveDefaultEventType(event));
-		for (final ApplicationListener<?> listener : getApplicationListeners(event, type)) {
-			Executor executor = getTaskExecutor();
+		Executor executor = getTaskExecutor();
+		for (final ApplicationListener<?> listener : getApplicationListeners(event, type)) {	
 			if (executor != null) {
 				executor.execute(() -> invokeListener(listener, event));
 			}


### PR DESCRIPTION
	@Override
	public void multicastEvent(final ApplicationEvent event, @Nullable ResolvableType eventType) {
		ResolvableType type = (eventType != null ? eventType : resolveDefaultEventType(event));

  //Here getTaskExecutor () method to get the foreach loop outside the performance can be optimized
		Executor executor = getTaskExecutor();
		for (final ApplicationListener<?> listener : getApplicationListeners(event, type)) {	
			if (executor != null) {
				executor.execute(() -> invokeListener(listener, event));
			}
			else {
				invokeListener(listener, event);
			}
		}
	}