### PR TITLE
SPR-16166: Handle top level json value in Jackson2JsonTokenizer

### DIFF
--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2TokenizerTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2TokenizerTests.java
@@ -18,13 +18,16 @@ package org.springframework.http.codec.json;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
 import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +36,6 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import org.springframework.core.io.buffer.AbstractDataBufferAllocatingTestCase;
-import org.springframework.core.io.buffer.DataBuffer;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -43,22 +45,37 @@ import static java.util.Collections.singletonList;
  */
 public class Jackson2TokenizerTests extends AbstractDataBufferAllocatingTestCase {
 
-	private JsonParser jsonParser;
-
-	private Jackson2Tokenizer tokenizer;
-
 	private ObjectMapper objectMapper;
+
+	private JsonFactory factory;
 
 	@Before
 	public void createParser() throws IOException {
-		JsonFactory factory = new JsonFactory();
-		this.jsonParser = factory.createNonBlockingByteArrayParser();
+		factory = new JsonFactory();
 		this.objectMapper = new ObjectMapper(factory);
 	}
 
 	@Test
-	public void doNotTokenizeArrayElements() {
-		this.tokenizer = new Jackson2Tokenizer(this.jsonParser, false);
+	public void doNotTokenizeArrayElements() throws IOException {
+		testTokenizeAsJsonToken(
+				singletonList("true"),
+				singletonList(JsonToken.VALUE_TRUE));
+
+		testTokenizeAsJsonToken(
+				asList("nu", "ll"),
+				singletonList(JsonToken.VALUE_NULL));
+
+		testTokenizeAsJsonToken(
+				asList("3" ,".14"),
+				singletonList(JsonToken.VALUE_NUMBER_FLOAT));
+
+		testTokenizeAsJsonToken(
+				asList("12", "3"),
+				singletonList(JsonToken.VALUE_NUMBER_INT));
+
+		testTokenize(
+				asList("\"hello ", "world\""),
+				singletonList("\"hello world\""));
 
 		testTokenize(
 				singletonList("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}"),
@@ -94,27 +111,39 @@ public class Jackson2TokenizerTests extends AbstractDataBufferAllocatingTestCase
 	}
 
 	@Test
-	public void tokenizeArrayElements() {
-		this.tokenizer = new Jackson2Tokenizer(this.jsonParser, true);
+	public void tokenizeArrayElements() throws IOException {
+		testTokenizeAsJsonToken(
+				singletonList("[true, false, null, 3.14]"),
+				asList(JsonToken.VALUE_TRUE, JsonToken.VALUE_FALSE, JsonToken.VALUE_NULL, JsonToken.VALUE_NUMBER_FLOAT),
+				true);
+
+		testTokenize(
+				singletonList("[\"hello\", \"world\"]"),
+				asList("\"hello\"", "\"world\""),
+				true);
 
 		testTokenize(
 				singletonList("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}"),
-				singletonList("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}"));
+				singletonList("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}"),
+				true);
 
 		testTokenize(
 				asList("{\"foo\": \"foofoo\"",
 						", \"bar\": \"barbar\"}"),
-				singletonList("{\"foo\":\"foofoo\",\"bar\":\"barbar\"}"));
+				singletonList("{\"foo\":\"foofoo\",\"bar\":\"barbar\"}"),
+				true);
 
 		testTokenize(
 				singletonList("[{\"foo\": \"foofoo\", \"bar\": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]"),
 				asList("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}",
-						"{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}"));
+						"{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}"),
+				true);
 
 		testTokenize(
 				singletonList("[{\"foo\": \"bar\"},{\"foo\": \"baz\"}]"),
 				asList("{\"foo\": \"bar\"}",
-						"{\"foo\": \"baz\"}"));
+						"{\"foo\": \"baz\"}"),
+				true);
 
 		// SPR-15803: nested array
 		testTokenize(
@@ -126,19 +155,22 @@ public class Jackson2TokenizerTests extends AbstractDataBufferAllocatingTestCase
 				asList(
 						"{\"id\":\"0\",\"start\":[-999999999,1,1],\"end\":[999999999,12,31]}",
 						"{\"id\":\"1\",\"start\":[-999999999,1,1],\"end\":[999999999,12,31]}",
-						"{\"id\":\"2\",\"start\":[-999999999,1,1],\"end\":[999999999,12,31]}")
+						"{\"id\":\"2\",\"start\":[-999999999,1,1],\"end\":[999999999,12,31]}"),
+				true
 		);
 
 		// SPR-15803: nested array, no top-level array
 		testTokenize(
 				singletonList("{\"speakerIds\":[\"tastapod\"],\"language\":\"ENGLISH\"}"),
-				singletonList("{\"speakerIds\":[\"tastapod\"],\"language\":\"ENGLISH\"}"));
+				singletonList("{\"speakerIds\":[\"tastapod\"],\"language\":\"ENGLISH\"}"),
+				true);
 
 		testTokenize(
 				asList("[{\"foo\": \"foofoo\", \"bar\"",
 						": \"barbar\"},{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}]"),
 				asList("{\"foo\": \"foofoo\", \"bar\": \"barbar\"}",
-						"{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}"));
+						"{\"foo\": \"foofoofoo\", \"bar\": \"barbarbar\"}"),
+				true);
 
 		testTokenize(
 				asList("[",
@@ -150,15 +182,16 @@ public class Jackson2TokenizerTests extends AbstractDataBufferAllocatingTestCase
 						"]"),
 				asList("{\"id\":1,\"name\":\"Robert\"}",
 						"{\"id\":2,\"name\":\"Raide\"}",
-						"{\"id\":3,\"name\":\"Ford\"}"));
+						"{\"id\":3,\"name\":\"Ford\"}"),
+				true);
 	}
 
