### PR TITLE
Fix `DelegatingServletInputStream#available`

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/DelegatingServletInputStream.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/DelegatingServletInputStream.java
@@ -87,4 +87,9 @@ public class DelegatingServletInputStream extends ServletInputStream {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
+	public int available() throws IOException {
+		return this.sourceStream.available();
+	}
+
 }


### PR DESCRIPTION
Ensure that the method returns the correct number of bytes that can be
read without blocking

Issue: #SPR-16416