### PR TITLE
MockHttpServletRequest return the requested Content-Type.

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -392,18 +392,6 @@ public class MockHttpServletRequest implements HttpServletRequest {
 	@Override
 	public void setCharacterEncoding(@Nullable String characterEncoding) {
 		this.characterEncoding = characterEncoding;
-		updateContentTypeHeader();
-	}
-
-	private void updateContentTypeHeader() {
-		if (StringUtils.hasLength(this.contentType)) {
-			StringBuilder sb = new StringBuilder(this.contentType);
-			if (!this.contentType.toLowerCase().contains(CHARSET_PREFIX) &&
-					StringUtils.hasLength(this.characterEncoding)) {
-				sb.append(";").append(CHARSET_PREFIX).append(this.characterEncoding);
-			}
-			doAddHeaderValue(HttpHeaders.CONTENT_TYPE, sb.toString(), true);
-		}
 	}
 
 	/**
@@ -480,7 +468,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 					this.characterEncoding = contentType.substring(charsetIndex + CHARSET_PREFIX.length());
 				}
 			}
-			updateContentTypeHeader();
+			doAddHeaderValue(HttpHeaders.CONTENT_TYPE, contentType, false);
 		}
 	}
 

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
@@ -159,19 +159,21 @@ public class MockHttpServletRequestTests {
 
 	@Test
 	public void setContentTypeThenCharacterEncoding() {
-		request.setContentType("test/plain");
+		String contentType = "test/plain";
+		request.setContentType(contentType);
 		request.setCharacterEncoding("UTF-8");
-		assertEquals("test/plain", request.getContentType());
-		assertEquals("test/plain;charset=UTF-8", request.getHeader(HttpHeaders.CONTENT_TYPE));
+		assertEquals(contentType, request.getContentType());
+		assertEquals(contentType, request.getHeader(HttpHeaders.CONTENT_TYPE));
 		assertEquals("UTF-8", request.getCharacterEncoding());
 	}
 
 	@Test
 	public void setCharacterEncodingThenContentType() {
+		String contentType = "test/plain";
 		request.setCharacterEncoding("UTF-8");
-		request.setContentType("test/plain");
-		assertEquals("test/plain", request.getContentType());
-		assertEquals("test/plain;charset=UTF-8", request.getHeader(HttpHeaders.CONTENT_TYPE));
+		request.setContentType(contentType);
+		assertEquals(contentType, request.getContentType());
+		assertEquals(contentType, request.getHeader(HttpHeaders.CONTENT_TYPE));
 		assertEquals("UTF-8", request.getCharacterEncoding());
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/HtmlUnitRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/HtmlUnitRequestBuilderTests.java
@@ -159,13 +159,13 @@ public class HtmlUnitRequestBuilderTests {
 
 	@Test  // SPR-14916
 	public void buildRequestContentTypeWithFormSubmission() {
+		String contentType = "application/x-www-form-urlencoded";
 		webRequest.setEncodingType(FormEncodingType.URL_ENCODED);
 
 		MockHttpServletRequest actualRequest = requestBuilder.buildRequest(servletContext);
 
-		assertThat(actualRequest.getContentType(), equalTo("application/x-www-form-urlencoded"));
-		assertThat(actualRequest.getHeader("Content-Type"),
-				equalTo("application/x-www-form-urlencoded;charset=ISO-8859-1"));
+		assertThat(actualRequest.getContentType(), equalTo(contentType));
+		assertThat(actualRequest.getHeader("Content-Type"), equalTo(contentType));
 	}
 
 


### PR DESCRIPTION
This PR updates MockHttpServletRequest does not overwrite Content-Type.

Issues: [SPR-16679](https://jira.spring.io/browse/SPR-16679)