### PR TITLE
Use an import instead of FQCN

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/jcache/JCacheCache.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/jcache/JCacheCache.java
@@ -17,6 +17,8 @@
 package org.springframework.cache.jcache;
 
 import java.util.concurrent.Callable;
+
+import javax.cache.Cache;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.MutableEntry;
@@ -37,14 +39,14 @@ import org.springframework.util.Assert;
  */
 public class JCacheCache extends AbstractValueAdaptingCache {
 
-	private final javax.cache.Cache<Object, Object> cache;
+	private final Cache<Object, Object> cache;
 
 
 	/**
 	 * Create an {@link org.springframework.cache.jcache.JCacheCache} instance.
 	 * @param jcache backing JCache Cache instance
 	 */
-	public JCacheCache(javax.cache.Cache<Object, Object> jcache) {
+	public JCacheCache(Cache<Object, Object> jcache) {
 		this(jcache, true);
 	}
 
@@ -53,7 +55,7 @@ public class JCacheCache extends AbstractValueAdaptingCache {
 	 * @param jcache backing JCache Cache instance
 	 * @param allowNullValues whether to accept and convert null values for this cache
 	 */
-	public JCacheCache(javax.cache.Cache<Object, Object> jcache, boolean allowNullValues) {
+	public JCacheCache(Cache<Object, Object> jcache, boolean allowNullValues) {
 		super(allowNullValues);
 		Assert.notNull(jcache, "Cache must not be null");
 		this.cache = jcache;
@@ -66,7 +68,7 @@ public class JCacheCache extends AbstractValueAdaptingCache {
 	}
 
 	@Override
-	public final javax.cache.Cache<Object, Object> getNativeCache() {
+	public final Cache<Object, Object> getNativeCache() {
 		return this.cache;
 	}
 

--- a/spring-context-support/src/main/java/org/springframework/cache/jcache/JCacheCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/jcache/JCacheCacheManager.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
 public class JCacheCacheManager extends AbstractTransactionSupportingCacheManager {
 
 	@Nullable
-	private javax.cache.CacheManager cacheManager;
+	private CacheManager cacheManager;
 
 	private boolean allowNullValues = true;
 
@@ -63,7 +63,7 @@ public class JCacheCacheManager extends AbstractTransactionSupportingCacheManage
 	/**
 	 * Set the backing JCache {@link javax.cache.CacheManager}.
 	 */
-	public void setCacheManager(@Nullable javax.cache.CacheManager cacheManager) {
+	public void setCacheManager(@Nullable CacheManager cacheManager) {
 		this.cacheManager = cacheManager;
 	}
 
@@ -71,7 +71,7 @@ public class JCacheCacheManager extends AbstractTransactionSupportingCacheManage
 	 * Return the backing JCache {@link javax.cache.CacheManager}.
 	 */
 	@Nullable
-	public javax.cache.CacheManager getCacheManager() {
+	public CacheManager getCacheManager() {
 		return this.cacheManager;
 	}
 


### PR DESCRIPTION
No that JCacheCache extends AbstractValueAdaptingCache instead of
directly implementing Cache an import statement can be used in favor
of using the FQCN for the field and constructor arguments.