### PR TITLE
SPR-16295 - Programmatic creation of caching proxies using CacheProxy…

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheProxyFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheProxyFactoryBean.java
@@ -16,9 +16,18 @@
 
 package org.springframework.cache.interceptor;
 
+import java.util.Optional;
+
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.framework.AbstractSingletonProxyFactoryBean;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.lang.Nullable;
 
 /**
  * Proxy factory bean for simplified declarative caching handling.
@@ -36,23 +45,74 @@ import org.springframework.aop.support.DefaultPointcutAdvisor;
  *
  * @author Costin Leau
  * @author Juergen Hoeller
+ * @author John Blum
  * @since 3.1
+ * @see org.springframework.aop.framework.AbstractSingletonProxyFactoryBean
  * @see org.springframework.aop.framework.ProxyFactoryBean
- * @see CacheInterceptor
+ * @see org.springframework.beans.factory.BeanFactoryAware
+ * @see org.springframework.beans.factory.SmartInitializingSingleton
+ * @see org.springframework.cache.interceptor.CacheInterceptor
  */
 @SuppressWarnings("serial")
-public class CacheProxyFactoryBean extends AbstractSingletonProxyFactoryBean {
+public class CacheProxyFactoryBean extends AbstractSingletonProxyFactoryBean
+		implements BeanFactoryAware, SmartInitializingSingleton {
+
+	// SimpleKeyGenerator is stateless and therefore Thread-safe; sharing instance using a static constant
+	protected static final KeyGenerator DEFAULT_KEY_GENERATOR = new SimpleKeyGenerator();
 
 	private final CacheInterceptor cachingInterceptor = new CacheInterceptor();
 
 	private Pointcut pointcut = Pointcut.TRUE;
 
+	/**
+	 * Returns a reference to the {@link CacheInterceptor} configured by
+	 * this {@link CacheProxyFactoryBean FactoryBean}.
+	 *
+	 * @return a reference to the {@link CacheInterceptor}.
+	 * @see org.springframework.cache.interceptor.CacheInterceptor
+	 */
+	protected CacheInterceptor getCachingInterceptor() {
+		return this.cachingInterceptor;
+	}
+
+	/**
+	 * Sets a reference to the owning {@link BeanFactory}.
+	 *
+	 * @param beanFactory owning BeanFactory (never {@code null}).
+	 * The bean can immediately call methods on the factory.
+	 * @throws BeansException in case of initialization errors.
+	 */
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+
+		CacheInterceptor cacheInterceptor = getCachingInterceptor();
+
+		cacheInterceptor.setBeanFactory(beanFactory);
+		cacheInterceptor.setCacheManager(beanFactory.getBean("cacheManager", CacheManager.class));
+	}
 
 	/**
 	 * Set the sources used to find cache operations.
 	 */
 	public void setCacheOperationSources(CacheOperationSource... cacheOperationSources) {
-		this.cachingInterceptor.setCacheOperationSources(cacheOperationSources);
+		getCachingInterceptor().setCacheOperationSources(cacheOperationSources);
+	}
+
+	/**
+	 * Sets a reference to the {@link CacheResolver} used to resolve {@link Cache Caches} identified
+	 * in the application's intercepted method invocations involving caching.
+	 *
+	 * @param cacheResolver {@link CacheResolver} used to determine the {@link Cache Cache or Caches}
+	 * used during the intercepted method invocation.
+	 * @see org.springframework.cache.interceptor.CacheResolver
+	 */
+	public void setCacheResolver(@Nullable CacheResolver cacheResolver) {
+		getCachingInterceptor().setCacheResolver(cacheResolver);
+	}
+
+	public void setKeyGenerator(@Nullable KeyGenerator keyGenerator) {
+		getCachingInterceptor().setKeyGenerator(Optional.ofNullable(keyGenerator)
+			.orElse(DEFAULT_KEY_GENERATOR));
 	}
 
 	/**
@@ -66,11 +126,19 @@ public class CacheProxyFactoryBean extends AbstractSingletonProxyFactoryBean {
 		this.pointcut = pointcut;
 	}
 
+	@Override
+	public void afterSingletonsInstantiated() {
+		getCachingInterceptor().afterSingletonsInstantiated();
+	}
 
 	@Override
 	protected Object createMainInterceptor() {
-		this.cachingInterceptor.afterPropertiesSet();
-		return new DefaultPointcutAdvisor(this.pointcut, this.cachingInterceptor);
+
+		CacheInterceptor cacheInterceptor = getCachingInterceptor();
+
+		cacheInterceptor.afterPropertiesSet();
+
+		return new DefaultPointcutAdvisor(this.pointcut, cacheInterceptor);
 	}
 
 }

--- a/spring-context/src/test/java/org/springframework/cache/interceptor/CacheProxyFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/interceptor/CacheProxyFactoryBeanTests.java
@@ -1,0 +1,227 @@
+package org.springframework.cache.interceptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Integration tests for {@link CacheProxyFactoryBean}.
+ *
+ * @author John Blum
+ * @see org.junit.Test
+ * @see org.springframework.cache.interceptor.CacheProxyFactoryBean
+ * @since 5.0.3
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CacheProxyFactoryBeanTests {
+
+	private ConfigurableApplicationContext applicationContext;
+
+	@Mock
+	private CacheInterceptor mockCacheInterceptor;
+
+	@Spy
+	private CacheProxyFactoryBean cacheProxyFactoryBean;
+
+	@Before
+	@SuppressWarnings("all")
+	public void setup() {
+		doReturn(this.mockCacheInterceptor).when(this.cacheProxyFactoryBean).getCachingInterceptor();
+	}
+
+	@After
+	@SuppressWarnings("all")
+	public void tearDown() {
+		Optional.ofNullable(this.applicationContext).ifPresent(ConfigurableApplicationContext::close);
+	}
+
+	private ConfigurableApplicationContext newApplicationContext(Class<?>... annotatedClasses) {
+		return new AnnotationConfigApplicationContext(annotatedClasses);
+	}
+
+	@Test
+	public void cachingConfiguredWithCacheProxyFactoryBeanIsSuccessful() {
+
+		this.applicationContext = newApplicationContext(CacheProxyFactoryBeanConfiguration.class);
+
+		Greeter greeter = this.applicationContext.getBean("greeter", Greeter.class);
+
+		assertNotNull(greeter);
+		assertFalse(greeter.isCacheMiss());
+		assertEquals("Hello John!", greeter.greet("John"));
+		assertTrue(greeter.isCacheMiss());
+		assertEquals("Hello Jon!", greeter.greet("Jon"));
+		assertTrue(greeter.isCacheMiss());
+		assertEquals("Hello John!", greeter.greet("John"));
+		assertFalse(greeter.isCacheMiss());
+		assertEquals("Hello World!", greeter.greet());
+		assertTrue(greeter.isCacheMiss());
+		assertEquals("Hello World!", greeter.greet());
+		assertFalse(greeter.isCacheMiss());
+	}
+
+	@Test
+	@SuppressWarnings("all")
+	public void setBeanFactoryConfiguresCacheInterceptorAppropriately() {
+
+		BeanFactory mockBeanFactory = mock(BeanFactory.class);
+
+		CacheManager mockCacheManager = mock(CacheManager.class);
+
+		when(mockBeanFactory.getBean(eq("cacheManager"), eq(CacheManager.class))).thenReturn(mockCacheManager);
+
+		this.cacheProxyFactoryBean.setBeanFactory(mockBeanFactory);
+
+		verify(this.mockCacheInterceptor, times(1)).setBeanFactory(eq(mockBeanFactory));
+		verify(this.mockCacheInterceptor, times(1)).setCacheManager(eq(mockCacheManager));
+	}
+
+	@Test
+	public void setCacheOperationSourcesConfiguresCacheInterceptorAppropriately() {
+
+		CacheOperationSource mockCacheOperationSourceOne =
+			mock(CacheOperationSource.class, "MockCacheOperationSourceOne");
+
+		CacheOperationSource mockCacheOperationSourceTwo =
+			mock(CacheOperationSource.class, "MockCacheOperationSourceTwo");
+
+		this.cacheProxyFactoryBean.setCacheOperationSources(mockCacheOperationSourceOne, mockCacheOperationSourceTwo);
+
+		verify(this.mockCacheInterceptor, times(1))
+			.setCacheOperationSources(eq(mockCacheOperationSourceOne), eq(mockCacheOperationSourceTwo));
+	}
+
+	@Test
+	public void setCacheResolverConfiguresCacheInterceptorCacheResolver() {
+
+		CacheResolver mockCacheResolver = mock(CacheResolver.class);
+
+		this.cacheProxyFactoryBean.setCacheResolver(mockCacheResolver);
+
+		verify(this.mockCacheInterceptor, times(1)).setCacheResolver(eq(mockCacheResolver));
+	}
+
+	@Test
+	public void setCustomKeyGeneratorConfiguresCacheInterceptorKeyGenerator() {
+
+		KeyGenerator mockKeyGenerator = mock(KeyGenerator.class);
+
+		this.cacheProxyFactoryBean.setKeyGenerator(mockKeyGenerator);
+
+		verify(this.mockCacheInterceptor, times(1)).setKeyGenerator(eq(mockKeyGenerator));
+	}
+
+	@Test
+	public void setKeyGeneratorWithNullConfiguresCacheInterceptorWithSimpleKeyGenerator() {
+
+		this.cacheProxyFactoryBean.setKeyGenerator(null);
+
+		verify(this.mockCacheInterceptor, times(1))
+			.setKeyGenerator(eq(CacheProxyFactoryBean.DEFAULT_KEY_GENERATOR));
+	}
+
+	@Configuration
+	@EnableCaching
+	static class CacheProxyFactoryBeanConfiguration {
+
+		@Bean
+		ConcurrentMapCacheManager cacheManager() {
+			return new ConcurrentMapCacheManager("Greetings");
+		}
+
+		@Bean
+		CacheProxyFactoryBean greeter() {
+
+			CacheProxyFactoryBean factoryBean = new CacheProxyFactoryBean();
+
+			factoryBean.setCacheOperationSources(
+				newCacheOperationSource("greet", newCacheOperation("Greetings")));
+
+			factoryBean.setTarget(new SimpleGreeter());
+
+			return factoryBean;
+		}
+
+		CacheOperationSource newCacheOperationSource(String methodName, CacheOperation... cacheOperations) {
+
+			NameMatchCacheOperationSource cacheOperationSource = new NameMatchCacheOperationSource();
+
+			cacheOperationSource.addCacheMethod(methodName, Arrays.asList(cacheOperations));
+
+			return cacheOperationSource;
+		}
+
+		CacheableOperation newCacheOperation(String cacheName) {
+
+			CacheableOperation.Builder builder = new CacheableOperation.Builder();
+
+			builder.setCacheManager("cacheManager");
+			builder.setCacheName(cacheName);
+
+			return builder.build();
+		}
+	}
+
+	interface Greeter {
+
+		default boolean isCacheHit() {
+			return !isCacheMiss();
+		}
+
+		boolean isCacheMiss();
+
+		void setCacheMiss();
+
+		default String greet() {
+			return greet("World");
+		}
+
+		default String greet(String name) {
+			setCacheMiss();
+			return String.format("Hello %s!", name);
+		}
+	}
+
+	static class SimpleGreeter implements Greeter {
+
+		private final AtomicBoolean cacheMiss = new AtomicBoolean(false);
+
+		@Override
+		public boolean isCacheMiss() {
+			return this.cacheMiss.getAndSet(false);
+		}
+
+		@Override
+		public void setCacheMiss() {
+			this.cacheMiss.set(true);
+		}
+	}
+
+}


### PR DESCRIPTION
…FactoryBean does not work.

This changes the o.s.cache.interceptor.CacheProxyFactoryBean to implement the SmartInitializingSingleton and BeanFactoryAware interfaces, which delegate to the internal CacheInterceptor in order to appropraiately configure the interceptor to enable the creation of cache proxies programmatically.

Resolves SPR-16295