### PR TITLE
SPR-16936 Fix PathVariable javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/PathVariable.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/PathVariable.java
@@ -29,8 +29,7 @@ import org.springframework.core.annotation.AliasFor;
  * variable. Supported for {@link RequestMapping} annotated handler methods in Servlet
  * environments.
  *
- * <p>If the method parameter is {@link java.util.Map Map&lt;String, String&gt;} or
- * {@link org.springframework.util.MultiValueMap MultiValueMap&lt;String, String&gt;}
+ * <p>If the method parameter is {@link java.util.Map Map&lt;String, String&gt;}
  * then the map is populated with all path variable names and values.
  *
  * @author Arjen Poutsma


### PR DESCRIPTION
`@PathVariable`'s javadoc states that it supports `MultiValueMap` parameters (introduced by commit df0902), but by reading through the code, that does not seem to be the case (compare, e.g.,
`PathVariableMapMethodArgumentResolver` to `RequestParamMapMethodArgumentResolver`).

Moreover, parsing `MultipleValueMap` is done according to the `;` character, and placing such a character in a path (e.g., consider something like `/app/{param}/show` would just break the path.

This patch fixes `PathVariable`'s javadoc by removing the mention of `MultiValueMap`.