### PR TITLE
Add backslash escape support to containsSqlScriptDelimiters

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -346,19 +346,17 @@ public abstract class ScriptUtils {
 		boolean inEscape = false;
 		for (int i = 0; i < script.length(); i++) {
 
-			char thisChar = script.charAt(i);
-			if (thisChar == '\\')
-			{
+			char c = script.charAt(i);
+			if (c == '\\') {
 				inEscape = !inEscape;
 				continue;
 			}
-			else if (inEscape)
-			{
+			else if (inEscape) {
 				inEscape = false;
 				continue;
 			}
 
-			if (thisChar == '\'') {
+			if (c == '\'') {
 				inLiteral = !inLiteral;
 			}
 			if (!inLiteral && script.startsWith(delim, i)) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -343,8 +343,22 @@ public abstract class ScriptUtils {
 	 */
 	public static boolean containsSqlScriptDelimiters(String script, String delim) {
 		boolean inLiteral = false;
+		boolean inEscape = false;
 		for (int i = 0; i < script.length(); i++) {
-			if (script.charAt(i) == '\'') {
+
+			char thisChar = script.charAt(i);
+			if (thisChar == '\\')
+			{
+				inEscape = !inEscape;
+				continue;
+			}
+			else if (inEscape)
+			{
+				inEscape = false;
+				continue;
+			}
+
+			if (thisChar == '\'') {
 				inLiteral = !inLiteral;
 			}
 			if (!inLiteral && script.startsWith(delim, i)) {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/init/ScriptUtilsUnitTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/init/ScriptUtilsUnitTests.java
@@ -170,6 +170,8 @@ public class ScriptUtilsUnitTests {
 		assertTrue(containsSqlScriptDelimiters("select 1\n select 2", "\n"));
 		assertFalse(containsSqlScriptDelimiters("select 1\n select 2", "\n\n"));
 		assertTrue(containsSqlScriptDelimiters("select 1\n\n select 2", "\n\n"));
+		assertTrue(containsSqlScriptDelimiters("insert into users(first_name, last_name)\nvalues('Charles', 'd\\'Artagnan');", ";"));
+		assertFalse(containsSqlScriptDelimiters("insert into users(first_name, last_name)\nvalues('a\\\\', 'b;')", ";"));
 	}
 
 	private String readScript(String path) throws Exception {


### PR DESCRIPTION
Issue: SPR-17120

This change makes containsSqlScriptDelimiters keep track of backslash escapes while it determines if the current character is inside a literal.

N.B backslash escaped quotes are supported by MySQL / MariaDB but I don't believe they're supported by HSQLDB.