### PR TITLE
Fix CorsWebFilter of WebFlux example

### DIFF
--- a/src/docs/asciidoc/web/webflux-cors.adoc
+++ b/src/docs/asciidoc/web/webflux-cors.adoc
@@ -228,7 +228,7 @@ CorsWebFilter corsFilter() {
 	config.addAllowedHeader("*");
 	config.addAllowedMethod("*");
 
-	UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+	UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource(new PathPatternParser());
 	source.registerCorsConfiguration("/**", config);
 
 	return new CorsWebFilter(source);


### PR DESCRIPTION
pass `new PathPatternParser()` to `UrlBasedCorsConfigurationSource` constructor