### PR TITLE
SPR-16766 - Improve performance of StringUtils#trimWhitespace

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -209,14 +209,18 @@ public abstract class StringUtils {
 			return str;
 		}
 
-		StringBuilder sb = new StringBuilder(str);
-		while (sb.length() > 0 && Character.isWhitespace(sb.charAt(0))) {
-			sb.deleteCharAt(0);
+		int beginIndex = 0;
+		int endIndex = str.length() - 1;
+
+		while (beginIndex <= endIndex && Character.isWhitespace(str.charAt(beginIndex))) {
+			beginIndex++;
 		}
-		while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1))) {
-			sb.deleteCharAt(sb.length() - 1);
+
+		while (endIndex > beginIndex && Character.isWhitespace(str.charAt(endIndex))) {
+			endIndex--;
 		}
-		return sb.toString();
+
+		return str.substring(beginIndex, endIndex + 1);
 	}
 
 	/**


### PR DESCRIPTION
Issue: SPR-16766
Cutting whitespaces once prevents calling System#arrayCopy on every deleted char. With using String#substring method it would be called just once.