### PR TITLE
SPR-16060 - Enhance AnnotationUtils to find annotations on generic interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out
 test-output
 atlassian-ide-plugin.xml
 .gradletasknamecache
+/.nb-gradle/
+

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
@@ -195,6 +195,13 @@ public class AnnotationUtilsTests {
 	}
 
 	@Test
+	public void findMethodAnnotationFromGenericInterfaceSuper() throws Exception {
+		Method method = ImplementsInterfaceWithGenericAnnotatedMethod.class.getMethod("foo", String.class);
+		Order order = findAnnotation(method, Order.class);
+		assertNotNull(order);
+	}
+
+	@Test
 	public void findMethodAnnotationFromInterfaceOnSuper() throws Exception {
 		Method method = SubOfImplementsInterfaceWithAnnotatedMethod.class.getMethod("foo");
 		Order order = findAnnotation(method, Order.class);
@@ -1753,6 +1760,17 @@ public class AnnotationUtilsTests {
 	}
 
 	public static class SubTransactionalAndOrderedClass extends TransactionalAndOrderedClass {
+	}
+
+	public static interface InterfaceWithGenericAnnotatedMethod<T> {
+		@Order
+		void foo(T t);
+	}
+
+	public static class ImplementsInterfaceWithGenericAnnotatedMethod implements InterfaceWithGenericAnnotatedMethod<String> {
+		public void foo(String t) {
+			// no body in test method
+		}
 	}
 
 	public interface InterfaceWithAnnotatedMethod {


### PR DESCRIPTION
When scanning for annotations on a class that implements a generic interface where the generic
type is specified in the implementing class, annotation scanning would fail to identify annotations
from the interface since the parameter types do not match.

For example, given an interface:
```
   public interface Foo<T> {
       @Order
       void foo(T t);
   }
```
and a class:
```
   public class StringFoo implements Foo<String> {
       public void foo(String s) { ... }
   }
```
when scanning StringFoo.foo for annotations, no annotations were identified.

This commit changes annotation scanning so that when scanning for annotations, the parameters are
compared for assignability (using Class.isAssignableFrom()) rather than requiring exact matches.

Issue: SEC-3081