### PR TITLE
SPR-16819 - Improve handling of unknown status codes by WebClient

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientResponse.java
@@ -61,8 +61,7 @@ public interface ClientResponse {
 	/**
 	 * Return the status code of this response.
 	 * @return the status as an HttpStatus enum value
-	 * @throws IllegalArgumentException in case of an unknown HTTP status
-	 * code
+	 * @throws IllegalArgumentException in case of an unknown HTTP status code
 	 * @see HttpStatus#valueOf(int)
 	 */
 	HttpStatus statusCode();

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientResponse.java
@@ -60,8 +60,22 @@ public interface ClientResponse {
 
 	/**
 	 * Return the status code of this response.
+	 * @return the status as an HttpStatus enum value
+	 * @throws IllegalArgumentException in case of an unknown HTTP status
+	 * code
+	 * @see HttpStatus#valueOf(int)
 	 */
 	HttpStatus statusCode();
+
+	/**
+	 * Return the status code (potentially non-standard and not resolvable
+	 * through the {@link HttpStatus} enum) as an integer.
+	 * @return the status as an integer
+	 * @since 5.0.7
+	 * @see #statusCode()
+	 * @see HttpStatus#resolve(int)
+	 */
+	int rawStatusCode();
 
 	/**
 	 * Return the headers of this response.
@@ -173,6 +187,17 @@ public interface ClientResponse {
 	}
 
 	/**
+	 * Create a response builder with the given status code and using default strategies for
+	 * reading the body.
+	 * @param statusCode the status code
+	 * @return the created builder
+	 * @since 5.0.7
+	 */
+	static Builder create(int statusCode) {
+		return create(statusCode, ExchangeStrategies.withDefaults());
+	}
+
+	/**
 	 * Create a response builder with the given status code and strategies for reading the body.
 	 * @param statusCode the status code
 	 * @param strategies the strategies
@@ -183,12 +208,44 @@ public interface ClientResponse {
 	}
 
 	/**
+	 * Create a response builder with the given status code and strategies for reading the body.
+	 * @param statusCode the status code
+	 * @param strategies the strategies
+	 * @return the created builder
+	 * @since 5.0.7
+	 */
+	static Builder create(int statusCode, ExchangeStrategies strategies) {
+		return new DefaultClientResponseBuilder(strategies).statusCode(statusCode);
+	}
+
+	/**
 	 * Create a response builder with the given status code and message body readers.
 	 * @param statusCode the status code
 	 * @param messageReaders the message readers
 	 * @return the created builder
 	 */
 	static Builder create(HttpStatus statusCode, List<HttpMessageReader<?>> messageReaders) {
+		return create(statusCode, new ExchangeStrategies() {
+			@Override
+			public List<HttpMessageReader<?>> messageReaders() {
+				return messageReaders;
+			}
+			@Override
+			public List<HttpMessageWriter<?>> messageWriters() {
+				// not used in the response
+				return Collections.emptyList();
+			}
+		});
+	}
+
+	/**
+	 * Create a response builder with the given status code and message body readers.
+	 * @param statusCode the status code
+	 * @param messageReaders the message readers
+	 * @return the created builder
+	 * @since 5.0.7
+	 */
+	static Builder create(int statusCode, List<HttpMessageReader<?>> messageReaders) {
 		return create(statusCode, new ExchangeStrategies() {
 			@Override
 			public List<HttpMessageReader<?>> messageReaders() {
@@ -246,6 +303,14 @@ public interface ClientResponse {
 		 * @return this builder
 		 */
 		Builder statusCode(HttpStatus statusCode);
+
+		/**
+		 * Set the status code of the response.
+		 * @param statusCode the new status code.
+		 * @return this builder
+		 * @since 5.0.7
+		 */
+		Builder statusCode(int statusCode);
 
 		/**
 		 * Add the given header value(s) under the given name.

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientResponse.java
@@ -73,6 +73,11 @@ class DefaultClientResponse implements ClientResponse {
 	}
 
 	@Override
+	public int rawStatusCode() {
+		return this.response.getRawStatusCode();
+	}
+
+	@Override
 	public Headers headers() {
 		return this.headers;
 	}
@@ -173,11 +178,11 @@ class DefaultClientResponse implements ClientResponse {
 
 	private <T> Mono<ResponseEntity<T>> toEntityInternal(Mono<T> bodyMono) {
 		HttpHeaders headers = headers().asHttpHeaders();
-		HttpStatus statusCode = statusCode();
+		int status = rawStatusCode();
 		return bodyMono
-				.map(body -> new ResponseEntity<>(body, headers, statusCode))
+				.map(body -> createEntity(body, headers, status))
 				.switchIfEmpty(Mono.defer(
-						() -> Mono.just(new ResponseEntity<>(headers, statusCode))));
+						() -> Mono.just(createEntity(headers, status))));
 	}
 
 	@Override
@@ -192,10 +197,24 @@ class DefaultClientResponse implements ClientResponse {
 
 	private <T> Mono<ResponseEntity<List<T>>> toEntityListInternal(Flux<T> bodyFlux) {
 		HttpHeaders headers = headers().asHttpHeaders();
-		HttpStatus statusCode = statusCode();
+		int status = rawStatusCode();
 		return bodyFlux
 				.collectList()
-				.map(body -> new ResponseEntity<>(body, headers, statusCode));
+				.map(body -> createEntity(body, headers, status));
+	}
+
+	private <T> ResponseEntity<T> createEntity(HttpHeaders headers, int status) {
+		HttpStatus resolvedStatus = HttpStatus.resolve(status);
+		return resolvedStatus != null
+				? new ResponseEntity<>(headers, resolvedStatus)
+				: ResponseEntity.status(status).headers(headers).build();
+	}
+
+	private <T> ResponseEntity<T> createEntity(T body, HttpHeaders headers, int status) {
+		HttpStatus resolvedStatus = HttpStatus.resolve(status);
+		return resolvedStatus != null
+				? new ResponseEntity<>(body, headers, resolvedStatus)
+				: ResponseEntity.status(status).headers(headers).body(body);
 	}
 
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientResponseBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientResponseBuilder.java
@@ -44,7 +44,7 @@ final class DefaultClientResponseBuilder implements ClientResponse.Builder {
 
 	private ExchangeStrategies strategies;
 
-	private HttpStatus statusCode = HttpStatus.OK;
+	private int statusCode = HttpStatus.OK.value();
 
 	private final HttpHeaders headers = new HttpHeaders();
 
@@ -61,7 +61,7 @@ final class DefaultClientResponseBuilder implements ClientResponse.Builder {
 	public DefaultClientResponseBuilder(ClientResponse other) {
 		Assert.notNull(other, "ClientResponse must not be null");
 		this.strategies = other.strategies();
-		statusCode(other.statusCode());
+		statusCode(other.rawStatusCode());
 		headers(headers -> headers.addAll(other.headers().asHttpHeaders()));
 		cookies(cookies -> cookies.addAll(other.cookies()));
 	}
@@ -70,6 +70,12 @@ final class DefaultClientResponseBuilder implements ClientResponse.Builder {
 	@Override
 	public DefaultClientResponseBuilder statusCode(HttpStatus statusCode) {
 		Assert.notNull(statusCode, "HttpStatus must not be null");
+		this.statusCode = statusCode.value();
+		return this;
+	}
+
+	@Override
+	public DefaultClientResponseBuilder statusCode(int statusCode) {
 		this.statusCode = statusCode;
 		return this;
 	}
@@ -137,7 +143,7 @@ final class DefaultClientResponseBuilder implements ClientResponse.Builder {
 
 	private static class BuiltClientHttpResponse implements ClientHttpResponse {
 
-		private final HttpStatus statusCode;
+		private final int statusCode;
 
 		private final HttpHeaders headers;
 
@@ -145,7 +151,7 @@ final class DefaultClientResponseBuilder implements ClientResponse.Builder {
 
 		private final Flux<DataBuffer> body;
 
-		public BuiltClientHttpResponse(HttpStatus statusCode, HttpHeaders headers,
+		public BuiltClientHttpResponse(int statusCode, HttpHeaders headers,
 				MultiValueMap<String, ResponseCookie> cookies, Flux<DataBuffer> body) {
 
 			this.statusCode = statusCode;
@@ -156,12 +162,12 @@ final class DefaultClientResponseBuilder implements ClientResponse.Builder {
 
 		@Override
 		public HttpStatus getStatusCode() {
-			return this.statusCode;
+			return HttpStatus.valueOf(this.statusCode);
 		}
 
 		@Override
 		public int getRawStatusCode() {
-			return this.statusCode.value();
+			return this.statusCode;
 		}
 
 		@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -59,6 +59,7 @@ import org.springframework.web.util.UriBuilderFactory;
  * Default implementation of {@link WebClient}.
  *
  * @author Rossen Stoyanchev
+ * @author Denys Ivano
  * @since 5.0
  */
 class DefaultWebClient implements WebClient {
@@ -369,11 +370,12 @@ class DefaultWebClient implements WebClient {
 	private static class DefaultResponseSpec implements ResponseSpec {
 
 		private static final StatusHandler DEFAULT_STATUS_HANDLER =
-				new StatusHandler(HttpStatus::isError, DefaultResponseSpec::createResponseException);
+				new StatusHandler(StatusCodePredicates.isError(),
+						DefaultResponseSpec::createResponseException);
 
 		private final Mono<ClientResponse> responseMono;
 
-		private List<StatusHandler> statusHandlers = new ArrayList<>(1);
+		private final List<StatusHandler> statusHandlers = new ArrayList<>(1);
 
 		DefaultResponseSpec(Mono<ClientResponse> responseMono) {
 			this.responseMono = responseMono;
@@ -384,12 +386,26 @@ class DefaultWebClient implements WebClient {
 		public ResponseSpec onStatus(Predicate<HttpStatus> statusPredicate,
 				Function<ClientResponse, Mono<? extends Throwable>> exceptionFunction) {
 
+			removeDefaultStatusHandler();
+			this.statusHandlers.add(new HttpStatusHandler(statusPredicate, exceptionFunction));
+
+			return this;
+		}
+
+		@Override
+		public ResponseSpec onStatusCode(Predicate<Integer> statusCodePredicate,
+				Function<ClientResponse, Mono<? extends Throwable>> exceptionFunction) {
+
+			removeDefaultStatusHandler();
+			this.statusHandlers.add(new StatusHandler(statusCodePredicate, exceptionFunction));
+
+			return this;
+		}
+
+		private void removeDefaultStatusHandler() {
 			if (this.statusHandlers.size() == 1 && this.statusHandlers.get(0) == DEFAULT_STATUS_HANDLER) {
 				this.statusHandlers.clear();
 			}
-			this.statusHandlers.add(new StatusHandler(statusPredicate, exceptionFunction));
-
-			return this;
 		}
 
 		@Override
@@ -435,7 +451,7 @@ class DefaultWebClient implements WebClient {
 				T bodyPublisher, Function<Mono<? extends Throwable>, T> errorFunction) {
 
 			return this.statusHandlers.stream()
-					.filter(statusHandler -> statusHandler.test(response.statusCode()))
+					.filter(statusHandler -> statusHandler.test(response.rawStatusCode()))
 					.findFirst()
 					.map(statusHandler -> statusHandler.apply(response))
 					.map(errorFunction::apply)
@@ -453,14 +469,16 @@ class DefaultWebClient implements WebClient {
 					})
 					.defaultIfEmpty(new byte[0])
 					.map(bodyBytes -> {
-						String msg = String.format("ClientResponse has erroneous status code: %d %s", response.statusCode().value(),
-								response.statusCode().getReasonPhrase());
+						int status = response.rawStatusCode();
+						HttpStatus resolvedStatus = HttpStatus.resolve(status);
+						String msg = "ClientResponse has erroneous status code: " + status +
+								(resolvedStatus != null ? " " + resolvedStatus.getReasonPhrase() : "");
 						Charset charset = response.headers().contentType()
 								.map(MimeType::getCharset)
 								.orElse(StandardCharsets.ISO_8859_1);
 						return new WebClientResponseException(msg,
-								response.statusCode().value(),
-								response.statusCode().getReasonPhrase(),
+								status,
+								resolvedStatus != null ? resolvedStatus.getReasonPhrase() : null,
 								response.headers().asHttpHeaders(),
 								bodyBytes,
 								charset
@@ -471,11 +489,11 @@ class DefaultWebClient implements WebClient {
 
 		private static class StatusHandler {
 
-			private final Predicate<HttpStatus> predicate;
+			private final Predicate<Integer> predicate;
 
 			private final Function<ClientResponse, Mono<? extends Throwable>> exceptionFunction;
 
-			public StatusHandler(Predicate<HttpStatus> predicate,
+			public StatusHandler(Predicate<Integer> predicate,
 					Function<ClientResponse, Mono<? extends Throwable>> exceptionFunction) {
 
 				Assert.notNull(predicate, "Predicate must not be null");
@@ -484,12 +502,28 @@ class DefaultWebClient implements WebClient {
 				this.exceptionFunction = exceptionFunction;
 			}
 
-			public boolean test(HttpStatus status) {
+			public boolean test(int status) {
 				return this.predicate.test(status);
 			}
 
 			public Mono<? extends Throwable> apply(ClientResponse response) {
 				return this.exceptionFunction.apply(response);
+			}
+		}
+
+		private static class HttpStatusHandler extends StatusHandler {
+
+			public HttpStatusHandler(Predicate<HttpStatus> predicate,
+					Function<ClientResponse, Mono<? extends Throwable>> exceptionFunction) {
+
+				super(statusCodePredicate(predicate), exceptionFunction);
+			}
+
+			private static Predicate<Integer> statusCodePredicate(Predicate<HttpStatus> predicate) {
+				return status -> {
+					HttpStatus resolvedStatus = HttpStatus.resolve(status);
+					return resolvedStatus != null && predicate.test(resolvedStatus);
+				};
 			}
 		}
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/StatusCodePredicates.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/StatusCodePredicates.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function.client;
+
+import java.util.function.Predicate;
+import org.springframework.util.Assert;
+
+/**
+ * Provides various methods for creating status code predicates.
+ *
+ * @author Denys Ivano
+ * @since 5.0.7
+ */
+public abstract class StatusCodePredicates {
+
+	/**
+	 * Return a status code predicate that tests whether the status code is in the
+	 * HTTP 1xx Informational series.
+	 * @return a predicate that matches on 1xx status codes
+	 */
+	public static Predicate<Integer> is1xxInformational() {
+		return between(100, 199);
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is in the
+	 * HTTP 2xx Successful series.
+	 * @return a predicate that matches on 2xx status codes
+	 */
+	public static Predicate<Integer> is2xxSuccessful() {
+		return between(200, 299);
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is in the
+	 * HTTP 3xx Redirection series.
+	 * @return a predicate that matches on 3xx status codes
+	 */
+	public static Predicate<Integer> is3xxRedirection() {
+		return between(300, 399);
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is in the
+	 * HTTP 4xx Client Error series.
+	 * @return a predicate that matches on 4xx status codes
+	 */
+	public static Predicate<Integer> is4xxClientError() {
+		return between(400, 499);
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is in the
+	 * HTTP 5xx Server Error series.
+	 * @return a predicate that matches on 5xx status codes
+	 */
+	public static Predicate<Integer> is5xxServerError() {
+		return between(500, 599);
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is in the
+	 * HTTP 4xx Client Error or 5xx Server Error series.
+	 * @return a predicate that matches on 4xx and 5xx status codes
+	 */
+	public static Predicate<Integer> isError() {
+		return between(400, 599);
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is between
+	 * the specified values.
+	 * @param from value from (inclusive)
+	 * @param to value to (inclusive)
+	 * @return the status code predicate
+	 * @throws IllegalArgumentException if 'from' value is greater than 'to'
+	 */
+	public static Predicate<Integer> between(int from, int to) {
+		Assert.isTrue(from <= to, "'from' value must be <= than 'to'");
+		return status -> status >= from && status <= to;
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is equal
+	 * to the specified status.
+	 * @param statusCode the status code to test against
+	 * @return the status code predicate
+	 */
+	public static Predicate<Integer> is(int statusCode) {
+		return status -> status == statusCode;
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is not equal
+	 * to the specified status.
+	 * @param statusCode the status code to test against
+	 * @return the status code predicate
+	 */
+	public static Predicate<Integer> not(int statusCode) {
+		return status -> status != statusCode;
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is among
+	 * the specified statuses.
+	 * @param statusCodes the status codes to test against
+	 * @return the status code predicate
+	 */
+	public static Predicate<Integer> anyOf(int ... statusCodes) {
+		Assert.notNull(statusCodes, "statuses must not be null");
+		return status -> {
+			for (int s : statusCodes) {
+				if (s == status) {
+					return true;
+				}
+			}
+			return false;
+		};
+	}
+
+	/**
+	 * Return a status code predicate that tests whether the status code is not among
+	 * the specified statuses.
+	 * @param statusCodes the status codes to test against
+	 * @return the status code predicate
+	 */
+	public static Predicate<Integer> noneOf(int ... statusCodes) {
+		return anyOf(statusCodes).negate();
+	}
+
+}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/StatusCodePredicates.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/StatusCodePredicates.java
@@ -17,6 +17,7 @@
 package org.springframework.web.reactive.function.client;
 
 import java.util.function.Predicate;
+
 import org.springframework.util.Assert;
 
 /**
@@ -121,7 +122,7 @@ public abstract class StatusCodePredicates {
 	 * @return the status code predicate
 	 */
 	public static Predicate<Integer> anyOf(int ... statusCodes) {
-		Assert.notNull(statusCodes, "statuses must not be null");
+		Assert.notNull(statusCodes, "Status codes must not be null");
 		return status -> {
 			for (int s : statusCodes) {
 				if (s == status) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -592,21 +592,44 @@ public interface WebClient {
 		/**
 		 * Register a custom error function that gets invoked when the given {@link HttpStatus}
 		 * predicate applies. The exception returned from the function will be returned from
-		 * {@link #bodyToMono(Class)} and {@link #bodyToFlux(Class)}.
-		 * <p>By default, an error handler is register that throws a
+		 * {@link #bodyToMono(Class)}, {@link #bodyToMono(ParameterizedTypeReference)},
+		 * {@link #bodyToFlux(Class)} and {@link #bodyToFlux(ParameterizedTypeReference)}.
+		 * <p>By default, an error handler is registered that throws a
 		 * {@link WebClientResponseException} when the response status code is 4xx or 5xx.
+		 * <p><b>Note:</b> when the response contains status code that can't be resolved through
+		 * {@link HttpStatus} enum, the specified predicate and exception function will not be
+		 * applied.
 		 * @param statusPredicate a predicate that indicates whether {@code exceptionFunction}
 		 * applies
 		 * @param exceptionFunction the function that returns the exception
 		 * @return this builder
+		 * @see #onStatusCode(Predicate, Function)
 		 */
 		ResponseSpec onStatus(Predicate<HttpStatus> statusPredicate,
 				Function<ClientResponse, Mono<? extends Throwable>> exceptionFunction);
 
 		/**
+		 * Register a custom error function that gets invoked when the given status code
+		 * predicate applies. The exception returned from the function will be returned from
+		 * {@link #bodyToMono(Class)}, {@link #bodyToMono(ParameterizedTypeReference)},
+		 * {@link #bodyToFlux(Class)} and {@link #bodyToFlux(ParameterizedTypeReference)}.
+		 * <p>By default, an error handler is registered that throws a
+		 * {@link WebClientResponseException} when the response status code is 4xx or 5xx.
+		 * @param statusCodePredicate a predicate that indicates whether {@code exceptionFunction}
+		 * applies
+		 * @param exceptionFunction the function that returns the exception
+		 * @return this builder
+		 * @since 5.0.7
+		 * @see StatusCodePredicates
+		 */
+		ResponseSpec onStatusCode(Predicate<Integer> statusCodePredicate,
+				Function<ClientResponse, Mono<? extends Throwable>> exceptionFunction);
+
+		/**
 		 * Extract the body to a {@code Mono}. By default, if the response has status code 4xx or
-		 * 5xx, the {@code Mono} will contain a {@link WebClientException}. This can be overridden
-		 * with {@link #onStatus(Predicate, Function)}.
+		 * 5xx, the {@code Mono} will contain a {@link WebClientResponseException}. This can be
+		 * overridden with {@link #onStatus(Predicate, Function)} and
+		 * {@link #onStatusCode(Predicate, Function)}.
 		 * @param bodyType the expected response body type
 		 * @param <T> response body type
 		 * @return a mono containing the body, or a {@link WebClientResponseException} if the
@@ -616,8 +639,9 @@ public interface WebClient {
 
 		/**
 		 * Extract the body to a {@code Mono}. By default, if the response has status code 4xx or
-		 * 5xx, the {@code Mono} will contain a {@link WebClientException}. This can be overridden
-		 * with {@link #onStatus(Predicate, Function)}.
+		 * 5xx, the {@code Mono} will contain a {@link WebClientResponseException}. This can be
+		 * overridden with {@link #onStatus(Predicate, Function)} and
+		 * {@link #onStatusCode(Predicate, Function)}
 		 * @param typeReference a type reference describing the expected response body type
 		 * @param <T> response body type
 		 * @return a mono containing the body, or a {@link WebClientResponseException} if the
@@ -627,9 +651,10 @@ public interface WebClient {
 
 		/**
 		 * Extract the body to a {@code Flux}. By default, if the response has status code 4xx or
-		 * 5xx, the {@code Flux} will contain a {@link WebClientException}. This can be overridden
-         * with {@link #onStatus(Predicate, Function)}.
-		 * @param elementType the type of element in the response
+		 * 5xx, the {@code Flux} will contain a {@link WebClientResponseException}. This can be
+		 * overridden with {@link #onStatus(Predicate, Function)} and
+		 * {@link #onStatusCode(Predicate, Function)}
+		 * @param elementType the type of elements in the response
 		 * @param <T> the type of elements in the response
 		 * @return a flux containing the body, or a {@link WebClientResponseException} if the
 		 * status code is 4xx or 5xx
@@ -638,9 +663,10 @@ public interface WebClient {
 
 		/**
 		 * Extract the body to a {@code Flux}. By default, if the response has status code 4xx or
-		 * 5xx, the {@code Flux} will contain a {@link WebClientException}. This can be overridden
-         * with {@link #onStatus(Predicate, Function)}.
-		 * @param typeReference a type reference describing the expected response body type
+		 * 5xx, the {@code Flux} will contain a {@link WebClientResponseException}. This can be
+		 * overridden with {@link #onStatus(Predicate, Function)} and
+		 * {@link #onStatusCode(Predicate, Function)}
+		 * @param typeReference a type reference describing the type of elements in the response
 		 * @param <T> the type of elements in the response
 		 * @return a flux containing the body, or a {@link WebClientResponseException} if the
 		 * status code is 4xx or 5xx

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ public class WebClientResponseException extends WebClientException {
 
 	private final int statusCode;
 
+	@Nullable
 	private final String statusText;
 
 	private final byte[] responseBody;
@@ -47,13 +48,14 @@ public class WebClientResponseException extends WebClientException {
 
 	/**
 	 * Construct a new instance of with the given response data.
+	 * @param message the exception message
 	 * @param statusCode the raw status code value
-	 * @param statusText the status text
+	 * @param statusText the status text (may be {@code null})
 	 * @param headers the response headers (may be {@code null})
 	 * @param responseBody the response body content (may be {@code null})
 	 * @param responseCharset the response body charset (may be {@code null})
 	 */
-	public WebClientResponseException(String message, int statusCode, String statusText,
+	public WebClientResponseException(String message, int statusCode, @Nullable String statusText,
 			@Nullable HttpHeaders headers, @Nullable byte[] responseBody,
 			@Nullable Charset responseCharset) {
 
@@ -84,6 +86,7 @@ public class WebClientResponseException extends WebClientException {
 	/**
 	 * Return the HTTP status text.
 	 */
+	@Nullable
 	public String getStatusText() {
 		return this.statusText;
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/support/ClientResponseWrapper.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/support/ClientResponseWrapper.java
@@ -78,6 +78,11 @@ public class ClientResponseWrapper implements ClientResponse {
 	}
 
 	@Override
+	public int rawStatusCode() {
+		return this.delegate.rawStatusCode();
+	}
+
+	@Override
 	public Headers headers() {
 		return this.delegate.headers();
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/HandlerFilterFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/HandlerFilterFunction.java
@@ -74,7 +74,7 @@ public interface HandlerFilterFunction<T extends ServerResponse, R extends Serve
 
 	/**
 	 * Adapt the given request processor function to a filter function that only operates
-	 * on the {@code ClientRequest}.
+	 * on the {@code ServerRequest}.
 	 * @param requestProcessor the request processor
 	 * @return the filter adaptation of the request processor
 	 */
@@ -87,8 +87,10 @@ public interface HandlerFilterFunction<T extends ServerResponse, R extends Serve
 
 	/**
 	 * Adapt the given response processor function to a filter function that only operates
-	 * on the {@code ClientResponse}.
+	 * on the {@code ServerResponse}.
 	 * @param responseProcessor the response processor
+	 * @param <T> the type of the {@linkplain HandlerFunction handler function} to filter
+	 * @param <R> the type of the response of the function
 	 * @return the filter adaptation of the request processor
 	 */
 	static <T extends ServerResponse, R extends ServerResponse> HandlerFilterFunction<T, R> ofResponseProcessor(

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientResponseBuilderTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientResponseBuilderTests.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.*;
 
 /**
  * @author Arjen Poutsma
+ * @author Denys Ivano
  */
 public class DefaultClientResponseBuilderTests {
 
@@ -57,10 +58,52 @@ public class DefaultClientResponseBuilderTests {
 				.build();
 
 		assertEquals(HttpStatus.BAD_GATEWAY, response.statusCode());
+		assertEquals(HttpStatus.BAD_GATEWAY.value(), response.rawStatusCode());
 		HttpHeaders responseHeaders = response.headers().asHttpHeaders();
 		assertEquals("bar", responseHeaders.getFirst("foo"));
 		assertNotNull("qux", response.cookies().getFirst("baz"));
 		assertEquals("qux", response.cookies().getFirst("baz").getValue());
+
+		StepVerifier.create(response.bodyToFlux(String.class))
+				.expectNext("baz")
+				.verifyComplete();
+	}
+
+	@Test
+	public void withRawStatusCode() {
+		Flux<DataBuffer> body = Flux.just("baz")
+				.map(s -> s.getBytes(StandardCharsets.UTF_8))
+				.map(dataBufferFactory::wrap);
+
+		ClientResponse response = ClientResponse.create(HttpStatus.BAD_GATEWAY.value(), ExchangeStrategies.withDefaults())
+				.body(body)
+				.build();
+
+		assertEquals(HttpStatus.BAD_GATEWAY, response.statusCode());
+		assertEquals(HttpStatus.BAD_GATEWAY.value(), response.rawStatusCode());
+
+		StepVerifier.create(response.bodyToFlux(String.class))
+				.expectNext("baz")
+				.verifyComplete();
+	}
+
+	@Test
+	public void withUnknownStatusCode() {
+		Flux<DataBuffer> body = Flux.just("baz")
+				.map(s -> s.getBytes(StandardCharsets.UTF_8))
+				.map(dataBufferFactory::wrap);
+
+		ClientResponse response = ClientResponse.create(999, ExchangeStrategies.withDefaults())
+				.body(body)
+				.build();
+
+		try {
+			response.statusCode();
+			fail("Expected IllegalArgumentException");
+		} catch (IllegalArgumentException ex) {
+			// do nothing
+		}
+		assertEquals(999, response.rawStatusCode());
 
 		StepVerifier.create(response.bodyToFlux(String.class))
 				.expectNext("baz")
@@ -90,10 +133,42 @@ public class DefaultClientResponseBuilderTests {
 				.build();
 
 		assertEquals(HttpStatus.BAD_REQUEST, result.statusCode());
+		assertEquals(HttpStatus.BAD_REQUEST.value(), result.rawStatusCode());
 		assertEquals(1, result.headers().asHttpHeaders().size());
 		assertEquals("baar", result.headers().asHttpHeaders().getFirst("foo"));
 		assertEquals(1, result.cookies().size());
 		assertEquals("quux", result.cookies().getFirst("baz").getValue());
+
+		StepVerifier.create(result.bodyToFlux(String.class))
+				.expectNext("baz")
+				.verifyComplete();
+	}
+
+	@Test
+	public void fromWithUnknownStatusCode() throws Exception {
+		Flux<DataBuffer> otherBody = Flux.just("foo", "bar")
+				.map(s -> s.getBytes(StandardCharsets.UTF_8))
+				.map(dataBufferFactory::wrap);
+
+		ClientResponse other = ClientResponse.create(999, ExchangeStrategies.withDefaults())
+				.body(otherBody)
+				.build();
+
+		Flux<DataBuffer> body = Flux.just("baz")
+				.map(s -> s.getBytes(StandardCharsets.UTF_8))
+				.map(dataBufferFactory::wrap);
+
+		ClientResponse result = ClientResponse.from(other)
+				.body(body)
+				.build();
+
+		try {
+			result.statusCode();
+			fail("Expected IllegalArgumentException");
+		} catch (IllegalArgumentException ex) {
+			// do nothing
+		}
+		assertEquals(999, result.rawStatusCode());
 
 		StepVerifier.create(result.bodyToFlux(String.class))
 				.expectNext("baz")

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/StatusCodePredicatesTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/StatusCodePredicatesTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function.client;
+
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Denys Ivano
+ */
+public class StatusCodePredicatesTests {
+
+	@Test
+	public void is1xxInformational() {
+		Predicate<Integer> predicate = StatusCodePredicates.is1xxInformational();
+
+		assertTrue(predicate.test(100));
+		assertTrue(predicate.test(101));
+		assertTrue(predicate.test(199));
+		assertFalse(predicate.test(200));
+	}
+
+	@Test
+	public void is2xxSuccessful() {
+		Predicate<Integer> predicate = StatusCodePredicates.is2xxSuccessful();
+
+		assertTrue(predicate.test(200));
+		assertTrue(predicate.test(204));
+		assertTrue(predicate.test(299));
+		assertFalse(predicate.test(300));
+	}
+
+	@Test
+	public void is3xxRedirection() {
+		Predicate<Integer> predicate = StatusCodePredicates.is3xxRedirection();
+
+		assertTrue(predicate.test(300));
+		assertTrue(predicate.test(302));
+		assertTrue(predicate.test(399));
+		assertFalse(predicate.test(400));
+	}
+
+	@Test
+	public void is4xxClientError() {
+		Predicate<Integer> predicate = StatusCodePredicates.is4xxClientError();
+
+		assertTrue(predicate.test(400));
+		assertTrue(predicate.test(404));
+		assertTrue(predicate.test(499));
+		assertFalse(predicate.test(500));
+	}
+
+	@Test
+	public void is5xxServerError() {
+		Predicate<Integer> predicate = StatusCodePredicates.is5xxServerError();
+
+		assertTrue(predicate.test(500));
+		assertTrue(predicate.test(502));
+		assertTrue(predicate.test(599));
+		assertFalse(predicate.test(600));
+	}
+
+	@Test
+	public void isError() {
+		Predicate<Integer> predicate = StatusCodePredicates.isError();
+
+		assertTrue(predicate.test(400));
+		assertTrue(predicate.test(404));
+		assertTrue(predicate.test(502));
+		assertFalse(predicate.test(200));
+		assertFalse(predicate.test(999));
+	}
+
+	@Test
+	public void between() {
+		assertTrue(StatusCodePredicates.between(100, 200).test(100));
+		assertTrue(StatusCodePredicates.between(100, 200).test(200));
+		assertTrue(StatusCodePredicates.between(400, 499).test(404));
+		assertFalse(StatusCodePredicates.between(400, 400).test(401));
+		assertFalse(StatusCodePredicates.between(400, 499).test(500));
+		try {
+			StatusCodePredicates.between(400, 399);
+			fail("Expected IllegalArgumentException");
+		} catch (IllegalArgumentException ex) {
+			// do nothing
+		}
+	}
+
+	@Test
+	public void is() {
+		assertTrue(StatusCodePredicates.is(400).test(400));
+		assertFalse(StatusCodePredicates.is(400).test(500));
+	}
+
+	@Test
+	public void not() {
+		assertTrue(StatusCodePredicates.not(200).test(400));
+		assertFalse(StatusCodePredicates.not(200).test(200));
+	}
+
+	@Test
+	public void anyOf() {
+		assertTrue(StatusCodePredicates.anyOf(400, 401, 403).test(401));
+		assertTrue(StatusCodePredicates.anyOf(500).test(500));
+		assertFalse(StatusCodePredicates.anyOf(new int[0]).test(500));
+		assertFalse(StatusCodePredicates.anyOf(400, 500).test(404));
+	}
+
+	@Test
+	public void noneOf() {
+		assertTrue(StatusCodePredicates.noneOf(new int[0]).test(500));
+		assertTrue(StatusCodePredicates.noneOf(200, 204).test(400));
+		assertFalse(StatusCodePredicates.noneOf(500).test(500));
+		assertFalse(StatusCodePredicates.noneOf(200, 204, 302).test(302));
+	}
+
+}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.zip.CRC32;
 
 import okhttp3.mockwebserver.MockResponse;
@@ -55,6 +56,7 @@ import static org.junit.Assert.*;
  *
  * @author Brian Clozel
  * @author Rossen Stoyanchev
+ * @author Denys Ivano
  */
 public class WebClientIntegrationTests {
 
@@ -411,7 +413,7 @@ public class WebClientIntegrationTests {
 				.bodyToMono(String.class);
 
 		StepVerifier.create(result)
-				.expectError(WebClientException.class)
+				.expectError(WebClientResponseException.class)
 				.verify(Duration.ofSeconds(3));
 
 		expectRequestCount(1);
@@ -431,7 +433,7 @@ public class WebClientIntegrationTests {
 				.bodyToMono(String.class);
 
 		StepVerifier.create(result)
-				.expectError(WebClientException.class)
+				.expectError(WebClientResponseException.class)
 				.verify(Duration.ofSeconds(3));
 
 		expectRequestCount(1);
@@ -457,6 +459,9 @@ public class WebClientIntegrationTests {
 					assertTrue(throwable instanceof WebClientResponseException);
 					WebClientResponseException ex = (WebClientResponseException) throwable;
 					assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatusCode());
+					assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getRawStatusCode());
+					assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+							ex.getStatusText());
 					assertEquals(MediaType.TEXT_PLAIN, ex.getHeaders().getContentType());
 					assertEquals(errorMessage, ex.getResponseBodyAsString());
 				})
@@ -466,6 +471,38 @@ public class WebClientIntegrationTests {
 		expectRequest(request -> {
 			assertEquals("*/*", request.getHeader(HttpHeaders.ACCEPT));
 			assertEquals("/greeting?name=Spring", request.getPath());
+		});
+	}
+
+	@Test
+	public void shouldGetErrorSignalOnUnknownErrorStatusCode() throws Exception {
+		int errorStatus = 555; // 4xx or 5xx
+		assertNull(HttpStatus.resolve(errorStatus));
+
+		String errorMessage = "Something went wrong";
+		prepareResponse(response -> response.setResponseCode(errorStatus)
+				.setHeader("Content-Type", "text/plain").setBody(errorMessage));
+
+		Mono<String> result = this.webClient.get()
+				.uri("/unknownPage")
+				.retrieve()
+				.bodyToMono(String.class);
+
+		StepVerifier.create(result)
+				.expectErrorSatisfies(throwable -> {
+					assertTrue(throwable instanceof WebClientResponseException);
+					WebClientResponseException ex = (WebClientResponseException) throwable;
+					assertEquals(errorStatus, ex.getRawStatusCode());
+					assertNull(ex.getStatusText());
+					assertEquals(MediaType.TEXT_PLAIN, ex.getHeaders().getContentType());
+					assertEquals(errorMessage, ex.getResponseBodyAsString());
+				})
+				.verify(Duration.ofSeconds(3));
+
+		expectRequestCount(1);
+		expectRequest(request -> {
+			assertEquals("*/*", request.getHeader(HttpHeaders.ACCEPT));
+			assertEquals("/unknownPage", request.getPath());
 		});
 	}
 
@@ -511,6 +548,100 @@ public class WebClientIntegrationTests {
 			assertEquals("*/*", request.getHeader(HttpHeaders.ACCEPT));
 			assertEquals("/greeting?name=Spring", request.getPath());
 		});
+	}
+
+	@Test
+	public void shouldApplyCustomStatusCodeHandler() throws Exception {
+		int status = 999;
+
+		prepareResponse(response -> response.setResponseCode(status)
+				.setHeader("Content-Type", "text/plain").setBody("Something went wrong"));
+
+		Mono<String> result = this.webClient.get()
+				.uri("/unknownServerPage")
+				.retrieve()
+				.onStatusCode(StatusCodePredicates.between(600, 999), response -> Mono.just(new MyException("Error!")))
+				.bodyToMono(String.class);
+
+		StepVerifier.create(result)
+				.expectError(MyException.class)
+				.verify(Duration.ofSeconds(3));
+
+		expectRequestCount(1);
+		expectRequest(request -> {
+			assertEquals("*/*", request.getHeader(HttpHeaders.ACCEPT));
+			assertEquals("/unknownServerPage", request.getPath());
+		});
+	}
+
+	@Test
+	public void shouldApplyCustomStatusAndStatusCodeHandlers() throws Exception {
+		Supplier<WebClient.ResponseSpec> responseSpec = () -> {
+			return this.webClient.get()
+					.uri("/greeting?name=Spring")
+					.retrieve()
+					.onStatus(HttpStatus::is4xxClientError, response -> Mono.just(new MyException("HttpStatus 4xx")))
+					.onStatusCode(StatusCodePredicates.is5xxServerError(), response -> Mono.just(new MyException("Status code 5xx")))
+					// this handler shouldn't be called
+					.onStatus(HttpStatus::is5xxServerError, response -> Mono.just(new MyException("HttpStatus 5xx")))
+					.onStatusCode(StatusCodePredicates.between(600, 999), response -> Mono.just(new MyException("Status code >= 600")));
+		};
+
+		// 400 -> "HttpStatus 4xx"
+		prepareResponse(response -> response.setResponseCode(400)
+				.setHeader("Content-Type", "text/plain").setBody("Something went wrong"));
+
+		Mono<String> result = responseSpec.get().bodyToMono(String.class);
+
+		StepVerifier.create(result)
+				.expectErrorSatisfies(throwable -> {
+					assertTrue(throwable instanceof MyException);
+					assertEquals("HttpStatus 4xx", throwable.getMessage());
+				})
+				.verify(Duration.ofSeconds(3));
+
+		expectRequest(request -> {
+			assertEquals("*/*", request.getHeader(HttpHeaders.ACCEPT));
+			assertEquals("/greeting?name=Spring", request.getPath());
+		});
+
+		// 500 -> "Status code 5xx"
+		prepareResponse(response -> response.setResponseCode(500)
+				.setHeader("Content-Type", "text/plain").setBody("Something went wrong"));
+
+		result = responseSpec.get().bodyToMono(String.class);
+
+		StepVerifier.create(result)
+				.expectErrorSatisfies(throwable -> {
+					assertTrue(throwable instanceof MyException);
+					assertEquals("Status code 5xx", throwable.getMessage());
+				})
+				.verify(Duration.ofSeconds(3));
+
+		expectRequest(request -> {
+			assertEquals("*/*", request.getHeader(HttpHeaders.ACCEPT));
+			assertEquals("/greeting?name=Spring", request.getPath());
+		});
+
+		// 999 -> "Status code >= 600"
+		prepareResponse(response -> response.setResponseCode(999)
+				.setHeader("Content-Type", "text/plain").setBody("Something went wrong"));
+
+		result = responseSpec.get().bodyToMono(String.class);
+
+		StepVerifier.create(result)
+				.expectErrorSatisfies(throwable -> {
+					assertTrue(throwable instanceof MyException);
+					assertEquals("Status code >= 600", throwable.getMessage());
+				})
+				.verify(Duration.ofSeconds(3));
+
+		expectRequest(request -> {
+			assertEquals("*/*", request.getHeader(HttpHeaders.ACCEPT));
+			assertEquals("/greeting?name=Spring", request.getPath());
+		});
+
+		expectRequestCount(3);
 	}
 
 	@Test
@@ -607,7 +738,10 @@ public class WebClientIntegrationTests {
 
 	@Test
 	public void shouldSupportUnknownStatusCodeOnExchange() throws Exception {
-		prepareResponse(response -> response.setResponseCode(999)
+		int status = 999;
+		assertNull(HttpStatus.resolve(status));
+
+		prepareResponse(response -> response.setResponseCode(status)
 				.setHeader("Content-Type", "text/plain")
 				.setBody("Hello Spring!"));
 
@@ -615,9 +749,35 @@ public class WebClientIntegrationTests {
 				.uri("/unknownStatusCode")
 				.exchange()
 				.flatMap(r -> {
-					assertEquals(999, r.rawStatusCode());
+					assertEquals(status, r.rawStatusCode());
 					return r.bodyToMono(String.class);
 				});
+
+		StepVerifier.create(result)
+				.expectNext("Hello Spring!")
+				.expectComplete()
+				.verify(Duration.ofSeconds(3));
+
+		expectRequestCount(1);
+		expectRequest(request -> {
+			assertEquals("*/*", request.getHeader(HttpHeaders.ACCEPT));
+			assertEquals("/unknownStatusCode", request.getPath());
+		});
+	}
+
+	@Test
+	public void shouldSupportUnknownStatusCodeOnRetrieve() throws Exception {
+		int status = 999;
+		assertNull(HttpStatus.resolve(status));
+
+		prepareResponse(response -> response.setResponseCode(status)
+				.setHeader("Content-Type", "text/plain")
+				.setBody("Hello Spring!"));
+
+		Mono<String> result = this.webClient.get()
+				.uri("/unknownStatusCode")
+				.retrieve()
+				.bodyToMono(String.class);
 
 		StepVerifier.create(result)
 				.expectNext("Hello Spring!")

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/support/ClientResponseWrapperTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/support/ClientResponseWrapperTests.java
@@ -66,6 +66,14 @@ public class ClientResponseWrapperTests {
 	}
 
 	@Test
+	public void rawStatusCode() throws Exception {
+		int status = 999;
+		when(mockResponse.rawStatusCode()).thenReturn(status);
+
+		assertEquals(status, wrapper.rawStatusCode());
+	}
+
+	@Test
 	public void headers() throws Exception {
 		ClientResponse.Headers headers = mock(ClientResponse.Headers.class);
 		when(mockResponse.headers()).thenReturn(headers);

--- a/src/docs/asciidoc/web/webflux-webclient.adoc
+++ b/src/docs/asciidoc/web/webflux-webclient.adoc
@@ -66,8 +66,8 @@ By default, responses with 4xx or 5xx status codes result in an error of type
 	Mono<Person> result = client.get()
 			.uri("/persons/{id}", id).accept(MediaType.APPLICATION_JSON)
 			.retrieve()
-			.onStatus(HttpStatus::is4xxServerError, response -> ...)
-			.onStatus(HttpStatus::is5xxServerError, response -> ...)
+			.onStatus(HttpStatus::is4xxClientError, response -> ...)
+			.onStatusCode(StatusCodePredicates.is(500), response -> ...)
 			.bodyToMono(Person.class);
 ----
 


### PR DESCRIPTION
These changes are aimed to improve handling of unknown status codes by reactive `WebClient`.

In `ClientResponse` the `getRawStatusCode()` method was introduced that allows to obtain raw status code value from response after the corresponding method in reactive `ClientHttpResponse` was provided (see [SPR-16748](https://jira.spring.io/browse/SPR-16748)).

Also the `retrieve()` method in default  `WebClient` implementation and `statusError()` in `ExchangeFilterFunctions` were changed in order to provide support of unknown status codes. The new `onStatusCode()` (`WebClient.ResponseSpec`) and `statusCodeError()` (`ExchangeFilterFunctions`) methods allow to specify exception function which should be applied on matching the status code (`int` value) against the specified predicate. The `StatusCodePredicates` provides convenient way to create predicates for these methods.

https://jira.spring.io/browse/SPR-16819