### PR TITLE
Set SameSite default to Lax

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/session/CookieWebSessionIdResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/server/session/CookieWebSessionIdResolver.java
@@ -125,7 +125,7 @@ public class CookieWebSessionIdResolver implements WebSessionIdResolver {
 				.maxAge(maxAge)
 				.httpOnly(true)
 				.secure("https".equalsIgnoreCase(exchange.getRequest().getURI().getScheme()))
-				.sameSite("Strict");
+				.sameSite("Lax");
 
 		if (this.cookieInitializer != null) {
 			this.cookieInitializer.accept(cookieBuilder);

--- a/spring-web/src/test/java/org/springframework/web/server/session/CookieWebSessionIdResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/session/CookieWebSessionIdResolverTests.java
@@ -44,13 +44,13 @@ public class CookieWebSessionIdResolverTests {
 		assertEquals(1, cookies.size());
 		ResponseCookie cookie = cookies.getFirst(this.resolver.getCookieName());
 		assertNotNull(cookie);
-		assertEquals("SESSION=123; Path=/; Secure; HttpOnly; SameSite=Strict", cookie.toString());
+		assertEquals("SESSION=123; Path=/; Secure; HttpOnly; SameSite=Lax", cookie.toString());
 	}
 
 	@Test
 	public void cookieInitializer() {
 		this.resolver.addCookieInitializer(builder -> builder.domain("example.org"));
-		this.resolver.addCookieInitializer(builder -> builder.sameSite("Lax"));
+		this.resolver.addCookieInitializer(builder -> builder.sameSite("Strict"));
 		this.resolver.addCookieInitializer(builder -> builder.secure(false));
 
 		MockServerHttpRequest request = MockServerHttpRequest.get("https://example.org/path").build();
@@ -61,7 +61,7 @@ public class CookieWebSessionIdResolverTests {
 		assertEquals(1, cookies.size());
 		ResponseCookie cookie = cookies.getFirst(this.resolver.getCookieName());
 		assertNotNull(cookie);
-		assertEquals("SESSION=123; Path=/; Domain=example.org; HttpOnly; SameSite=Lax", cookie.toString());
+		assertEquals("SESSION=123; Path=/; Domain=example.org; HttpOnly; SameSite=Strict", cookie.toString());
 	}
 
 }


### PR DESCRIPTION
See [SPR-16418 (comment)](https://jira.spring.io/browse/SPR-16418?focusedCommentId=160945&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-160945):

> Isn't `Strict` as a default value for `SameSite` attribute bit too aggressive? If site A issues a session cookie with `SameSite` set to `Strict` that would effectively mean that if users follows a link to site A from any other site, they wouldn't be logged in even though they have a valid session. This can be a bit confusing.
>
> See [this article](https://scotthelme.co.uk/csrf-is-dead/) for some considerations around the topic. The [owasp.org](https://www.owasp.org/index.php/SameSite) also supports Lax as default since it _provides a reasonable balance between security and usability_.

/cc @rwinch