### PR TITLE
Directory Traversal Attack

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
@@ -257,9 +257,10 @@ public class PathResourceResolver extends AbstractResourceResolver {
 
 		if (resourcePath.contains("%")) {
 			// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars...
-			if (URLDecoder.decode(resourcePath, "UTF-8").contains("../")) {
+			String decodedResourcePath = URLDecoder.decode(resourcePath, "UTF-8");
+			if (decodedResourcePath.contains("../") || decodedResourcePath.contains("..\")) {
 				if (logger.isTraceEnabled()) {
-					logger.trace("Resolved resource path contains \"../\" after decoding: " + resourcePath);
+					logger.trace("Resolved resource path contains \"../\" or \"..\\\" after decoding: " + resourcePath);
 				}
 				return false;
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/PathResourceResolver.java
@@ -258,7 +258,7 @@ public class PathResourceResolver extends AbstractResourceResolver {
 		if (resourcePath.contains("%")) {
 			// Use URLDecoder (vs UriUtils) to preserve potentially decoded UTF-8 chars...
 			String decodedResourcePath = URLDecoder.decode(resourcePath, "UTF-8");
-			if (decodedResourcePath.contains("../") || decodedResourcePath.contains("..\")) {
+			if (decodedResourcePath.contains("../") || decodedResourcePath.contains("..\\")) {
 				if (logger.isTraceEnabled()) {
 					logger.trace("Resolved resource path contains \"../\" or \"..\\\" after decoding: " + resourcePath);
 				}


### PR DESCRIPTION
[Obvious Fix] Extend the existing directory traversal attack to protect against URL encoded `..\`  attack example: http://<myhost>/my-servlet/%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5cwindows%5cSystem32%5cdrivers%5cetc%5chosts