### PR TITLE
Handle parameters of Kotlin extension methods correctly.

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/KotlinReflectionParameterNameDiscoverer.java
+++ b/spring-core/src/main/java/org/springframework/core/KotlinReflectionParameterNameDiscoverer.java
@@ -75,11 +75,16 @@ public class KotlinReflectionParameterNameDiscoverer implements ParameterNameDis
 	private String[] getParameterNames(List<KParameter> parameters) {
 		List<KParameter> filteredParameters = parameters
 				.stream()
-				.filter(p -> KParameter.Kind.VALUE.equals(p.getKind()))
+				// SPR-16119: Extension receivers of extension methods must be included as they appear as normal method
+				//            parameters in Java
+				.filter(p -> KParameter.Kind.VALUE.equals(p.getKind()) || KParameter.Kind.EXTENSION_RECEIVER.equals(p.getKind()))
 				.collect(Collectors.toList());
 		String[] parameterNames = new String[filteredParameters.size()];
 		for (int i = 0; i < filteredParameters.size(); i++) {
-			String name = filteredParameters.get(i).getName();
+			KParameter parameter = filteredParameters.get(i);
+			// extension receivers are not explicitly named, but require a name for Java interoperability
+			// $receiver is not a valid Kotlin identifier, but valid in Java, so it can be used here
+			String name = KParameter.Kind.EXTENSION_RECEIVER.equals(parameter.getKind())  ? "$receiver" : parameter.getName();
 			if (name == null) {
 				return null;
 			}

--- a/spring-core/src/test/kotlin/org/springframework/core/KotlinReflectionParameterNameDiscovererTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/KotlinReflectionParameterNameDiscovererTests.kt
@@ -42,11 +42,22 @@ class KotlinReflectionParameterNameDiscovererTests {
 		assertThat(actualParams, `is`(arrayOf("message")))
 	}
 
+	@Test
+	fun getParameterNamesOnExtensionMethod() {
+		val method = ReflectionUtils.findMethod(UtilityClass::class.java, "identity", String::class.java)!!
+		val actualParams = parameterNameDiscoverer.getParameterNames(method)!!
+		assertThat(actualParams, `is`(arrayOf("\$receiver")))
+	}
+
 	interface MessageService {
 		fun sendMessage(message: String)
 	}
 
 	class MessageServiceImpl {
 		fun sendMessage(message: String) = message
+	}
+
+	class UtilityClass {
+		fun String.identity() = this
 	}
 }


### PR DESCRIPTION
As described in [SPR-16119](https://jira.spring.io/browse/SPR-16119):

The `EXTENSION_RECEIVER` parameter of Kotlin's extension methods appear as
normal method parameters to Java and thus require a name. The synthetic
name `$receiver` is used here, as it is not a valid Kotlin identifier,
but valid in Java.