### PR TITLE
Expose publicly ServerSentEvent constructor

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/ServerSentEvent.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerSentEvent.java
@@ -51,7 +51,7 @@ public class ServerSentEvent<T> {
 	private final T data;
 
 
-    private ServerSentEvent(@Nullable String id, @Nullable String event, @Nullable Duration retry,
+    public ServerSentEvent(@Nullable String id, @Nullable String event, @Nullable Duration retry,
 			@Nullable String comment, @Nullable T data) {
 
         this.id = id;


### PR DESCRIPTION
Hello,

In my project, I would like to have an event stream of data and keep-alive messages each 15 seconds, [to support legacy proxy as explained here](https://www.w3.org/TR/eventsource/#notes).
In order to do this, I need to have a `Flux`, merged from the original `Flux` containing data with the keep-alive messages as server sent event comments.

I wanted to use the `ServerSentEvent` class, which can handle `comment` and `data` but the constructor is not `public`.
So I cannot do this:
```
    @GetMapping(value = "/sse", produces = TEXT_EVENT_STREAM_VALUE)
    public Flux<ServerSentEvent> get() {
        Flux<Long> interval = Flux.interval(Duration.ofMillis(15_000));
        Flux<ServerSentEvent> keepAliveFlux = Flux.fromStream(Stream.generate(()-> new ServerSentEvent<String>(null, null, null, "keep-alive", null));
        Flux<ServerSentEvent> keepAliveFluxWithInterval = Flux.zip(interval, keepAliveFlux).map(Tuple2::getT2);
        return Flux.merge(keepAliveFluxWithInterval, otherFluxContainingData);
    }
```
The `ServerSentEvent.BuilderImpl` is `private` too, so there is apparently no way to create a custom `ServerSentEvent`.

This PR exposes the `ServerSentEvent` constructor in order to send custom events (containing only `comment` for this example).

Thanks!