### PR TITLE
SPR-16630 - Delete white space befor and after the delimiter

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -224,8 +224,8 @@ public abstract class MimeTypeUtils {
 				}
 				int eqIndex = parameter.indexOf('=');
 				if (eqIndex >= 0) {
-					String attribute = parameter.substring(0, eqIndex);
-					String value = parameter.substring(eqIndex + 1, parameter.length());
+					String attribute = parameter.substring(0, eqIndex).trim();
+					String value = parameter.substring(eqIndex + 1, parameter.length()).trim();
 					parameters.put(attribute, value);
 				}
 			}


### PR DESCRIPTION
An error occurs if a blank character exists before and after the delimiter of the MIME type parameter.

example:
```
Caused by: org.springframework.util.InvalidMimeTypeException: Invalid mime type "multipart/x-mixed-replace;boundary = --myboundary": Invalid token character ' ' in token "boundary "
	at org.springframework.util.MimeTypeUtils.parseMimeType
```
