### PR TITLE
Protect getters consistently in AbstractRequestLoggingFilter

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/AbstractRequestLoggingFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/AbstractRequestLoggingFilter.java
@@ -137,7 +137,7 @@ public abstract class AbstractRequestLoggingFilter extends OncePerRequestFilter 
 	 * Return whether the request headers should be included in the log message.
 	 * @since 4.3
 	 */
-	public boolean isIncludeHeaders() {
+	protected boolean isIncludeHeaders() {
 		return this.includeHeaders;
 	}
 


### PR DESCRIPTION
Picked it up when writing some code in a Kotlin app.