### PR TITLE
SPR-7961 Allow MailMessage to have multiple Reply-To addresses

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/mail/MailMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/MailMessage.java
@@ -24,20 +24,22 @@ import java.util.Date;
  * the underlying message is a simple text message or a more sophisticated
  * MIME message.
  *
- * <p>Implemented by both SimpleMailMessage and MimeMessageHelper,
+ * <p>Implemented by both SimpleMailMessage and MimeMailMessage,
  * to let message population code interact with a simple message or a
  * MIME message through a common interface.
  *
  * @author Juergen Hoeller
  * @since 1.1.5
  * @see SimpleMailMessage
- * @see org.springframework.mail.javamail.MimeMessageHelper
+ * @see org.springframework.mail.javamail.MimeMailMessage
  */
 public interface MailMessage {
 
 	void setFrom(String from) throws MailParseException;
 
 	void setReplyTo(String replyTo) throws MailParseException;
+
+	void setReplyTo(String[] replyTo) throws MailParseException;
 
 	void setTo(String to) throws MailParseException;
 

--- a/spring-context-support/src/main/java/org/springframework/mail/SimpleMailMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/SimpleMailMessage.java
@@ -47,7 +47,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	private String from;
 
 	@Nullable
-	private String replyTo;
+	private String[] replyTo;
 
 	@Nullable
 	private String[] to;
@@ -81,7 +81,9 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	public SimpleMailMessage(SimpleMailMessage original) {
 		Assert.notNull(original, "'original' message argument must not be null");
 		this.from = original.getFrom();
-		this.replyTo = original.getReplyTo();
+		if (original.getReplyTo() != null) {
+			this.replyTo = copy(original.getReplyTo());
+		}
 		if (original.getTo() != null) {
 			this.to = copy(original.getTo());
 		}
@@ -109,11 +111,16 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 
 	@Override
 	public void setReplyTo(@Nullable String replyTo) {
+		this.replyTo = new String[] {replyTo};
+	}
+
+	@Override
+	public void setReplyTo(@Nullable String[] replyTo) {
 		this.replyTo = replyTo;
 	}
 
 	@Nullable
-	public String getReplyTo() {
+	public String[] getReplyTo() {
 		return this.replyTo;
 	}
 
@@ -231,7 +238,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	public String toString() {
 		StringBuilder sb = new StringBuilder("SimpleMailMessage: ");
 		sb.append("from=").append(this.from).append("; ");
-		sb.append("replyTo=").append(this.replyTo).append("; ");
+		sb.append("replyTo=").append(StringUtils.arrayToCommaDelimitedString(this.replyTo)).append("; ");
 		sb.append("to=").append(StringUtils.arrayToCommaDelimitedString(this.to)).append("; ");
 		sb.append("cc=").append(StringUtils.arrayToCommaDelimitedString(this.cc)).append("; ");
 		sb.append("bcc=").append(StringUtils.arrayToCommaDelimitedString(this.bcc)).append("; ");
@@ -251,7 +258,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 		}
 		SimpleMailMessage otherMessage = (SimpleMailMessage) other;
 		return (ObjectUtils.nullSafeEquals(this.from, otherMessage.from) &&
-				ObjectUtils.nullSafeEquals(this.replyTo, otherMessage.replyTo) &&
+				java.util.Arrays.equals(this.replyTo, otherMessage.replyTo) &&
 				java.util.Arrays.equals(this.to, otherMessage.to) &&
 				java.util.Arrays.equals(this.cc, otherMessage.cc) &&
 				java.util.Arrays.equals(this.bcc, otherMessage.bcc) &&
@@ -263,15 +270,17 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	@Override
 	public int hashCode() {
 		int hashCode = (this.from == null ? 0 : this.from.hashCode());
-		hashCode = 29 * hashCode + (this.replyTo == null ? 0 : this.replyTo.hashCode());
+		for (int i = 0; this.replyTo != null && i < this.replyTo.length; i++) {
+			hashCode = 29 * hashCode + this.replyTo[i].hashCode();
+		}
 		for (int i = 0; this.to != null && i < this.to.length; i++) {
-			hashCode = 29 * hashCode + (this.to == null ? 0 : this.to[i].hashCode());
+			hashCode = 29 * hashCode + this.to[i].hashCode();
 		}
 		for (int i = 0; this.cc != null && i < this.cc.length; i++) {
-			hashCode = 29 * hashCode + (this.cc == null ? 0 : this.cc[i].hashCode());
+			hashCode = 29 * hashCode + this.cc[i].hashCode();
 		}
 		for (int i = 0; this.bcc != null && i < this.bcc.length; i++) {
-			hashCode = 29 * hashCode + (this.bcc == null ? 0 : this.bcc[i].hashCode());
+			hashCode = 29 * hashCode + this.bcc[i].hashCode();
 		}
 		hashCode = 29 * hashCode + (this.sentDate == null ? 0 : this.sentDate.hashCode());
 		hashCode = 29 * hashCode + (this.subject == null ? 0 : this.subject.hashCode());

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/MimeMailMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/MimeMailMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,16 @@ public class MimeMailMessage implements MailMessage {
 
 	@Override
 	public void setReplyTo(String replyTo) throws MailParseException {
+		try {
+			this.helper.setReplyTo(replyTo);
+		}
+		catch (MessagingException ex) {
+			throw new MailParseException(ex);
+		}
+	}
+
+	@Override
+	public void setReplyTo(String[] replyTo) throws MailParseException {
 		try {
 			this.helper.setReplyTo(replyTo);
 		}

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/MimeMessageHelper.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/MimeMessageHelper.java
@@ -559,9 +559,24 @@ public class MimeMessageHelper {
 		this.mimeMessage.setReplyTo(new InternetAddress[] {replyTo});
 	}
 
+	public void setReplyTo(InternetAddress[] replyTo) throws MessagingException {
+		Assert.notNull(replyTo, "Reply-to address array must not be null");
+		validateAddresses(replyTo);
+		this.mimeMessage.setReplyTo(replyTo);
+	}
+
 	public void setReplyTo(String replyTo) throws MessagingException {
 		Assert.notNull(replyTo, "Reply-to address must not be null");
 		setReplyTo(parseAddress(replyTo));
+	}
+
+	public void setReplyTo(String[] replyTo) throws MessagingException {
+		Assert.notNull(replyTo, "Reply-to address array must not be null");
+		InternetAddress[] addresses = new InternetAddress[replyTo.length];
+		for (int i = 0; i < replyTo.length; i++) {
+			addresses[i] = parseAddress(replyTo[i]);
+		}
+		setReplyTo(addresses);
 	}
 
 	public void setReplyTo(String replyTo, String personal) throws MessagingException, UnsupportedEncodingException {

--- a/spring-context-support/src/test/java/org/springframework/mail/SimpleMailMessageTests.java
+++ b/spring-context-support/src/test/java/org/springframework/mail/SimpleMailMessageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2007 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class SimpleMailMessageTests {
 		message.setText("my text");
 
 		assertEquals("me@mail.org", message.getFrom());
-		assertEquals("reply@mail.org", message.getReplyTo());
+		assertEquals("reply@mail.org", message.getReplyTo()[0]);
 		assertEquals("you@mail.org", message.getTo()[0]);
 		List<String> ccs = Arrays.asList(message.getCc());
 		assertTrue(ccs.contains("he@mail.org"));
@@ -66,7 +66,7 @@ public class SimpleMailMessageTests {
 
 		messageCopy = new SimpleMailMessage(message);
 		assertEquals("me@mail.org", messageCopy.getFrom());
-		assertEquals("reply@mail.org", messageCopy.getReplyTo());
+		assertEquals("reply@mail.org", messageCopy.getReplyTo()[0]);
 		assertEquals("you@mail.org", messageCopy.getTo()[0]);
 		ccs = Arrays.asList(messageCopy.getCc());
 		assertTrue(ccs.contains("he@mail.org"));

--- a/spring-context-support/src/test/java/org/springframework/mail/javamail/MimeMailMessageTests.java
+++ b/spring-context-support/src/test/java/org/springframework/mail/javamail/MimeMailMessageTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.mail.javamail;
+
+import javax.mail.internet.MimeMessage;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Roland Weisleder
+ */
+public class MimeMailMessageTests {
+
+	@Test
+	public void testSetMultipleReplyTo() throws Exception {
+		MimeMessage mimeMessage = new JavaMailSenderImpl().createMimeMessage();
+		MimeMailMessage mimeMailMessage = new MimeMailMessage(mimeMessage);
+		mimeMailMessage.setReplyTo(new String[]{"you@mail.org", "us@mail.org"});
+		assertEquals("you@mail.org", mimeMessage.getReplyTo()[0].toString());
+		assertEquals("us@mail.org", mimeMessage.getReplyTo()[1].toString());
+	}
+}


### PR DESCRIPTION
As proposed in [SPR-7961](https://jira.spring.io/browse/SPR-7961).

The JavaMail API states that "normally only a single address will be specified", but `MailMessage` should be consistent with `MimeMessage`.