### PR TITLE
Fix inclusion of license in jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ configure(subprojects - project(":spring-build-src")) { subproject ->
 		manifest.attributes["Created-By"] =
 				"${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
 
-		from("${rootProject.projectDir}/src/dist") {
+		from("${rootProject.projectDir}/src/docs/dist") {
 			include "license.txt"
 			include "notice.txt"
 			into "META-INF"


### PR DESCRIPTION
The path to license.txt and notice.txt is pointing to a non-existent directory.