### PR TITLE
Polish: "equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/support/MethodMatchers.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/MethodMatchers.java
@@ -18,6 +18,7 @@ package org.springframework.aop.support;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 import org.springframework.aop.ClassFilter;
 import org.springframework.aop.IntroductionAwareMethodMatcher;
@@ -208,6 +209,11 @@ public abstract class MethodMatchers {
 				otherCf2 = cfa.cf2;
 			}
 			return (this.cf1.equals(otherCf1) && this.cf2.equals(otherCf2));
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), cf1, cf2);
 		}
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/DependencyDescriptor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/DependencyDescriptor.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import kotlin.reflect.KProperty;
@@ -388,6 +389,10 @@ public class DependencyDescriptor extends InjectionPoint implements Serializable
 				this.nestingLevel == otherDesc.nestingLevel && this.containingClass == otherDesc.containingClass);
 	}
 
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), required, eager, nestingLevel, containingClass);
+	}
 
 	//---------------------------------------------------------------------
 	// Serialization support

--- a/spring-jms/src/main/java/org/springframework/jms/connection/CachingConnectionFactory.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/CachingConnectionFactory.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.jms.Connection;
@@ -578,6 +579,11 @@ public class CachingConnectionFactory extends SingleConnectionFactory {
 					ObjectUtils.nullSafeEquals(this.noLocal, otherKey.noLocal) &&
 					ObjectUtils.nullSafeEquals(this.subscription, otherKey.subscription) &&
 					this.durable == otherKey.durable);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), selector, noLocal, subscription, durable);
 		}
 
 		@Override


### PR DESCRIPTION
According to the Java Language Specification, there is a contract between equals(Object) and hashCode()