### PR TITLE
Remove redundant lower cased strings creation for their comparison in startsWithIgnoreCase method.

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -333,9 +333,8 @@ public abstract class StringUtils {
 			return false;
 		}
 
-		String lcStr = str.substring(0, prefix.length()).toLowerCase();
-		String lcPrefix = prefix.toLowerCase();
-		return lcStr.equals(lcPrefix);
+		String strPrefix = str.substring(0, prefix.length());
+		return strPrefix.equalsIgnoreCase(prefix);
 	}
 
 	/**


### PR DESCRIPTION
Remove redundant lower cased strings creation for their comparison in startsWithIgnoreCase method.