### PR TITLE
Tokenizer - removing unnecessary boxing

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -265,7 +265,7 @@ class Tokenizer {
 						raiseParseException(this.pos, SpelMessage.UNEXPECTED_ESCAPE_CHAR);
 						break;
 					default:
-						throw new IllegalStateException("Cannot handle (" + Integer.valueOf(ch) + ") '" + ch + "'");
+						throw new IllegalStateException("Cannot handle (" + (int) ch + ") '" + ch + "'");
 				}
 			}
 		}


### PR DESCRIPTION
Instead of "Integer.valueOf(ch)" can be simply "(int) ch"