### PR TITLE
Fix issue: getters and setters should be synchronized in pairs

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/target/AbstractBeanFactoryBasedTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/AbstractBeanFactoryBasedTargetSource.java
@@ -95,7 +95,7 @@ public abstract class AbstractBeanFactoryBasedTargetSource implements TargetSour
 	 * <p>Default is to detect the type automatically, through a {@code getType}
 	 * call on the BeanFactory (or even a full {@code getBean} call as fallback).
 	 */
-	public void setTargetClass(Class<?> targetClass) {
+	public synchronized void setTargetClass(Class<?> targetClass) {
 		this.targetClass = targetClass;
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcAccessor.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcAccessor.java
@@ -98,7 +98,7 @@ public abstract class JdbcAccessor implements InitializingBean {
 	 * @see org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator
 	 * @see org.springframework.jdbc.support.SQLStateSQLExceptionTranslator
 	 */
-	public void setExceptionTranslator(SQLExceptionTranslator exceptionTranslator) {
+	public synchronized void setExceptionTranslator(SQLExceptionTranslator exceptionTranslator) {
 		this.exceptionTranslator = exceptionTranslator;
 	}
 


### PR DESCRIPTION
When one part of a getter/setter pair is synchronized the other part should be too. Failure to synchronize both sides of a pair may result in inconsistent behaviour at runtime as callers access an inconsistent method state.