### PR TITLE
SPR-16022: avoid implicit autowiring with Kotlin secondary ctors

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
@@ -284,8 +284,12 @@ public class AutowiredAnnotationBeanPostProcessor extends InstantiationAwareBean
 					Constructor<?> requiredConstructor = null;
 					Constructor<?> defaultConstructor = null;
 					Constructor<?> primaryConstructor = BeanUtils.findPrimaryConstructor(beanClass);
+					int nonSyntheticConstructors = 0;
 					for (Constructor<?> candidate : rawCandidates) {
-						if (primaryConstructor != null && candidate.isSynthetic()) {
+						if (!candidate.isSynthetic()) {
+							nonSyntheticConstructors++;
+						}
+						else if (primaryConstructor != null) {
 							continue;
 						}
 						AnnotationAttributes ann = findAutowiredAnnotation(candidate);
@@ -343,10 +347,11 @@ public class AutowiredAnnotationBeanPostProcessor extends InstantiationAwareBean
 					else if (rawCandidates.length == 1 && rawCandidates[0].getParameterCount() > 0) {
 						candidateConstructors = new Constructor<?>[] {rawCandidates[0]};
 					}
-					else if (primaryConstructor != null) {
-						candidateConstructors = (defaultConstructor != null ?
-								new Constructor<?>[] {primaryConstructor, defaultConstructor} :
-								new Constructor<?>[] {primaryConstructor});
+					else if (nonSyntheticConstructors == 2 && primaryConstructor != null && defaultConstructor != null) {
+						candidateConstructors = new Constructor<?>[] {primaryConstructor, defaultConstructor};
+					}
+					else if (nonSyntheticConstructors == 1 && primaryConstructor != null) {
+						candidateConstructors = new Constructor<?>[] {primaryConstructor};
 					}
 					else {
 						candidateConstructors = new Constructor<?>[0];

--- a/spring-context/src/test/kotlin/org/springframework/context/annotation/Spr16022Tests.kt
+++ b/spring-context/src/test/kotlin/org/springframework/context/annotation/Spr16022Tests.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.context.annotation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.getBean
+import org.springframework.context.support.ClassPathXmlApplicationContext
+
+/**
+ * @author Sebastien Deleuze
+ */
+class Spr16022Tests {
+
+	@Test
+	fun `Register beans with multiple constructors with AnnotationConfigApplicationContext`() {
+		assert(AnnotationConfigApplicationContext(Config::class.java))
+	}
+
+	@Test
+	fun `Register beans with multiple constructors with ClassPathXmlApplicationContext`() {
+		assert(ClassPathXmlApplicationContext(CONTEXT))
+	}
+
+	private fun assert(context: BeanFactory) {
+		val bean1 = context.getBean<MultipleConstructorsTestBean>("bean1")
+		assertEquals(0, bean1.foo)
+		val bean2 = context.getBean<MultipleConstructorsTestBean>("bean2")
+		assertEquals(1, bean2.foo)
+		val bean3 = context.getBean<MultipleConstructorsTestBean>("bean3")
+		assertEquals(3, bean3.foo)
+
+	}
+
+	@Suppress("unused")
+	class MultipleConstructorsTestBean(val foo: Int) {
+		constructor(bar: String) : this(bar.length)
+		constructor(foo: Int, bar: String) : this(foo + bar.length)
+	}
+
+	@Configuration @ImportResource(CONTEXT)
+	open class Config
+}
+
+private const val CONTEXT = "org/springframework/context/annotation/multipleConstructors.xml"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/multipleConstructors.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/multipleConstructors.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean class="org.springframework.context.annotation.Spr16022Tests.MultipleConstructorsTestBean" name="bean1">
+		<constructor-arg value="0" type="int" />
+	</bean>
+
+	<bean class="org.springframework.context.annotation.Spr16022Tests.MultipleConstructorsTestBean" name="bean2">
+		<constructor-arg value="a" type="java.lang.String" />
+	</bean>
+
+	<bean class="org.springframework.context.annotation.Spr16022Tests.MultipleConstructorsTestBean" name="bean3">
+		<constructor-arg value="2" type="int" />
+		<constructor-arg value="b" type="java.lang.String" />
+	</bean>
+
+</beans>


### PR DESCRIPTION
This one is tricky, but after some time to think and experiment on it, I tend to think we went maybe a little bit to far with implicit autowiring of Kotlin classes with secondary constructors, which has impact on `ConstructorResolver`.

In order to fix [SPR-16022](https://jira.spring.io/browse/SPR-16022), my proposal is to avoid implicit autowiring when the Kotlin class has secondary constructors.

Notice that Kotlin compiler can generate (in additional to the synthetic constructor generated for primary constructor) a non-synthetic default constructor when using no-arg compiler plugin or when a class have primary constructor with optional parameters that have all default values. This proposed change try to handle all these use cases.