### PR TITLE
SPR-16812 extract createRunnable() in ScheduledAnnotationBeanPostProcessor

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -290,13 +290,17 @@ public class ScheduledAnnotationBeanPostProcessor implements DestructionAwareBea
 		return bean;
 	}
 
+	protected Runnable createRunnable(Method method, Object bean) {
+		Assert.isTrue(method.getParameterCount() == 0,
+				"Only no-arg methods may be annotated with @Scheduled");
+
+		Method invocableMethod = AopUtils.selectInvocableMethod(method, bean.getClass());
+		return new ScheduledMethodRunnable(bean, invocableMethod);
+	}
+
 	protected void processScheduled(Scheduled scheduled, Method method, Object bean) {
 		try {
-			Assert.isTrue(method.getParameterCount() == 0,
-					"Only no-arg methods may be annotated with @Scheduled");
-
-			Method invocableMethod = AopUtils.selectInvocableMethod(method, bean.getClass());
-			Runnable runnable = new ScheduledMethodRunnable(bean, invocableMethod);
+			Runnable runnable = createRunnable(method, bean);
 			boolean processedSchedule = false;
 			String errorMessage =
 					"Exactly one of the 'cron', 'fixedDelay(String)', or 'fixedRate(String)' attributes is required";


### PR DESCRIPTION
I am interested in overriding this method and having some custom logic in it.
At the moment this project uses 4.3, so it would be nice it this change is backported.

~Please let me know if this change is trivial enough or if I should create a ticket.~

https://jira.spring.io/browse/SPR-16812