### PR TITLE
Fix a typo in javadoc

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/object/RdbmsOperation.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/object/RdbmsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
  * arguments. Subclasses should be JavaBeans, allowing easy configuration.
  *
  * <p>This class and subclasses throw runtime exceptions, defined in the
- * <codeorg.springframework.dao package</code> (and as thrown by the
+ * {@code org.springframework.dao} package (and as thrown by the
  * {@code org.springframework.jdbc.core} package, which the classes
  * in this package use under the hood to perform raw JDBC operations).
  *


### PR DESCRIPTION
And use {@code} instead.