### PR TITLE
SPR-16729 - Add generic matches assertion to JsonPathAssertions

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/JsonPathAssertions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/JsonPathAssertions.java
@@ -16,6 +16,8 @@
 
 package org.springframework.test.web.reactive.server;
 
+import org.hamcrest.Matcher;
+
 import org.springframework.test.util.JsonPathExpectationsHelper;
 
 /**
@@ -132,4 +134,11 @@ public class JsonPathAssertions {
 		return this.bodySpec;
 	}
 
+	/**
+	 * Applies {@link JsonPathExpectationsHelper#assertValue(String, Matcher)}
+	 */
+	public <T> WebTestClient.BodyContentSpec matches(Matcher<T> matcher) {
+		this.pathHelper.assertValue(this.content, matcher);
+		return this.bodySpec;
+	}
 }

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
@@ -18,8 +18,8 @@ package org.springframework.test.web.reactive.server.samples;
 
 import java.net.URI;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
-import reactor.core.publisher.Flux;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +30,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Flux;
 
 /**
  * Samples of tests using {@link WebTestClient} with serialized JSON content.
@@ -62,6 +64,19 @@ public class JsonContentTests {
 				.jsonPath("$[0].name").isEqualTo("Jane")
 				.jsonPath("$[1].name").isEqualTo("Jason")
 				.jsonPath("$[2].name").isEqualTo("John");
+	}
+
+	@Test
+	public void jsonPathMatches() {
+		this.client.get().uri("/persons")
+				.accept(MediaType.APPLICATION_JSON_UTF8)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody()
+				.jsonPath("$[*]").matches(Matchers.hasSize(3))
+				.jsonPath("$[0].name").matches(Matchers.is("Jane"))
+				.jsonPath("$[1].name").matches(Matchers.is("Jason"))
+				.jsonPath("$[2].name").matches(Matchers.is("John"));
 	}
 
 	@Test // https://stackoverflow.com/questions/49149376/webtestclient-check-that-jsonpath-contains-sub-string


### PR DESCRIPTION
Adds a generic matches assertion to JsonPathAssertions that
can use a generic Hamcrest Matcher.

Issue: SPR-16729