### PR TITLE
SPR-17074 pass argument of addAll/putAll into constructor

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/PropertyOrFieldReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/PropertyOrFieldReference.java
@@ -322,8 +322,7 @@ public class PropertyOrFieldReference extends SpelNodeImpl {
 				}
 			}
 		}
-		List<PropertyAccessor> resolvers = new ArrayList<>();
-		resolvers.addAll(specificAccessors);
+		List<PropertyAccessor> resolvers = new ArrayList<>(specificAccessors);
 		generalAccessors.removeAll(specificAccessors);
 		resolvers.addAll(generalAccessors);
 		return resolvers;

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -362,8 +362,7 @@ public class CallMetaDataContext {
 		}
 		setOutParameterNames(outParamNames);
 
-		List<SqlParameter> workParams = new ArrayList<>();
-		workParams.addAll(declaredReturnParams);
+		List<SqlParameter> workParams = new ArrayList<>(declaredReturnParams);
 		if (!provider.isProcedureColumnMetaDataUsed()) {
 			workParams.addAll(declaredParams.values());
 			return workParams;

--- a/spring-web/src/main/java/org/springframework/web/multipart/support/StandardMultipartHttpServletRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/support/StandardMultipartHttpServletRequest.java
@@ -159,8 +159,7 @@ public class StandardMultipartHttpServletRequest extends AbstractMultipartHttpSe
 
 		// Servlet 3.0 getParameterMap() not guaranteed to include multipart form items
 		// (e.g. on WebLogic 12) -> need to merge them here to be on the safe side
-		Map<String, String[]> paramMap = new LinkedHashMap<>();
-		paramMap.putAll(super.getParameterMap());
+		Map<String, String[]> paramMap = new LinkedHashMap<>(super.getParameterMap());
 		for (String paramName : this.multipartParameterNames) {
 			if (!paramMap.containsKey(paramName)) {
 				paramMap.put(paramName, getParameterValues(paramName));


### PR DESCRIPTION
Pass argument of `Collection::addAll`/`Map::putAll` directly into constructor. This is shorter and allocates collection/map of exact size