### PR TITLE
Fix docs formatting

### DIFF
--- a/src/docs/asciidoc/core/core-appendix.adoc
+++ b/src/docs/asciidoc/core/core-appendix.adoc
@@ -156,7 +156,7 @@ Now consider a setter of type `PersistenceContextType`:
 	}
 ----
 
-.. and the corresponding bean definition:
+and the corresponding bean definition:
 
 [source,xml,indent=0]
 [subs="verbatim,quotes"]

--- a/src/docs/asciidoc/core/core-databuffer-codec.adoc
+++ b/src/docs/asciidoc/core/core-databuffer-codec.adoc
@@ -43,6 +43,8 @@ This is different from the JDK's `ByteBuffer`, which only exposes one position f
 writing, and a separate `flip()` operation to switch between the two  I/O operations.
 In general, the following invariant holds for the read position, write position, and the capacity:
 
+[literal]
+[subs="verbatim,quotes"]
 --
 	`0` <= _read position_ <= _write position_ <= _capacity_
 --


### PR DESCRIPTION
"Obvious Fix" of AsciiDoc formatting errors in core appendix documentation and data buffer documentation.

