### PR TITLE
Move "Note" before "source" in webmvc.adoc

### DIFF
--- a/src/docs/asciidoc/web/webmvc.adoc
+++ b/src/docs/asciidoc/web/webmvc.adoc
@@ -3103,6 +3103,9 @@ status code or exception type. Starting with Servlet 3 an error page does not ne
 mapped, which effectively means the specified location customizes the default Servlet
 container error page.
 
+Note that the actual location for the error page can be a JSP page or some other URL
+within the container including one handled through an `@Controller` method:
+
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3110,9 +3113,6 @@ container error page.
 		<location>/error</location>
 	</error-page>
 ----
-
-Note that the actual location for the error page can be a JSP page or some other URL
-within the container including one handled through an `@Controller` method:
 
 When writing error information, the status code and the error message set on the
 `HttpServletResponse` can be accessed through request attributes in a controller:


### PR DESCRIPTION
There is a ":" in the end of the "Note" sentence, just like the sentence below, so move the "Note" sentence before "source".