### PR TITLE
SPR-16324 - Added overloading methods to addPathPatterns and excludePathPatterns

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/InterceptorRegistration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/InterceptorRegistration.java
@@ -65,10 +65,26 @@ public class InterceptorRegistration {
 	}
 
 	/**
+	 * Add URL patterns as list to which the registered interceptor should apply to.
+	 */
+	public InterceptorRegistration addPathPatterns(List<String> patterns) {
+		this.includePatterns.addAll(patterns);
+		return this;
+	}
+
+	/**
 	 * Add URL patterns to which the registered interceptor should not apply to.
 	 */
 	public InterceptorRegistration excludePathPatterns(String... patterns) {
 		this.excludePatterns.addAll(Arrays.asList(patterns));
+		return this;
+	}
+
+	/**
+	 * Add URL patterns as list to which the registered interceptor should not apply to.
+	 */
+	public InterceptorRegistration excludePathPatterns(List<String> patterns) {
+		this.excludePatterns.addAll(patterns);
 		return this;
 	}
 


### PR DESCRIPTION
I've decided to add these methods because it's inconvenient to add paths to method one by one, separating them by commas, if I want to include them to properties file, I'm forced to add them through cycle. This is an implementation of method that makes it possible to use the list of strings in a way that's more convenient.