### PR TITLE
Change method signature to return covariant type

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/MethodInvocationProceedingJoinPoint.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/MethodInvocationProceedingJoinPoint.java
@@ -62,7 +62,7 @@ public class MethodInvocationProceedingJoinPoint implements ProceedingJoinPoint,
 
 	/** Lazily initialized signature object */
 	@Nullable
-	private Signature signature;
+	private MethodSignature signature;
 
 	/** Lazily initialized source location object */
 	@Nullable
@@ -129,7 +129,7 @@ public class MethodInvocationProceedingJoinPoint implements ProceedingJoinPoint,
 	}
 
 	@Override
-	public Signature getSignature() {
+	public MethodSignature getSignature() {
 		if (this.signature == null) {
 			this.signature = new MethodSignatureImpl();
 		}


### PR DESCRIPTION
It is more convenient to get a MethodSignature as a return type instead of SIgnature since it is a method invocation proceeding join point.