### PR TITLE
SPR-16404 - Removed unnecessary cast to int

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/SimpleStreamingClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleStreamingClientHttpRequest.java
@@ -73,7 +73,7 @@ final class SimpleStreamingClientHttpRequest extends AbstractClientHttpRequest {
 	protected OutputStream getBodyInternal(HttpHeaders headers) throws IOException {
 		if (this.body == null) {
 			if (this.outputStreaming) {
-				int contentLength = (int) headers.getContentLength();
+				long contentLength = headers.getContentLength();
 				if (contentLength >= 0) {
 					this.connection.setFixedLengthStreamingMode(contentLength);
 				}


### PR DESCRIPTION
Since Java7 HttpURLConnection offers setFixedLengthStreamingMode method with long parameter which should be prefered over version with int argument, therefore casting ContentLength to int is no longer needed. Moreover it makes impossible to stream payload larger than Integer.MAX_VALUE

The issue was actually caught within one of our production applications where RestTemplate is used to stream large binaries. I understand that this is not the intended use of RestTemplate, but since the Spring Framework is baselined on Java8 there is no harm of applying this fix. Moreover according to HttpURLConnection javadoc using the method with long argument must be preferred and it takes precedence over the int version

Excerpt from HttpURLConnection.fixedContentLength javadoc: 

     * <P> <B>NOTE:</B> {@link #fixedContentLengthLong} is recommended instead
     * of this field, as it allows larger content lengths to be set.
