### PR TITLE
Preserve "type" parameter in media type for Atom Feed/Entry message conversion

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/feed/AbstractWireFeedHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/feed/AbstractWireFeedHttpMessageConverter.java
@@ -90,7 +90,7 @@ public abstract class AbstractWireFeedHttpMessageConverter<T extends WireFeed>
 				Charset.forName(wireFeed.getEncoding()) : DEFAULT_CHARSET);
 		MediaType contentType = outputMessage.getHeaders().getContentType();
 		if (contentType != null) {
-			contentType = new MediaType(contentType.getType(), contentType.getSubtype(), charset);
+			contentType = new MediaType(contentType, charset);
 			outputMessage.getHeaders().setContentType(contentType);
 		}
 

--- a/spring-web/src/test/java/org/springframework/http/converter/feed/AtomFeedHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/feed/AtomFeedHttpMessageConverterTests.java
@@ -24,7 +24,9 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.rometools.rome.feed.atom.Entry;
 import com.rometools.rome.feed.atom.Feed;
@@ -38,6 +40,8 @@ import org.xmlunit.diff.NodeMatcher;
 import org.springframework.http.MediaType;
 import org.springframework.http.MockHttpInputMessage;
 import org.springframework.http.MockHttpOutputMessage;
+
+import static java.util.Collections.singletonMap;
 
 /**
  * @author Arjen Poutsma
@@ -127,6 +131,20 @@ public class AtomFeedHttpMessageConverterTests {
 		converter.write(feed, null, outputMessage);
 
 		assertEquals("Invalid content-type", new MediaType("application", "atom+xml", Charset.forName(encoding)),
+				outputMessage.getHeaders().getContentType());
+	}
+
+	@Test
+	public void writeOtherContentTypeParameters() throws IOException {
+		Feed feed = new Feed("atom_1.0");
+
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+		converter.write(feed, new MediaType("application", "atom+xml", singletonMap("type", "feed")), outputMessage);
+
+		Map<String, String> expectedParameters = new HashMap<>();
+		expectedParameters.put("charset", "UTF-8");
+		expectedParameters.put("type", "feed");
+		assertEquals("Invalid content-type", new MediaType("application", "atom+xml", expectedParameters),
 				outputMessage.getHeaders().getContentType());
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/converter/feed/RssChannelHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/feed/RssChannelHttpMessageConverterTests.java
@@ -23,7 +23,9 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.rometools.rome.feed.rss.Channel;
 import com.rometools.rome.feed.rss.Item;
@@ -35,6 +37,8 @@ import org.xmlunit.matchers.CompareMatcher;
 import org.springframework.http.MediaType;
 import org.springframework.http.MockHttpInputMessage;
 import org.springframework.http.MockHttpOutputMessage;
+
+import static java.util.Collections.singletonMap;
 
 /**
  * @author Arjen Poutsma
@@ -130,6 +134,23 @@ public class RssChannelHttpMessageConverterTests {
 		converter.write(channel, null, outputMessage);
 
 		assertEquals("Invalid content-type", new MediaType("application", "rss+xml", Charset.forName(encoding)),
+				outputMessage.getHeaders().getContentType());
+	}
+
+	@Test
+	public void writeOtherContentTypeParameters() throws IOException {
+		Channel channel = new Channel("rss_2.0");
+		channel.setTitle("title");
+		channel.setLink("http://example.com");
+		channel.setDescription("description");
+
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+		converter.write(channel, new MediaType("application", "rss+xml", singletonMap("x", "y")), outputMessage);
+
+		Map<String, String> expectedParameters = new HashMap<>();
+		expectedParameters.put("charset", "UTF-8");
+		expectedParameters.put("x", "y");
+		assertEquals("Invalid content-type", new MediaType("application", "rss+xml", expectedParameters),
 				outputMessage.getHeaders().getContentType());
 	}
 


### PR DESCRIPTION
`AtomFeedHttpMessageConverter` and `RssChannelHttpMessageConverter` currently discard any media type parameters that are supplied to `write()`. They are overwritten when adding the charset parameter.

Issue: SPR-17040

Submitted ICLA.