### PR TITLE
Polish: Array designators "[]" should be on the type, not the variable

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/PropertyDescriptorUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyDescriptorUtils.java
@@ -79,7 +79,7 @@ class PropertyDescriptorUtils {
 		}
 
 		if (writeMethod != null) {
-			Class<?> params[] = writeMethod.getParameterTypes();
+			Class<?>[] params = writeMethod.getParameterTypes();
 			if (params.length != 1) {
 				throw new IntrospectionException("Bad write method arg count: " + writeMethod);
 			}
@@ -114,7 +114,7 @@ class PropertyDescriptorUtils {
 		Class<?> indexedPropertyType = null;
 
 		if (indexedReadMethod != null) {
-			Class<?> params[] = indexedReadMethod.getParameterTypes();
+			Class<?>[] params = indexedReadMethod.getParameterTypes();
 			if (params.length != 1) {
 				throw new IntrospectionException("Bad indexed read method arg count: " + indexedReadMethod);
 			}
@@ -128,7 +128,7 @@ class PropertyDescriptorUtils {
 		}
 
 		if (indexedWriteMethod != null) {
-			Class<?> params[] = indexedWriteMethod.getParameterTypes();
+			Class<?>[] params = indexedWriteMethod.getParameterTypes();
 			if (params.length != 2) {
 				throw new IntrospectionException("Bad indexed write method arg count: " + indexedWriteMethod);
 			}

--- a/spring-beans/src/main/java/org/springframework/beans/PropertyMatches.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyMatches.java
@@ -155,7 +155,7 @@ public abstract class PropertyMatches {
 		if (s2.isEmpty()) {
 			return s1.length();
 		}
-		int d[][] = new int[s1.length() + 1][s2.length() + 1];
+		int[][] d = new int[s1.length() + 1][s2.length() + 1];
 
 		for (int i = 0; i <= s1.length(); i++) {
 			d[i][0] = i;

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/ConstructorResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/ConstructorResolver.java
@@ -833,11 +833,11 @@ class ConstructorResolver {
 	 */
 	private static class ArgumentsHolder {
 
-		public final Object rawArguments[];
+		public final Object[] rawArguments;
 
-		public final Object arguments[];
+		public final Object[] arguments;
 
-		public final Object preparedArguments[];
+		public final Object[] preparedArguments;
 
 		public boolean resolveNecessary = false;
 

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -1258,12 +1258,12 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 	//---------------------------------------------------------------------
 
 	@Override
-	public String getMessage(String code, @Nullable Object args[], @Nullable String defaultMessage, Locale locale) {
+	public String getMessage(String code, @Nullable Object[] args, @Nullable String defaultMessage, Locale locale) {
 		return getMessageSource().getMessage(code, args, defaultMessage, locale);
 	}
 
 	@Override
-	public String getMessage(String code, @Nullable Object args[], Locale locale) throws NoSuchMessageException {
+	public String getMessage(String code, @Nullable Object[] args, Locale locale) throws NoSuchMessageException {
 		return getMessageSource().getMessage(code, args, locale);
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/DigestUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/DigestUtils.java
@@ -169,7 +169,7 @@ public abstract class DigestUtils {
 	}
 
 	private static char[] encodeHex(byte[] bytes) {
-		char chars[] = new char[32];
+		char[] chars = new char[32];
 		for (int i = 0; i < chars.length; i = i + 2) {
 			byte b = bytes[i / 2];
 			chars[i] = HEX_CHARS[(b >>> 0x4) & 0xf];

--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -167,7 +167,7 @@ public abstract class StreamUtils {
 		}
 
 		long bytesToCopy = end - start + 1;
-		byte buffer[] = new byte[StreamUtils.BUFFER_SIZE];
+		byte[] buffer = new byte[StreamUtils.BUFFER_SIZE];
 		while (bytesToCopy > 0) {
 			int bytesRead = in.read(buffer);
 			if (bytesRead == -1) {

--- a/spring-core/src/main/java/org/springframework/util/xml/AbstractStaxHandler.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/AbstractStaxHandler.java
@@ -102,7 +102,7 @@ abstract class AbstractStaxHandler implements ContentHandler, LexicalHandler {
 	}
 
 	@Override
-	public final void characters(char ch[], int start, int length) throws SAXException {
+	public final void characters(char[] ch, int start, int length) throws SAXException {
 		try {
 			String data = new String(ch, start, length);
 			if (!this.inCData) {

--- a/spring-core/src/main/java/org/springframework/util/xml/DomContentHandler.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/DomContentHandler.java
@@ -94,7 +94,7 @@ class DomContentHandler implements ContentHandler {
 	}
 
 	@Override
-	public void characters(char ch[], int start, int length) throws SAXException {
+	public void characters(char[] ch, int start, int length) throws SAXException {
 		String data = new String(ch, start, length);
 		Node parent = getParent();
 		Node lastChild = parent.getLastChild();
@@ -139,7 +139,7 @@ class DomContentHandler implements ContentHandler {
 	}
 
 	@Override
-	public void ignorableWhitespace(char ch[], int start, int length) throws SAXException {
+	public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
 	}
 
 	@Override

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -38,7 +38,7 @@ class Tokenizer {
 	private static final String[] ALTERNATIVE_OPERATOR_NAMES =
 			{"DIV", "EQ", "GE", "GT", "LE", "LT", "MOD", "NE", "NOT"};
 
-	private static final byte FLAGS[] = new byte[256];
+	private static final byte[] FLAGS = new byte[256];
 
 	private static final byte IS_DIGIT = 0x01;
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/lob/PassThroughBlob.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/lob/PassThroughBlob.java
@@ -96,7 +96,7 @@ class PassThroughBlob implements Blob {
 	}
 
 	@Override
-	public long position(byte pattern[], long start) throws SQLException {
+	public long position(byte[] pattern, long start) throws SQLException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/spring-test/src/main/java/org/springframework/mock/web/MockBodyContent.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockBodyContent.java
@@ -123,7 +123,7 @@ public class MockBodyContent extends BodyContent {
 	}
 
 	@Override
-	public void write(char value[], int offset, int length) throws IOException {
+	public void write(char[] value, int offset, int length) throws IOException {
 		getEnclosingWriter().write(value, offset, length);
 	}
 

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -717,7 +717,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 		}
 
 		@Override
-		public void write(char buf[], int off, int len) {
+		public void write(char[] buf, int off, int len) {
 			super.write(buf, off, len);
 			super.flush();
 			setCommittedIfBufferSizeExceeded();

--- a/spring-test/src/main/java/org/springframework/mock/web/MockJspWriter.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockJspWriter.java
@@ -116,7 +116,7 @@ public class MockJspWriter extends JspWriter {
 	}
 
 	@Override
-	public void write(char value[], int offset, int length) throws IOException {
+	public void write(char[] value, int offset, int length) throws IOException {
 		getTargetWriter().write(value, offset, length);
 	}
 

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StubWebApplicationContext.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StubWebApplicationContext.java
@@ -303,12 +303,12 @@ class StubWebApplicationContext implements WebApplicationContext {
 	//---------------------------------------------------------------------
 
 	@Override
-	public String getMessage(String code, @Nullable Object args[], @Nullable String defaultMessage, Locale locale) {
+	public String getMessage(String code, @Nullable Object[] args, @Nullable String defaultMessage, Locale locale) {
 		return this.messageSource.getMessage(code, args, defaultMessage, locale);
 	}
 
 	@Override
-	public String getMessage(String code, @Nullable Object args[], Locale locale) throws NoSuchMessageException {
+	public String getMessage(String code, @Nullable Object[] args, Locale locale) throws NoSuchMessageException {
 		return this.messageSource.getMessage(code, args, locale);
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/util/ContentCachingResponseWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ContentCachingResponseWrapper.java
@@ -271,7 +271,7 @@ public class ContentCachingResponseWrapper extends HttpServletResponseWrapper {
 		}
 
 		@Override
-		public void write(char buf[], int off, int len) {
+		public void write(char[] buf, int off, int len) {
 			super.write(buf, off, len);
 			super.flush();
 		}

--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -503,7 +503,7 @@ public abstract class WebUtils {
 	@Nullable
 	public static Cookie getCookie(HttpServletRequest request, String name) {
 		Assert.notNull(request, "Request must not be null");
-		Cookie cookies[] = request.getCookies();
+		Cookie[] cookies = request.getCookies();
 		if (cookies != null) {
 			for (Cookie cookie : cookies) {
 				if (name.equals(cookie.getName())) {


### PR DESCRIPTION
Array designators should always be located on the type for better code readability. Otherwise, developers must look both at the type and the variable name to know whether or not a variable is an array.