### PR TITLE
Make "PathVariable reflects value up to 1st semicolon" consistent

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
@@ -155,17 +155,14 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 				return;
 			}
 
-			int semicolonIndex = uriVarValue.indexOf(';');
-			if (semicolonIndex != -1 && semicolonIndex != 0) {
-				uriVariables.put(uriVarKey, uriVarValue.substring(0, semicolonIndex));
-			}
-
 			String matrixVariables;
-			if (semicolonIndex == -1 || semicolonIndex == 0 || equalsIndex < semicolonIndex) {
-				matrixVariables = uriVarValue;
+			int semicolonIndex = uriVarValue.indexOf(';');
+			if (semicolonIndex > 0) {
+				uriVariables.put(uriVarKey, uriVarValue.substring(0, semicolonIndex));
+				matrixVariables = uriVarValue.substring(semicolonIndex + 1);
 			}
 			else {
-				matrixVariables = uriVarValue.substring(semicolonIndex + 1);
+				matrixVariables = uriVarValue;
 			}
 
 			MultiValueMap<String, String> vars = WebUtils.parseMatrixVariables(matrixVariables);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
@@ -355,7 +355,7 @@ public class RequestMappingInfoHandlerMappingTests {
 		uriVariables = getUriTemplateVariables(request);
 
 		assertNotNull(matrixVariables);
-		assertEquals("42", matrixVariables.getFirst("a"));
+		assertEquals(1, matrixVariables.size());
 		assertEquals("c", matrixVariables.getFirst("b"));
 		assertEquals("a=42", uriVariables.get("foo"));
 	}


### PR DESCRIPTION
When I was reading 66d73017d5406e46c176a44e5204922d167bef93, I noticed that assertions for "reactive" and ones for "servlet" are different. This PR tries to make "servlet" codes align with "reactive" ones to be consistent with an assumption that "reactive" ones are correct.