### PR TITLE
Fix JMS Doc typo

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -2677,7 +2677,7 @@ the time to live, you can configure the `JmsListenerContainerFactory` accordingl
 		public DefaultJmsListenerContainerFactory jmsListenerContainerFactory() {
 			DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
 			factory.setConnectionFactory(connectionFactory());
-			QosSettings replyQosSettings = new ReplyQosSettings();
+			QosSettings replyQosSettings = new QosSettings();
 			replyQosSettings.setPriority(2);
 			replyQosSettings.setTimeToLive(10000);
 			factory.setReplyQosSettings(replyQosSettings);


### PR DESCRIPTION
There is no such class `ReplyQosSettings`.

__cherry-pick to 5.0.x__