### PR TITLE
Fix typo in javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/WebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/WebRequest.java
@@ -223,7 +223,7 @@ public interface WebRequest extends RequestAttributes {
 	 * also with conditional POST/PUT/DELETE requests.
 	 * <p><strong>Note:</strong> The HTTP specification recommends
 	 * setting both ETag and Last-Modified values, but you can also
-	 * use {@code #checkNotModified(String)} or
+	 * use {@link #checkNotModified(String)} or
 	 * {@link #checkNotModified(long)}.
 	 * @param etag the entity tag that the application determined
 	 * for the underlying resource. This parameter will be padded


### PR DESCRIPTION
Change "@code" to "@link".