### PR TITLE
Remove redundant lower cased strings creation for their comparision in endsWithIgnoreCase method.

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -356,9 +356,8 @@ public abstract class StringUtils {
 			return false;
 		}
 
-		String lcStr = str.substring(str.length() - suffix.length()).toLowerCase();
-		String lcSuffix = suffix.toLowerCase();
-		return lcStr.equals(lcSuffix);
+		String strSuffix = str.substring(str.length() - suffix.length());
+		return strSuffix.equalsIgnoreCase(suffix);
 	}
 
 	/**


### PR DESCRIPTION
Remove redundant lower cased strings creation for their comparision in endsWithIgnoreCase method.