### PR TITLE
Make MockRestRequestMatchers independent of JUnit

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/match/MockRestRequestMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/match/MockRestRequestMatchers.java
@@ -32,7 +32,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.util.AssertionErrors.assertEquals;
 import static org.springframework.test.util.AssertionErrors.assertTrue;
 
@@ -148,7 +147,7 @@ public abstract class MockRestRequestMatchers {
 		List<String> values = map.get(name);
 
 		String message = "Expected " + valueType + " <" + name + ">";
-		assertNotNull(message, values);
+		Assert.notNull(values, message);
 
 		assertTrue(message + " to have at least <" + count + "> values but found " + values,
 				count <= values.size());


### PR DESCRIPTION
The MockRestRequestMatchers was using `org.junit.Assert.assertNotNull` and thus it could not be used in projects that use e.g. TestNG instead of JUnit, because this causes a `java.lang.NoClassDefFoundError: org/junit/Assert` at runtime.

This PR removes that dependency.