### PR TITLE
Avoid message listener recovery in case of persistence exceptions from external transaction manager

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/AbstractPollingMessageListenerContainer.java
@@ -248,7 +248,19 @@ public abstract class AbstractPollingMessageListenerContainer extends AbstractMe
 				rollbackOnException(this.transactionManager, status, ex);
 				throw ex;
 			}
-			this.transactionManager.commit(status);
+			try {
+				this.transactionManager.commit(status);
+			}
+			catch (Throwable ex) {
+				if (status.isCompleted()) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Caught exception committing transaction and rolled back: " + ex);
+					}
+				}
+				else {
+					throw ex;
+				}
+			}
 			return messageReceived;
 		}
 


### PR DESCRIPTION
If we get an exception, but the transaction completed, log to indicate
we rolled back the transaction, but do not re-throw the exception.
If the transaction did not complete, then throw the exception as there
was likely an infrastructure failure and this listener needs to retry.