### PR TITLE
Handle end of stream when reading the request body

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServletServerHttpRequest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.http.server.reactive;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -208,7 +209,9 @@ class ServletServerHttpRequest extends AbstractServerHttpRequest {
 			dataBuffer.write(this.buffer, 0, read);
 			return dataBuffer;
 		}
-
+		else if (read == -1) {
+			throw new EOFException("All data read.");
+		}
 		return null;
 	}
 
@@ -266,7 +269,12 @@ class ServletServerHttpRequest extends AbstractServerHttpRequest {
 		@Nullable
 		protected DataBuffer read() throws IOException {
 			if (this.inputStream.isReady()) {
-				return readFromInputStream();
+				try {
+					return readFromInputStream();
+				}
+				catch (EOFException e) {
+					onAllDataRead();
+				}
 			}
 			return null;
 		}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/TomcatHttpHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/TomcatHttpHandlerAdapter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.http.server.reactive;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import javax.servlet.AsyncContext;
@@ -93,9 +94,10 @@ public class TomcatHttpHandlerAdapter extends ServletHttpHandlerAdapter {
 					release = false;
 					return dataBuffer;
 				}
-				else {
-					return null;
+				else if (read == -1) {
+					throw new EOFException("All data read.");
 				}
+				return null;
 			}
 			finally {
 				if (release) {


### PR DESCRIPTION
When reading request body -1 means all data read.
Instead of waiting for an event from the server, call
onAllDataRead immediately.