### PR TITLE
SPR-16383 - Log SQL parameters in EclipseLink when using showSql

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/EclipseLinkJpaVendorAdapter.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/EclipseLinkJpaVendorAdapter.java
@@ -81,6 +81,7 @@ public class EclipseLinkJpaVendorAdapter extends AbstractJpaVendorAdapter {
 		if (isShowSql()) {
 			jpaProperties.put(PersistenceUnitProperties.CATEGORY_LOGGING_LEVEL_ +
 					org.eclipse.persistence.logging.SessionLog.SQL, Level.FINE.toString());
+			jpaProperties.put(PersistenceUnitProperties.LOGGING_PARAMETERS, Boolean.TRUE.toString());
 		}
 
 		return jpaProperties;


### PR DESCRIPTION
As of EclipseLink 2.4.0 - Juno this is not sufficient to log
SQL parameter binding. Additionally,
eclipselink.logging.parameters must be enabled.

Issue: SPR-16383