### PR TITLE
SPR-9989 Using multiple PropertyPlaceholderConfigurer breaks @Value default value behaviour

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/ConfigurableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/ConfigurableBeanFactory.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.HierarchicalBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.lang.Nullable;
+import org.springframework.util.DefaultIgnorableStringValueResolver;
 import org.springframework.util.StringValueResolver;
 
 /**
@@ -212,7 +213,7 @@ public interface ConfigurableBeanFactory extends HierarchicalBeanFactory, Single
 	 * @param valueResolver the String resolver to apply to embedded values
 	 * @since 3.0
 	 */
-	void addEmbeddedValueResolver(StringValueResolver valueResolver);
+	void addEmbeddedValueResolver(DefaultIgnorableStringValueResolver valueResolver);
 
 	/**
 	 * Determine whether an embedded value resolver has been registered with this

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/PlaceholderConfigurerSupport.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/PlaceholderConfigurerSupport.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.lang.Nullable;
+import org.springframework.util.DefaultIgnorableStringValueResolver;
 import org.springframework.util.StringValueResolver;
 
 /**
@@ -211,7 +212,7 @@ public abstract class PlaceholderConfigurerSupport extends PropertyResourceConfi
 
 
 	protected void doProcessProperties(ConfigurableListableBeanFactory beanFactoryToProcess,
-			StringValueResolver valueResolver) {
+			DefaultIgnorableStringValueResolver valueResolver) {
 
 		BeanDefinitionVisitor visitor = new BeanDefinitionVisitor(valueResolver);
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/PropertyPlaceholderConfigurer.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/PropertyPlaceholderConfigurer.java
@@ -23,6 +23,7 @@ import org.springframework.core.Constants;
 import org.springframework.core.SpringProperties;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.lang.Nullable;
+import org.springframework.util.DefaultIgnorableStringValueResolver;
 import org.springframework.util.PropertyPlaceholderHelper;
 import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
 import org.springframework.util.StringValueResolver;
@@ -221,12 +222,12 @@ public class PropertyPlaceholderConfigurer extends PlaceholderConfigurerSupport 
 	protected void processProperties(ConfigurableListableBeanFactory beanFactoryToProcess, Properties props)
 			throws BeansException {
 
-		StringValueResolver valueResolver = new PlaceholderResolvingStringValueResolver(props);
+		DefaultIgnorableStringValueResolver valueResolver = new PlaceholderResolvingStringValueResolver(props);
 		doProcessProperties(beanFactoryToProcess, valueResolver);
 	}
 
 
-	private class PlaceholderResolvingStringValueResolver implements StringValueResolver {
+	private class PlaceholderResolvingStringValueResolver implements DefaultIgnorableStringValueResolver {
 
 		private final PropertyPlaceholderHelper helper;
 
@@ -241,7 +242,19 @@ public class PropertyPlaceholderConfigurer extends PlaceholderConfigurerSupport 
 		@Override
 		@Nullable
 		public String resolveStringValue(String strVal) throws BeansException {
-			String resolved = this.helper.replacePlaceholders(strVal, this.resolver);
+			return doResolveStringValue(strVal, true);
+		}
+
+		@Override
+		@Nullable
+		public String resolveStringValueIgnoringDefault(String strVal) throws BeansException {
+			return doResolveStringValue(strVal, false);
+		}
+
+		private String doResolveStringValue(String strVal, boolean ignoreDefault) throws BeansException {
+			String resolved = (ignoreDefault ?
+					this.helper.replacePlaceholdersIgnoringDefault(strVal, this.resolver) :
+					this.helper.replacePlaceholders(strVal, this.resolver));
 			if (trimValues) {
 				resolved = resolved.trim();
 			}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -71,11 +71,7 @@ import org.springframework.core.NamedThreadLocal;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ObjectUtils;
-import org.springframework.util.StringUtils;
-import org.springframework.util.StringValueResolver;
+import org.springframework.util.*;
 
 /**
  * Abstract base class for {@link org.springframework.beans.factory.BeanFactory}
@@ -146,7 +142,7 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 	private TypeConverter typeConverter;
 
 	/** String resolvers to apply e.g. to annotation attribute values */
