### PR TITLE
SPR-16642 - DefaultMessageListenerContainer JMS Pool leak with CACHE_CONSUMER and Bitronix in error path

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/listener/DefaultMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/DefaultMessageListenerContainer.java
@@ -540,7 +540,7 @@ public class DefaultMessageListenerContainer extends AbstractPollingMessageListe
 	public void initialize() {
 		// Adapt default cache level.
 		if (this.cacheLevel == CACHE_AUTO) {
-			this.cacheLevel = (getTransactionManager() != null && !this.cacheSharedConnection ? CACHE_NONE : CACHE_CONSUMER);
+			this.cacheLevel = (getTransactionManager() != null && this.cacheSharedConnection ? CACHE_NONE : CACHE_CONSUMER);
 		}
 
 		// Prepare taskExecutor and maxMessagesPerTask.

--- a/spring-jms/src/main/java/org/springframework/jms/listener/DefaultMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/DefaultMessageListenerContainer.java
@@ -1237,6 +1237,7 @@ public class DefaultMessageListenerContainer extends AbstractPollingMessageListe
 					this.connection = getSharedConnection();
 				} else {
 					this.connection = createConnection();
+					this.connection.start();
 				}
 				if (this.session == null && getCacheLevel() >= CACHE_SESSION) {
 					updateRecoveryMarker();
@@ -1274,7 +1275,7 @@ public class DefaultMessageListenerContainer extends AbstractPollingMessageListe
 			else {
 				JmsUtils.closeMessageConsumer(this.consumer);
 				JmsUtils.closeSession(this.session);
-				JmsUtils.closeConnection(this.connection);
+				JmsUtils.closeConnection(this.connection, true);
 			}
 			if (this.consumer != null) {
 				synchronized (lifecycleMonitor) {


### PR DESCRIPTION
f the error handling path in the DefaultMessageListenerContainer the JMS connection is closed and re-opened.

Combining this with CACHE_CONSUMER with bitronix results in an error from DualSessionWrapper due to the Connection being involved in multiple XA transactions during the close attempt, which bitronix rejects and DMLC logs, swallows and continues.

This results in the Connection not being closed and a new Connection obtained from the bitronix pool resulting in a gradual leak from the pool.

Utilising dedicated connections alleviates this and enables CACHE_CONSUMER to function without issue. So making this a configuration option to not use the shared connection whilst CACHE_* is enabled means we can avoid this path and only have a single thread using a dedicated connection avoiding the multiple active transaction close issue.