### PR TITLE
Take brotli encoding into account for caching

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/CachingResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/CachingResourceResolver.java
@@ -99,6 +99,9 @@ public class CachingResourceResolver extends AbstractResourceResolver {
 			if (encoding != null && encoding.contains("gzip")) {
 				key.append("+encoding=gzip");
 			}
+			if (encoding != null && encoding.contains("br")) {
+				key.append("+encoding=brotli");
+			}
 		}
 		return key.toString();
 	}


### PR DESCRIPTION
We use a BrotliResourceResolver to deliver pre compressed content. If we use the `CachingResourceResolver` including `ResourceHandlerRegistry.resourceChain(true)` we cache brotli compressed content and deliver it to only gzip aware clients.  This fix resolves that by taking the brotli encoding into account. As all brotli aware browsers most likely supports gzip I think those two ifs are fine :-)