### PR TITLE
SPR-16604 - Prevent response body from being read at DefaultResponseErrorHandler.hasError() on unknown HTTP status code

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
@@ -37,6 +37,7 @@ import org.springframework.util.FileCopyUtils;
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
  * @author Juergen Hoeller
+ * @author Denys Ivano
  * @since 3.0
  * @see RestTemplate#setErrorHandler
  */
@@ -46,13 +47,15 @@ public class DefaultResponseErrorHandler implements ResponseErrorHandler {
 	 * Delegates to {@link #hasError(HttpStatus)} with the response status code.
 	 */
 	@Override
-	public boolean hasError(ClientHttpResponse response) throws IOException {
+        public boolean hasError(ClientHttpResponse response) throws IOException {
+		HttpStatus statusCode;
 		try {
-			return hasError(getHttpStatusCode(response));
+			statusCode = response.getStatusCode();
 		}
-		catch (UnknownHttpStatusCodeException ex) {
+		catch (IllegalArgumentException ex) {
 			return false;
 		}
+		return hasError(statusCode);
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class DefaultResponseErrorHandler implements ResponseErrorHandler {
 	 * Delegates to {@link #hasError(HttpStatus)} with the response status code.
 	 */
 	@Override
-        public boolean hasError(ClientHttpResponse response) throws IOException {
+	public boolean hasError(ClientHttpResponse response) throws IOException {
 		HttpStatus statusCode;
 		try {
 			statusCode = response.getStatusCode();

--- a/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerTests.java
@@ -18,6 +18,7 @@ package org.springframework.web.client;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 import org.junit.Test;
 
@@ -25,6 +26,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StreamUtils;
 
 import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.*;
@@ -34,8 +36,11 @@ import static org.mockito.BDDMockito.*;
  *
  * @author Arjen Poutsma
  * @author Juergen Hoeller
+ * @author Denys Ivano
  */
 public class DefaultResponseErrorHandlerTests {
+
+	private final Charset UTF8 = Charset.forName("UTF-8");
 
 	private final DefaultResponseErrorHandler handler = new DefaultResponseErrorHandler();
 
@@ -120,6 +125,57 @@ public class DefaultResponseErrorHandlerTests {
 		given(response.getHeaders()).willReturn(headers);
 
 		assertFalse(handler.hasError(response));
+	}
+
+	@Test  // SPR-16604
+	public void bodyAvailableAfterHasErrorForUnknownStatusCode() throws Exception {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.TEXT_PLAIN);
+		TestByteArrayInputStream body = new TestByteArrayInputStream("Hello World".getBytes("UTF-8"));
+
+		given(response.getStatusCode()).willThrow(new IllegalArgumentException("No matching constant for 999"));
+		given(response.getStatusText()).willReturn("Custom status code");
+		given(response.getHeaders()).willReturn(headers);
+		given(response.getBody()).willReturn(body);
+
+		assertFalse(handler.hasError(response));
+		assertFalse(body.isClosed());
+		assertEquals("Hello World", StreamUtils.copyToString(response.getBody(), UTF8));
+	}
+
+	class TestByteArrayInputStream extends ByteArrayInputStream {
+
+		private boolean closed;
+
+		public TestByteArrayInputStream(byte[] buf) {
+			super(buf);
+			this.closed = false;
+		}
+
+		public boolean isClosed() {
+			return closed;
+		}
+
+		@Override
+		public boolean markSupported() {
+			return false;
+		}
+
+		@Override
+		public synchronized void mark(int readlimit) {
+			throw new UnsupportedOperationException("mark/reset not supported");
+		}
+
+		@Override
+		public synchronized void reset() {
+			throw new UnsupportedOperationException("mark/reset not supported");
+		}
+
+		@Override
+		public void close() throws IOException {
+			super.close();
+			this.closed = true;
+		}
 	}
 
 }


### PR DESCRIPTION
When response contains HTTP status code not defined in `HttpStatus` enum, `DefaultResponseErrorHandler.hasError(ClientHttpResponse response)` calls `getHttpStatusCode(ClientHttpResponse response)` which reads response body and throws `UnknownHttpStatusCodeException`. In this case `false` value will be returned (which means response doesn't have error) and `ResponseExtractor.extract()` in `RestTemplate` is called with response which body has been already read.

Issue: [SPR-16604](https://jira.spring.io/browse/SPR-16604)