### PR TITLE
Fix typo

### DIFF
--- a/src/reference/docbook/new-in-3.2.xml
+++ b/src/reference/docbook/new-in-3.2.xml
@@ -148,7 +148,7 @@
     interface is implemented by the
     <classname>MappingJacksonHttpMessageConverter</classname> and also by a
     new <classname>Jaxb2CollectionHttpMessageConverter</classname> that can
-    read read a generic <interfacename>Collection</interfacename> where the
+    read a generic <interfacename>Collection</interfacename> where the
     generic type is a JAXB type annotated with
     <interfacename>@XmlRootElement</interfacename> or
     <interfacename>@XmlType</interfacename>.</para>


### PR DESCRIPTION
`read read `was mentioned 2 times in the `New in 3.2` Chapter.
Issue was opened here: https://jira.spring.io/browse/GREENHOUSE-557
and is very old at this point.