### PR TITLE
Allow empty usernames for BasicAuth

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/support/BasicAuthorizationInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/http/client/support/BasicAuthorizationInterceptor.java
@@ -46,9 +46,9 @@ public class BasicAuthorizationInterceptor implements ClientHttpRequestIntercept
 	 * @param username the username to use
 	 * @param password the password to use
 	 */
-	public BasicAuthorizationInterceptor(String username, @Nullable String password) {
-		Assert.hasLength(username, "Username must not be empty");
-		this.username = username;
+	public BasicAuthorizationInterceptor(@Nullable String username, @Nullable String password) {
+		Assert.doesNotContain(username, ":", "Username must not contain a colon");
+		this.username = (username != null ? username : "");
 		this.password = (password != null ? password : "");
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/client/support/BasicAuthorizationInterceptorTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/support/BasicAuthorizationInterceptorTests.java
@@ -43,17 +43,17 @@ public class BasicAuthorizationInterceptorTests {
 	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
-	public void createWhenUsernameIsNullShouldThrowException() {
+	public void createWhenUsernameContainsColonShouldThrowException() {
 		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("Username must not be empty");
-		new BasicAuthorizationInterceptor(null, "password");
+		this.thrown.expectMessage("Username must not contain a colon");
+		new BasicAuthorizationInterceptor("username:", "password");
 	}
 
 	@Test
-	public void createWhenUsernameIsEmptyShouldThrowException() throws Exception {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("Username must not be empty");
-		new BasicAuthorizationInterceptor("", "password");
+	public void createWhenUsernameIsNullShouldUseEmptyUsername() throws Exception {
+		BasicAuthorizationInterceptor interceptor = new BasicAuthorizationInterceptor(
+				null, "password");
+		assertEquals("", new DirectFieldAccessor(interceptor).getPropertyValue("username"));
 	}
 
 	@Test


### PR DESCRIPTION
As described in [SPR-16116](https://jira.spring.io/browse/SPR-16116):

The RFCs around basic authentication don't explicitly disallow empty
usernames. On the other hand usernames containing colons are, as colons
are used to separate the username from the password.

This PR will allow empty usernames (empty string or NULL) to be used, but will disallow to use usernames containing a colon.