### PR TITLE
Polishing

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AspectJProxyFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AspectJProxyFactory.java
@@ -26,6 +26,7 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJProxyUtils;
 import org.springframework.aop.aspectj.SimpleAspectInstanceFactory;
 import org.springframework.aop.framework.ProxyCreatorSupport;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.util.Assert;
@@ -47,7 +48,7 @@ import org.springframework.util.ClassUtils;
  * @see org.springframework.aop.framework.ProxyFactory
  */
 @SuppressWarnings("serial")
-public class AspectJProxyFactory extends ProxyCreatorSupport {
+public class AspectJProxyFactory extends ProxyFactory {
 
 	/** Cache for singleton aspect instances. */
 	private static final Map<Class<?>, Object> aspectCache = new ConcurrentHashMap<>();
@@ -177,33 +178,6 @@ public class AspectJProxyFactory extends ProxyCreatorSupport {
 			}
 		}
 		return instance;
-	}
-
-
-	/**
-	 * Create a new proxy according to the settings in this factory.
-	 * <p>Can be called repeatedly. Effect will vary if we've added
-	 * or removed interfaces. Can add and remove interceptors.
-	 * <p>Uses a default class loader: Usually, the thread context class loader
-	 * (if necessary for proxy creation).
-	 * @return the new proxy
-	 */
-	@SuppressWarnings("unchecked")
-	public <T> T getProxy() {
-		return (T) createAopProxy().getProxy();
-	}
-
-	/**
-	 * Create a new proxy according to the settings in this factory.
-	 * <p>Can be called repeatedly. Effect will vary if we've added
-	 * or removed interfaces. Can add and remove interceptors.
-	 * <p>Uses the given class loader (if necessary for proxy creation).
-	 * @param classLoader the class loader to create the proxy with
-	 * @return the new proxy
-	 */
-	@SuppressWarnings("unchecked")
-	public <T> T getProxy(ClassLoader classLoader) {
-		return (T) createAopProxy().getProxy(classLoader);
 	}
 
 }

--- a/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactory.java
@@ -16,10 +16,12 @@
 
 package org.springframework.aop.framework;
 
