### PR TITLE
Matcher for asserting that header does exists

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/HeaderResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/HeaderResultMatchers.java
@@ -100,6 +100,15 @@ public class HeaderResultMatchers {
 	}
 
 	/**
+	 * Assert that the named response header does exist.
+	 * @since 4.3
+	 */
+	public ResultMatcher doesExist(final String name) {
+		return result -> assertTrue("Response should contain header '" + name + "'",
+									result.getResponse().containsHeader(name));
+	}
+
+	/**
 	 * Assert the primary value of the named response header as a {@code long}.
 	 * <p>The {@link ResultMatcher} returned by this method throws an
 	 * {@link AssertionError} if the response does not contain the specified

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resultmatchers/HeaderAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resultmatchers/HeaderAssertionTests.java
@@ -155,6 +155,16 @@ public class HeaderAssertionTests {
 	}
 
 	@Test
+	public void doesExist() throws Exception {
+		this.mockMvc.perform(get("/persons/1")).andExpect(header().doesExist(LAST_MODIFIED));
+	}
+
+	@Test(expected = AssertionError.class)  // SPR-10771
+	public void doesExistFail() throws Exception {
+		this.mockMvc.perform(get("/persons/1")).andExpect(header().doesExist("X-Custom-Header"));
+	}
+
+	@Test
 	public void stringWithIncorrectResponseHeaderValue() throws Exception {
 		assertIncorrectResponseHeader(header().string(LAST_MODIFIED, secondLater), secondLater);
 	}


### PR DESCRIPTION
Opposite of existing matcher HeaderResultMatchers#doesNotExist
this is minor change so i dont created jira issue