### PR TITLE
Updating WebClient's javadocs

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -51,8 +51,8 @@ import org.springframework.web.util.UriBuilderFactory;
  * // Perform requests...
  * Mono&#060;String&#062; result = client.get()
  *     .uri("/foo")
- *     .exchange()
- *     .then(response -> response.bodyToMono(String.class));
+ *     .retrieve()
+ *     .bodyToMono(String.class);
  * </pre>
  *
  * @author Rossen Stoyanchev


### PR DESCRIPTION
without this change the code in the Javadocs of `WebClient` is invalid. It doesn't compile.
with this change, I've updated the Javadocs to be consistent with the current implementation

related issue - https://jira.spring.io/browse/SPR-16197