### PR TITLE
fixed issue where expired timestamp on cookie.toString method produce…

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseCookie.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseCookie.java
@@ -143,7 +143,7 @@ public final class ResponseCookie extends HttpCookie {
 			sb.append("; Expires=");
 			HttpHeaders headers = new HttpHeaders();
 			long seconds = this.maxAge.getSeconds();
-			headers.setExpires(seconds > 0 ? System.currentTimeMillis() + seconds : 0);
+			headers.setExpires(seconds > 0 ? System.currentTimeMillis() + (1000 * seconds) : 0);
 			sb.append(headers.getFirst(HttpHeaders.EXPIRES));
 		}
 


### PR DESCRIPTION
The expires date is not correctly generated.
The max age duration as seconds is added to the system time in millis.

@rstoyanchev - not sure if you already caught this ?