### PR TITLE
SPR-16628 - Improve NoSuchBeanDefinitionException to include a reference to the dependent bean

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/NoSuchBeanDefinitionException.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/NoSuchBeanDefinitionException.java
@@ -41,6 +41,9 @@ public class NoSuchBeanDefinitionException extends BeansException {
 	@Nullable
 	private ResolvableType resolvableType;
 
+	@Nullable
+	private ResolvableType dependentBeanType;
+
 
 	/**
 	 * Create a new {@code NoSuchBeanDefinitionException}.
@@ -59,6 +62,12 @@ public class NoSuchBeanDefinitionException extends BeansException {
 	public NoSuchBeanDefinitionException(String name, String message) {
 		super("No bean named '" + name + "' available: " + message);
 		this.beanName = name;
+	}
+
+	public NoSuchBeanDefinitionException(String name, ResolvableType dependentBeanType) {
+		super("'" + dependentBeanType + "' depends on a bean named '" + name + "' but it wasn't available");
+		this.beanName = name;
+		this.dependentBeanType = dependentBeanType;
 	}
 
 	/**
@@ -99,7 +108,6 @@ public class NoSuchBeanDefinitionException extends BeansException {
 		this.resolvableType = type;
 	}
 
-
 	/**
 	 * Return the name of the missing bean, if it was a lookup <em>by name</em> that failed.
 	 */
@@ -134,6 +142,11 @@ public class NoSuchBeanDefinitionException extends BeansException {
 	 */
 	public int getNumberOfBeansFound() {
 		return 0;
+	}
+
+	@Nullable
+	public ResolvableType getDependentBeanType() {
+		return this.dependentBeanType;
 	}
 
 }

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -300,7 +300,18 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 									"Circular depends-on relationship between '" + beanName + "' and '" + dep + "'");
 						}
 						registerDependentBean(dep, beanName);
-						getBean(dep);
+						try {
+							getBean(dep);
+						}catch(NoSuchBeanDefinitionException ex) {
+							Class dependentClass = null;
+							try {
+								dependentClass = Class.forName(mbd.getBeanClassName());
+							}
+							catch (ClassNotFoundException e) {} //swallow
+							finally {
+								throw new NoSuchBeanDefinitionException(dep, ResolvableType.forClass(dependentClass));
+							}
+						}
 					}
 				}
 


### PR DESCRIPTION
[SPR-16628](https://jira.spring.io/browse/SPR-16628)

This PR allows a `NoSuchBeanDefinitionException` to refer to the dependent bean which improves clarity and traceability.

Additionally this information will be useful in a Spring Boot Failure Analyzer.