### PR TITLE
SPR-16282 Deprecate classes removed in 5

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/access/BeanFactoryLocator.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/access/BeanFactoryLocator.java
@@ -49,6 +49,7 @@ import org.springframework.beans.BeansException;
  * @see org.springframework.beans.factory.BeanFactory
  * @see org.springframework.context.access.DefaultLocatorFactory
  * @see org.springframework.context.ApplicationContext
+ * @deprecated removed in 5
  */
 public interface BeanFactoryLocator {
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/access/BeanFactoryReference.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/access/BeanFactoryReference.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.BeanFactory;
  * @author Colin Sampaleanu
  * @see BeanFactoryLocator
  * @see org.springframework.context.access.ContextBeanFactoryReference
+ * @deprecated removed in 5
  */
 public interface BeanFactoryReference {
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/access/BootstrapException.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/access/BootstrapException.java
@@ -23,6 +23,7 @@ import org.springframework.beans.FatalBeanException;
  *
  * @author Rod Johnson
  * @since 02.12.2002
+ * @deprecated removed in 5
  */
 @SuppressWarnings("serial")
 public class BootstrapException extends FatalBeanException {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/access/SingletonBeanFactoryLocator.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/access/SingletonBeanFactoryLocator.java
@@ -268,6 +268,7 @@ import org.springframework.core.io.support.ResourcePatternUtils;
  * @see org.springframework.context.access.ContextSingletonBeanFactoryLocator
  * @see org.springframework.context.access.DefaultLocatorFactory
  */
+@Deprecated
 public class SingletonBeanFactoryLocator implements BeanFactoryLocator {
 
 	private static final String DEFAULT_RESOURCE_LOCATION = "classpath*:beanRefFactory.xml";

--- a/spring-beans/src/main/java/org/springframework/beans/factory/access/el/SimpleSpringBeanELResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/access/el/SimpleSpringBeanELResolver.java
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
  * @author Juergen Hoeller
  * @since 2.5.2
  */
+@Deprecated
 public class SimpleSpringBeanELResolver extends SpringBeanELResolver {
 
 	private final BeanFactory beanFactory;

--- a/spring-beans/src/main/java/org/springframework/beans/factory/access/el/SpringBeanELResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/access/el/SpringBeanELResolver.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.BeanFactory;
  * @author Juergen Hoeller
  * @since 2.5.2
  * @see org.springframework.web.jsf.el.SpringBeanFacesELResolver
+ * @deprecated removed in 5
  */
 public abstract class SpringBeanELResolver extends ELResolver {
 

--- a/spring-context/src/main/java/org/springframework/context/access/ContextBeanFactoryReference.java
+++ b/spring-context/src/main/java/org/springframework/context/access/ContextBeanFactoryReference.java
@@ -34,6 +34,7 @@ import org.springframework.context.ConfigurableApplicationContext;
  * @since 13.02.2004
  * @see org.springframework.context.ConfigurableApplicationContext#close
  */
+@Deprecated
 public class ContextBeanFactoryReference implements BeanFactoryReference {
 
 	private ApplicationContext applicationContext;

--- a/spring-context/src/main/java/org/springframework/context/access/ContextJndiBeanFactoryLocator.java
+++ b/spring-context/src/main/java/org/springframework/context/access/ContextJndiBeanFactoryLocator.java
@@ -39,6 +39,7 @@ import org.springframework.util.StringUtils;
  * @author Juergen Hoeller
  * @see #createBeanFactory
  */
+@Deprecated
 public class ContextJndiBeanFactoryLocator extends JndiLocatorSupport implements BeanFactoryLocator {
 
 	/**

--- a/spring-context/src/main/java/org/springframework/context/access/ContextSingletonBeanFactoryLocator.java
+++ b/spring-context/src/main/java/org/springframework/context/access/ContextSingletonBeanFactoryLocator.java
@@ -49,6 +49,7 @@ import org.springframework.core.io.support.ResourcePatternUtils;
  * @see org.springframework.beans.factory.access.SingletonBeanFactoryLocator
  * @see org.springframework.context.access.DefaultLocatorFactory
  */
+@Deprecated
 public class ContextSingletonBeanFactoryLocator extends SingletonBeanFactoryLocator {
 
 	private static final String DEFAULT_RESOURCE_LOCATION = "classpath*:beanRefContext.xml";

--- a/spring-context/src/main/java/org/springframework/context/access/DefaultLocatorFactory.java
+++ b/spring-context/src/main/java/org/springframework/context/access/DefaultLocatorFactory.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.access.BeanFactoryLocator;
  * @author Colin Sampaleanu
  * @see org.springframework.context.access.ContextSingletonBeanFactoryLocator
  */
+@Deprecated
 public class DefaultLocatorFactory {
 
 	/**

--- a/spring-context/src/main/java/org/springframework/ejb/interceptor/SpringBeanAutowiringInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/ejb/interceptor/SpringBeanAutowiringInterceptor.java
@@ -71,6 +71,7 @@ import org.springframework.context.access.ContextSingletonBeanFactoryLocator;
  * @see org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor
  * @see org.springframework.context.access.ContextSingletonBeanFactoryLocator
  * @see #getBeanFactoryLocatorKey
+ * @deprecated removed in 5
  */
 public class SpringBeanAutowiringInterceptor {
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -187,6 +187,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 	 * Useful if native Statement and/or ResultSet handles are expected for casting
 	 * to database-specific implementation classes, but a connection pool that wraps
 	 * JDBC objects is used (note: <i>any</i> pool will return wrapped Connections).
+	 * @deprecated use {@link Wrapper#unwrap(Class)}
 	 */
 	public void setNativeJdbcExtractor(NativeJdbcExtractor extractor) {
 		this.nativeJdbcExtractor = extractor;
@@ -194,6 +195,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 
 	/**
 	 * Return the current NativeJdbcExtractor implementation.
+	 * @deprecated use {@link Wrapper#unwrap(Class)}
 	 */
 	public NativeJdbcExtractor getNativeJdbcExtractor() {
 		return this.nativeJdbcExtractor;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/C3P0NativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/C3P0NativeJdbcExtractor.java
@@ -45,6 +45,7 @@ import org.springframework.util.ReflectionUtils;
  * @see com.mchange.v2.c3p0.C3P0ProxyConnection#rawConnectionOperation
  * @see SimpleNativeJdbcExtractor
  */
+@Deprecated
 public class C3P0NativeJdbcExtractor extends NativeJdbcExtractorAdapter {
 
 	private final Method getRawConnectionMethod;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/JBossNativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/JBossNativeJdbcExtractor.java
@@ -46,6 +46,7 @@ import org.springframework.util.ReflectionUtils;
  * @see org.jboss.resource.adapter.jdbc.WrappedStatement#getUnderlyingStatement
  * @see org.jboss.resource.adapter.jdbc.WrappedResultSet#getUnderlyingResultSet
  */
+@Deprecated
 public class JBossNativeJdbcExtractor extends NativeJdbcExtractorAdapter {
 
 	// JBoss 7

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/Jdbc4NativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/Jdbc4NativeJdbcExtractor.java
@@ -44,6 +44,7 @@ import java.sql.Statement;
  * @see org.springframework.jdbc.core.JdbcTemplate#setNativeJdbcExtractor
  * @see org.springframework.jdbc.support.lob.OracleLobHandler#setNativeJdbcExtractor
  */
+@Deprecated
 public class Jdbc4NativeJdbcExtractor extends NativeJdbcExtractorAdapter {
 
 	private Class<? extends Connection> connectionType = Connection.class;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/NativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/NativeJdbcExtractor.java
@@ -64,6 +64,7 @@ import java.sql.Statement;
  * @see CommonsDbcpNativeJdbcExtractor
  * @see org.springframework.jdbc.core.JdbcTemplate#setNativeJdbcExtractor
  * @see org.springframework.jdbc.support.lob.OracleLobHandler#setNativeJdbcExtractor
+ * @deprecated use {@link Wrapper#unwrap(Class)}
  */
 public interface NativeJdbcExtractor {
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/NativeJdbcExtractorAdapter.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/NativeJdbcExtractorAdapter.java
@@ -56,6 +56,7 @@ import org.springframework.jdbc.datasource.DataSourceUtils;
  * @see #getNativeConnectionFromStatement
  * @see org.springframework.jdbc.datasource.ConnectionProxy
  */
+@Deprecated
 public abstract class NativeJdbcExtractorAdapter implements NativeJdbcExtractor {
 
 	/**

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/OracleJdbc4NativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/OracleJdbc4NativeJdbcExtractor.java
@@ -40,6 +40,7 @@ import java.sql.Statement;
  * @author Juergen Hoeller
  * @since 3.0.5
  */
+@Deprecated
 public class OracleJdbc4NativeJdbcExtractor extends Jdbc4NativeJdbcExtractor {
 
 	@SuppressWarnings("unchecked")

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/SimpleNativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/SimpleNativeJdbcExtractor.java
@@ -60,6 +60,7 @@ package org.springframework.jdbc.support.nativejdbc;
  * @see org.springframework.jdbc.core.JdbcTemplate#setNativeJdbcExtractor
  * @see org.springframework.jdbc.support.lob.OracleLobHandler#setNativeJdbcExtractor
  */
+@Deprecated
 public class SimpleNativeJdbcExtractor extends NativeJdbcExtractorAdapter {
 
 	private boolean nativeConnectionNecessaryForNativeStatements = false;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/WebLogicNativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/WebLogicNativeJdbcExtractor.java
@@ -41,6 +41,7 @@ import org.springframework.util.ReflectionUtils;
  * @see #getNativeConnection
  * @see weblogic.jdbc.extensions.WLConnection#getVendorConnection
  */
+@Deprecated
 public class WebLogicNativeJdbcExtractor extends NativeJdbcExtractorAdapter {
 
 	private static final String JDBC_EXTENSION_NAME = "weblogic.jdbc.extensions.WLConnection";

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/WebSphereNativeJdbcExtractor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/nativejdbc/WebSphereNativeJdbcExtractor.java
@@ -38,6 +38,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Juergen Hoeller
  * @since 1.1
  */
+@Deprecated
 public class WebSphereNativeJdbcExtractor extends NativeJdbcExtractorAdapter {
 
 	private static final String JDBC_ADAPTER_CONNECTION_NAME = "com.ibm.ws.rsadapter.jdbc.WSJdbcConnection";


### PR DESCRIPTION
This commit deprecates the following things

 * the entire NativeJdbcExtractor hierarchy
 * all types in the org.springframework.beans.factory.access package
 * all types in the org.springframework.context.access package
 * all types in the org.springframework.ejb.interceptor package

Issue: SPR-16282