### PR TITLE
improve performance of projection instantiation

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -94,7 +93,7 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 	 * List of Advisors. If an Advice is added, it will be wrapped
 	 * in an Advisor before being added to this List.
 	 */
-	private List<Advisor> advisors = new LinkedList<>();
+	private List<Advisor> advisors = new ArrayList<>();
 
 	/**
 	 * Array updated on changes to the advisors list, which is easier

--- a/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
+++ b/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
@@ -653,7 +653,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 
 		@SuppressWarnings("unchecked")
 		private Reference<K, V>[] createReferenceArray(int size) {
-			return (Reference<K, V>[]) Array.newInstance(Reference.class, size);
+			return new Reference[size];
 		}
 
 		private int getIndex(int hash, Reference<K, V>[] references) {


### PR DESCRIPTION
I've run into poor performance of projection creation with Spring Data JPA. Using async profiler I've measured 10 hottest methods for my particular case:
```
          ns  percent  samples  top
  ----------  -------  -------  ---
  1719680599   17.75%     1719  org.springframework.util.ConcurrentReferenceHashMap.calculateShift
  1075919136   11.11%     1076  org.springframework.util.ConcurrentReferenceHashMap.<init>
   995216304   10.27%      995  org.springframework.aop.framework.JdkDynamicAopProxy.findDefinedEqualsAndHashCodeMethods
   549197362    5.67%      549  java.util.LinkedList.toArray
   505954398    5.22%      506  java.lang.String.regionMatches
   441133709    4.55%      441  java.util.concurrent.ConcurrentHashMap.get
   187450280    1.93%      187  /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
   166974974    1.72%      167  java.util.ArrayList$Itr.<init>
   160991064    1.66%      161  org.springframework.aop.framework.JdkDynamicAopProxy.getProxy
   155019312    1.60%      155  org.apache.logging.slf4j.SLF4JLogger.isEnabledFor
```

The simple way to slightly improve this is to get rid of `LinkedList` in `org.springframework.aop.framework.AdvisedSupport` and use plain constructor call in `org.springframework.util.ConcurrentReferenceHashMap.<init>`.

`LinkedList::toArray` is obviously slower than `ArrayList::toArray`.

In `ConcurrentReferenceHashMap`  method `createReferenceArray` can use plain constructor to instantiate array which yields equal performance when compiled with C2 but 3 times better performance in interpreter mode.