-	private void testTokenize(List<String> source, List<String> expected) {
-		Flux<DataBuffer> sourceFlux = Flux.fromIterable(source)
-				.map(this::stringBuffer);
+	private void testTokenize(List<String> source, List<String> expected) throws IOException {
+		testTokenize(source, expected, false);
+	}
 
-		Flux<String> result = sourceFlux
-				.flatMap(this.tokenizer)
+	private void testTokenize(List<String> source, List<String> expected, boolean tokenizeArrayElement) throws IOException {
+		Flux<String> result = tokenize(source, tokenizeArrayElement)
 				.map(tokenBuffer -> {
 					try {
 						TreeNode root = this.objectMapper.readTree(tokenBuffer.asParser());
@@ -174,6 +207,44 @@ public class Jackson2TokenizerTests extends AbstractDataBufferAllocatingTestCase
 			builder.assertNext(new JSONAssertConsumer(s));
 		}
 		builder.verifyComplete();
+	}
+
+	private void testTokenizeAsJsonToken(List<String> source, List<JsonToken> expected) throws IOException {
+		testTokenizeAsJsonToken(source, expected, false);
+	}
+
+	private void testTokenizeAsJsonToken(List<String> source, List<JsonToken> expected, boolean tokenizeArrayElement) throws IOException {
+		Flux<JsonToken> result = tokenize(source, tokenizeArrayElement)
+				.map(tokenBuffer -> {
+					List<JsonToken> tokens = new ArrayList<>();
+					final JsonParser parser = tokenBuffer.asParser();
+					JsonToken currentToken;
+					try {
+						while ((currentToken = parser.nextToken()) != null) {
+							tokens.add(currentToken);
+						}
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+					return tokens;
+				})
+				.flatMapIterable(jsonTokens -> jsonTokens);
+
+		StepVerifier.FirstStep<JsonToken> builder = StepVerifier.create(result);
+		for (JsonToken token : expected) {
+			builder.expectNext(token);
+		}
+		builder.verifyComplete();
+	}
+
+	private Flux<TokenBuffer> tokenize(List<String> source, boolean tokenizeArrayElement) throws IOException {
+		JsonParser jsonParser = factory.createNonBlockingByteArrayParser();
+		Jackson2Tokenizer tokenizer = new Jackson2Tokenizer(jsonParser, tokenizeArrayElement);
+
+		return Flux.zip(
+				Flux.fromIterable(source).map(this::stringBuffer),
+				Flux.range(0, source.size()).map(index -> index == (source.size() - 1))
+			).flatMap(tokenizer);
 	}
 
 	private static class JSONAssertConsumer implements Consumer<String> {

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
@@ -236,6 +236,52 @@ public class WebClientIntegrationTests {
 	}
 
 	@Test
+	public void shouldReceiveBooleanValueJsonAsMonoBoolean() throws Exception {
+		String content = "true";
+		prepareResponse(response -> response
+				.setHeader("Content-Type", "application/json").setBody(content));
+
+		Mono<Boolean> result = this.webClient.get()
+				.uri("/json").accept(MediaType.APPLICATION_JSON)
+				.retrieve()
+				.bodyToMono(Boolean.class);
+
+		StepVerifier.create(result)
+				.expectNext(true)
+				.expectComplete().verify(Duration.ofSeconds(3));
+
+		expectRequestCount(1);
+		expectRequest(request -> {
+			assertEquals("/json", request.getPath());
+			assertEquals("application/json", request.getHeader(HttpHeaders.ACCEPT));
+		});
+	}
+
+	@Test
+	public void shouldReceiveBooleanJsonArrayAsFluxBoolean() throws Exception {
+		String content = "[true, false, true]";
+		prepareResponse(response -> response
+				.setHeader("Content-Type", "application/json").setBody(content));
+
+		Flux<Boolean> result = this.webClient.get()
+				.uri("/json").accept(MediaType.APPLICATION_JSON)
+				.retrieve()
+				.bodyToFlux(Boolean.class);
+
+		StepVerifier.create(result)
+				.expectNext(true)
+				.expectNext(false)
+				.expectNext(true)
+				.expectComplete().verify(Duration.ofSeconds(3));
+
+		expectRequestCount(1);
+		expectRequest(request -> {
+			assertEquals("/json", request.getPath());
+			assertEquals("application/json", request.getHeader(HttpHeaders.ACCEPT));
+		});
+	}
+
+	@Test
 	public void shouldReceiveJsonAsPojo() throws Exception {
 		prepareResponse(response -> response
 				.setHeader("Content-Type", "application/json")


### PR DESCRIPTION
This commit introduces support for top level Json value
`String`, `true`, `false`, `null`, `number`) to `Jackson2JsonTokenizer`.

Before this change `Jackson2JsonTokenizer` would only consider token in an object or array and this scenario will fail:

```
@RestController
public class JsonValueResource {
    @GetMapping("/fail")
    public Mono<Boolean> fail() {
        return WebClient.builder().baseUrl("http://localhost:8000")
                .build().get().uri("/")
                .accept(MediaType.APPLICATION_JSON)
                .retrieve()
                .bodyToMono(Boolean.class)
                .switchIfEmpty(Mono.error(new RuntimeException("No response")));
    }

    @GetMapping
    Mono<Boolean> jsonValueBoolean() {
        return Mono.just(true);
    }

}
```

Issue: SPR-16166