### PR TITLE
SPR-16138 - MockHttpServletRequest: use computed serverName

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -1199,7 +1199,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	@Override
 	public StringBuffer getRequestURL() {
-		StringBuffer url = new StringBuffer(this.scheme).append("://").append(this.serverName);
+		StringBuffer url = new StringBuffer(this.scheme).append("://").append(getServerName());
 		if (this.serverPort > 0 && ((HTTP.equalsIgnoreCase(this.scheme) && this.serverPort != 80) ||
 				(HTTPS.equalsIgnoreCase(this.scheme) && this.serverPort != 443))) {
 			url.append(':').append(this.serverPort);


### PR DESCRIPTION
otherwise it's easy to accidentally get 'localhost' even if you set a `Host:` header