### PR TITLE
Remove redundant check for string emptiness before calling overridden method for checking text presence.

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -163,7 +163,7 @@ public abstract class StringUtils {
 	 * @see #hasText(CharSequence)
 	 */
 	public static boolean hasText(@Nullable String str) {
-		return (str != null && !str.isEmpty() && hasText((CharSequence) str));
+		return hasText((CharSequence) str);
 	}
 
 	/**


### PR DESCRIPTION
Remove redundant check for string emptiness before calling overridden method for checking text presence. This check is already present in called method for CharSequence.