### PR TITLE
Polish: remove unreachable statement

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java
@@ -127,9 +127,6 @@ public class TypeReference extends SpelNodeImpl {
 			else if (this.type == Long.TYPE) {
 				mv.visitFieldInsn(GETSTATIC, "java/lang/Long", "TYPE", "Ljava/lang/Class;");
 			}
-			else if (this.type == Boolean.TYPE) {
-				mv.visitFieldInsn(GETSTATIC, "java/lang/Boolean", "TYPE", "Ljava/lang/Class;");
-	        }
 		}
 		else {
 			mv.visitLdcInsn(Type.getType(this.type));


### PR DESCRIPTION
Branch can not be reached because the condition duplicates a previous condition in the same sequence of "if/else if" statements from [line 109](https://github.com/igor-suhorukov/spring-framework/blob/d2f9090766a3f4f92266de7a0552b23ae1a05f60/spring-expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java#L109)