### PR TITLE
SPR-16098: Fix Reactive JsonView + HttpEntity handling

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageWriterResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageWriterResultHandler.java
@@ -43,6 +43,7 @@ import org.springframework.web.server.ServerWebExchange;
  * to the response with {@link HttpMessageWriter}.
  *
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  * @since 5.0
  */
 public abstract class AbstractMessageWriterResultHandler extends HandlerResultHandlerSupport {
@@ -86,9 +87,36 @@ public abstract class AbstractMessageWriterResultHandler extends HandlerResultHa
 	}
 
 
-	@SuppressWarnings("unchecked")
+	/**
+	 * Write a given body to the response with {@link HttpMessageWriter}.
+	 * @param body the object to write
+	 * @param bodyParameter the {@link MethodParameter} of the body to write
+	 * @param exchange the current exchange
+	 * @return indicates completion or error
+	 * @see #writeBody(Object, MethodParameter, MethodParameter, ServerWebExchange)
+	 */
 	protected Mono<Void> writeBody(@Nullable Object body, MethodParameter bodyParameter, ServerWebExchange exchange) {
+		return this.writeBody(body, bodyParameter, null, exchange);
+	}
+
+	/**
+	 * Write a given body to the response with {@link HttpMessageWriter}.
+	 * @param body the object to write
+	 * @param bodyParameter the {@link MethodParameter} of the body to write
+	 * @param actualParameter the actual return type of the method that returned the
+	 * value; could be different from {@code bodyParameter} when processing {@code ResponseEntity}
+	 * for example
+	 * @param exchange the current exchange
+	 * @return indicates completion or error
+	 * @since 5.0.2
+	 */
+	@SuppressWarnings("unchecked")
+	protected Mono<Void> writeBody(@Nullable Object body, MethodParameter bodyParameter,
+			@Nullable MethodParameter actualParameter, ServerWebExchange exchange) {
+
 		ResolvableType bodyType = ResolvableType.forMethodParameter(bodyParameter);
+		ResolvableType actualType = (actualParameter == null ?
+				bodyType : ResolvableType.forMethodParameter(actualParameter));
 		Class<?> bodyClass = bodyType.resolve();
 		ReactiveAdapter adapter = getAdapterRegistry().getAdapter(bodyClass, body);
 
@@ -115,7 +143,7 @@ public abstract class AbstractMessageWriterResultHandler extends HandlerResultHa
 		if (bestMediaType != null) {
 			for (HttpMessageWriter<?> writer : getMessageWriters()) {
 				if (writer.canWrite(elementType, bestMediaType)) {
-					return writer.write((Publisher) publisher, bodyType, elementType,
+					return writer.write((Publisher) publisher, actualType, elementType,
 							bestMediaType, request, response, Collections.emptyMap());
 				}
 			}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/HttpEntityArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/HttpEntityArgumentResolver.java
@@ -58,7 +58,7 @@ public class HttpEntityArgumentResolver extends AbstractMessageReaderArgumentRes
 			MethodParameter parameter, BindingContext bindingContext, ServerWebExchange exchange) {
 
 		Class<?> entityType = parameter.getParameterType();
-		return readBody(parameter.nested(), false, bindingContext, exchange)
+		return readBody(parameter.nested(), parameter, false, bindingContext, exchange)
 				.map(body -> createEntity(body, entityType, exchange.getRequest()))
 				.defaultIfEmpty(createEntity(null, entityType, exchange.getRequest()));
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityResultHandler.java
@@ -114,15 +114,16 @@ public class ResponseEntityResultHandler extends AbstractMessageWriterResultHand
 		Mono<?> returnValueMono;
 		MethodParameter bodyParameter;
 		ReactiveAdapter adapter = getAdapter(result);
+		MethodParameter actualParameter = result.getReturnTypeSource();
 
 		if (adapter != null) {
 			Assert.isTrue(!adapter.isMultiValue(), "Only a single ResponseEntity supported");
 			returnValueMono = Mono.from(adapter.toPublisher(result.getReturnValue()));
-			bodyParameter = result.getReturnTypeSource().nested().nested();
+			bodyParameter = actualParameter.nested().nested();
 		}
 		else {
 			returnValueMono = Mono.justOrEmpty(result.getReturnValue());
-			bodyParameter = result.getReturnTypeSource().nested();
+			bodyParameter = actualParameter.nested();
 		}
 
 		return returnValueMono.flatMap(returnValue -> {
@@ -169,7 +170,7 @@ public class ResponseEntityResultHandler extends AbstractMessageWriterResultHand
 				return exchange.getResponse().setComplete();
 			}
 
-			return writeBody(httpEntity.getBody(), bodyParameter, exchange);
+			return writeBody(httpEntity.getBody(), bodyParameter, actualParameter, exchange);
 		});
 	}
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/JacksonHintsIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/JacksonHintsIntegrationTests.java
@@ -28,7 +28,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,6 +65,12 @@ public class JacksonHintsIntegrationTests extends AbstractRequestMappingIntegrat
 		assertEquals(expected, performGet("/response/mono", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
 	}
 
+	@Test  // SPR-16098
+	public void jsonViewWithMonoResponseEntity() throws Exception {
+		String expected = "{\"withView1\":\"with\"}";
+		assertEquals(expected, performGet("/response/entity", MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
 	@Test
 	public void jsonViewWithFluxResponse() throws Exception {
 		String expected = "[{\"withView1\":\"with\"},{\"withView1\":\"with\"}]";
@@ -81,6 +89,25 @@ public class JacksonHintsIntegrationTests extends AbstractRequestMappingIntegrat
 		String expected = "{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}";
 		assertEquals(expected, performPost("/request/mono", MediaType.APPLICATION_JSON,
 				new JacksonViewBean("with", "with", "without"), MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test  // SPR-16098
+	public void jsonViewWithEntityMonoRequest() throws Exception {
+		String expected = "{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}";
+		assertEquals(expected, performPost("/request/entity/mono", MediaType.APPLICATION_JSON,
+				new JacksonViewBean("with", "with", "without"),
+				MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
+	}
+
+	@Test  // SPR-16098
+	public void jsonViewWithEntityFluxRequest() throws Exception {
+		String expected = "[" +
+				"{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}," +
+				"{\"withView1\":\"with\",\"withView2\":null,\"withoutView\":null}]";
+		assertEquals(expected, performPost("/request/entity/flux", MediaType.APPLICATION_JSON,
+				Arrays.asList(new JacksonViewBean("with", "with", "without"),
+						new JacksonViewBean("with", "with", "without")),
+				MediaType.APPLICATION_JSON_UTF8, String.class).getBody());
 	}
 
 	@Test
@@ -120,6 +147,12 @@ public class JacksonHintsIntegrationTests extends AbstractRequestMappingIntegrat
 			return Mono.just(new JacksonViewBean("with", "with", "without"));
 		}
 
+		@GetMapping("/response/entity")
+		@JsonView(MyJacksonView1.class)
+		public Mono<ResponseEntity<JacksonViewBean>> monoResponseEntity() {
+			return Mono.just(ResponseEntity.ok(new JacksonViewBean("with", "with", "without")));
+		}
+
 		@GetMapping("/response/flux")
 		@JsonView(MyJacksonView1.class)
 		public Flux<JacksonViewBean> fluxResponse() {
@@ -134,6 +167,16 @@ public class JacksonHintsIntegrationTests extends AbstractRequestMappingIntegrat
 		@PostMapping("/request/mono")
 		public Mono<JacksonViewBean> monoRequest(@JsonView(MyJacksonView1.class) @RequestBody Mono<JacksonViewBean> mono) {
 			return mono;
+		}
+
+		@PostMapping("/request/entity/mono")
+		public Mono<JacksonViewBean> entityMonoRequest(@JsonView(MyJacksonView1.class) HttpEntity<Mono<JacksonViewBean>> entityMono) {
+			return entityMono.getBody();
+		}
+
+		@PostMapping("/request/entity/flux")
+		public Flux<JacksonViewBean> entityFluxRequest(@JsonView(MyJacksonView1.class) HttpEntity<Flux<JacksonViewBean>> entityFlux) {
+			return entityFlux.getBody();
 		}
 
 		@PostMapping("/request/flux")


### PR DESCRIPTION
This commit adds an `AbstractMessageWriterResultHandler#writeBody` variant which allows to pass the actual `MethodParameter` in order to perform proper annotation-based hint resolution with nested generics like with `ResponseEntityResultHandler`.