### PR TITLE
SPR-14818 - Implement MissingServletRequestAttributeException

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/MissingServletRequestAttributeException.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/MissingServletRequestAttributeException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.bind;
+
+/**
+ * {@link ServletRequestBindingException} subclass that indicates a missing attribute.
+ *
+ * @author Carter Kozak
+ * @since 5.0.7
+ */
+@SuppressWarnings("serial")
+public class MissingServletRequestAttributeException extends ServletRequestBindingException {
+
+	private final String attributeName;
+
+	private final Class<?> attributeType;
+
+
+	/**
+	 * Constructor for MissingServletRequestAttributeException.
+	 * @param attributeName the name of the missing attribute
+	 * @param attributeType the expected type of the missing attribute
+	 */
+	public MissingServletRequestAttributeException(String attributeName, Class<?> attributeType) {
+		super("");
+		this.attributeName = attributeName;
+		this.attributeType = attributeType;
+	}
+
+
+	@Override
+	public String getMessage() {
+		return "Missing request attribute '" + this.attributeName + "' of type " + this.attributeType.getSimpleName();
+	}
+
+	/**
+	 * Return the name of the offending parameter.
+	 */
+	public final String getAttributeName() {
+		return this.attributeName;
+	}
+
+	/**
+	 * Return the expected type of the offending parameter.
+	 */
+	public final Class<?> getAttributeType() {
+		return this.attributeType;
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/web/bind/MissingSessionAttributeException.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/MissingSessionAttributeException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.bind;
+
+/**
+ * {@link ServletRequestBindingException} subclass that indicates a missing attribute.
+ *
+ * @author Carter Kozak
+ * @since 5.0.7
+ */
+@SuppressWarnings("serial")
+public class MissingSessionAttributeException extends ServletRequestBindingException {
+
+	private final String attributeName;
+
+	private final Class<?> attributeType;
+
+
+	/**
+	 * Constructor for MissingSessionAttributeException.
+	 * @param attributeName the name of the missing attribute
+	 * @param attributeType the expected type of the missing attribute
+	 */
+	public MissingSessionAttributeException(String attributeName, Class<?> attributeType) {
+		super("");
+		this.attributeName = attributeName;
+		this.attributeType = attributeType;
+	}
+
+
+	@Override
+	public String getMessage() {
+		return "Missing session attribute '" + this.attributeName + "' of type " + this.attributeType.getSimpleName();
+	}
+
+	/**
+	 * Return the name of the offending parameter.
+	 */
+	public final String getAttributeName() {
+		return this.attributeName;
+	}
+
+	/**
+	 * Return the expected type of the offending parameter.
+	 */
+	public final Class<?> getAttributeType() {
+		return this.attributeType;
+	}
+
+}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolver.java
@@ -21,7 +21,7 @@ import javax.servlet.ServletException;
 import org.springframework.core.MethodParameter;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.bind.MissingServletRequestAttributeException;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.ValueConstants;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -56,8 +56,7 @@ public class RequestAttributeMethodArgumentResolver extends AbstractNamedValueMe
 
 	@Override
 	protected void handleMissingValue(String name, MethodParameter parameter) throws ServletException {
-		throw new ServletRequestBindingException("Missing request attribute '" + name +
-				"' of type " +  parameter.getNestedParameterType().getSimpleName());
+		throw new MissingServletRequestAttributeException(name, parameter.getNestedParameterType());
 	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SessionAttributeMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SessionAttributeMethodArgumentResolver.java
@@ -21,7 +21,7 @@ import javax.servlet.ServletException;
 import org.springframework.core.MethodParameter;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.bind.MissingSessionAttributeException;
 import org.springframework.web.bind.annotation.SessionAttribute;
 import org.springframework.web.bind.annotation.ValueConstants;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -56,8 +56,7 @@ public class SessionAttributeMethodArgumentResolver extends AbstractNamedValueMe
 
 	@Override
 	protected void handleMissingValue(String name, MethodParameter parameter) throws ServletException {
-		throw new ServletRequestBindingException("Missing session attribute '" + name +
-				"' of type " +  parameter.getNestedParameterType().getSimpleName());
+		throw new MissingSessionAttributeException(name,  parameter.getNestedParameterType());
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/AbstractRequestAttributesArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/AbstractRequestAttributesArgumentResolverTests.java
@@ -79,6 +79,8 @@ public abstract class AbstractRequestAttributesArgumentResolverTests {
 
 	protected abstract int getScope();
 
+	protected abstract Class<? extends ServletRequestBindingException> getMissingArgumentExceptionType();
+
 
 	@Test
 	public void supportsParameter() throws Exception {
@@ -95,6 +97,7 @@ public abstract class AbstractRequestAttributesArgumentResolverTests {
 		}
 		catch (ServletRequestBindingException ex) {
 			assertTrue(ex.getMessage().startsWith("Missing "));
+			assertEquals(getMissingArgumentExceptionType(), ex.getClass());
 		}
 
 		Foo foo = new Foo();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolverTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.servlet.mvc.method.annotation;
 
+import org.springframework.web.bind.MissingServletRequestAttributeException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 
@@ -40,6 +42,11 @@ public class RequestAttributeMethodArgumentResolverTests extends AbstractRequest
 	@Override
 	protected int getScope() {
 		return RequestAttributes.SCOPE_REQUEST;
+	}
+
+	@Override
+	protected Class<? extends ServletRequestBindingException> getMissingArgumentExceptionType() {
+		return MissingServletRequestAttributeException.class;
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/SessionAttributeMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/SessionAttributeMethodArgumentResolverTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.servlet.mvc.method.annotation;
 
+import org.springframework.web.bind.MissingSessionAttributeException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 
@@ -40,6 +42,11 @@ public class SessionAttributeMethodArgumentResolverTests extends AbstractRequest
 	@Override
 	protected int getScope() {
 		return RequestAttributes.SCOPE_SESSION;
+	}
+
+	@Override
+	protected Class<? extends ServletRequestBindingException> getMissingArgumentExceptionType() {
+		return MissingSessionAttributeException.class;
 	}
 
 }


### PR DESCRIPTION
Provides a way to programatically detect when specific attributes
are not provided.