### PR TITLE
SPR-16663 - Update NamedParameterUtils.parseSqlStatement

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
@@ -130,7 +130,7 @@ public abstract class NamedParameterUtils {
 						throw new InvalidDataAccessApiUsageException(
 								"Non-terminated named parameter declaration at position " + i + " in statement: " + sql);
 					}
-					if (j - i > 3) {
+					if (j - i > 2) {
 						parameter = sql.substring(i + 2, j);
 						namedParameterCount = addNewNamedParameter(namedParameters, namedParameterCount, parameter);
 						totalParameterCount = addNamedParameter(parameterList, totalParameterCount, escapes, i, j + 1, parameter);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterUtilsTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/namedparam/NamedParameterUtilsTests.java
@@ -253,6 +253,18 @@ public class NamedParameterUtilsTests {
 		assertEquals(expectedSql2, finalSql2);
 	}
 
+	@Test
+	public void parseSqlStatementWithSingleLetterInBrackets() {
+		String expectedSql = "select foo from bar where baz = b?z";
+		String sql = "select foo from bar where baz = b:{p}z";
+		
+		ParsedSql parsedSql = NamedParameterUtils.parseSqlStatement(sql);
+		assertEquals(1, parsedSql.getParameterNames().size());
+		assertEquals("p", parsedSql.getParameterNames().get(0));
+		String finalSql = NamedParameterUtils.substituteNamedParameters(parsedSql, null);
+		assertEquals(expectedSql, finalSql);
+	}
+
 	@Test  // SPR-2544
 	public void parseSqlStatementWithLogicalAnd() {
 		String expectedSql = "xxx & yyyy";


### PR DESCRIPTION
In my opinion, we should parse `:{x}` style parameter as `x` is parameter using `NamedParameterUtils.parseSqlStatement`,
so the condition `j - i > 2` is the correct condition, not `j - i > 3`, because if `i` is the index of
`:` in `:{x}`, and `j` is the index of `}` in `:{x}`,  `j - i == 3` is true.
Also add a test case for SPR-16663.