### PR TITLE
Polish build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -289,9 +289,6 @@ configure(rootProject) {
 	}
 
 	wrapper {
-		description = "Generates gradlew[.bat] scripts"
-		gradleVersion = '4.8.1'
-
 		doLast() {
 			def gradleOpts = "-XX:MaxMetaspaceSize=1024m -Xmx1024m"
 			def gradleBatOpts = "$gradleOpts -XX:MaxHeapSize=256m"


### PR DESCRIPTION
This simplifies build script by removing the following unnecessary properties from `wrapper` task configuration:

- `description`: has no effect as no such property exists in Gradle's [`Wrapper`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.wrapper.Wrapper.html#N2855B) which can be verified with:

```shell
$ ./gradlew tasks | grep wrapper
wrapper - Generates Gradle wrapper files.
```

- `gradleVersion`: not needed as `wrapper` task should preferably be [invoked with `--gradle-version`](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper) option which also eliminates the need to modify the build script on each upgrade of Gradle:

```shell
$ ./gradlew wrapper --gradle-version 4.8.1
```