### PR TITLE
Fix AsciiDoc typos in AOP documentation

### DIFF
--- a/src/docs/asciidoc/core/core-aop.adoc
+++ b/src/docs/asciidoc/core/core-aop.adoc
@@ -1630,7 +1630,7 @@ using the `ref` attribute:
 	</bean>
 ----
 
-The bean backing the aspect (" `aBean`" in this case) can of course be configured and
+The bean backing the aspect (" `aBean` " in this case) can of course be configured and
 dependency injected just like any other Spring bean.
 
 
@@ -1732,7 +1732,7 @@ the keywords 'and', 'or' and 'not' can be used in place of '&&', '||' and '!'
 respectively. For example, the previous pointcut may be better written as:
 
 [source,xml,indent=0]
-[subs="verbatim"]
+[subs="verbatim,quotes"]
 ----
 	<aop:config>
 

--- a/src/docs/asciidoc/core/core-aop.adoc
+++ b/src/docs/asciidoc/core/core-aop.adoc
@@ -1630,7 +1630,7 @@ using the `ref` attribute:
 	</bean>
 ----
 
-The bean backing the aspect (" `aBean` " in this case) can of course be configured and
+The bean backing the aspect (`"aBean"` in this case) can of course be configured and
 dependency injected just like any other Spring bean.
 
 

--- a/src/docs/asciidoc/core/core-aop.adoc
+++ b/src/docs/asciidoc/core/core-aop.adoc
@@ -1727,8 +1727,8 @@ parameters of the matching names:
 	}
 ----
 
-When combining pointcut sub-expressions, '&&' is awkward within an XML document, and so
-the keywords 'and', 'or' and 'not' can be used in place of '&&', '||' and '!'
+When combining pointcut sub-expressions, `&&` is awkward within an XML document, and so
+the keywords `and`, `or`, and `not` can be used in place of `&&`, `||`, and `!`
 respectively. For example, the previous pointcut may be better written as:
 
 [source,xml,indent=0]


### PR DESCRIPTION
"Obvious Fix" of AsciiDoc typos in AOP documentation.