### PR TITLE
[SPR-16816] Catching quartz fails to initialize, shutdown scheduler and rethrows

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SchedulerFactoryBean.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SchedulerFactoryBean.java
@@ -540,7 +540,14 @@ public class SchedulerFactoryBean extends SchedulerAccessor implements FactoryBe
 		}
 
 		registerListeners();
-		registerJobsAndTriggers();
+		try {
+			// Catching quartz fails to initialize, shutdown scheduler and rethrows
+			registerJobsAndTriggers();
+		} catch (Exception e) {
+			waitForJobsToCompleteOnShutdown = true;
+			destroy();
+			throw e;
+		}
 	}
 
 


### PR DESCRIPTION
jira: https://jira.spring.io/browse/SPR-16816

For some reason, there is an occasional exception arise from database queries when using quartz's cluster mode. when this exception occurs, the Spring container will close and exit, leaving Java Process suspending.

If an exception is thrown in `afterPropertiesSet`, the `destroy` method will not be called, subsequently, these threads will not be closed in the meanwhile.

So I prepare to catch the invocation of `registerJobsAndTriggers` and manually call the destroy method when it throwing an exception.