### PR TITLE
SPR-12756: Local visibility for writes to caches with transactional decorators

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/transaction/BufferedCache.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/transaction/BufferedCache.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.transaction;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.AbstractValueAdaptingCache;
+import org.springframework.lang.Nullable;
+
+/**
+ * Buffers write ops for batched {@link #commit} to the target cache.
+ * <p>
+ * Get operations read through the buffer first then from the target cache if no local
+ * value is found.
+ *
+ * @implNote operations are not synchronized; this is a utility class that is only used by
+ * instances of {@link TransactionalCacheDecorator} in a thread local context.
+ *
+ * @author William Hoyle
+ * @see TransactionalCacheDecorator
+ */
+class BufferedCache extends AbstractValueAdaptingCache {
+
+	/**
+	 * Sentinel value associated with evicted keys in the buffer.
+	 */
+	private static final Object EVICTED = new Object();
+
+	private final String name;
+	private final Cache targetCache;
+	private final Map<Object, Object> buffer = new HashMap<>();
+
+	/**
+	 * True if a {@link #clear()} has been issued.
+	 */
+	private boolean cleared;
+
+
+	/**
+	 * Create a new BufferedCache for the given target Cache.
+	 *
+	 * @param targetCache the target Cache to decorate
+	 */
+	public BufferedCache(Cache targetCache) {
+		super(true);
+		Objects.requireNonNull(targetCache);
+		this.name = targetCache.getName() + ".buffer";
+		this.targetCache = targetCache;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @return null
+	 */
+	@Override
+	@Nullable
+	public Object getNativeCache() {
+		return null;
+	}
+
+	@Override
+	@Nullable
+	protected Object lookup(Object key) {
+		ValueWrapper wrapper = delegatingGet(key);
+		return (wrapper != null ? toStoreValue(wrapper.get()) : null);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	@Nullable
+	public <T> T get(Object key, Callable<T> valueLoader) {
+		T value;
+		ValueWrapper wrapper = delegatingGet(key);
+		if (wrapper == null) {
+			try {
+				value = valueLoader.call();
+				put(key, value);
+			}
+			catch (Exception e) {
+				throw new ValueRetrievalException(key, valueLoader, e);
+			}
+		}
+		else {
+			value = (T) wrapper.get();
+		}
+		return value;
+	}
+
+	@Override
+	@Nullable
+	public ValueWrapper putIfAbsent(Object key, @Nullable Object value) {
+		ValueWrapper wrapper = delegatingGet(key);
+		if (wrapper == null) {
+			put(key, value);
+		}
+		return wrapper;
+	}
+
+	@Override
+	public void put(Object key, @Nullable Object value) {
+		buffer.put(key, toStoreValue(value));
+	}
+
+	@Override
+	public void evict(Object key) {
+		buffer.put(key, EVICTED);
+	}
+
+	@Override
+	public void clear() {
+		buffer.clear();
+		cleared = true;
+	}
+
+	/**
+	 * Write all changes since the last commit to the underlying cache.
+	 */
+	public void commit() {
+		if (cleared) {
+			targetCache.clear();
+		}
+		for (Map.Entry<Object, Object> entry : buffer.entrySet()) {
+			Object key = entry.getKey();
+			Object value = entry.getValue();
+			if (value == EVICTED) {
+				targetCache.evict(key);
+			}
+			else {
+				targetCache.put(key, fromStoreValue(value));
+			}
+		}
+		clearBuffer();
+	}
+
+	/**
+	 * Discard all changes since the last commit without writing them to the underlying
+	 * cache.
+	 */
+	public void rollback() {
+		clearBuffer();
+	}
+
+	private void clearBuffer() {
+		buffer.clear();
+		cleared = false;
+	}
+
+	/**
+	 * Get a value from the buffer, or fall back to get the value from the target cache if
+	 * the value isn't in the buffer.
+	 * <p>
+	 * If the key has been evicted or cleared from the buffer this method will return null
+	 * rather than fetching the value from the underlying cache.
+	 */
+	@Nullable
+	private ValueWrapper delegatingGet(Object key) {
+		Object value = buffer.get(key);
+		ValueWrapper wrapper;
+		if (value != null) {
+			wrapper = (value != EVICTED ? toValueWrapper(value) : null);
+		}
+		else if (cleared) {
+			wrapper = null;
+		}
+		else {
+			wrapper = targetCache.get(key);
+		}
+		return wrapper;
+	}
+}

--- a/spring-context-support/src/main/java/org/springframework/cache/transaction/TransactionAwareCacheManagerProxy.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/transaction/TransactionAwareCacheManagerProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,9 @@
 
 package org.springframework.cache.transaction;
 
-import java.util.Collection;
-
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
+import org.springframework.cache.support.CacheManagerProxy;
 
 /**
  * Proxy for a target {@link CacheManager}, exposing transaction-aware {@link Cache} objects
@@ -37,17 +33,14 @@ import org.springframework.util.Assert;
  * @see TransactionAwareCacheDecorator
  * @see org.springframework.transaction.support.TransactionSynchronizationManager
  */
-public class TransactionAwareCacheManagerProxy implements CacheManager, InitializingBean {
-
-	@Nullable
-	private CacheManager targetCacheManager;
-
+public class TransactionAwareCacheManagerProxy extends CacheManagerProxy {
 
 	/**
 	 * Create a new TransactionAwareCacheManagerProxy, setting the target CacheManager
 	 * through the {@link #setTargetCacheManager} bean property.
 	 */
 	public TransactionAwareCacheManagerProxy() {
+		setCacheDecoratorFactory(TransactionAwareCacheDecorator::new);
 	}
 
 	/**
@@ -55,38 +48,6 @@ public class TransactionAwareCacheManagerProxy implements CacheManager, Initiali
 	 * @param targetCacheManager the target CacheManager to proxy
 	 */
 	public TransactionAwareCacheManagerProxy(CacheManager targetCacheManager) {
-		Assert.notNull(targetCacheManager, "Target CacheManager must not be null");
-		this.targetCacheManager = targetCacheManager;
+		super(targetCacheManager, TransactionAwareCacheDecorator::new);
 	}
-
-
-	/**
-	 * Set the target CacheManager to proxy.
-	 */
-	public void setTargetCacheManager(CacheManager targetCacheManager) {
-		this.targetCacheManager = targetCacheManager;
-	}
-
-	@Override
-	public void afterPropertiesSet() {
-		if (this.targetCacheManager == null) {
-			throw new IllegalArgumentException("Property 'targetCacheManager' is required");
-		}
-	}
-
-
-	@Override
-	@Nullable
-	public Cache getCache(String name) {
-		Assert.state(this.targetCacheManager != null, "No target CacheManager set");
-		Cache targetCache = this.targetCacheManager.getCache(name);
-		return (targetCache != null ? new TransactionAwareCacheDecorator(targetCache) : null);
-	}
-
-	@Override
-	public Collection<String> getCacheNames() {
-		Assert.state(this.targetCacheManager != null, "No target CacheManager set");
-		return this.targetCacheManager.getCacheNames();
-	}
-
 }

--- a/spring-context-support/src/main/java/org/springframework/cache/transaction/TransactionalCacheDecorator.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/transaction/TransactionalCacheDecorator.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.transaction;
+
+import java.util.concurrent.Callable;
+
+import org.springframework.cache.Cache;
+import org.springframework.lang.Nullable;
+import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * An alternative strategy to {@link TransactionAwareCacheDecorator} for use with
+ * {@link TransactionAwareCacheManagerProxy}.
+ *
+ * This decorator collects cache updates during a transaction and writes them to the
+ * target cache on commit, or discards them on rollback. It differs from the default
+ * decorator used by the TransactionAwareCacheManagerProxy in that updates are visible
+ * immediately (i.e callers within the scope of the transaction can read the changes
+ * made before commit).
+ * <p>
+ * If there is no transaction in progress all operations are performed immediately.
+ * <p>
+ * <b>Note:</b> When a transaction is active {@link Cache#get(Object, Callable)} and
+ * {@link Cache#putIfAbsent} are implemented as a get and, if required, a
+ * subsequent deferred put to the target cache; they are not performed atomically.
+ *
+ * @author William Hoyle
+ * @see TransactionAwareCacheManagerProxy#setCacheDecoratorFactory
+ * @see TransactionalCacheDecoratorFactory
+ */
+public class TransactionalCacheDecorator implements Cache {
+
+	private final Cache targetCache;
+	private String name;
+
+
+	/**
+	 * Create a new TransactionalCacheDecorator for the given target Cache, defaulting
+	 * the cache name to the name of the target cache with the suffix {@code ".tx"}.
+	 *
+	 * @param targetCache the target Cache to decorate
+	 */
+	public TransactionalCacheDecorator(Cache targetCache) {
+		this(targetCache, targetCache.getName() + ".tx");
+	}
+
+	/**
+	 * Create a new TransactionalCacheDecorator for the given target Cache.
+	 *
+	 * @param targetCache the target Cache to decorate
+	 * @param name the name used by the CacheManager to refer to the cache
+	 */
+	public TransactionalCacheDecorator(Cache targetCache, String name) {
+		this.name = name;
+		this.targetCache = targetCache;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @return null
+	 */
+	@Override
+	@Nullable
+	public Object getNativeCache() {
+		return null;
+	}
+
+	/**
+	 * @return the cache that this decorator delegates to
+	 */
+	public Cache getTargetCache() {
+		return targetCache;
+	}
+
+	@Override
+	public ValueWrapper get(Object key) {
+		return getCache().get(key);
+	}
+
+	@Override
+	public <T> T get(Object key, @Nullable Class<T> type) {
+		return getCache().get(key, type);
+	}
+
+	/**
+	 * @implNote If a transaction is in progress this operation is implemented as a get
+	 * and, if required, a subsequent put on commit to the target cache; it will not
+	 * be performed atomically. If there is no transaction the operation will be delegated
+	 * directly to the target cache an may be performed atomically if the implementation
+	 * supports it.
+	 */
+	@Override
+	public <T> T get(Object key, Callable<T> valueLoader) {
+		return getCache().get(key, valueLoader);
+	}
+
+	@Override
+	public void put(Object key, @Nullable Object value) {
+		getCache().put(key, value);
+	}
+
+	/**
+	 * @implNote If a transaction is in progress this operation is implemented as a get
+	 * and, if required, a subsequent put on commit to the target cache; it will not
+	 * be performed atomically. If there is no transaction the operation will be delegated
+	 * directly to the target cache an may be performed atomically if the implementation
+	 * supports it.
+	 */
+	@Override
+	public ValueWrapper putIfAbsent(Object key, @Nullable Object value) {
+		return getCache().putIfAbsent(key, value);
+	}
+
+	@Override
+	public void evict(Object key) {
+		getCache().evict(key);
+	}
+
+	@Override
+	public void clear() {
+		getCache().clear();
+	}
+
+	private Cache getCache() {
+		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+			return targetCache;
+		}
+		else {
+			BufferedCache cache = (BufferedCache) TransactionSynchronizationManager.getResource(this);
+			if (cache == null) {
+				cache = new BufferedCache(targetCache);
+				TransactionSynchronizationManager.bindResource(this, cache);
+				TransactionSynchronizationManager.registerSynchronization(new CacheSynchronization());
+			}
+			return cache;
+		}
+	}
+
+	/**
+	 * On commit, flushes changes to the target cache.
+	 * <p>
+	 * Also responsible for resource cleanup at the end of the transaction.
+	 */
+	private class CacheSynchronization extends TransactionSynchronizationAdapter {
+
+		@Nullable
+		private BufferedCache transactionLocalCache;
+
+		@Override
+		public void suspend() {
+			if (transactionLocalCache != null) {
+				throw new IllegalStateException();
+			}
+			transactionLocalCache = (BufferedCache) TransactionSynchronizationManager
+					.unbindResource(TransactionalCacheDecorator.this);
+		}
+
+		@Override
+		public void resume() {
+			if (transactionLocalCache == null) {
+				throw new IllegalStateException();
+			}
+			TransactionSynchronizationManager
+					.bindResource(TransactionalCacheDecorator.this, transactionLocalCache);
+			transactionLocalCache = null;
+		}
+
+
+		@Override
+		public void afterCommit() {
+			BufferedCache cache = (BufferedCache) TransactionSynchronizationManager
+					.getResource(TransactionalCacheDecorator.this);
+			if (cache == null) {
+				throw new IllegalStateException();
+			}
+			cache.commit();
+		}
+
+		@Override
+		public void afterCompletion(int status) {
+			TransactionSynchronizationManager
+					.unbindResourceIfPossible(TransactionalCacheDecorator.this);
+		}
+	}
+}

--- a/spring-context-support/src/main/java/org/springframework/cache/transaction/TransactionalCacheDecoratorFactory.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/transaction/TransactionalCacheDecoratorFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.transaction;
+
+import java.util.function.UnaryOperator;
+
+import org.springframework.cache.Cache;
+
+/**
+ * A factory that decorates caches with {@link TransactionalCacheDecorator}.
+ *
+ * @author William Hoyle
+ * @see TransactionalCacheDecorator
+ * @see TransactionAwareCacheManagerProxy#setCacheDecoratorFactory
+ */
+public class TransactionalCacheDecoratorFactory implements UnaryOperator<Cache> {
+
+	@Override
+	public Cache apply(Cache cache) {
+		return new TransactionalCacheDecorator(cache);
+	}
+}

--- a/spring-context-support/src/test/java/org/springframework/cache/transaction/TransactionalCacheDecoratorTests.java
+++ b/spring-context-support/src/test/java/org/springframework/cache/transaction/TransactionalCacheDecoratorTests.java
@@ -1,0 +1,653 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.transaction;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueRetrievalException;
+import org.springframework.cache.Cache.ValueWrapper;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.lang.Nullable;
+import org.springframework.tests.transaction.CallCountingTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the {@link TransactionalCacheDecorator}.
+ *
+ * @author William Hoyle
+ */
+public class TransactionalCacheDecoratorTests {
+
+	private final PlatformTransactionManager txManager = new CallCountingTransactionManager();
+	private final TransactionTemplate transactionTemplate =
+			new TransactionTemplate(txManager, new DefaultTransactionDefinition(
+					TransactionDefinition.PROPAGATION_REQUIRES_NEW)
+			);
+
+	private final Cache targetCache = new ConcurrentMapCache("cache.test");
+	private final TransactionalCacheDecorator transactionalCacheDecorator =
+			new TransactionalCacheDecorator(targetCache);
+
+	@Before
+	public void init() {
+		targetCache.clear();
+	}
+
+	@Test
+	public void get() {
+		targetCache.put("test", "value");
+		assertEquals("value", targetCache.get("test", String.class));
+		transactionTemplate.execute(status -> {
+			assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+			return null;
+		});
+	}
+
+	@Test
+	public void getNull() {
+		targetCache.put("test", null);
+		transactionTemplate.execute(status -> {
+			assertWrappedValueNull(transactionalCacheDecorator.get("test"));
+			return null;
+		});
+	}
+
+	@Test
+	public void getNoTransaction() {
+		targetCache.put("test", "value");
+		assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+		assertWrappedValueEquals("value", transactionalCacheDecorator.get("test"));
+	}
+
+	@Test
+	public void getNativeCache() {
+		assertNull(transactionalCacheDecorator.getNativeCache());
+	}
+
+	@Test
+	public void getWithValueLoader() {
+		assertNull(targetCache.get("test"));
+		transactionTemplate.execute(status -> {
+			assertNull(transactionalCacheDecorator.get("test", String.class));
+			assertEquals("value", transactionalCacheDecorator.get("test", () -> "value"));
+			// Value should have been loaded
+			assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+			// Value should not have been written to the target cache
+			assertNull(targetCache.get("test"));
+			return null;
+		});
+
+		// Value should have been written to the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void getWithValueLoaderNoTransaction() {
+		assertNull(targetCache.get("test"));
+		assertNull(transactionalCacheDecorator.get("test", String.class));
+		assertEquals("value", transactionalCacheDecorator.get("test", () -> "value"));
+		// Value should have been written to the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void getNullWithValueLoader() {
+		transactionTemplate.execute(status -> {
+			assertNull(transactionalCacheDecorator.get("test", () -> null));
+			// Value should have been loaded
+			assertWrappedValueNull(transactionalCacheDecorator.get("test"));
+			return null;
+		});
+
+		// Null value should have been written to the target cache
+		assertWrappedValueNull(targetCache.get("test"));
+	}
+
+	@Test
+	public void getExistingValueWithValueLoader() {
+		targetCache.put("test", "present");
+		transactionTemplate.execute(status -> {
+			// Get with loader should return the existing value
+			assertEquals("present", transactionalCacheDecorator.get("test", () -> "value"));
+			// Value should not have been reloaded
+			assertEquals("present", transactionalCacheDecorator.get("test", String.class));
+			return null;
+		});
+
+		// Value should not have been updated in the target cache
+		assertEquals("present", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void getExistingNullValueWithValueLoader() {
+		targetCache.put("test", null);
+		transactionTemplate.execute(status -> {
+			// Get with loader should return the existing null mapping
+			assertNull(transactionalCacheDecorator.get("test", () -> "value"));
+			// Null value should not have been overwritten
+			assertWrappedValueNull(transactionalCacheDecorator.get("test"));
+			return null;
+		});
+
+		// Null value should not have been overwritten in the target cache
+		assertWrappedValueNull(targetCache.get("test"));
+	}
+
+	@Test
+	public void getValueRetrievalException() {
+		assertNull(targetCache.get("test"));
+		transactionTemplate.execute(status -> {
+			Callable<Object> loader = () -> {
+				throw new IllegalStateException();
+			};
+			try {
+				transactionalCacheDecorator.get("test", loader);
+				fail("Expected ValueRetrievalException");
+			}
+			catch (ValueRetrievalException e) {
+				assertEquals("test", e.getKey());
+				assertThat(e.getCause(), is(instanceOf(IllegalStateException.class)));
+			}
+			// No value should have been loaded
+			assertNull(transactionalCacheDecorator.get("test"));
+			// Value should not have been written to the target cache
+			assertNull(targetCache.get("test"));
+			return null;
+		});
+
+		// No value should have been written to the target cache
+		assertNull(targetCache.get("test"));
+	}
+
+	@Test
+	public void put() {
+		assertNull(targetCache.get("test"));
+		transactionTemplate.execute(status -> {
+			assertNull(transactionalCacheDecorator.get("test"));
+			transactionalCacheDecorator.put("test", "value");
+			// Value should not have been written to the target cache
+			assertNull(targetCache.get("test"));
+			return null;
+		});
+
+		// Value should have been written to the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void putNull() {
+		assertNull(targetCache.get("test"));
+		transactionTemplate.execute(status -> {
+			transactionalCacheDecorator.put("test", null);
+			// Value should not have been written to the target cache
+			assertNull(targetCache.get("test"));
+			return null;
+		});
+
+		// Null value should have been written to the target cache
+		assertWrappedValueNull(targetCache.get("test"));
+	}
+
+	@Test
+	public void putNoTransaction() {
+		assertNull(targetCache.get("test"));
+		transactionalCacheDecorator.put("test", "value");
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void rollbackPut() {
+		assertNull(targetCache.get("test"));
+		try {
+			transactionTemplate.execute(status -> {
+				transactionalCacheDecorator.put("test", "value");
+				throw new CacheTestException("rollback");
+			});
+			fail("Expected CacheTestException");
+		}
+		catch (CacheTestException e) {
+			// expected
+		}
+
+		// Value should not have been written to the target cache
+		assertNull(targetCache.get("test"));
+	}
+
+	@Test
+	public void rollbackPutNull() {
+		assertNull(targetCache.get("test"));
+		try {
+			transactionTemplate.execute(status -> {
+				transactionalCacheDecorator.put("test", null);
+				throw new CacheTestException("rollback");
+			});
+			fail("Expected CacheTestException");
+		}
+		catch (CacheTestException e) {
+			// expected
+		}
+
+		// Value should not have been written to the target cache
+		assertNull(targetCache.get("test"));
+	}
+
+	@Test
+	public void putIfAbsent() {
+		assertNull(targetCache.get("test"));
+		transactionTemplate.execute(status -> {
+			assertNull(transactionalCacheDecorator.putIfAbsent("test", "value"));
+			// Value should not have been written to the target cache
+			assertNull(targetCache.get("test"));
+			return null;
+		});
+
+		// Value should have been written to the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void putIfAbsentNoTransaction() {
+		assertNull(targetCache.get("test"));
+		assertNull(transactionalCacheDecorator.putIfAbsent("test", "value"));
+		// Value should have been written to the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void rollbackPutIfAbsent() {
+		assertNull(targetCache.get("test"));
+		try {
+			transactionTemplate.execute(status -> {
+				assertNull(transactionalCacheDecorator.putIfAbsent("test", "value"));
+				// Value should have been written to the transactional cache
+				assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+				// Value should not have been written to the target cache
+				assertNull(targetCache.get("test"));
+				throw new CacheTestException("rollback");
+			});
+			fail("Expected CacheTestException");
+		}
+		catch (CacheTestException e) {
+			// expected
+		}
+
+		// Value should not have been written to the target cache
+		assertNull(targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void putIfAbsentWithExistingValue() {
+		targetCache.put("test", "present");
+		transactionTemplate.execute(status -> {
+			// Put if absent should return the existing value if it is already present in the target cache
+			assertWrappedValueEquals("present", transactionalCacheDecorator.putIfAbsent("test", "value"));
+			// Value should not have been updated
+			assertEquals("present", transactionalCacheDecorator.get("test", String.class));
+			return null;
+		});
+
+		// Value in the target cache should no have been overwritten
+		assertEquals("present", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void putNullIfAbsent() {
+		assertNull(targetCache.get("test"));
+		transactionTemplate.execute(status -> {
+			assertNull(transactionalCacheDecorator.putIfAbsent("test", null));
+			// Value should not have been written to the target cache
+			assertNull(targetCache.get("test"));
+			return null;
+		});
+
+		// Null value should have been written to the target cache
+		assertWrappedValueNull(targetCache.get("test"));
+	}
+
+	@Test
+	public void putIfAbsentWithExistingNullValue() {
+		targetCache.put("test", null);
+		transactionTemplate.execute(status -> {
+			// Put if absent should not update if the value is already present in the target cache
+			assertWrappedValueNull(transactionalCacheDecorator.putIfAbsent("test", "value"));
+			// Null value should have been written to the target cache
+			assertWrappedValueNull(targetCache.get("test"));
+			return null;
+		});
+
+		// Value in the target cache should not have been overwritten
+		assertWrappedValueNull(targetCache.get("test"));
+	}
+
+	@Test
+	public void evict() {
+		targetCache.put("test", "value");
+		transactionTemplate.execute(status -> {
+			assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+			transactionalCacheDecorator.evict("test");
+			// Value should have been evicted from the transactional cache
+			assertNull(transactionalCacheDecorator.get("test"));
+			return null;
+		});
+
+		// Value should have been evicted from the target cache
+		assertNull(targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void evictNoTransaction() {
+		targetCache.put("test", "value");
+		transactionalCacheDecorator.evict("test");
+		// Value should have been evicted from the target cache
+		assertNull(targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void rollbackEvict() {
+		targetCache.put("test", "value");
+		try {
+			transactionTemplate.execute(status -> {
+				transactionalCacheDecorator.evict("test");
+				// Value should have been evicted from the transactional cache
+				assertNull(transactionalCacheDecorator.get("test"));
+				throw new CacheTestException("rollback");
+			});
+			fail("Expected CacheTestException");
+		}
+		catch (CacheTestException e) {
+			// expected
+		}
+
+		// Value should not have been evicted from the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void clear() {
+		targetCache.put("test", "value");
+		targetCache.put("test2", "value2");
+		transactionTemplate.execute(status -> {
+			assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+			transactionalCacheDecorator.clear();
+			// Values should have been cleared from the transactional cache
+			assertNull(transactionalCacheDecorator.get("test"));
+			assertNull(transactionalCacheDecorator.get("test2"));
+			// But not the target cache
+			assertEquals("value", targetCache.get("test", String.class));
+			assertEquals("value2", targetCache.get("test2", String.class));
+			return null;
+		});
+
+		// Values should have been cleared from the target cache
+		assertNull(targetCache.get("test"));
+		assertNull(targetCache.get("test2"));
+	}
+
+	@Test
+	public void clearNoTransaction() {
+		targetCache.put("test", "value");
+		targetCache.put("test2", "value2");
+		transactionalCacheDecorator.clear();
+		// Values should have been cleared from the target cache
+		assertNull(targetCache.get("test"));
+		assertNull(targetCache.get("test2"));
+	}
+
+	@Test
+	public void rollbackClear() {
+		targetCache.put("test", "value");
+		targetCache.put("test2", "value2");
+		try {
+			transactionTemplate.execute(status -> {
+				transactionalCacheDecorator.clear();
+				// Values should have been evicted from the transactional cache
+				assertNull(transactionalCacheDecorator.get("test"));
+				assertNull(transactionalCacheDecorator.get("test2"));
+				throw new CacheTestException("rollback");
+			});
+			fail("Expected CacheTestException");
+		}
+		catch (CacheTestException e) {
+			// expected
+		}
+
+		// Values should not have been cleared from the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+		assertEquals("value2", targetCache.get("test2", String.class));
+	}
+
+	@Test
+	public void evictThenPut() {
+		targetCache.put("test", "value");
+		transactionTemplate.execute(status -> {
+			assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+			transactionalCacheDecorator.evict("test");
+			transactionalCacheDecorator.put("test", "updated");
+			// Value should have been overwritten in the transactional cache
+			assertEquals("updated", transactionalCacheDecorator.get("test", String.class));
+			// But not the target cache
+			assertEquals("value", targetCache.get("test", String.class));
+			return null;
+		});
+
+		// Value should have been overwritten in the target cache
+		assertEquals("updated", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void clearThenPut() {
+		targetCache.put("test", "value");
+		targetCache.put("test2", "value2");
+		transactionTemplate.execute(status -> {
+			assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+			transactionalCacheDecorator.clear();
+			transactionalCacheDecorator.put("test", "updated");
+			// Value should have been overwritten in the transactional cache
+			assertEquals("updated", transactionalCacheDecorator.get("test", String.class));
+			// But not the target cache
+			assertEquals("value", targetCache.get("test", String.class));
+			return null;
+		});
+
+		// Value should have been overwritten in the target cache
+		assertEquals("updated", targetCache.get("test", String.class));
+		// Second value should have been cleared
+		assertNull(targetCache.get("test2"));
+	}
+
+	@Test
+	public void threadLocalVisibility() throws InterruptedException, BrokenBarrierException, ExecutionException {
+		assertNull(targetCache.get("test", String.class));
+
+		ExecutorService executor = Executors.newCachedThreadPool();
+		CyclicBarrier barrier = new CyclicBarrier(2);
+
+		// Write thread
+		Future<Boolean> pass = executor.submit(() -> transactionTemplate.execute(status -> {
+			try {
+				// Populate the cache
+				transactionalCacheDecorator.put("test", "value");
+				// Put has populated the cache decorator
+				assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+				// But not the target cache
+				assertNull(targetCache.get("test"));
+				// Sync 1. with the main thread signals that the above write is complete
+				barrier.await();
+				// Sync 2. with the main thread before exit
+				barrier.await();
+				return true;
+			}
+			catch (InterruptedException | BrokenBarrierException e) {
+				throw new AssertionError("Exception waiting for read thread", e);
+			}
+		}));
+
+		transactionTemplate.execute(status -> {
+			try {
+				// Sync 1. with the writer thread after it completes its write
+				barrier.await();
+				// The put from the write thread is not visible in this thread, even
+				// though it is visible in the write thread at this point in time
+				assertNull(transactionalCacheDecorator.get("test"));
+				return null;
+			}
+			catch (InterruptedException | BrokenBarrierException e) {
+				throw new AssertionError("Exception waiting for write thread", e);
+			}
+		});
+
+		// The writer thread will wait on the barrier before the end of its transaction
+
+		// The value should not have been written to the target cache
+		assertNull(targetCache.get("test", String.class));
+
+		// Sync 2. with the writer thread allows it to continue to complete its transaction
+		barrier.await();
+
+		// Join the writer thread
+		assertTrue(pass.get());
+		executor.shutdownNow();
+
+		// Value should have been committed to the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void suspendAndResume() {
+		assertNull(targetCache.get("test"));
+		transactionTemplate.execute(s1 -> {
+			assertNull(transactionalCacheDecorator.get("test"));
+			transactionalCacheDecorator.put("test", "value");
+			// Value should not have been written to the target cache
+			assertNull(targetCache.get("test"));
+
+			// The template is set to "PROPAGATION_REQUIRES_NEW", so running a new
+			// transaction should suspend the existing one.
+			transactionTemplate.execute(s2 -> {
+				// The value written in the outer transaction should not be visible here
+				assertNull(transactionalCacheDecorator.get("test"));
+				transactionalCacheDecorator.put("test", "inner");
+				// Value should not have been written to the target cache
+				assertNull(targetCache.get("test"));
+
+				// The synchronisation strategy can handle multiple suspended transactions
+				transactionTemplate.execute(s3 -> {
+					// The value written in the outer transaction should not be visible here
+					assertNull(transactionalCacheDecorator.get("test"));
+					transactionalCacheDecorator.put("test", "inner2");
+					return null;
+				});
+
+				// Value in the target cache should have been updated by the nested
+				// transaction when it committed
+				assertEquals("inner2", targetCache.get("test", String.class));
+				// But the value visible in this transaction is the one we wrote in this transaction
+				assertEquals("inner", transactionalCacheDecorator.get("test", String.class));
+
+				return null;
+			});
+
+			// Value in the target cache should have been updated by the nested
+			// transaction when it committed
+			assertEquals("inner", targetCache.get("test", String.class));
+			// But the value visible in this transaction is the one we wrote in this transaction
+			assertEquals("value", transactionalCacheDecorator.get("test", String.class));
+			return null;
+		});
+
+		// Value from the outer transaction should have been written to the target cache
+		assertEquals("value", targetCache.get("test", String.class));
+	}
+
+	@Test
+	public void rollbackSuspendAndResume() {
+		assertNull(targetCache.get("test"));
+		try {
+			transactionTemplate.execute(status -> {
+				assertNull(transactionalCacheDecorator.get("test"));
+				transactionalCacheDecorator.put("test", "value");
+
+				// Begin a new transaction
+				transactionTemplate.execute(status2 -> {
+					// The value written in the outer transaction should not be visible here
+					assertNull(transactionalCacheDecorator.get("test"));
+					transactionalCacheDecorator.put("test", "inner");
+
+					// The synchronisation strategy can handle multiple suspended transactions
+					transactionTemplate.execute(status3 -> {
+						// The value written in the outer transaction should not be visible here
+						assertNull(transactionalCacheDecorator.get("test"));
+						transactionalCacheDecorator.put("test", "inner2");
+
+						throw new CacheTestException("rollback");
+					});
+
+					fail("Expected CacheTestException");
+					return null;
+				});
+
+				fail("Expected CacheTestException");
+				return null;
+			});
+
+			fail("Expected CacheTestException");
+		}
+		catch (CacheTestException e) {
+			// expected
+		}
+
+		// Value should not have been written to the target cache
+		assertNull(targetCache.get("test"));
+	}
+
+	/**
+	 * Assert that a {@code ValueWrapper} is non-null and that the wrapped value is null.
+	 */
+	private static void assertWrappedValueNull(@Nullable ValueWrapper wrapper) {
+		assertWrappedValueEquals(null, wrapper);
+	}
+
+	/**
+	 * Assert that a {@code ValueWrapper} is non-null and the wrapped value equals the expected value.
+	 */
+	private static void assertWrappedValueEquals(@Nullable Object expected, @Nullable ValueWrapper wrapper) {
+		assertNotNull(wrapper);
+		assertEquals(expected, wrapper.get());
+	}
+
+	private static class CacheTestException extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+		public CacheTestException(String message) {
+			super(message);
+		}
+	}
+}

--- a/spring-context/src/main/java/org/springframework/cache/support/CacheManagerProxy.java
+++ b/spring-context/src/main/java/org/springframework/cache/support/CacheManagerProxy.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cache.support;
+
+import java.util.Collection;
+import java.util.function.UnaryOperator;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Proxy for a target {@link CacheManager} that decorates caches using the configured
+ * {@link #setCacheDecoratorFactory cache decorator factory}.
+ *
+ * @author Juergen Hoeller
+ * @see #setTargetCacheManager
+ * @see #setCacheDecoratorFactory
+ */
+public class CacheManagerProxy implements CacheManager, InitializingBean {
+
+	@Nullable
+	private CacheManager targetCacheManager;
+
+	@Nullable
+	private UnaryOperator<Cache> cacheDecoratorFactory;
+
+	/**
+	 * Create a new CacheManagerProxy, setting the target
+	 * {@link #setTargetCacheManager cache manager} and
+	 * {@link #setCacheDecoratorFactory cache decorator factory}
+	 * through the bean property setters.
+	 */
+	public CacheManagerProxy() {
+	}
+
+	/**
+	 * Create a new CacheManagerProxy for the given target CacheManager.
+	 * @param targetCacheManager the target CacheManager to proxy
+	 * @param cacheDecoratorFactory factory to use to decorate caches
+	 */
+	public CacheManagerProxy(CacheManager targetCacheManager, UnaryOperator<Cache> cacheDecoratorFactory) {
+		Assert.notNull(targetCacheManager, "Target CacheManager must not be null");
+		Assert.notNull(cacheDecoratorFactory, "cacheDecoratorFactory must not be null");
+		this.targetCacheManager = targetCacheManager;
+		this.cacheDecoratorFactory = cacheDecoratorFactory;
+	}
+
+
+	/**
+	 * Set the target CacheManager to proxy.
+	 */
+	public void setTargetCacheManager(CacheManager targetCacheManager) {
+		this.targetCacheManager = targetCacheManager;
+	}
+
+	/**
+	 * Set the factory to use to decorate caches.
+	 */
+	public void setCacheDecoratorFactory(UnaryOperator<Cache> cacheDecoratorFactory) {
+		this.cacheDecoratorFactory = cacheDecoratorFactory;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		if (this.targetCacheManager == null) {
+			throw new IllegalArgumentException("Property 'targetCacheManager' is required");
+		}
+		if (this.cacheDecoratorFactory == null) {
+			throw new IllegalArgumentException("Property 'cacheDecoratorFactory' is required");
+		}
+	}
+
+	@Override
+	@Nullable
+	public Cache getCache(String name) {
+		Assert.state(this.targetCacheManager != null, "No targetCacheManager set");
+		Assert.state(this.cacheDecoratorFactory != null, "No cacheDecoratorFactory set");
+		Cache targetCache = this.targetCacheManager.getCache(name);
+		return (targetCache != null ? this.cacheDecoratorFactory.apply(targetCache) : null);
+	}
+
+	@Override
+	public Collection<String> getCacheNames() {
+		Assert.state(this.targetCacheManager != null, "No targetCacheManager set");
+		return this.targetCacheManager.getCacheNames();
+	}
+}


### PR DESCRIPTION
This patch adds an alternative to the TransactionAwareCacheDecorator that addresses issues raised in SPR-12756 - it makes writes to decorated caches visible within the scope of the transaction.

It is intended to be minimally obtrusive. The current interface is not changed beyond adding a `setCacheDecoratorFactory` method to the `TransactionAwareCacheManagerProxy` to allow the strategy to be selected. The behaviour defaults to use the existing `TransactionAwareCacheDecorator`. 