### PR TITLE
Added bean DSL function to get all beans of a given type

### DIFF
--- a/spring-context/src/main/kotlin/org/springframework/context/support/BeanDefinitionDsl.kt
+++ b/spring-context/src/main/kotlin/org/springframework/context/support/BeanDefinitionDsl.kt
@@ -232,6 +232,17 @@ open class BeanDefinitionDsl(private val condition: (ConfigurableEnvironment) ->
 		null -> context.getBean(T::class.java)
 		else -> context.getBean(name, T::class.java)
 	}
+		
+	/**
+	 * Get references to the all available beans for a given type with the syntax
+	 * `refAll<Foo>()`.
+	 * @param T type the beans must match, can be an interface or superclass
+	 * @return a Map with the matching beans, containing the bean names as
+	 * keys and the corresponding bean instances as values
+	 */
+	inline fun <reified T : Any> BeanDefinitionDsl.refAll() : Map<String, T> {
+		return context.getBeansOfType(T::class.java)
+	}
 
 	/**
 	 * Take in account bean definitions enclosed in the provided lambda only when the

--- a/spring-context/src/main/kotlin/org/springframework/context/support/BeanDefinitionDsl.kt
+++ b/spring-context/src/main/kotlin/org/springframework/context/support/BeanDefinitionDsl.kt
@@ -240,7 +240,7 @@ open class BeanDefinitionDsl(private val condition: (ConfigurableEnvironment) ->
 	 * @return a Map with the matching beans, containing the bean names as
 	 * keys and the corresponding bean instances as values
 	 */
-	inline fun <reified T : Any> BeanDefinitionDsl.refAll() : Map<String, T> {
+	inline fun <reified T : Any> refAll() : Map<String, T> {
 		return context.getBeansOfType(T::class.java)
 	}
 


### PR DESCRIPTION
This is a DSL equivalent of autowiring a list of a bean type into a component.

The issue was originally raised in [this](https://stackoverflow.com/q/49936982/4465208) StackOverflow question, which contains a code example as well.