### PR TITLE
Fix log level guard in DatabaseStartupValidator.afterPropertiesSet()

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/DatabaseStartupValidator.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/DatabaseStartupValidator.java
@@ -136,7 +136,7 @@ public class DatabaseStartupValidator implements InitializingBean {
 					if (logger.isDebugEnabled()) {
 						logger.debug("Validation query [" + this.validationQuery + "] threw exception", ex);
 					}
-					if (logger.isWarnEnabled()) {
+					if (logger.isInfoEnabled()) {
 						float rest = ((float) (deadLine - System.currentTimeMillis())) / 1000;
 						if (rest > this.interval) {
 							logger.info("Database has not started up yet - retrying in " + this.interval +


### PR DESCRIPTION
A log level has been changed in 9a43d2ec208d2e8cd0866431acf26af3529f8677 but a log level guard for it hasn't been updated. This PR updates the log level guard to align with the log level.