### PR TITLE
SPR-7925 Introduce Assert.noNullElements for collections

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/Assert.java
+++ b/spring-core/src/main/java/org/springframework/util/Assert.java
@@ -480,6 +480,49 @@ public abstract class Assert {
 	}
 
 	/**
+	 * Assert that a collection contains no {@code null} elements.
+	 * <p>Note: Does not complain if the collection is empty!
+	 * <pre class="code">
+	 * Assert.noNullElements(collection, "The collection must contain non-null elements");
+	 * </pre>
+	 * @param collection the collection to check
+	 * @param message the exception message to use if the assertion fails
+	 * @throws IllegalArgumentException if the collection contains a {@code null} element
+	 * @since 5.0
+	 */
+	public static void noNullElements(@Nullable Collection<?> collection, String message) {
+		if (collection != null) {
+			for (Object element : collection) {
+				if (element == null) {
+					throw new IllegalArgumentException(message);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Assert that a collection contains no {@code null} elements.
+	 * <p>Note: Does not complain if the collection is empty!
+	 * <pre class="code">
+	 * Assert.noNullElements(collection, () -&gt; "The " + collectionType + " collection must contain non-null elements");
+	 * </pre>
+	 * @param collection the collection to check
+	 * @param messageSupplier a supplier for the exception message to use if the
+	 * assertion fails
+	 * @throws IllegalArgumentException if the collection contains a {@code null} element
+	 * @since 5.0
+	 */
+	public static void noNullElements(@Nullable Collection<?> collection, Supplier<String> messageSupplier) {
+		if (collection != null) {
+			for (Object element : collection) {
+				if (element == null) {
+					throw new IllegalArgumentException(nullSafeGet(messageSupplier));
+				}
+			}
+		}
+	}
+
+	/**
 	 * Assert that a Map contains entries; that is, it must not be {@code null}
 	 * and must contain at least one entry.
 	 * <pre class="code">Assert.notEmpty(map, "Map must contain entries");</pre>

--- a/spring-core/src/test/java/org/springframework/util/AssertTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AssertTests.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static java.util.Arrays.*;
 import static java.util.Collections.*;
 import static org.hamcrest.CoreMatchers.*;
 
@@ -448,6 +449,57 @@ public class AssertTests {
 		thrown.expect(IllegalArgumentException.class);
 		thrown.expectMessage(equalTo(null));
 		Assert.notEmpty(emptyList(), (Supplier<String>) null);
+	}
+
+	@Test
+	public void noNullElementsWithCollection() {
+		Assert.noNullElements(asList("foo", "bar"), "enigma");
+	}
+
+	@Test
+	public void noNullElementsWithEmptyCollection() {
+		Assert.noNullElements(emptyList(), "enigma");
+	}
+
+	@Test
+	public void noNullElementsWithNullCollection() {
+		Assert.noNullElements((Collection<Object>) null, "enigma");
+	}
+
+	@Test
+	public void noNullElementsWithCollectionAndNullElement() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("enigma");
+		Assert.noNullElements(asList("foo", null, "bar"), "enigma");
+	}
+
+	@Test
+	public void noNullElementsWithCollectionAndMessageSupplier() {
+		Assert.noNullElements(asList("foo", "bar"), () -> "enigma");
+	}
+
+	@Test
+	public void noNullElementsWithEmptyCollectionAndMessageSupplier() {
+		Assert.noNullElements(emptyList(), "enigma");
+	}
+
+	@Test
+	public void noNullElementsWithNullCollectionAndMessageSupplier() {
+		Assert.noNullElements((Collection<Object>) null, () -> "enigma");
+	}
+
+	@Test
+	public void noNullElementsWithCollectionAndNullElementAndMessageSupplier() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("enigma");
+		Assert.noNullElements(asList("foo", null, "bar"), () -> "enigma");
+	}
+
+	@Test
+	public void noNullElementsWithCollectionAndNullElementAndNullMessageSupplier() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage(equalTo(null));
+		Assert.noNullElements(asList("foo", null, "bar"), (Supplier<String>) null);
 	}
 
 	@Test


### PR DESCRIPTION
As proposed in [SPR-7925](https://jira.spring.io/browse/SPR-7925).

The issue also proposes a `noNullKeys(Map)` and `noNullValues(Map)`. If this makes sense I would also implement it with this or a separate PR.