### PR TITLE
Use ArrayList instead of LinkedList for known size

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/SqlParameter.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/SqlParameter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.jdbc.core;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -184,11 +185,15 @@ public class SqlParameter {
 	 * to a List of SqlParameter objects as used in this package.
 	 */
 	public static List<SqlParameter> sqlTypesToAnonymousParameterList(@Nullable int... types) {
-		List<SqlParameter> result = new LinkedList<>();
+		List<SqlParameter> result;
 		if (types != null) {
+			result = new ArrayList<>(types.length);
 			for (int type : types) {
 				result.add(new SqlParameter(type));
 			}
+		}
+		else {
+			result = new LinkedList<>();
 		}
 		return result;
 	}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -423,7 +422,7 @@ public abstract class NamedParameterUtils {
 	 */
 	public static List<SqlParameter> buildSqlParameterList(ParsedSql parsedSql, SqlParameterSource paramSource) {
 		List<String> paramNames = parsedSql.getParameterNames();
-		List<SqlParameter> params = new LinkedList<>();
+		List<SqlParameter> params = new ArrayList<>(paramNames.size());
 		for (String paramName : paramNames) {
 			params.add(new SqlParameter(
 					paramName, paramSource.getSqlType(paramName), paramSource.getTypeName(paramName)));


### PR DESCRIPTION
Spring JDBC unlike other modules uses LinkedList instead of ArrayList
in several places. There is a large body of evidence suggesting that on
contemporary hardware ArrayList is both faster and has less overhead
than even in degenerate cases of empty lists [3] or unknown size.

There are two places in Spring JDBC where the size of the list is known
in advance and an ArrayList of the correct final size can be created

 [1] https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8011200
 [2] http://cliffc.org/blog/2017/11/05/modern-hardware-performance-cache-lines/
 [3] https://bugs.openjdk.java.net/browse/JDK-8011200

Issue: SPR-16378