### PR TITLE
Fix a  obvious typo in javadoc

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AspectMetadata.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AspectMetadata.java
@@ -148,7 +148,7 @@ public class AspectMetadata implements Serializable {
 	}
 
 	/**
-	 * Return the aspect class.
+	 * Return the aspect name.
 	 */
 	public String getAspectName() {
 		return this.aspectName;


### PR DESCRIPTION
A  obvious typo.