### PR TITLE
SPR-16211 - Change getter method visibility of ParsedSql

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/ParsedSql.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/ParsedSql.java
@@ -52,7 +52,7 @@ public class ParsedSql {
 	/**
 	 * Return the SQL statement that is being parsed.
 	 */
-	String getOriginalSql() {
+	public String getOriginalSql() {
 		return this.originalSql;
 	}
 
@@ -72,7 +72,7 @@ public class ParsedSql {
 	 * Return all of the parameters (bind variables) in the parsed SQL statement.
 	 * Repeated occurrences of the same parameter name are included here.
 	 */
-	List<String> getParameterNames() {
+	public List<String> getParameterNames() {
 		return this.parameterNames;
 	}
 


### PR DESCRIPTION
ParsedSql parsedSql = NamedParameterUtils.parseSqlStatement(sql);
parsedSql.getParameterNames(); //NOT public