### PR TITLE
Remove unnecessary iterator allocation in type handlers

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/AbstractMethodMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/AbstractMethodMessageHandler.java
@@ -84,7 +84,7 @@ public abstract class AbstractMethodMessageHandler<T>
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	private Collection<String> destinationPrefixes = new ArrayList<>();
+	private final List<String> destinationPrefixes = new ArrayList<>();
 
 	private final List<HandlerMethodArgumentResolver> customArgumentResolvers = new ArrayList<>(4);
 
@@ -428,7 +428,9 @@ public abstract class AbstractMethodMessageHandler<T>
 		if (CollectionUtils.isEmpty(this.destinationPrefixes)) {
 			return destination;
 		}
-		for (String prefix : this.destinationPrefixes) {
+		// Avoid unnecessary iterator allocation
+		for (int i = 0, size = this.destinationPrefixes.size(); i < size; i++) {
+			String prefix = this.destinationPrefixes.get(i);
 			if (destination.startsWith(prefix)) {
 				return destination.substring(prefix.length());
 			}

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/HandlerMethodArgumentResolverComposite.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/HandlerMethodArgumentResolverComposite.java
@@ -71,9 +71,7 @@ public class HandlerMethodArgumentResolverComposite implements HandlerMethodArgu
 			@Nullable List<? extends HandlerMethodArgumentResolver> argumentResolvers) {
 
 		if (argumentResolvers != null) {
-			for (HandlerMethodArgumentResolver resolver : argumentResolvers) {
-				this.argumentResolvers.add(resolver);
-			}
+			this.argumentResolvers.addAll(argumentResolvers);
 		}
 		return this;
 	}

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/HandlerMethodReturnValueHandlerComposite.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/HandlerMethodReturnValueHandlerComposite.java
@@ -71,9 +71,7 @@ public class HandlerMethodReturnValueHandlerComposite implements AsyncHandlerMet
 			@Nullable List<? extends HandlerMethodReturnValueHandler> handlers) {
 
 		if (handlers != null) {
-			for (HandlerMethodReturnValueHandler handler : handlers) {
-				this.returnValueHandlers.add(handler);
-			}
+			this.returnValueHandlers.addAll(handlers);
 		}
 		return this;
 	}
@@ -85,7 +83,9 @@ public class HandlerMethodReturnValueHandlerComposite implements AsyncHandlerMet
 
 	@Nullable
 	private HandlerMethodReturnValueHandler getReturnValueHandler(MethodParameter returnType) {
-		for (HandlerMethodReturnValueHandler handler : this.returnValueHandlers) {
+		// Avoid allocating an iterator
+		for (int i = 0, size = this.returnValueHandlers.size(); i < size; i++) {
+			HandlerMethodReturnValueHandler handler = this.returnValueHandlers.get(i);
 			if (handler.supportsReturnType(returnType)) {
 				return handler;
 			}


### PR DESCRIPTION
HandlerMethodReturnValueHandlerComposite and
AbstractMethodMessageHandler iterate using index over collections
implementing RandomAccess to avoid unnecessary iterators.