### PR TITLE
Enhanced MockRestResponseCreators by a withStatus with body and media type

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
@@ -116,4 +116,15 @@ public abstract class MockRestResponseCreators {
 		return new DefaultResponseCreator(status);
 	}
 
+	/**
+	 * {@code ResponseCreator} with a specific HTTP status with String body.
+	 * @param status the response status
+	 * @param body the response body, a "UTF-8" string
+	 * @param contentType the type of the content (may be {@code null})
+	 */
+	public static DefaultResponseCreator withStatus(HttpStatus status, String body, @Nullable MediaType contentType) {
+		DefaultResponseCreator creator = new DefaultResponseCreator(status).body(body);
+		return (contentType != null ? creator.contentType(contentType) : creator);
+	}
+
 }

--- a/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
@@ -124,4 +124,16 @@ public class ResponseCreatorsTests {
 		assertEquals(0, StreamUtils.copyToByteArray(response.getBody()).length);
 	}
 
+	@Test
+	public void withStatusAndContent() throws Exception {
+		DefaultResponseCreator responseCreator =
+				MockRestResponseCreators.withStatus(HttpStatus.FORBIDDEN, "foo", MediaType.TEXT_PLAIN);
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+		assertEquals(response.getHeaders().size(), 1);
+		assertEquals(MediaType.TEXT_PLAIN, response.getHeaders().getContentType());
+		assertArrayEquals("foo".getBytes(), StreamUtils.copyToByteArray(response.getBody()));
+	}
+
 }


### PR DESCRIPTION
Otherwise one have to do something like this:
```
    private static class SomeResponseCreator extends DefaultResponseCreator {

        SomeResponseCreator(HttpStatus statusCode) {
            super(statusCode);
        }
    }
```