### PR TITLE
Move requests.add(request) into finally block.

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/AbstractRequestExpectationManager.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/AbstractRequestExpectationManager.java
@@ -80,9 +80,12 @@ public abstract class AbstractRequestExpectationManager implements RequestExpect
 			if (requests.isEmpty()) {
 				afterExpectationsDeclared();
 			}
-			ClientHttpResponse response = validateRequestInternal(request);
-			requests.add(request);
-			return response;
+			try {
+				return validateRequestInternal(request);
+			}
+			finally {
+				requests.add(request);
+			}
 		}
 	}
 


### PR DESCRIPTION
This avoids "IllegalStateException: Expectations already declared" when
a MockRestServiceServer is used after one request throws an exception.
I consider this a trivial fix.

Issues: SPR-16132