### PR TITLE
Fix an exception message in ScheduledAnnotationBeanPostProcessor

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -443,7 +443,7 @@ public class ScheduledAnnotationBeanPostProcessor
 					}
 					catch (NumberFormatException ex) {
 						throw new IllegalArgumentException(
-								"Invalid fixedRateString value \"" + fixedRateString + "\" - cannot parse into integer");
+								"Invalid fixedRateString value \"" + fixedRateString + "\" - cannot parse into long");
 					}
 					tasks.add(this.registrar.scheduleFixedRateTask(new FixedRateTask(runnable, fixedRate, initialDelay)));
 				}


### PR DESCRIPTION
This PR fixes an exception message missed in 591429e538d1e59b47dff4c760cfd8763c57ebd7.