### PR TITLE
SPR-16291 - Declarative null checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
 	id "org.jetbrains.kotlin.jvm" version "1.2.0" apply false
 	id "org.jetbrains.dokka" version "0.9.15"
 	id "org.asciidoctor.convert" version "1.5.6"
+	id "tech.harmonysoft.oss.traute" version "1.0.5"
 }
 
 buildScan {
@@ -68,6 +69,7 @@ configure(allprojects) { project ->
 	apply plugin: "java"
 	apply plugin: "test-source-set-dependencies"
 	apply from: "${gradleScriptDir}/ide.gradle"
+	apply plugin: "tech.harmonysoft.oss.traute"
 
 	apply plugin: "kotlin"
 	compileKotlin {
@@ -108,6 +110,12 @@ configure(allprojects) { project ->
 		sourceCompatibility = 1.8
 		targetCompatibility = 1.8
 		options.encoding = 'UTF-8'
+	}
+
+	traute {
+		javacPluginVersion = "1.0.10"
+		notNullAnnotations = ["org.springframework.lang.NonNull"]
+		exceptionTexts = [ 'parameter' : '${PARAMETER_NAME} must not be null' ]
 	}
 
 	compileTestJava {

--- a/spring-core/src/main/java/org/springframework/core/annotation/AbstractAliasAwareAnnotationAttributeExtractor.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AbstractAliasAwareAnnotationAttributeExtractor.java
@@ -21,8 +21,8 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -57,10 +57,8 @@ abstract class AbstractAliasAwareAnnotationAttributeExtractor<S> implements Anno
 	 * @param source the underlying source of annotation attributes; never {@code null}
 	 */
 	AbstractAliasAwareAnnotationAttributeExtractor(
-			Class<? extends Annotation> annotationType, @Nullable Object annotatedElement, S source) {
+			@NonNull Class<? extends Annotation> annotationType, @Nullable Object annotatedElement, @NonNull S source) {
 
-		Assert.notNull(annotationType, "annotationType must not be null");
-		Assert.notNull(source, "source must not be null");
 		this.annotationType = annotationType;
 		this.annotatedElement = annotatedElement;
 		this.source = source;


### PR DESCRIPTION
This *PR* illustrates an approach when explicit *null*-checks are replaced
by a *NonNull* annotations on method parameters. Actual checks are
generated during compilation and inserted into resulting byte code
by the [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin.  

Example: [here](https://github.com/denis-zhdanov/spring-framework/commit/5a126cf58a9c30cfbf55ebc5a88eafbc188efc34#diff-bf9a31b564bfe45387eb54a9f23560a0) we mark the parameters by Spring's *NonNull* annotation. Result:  

```
javap -c ./spring-core/build/classes/java/main/org/springframework/core/annotation/AbstractAliasAwareAnnotationAttributeExtractor.class
...
  org.springframework.core.annotation.AbstractAliasAwareAnnotationAttributeExtractor(java.lang.Class<? extends java.lang.annotation.Annotation>, java.lang.Object, S);
    Code:
       0: aload_0
       1: invokespecial #1                  // Method java/lang/Object."<init>":()V
       4: aload_1
       5: ifnonnull     18
       8: new           #2                  // class java/lang/NullPointerException
      11: dup
      12: ldc           #3                  // String annotationType must not be null
      14: invokespecial #4                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      17: athrow
      18: aload_3
      19: ifnonnull     32
      22: new           #2                  // class java/lang/NullPointerException
      25: dup
      26: ldc           #5                  // String source must not be null
      28: invokespecial #4                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      31: athrow
...
```

I'm fine with creating new *PR* where the change is applied to all use-cases within the project if the team likes the idea.