### PR TITLE
Modify a parameter name in document

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -8441,9 +8441,9 @@ simple class that extends Spring's `ApplicationEvent` base class:
 	public class BlackListEvent extends ApplicationEvent {
 
 		private final String address;
-		private final String test;
+		private final String text;
 
-		public BlackListEvent(Object source, String address, String test) {
+		public BlackListEvent(Object source, String address, String text) {
 			super(source);
 			this.address = address;
 			this.test = test;


### PR DESCRIPTION
The “text” is more meaningful than "test" in context.