-	private final List<StringValueResolver> embeddedValueResolvers = new LinkedList<>();
+	private final List<DefaultIgnorableStringValueResolver> embeddedValueResolvers = new LinkedList<>();
 
 	/** BeanPostProcessors to apply in createBean */
 	private final List<BeanPostProcessor> beanPostProcessors = new ArrayList<>();
@@ -813,8 +809,8 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 	}
 
 	@Override
-	public void addEmbeddedValueResolver(StringValueResolver valueResolver) {
-		Assert.notNull(valueResolver, "StringValueResolver must not be null");
+	public void addEmbeddedValueResolver(DefaultIgnorableStringValueResolver valueResolver) {
+		Assert.notNull(valueResolver, "DefaultIgnorableStringValueResolver must not be null");
 		this.embeddedValueResolvers.add(valueResolver);
 	}
 
@@ -830,8 +826,10 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 			return null;
 		}
 		String result = value;
-		for (StringValueResolver resolver : this.embeddedValueResolvers) {
-			result = resolver.resolveStringValue(result);
+		Iterator<DefaultIgnorableStringValueResolver> resolverIterator = this.embeddedValueResolvers.iterator();
+		while (resolverIterator.hasNext()) {
+			DefaultIgnorableStringValueResolver resolver = resolverIterator.next();
+			result = (resolverIterator.hasNext() ? resolver.resolveStringValueIgnoringDefault(result) : resolver.resolveStringValue(result));
 			if (result == null) {
 				return null;
 			}

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -76,9 +76,7 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
-import org.springframework.util.ReflectionUtils;
+import org.springframework.util.*;
 
 /**
  * Abstract implementation of the {@link org.springframework.context.ApplicationContext}
@@ -849,7 +847,18 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 		// (such as a PropertyPlaceholderConfigurer bean) registered any before:
 		// at this point, primarily for resolution in annotation attribute values.
 		if (!beanFactory.hasEmbeddedValueResolver()) {
-			beanFactory.addEmbeddedValueResolver(strVal -> getEnvironment().resolvePlaceholders(strVal));
+			beanFactory.addEmbeddedValueResolver(new DefaultIgnorableStringValueResolver() {
+				@Nullable
+				@Override
+				public String resolveStringValue(String strVal) {
+					return getEnvironment().resolvePlaceholders(strVal);
+				}
+				@Nullable
+				@Override
+				public String resolveStringValueIgnoringDefault(String strVal) {
+					return getEnvironment().resolvePlaceholdersIgnoringDefault(strVal);
+				}
+			});
 		}
 
 		// Initialize LoadTimeWeaverAware beans early to allow for registering their transformers early.

--- a/spring-core/src/main/java/org/springframework/core/env/AbstractEnvironment.java
+++ b/spring-core/src/main/java/org/springframework/core/env/AbstractEnvironment.java
@@ -563,10 +563,19 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	}
 
 	@Override
+	public String resolvePlaceholdersIgnoringDefault(String text) {
+		return this.propertyResolver.resolvePlaceholdersIgnoringDefault(text);
+	}
+
+	@Override
 	public String resolveRequiredPlaceholders(String text) throws IllegalArgumentException {
 		return this.propertyResolver.resolveRequiredPlaceholders(text);
 	}
 
+	@Override
+	public String resolveRequiredPlaceholdersIgnoringDefault(String text) throws IllegalArgumentException {
+		return this.propertyResolver.resolveRequiredPlaceholdersIgnoringDefault(text);
+	}
 
 	@Override
 	public String toString() {

--- a/spring-core/src/main/java/org/springframework/core/env/AbstractPropertyResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/env/AbstractPropertyResolver.java
@@ -204,11 +204,27 @@ public abstract class AbstractPropertyResolver implements ConfigurablePropertyRe
 	}
 
 	@Override
+	public String resolvePlaceholdersIgnoringDefault(String text) {
+		if (this.nonStrictHelper == null) {
+			this.nonStrictHelper = createPlaceholderHelper(true);
+		}
+		return doResolvePlaceholdersIgnoringDefault(text, this.nonStrictHelper);
+	}
+
+	@Override
 	public String resolveRequiredPlaceholders(String text) throws IllegalArgumentException {
 		if (this.strictHelper == null) {
 			this.strictHelper = createPlaceholderHelper(false);
 		}
 		return doResolvePlaceholders(text, this.strictHelper);
+	}
+
+	@Override
+	public String resolveRequiredPlaceholdersIgnoringDefault(String text) throws IllegalArgumentException {
+		if (this.strictHelper == null) {
+			this.strictHelper = createPlaceholderHelper(false);
+		}
+		return doResolvePlaceholdersIgnoringDefault(text, this.strictHelper);
 	}
 
 	/**
@@ -235,6 +251,10 @@ public abstract class AbstractPropertyResolver implements ConfigurablePropertyRe
 
 	private String doResolvePlaceholders(String text, PropertyPlaceholderHelper helper) {
 		return helper.replacePlaceholders(text, this::getPropertyAsRawString);
+	}
+
+	private String doResolvePlaceholdersIgnoringDefault(String text, PropertyPlaceholderHelper helper) {
+		return helper.replacePlaceholdersIgnoringDefault(text, this::getPropertyAsRawString);
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/core/env/PropertyResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/env/PropertyResolver.java
@@ -102,6 +102,8 @@ public interface PropertyResolver {
 	 */
 	String resolvePlaceholders(String text);
 
+	String resolvePlaceholdersIgnoringDefault(String text);
+
 	/**
 	 * Resolve ${...} placeholders in the given text, replacing them with corresponding
 	 * property values as resolved by {@link #getProperty}. Unresolvable placeholders with
@@ -112,5 +114,7 @@ public interface PropertyResolver {
 	 * @see org.springframework.util.SystemPropertyUtils#resolvePlaceholders(String, boolean)
 	 */
 	String resolveRequiredPlaceholders(String text) throws IllegalArgumentException;
+
+	String resolveRequiredPlaceholdersIgnoringDefault(String text) throws IllegalArgumentException;
 
 }

--- a/spring-core/src/main/java/org/springframework/util/DefaultIgnorableStringValueResolver.java
+++ b/spring-core/src/main/java/org/springframework/util/DefaultIgnorableStringValueResolver.java
@@ -1,0 +1,9 @@
+package org.springframework.util;
+
+import org.springframework.lang.Nullable;
+
+public interface DefaultIgnorableStringValueResolver extends StringValueResolver {
+
+	@Nullable
+	String resolveStringValueIgnoringDefault(String strVal);
+}

--- a/spring-core/src/test/java/org/springframework/core/env/DummyEnvironment.java
+++ b/spring-core/src/test/java/org/springframework/core/env/DummyEnvironment.java
@@ -59,7 +59,17 @@ public class DummyEnvironment implements Environment {
 	}
 
 	@Override
+	public String resolvePlaceholdersIgnoringDefault(String text) {
+		return null;
+	}
+
+	@Override
 	public String resolveRequiredPlaceholders(String text) throws IllegalArgumentException {
+		return null;
+	}
+
+	@Override
+	public String resolveRequiredPlaceholdersIgnoringDefault(String text) throws IllegalArgumentException {
 		return null;
 	}
 


### PR DESCRIPTION
This is a difficult ticket requiring nontrivial refactoring (see comments on https://jira.spring.io/browse/SPR-9989 for details). I explored quite some alternatives and found the following plan most ideal:

- tweak PropertyPlaceholderHelper's implementation to accept a new boolean parameter (ignoreDefault) to control whether default value will be used for a specific StringValueResolver;

- change AbstractBeanFactory's internal implementation of 'resolveStringValue(String)' to dictate that only the last StringValueResolver will go about default value return (if needed) and ignore default value for all the other ones, by passing appropriate boolean parameter to the above tweaked PropertyPlaceHolderHelper's public method;

A a new unit testing method named 'resolveEmbeddedDefaultValue' was added to DefaultListableBeanFactoryTests.

