### PR TITLE
Use an import instead of FQCN in StaxStreamXMLReader

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/xml/StaxStreamXMLReader.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/StaxStreamXMLReader.java
@@ -243,7 +243,7 @@ class StaxStreamXMLReader extends AbstractStaxXMLReader {
 
 	private void handleDtd() throws SAXException {
 		if (getLexicalHandler() != null) {
-			javax.xml.stream.Location location = this.reader.getLocation();
+			Location location = this.reader.getLocation();
 			getLexicalHandler().startDTD(null, location.getPublicId(), location.getSystemId());
 		}
 		if (getLexicalHandler() != null) {


### PR DESCRIPTION
javax.xml.stream.Location is already there as an import there is no need
to use the FQCN in the handleDtd method.