### PR TITLE
Fix SpEL comparison operator for comparable types

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/Operator.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/Operator.java
@@ -221,11 +221,8 @@ public abstract class Operator extends SpelNodeImpl {
 			return true;
 		}
 
-		if (left instanceof Comparable && right instanceof Comparable) {
-			Class<?> ancestor = ClassUtils.determineCommonAncestor(left.getClass(), right.getClass());
-			if (ancestor != null && Comparable.class.isAssignableFrom(ancestor)) {
-				return (context.getTypeComparator().compare(left, right) == 0);
-			}
+		if (context.getTypeComparator().canCompare(left, right)) {
+			return context.getTypeComparator().compare(left, right) == 0;
 		}
 
 		return false;

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/StandardTypeComparator.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/StandardTypeComparator.java
@@ -23,6 +23,7 @@ import org.springframework.expression.TypeComparator;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelMessage;
 import org.springframework.lang.Nullable;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.NumberUtils;
 
 /**
@@ -44,8 +45,9 @@ public class StandardTypeComparator implements TypeComparator {
 		if (left instanceof Number && right instanceof Number) {
 			return true;
 		}
-		if (left instanceof Comparable) {
-			return true;
+		if (left instanceof Comparable && right instanceof Comparable) {
+            Class<?> ancestor = ClassUtils.determineCommonAncestor(left.getClass(), right.getClass());
+			return ancestor != null && Comparable.class.isAssignableFrom(ancestor);
 		}
 		return false;
 	}

--- a/spring-expression/src/test/java/org/springframework/expression/spel/AlternativeComparatorTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/AlternativeComparatorTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.expression.spel;
+
+import org.junit.Test;
+import org.springframework.lang.Nullable;
+import org.springframework.expression.Expression;
+import org.springframework.expression.TypeComparator;
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test construction of arrays.
+ *
+ * @author Andy Clement
+ */
+public class AlternativeComparatorTests {
+	private ExpressionParser parser = new SpelExpressionParser();
+
+	// A silly comparator declaring everything to be equal
+	private TypeComparator customComparator = new TypeComparator() {
+		@Override
+		public boolean canCompare(@Nullable Object firstObject, @Nullable Object secondObject) {
+			return true;
+		}
+
+		@Override
+		public int compare(@Nullable Object firstObject, @Nullable Object secondObject) throws EvaluationException {
+			return 0;
+		}
+
+	};
+
+	@Test
+	public void customComparatorWorksWithEquality() {
+		final StandardEvaluationContext ctx = new StandardEvaluationContext();
+		ctx.setTypeComparator(customComparator);
+
+		Expression expr = parser.parseExpression("'1' == 1");
+
+		assertEquals(true, expr.getValue(ctx, Boolean.class));
+
+	}
+}

--- a/spring-expression/src/test/java/org/springframework/expression/spel/DefaultComparatorUnitTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/DefaultComparatorUnitTests.java
@@ -115,7 +115,7 @@ public class DefaultComparatorUnitTests {
 
 		assertTrue(comparator.canCompare(2,1));
 		assertTrue(comparator.canCompare("abc","def"));
-		assertTrue(comparator.canCompare("abc",3));
+		assertFalse(comparator.canCompare("abc",3));
 		assertFalse(comparator.canCompare(String.class,3));
 	}
 


### PR DESCRIPTION
This is my first contribution to spring, so please advise if I have missed anything.

This PR fixes SPR-16141 by allowing equality checking to defer to the `TypeComparator`'s `canCompare`, rather than hardcoding conditions.