### PR TITLE
Changed min accepted day of month to 1

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
@@ -317,7 +317,7 @@ public class CronSequenceGenerator {
 		if (field.contains("?")) {
 			field = "*";
 		}
-		setNumberHits(bits, field, 0, max);
+		setNumberHits(bits, field, 1, max);
 	}
 
 	private void setMonths(BitSet bits, String value) {


### PR DESCRIPTION
The minimum accepted day was 0, but as the comment in the `setDaysOfMonth` method says, the days of month start with 1. So an invalid cron expression could be created, causing an exception in the `findNextDay` method.