### PR TITLE
Align spring-webflux's Webjars Locator dependency with spring-webmvc

### DIFF
--- a/spring-webflux/spring-webflux.gradle
+++ b/spring-webflux/spring-webflux.gradle
@@ -22,7 +22,7 @@ dependencies {
 	optional(project(":spring-context-support"))  // for FreeMarker support
 	optional("javax.servlet:javax.servlet-api:3.1.0")
 	optional("javax.websocket:javax.websocket-api:1.1")
-	optional("org.webjars:webjars-locator:0.32-1")
+	optional("org.webjars:webjars-locator-core:0.35")
 	optional("org.freemarker:freemarker:${freemarkerVersion}")
 	optional("com.fasterxml.jackson.core:jackson-databind:${jackson2Version}")
 	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jackson2Version}")


### PR DESCRIPTION
The intention is to align with [this change](https://github.com/spring-projects/spring-framework/commit/8d42888476e892dfa1b099684c9a381bbd26f916#diff-6b23f872b29c97049a56354504169781L29) to spring-webmvc.