### PR TITLE
SPR-16368 - jdbcTemplate in JdbcDaoSupport should have non-null 'dataSource'

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/JdbcDaoSupport.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/JdbcDaoSupport.java
@@ -112,7 +112,7 @@ public abstract class JdbcDaoSupport extends DaoSupport {
 
 	@Override
 	protected void checkDaoConfig() {
-		if (this.jdbcTemplate == null) {
+		if (this.jdbcTemplate == null || this.jdbcTemplate.getDataSource() == null) {
 			throw new IllegalArgumentException("'dataSource' or 'jdbcTemplate' is required");
 		}
 	}


### PR DESCRIPTION
The method checkDaoConfig() may throw an IllegalArgumentException which message is "'dataSource' or 'jdbcTemplate' is required", but doesn't require that jdbcTemplate has non-null 'dataSource' value, this message may confuse users, or maybe the IllegalArgumentException's message  should be "'jdbcTemplate' is required"?

[SPR-16368](https://jira.spring.io/browse/SPR-16368)