### PR TITLE
Prevent instantiation of AnnotatedElementUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotatedElementUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotatedElementUtils.java
@@ -94,7 +94,7 @@ import org.springframework.util.MultiValueMap;
  * @see AnnotationUtils
  * @see BridgeMethodResolver
  */
-public class AnnotatedElementUtils {
+public abstract class AnnotatedElementUtils {
 
 	/**
 	 * {@code null} constant used to denote that the search algorithm should continue.


### PR DESCRIPTION
I think. The Util class should not be able to create objects.
So I added the abstract keyword to the AnnotatedElementUtils class