### PR TITLE
Support Kotlin parameter default values in handler methods

### DIFF
--- a/spring-core/src/test/kotlin/org/springframework/core/KotlinMethodParameterTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/KotlinMethodParameterTests.kt
@@ -36,12 +36,18 @@ class KotlinMethodParameterTests {
 
 	lateinit var nonNullableMethod: Method
 
+	lateinit var withDefaultParameterMethod: Method
+
+	lateinit var withoutDefaultParameterMethod: Method
+
 
 	@Before
 	@Throws(NoSuchMethodException::class)
 	fun setup() {
 		nullableMethod = javaClass.getMethod("nullable", String::class.java)
 		nonNullableMethod = javaClass.getMethod("nonNullable", String::class.java)
+		withDefaultParameterMethod = javaClass.getMethod("withDefaultParameter", String::class.java)
+		withoutDefaultParameterMethod = javaClass.getMethod("withoutDefaultParameter", String::class.java)
 	}
 
 
@@ -57,11 +63,22 @@ class KotlinMethodParameterTests {
 		assertFalse(MethodParameter(nonNullableMethod, -1).isOptional())
 	}
 
+	@Test
+	fun `Method parameter default value`() {
+		assertTrue(MethodParameter(withDefaultParameterMethod, 0).hasDefaultValue())
+		assertFalse(MethodParameter(withoutDefaultParameterMethod, 0).hasDefaultValue())
+	}
 
 	@Suppress("unused", "unused_parameter")
 	fun nullable(p1: String?): Int? = 42
 
 	@Suppress("unused", "unused_parameter")
 	fun nonNullable(p1: String): Int = 42
+
+	@Suppress("unused", "unused_parameter")
+	fun withDefaultParameter(p1: String = "42") = 42
+
+	@Suppress("unused", "unused_parameter")
+	fun withoutDefaultParameter(p1: String) = 42
 
 }

--- a/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
@@ -217,7 +217,7 @@ public class InvocableHandlerMethod extends HandlerMethod {
 	 */
 	protected Object doInvoke(Object... args) throws Exception {
 		ReflectionUtils.makeAccessible(getBridgedMethod());
-		if (kotlinFunction == KOTLIN_NOT_CHECKED) {
+		if (KOTLIN_NOT_CHECKED.equals(kotlinFunction)) {
 			initKotlinFunction();
 		}
 		try {

--- a/spring-web/src/test/kotlin/org/springframework/web/method/annotation/RequestParamMethodArgumentResolverKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/method/annotation/RequestParamMethodArgumentResolverKotlinTests.kt
@@ -62,6 +62,8 @@ class RequestParamMethodArgumentResolverKotlinTests {
 	lateinit var nonNullableMultipartParamRequired: MethodParameter
 	lateinit var nonNullableMultipartParamNotRequired: MethodParameter
 
+	lateinit var defaultParam: MethodParameter
+
 
 	@Before
 	fun setup() {
@@ -75,7 +77,8 @@ class RequestParamMethodArgumentResolverKotlinTests {
 		val method = ReflectionUtils.findMethod(javaClass, "handle", String::class.java,
 				String::class.java, String::class.java, String::class.java,
 				MultipartFile::class.java, MultipartFile::class.java,
-				MultipartFile::class.java, MultipartFile::class.java)!!
+				MultipartFile::class.java, MultipartFile::class.java,
+				String::class.java)!!
 
 		nullableParamRequired = SynthesizingMethodParameter(method, 0)
 		nullableParamNotRequired = SynthesizingMethodParameter(method, 1)
@@ -86,6 +89,8 @@ class RequestParamMethodArgumentResolverKotlinTests {
 		nullableMultipartParamNotRequired = SynthesizingMethodParameter(method, 5)
 		nonNullableMultipartParamRequired = SynthesizingMethodParameter(method, 6)
 		nonNullableMultipartParamNotRequired = SynthesizingMethodParameter(method, 7)
+
+		defaultParam = SynthesizingMethodParameter(method, 8)
 	}
 
 	@Test
@@ -138,6 +143,18 @@ class RequestParamMethodArgumentResolverKotlinTests {
 		resolver.resolveArgument(nonNullableParamNotRequired, null, webRequest, binderFactory) as String
 	}
 
+	@Test
+	fun resolveDefaultValueWithoutParameter() {
+		val result = resolver.resolveArgument(defaultParam, null, webRequest, binderFactory)
+		assertNull(result)
+	}
+
+	@Test
+	fun resolveDefaultValueWithParameter() {
+		request.addParameter("name", "123")
+		val result = resolver.resolveArgument(defaultParam, null, webRequest, binderFactory)
+		assertEquals("123", result)
+	}
 
 	@Test
 	fun resolveNullableRequiredWithMultipartParameter() {
@@ -215,7 +232,6 @@ class RequestParamMethodArgumentResolverKotlinTests {
 		resolver.resolveArgument(nonNullableMultipartParamNotRequired, null, webRequest, binderFactory) as MultipartFile
 	}
 
-
 	@Suppress("unused_parameter")
 	fun handle(
 			@RequestParam("name") nullableParamRequired: String?,
@@ -226,7 +242,9 @@ class RequestParamMethodArgumentResolverKotlinTests {
 			@RequestParam("mfile") nullableMultipartParamRequired: MultipartFile?,
 			@RequestParam("mfile", required = false) nullableMultipartParamNotRequired: MultipartFile?,
 			@RequestParam("mfile") nonNullableMultipartParamRequired: MultipartFile,
-			@RequestParam("mfile", required = false) nonNullableMultipartParamNotRequired: MultipartFile) {
+			@RequestParam("mfile", required = false) nonNullableMultipartParamNotRequired: MultipartFile,
+
+			@RequestParam("name") paramDefaultValue: String = "42") {
 	}
 
 }


### PR DESCRIPTION
Allows using default parameter values for any method parameters resolved
via `AbstractNamedValueMethodArgumentResolver`, similar to `defaultValue`
parameter of e.g. `@RequestParam` annotation, but skipping the converter
chain.

Issues: [SPR-16598](https://jira.spring.io/browse/SPR-16598).