### PR TITLE
SPR-17105 HttpMethod improvement: stop resizing inner map during initialization.

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -35,7 +35,7 @@ public enum HttpMethod {
 	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE;
 
 
-	private static final Map<String, HttpMethod> mappings = new HashMap<>(8);
+	private static final Map<String, HttpMethod> mappings = new HashMap<>(8, 1);
 
 	static {
 		for (HttpMethod httpMethod : values()) {


### PR DESCRIPTION
Issue: https://jira.spring.io/browse/SPR-17105

Putting all 8 values in the map triggers map's resizing (when it's filled with 6 values), which could be avoided, changing load factor to 1.