### PR TITLE
Rename SingleColumnRowMapperTest to align with the other tests

### DIFF
--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/SingleColumnRowMapperTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/SingleColumnRowMapperTests.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.*;
  * @author Kazuki Shimizu
  * @since 5.0.4
  */
-public class SingleColumnRowMapperTest {
+public class SingleColumnRowMapperTests {
 
 	@Test // SPR-16483
 	public void useDefaultConversionService() throws SQLException {


### PR DESCRIPTION
This PR renames `SingleColumnRowMapperTest` to align with the other tests.