### PR TITLE
SPR-17144 - Fix ContextPathCompositeHandler response completion

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ContextPathCompositeHandler.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ContextPathCompositeHandler.java
@@ -75,8 +75,7 @@ public class ContextPathCompositeHandler implements HttpHandler {
 				})
 				.orElseGet(() -> {
 					response.setStatusCode(HttpStatus.NOT_FOUND);
-					response.setComplete();
-					return Mono.empty();
+					return Mono.defer(response::setComplete);
 				});
 	}
 


### PR DESCRIPTION
Updated ContextPathCompositeHandler so that it does not discard the
result of setting the response as complete. This was causing a 200
status code to be returned instead of the intended 404 status code.

Issues: SPR-17144