### PR TITLE
Support background init tasks via `@Scheduled(cron="@start")`

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -54,6 +54,8 @@ import java.lang.annotation.Target;
 @Repeatable(Schedules.class)
 public @interface Scheduled {
 
+	String AT_START = "@start";
+
 	/**
 	 * A cron-like expression, extending the usual UN*X definition to include
 	 * triggers on the second as well as minute, hour, day of month, month

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -405,7 +405,7 @@ public class ScheduledAnnotationBeanPostProcessor
 					zone = this.embeddedValueResolver.resolveStringValue(zone);
 				}
 				if (StringUtils.hasLength(cron)) {
-					if ("@start".equals(cron)) {
+					if (Scheduled.AT_START.equals(cron)) {
 						processedSchedule = true;
 						tasks.add(this.registrar.scheduleStartupTask(new StartupTask(runnable, initialDelay)));
 					} else {

--- a/spring-context/src/main/java/org/springframework/scheduling/config/StartupTask.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/config/StartupTask.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scheduling.config;
+
+/**
+ * {@link Task} implementation defining a {@code Runnable} to be executed after a given
+ * millisecond delay.
+ *
+ * @author Alex Panchenko
+ * @since 5.x
+ * @see ScheduledTaskRegistrar#addStartupTask(StartupTask)
+ */
+public class StartupTask extends Task {
+
+	private final long initialDelay;
+
+	/**
+	 * Create a new {@code IntervalTask}.
+	 * @param runnable the underlying task to execute
+	 * @param initialDelay the initial delay before first execution of the task
+	 */
+	public StartupTask(Runnable runnable, long initialDelay) {
+		super(runnable);
+		this.initialDelay = initialDelay;
+	}
+
+	/**
+	 * Return the initial delay before first execution of the task.
+	 */
+	public long getInitialDelay() {
+		return this.initialDelay;
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
@@ -237,7 +237,6 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 		context.refresh();
 
 		Object postProcessor = context.getBean("postProcessor");
-		Object target = context.getBean("target");
 		ScheduledTaskRegistrar registrar = (ScheduledTaskRegistrar)
 				new DirectFieldAccessor(postProcessor).getPropertyValue("registrar");
 		@SuppressWarnings("unchecked")

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
@@ -723,7 +723,7 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 
 
 	static class StartupTestBean {
-		static final CopyOnWriteArrayList<String> executions = new CopyOnWriteArrayList<>();
+		public static final CopyOnWriteArrayList<String> executions = new CopyOnWriteArrayList<>();
 
 		@Scheduled(cron = Scheduled.AT_START)
 		private void start0() {


### PR DESCRIPTION
I would like to use `@Scheduled` to perform some initialization tasks in background.
The syntax is inspired by `@reboot` in `crontab`.

#21557

WDYT?