+import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.Interceptor;
 
 import org.springframework.aop.TargetSource;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -93,8 +95,9 @@ public class ProxyFactory extends ProxyCreatorSupport {
 	 * (if necessary for proxy creation).
 	 * @return the proxy object
 	 */
-	public Object getProxy() {
-		return createAopProxy().getProxy();
+	@SuppressWarnings("unchecked")
+	public <T> T getProxy() {
+		return (T)createAopProxy().getProxy();
 	}
 
 	/**
@@ -106,8 +109,9 @@ public class ProxyFactory extends ProxyCreatorSupport {
 	 * (or {@code null} for the low-level proxy facility's default)
 	 * @return the proxy object
 	 */
-	public Object getProxy(@Nullable ClassLoader classLoader) {
-		return createAopProxy().getProxy(classLoader);
+	@SuppressWarnings("unchecked")
+	public <T> T getProxy(@Nullable ClassLoader classLoader) {
+		return (T)createAopProxy().getProxy(classLoader);
 	}
 
 
@@ -145,13 +149,28 @@ public class ProxyFactory extends ProxyCreatorSupport {
 	 * @param targetSource the TargetSource that the proxy should invoke
 	 * @return the proxy object
 	 */
-	public static Object getProxy(TargetSource targetSource) {
+	public static <T> T getProxy(TargetSource targetSource) {
 		if (targetSource.getTargetClass() == null) {
 			throw new IllegalArgumentException("Cannot create class proxy for TargetSource with null target class");
 		}
 		ProxyFactory proxyFactory = new ProxyFactory();
 		proxyFactory.setTargetSource(targetSource);
 		proxyFactory.setProxyTargetClass(true);
+		return proxyFactory.getProxy();
+	}
+
+	/**
+	 * Create a proxy for given target and interceptor.
+	 * Convenience method for creating a proxy for a single advice.
+	 * @param advice the advice that the proxy should invoke
+	 * @param target the target object to be proxied
+	 * @return the proxy object
+	 */
+	public static <T> T getProxy(T target, Advice advice) {
+		Assert.notNull(target, "Target can not be null");
+		Assert.notNull(target, "Interceptor can not be null");
+		ProxyFactory proxyFactory = new ProxyFactory(target);
+		proxyFactory.addAdvice(advice);
 		return proxyFactory.getProxy();
 	}
 

--- a/spring-aop/src/test/java/org/springframework/aop/framework/ProxyFactoryTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/framework/ProxyFactoryTests.java
@@ -16,19 +16,10 @@
 
 package org.springframework.aop.framework;
 
-import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.List;
-import javax.accessibility.Accessible;
-import javax.swing.JFrame;
-import javax.swing.RootPaneContainer;
-
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.springframework.aop.Advisor;
 import org.springframework.aop.interceptor.DebugInterceptor;
 import org.springframework.aop.support.AopUtils;
@@ -44,7 +35,13 @@ import org.springframework.tests.sample.beans.IOther;
 import org.springframework.tests.sample.beans.ITestBean;
 import org.springframework.tests.sample.beans.TestBean;
 
-import static org.hamcrest.CoreMatchers.*;
+import javax.accessibility.Accessible;
+import javax.swing.*;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
 /**

--- a/spring-aop/src/test/java/org/springframework/aop/framework/ProxyFactoryTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/framework/ProxyFactoryTests.java
@@ -385,11 +385,11 @@ public class ProxyFactoryTests {
 	public void testGetProxyByTargetAndInterceptor(){
 			CountingBeforeAdvice cba = new CountingBeforeAdvice();
 		ITestBean iTestBean = ProxyFactory.getProxy(new TestBean(),cba);
-		Assert.assertTrue(Proxy.isProxyClass(iTestBean.getClass()));
+		assertTrue(Proxy.isProxyClass(iTestBean.getClass()));
 		iTestBean.setName("TestBean");
-		Assert.assertEquals(1,cba.getCalls());
-		Assert.assertEquals("TestBean",iTestBean.getName());
-		Assert.assertEquals(2,cba.getCalls());
+		assertEquals(1,cba.getCalls());
+		assertEquals("TestBean",iTestBean.getName());
+		assertEquals(2,cba.getCalls());
 	}
 
 

--- a/spring-aop/src/test/java/org/springframework/aop/framework/ProxyFactoryTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/framework/ProxyFactoryTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.aop.framework;
 
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import javax.accessibility.Accessible;
@@ -24,6 +25,7 @@ import javax.swing.RootPaneContainer;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -377,6 +379,17 @@ public class ProxyFactoryTests {
 			return invocation.getMethod().invoke(target, invocation.getArguments());
 		});
 		assertEquals("tb", proxy.getName());
+	}
+
+	@Test
+	public void testGetProxyByTargetAndInterceptor(){
+			CountingBeforeAdvice cba = new CountingBeforeAdvice();
+		ITestBean iTestBean = ProxyFactory.getProxy(new TestBean(),cba);
+		Assert.assertTrue(Proxy.isProxyClass(iTestBean.getClass()));
+		iTestBean.setName("TestBean");
+		Assert.assertEquals(1,cba.getCalls());
+		Assert.assertEquals("TestBean",iTestBean.getName());
+		Assert.assertEquals(2,cba.getCalls());
 	}
 
 


### PR DESCRIPTION
I think AspectJProxyFactory is the extension of ProxyFactory,AspectJProxyFactory can reuse the functionality of ProxyFactory; but i found both class has such method:
```
  public <T> T getProxy()
  public <T> getProxy(ClassLoader classLoader)
```
so i make AspectJProxyFactory extends ProxyFactory directly, eliminate duplicate code.
In addition, i add a convenience method that create Proxy in ProxyFactory, though ProxyFactory has some convenience method by TargetSource, its not useful, because common developer may not what is TargetSource，TargetSource is inner API, but they know target object。