### PR TITLE
SPR-16162 make JpaVendorAdapter configuration properties more transaction type aware

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaVendorAdapter.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaVendorAdapter.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.spi.PersistenceProvider;
+import javax.persistence.spi.PersistenceUnitTransactionType;
 
 import org.springframework.lang.Nullable;
 
@@ -64,6 +65,20 @@ public interface JpaVendorAdapter {
 	 */
 	@Nullable
 	Map<String, ?> getJpaPropertyMap();
+
+	/**
+	 * Return a Map of vendor-specific JPA properties based on the transaction type,
+	 * typically based on settings in this JpaVendorAdapter instance.
+	 * <p>Note that there might be further JPA properties defined on
+	 * the EntityManagerFactory bean, which might potentially override
+	 * individual JPA property values specified here.
+	 * @param transactionType the transaction type if can determine it or null if we can't
+	 * @return a Map of JPA properties, as accepted by the standard
+	 * JPA bootstrap facilities, or an empty Map if there are no such properties to expose
+	 * @see javax.persistence.Persistence#createEntityManagerFactory(String, java.util.Map)
+	 * @see javax.persistence.spi.PersistenceProvider#createContainerEntityManagerFactory(javax.persistence.spi.PersistenceUnitInfo, java.util.Map)
+	 */
+	Map<String, ?> getAdditionalJpaPropertyMapByTransactionType(@Nullable PersistenceUnitTransactionType transactionType);
 
 	/**
 	 * Return the vendor-specific JpaDialect implementation for this

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/LocalContainerEntityManagerFactoryBean.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/LocalContainerEntityManagerFactoryBean.java
@@ -22,6 +22,7 @@ import javax.persistence.SharedCacheMode;
 import javax.persistence.ValidationMode;
 import javax.persistence.spi.PersistenceProvider;
 import javax.persistence.spi.PersistenceUnitInfo;
+import javax.persistence.spi.PersistenceUnitTransactionType;
 import javax.sql.DataSource;
 
 import org.springframework.beans.BeanUtils;
@@ -320,9 +321,8 @@ public class LocalContainerEntityManagerFactoryBean extends AbstractEntityManage
 		this.internalPersistenceUnitManager.setResourceLoader(resourceLoader);
 	}
 
-
 	@Override
-	protected EntityManagerFactory createNativeEntityManagerFactory() throws PersistenceException {
+	protected void beforeAfterPropertiesSet() {
 		PersistenceUnitManager managerToUse = this.persistenceUnitManager;
 		if (this.persistenceUnitManager == null) {
 			this.internalPersistenceUnitManager.afterPropertiesSet();
@@ -330,6 +330,10 @@ public class LocalContainerEntityManagerFactoryBean extends AbstractEntityManage
 		}
 
 		this.persistenceUnitInfo = determinePersistenceUnitInfo(managerToUse);
+	}
+
+	@Override
+	protected EntityManagerFactory createNativeEntityManagerFactory() throws PersistenceException {
 		JpaVendorAdapter jpaVendorAdapter = getJpaVendorAdapter();
 		if (jpaVendorAdapter != null && this.persistenceUnitInfo instanceof SmartPersistenceUnitInfo) {
 			String rootPackage = jpaVendorAdapter.getPersistenceProviderRootPackage();
@@ -392,6 +396,13 @@ public class LocalContainerEntityManagerFactoryBean extends AbstractEntityManage
 	protected void postProcessEntityManagerFactory(EntityManagerFactory emf, PersistenceUnitInfo pui) {
 	}
 
+	@Override
+	protected PersistenceUnitTransactionType determineTransactionType() {
+		if (this.persistenceUnitInfo != null) {
+			return this.persistenceUnitInfo.getTransactionType();
+		}
+		return super.determineTransactionType();
+	}
 
 	@Override
 	@Nullable

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/AbstractJpaVendorAdapter.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/AbstractJpaVendorAdapter.java
@@ -16,9 +16,11 @@
 
 package org.springframework.orm.jpa.vendor;
 
+import java.util.Collections;
 import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.spi.PersistenceUnitTransactionType;
 
 import org.springframework.lang.Nullable;
 import org.springframework.orm.jpa.JpaDialect;
@@ -127,6 +129,11 @@ public abstract class AbstractJpaVendorAdapter implements JpaVendorAdapter {
 	@Nullable
 	public Map<String, ?> getJpaPropertyMap() {
 		return null;
+	}
+
+	@Override
+	public Map<String, ?> getAdditionalJpaPropertyMapByTransactionType(@Nullable PersistenceUnitTransactionType transactionType) {
+		return Collections.emptyMap();
 	}
 
 	@Override

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaVendorAdapter.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaVendorAdapter.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.spi.PersistenceProvider;
+import javax.persistence.spi.PersistenceUnitTransactionType;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.DB2Dialect;
@@ -35,6 +36,8 @@ import org.hibernate.dialect.SQLServer2012Dialect;
 import org.hibernate.dialect.SybaseDialect;
 
 import org.springframework.lang.Nullable;
+
+import static javax.persistence.spi.PersistenceUnitTransactionType.JTA;
 
 /**
  * {@link org.springframework.orm.jpa.JpaVendorAdapter} implementation for Hibernate
@@ -130,7 +133,13 @@ public class HibernateJpaVendorAdapter extends AbstractJpaVendorAdapter {
 			jpaProperties.put(AvailableSettings.SHOW_SQL, "true");
 		}
 
-		if (this.jpaDialect.prepareConnection) {
+		return jpaProperties;
+	}
+
+	@Override
+	public Map<String, ?> getAdditionalJpaPropertyMapByTransactionType(@Nullable PersistenceUnitTransactionType transactionType) {
+		Map<String, Object> jpaProperties = new HashMap<>();
+		if (this.jpaDialect.prepareConnection && transactionType != JTA) {
 			// Hibernate 5.1/5.2: manually enforce connection release mode ON_CLOSE (the former default)
 			try {
 				// Try Hibernate 5.2
@@ -148,7 +157,6 @@ public class HibernateJpaVendorAdapter extends AbstractJpaVendorAdapter {
 				}
 			}
 		}
-
 		return jpaProperties;
 	}
 


### PR DESCRIPTION
Autoconfigure based on the transaction type if detected. If the transaction type cannot be detected for whatever reason, it falls back to the current behavior.

This is basically to prevent the Vendor Adapter to set an invalid connection release mode for JTA transactions but can be used for further configuration based on the detected transaction type.

Running the application with embedded tomcat:
![image](https://user-images.githubusercontent.com/4395571/32646606-f2147598-c5f5-11e7-89a1-63b37dea955b.png)

Running with weblogic
![image](https://user-images.githubusercontent.com/4395571/32659057-8aafb630-c625-11e7-8576-4821add6d828.png)
