### PR TITLE
[DOC] Delete MockServer when using RestTemplate with MockMvc

### DIFF
--- a/src/docs/asciidoc/testing.adoc
+++ b/src/docs/asciidoc/testing.adoc
@@ -5590,8 +5590,6 @@ server-side logic but without running a server. Here is an example:
 	this.restTemplate = new RestTemplate(new MockMvcClientHttpRequestFactory(mockMvc));
 
 	// Test code that uses the above RestTemplate ...
-
-	mockServer.verify();
 ----
 
 [[spring-mvc-test-client-static-imports]]


### PR DESCRIPTION
I think the `mockServer.verify()` call shouldn't be in this example (as I don't see it defined) but please ignore if I'm wrong.