### PR TITLE
Fixed a typo in documentation.

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/AbstractFactoryBean.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/AbstractFactoryBean.java
@@ -161,7 +161,7 @@ public abstract class AbstractFactoryBean<T>
 	}
 
 	/**
-	 * Determine an 'eager singleton' instance, exposed in case of a
+	 * Determine an 'early singleton' instance, exposed in case of a
 	 * circular reference. Not called in a non-circular scenario.
 	 */
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
'AbstractFactoryBean#getEarlySingletonInstance' documentation mentions "eager singleton". I'm quite sure it should be fixed to "early singleton".