### PR TITLE
SPR-16501: add caching support for cache2k

### DIFF
--- a/spring-context-support/spring-context-support.gradle
+++ b/spring-context-support/spring-context-support.gradle
@@ -9,6 +9,7 @@ dependencies {
 	optional("javax.activation:activation:1.1.1")
 	optional("javax.mail:javax.mail-api:1.6.1")
 	optional("javax.cache:cache-api:1.1.0")
+	optional("org.cache2k:cache2k-api:1.1.1.Alpha")
 	optional("com.github.ben-manes.caffeine:caffeine:2.6.2")
 	optional("net.sf.ehcache:ehcache:2.10.4")
 	optional("org.quartz-scheduler:quartz:2.3.0")
@@ -22,4 +23,5 @@ dependencies {
 	testRuntime("org.ehcache:ehcache:3.4.0")
 	testRuntime("org.glassfish:javax.el:3.0.1-b08")
 	testRuntime("com.sun.mail:javax.mail:1.6.1")
+	testRuntime("org.cache2k:cache2k-impl:1.1.1.Alpha")
 }

--- a/spring-context-support/src/main/java/org/springframework/cache/cache2k/Cache2kCache.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/cache2k/Cache2kCache.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.cache2k;
+
+import org.cache2k.SimpleCacheEntry;
+import org.cache2k.integration.CacheLoaderException;
+import org.cache2k.processor.EntryProcessor;
+import org.cache2k.processor.MutableCacheEntry;
+import org.springframework.cache.Cache;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Spring {@link org.springframework.cache.Cache} adapter implementation
+ * for a cache2k {@link org.cache2k.Cache} instance.
+ *
+ * @author Jens Wilke
+ */
+public class Cache2kCache implements Cache {
+
+	private final org.cache2k.Cache<Object,Object> cache;
+
+	private boolean loaderPresent = false;
+
+	/**
+	 * Create an adapter instance for the given cache2k instance.
+	 *
+	 * @param cache the cache2k cache instance to adapt
+	 * values for this cache
+	 */
+	public Cache2kCache(org.cache2k.Cache<Object,Object> cache) {
+		Assert.notNull(cache, "Cache must not be null");
+		this.cache = cache;
+	}
+
+	/**
+	 * Create an adapter instance for the given cache2k instance.
+	 *
+	 * @param loaderPresent the cache is constructed with a loader
+	 * @param cache the cache2k cache instance to adapt
+	 * values for this cache
+	 */
+	public Cache2kCache(org.cache2k.Cache<Object,Object> cache, boolean loaderPresent) {
+		Assert.notNull(cache, "Cache must not be null");
+		this.cache = cache;
+		this.loaderPresent = loaderPresent;
+	}
+
+	@Override
+	public String getName() {
+		return cache.getName();
+	}
+
+	@Override
+	public org.cache2k.Cache<Object,Object> getNativeCache() {
+		return cache;
+	}
+
+	@Nullable
+	@Override
+	public ValueWrapper get(final Object key) {
+		final SimpleCacheEntry<Object,Object> entry = cache.getSimpleEntry(key);
+		if (entry == null) {
+			return null;
+		}
+		return returnWrappedValue(entry);
+	}
+
+	private ValueWrapper returnWrappedValue(final SimpleCacheEntry<Object, Object> entry) {
+		return new ValueWrapper() {
+			@Nullable
+			@Override
+			public Object get() {
+				return entry.getValue();
+			}
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	@Override
+	public <T> T get(final Object key, @Nullable final Class<T> type) {
+		Object value = cache.get(key);
+		if (value != null && type != null && !type.isInstance(value)) {
+			throw new IllegalStateException("Cached value is not of required type [" + type.getName() + "]: " + value);
+		}
+		return (T) value;
+	}
+
+	/**
+	 * cache2k will throw an exception if the callable yields and exception.
+	 * Future versions may throw a {@code RuntimeException} directly so wrap this also.
+	 *
+	 * <p>Ignore the {@code valueLoader} parameter in case a loader is present. This makes
+	 * sure the loader is consistently used and the cache2k features refresh ahead and resilience work
+	 * as expected.
+	 */
+	@SuppressWarnings("unchecked")
+	@Nullable
+	@Override
+	public <T> T get(final Object key, final Callable<T> valueLoader) {
+		if (loaderPresent) {
+			return (T) cache.get(key);
+		} else {
+			try {
+				return (T) cache.computeIfAbsent(key, (Callable<Object>) valueLoader);
+			} catch (CacheLoaderException ex) {
+				throw new ValueRetrievalException(key, valueLoader, ex.getCause());
+			} catch (RuntimeException ex) {
+				throw new ValueRetrievalException(key, valueLoader, ex);
+			}
+		}
+	}
+
+	@Override
+	public void put(final Object key, @Nullable final Object value) {
+		cache.put(key, value);
+	}
+
+	@Nullable
+	@Override
+	public ValueWrapper putIfAbsent(final Object key, @Nullable final Object value) {
+		return cache.invoke(key, new EntryProcessor<Object, Object, ValueWrapper>() {
+			@Override
+			public ValueWrapper process(final MutableCacheEntry<Object, Object> e) throws Exception {
+				if (e.exists()) {
+					return returnWrappedValue(e);
+				}
+				e.setValue(value);
+				return null;
+			}
+		});
+	}
+
+	@Override
+	public void evict(final Object key) {
+		cache.remove(key);
+	}
+
+	@Override
+	public void clear() {
+		cache.clear();
+	}
+
+	public boolean isLoaderPresent() {
+		return loaderPresent;
+	}
+
+}

--- a/spring-context-support/src/main/java/org/springframework/cache/cache2k/Cache2kCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/cache2k/Cache2kCacheManager.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2018-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.cache2k;
+
+import org.cache2k.Cache2kBuilder;
+import org.cache2k.configuration.Cache2kConfiguration;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.lang.Nullable;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache manager implementation on top of the cache2k cache manager. The default cache2k
+ * cache manager is used to resolve caches.
+ *
+ * @author Jens Wilke
+ */
+public class Cache2kCacheManager implements CacheManager {
+
+	private final org.cache2k.CacheManager manager;
+
+	private final Map<String, Cache> name2cache = new ConcurrentHashMap<>();
+
+	/**
+	 * Construct a spring cache manager, using the default cache2k cache manager instance.
+	 *
+	 * @see org.cache2k.CacheManager
+	 * @see org.cache2k.CacheManager#getInstance()
+	 */
+	public Cache2kCacheManager() {
+		manager = org.cache2k.CacheManager.getInstance();
+	}
+
+	/**
+	 * Construct a spring cache manager, using a custom cache2k cache manager. This
+	 * allows for the use of a different manager name and classloader.
+	 *
+	 * @see org.cache2k.CacheManager
+	 * @see org.cache2k.CacheManager#getInstance(String)
+	 * @see org.cache2k.CacheManager#getInstance(ClassLoader)
+	 * @see org.cache2k.CacheManager#getInstance(ClassLoader, String)
+	 */
+	public Cache2kCacheManager(org.cache2k.CacheManager manager) { this.manager = manager; }
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	@Override
+	public Cache getCache(final String name) {
+		Cache cache = name2cache.get(name);
+		if (cache != null) {
+			return cache;
+		}
+		synchronized (name2cache) {
+			cache = name2cache.get(name);
+			if (cache != null) {
+				return cache;
+			}
+			cache = buildAndWrap(configureCache(Cache2kBuilder.forUnknownTypes().manager(manager), name));
+			name2cache.put(name, cache);
+		}
+		return cache;
+	}
+
+	/**
+	 * There is no way in cache2k to return all known caches. Caches may be created ad hoc
+	 * only within the code and do not need to be enlisted in a configuration.
+	 * Checking Spring version 4.4.1 the framework is actually not using this method.
+	 *
+	 * <p>To be future proof this method returns the names of caches that have been
+	 * created within the cache manager. Future version of cache2k may get a flag
+	 * per cache that activates caches on startup, before they are requested by the application.
+	 */
+	@Override
+	public Collection<String> getCacheNames() {
+		Set<String> cacheNames = new HashSet<>();
+		for (org.cache2k.Cache<?,?> cache : manager.getActiveCaches()) {
+			cacheNames.add(cache.getName());
+		}
+		return cacheNames;
+	}
+
+	/**
+	 * Expose the native cache manager.
+	 */
+	public org.cache2k.CacheManager getNativeCacheManager() {
+		return manager;
+	}
+
+	/**
+	 * Expose the map of known wrapped caches.
+	 */
+	public Map<String, Cache> getCacheMap() {
+		return name2cache;
+	}
+
+	private static final Callable<Object> DUMMY_CALLABLE = new Callable<Object>() {
+		@Override
+		public Object call() {
+			return null;
+		}
+		public String toString() {
+			return "Callable(DUMMY)";
+		}
+	};
+
+	public static Cache2kBuilder<Object,Object> configureCache(Cache2kBuilder<Object, Object> builder, String name) {
+		return builder
+				.name(name)
+				.permitNullValues(true)
+				.exceptionPropagator(
+					(key, exceptionInformation) ->
+					new Cache.ValueRetrievalException(key, DUMMY_CALLABLE, exceptionInformation.getException()));
+	}
+
+	public static Cache2kCache buildAndWrap(Cache2kBuilder<Object, Object> builder) {
+		org.cache2k.Cache<Object, Object> nativeCache = builder.build();
+		Cache2kConfiguration<?,?> cfg = builder.toConfiguration();
+		boolean loaderPresent = cfg.getLoader() != null || cfg.getAdvancedLoader() != null;
+		return new Cache2kCache(nativeCache, loaderPresent);
+	}
+
+}

--- a/spring-context-support/src/main/java/org/springframework/cache/cache2k/package-info.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/cache2k/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Support classes for <a href="https://cache2k.org">cache2k</a> open source
+ * cache implementation allowing to set up cache2k caches within Spring's cache abstraction.
+ *
+ * <p>Note: cache2k has support for JSR107/JCache and can be used via
+ * Spring's support in {@code org.springframework.cache.jcache} as well. Using
+ * cache2k direct support instead of JCache reduces memory overhead and enhances overall
+ * caching performance.
+ */
+@NonNullApi
+@NonNullFields
+package org.springframework.cache.cache2k;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-context-support/src/test/java/org/springframework/cache/cache2k/Cache2kCacheManagerTests.java
+++ b/spring-context-support/src/test/java/org/springframework/cache/cache2k/Cache2kCacheManagerTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.cache2k;
+
+import org.junit.Test;
+import org.springframework.cache.Cache;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test for the cache2k manager wrapper.
+ *
+ * @author Jens Wilke
+ * @author Ben Manes
+ * @author Juergen Hoeller
+ * @author Stephane Nicoll
+ */
+public class Cache2kCacheManagerTests {
+
+	@Test
+	public void testAll() {
+		Cache2kCacheManager cm = new Cache2kCacheManager();
+		assertEquals(org.cache2k.CacheManager.getInstance(), cm.getNativeCacheManager());
+		Cache cache1 = cm.getCache("c1");
+		assertTrue(cache1 instanceof Cache2kCache);
+		Cache cache1again = cm.getCache("c1");
+		assertSame(cache1again, cache1);
+		Cache cache2 = cm.getCache("c2");
+		assertTrue(cache2 instanceof Cache2kCache);
+		Cache cache2again = cm.getCache("c2");
+		assertSame(cache2again, cache2);
+		Cache cache3 = cm.getCache("c3");
+		assertTrue(cache3 instanceof Cache2kCache);
+		Cache cache3again = cm.getCache("c3");
+		assertSame(cache3again, cache3);
+		cache1.put("key1", "value1");
+		assertEquals("value1", cache1.get("key1").get());
+		cache1.put("key2", 2);
+		assertEquals(2, cache1.get("key2").get());
+		cache1.put("key3", null);
+		assertNull(cache1.get("key3").get());
+		cache1.evict("key3");
+		assertNull(cache1.get("key3"));
+		assertTrue(cm.getCacheNames().contains("c1"));
+		assertTrue(cm.getCacheNames().contains("c2"));
+		assertTrue(cm.getCacheNames().contains("c3"));
+		assertTrue(cm.getCacheMap().containsKey("c3"));
+	}
+
+}

--- a/spring-context-support/src/test/java/org/springframework/cache/cache2k/Cache2kCacheTests.java
+++ b/spring-context-support/src/test/java/org/springframework/cache/cache2k/Cache2kCacheTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.cache2k;
+
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
+import org.cache2k.CacheEntry;
+import org.cache2k.integration.AdvancedCacheLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cache.AbstractCacheTests;
+import static org.junit.Assert.*;
+
+/**
+ * @author Jens Wilke
+ */
+public class Cache2kCacheTests extends AbstractCacheTests<Cache2kCache> {
+
+	private Cache nativeCache;
+	private Cache2kCache cache;
+
+	@Before
+	public void setUp() {
+		Cache2kBuilder builder = Cache2kCacheManager.configureCache(Cache2kBuilder.forUnknownTypes(), CACHE_NAME);
+		cache = Cache2kCacheManager.buildAndWrap(builder);
+		nativeCache = cache.getNativeCache();
+	}
+
+	@After
+	public void tearDown() {
+		nativeCache.close();
+	}
+
+	@Override
+	protected Cache2kCache getCache() {
+		return cache;
+	}
+
+	@Override
+	protected Cache getNativeCache() {
+		return nativeCache;
+	}
+
+	@Test
+	public void testNoLoadingCache() {
+		assertFalse(cache.isLoaderPresent());
+	}
+
+	@Test
+	public void testLoadingCache() {
+		Cache2kBuilder builder =
+				Cache2kCacheManager.configureCache(Cache2kBuilder.forUnknownTypes(), CACHE_NAME + "-withloader")
+				.loader(key -> "123");
+		Cache2kCache cacheWithLoader = Cache2kCacheManager.buildAndWrap(builder);
+		assertTrue(cacheWithLoader.isLoaderPresent());
+		cacheWithLoader.getNativeCache().close();
+	}
+
+	@Test
+	public void testLoadingCacheAdvancedLoader() {
+		Cache2kBuilder builder =
+				Cache2kCacheManager.configureCache(Cache2kBuilder.forUnknownTypes(), CACHE_NAME + "-withloader")
+						.loader(new AdvancedCacheLoader() {
+							@Override
+							public Object load(
+									final Object key, final long currentTime, final CacheEntry currentEntry) {
+								return "123";
+							}
+						});
+		Cache2kCache cacheWithLoader = Cache2kCacheManager.buildAndWrap(builder);
+		assertTrue(cacheWithLoader.isLoaderPresent());
+		cacheWithLoader.getNativeCache().close();
+	}
+
+}

--- a/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCacheManager.java
+++ b/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCacheManager.java
@@ -40,7 +40,8 @@ import org.springframework.lang.Nullable;
  * caching scenarios. For advanced local caching needs, consider
  * {@link org.springframework.cache.jcache.JCacheCacheManager},
  * {@link org.springframework.cache.ehcache.EhCacheCacheManager},
- * {@link org.springframework.cache.caffeine.CaffeineCacheManager}.
+ * {@link org.springframework.cache.caffeine.CaffeineCacheManager},
+ * {@link org.springframework.cache.caffeine.Cache2kCacheManager}.
  *
  * @author Juergen Hoeller
  * @since 3.1


### PR DESCRIPTION
[cache2k](https://cache2k.org) is one of the [best performing Java caches](https://cruftex.net/2017/09/01/Java-Caching-Benchmarks-Part-3.html) with a hit rate efficiency similar to Caffeine.

The jar size of cache2k is smaller than the currently available alternatives like EHCache and Caffeine. Although its small jar size it comes with XML configuration and JMX support.

The direct support of cache2k makes use of the build in `null` value support which leads to less overhead than Caffeine or using the JCache API.