### PR TITLE
Support identical minPort and maxPort in SocketUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/SocketUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/SocketUtils.java
@@ -258,7 +258,7 @@ public class SocketUtils {
 			int candidatePort;
 			int searchCounter = 0;
 			do {
-				if (++searchCounter > portRange) {
+				if (searchCounter++ > portRange) {
 					throw new IllegalStateException(String.format(
 							"Could not find an available %s port in the range [%d, %d] after %d attempts",
 							name(), minPort, maxPort, searchCounter));

--- a/spring-core/src/test/java/org/springframework/util/SocketUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/SocketUtilsTests.java
@@ -53,6 +53,13 @@ public class SocketUtilsTests {
 		assertPortInRange(port, PORT_RANGE_MIN, PORT_RANGE_MAX);
 	}
 
+	@Test
+	public void findAvailableTcpPortWithMinPortEqualsMaxPort() {
+		int minMaxPort = 20000;
+		int port = SocketUtils.findAvailableTcpPort(minMaxPort, minMaxPort);
+		assertEquals(minMaxPort, port);
+	}
+
 	@Test(expected = IllegalStateException.class)
 	public void findAvailableTcpPortWhenPortOnLoopbackInterfaceIsNotAvailable() throws Exception {
 		int port = SocketUtils.findAvailableTcpPort();

--- a/spring-core/src/test/java/org/springframework/util/SocketUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/SocketUtilsTests.java
@@ -54,8 +54,8 @@ public class SocketUtilsTests {
 	}
 
 	@Test
-	public void findAvailableTcpPortWithMinPortEqualsMaxPort() {
-		int minMaxPort = 20000;
+	public void findAvailableTcpPortWithMinPortEqualToMaxPort() {
+		int minMaxPort = SocketUtils.findAvailableTcpPort();
 		int port = SocketUtils.findAvailableTcpPort(minMaxPort, minMaxPort);
 		assertEquals(minMaxPort, port);
 	}


### PR DESCRIPTION
Found and fixed a defect with SocketUtils.findAvailableTcpPort when minPort == maxPort