### PR TITLE
Specify AbstractWebSocketMessageBrokerConfigurer as depricated

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/AbstractWebSocketMessageBrokerConfigurer.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/AbstractWebSocketMessageBrokerConfigurer.java
@@ -30,6 +30,9 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
  *
  * @author Rossen Stoyanchev
  * @since 4.0.1
+ * @deprecated {@link WebSocketMessageBrokerConfigurer} has default methods (made
+ * possible by a Java 8 baseline) and can be implemented directly without the
+ * need for this abstract class
  */
 public abstract class AbstractWebSocketMessageBrokerConfigurer implements WebSocketMessageBrokerConfigurer {
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebSocketMessageBrokerConfigurer.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebSocketMessageBrokerConfigurer.java
@@ -40,13 +40,15 @@ public interface WebSocketMessageBrokerConfigurer {
 	 * Register STOMP endpoints mapping each to a specific URL and (optionally)
 	 * enabling and configuring SockJS fallback options.
 	 */
-	void registerStompEndpoints(StompEndpointRegistry registry);
+	default void registerStompEndpoints(StompEndpointRegistry registry) {
+	}
 
 	/**
 	 * Configure options related to the processing of messages received from and
 	 * sent to WebSocket clients.
 	 */
-	void configureWebSocketTransport(WebSocketTransportRegistration registry);
+	default void configureWebSocketTransport(WebSocketTransportRegistration registry) {
+	}
 
 	/**
 	 * Configure the {@link org.springframework.messaging.MessageChannel} used for
@@ -54,7 +56,8 @@ public interface WebSocketMessageBrokerConfigurer {
 	 * by a thread pool of size 1. It is recommended to customize thread pool
 	 * settings for production use.
 	 */
-	void configureClientInboundChannel(ChannelRegistration registration);
+	default void configureClientInboundChannel(ChannelRegistration registration) {
+	}
 
 	/**
 	 * Configure the {@link org.springframework.messaging.MessageChannel} used for
@@ -62,7 +65,8 @@ public interface WebSocketMessageBrokerConfigurer {
 	 * by a thread pool of size 1. It is recommended to customize thread pool
 	 * settings for production use.
 	 */
-	void configureClientOutboundChannel(ChannelRegistration registration);
+	default void configureClientOutboundChannel(ChannelRegistration registration) {
+	}
 
 	/**
 	 * Add resolvers to support custom controller method argument types.
@@ -72,7 +76,8 @@ public interface WebSocketMessageBrokerConfigurer {
 	 * @param argumentResolvers the resolvers to register (initially an empty list)
 	 * @since 4.1.1
 	 */
-	void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers);
+	default void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+	}
 
 	/**
 	 * Add handlers to support custom controller method return value types.
@@ -82,7 +87,8 @@ public interface WebSocketMessageBrokerConfigurer {
 	 * @param returnValueHandlers the handlers to register (initially an empty list)
 	 * @since 4.1.1
 	 */
-	void addReturnValueHandlers(List<HandlerMethodReturnValueHandler> returnValueHandlers);
+	default void addReturnValueHandlers(List<HandlerMethodReturnValueHandler> returnValueHandlers) {
+	}
 
 	/**
 	 * Configure the message converters to use when extracting the payload of
@@ -94,11 +100,14 @@ public interface WebSocketMessageBrokerConfigurer {
 	 * @param messageConverters the converters to configure (initially an empty list)
 	 * @return whether to also add default converter or not
 	 */
-	boolean configureMessageConverters(List<MessageConverter> messageConverters);
+	default boolean configureMessageConverters(List<MessageConverter> messageConverters) {
+		return true;
+	}
 
 	/**
 	 * Configure message broker options.
 	 */
-	void configureMessageBroker(MessageBrokerRegistry registry);
+	default void configureMessageBroker(MessageBrokerRegistry registry) {
+	}
 
 }


### PR DESCRIPTION
Specify AbstractWebSocketMessageBrokerConfigurer as depricated.

Add to interface WebSocketMessageBrokerConfigurer default methods (made possible by a Java 8 baseline) from AbstractWebSocketMessageBrokerConfigurer and can be implemented WebSocketMessageBrokerConfigurer interface directly without the need abstract class using default methods