### PR TITLE
MockHttpServletRequestBuilder decodes pathInfo

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
@@ -59,6 +59,7 @@ import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.support.SessionFlashMapManager;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
+import org.springframework.web.util.UrlPathHelper;
 
 /**
  * Default builder for {@link MockHttpServletRequest} required as input to perform
@@ -79,6 +80,8 @@ import org.springframework.web.util.UriUtils;
  */
 public class MockHttpServletRequestBuilder
 		implements ConfigurableSmartRequestBuilder<MockHttpServletRequestBuilder>, Mergeable {
+
+	private final UrlPathHelper urlPathHelper = new UrlPathHelper();
 
 	private final String method;
 
@@ -696,7 +699,7 @@ public class MockHttpServletRequestBuilder
 						"Invalid servlet path [" + this.servletPath + "] for request URI [" + requestUri + "]");
 			}
 			String extraPath = requestUri.substring(this.contextPath.length() + this.servletPath.length());
-			this.pathInfo = (StringUtils.hasText(extraPath) ? extraPath : null);
+			this.pathInfo = (StringUtils.hasText(extraPath) ? this.urlPathHelper.decodeRequestString(request, extraPath) : null);
 		}
 		request.setPathInfo(this.pathInfo);
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
@@ -165,6 +165,14 @@ public class MockHttpServletRequestBuilderTests {
 	}
 
 	@Test
+	public void pathInfoIsDecoded() {
+		this.builder = new MockHttpServletRequestBuilder(HttpMethod.GET, "/travel/hotels 42");
+		MockHttpServletRequest request = this.builder.buildRequest(this.servletContext);
+
+		assertEquals("/travel/hotels 42", request.getPathInfo());
+	}
+
+	@Test
 	public void contextPathServletPathInvalid() {
 		testContextPathServletPathInvalid("/Foo", "", "Request URI [/foo/bar] does not start with context path [/Foo]");
 		testContextPathServletPathInvalid("foo", "", "Context path must start with a '/'");


### PR DESCRIPTION
Previously MockHttpServletRequestBuilder calculated the pathInfo from the
provided URL without decoding the value. This meant that the pathInfo
incorrectly included URL encoded values.

Now MockHttpServletRequestBuilder properly decodes the pathInfo.

Fixes: SPR-16453