### PR TITLE
Polish: inner class calls to super class methods should be unambiguous

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/DefaultResourceLoader.java
+++ b/spring-core/src/main/java/org/springframework/core/io/DefaultResourceLoader.java
@@ -204,7 +204,7 @@ public class DefaultResourceLoader implements ResourceLoader {
 		@Override
 		public Resource createRelative(String relativePath) {
 			String pathToUse = StringUtils.applyRelativePath(getPath(), relativePath);
-			return new ClassPathContextResource(pathToUse, getClassLoader());
+			return new ClassPathContextResource(pathToUse, super.getClassLoader());
 		}
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
+++ b/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
@@ -1011,7 +1011,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 		@Override
 		public void release() {
 			enqueue();
-			clear();
+			super.clear();
 		}
 	}
 
@@ -1048,7 +1048,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 		@Override
 		public void release() {
 			enqueue();
-			clear();
+			super.clear();
 		}
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/concurrent/SettableListenableFuture.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/SettableListenableFuture.java
@@ -154,18 +154,18 @@ public class SettableListenableFuture<T> implements ListenableFuture<T> {
 		}
 
 		public boolean setResultValue(@Nullable T value) {
-			set(value);
+			super.set(value);
 			return checkCompletingThread();
 		}
 
 		public boolean setExceptionResult(Throwable exception) {
-			setException(exception);
+			super.setException(exception);
 			return checkCompletingThread();
 		}
 
 		@Override
 		protected void done() {
-			if (!isCancelled()) {
+			if (!super.isCancelled()) {
 				// Implicitly invoked by set/setException: store current thread for
 				// determining whether the given result has actually triggered completion
 				// (since FutureTask.set/setException unfortunately don't expose that)

--- a/spring-messaging/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
@@ -642,7 +642,7 @@ public class MessageHeaderAccessor {
 				return;
 			}
 
-			if (getId() == null) {
+			if (super.getId() == null) {
 				IdGenerator idGenerator = (MessageHeaderAccessor.this.idGenerator != null ?
 						MessageHeaderAccessor.this.idGenerator : MessageHeaders.getIdGenerator());
 				UUID id = idGenerator.generateId();
@@ -651,7 +651,7 @@ public class MessageHeaderAccessor {
 				}
 			}
 
-			if (getTimestamp() == null) {
+			if (super.getTimestamp() == null) {
 				if (MessageHeaderAccessor.this.enableTimestamp) {
 					getRawHeaders().put(TIMESTAMP, System.currentTimeMillis());
 				}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ReactiveTypeHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ReactiveTypeHandler.java
@@ -338,10 +338,10 @@ class ReactiveTypeHandler {
 		protected void send(Object element) throws IOException {
 			if (element instanceof ServerSentEvent) {
 				ServerSentEvent<?> event = (ServerSentEvent<?>) element;
-				((SseEmitter) getEmitter()).send(adapt(event));
+				((SseEmitter) super.getEmitter()).send(adapt(event));
 			}
 			else {
-				getEmitter().send(element, MediaType.APPLICATION_JSON);
+				super.getEmitter().send(element, MediaType.APPLICATION_JSON);
 			}
 		}
 
@@ -380,8 +380,8 @@ class ReactiveTypeHandler {
 
 		@Override
 		protected void send(Object element) throws IOException {
-			getEmitter().send(element, MediaType.APPLICATION_JSON);
-			getEmitter().send("\n", MediaType.TEXT_PLAIN);
+			super.getEmitter().send(element, MediaType.APPLICATION_JSON);
+			super.getEmitter().send("\n", MediaType.TEXT_PLAIN);
 		}
 	}
 
@@ -394,7 +394,7 @@ class ReactiveTypeHandler {
 
 		@Override
 		protected void send(Object element) throws IOException {
-			getEmitter().send(element, MediaType.TEXT_PLAIN);
+			super.getEmitter().send(element, MediaType.TEXT_PLAIN);
 		}
 	}
 


### PR DESCRIPTION
When an inner class extends another class, and both its outer class and its parent class have a method with the same name, calls to that method can be confusing. The compiler will resolve the call to the superclass method, but maintainers may be confused, so the superclass method should be called explicitly, using super.