### PR TITLE
SPR-16642 - DefaultMessageListenerContainer JMS Pool leak with CACHE_CONSUMER and Bitronix in error path

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/listener/DefaultMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/DefaultMessageListenerContainer.java
@@ -1235,7 +1235,8 @@ public class DefaultMessageListenerContainer extends AbstractPollingMessageListe
 			else {
 				if ( sharedConnectionEnabled() ) {
 					this.connection = getSharedConnection();
-				} else {
+				}
+				else {
 					if (this.connection == null && getCacheLevel() >= CACHE_CONNECTION) {
 						this.connection = createConnection();
 						this.connection.start();


### PR DESCRIPTION
Add a boolean flag to control the use of a dedicated connection for caching.

This enables using a dedicated connection per task which may be required
for some XA Transaction managers to avoid connection closing issues
in the error handling path resulting in a leak from a connection pool.

This has been seen with CACHE_CONSUMER and btm at least.