### PR TITLE
fixed the javadoc mistake casued by copy

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/ConfigurableEnvironment.java
+++ b/spring-core/src/main/java/org/springframework/core/env/ConfigurableEnvironment.java
@@ -107,9 +107,9 @@ public interface ConfigurableEnvironment extends Environment, ConfigurableProper
 	 * be searched when resolving properties against this {@code Environment} object.
 	 * The various {@link MutablePropertySources} methods such as
 	 * {@link MutablePropertySources#addFirst addFirst},
-	 * {@link MutablePropertySources#addFirst addLast},
-	 * {@link MutablePropertySources#addFirst addBefore} and
-	 * {@link MutablePropertySources#addFirst addAfter} allow for fine-grained control
+	 * {@link MutablePropertySources#addLast addLast},
+	 * {@link MutablePropertySources#addBefore addBefore} and
+	 * {@link MutablePropertySources#addAfter addAfter} allow for fine-grained control
 	 * over property source ordering. This is useful, for example, in ensuring that
 	 * certain user-defined property sources have search precedence over default property
 	 * sources such as the set of system properties or the set of system environment


### PR DESCRIPTION
I think this is a little mistake in javadoc, or not.