### PR TITLE
Add JDBC SqlValue classes for arrays

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/AbstractSqlArrayValue.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/AbstractSqlArrayValue.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.core.support;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.springframework.dao.CleanupFailureDataAccessException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.jdbc.support.SqlValue;
+
+
+/**
+ * Abstract base class for array values.
+ * <p>
+ * Individual subclasses classes can define how arrays are created and
+ * therefore use vendor extensions.
+ *
+ * @author Philippe Marschall
+ * @since 5.1
+ */
+public abstract class AbstractSqlArrayValue implements SqlValue {
+
+	private Array array;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.jdbc.support.SqlValue#setValue(java.sql.PreparedStatement, int)
+	 */
+	@Override
+	public void setValue(PreparedStatement ps, int paramIndex) throws SQLException {
+		if (array != null) {
+			throw new InvalidDataAccessApiUsageException("Value bound more than once");
+		}
+		array = this.createArray(ps.getConnection());
+		ps.setArray(paramIndex, array);
+	}
+
+	/**
+	 * Create the Array on the given Connection.
+	 * @param conn the Connection to work on
+	 * @return the Array
+	 * @throws SQLException if a SQLException is encountered while creating the array
+	 */
+	protected abstract Array createArray(Connection conn) throws SQLException;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.jdbc.support.SqlValue#cleanup()
+	 */
+	@Override
+	public void cleanup() {
+		if (array == null) {
+			// #cleanup may be called twice in case of exceptions
+			// avoid calling #free twice
+			return;
+		}
+		try {
+			array.free();
+			array = null;
+		} catch (SQLException e) {
+			throw new CleanupFailureDataAccessException("could not free array", e);
+		}
+	}
+
+}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/SqlArrayValue.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/SqlArrayValue.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.core.support;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Default {@link AbstractSqlArrayValue} implementation that uses
+ * {@link Connection#createArrayOf(String, Object[])} to create an
+ * {@link Array}.
+ *
+ * @author Philippe Marschall
+ * @since 5.1
+ * @see Connection#createArrayOf(String, Object[])
+ */
+public class SqlArrayValue extends AbstractSqlArrayValue {
+
+	private final Object[] elements;
+
+	private final String typeName;
+
+	/**
+	 * Constructor that takes two parameters, the array type and and
+	 * the array of values passed in to the statement.
+	 * @param typeName the type name
+	 * @param elements the array containing the values
+	 */
+	public SqlArrayValue(String typeName, Object... elements) {
+		this.elements = elements;
+		this.typeName = typeName;
+	}
+
+	@Override
+	protected Array createArray(Connection conn) throws SQLException {
+		return conn.createArrayOf(typeName, elements);
+	}
+
+}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/support/SqlArrayValueTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/support/SqlArrayValueTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.core.support;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.junit.Test;
+
+import static org.mockito.BDDMockito.*;
+
+
+/**
+ *
+ * @author Philippe Marschall
+ * @since 04.18.2003
+ */
+public class SqlArrayValueTests {
+
+	private final Connection con = mock(Connection.class);
+
+	private final PreparedStatement ps = mock(PreparedStatement.class);
+
+	private final Array arr = mock(Array.class);
+	
+	private final Object[] elements = new Object[] {1, 2, 3};
+
+	private final SqlArrayValue sqlArrayValue = new SqlArrayValue("smallint", elements);
+
+	@Test
+	public void setValue() throws SQLException {
+		given(this.ps.getConnection()).willReturn(this.con);
+		given(this.con.createArrayOf("smallint", elements)).willReturn(this.arr);
+
+		int paramIndex = 42;
+		this.sqlArrayValue.setValue(this.ps, paramIndex);
+		verify(ps).setArray(paramIndex, arr);
+		
+		this.sqlArrayValue.cleanup();
+		verify(this.arr).free();
+	}
+
+}


### PR DESCRIPTION
Introduce two SqlValue classes for more convenient use of arrays from
Spring JDBC.

- AbstractSqlArrayValue abstract base class for array values
- SqlArrayValue concrete implementation class that uses JDBC 4.0 to
  create an array

Issue: SPR-16904