### PR TITLE
SPR-16216 Make annotation of param can be inherited

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/MethodParameter.java
+++ b/spring-core/src/main/java/org/springframework/core/MethodParameter.java
@@ -37,6 +37,7 @@ import kotlin.reflect.jvm.ReflectJvmMapping;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Helper class that encapsulates the specification of a method parameter, i.e. a {@link Method}
@@ -513,13 +514,25 @@ public class MethodParameter {
 	public Annotation[] getParameterAnnotations() {
 		Annotation[] paramAnns = this.parameterAnnotations;
 		if (paramAnns == null) {
-			Annotation[][] annotationArray = this.executable.getParameterAnnotations();
-			if (this.parameterIndex >= 0 && this.parameterIndex < annotationArray.length) {
-				paramAnns = adaptAnnotationArray(annotationArray[this.parameterIndex]);
+			// Executable is a method
+			if(this.getMethod() != null){
+				if (this.parameterIndex >= 0 && this.parameterIndex < this.executable.getParameterCount()) {
+					paramAnns = ReflectionUtils.getInheritedParamAnnotations(this.getMethod(), this.parameterIndex);
+				}
+				else{
+					paramAnns = ReflectionUtils.getInheritedParamAnnotations(this.getMethod(), 0);
+				}
 			}
-			else {
-				paramAnns = new Annotation[0];
+			else{
+				Annotation[][] annotationArray = this.executable.getParameterAnnotations();
+				if (this.parameterIndex >= 0 && this.parameterIndex < annotationArray.length) {
+					paramAnns = adaptAnnotationArray(annotationArray[this.parameterIndex]);
+				}
+				else {
+					paramAnns = new Annotation[0];
+				}
 			}
+
 			this.parameterAnnotations = paramAnns;
 		}
 		return paramAnns;

--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -16,6 +16,7 @@
 
 package org.springframework.util;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -23,11 +24,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.springframework.lang.Nullable;
 
@@ -68,6 +66,11 @@ public abstract class ReflectionUtils {
 	 * Cache for {@link Class#getDeclaredFields()}, allowing for fast iteration.
 	 */
 	private static final Map<Class<?>, Field[]> declaredFieldsCache = new ConcurrentReferenceHashMap<>(256);
+
+	/**
+	 * Cache for {@link ReflectionUtils#getInheritedParamAnnotations(Method, int)} ()}, allowing for fast iteration.
+	 */
+	private static final Map<Method, Annotation[][]> inheritedParamAnnotationsCache = new ConcurrentReferenceHashMap<>(256);
 
 
 	/**
@@ -783,12 +786,83 @@ public abstract class ReflectionUtils {
 	}
 
 	/**
+	 * This will get parameter's annotations from super class or interface
+	 * The order of result is current class, interfaces, super class
+	 * @param method which method's param want to get
+	 * @param paramIndex param index of method
+	 * @return
+	 */
+	public static Annotation[] getInheritedParamAnnotations(final Method method, int paramIndex){
+		Annotation[][] cachedResult = inheritedParamAnnotationsCache.get(method);
+		if(cachedResult == null){
+			inheritedParamAnnotationsCache.put(method, new Annotation[method.getParameterCount()][]);
+
+			// Recursion call it again make sure cache is available
+			return getInheritedParamAnnotations(method, paramIndex);
+		}
+		else{
+			if(cachedResult[paramIndex] == null){
+				List<Annotation> annotations = getInheritedParamAnnotations(method.getDeclaringClass(), method, paramIndex);
+
+				// Remove duplicated annotation in result
+				Set<Annotation> annotationSet = new LinkedHashSet<>(annotations);
+				Annotation[] result = annotationSet.toArray(new Annotation[0]);
+
+				// Add result to cache
+				cachedResult[paramIndex] = result;
+			}
+
+			return cachedResult[paramIndex];
+		}
+	}
+
+	@SuppressWarnings("unchecked call")
+	private static List<Annotation> getInheritedParamAnnotations(@Nullable final Class clazz, final Method method, final int paramIndex) {
+		if(clazz == null){
+			return new ArrayList<>();
+		}
+
+		Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+		final int index;
+		if (paramIndex >= paramAnnotations.length || paramIndex< 0) {
+			index = 0; // Should we throw a exception?
+		}
+		else{
+			index = paramIndex;
+		}
+
+		List<Annotation> annotations = new ArrayList<>();
+
+		// Add all annotations from current clazz
+		try{
+			// Get method with same signature
+			Method currentMethod = clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
+			Annotation[] currentParamAnnotations = currentMethod.getParameterAnnotations()[paramIndex];
+			annotations.addAll(Arrays.asList(currentParamAnnotations));
+		}catch (NoSuchMethodException ignore){
+			// Ignored 'NoSuchMethodException' for class which has no method
+		}
+
+		// Then add all annotations from interfaces(recursion call)
+		annotations.addAll(Arrays.stream(clazz.getInterfaces())
+				.map(item-> getInheritedParamAnnotations(item, method, index))
+				.flatMap(Collection::stream).collect(Collectors.toList()));
+
+		// Add all annotations from super class finally(recursion call)
+		annotations.addAll(getInheritedParamAnnotations(clazz.getSuperclass(), method, index));
+
+		return annotations;
+	}
+
+	/**
 	 * Clear the internal method/field cache.
 	 * @since 4.2.4
 	 */
 	public static void clearCache() {
 		declaredMethodsCache.clear();
 		declaredFieldsCache.clear();
+		inheritedParamAnnotationsCache.clear();
 	}
 
 


### PR DESCRIPTION
# Purpose
This PR make spring can read annotations of param from interface or super class.
It is a sample:
```Java
interface InterfaceA{
    void method(@TestAnnotation String param0);
}

class ClassB implements InterfaceA{
    @Override
    public void method(String param0){
    }
}
```
When you create a `ClassB` bean, Spring can find `TestAnnotation` from `ClassB.method param0` even this method is been override.

# How it work
I will scan all annotations from same signature method from interfaces and super class.

# Scenarios
I think it is very usefully for feign and service.
We usually create a feign project for our service(Spring MVC), like this:
```Java
@FeignClient(name = "Editor")
public interface AFeignClient {
    @RequestMapping(path = "/api/test/{id}", method = RequestMethod.GET)
    ResultModel getTestResult(@PathVariable("id") String id, @RequestParam(value = "paging", required = false) String paging);
```
As you see, we create a feign client for a API, then we will create controller from this feign client, like this:
```Java
@RestController
public class ServiceController implements AFeignClient {
    @Override
     ResultModel getTestResult(@PathVariable("id") String id, @RequestParam(value = "paging", required = false) String paging){
     // Business code here
    }
}
```
Yes, we don't need re-add `RequestMapping` for controller, but we should re-add `PathVariable`, `RequestParam`...It is very easy to forget re-add annotations for controller, and IDE can't add those annotations automatically
This PR will solve this problem, you just need your controller implement FeignClient then all will be done by spring.