### PR TITLE
Editing pass for the Spring Framework Reference Guide

### DIFF
--- a/src/docs/asciidoc/core.adoc
+++ b/src/docs/asciidoc/core.adoc
@@ -7,18 +7,18 @@
 :tabsize: 4
 :docinfo1:
 
-This part of the reference documentation covers all of those technologies that are
+This part of the reference documentation covers all the technologies that are
 absolutely integral to the Spring Framework.
 
 Foremost amongst these is the Spring Framework's Inversion of Control (IoC) container. A
 thorough treatment of the Spring Framework's IoC container is closely followed by
 comprehensive coverage of Spring's Aspect-Oriented Programming (AOP) technologies. The
-Spring Framework has its own AOP framework, which is conceptually easy to understand,
+Spring Framework has its own AOP framework, which is conceptually easy to understand
 and which successfully addresses the 80% sweet spot of AOP requirements in Java
 enterprise programming.
 
-Coverage of Spring's integration with AspectJ (currently the richest - in terms of
-features - and certainly most mature AOP implementation in the Java enterprise space) is
+Coverage of Spring's integration with AspectJ (currently the richest -- in terms of
+features -- and certainly most mature AOP implementation in the Java enterprise space) is
 also provided.
 
 include::core/core-beans.adoc[leveloffset=+1]

--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -5,19 +5,18 @@
 
 
 [[beans-introduction]]
-== Introduction to the Spring IoC container and beans
+== Introduction to the Spring IoC Container and Beans
 
 This chapter covers the Spring Framework implementation of the Inversion of Control
-(IoC) footnote:[See pass:specialcharacters,macros[<<overview.adoc#background-ioc,
-Inversion of Control>>] ] principle. IoC
-is also known as __dependency injection__ (DI). It is a process whereby objects define
-their dependencies, that is, the other objects they work with, only through constructor
+(IoC) principle. (See <<overview.adoc#background-ioc,Inversion of Control>>.) IoC
+is also known as dependency injection (DI). It is a process whereby objects define
+their dependencies (that is, the other objects they work with) only through constructor
 arguments, arguments to a factory method, or properties that are set on the object
 instance after it is constructed or returned from a factory method. The container then
-__injects__ those dependencies when it creates the bean. This process is fundamentally
-the inverse, hence the name __Inversion of Control__ (IoC), of the bean itself
+injects those dependencies when it creates the bean. This process is fundamentally
+the inverse (hence the name, Inversion of Control) of the bean itself
 controlling the instantiation or location of its dependencies by using direct
-construction of classes, or a mechanism such as the __Service Locator__ pattern.
+construction of classes or a mechanism such as the Service Locator pattern.
 
 The `org.springframework.beans` and `org.springframework.context` packages are the basis
 for Spring Framework's IoC container. The
@@ -25,44 +24,46 @@ for Spring Framework's IoC container. The
 interface provides an advanced configuration mechanism capable of managing any type of
 object.
 {api-spring-framework}/context/ApplicationContext.html[`ApplicationContext`]
-is a sub-interface of `BeanFactory`. It adds easier integration with Spring's AOP
-features; message resource handling (for use in internationalization), event
-publication; and application-layer specific contexts such as the `WebApplicationContext`
+is a sub-interface of `BeanFactory`. It adds:
+* Easier integration with Spring's AOP features
+* Message resource handling (for use in internationalization)
+* Event publication
+* Application-layer specific contexts such as the `WebApplicationContext`
 for use in web applications.
 
 In short, the `BeanFactory` provides the configuration framework and basic
 functionality, and the `ApplicationContext` adds more enterprise-specific functionality.
-The `ApplicationContext` is a complete superset of the `BeanFactory`, and is used
+The `ApplicationContext` is a complete superset of the `BeanFactory` and is used
 exclusively in this chapter in descriptions of Spring's IoC container. For more
-information on using the `BeanFactory` instead of the `ApplicationContext,` refer to
+information on using the `BeanFactory` instead of the `ApplicationContext,` see
 <<beans-beanfactory>>.
 
 In Spring, the objects that form the backbone of your application and that are managed
-by the Spring IoC __container__ are called __beans__. A bean is an object that is
+by the Spring IoC container are called beans. A bean is an object that is
 instantiated, assembled, and otherwise managed by a Spring IoC container. Otherwise, a
-bean is simply one of many objects in your application. Beans, and the __dependencies__
-among them, are reflected in the __configuration metadata__ used by a container.
+bean is simply one of many objects in your application. Beans, and the dependencies
+among them, are reflected in the configuration metadata used by a container.
 
 
 
 
 [[beans-basics]]
-== Container overview
+== Container Overview
 
-The interface `org.springframework.context.ApplicationContext` represents the Spring IoC
+The `org.springframework.context.ApplicationContext` interface represents the Spring IoC
 container and is responsible for instantiating, configuring, and assembling the
-aforementioned beans. The container gets its instructions on what objects to
+beans. The container gets its instructions on what objects to
 instantiate, configure, and assemble by reading configuration metadata. The
-configuration metadata is represented in XML, Java annotations, or Java code. It allows
-you to express the objects that compose your application and the rich interdependencies
-between such objects.
+configuration metadata is represented in XML, Java annotations, or Java code. It lets
+you express the objects that compose your application and the rich interdependencies
+between those objects.
 
 Several implementations of the `ApplicationContext` interface are supplied
-out-of-the-box with Spring. In standalone applications it is common to create an
+with Spring. In stand-alone applications, it is common to create an
 instance of
 {api-spring-framework}/context/support/ClassPathXmlApplicationContext.html[`ClassPathXmlApplicationContext`]
 or {api-spring-framework}/context/support/FileSystemXmlApplicationContext.html[`FileSystemXmlApplicationContext`].
- While XML has been the traditional format for defining configuration metadata you can
+While XML has been the traditional format for defining configuration metadata, you can
 instruct the container to use Java annotations or code as the metadata format by
 providing a small amount of XML configuration to declaratively enable support for these
 additional metadata formats.
@@ -70,13 +71,13 @@ additional metadata formats.
 In most application scenarios, explicit user code is not required to instantiate one or
 more instances of a Spring IoC container. For example, in a web application scenario, a
 simple eight (or so) lines of boilerplate web descriptor XML in the `web.xml` file
-of the application will typically suffice (see <<context-create>>). If you are using the
-https://spring.io/tools/sts[Spring Tool Suite] Eclipse-powered development
-environment this boilerplate configuration can be easily created with few mouse clicks or
+of the application typically suffices (see <<context-create>>). If you use the
+https://spring.io/tools/sts[Spring Tool Suite] (an Eclipse-powered development
+environment), you can easily create this boilerplate configuration with a few mouse clicks or
 keystrokes.
 
-The following diagram is a high-level view of how Spring works. Your application classes
-are combined with configuration metadata so that after the `ApplicationContext` is
+The following diagram shows a high-level view of how Spring works. Your application classes
+are combined with configuration metadata so that, after the `ApplicationContext` is
 created and initialized, you have a fully configured and executable system or
 application.
 
@@ -86,24 +87,21 @@ image::images/container-magic.png[]
 
 
 [[beans-factory-metadata]]
-=== Configuration metadata
+=== Configuration Metadata
 
 As the preceding diagram shows, the Spring IoC container consumes a form of
-__configuration metadata__; this configuration metadata represents how you as an
-application developer tell the Spring container to instantiate, configure, and assemble
+configuration metadata. This configuration metadata represents how you, as an
+application developer, tell the Spring container to instantiate, configure, and assemble
 the objects in your application.
 
 Configuration metadata is traditionally supplied in a simple and intuitive XML format,
 which is what most of this chapter uses to convey key concepts and features of the
 Spring IoC container.
 
-[NOTE]
-====
-XML-based metadata is __not__ the only allowed form of configuration metadata. The
-Spring IoC container itself is __totally__ decoupled from the format in which this
-configuration metadata is actually written. These days many developers choose
+NOTE: XML-based metadata is not the only allowed form of configuration metadata. The
+Spring IoC container itself is totally decoupled from the format in which this
+configuration metadata is actually written. These days, many developers choose
 <<beans-java,Java-based configuration>> for their Spring applications.
-====
 
 For information about using other forms of metadata with the Spring container, see:
 
@@ -111,19 +109,22 @@ For information about using other forms of metadata with the Spring container, s
   support for annotation-based configuration metadata.
 * <<beans-java,Java-based configuration>>: Starting with Spring 3.0, many features
   provided by the Spring JavaConfig project became part of the core Spring Framework.
-  Thus you can define beans external to your application classes by using Java rather
-  than XML files. To use these new features, see the `@Configuration`, `@Bean`, `@Import`
-  and `@DependsOn` annotations.
+  Thus, you can define beans external to your application classes by using Java rather
+  than XML files. To use these new features, see the
+  https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html[`@Configuration`],
+  https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Bean.html[`@Bean`],
+  https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Import.html[`@Import`],
+  and https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/DependsOn.html[`@DependsOn`] annotations.
 
 Spring configuration consists of at least one and typically more than one bean
-definition that the container must manage. XML-based configuration metadata shows these
-beans configured as `<bean/>` elements inside a top-level `<beans/>` element. Java
-configuration typically uses `@Bean` annotated methods within a `@Configuration` class.
+definition that the container must manage. XML-based configuration metadata configures these
+beans as `<bean/>` elements inside a top-level `<beans/>` element. Java
+configuration typically uses `@Bean`-annotated methods within a `@Configuration` class.
 
 These bean definitions correspond to the actual objects that make up your application.
-Typically you define service layer objects, data access objects (DAOs), presentation
+Typically, you define service layer objects, data access objects (DAOs), presentation
 objects such as Struts `Action` instances, infrastructure objects such as Hibernate
-`SessionFactories`, JMS `Queues`, and so forth. Typically one does not configure
+`SessionFactories`, JMS `Queues`, and so forth. Typically, one does not configure
 fine-grained domain objects in the container, because it is usually the responsibility
 of DAOs and business logic to create and load domain objects. However, you can use
 Spring's integration with AspectJ to configure objects that have been created outside
@@ -132,6 +133,7 @@ dependency-inject domain objects with Spring>>.
 
 The following example shows the basic structure of XML-based configuration metadata:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -141,7 +143,7 @@ The following example shows the basic structure of XML-based configuration metad
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-		<bean id="..." class="...">
+		<bean id="..." class="...">                                       <1> <2>
 			<!-- collaborators and configuration for this bean go here -->
 		</bean>
 
@@ -154,39 +156,43 @@ The following example shows the basic structure of XML-based configuration metad
 	</beans>
 ----
 
-The `id` attribute is a string that you use to identify the individual bean definition.
-The `class` attribute defines the type of the bean and uses the fully qualified
-classname. The value of the id attribute refers to collaborating objects. The XML for
-referring to collaborating objects is not shown in this example; see
+<1> The `id` attribute is a string that identifies the individual bean definition.
+
+<2> The `class` attribute defines the type of the bean and uses the fully qualified
+classname.
+====
+
+The value of the `id` attribute refers to collaborating objects. The XML for
+referring to collaborating objects is not shown in this example. See
 <<beans-dependencies,Dependencies>> for more information.
 
 
 
 [[beans-factory-instantiation]]
-=== Instantiating a container
+=== Instantiating a Container
 
-Instantiating a Spring IoC container is straightforward. The location path or paths
-supplied to an `ApplicationContext` constructor are actually resource strings that allow
-the container to load configuration metadata from a variety of external resources such
-as the local file system, from the Java `CLASSPATH`, and so on.
+The location path or paths
+supplied to an `ApplicationContext` constructor are resource strings that let
+the container load configuration metadata from a variety of external resources, such
+as the local file system, the Java `CLASSPATH`, and so on.
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	ApplicationContext context = new ClassPathXmlApplicationContext("services.xml", "daos.xml");
 ----
+====
 
-[NOTE]
-====
-After you learn about Spring's IoC container, you may want to know more about Spring's
-`Resource` abstraction, as described in <<resources>>, which provides a convenient
+NOTE:After you learn about Spring's IoC container, you may want to know more about Spring's
+`Resource` abstraction (as described in <<resources>>), which provides a convenient
 mechanism for reading an InputStream from locations defined in a URI syntax. In
-particular, `Resource` paths are used to construct applications contexts as described in
+particular, `Resource` paths are used to construct applications contexts, as described in
 <<resources-app-ctx>>.
-====
 
 The following example shows the service layer objects `(services.xml)` configuration file:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -208,9 +214,11 @@ The following example shows the service layer objects `(services.xml)` configura
 
 	</beans>
 ----
+====
 
 The following example shows the data access objects `daos.xml` file:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -233,27 +241,31 @@ The following example shows the data access objects `daos.xml` file:
 
 	</beans>
 ----
+====
 
-In the preceding example, the service layer consists of the class `PetStoreServiceImpl`,
-and two data access objects of the type `JpaAccountDao` and `JpaItemDao` (based
-on the JPA Object/Relational mapping standard). The `property name` element refers to the
+In the preceding example, the service layer consists of the `PetStoreServiceImpl` class
+and two data access objects of the types `JpaAccountDao` and `JpaItemDao` (based
+on the JPA Object-Relational Mapping standard). The `property name` element refers to the
 name of the JavaBean property, and the `ref` element refers to the name of another bean
 definition. This linkage between `id` and `ref` elements expresses the dependency between
 collaborating objects. For details of configuring an object's dependencies, see
 <<beans-dependencies,Dependencies>>.
 
 
-[[beans-factory-xml-import]]
-==== Composing XML-based configuration metadata
 
-It can be useful to have bean definitions span multiple XML files. Often each individual
+[[beans-factory-xml-import]]
+==== Composing XML-based Configuration Metadata
+
+It can be useful to have bean definitions span multiple XML files. Often, each individual
 XML configuration file represents a logical layer or module in your architecture.
 
 You can use the application context constructor to load bean definitions from all these
 XML fragments. This constructor takes multiple `Resource` locations, as was shown in the
-previous section. Alternatively, use one or more occurrences of the `<import/>` element
-to load bean definitions from another file or files. For example:
+<<beans-factory-instantiation,previous section>>. Alternatively, use one or more
+occurrences of the `<import/>` element to load bean definitions from another file or
+files. The following example shows how to do so:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -266,37 +278,39 @@ to load bean definitions from another file or files. For example:
 		<bean id="bean2" class="..."/>
 	</beans>
 ----
+====
 
 In the preceding example, external bean definitions are loaded from three files:
 `services.xml`, `messageSource.xml`, and `themeSource.xml`. All location paths are
 relative to the definition file doing the importing, so `services.xml` must be in the
 same directory or classpath location as the file doing the importing, while
 `messageSource.xml` and `themeSource.xml` must be in a `resources` location below the
-location of the importing file. As you can see, a leading slash is ignored, but given
+location of the importing file. As you can see, a leading slash is ignored. However, given
 that these paths are relative, it is better form not to use the slash at all. The
 contents of the files being imported, including the top level `<beans/>` element, must
-be valid XML bean definitions according to the Spring Schema.
+be valid XML bean definitions, according to the Spring Schema.
 
 [NOTE]
 ====
 It is possible, but not recommended, to reference files in parent directories using a
 relative "../" path. Doing so creates a dependency on a file that is outside the current
-application. In particular, this reference is not recommended for "classpath:" URLs (for
-example, "classpath:../services.xml"), where the runtime resolution process chooses the
-"nearest" classpath root and then looks into its parent directory. Classpath
+application. In particular, this reference is not recommended for `classpath:` URLs (for
+example, `classpath:../services.xml`), where the runtime resolution process chooses the
+"`nearest`" classpath root and then looks into its parent directory. Classpath
 configuration changes may lead to the choice of a different, incorrect directory.
 
 You can always use fully qualified resource locations instead of relative paths: for
-example, "file:C:/config/services.xml" or "classpath:/config/services.xml". However, be
+example, `file:C:/config/services.xml` or `classpath:/config/services.xml`. However, be
 aware that you are coupling your application's configuration to specific absolute
 locations. It is generally preferable to keep an indirection for such absolute
-locations, for example, through "${...}" placeholders that are resolved against JVM
+locations -- for example, through "${...}" placeholders that are resolved against JVM
 system properties at runtime.
 ====
 
-The import directive is a feature provided by the beans namespace itself. Further
+The namespace itself provices the import directive feature. Further
 configuration features beyond plain bean definitions are available in a selection
-of XML namespaces provided by Spring, e.g. the "context" and the "util" namespace.
+of XML namespaces provided by Spring -- for example, the `context` and `util` namespaces.
+
 
 
 [[groovy-bean-definition-dsl]]
@@ -304,8 +318,10 @@ of XML namespaces provided by Spring, e.g. the "context" and the "util" namespac
 
 As a further example for externalized configuration metadata, bean definitions can also
 be expressed in Spring's Groovy Bean Definition DSL, as known from the Grails framework.
-Typically, such configuration will live in a ".groovy" file with a structure as follows:
+Typically, such configuration live in a ".groovy" file with the structure shown in the
+following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -327,22 +343,25 @@ Typically, such configuration will live in a ".groovy" file with a structure as 
 		}
 	}
 ----
+====
 
 This configuration style is largely equivalent to XML bean definitions and even
 supports Spring's XML configuration namespaces. It also allows for importing XML
-bean definition files through an "importBeans" directive.
+bean definition files through an `importBeans` directive.
 
 
 
 [[beans-factory-client]]
-=== Using the container
+=== Using the Container
 
 The `ApplicationContext` is the interface for an advanced factory capable of maintaining
-a registry of different beans and their dependencies. Using the method `T getBean(String
-name, Class<T> requiredType)` you can retrieve instances of your beans.
+a registry of different beans and their dependencies. By using the method `T getBean(String
+name, Class<T> requiredType)`, you can retrieve instances of your beans.
 
-The `ApplicationContext` enables you to read bean definitions and access them as follows:
+The `ApplicationContext` lets you read bean definitions and access them, as the following
+example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -355,9 +374,11 @@ The `ApplicationContext` enables you to read bean definitions and access them as
 	// use configured instance
 	List<String> userList = service.getUsernameList();
 ----
+====
 
-With Groovy configuration, bootstrapping looks very similar, just a different context
-implementation class which is Groovy-aware (but also understands XML bean definitions):
+With Groovy configuration, bootstrapping looks very similar. It has a different context
+implementation class which is Groovy-aware (but also understands XML bean definitions).
+The following example shows Groovy configuration:
 
 [source,java,indent=0]
 [subs="verbatim,quotes"]
@@ -366,8 +387,10 @@ implementation class which is Groovy-aware (but also understands XML bean defini
 ----
 
 The most flexible variant is `GenericApplicationContext` in combination with reader
-delegates, e.g. with `XmlBeanDefinitionReader` for XML files:
+delegates -- for example, with `XmlBeanDefinitionReader` for XML files, as the following
+example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -375,9 +398,12 @@ delegates, e.g. with `XmlBeanDefinitionReader` for XML files:
 	new XmlBeanDefinitionReader(context).loadBeanDefinitions("services.xml", "daos.xml");
 	context.refresh();
 ----
+====
 
-Or with `GroovyBeanDefinitionReader` for Groovy files:
+You can also use the `GroovyBeanDefinitionReader` for Groovy files, as the following
+example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -385,118 +411,117 @@ Or with `GroovyBeanDefinitionReader` for Groovy files:
 	new GroovyBeanDefinitionReader(context).loadBeanDefinitions("services.groovy", "daos.groovy");
 	context.refresh();
 ----
+====
 
-Such reader delegates can be mixed and matched on the same `ApplicationContext`,
-reading bean definitions from diverse configuration sources, if desired.
+You can mix and match such reader delegates on the same `ApplicationContext`,
+reading bean definitions from diverse configuration sources.
 
 You can then use `getBean` to retrieve instances of your beans. The `ApplicationContext`
-interface has a few other methods for retrieving beans, but ideally your application
+interface has a few other methods for retrieving beans, but, ideally, your application
 code should never use them. Indeed, your application code should have no calls to the
-`getBean()` method at all, and thus no dependency on Spring APIs at all. For example,
+`getBean()` method at all and thus have no dependency on Spring APIs at all. For example,
 Spring's integration with web frameworks provides dependency injection for various web
-framework components such as controllers and JSF-managed beans, allowing you to declare
-a dependency on a specific bean through metadata (e.g. an autowiring annotation).
+framework components such as controllers and JSF-managed beans, letting you declare
+a dependency on a specific bean through metadata (such as an autowiring annotation).
 
 
 
 
 [[beans-definition]]
-== Bean overview
+== Bean Overview
 
-A Spring IoC container manages one or more __beans__. These beans are created with the
-configuration metadata that you supply to the container, for example, in the form of XML
-`<bean/>` definitions.
+A Spring IoC container manages one or more beans. These beans are created with the
+configuration metadata that you supply to the container (for example, in the form of XML
+`<bean/>` definitions).
 
 Within the container itself, these bean definitions are represented as `BeanDefinition`
 objects, which contain (among other information) the following metadata:
 
-* __A package-qualified class name:__ typically the actual implementation class of the
+* A package-qualified class name: typically, the actual implementation class of the
   bean being defined.
 * Bean behavioral configuration elements, which state how the bean should behave in the
   container (scope, lifecycle callbacks, and so forth).
-* References to other beans that are needed for the bean to do its work; these
-  references are also called __collaborators__ or __dependencies__.
-* Other configuration settings to set in the newly created object, for example, the
-  number of connections to use in a bean that manages a connection pool, or the size
-  limit of the pool.
+* References to other beans that are needed for the bean to do its work. These
+  references are also called collaborators or dependencies.
+* Other configuration settings to set in the newly created object -- for example, the size
+  limit of the pool or the number of connections to use in a bean that manages a
+  connection pool.
 
 This metadata translates to a set of properties that make up each bean definition.
+The following table describes these properties:
 
 [[beans-factory-bean-definition-tbl]]
 .The bean definition
 |===
 | Property| Explained in...
 
-| class
+| Class
 | <<beans-factory-class>>
 
-| name
+| Name
 | <<beans-beanname>>
 
-| scope
+| Scope
 | <<beans-factory-scopes>>
 
-| constructor arguments
+| Constructor arguments
 | <<beans-factory-collaborators>>
 
-| properties
+| Properties
 | <<beans-factory-collaborators>>
 
-| autowiring mode
+| Autowiring mode
 | <<beans-factory-autowire>>
 
-| lazy-initialization mode
+| Lazy initialization mode
 | <<beans-factory-lazy-init>>
 
-| initialization method
+| Initialization method
 | <<beans-factory-lifecycle-initializingbean>>
 
-| destruction method
+| Destruction method
 | <<beans-factory-lifecycle-disposablebean>>
 |===
 
 In addition to bean definitions that contain information on how to create a specific
 bean, the `ApplicationContext` implementations also permit the registration of existing
-objects that are created outside the container, by users. This is done by accessing the
-ApplicationContext's BeanFactory via the method `getBeanFactory()` which returns the
-BeanFactory implementation `DefaultListableBeanFactory`. `DefaultListableBeanFactory`
-supports this registration through the methods `registerSingleton(..)` and
-`registerBeanDefinition(..)`. However, typical applications work solely with beans
+objects that are created outside the container (by users). This is done by accessing the
+ApplicationContext's BeanFactory through the `getBeanFactory()` method, which returns the
+BeanFactory `DefaultListableBeanFactory` implementation. `DefaultListableBeanFactory`
+supports this registration through the `registerSingleton(..)` and
+`registerBeanDefinition(..)` methods. However, typical applications work solely with beans
 defined through metadata bean definitions.
 
-[NOTE]
-====
-Bean metadata and manually supplied singleton instances need to be registered as early
+NOTE: Bean metadata and manually supplied singleton instances need to be registered as early
 as possible, in order for the container to properly reason about them during autowiring
-and other introspection steps. While overriding of existing metadata and existing
+and other introspection steps. While overriding existing metadata and existing
 singleton instances is supported to some degree, the registration of new beans at
-runtime (concurrently with live access to factory) is not officially supported and may
-lead to concurrent access exceptions and/or inconsistent state in the bean container.
-====
+runtime (concurrently with live access to the factory) is not officially supported and may
+lead to concurrent access exceptions, inconsistent state in the bean container, or both.
 
 
 
 [[beans-beanname]]
-=== Naming beans
+=== Naming Beans
 
 Every bean has one or more identifiers. These identifiers must be unique within the
-container that hosts the bean. A bean usually has only one identifier, but if it
+container that hosts the bean. A bean usually has only one identifier. However, if it
 requires more than one, the extra ones can be considered aliases.
 
-In XML-based configuration metadata, you use the `id` and/or `name` attributes
-to specify the bean identifier(s). The `id` attribute allows you to specify
-exactly one id. Conventionally these names are alphanumeric ('myBean',
-'fooService', etc.), but may contain special characters as well. If you want to
-introduce other aliases to the bean, you can also specify them in the `name`
+In XML-based configuration metadata, you use the `id` attribute, the `name` attribute, or
+both to specify the bean identifiers. The `id` attribute lets you specify
+exactly one id. Conventionally, these names are alphanumeric ('myBean',
+'someService', etc.), but they can contain special characters as well. If you want to
+introduce other aliases for the bean, you can also specify them in the `name`
 attribute, separated by a comma (`,`), semicolon (`;`), or white space. As a
 historical note, in versions prior to Spring 3.1, the `id` attribute was
 defined as an `xsd:ID` type, which constrained possible characters. As of 3.1,
 it is defined as an `xsd:string` type. Note that bean `id` uniqueness is still
 enforced by the container, though no longer by XML parsers.
 
-You are not required to supply a name or id for a bean. If no name or id is supplied
-explicitly, the container generates a unique name for that bean. However, if you want to
-refer to that bean by name, through the use of the `ref` element or
+You are not required to supply a `name` or an `id` for a bean. If you do not supply a
+`name` or `id` explicitly, the container generates a unique name for that bean. However,
+if you want to refer to that bean by name, through the use of the `ref` element or a
 <<beans-servicelocator,Service Locator>> style lookup, you must provide a name.
 Motivations for not supplying a name are related to using <<beans-inner-beans,inner
 beans>> and <<beans-factory-autowire,autowiring collaborators>>.
@@ -504,64 +529,67 @@ beans>> and <<beans-factory-autowire,autowiring collaborators>>.
 .Bean Naming Conventions
 ****
 The convention is to use the standard Java convention for instance field names when
-naming beans. That is, bean names start with a lowercase letter, and are camel-cased
-from then on. Examples of such names would be (without quotes) `'accountManager'`,
-`'accountService'`, `'userDao'`, `'loginController'`, and so forth.
+naming beans. That is, bean names start with a lowercase letter and are camel-cased
+from there. Examples of such names include `accountManager`,
+`accountService`, `userDao`, `loginController`, and so forth.
 
-Naming beans consistently makes your configuration easier to read and understand, and if
-you are using Spring AOP it helps a lot when applying advice to a set of beans related
+Naming beans consistently makes your configuration easier to read and understand. Also, if
+you use Spring AOP, it helps a lot when applying advice to a set of beans related
 by name.
 ****
 
-[NOTE]
-====
-With component scanning in the classpath, Spring generates bean names for unnamed
-components, following the rules above: essentially, taking the simple class name
+NOTE: With component scanning in the classpath, Spring generates bean names for unnamed
+components, following the rules described earlier: essentially, taking the simple class name
 and turning its initial character to lower-case. However, in the (unusual) special
 case when there is more than one character and both the first and second characters
 are upper case, the original casing gets preserved. These are the same rules as
-defined by `java.beans.Introspector.decapitalize` (which Spring is using here).
-====
+defined by `java.beans.Introspector.decapitalize` (which Spring uses here).
+
 
 
 [[beans-beanname-alias]]
-==== Aliasing a bean outside the bean definition
+==== Aliasing a Bean outside the Bean Definition
 
 In a bean definition itself, you can supply more than one name for the bean, by using a
-combination of up to one name specified by the `id` attribute, and any number of other
-names in the `name` attribute. These names can be equivalent aliases to the same bean,
-and are useful for some situations, such as allowing each component in an application to
+combination of up to one name specified by the `id` attribute and any number of other
+names in the `name` attribute. These names can be equivalent aliases to the same bean
+and are useful for some situations, such as letting each component in an application
 refer to a common dependency by using a bean name that is specific to that component
 itself.
 
 Specifying all aliases where the bean is actually defined is not always adequate,
 however. It is sometimes desirable to introduce an alias for a bean that is defined
 elsewhere. This is commonly the case in large systems where configuration is split
-amongst each subsystem, each subsystem having its own set of object definitions. In
+amongst each subsystem, with each subsystem having its own set of object definitions. In
 XML-based configuration metadata, you can use the `<alias/>` element to accomplish this.
+The following example shows how to do so:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<alias name="fromName" alias="toName"/>
 ----
+====
 
-In this case, a bean in the same container which is named `fromName`, may also,
+In this case, a bean (in the same container) named `fromName` may also,
 after the use of this alias definition, be referred to as `toName`.
 
-For example, the configuration metadata for subsystem A may refer to a DataSource via
-the name `subsystemA-dataSource`. The configuration metadata for subsystem B may refer to
-a DataSource via the name `subsystemB-dataSource`. When composing the main application
-that uses both these subsystems the main application refers to the DataSource via the
-name `myApp-dataSource`. To have all three names refer to the same object you add to the
-MyApp configuration metadata the following aliases definitions:
+For example, the configuration metadata for subsystem A may refer to a DataSource by
+the name of `subsystemA-dataSource`. The configuration metadata for subsystem B may refer to
+a DataSource by the name of `subsystemB-dataSource`. When composing the main application
+that uses both these subsystems, the main application refers to the DataSource by the
+name of `myApp-dataSource`. To have all three names refer to the same object, you can add
+the following alias definitions to the configuration metadata:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<alias name="subsystemA-dataSource" alias="subsystemB-dataSource"/>
 	<alias name="subsystemA-dataSource" alias="myApp-dataSource" />
 ----
+====
 
 Now each component and the main application can refer to the dataSource through a name
 that is unique and guaranteed not to clash with any other definition (effectively
@@ -569,45 +597,43 @@ creating a namespace), yet they refer to the same bean.
 
 .Java-configuration
 ****
-If you are using Java-configuration, the `@Bean` annotation can be used to provide aliases
-see <<beans-java-bean-annotation>> for details.
+If you use Javaconfiguration, the `@Bean` annotation can be used to provide aliases.
+See <<beans-java-bean-annotation>> for details.
 ****
 
 
 
 [[beans-factory-class]]
-=== Instantiating beans
+=== Instantiating Beans
 
-A bean definition essentially is a recipe for creating one or more objects. The
-container looks at the recipe for a named bean when asked, and uses the configuration
+A bean definition is essentially a recipe for creating one or more objects. The
+container looks at the recipe for a named bean when asked and uses the configuration
 metadata encapsulated by that bean definition to create (or acquire) an actual object.
 
 If you use XML-based configuration metadata, you specify the type (or class) of object
 that is to be instantiated in the `class` attribute of the `<bean/>` element. This
-`class` attribute, which internally is a `Class` property on a `BeanDefinition`
-instance, is usually mandatory. (For exceptions, see
+`class` attribute (which, internally, is a `Class` property on a `BeanDefinition`
+instance) is usually mandatory. (For exceptions, see
 <<beans-factory-class-instance-factory-method>> and <<beans-child-bean-definitions>>.)
-You use the `Class` property in one of two ways:
+You can use the `Class` property in one of two ways:
 
 * Typically, to specify the bean class to be constructed in the case where the container
   itself directly creates the bean by calling its constructor reflectively, somewhat
-  equivalent to Java code using the `new` operator.
-* To specify the actual class containing the `static` factory method that will be
+  equivalent to Java code with the `new` operator.
+* To specify the actual class containing the `static` factory method that is
   invoked to create the object, in the less common case where the container invokes a
-  `static` __factory__ method on a class to create the bean. The object type returned
+  `static` factory method on a class to create the bean. The object type returned
   from the invocation of the `static` factory method may be the same class or another
   class entirely.
 
 ****
 .Inner class names
 If you want to configure a bean definition for a `static` nested class, you have to use
-the __binary__ name of the nested class.
+the binary name of the nested class.
 
-For example, if you have a class called `Foo` in the `com.example` package, and this
-`Foo` class has a `static` nested class called `Bar`, the value of the `'class'`
-attribute on a bean definition would be...
-
-`com.example.Foo$Bar`
+For example, if you have a class called `SomeThing` in the `com.example` package, and this
+`SomeThing` class has a `static` nested class called `OtherThing`, the value of the `class`
+attribute on a bean definition would be `com.example.SomeThing$OtherThing`.
 
 Notice the use of the `$` character in the name to separate the nested class name from
 the outer class name.
@@ -615,7 +641,7 @@ the outer class name.
 
 
 [[beans-factory-class-ctor]]
-==== Instantiation with a constructor
+==== Instantiation with a Constructor
 
 When you create a bean by the constructor approach, all normal classes are usable by and
 compatible with Spring. That is, the class being developed does not need to implement
@@ -623,7 +649,7 @@ any specific interfaces or to be coded in a specific fashion. Simply specifying 
 class should suffice. However, depending on what type of IoC you use for that specific
 bean, you may need a default (empty) constructor.
 
-The Spring IoC container can manage virtually __any__ class you want it to manage; it is
+The Spring IoC container can manage virtually any class you want it to manage. It is
 not limited to managing true JavaBeans. Most Spring users prefer actual JavaBeans with
 only a default (no-argument) constructor and appropriate setters and getters modeled
 after the properties in the container. You can also have more exotic non-bean-style
@@ -633,6 +659,7 @@ well.
 
 With XML-based configuration metadata you can specify your bean class as follows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -640,27 +667,30 @@ With XML-based configuration metadata you can specify your bean class as follows
 
 	<bean name="anotherExample" class="examples.ExampleBeanTwo"/>
 ----
+====
 
 For details about the mechanism for supplying arguments to the constructor (if required)
 and setting object instance properties after the object is constructed, see
 <<beans-factory-collaborators,Injecting Dependencies>>.
 
 
-[[beans-factory-class-static-factory-method]]
-==== Instantiation with a static factory method
 
-When defining a bean that you create with a static factory method, you use the `class`
-attribute to specify the class containing the `static` factory method and an attribute
+[[beans-factory-class-static-factory-method]]
+==== Instantiation with a Static Factory Method
+
+When defining a bean that you create with a static factory method, use the `class`
+attribute to specify the class that contains the `static` factory method and an attribute
 named `factory-method` to specify the name of the factory method itself. You should be
-able to call this method (with optional arguments as described later) and return a live
+able to call this method (with optional arguments, as described later) and return a live
 object, which subsequently is treated as if it had been created through a constructor.
 One use for such a bean definition is to call `static` factories in legacy code.
 
-The following bean definition specifies that the bean will be created by calling a
-factory-method. The definition does not specify the type (class) of the returned object,
+The following bean definition specifies that the bean be created by calling a
+factory method. The definition does not specify the type (class) of the returned object,
 only the class containing the factory method. In this example, the `createInstance()`
-method must be a __static__ method.
+method must be a static method. The following example shows how to specify a factory method:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -668,7 +698,11 @@ method must be a __static__ method.
 		class="examples.ClientService"
 		factory-method="createInstance"/>
 ----
+====
 
+The following example shows a class that would work with the preceding bean definition:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -681,23 +715,26 @@ method must be a __static__ method.
 		}
 	}
 ----
+====
 
 For details about the mechanism for supplying (optional) arguments to the factory method
 and setting object instance properties after the object is returned from the factory,
-see <<beans-factory-properties-detailed,Dependencies and configuration in detail>>.
+see <<beans-factory-properties-detailed,Dependencies and Configuration in Detail>>.
 
 
 [[beans-factory-class-instance-factory-method]]
-==== Instantiation using an instance factory method
+==== Instantiation by Using an Instance Factory Method
 
 Similar to instantiation through a <<beans-factory-class-static-factory-method,static
 factory method>>, instantiation with an instance factory method invokes a non-static
 method of an existing bean from the container to create a new bean. To use this
-mechanism, leave the `class` attribute empty, and in the `factory-bean` attribute,
-specify the name of a bean in the current (or parent/ancestor) container that contains
+mechanism, leave the `class` attribute empty and, in the `factory-bean` attribute,
+specify the name of a bean in the current (or parent or ancestor) container that contains
 the instance method that is to be invoked to create the object. Set the name of the
-factory method itself with the `factory-method` attribute.
+factory method itself with the `factory-method` attribute. The following example shows
+how to configure such a bean:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -711,7 +748,11 @@ factory method itself with the `factory-method` attribute.
 		factory-bean="serviceLocator"
 		factory-method="createClientServiceInstance"/>
 ----
+====
 
+The following example shows the corresponding Java class:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -724,9 +765,11 @@ factory method itself with the `factory-method` attribute.
 		}
 	}
 ----
+====
 
-One factory class can also hold more than one factory method as shown here:
+One factory class can also hold more than one factory method, as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -742,7 +785,11 @@ One factory class can also hold more than one factory method as shown here:
 		factory-bean="serviceLocator"
 		factory-method="createAccountServiceInstance"/>
 ----
+====
 
+The following example shows the corresponding Java class:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -761,20 +808,18 @@ One factory class can also hold more than one factory method as shown here:
 		}
 	}
 ----
+====
 
 This approach shows that the factory bean itself can be managed and configured through
 dependency injection (DI). See <<beans-factory-properties-detailed,Dependencies and
-configuration in detail>>.
+Configuration in Detail>>.
 
-[NOTE]
-====
-In Spring documentation,__ factory bean__ refers to a bean that is configured in the
-Spring container that will create objects through an
+NOTE: In Spring documentation, "`factory bean`" refers to a bean that is configured in the
+Spring container and that creates objects through an
 <<beans-factory-class-instance-factory-method,instance>> or
 <<beans-factory-class-static-factory-method,static>> factory method. By contrast,
 `FactoryBean` (notice the capitalization) refers to a Spring-specific
 <<beans-factory-extension-factorybean, `FactoryBean` >>.
-====
 
 
 
@@ -793,36 +838,36 @@ application where objects collaborate to achieve a goal.
 [[beans-factory-collaborators]]
 === Dependency Injection
 
-__Dependency injection__ (DI) is a process whereby objects define their dependencies,
-that is, the other objects they work with, only through constructor arguments, arguments
+Dependency injection (DI) is a process whereby objects define their dependencies
+(that is, the other objects with which they work) only through constructor arguments, arguments
 to a factory method, or properties that are set on the object instance after it is
-constructed or returned from a factory method. The container then __injects__ those
-dependencies when it creates the bean. This process is fundamentally the inverse, hence
-the name __Inversion of Control__ (IoC), of the bean itself controlling the instantiation
-or location of its dependencies on its own by using direct construction of classes, or
-the __Service Locator__ pattern.
+constructed or returned from a factory method. The container then injects those
+dependencies when it creates the bean. This process is fundamentally the inverse (hence
+the name, Inversion of Control) of the bean itself controlling the instantiation
+or location of its dependencies on its own by using direct construction of classes or
+the Service Locator pattern.
 
-Code is cleaner with the DI principle and decoupling is more effective when objects are
-provided with their dependencies. The object does not look up its dependencies, and does
-not know the location or class of the dependencies. As such, your classes become easier
-to test, in particular when the dependencies are on interfaces or abstract base classes,
+Code is cleaner with the DI principle, and decoupling is more effective when objects are
+provided with their dependencies. The object does not look up its dependencies and does
+not know the location or class of the dependencies. As a result, your classes become easier
+to test, particularly when the dependencies are on interfaces or abstract base classes,
 which allow for stub or mock implementations to be used in unit tests.
 
-DI exists in two major variants, <<beans-constructor-injection,Constructor-based
+DI exists in two major variants: <<beans-constructor-injection,Constructor-based
 dependency injection>> and <<beans-setter-injection,Setter-based dependency injection>>.
 
 
 [[beans-constructor-injection]]
-==== Constructor-based dependency injection
+==== Constructor-based Dependency Injection
 
-__Constructor-based__ DI is accomplished by the container invoking a constructor with a
+Constructor-based DI is accomplished by the container invoking a constructor with a
 number of arguments, each representing a dependency. Calling a `static` factory method
 with specific arguments to construct the bean is nearly equivalent, and this discussion
 treats arguments to a constructor and to a `static` factory method similarly. The
 following example shows a class that can only be dependency-injected with constructor
-injection. Notice that there is nothing __special__ about this class, it is a POJO that
-has no dependencies on container specific interfaces, base classes or annotations.
+injection:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -839,54 +884,65 @@ has no dependencies on container specific interfaces, base classes or annotation
 		// business logic that actually uses the injected MovieFinder is omitted...
 	}
 ----
+====
+
+Notice that there is nothing special about this class. It is a POJO that
+has no dependencies on container specific interfaces, base classes or annotations.
+
+
 
 [[beans-factory-ctor-arguments-resolution]]
-===== Constructor argument resolution
+===== Constructor Argument Resolution
 
-Constructor argument resolution matching occurs using the argument's type. If no
-potential ambiguity exists in the constructor arguments of a bean definition, then the
+Constructor argument resolution matching occurs by using the argument's type. If no
+potential ambiguity exists in the constructor arguments of a bean definition, the
 order in which the constructor arguments are defined in a bean definition is the order
 in which those arguments are supplied to the appropriate constructor when the bean is
 being instantiated. Consider the following class:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	package x.y;
 
-	public class Foo {
+	public class ThingOne {
 
-		public Foo(Bar bar, Baz baz) {
+		public ThingOne(ThingTwo thingTwo, ThingThree thingThree) {
 			// ...
 		}
 	}
 ----
+====
 
-No potential ambiguity exists, assuming that `Bar` and `Baz` classes are not related by
-inheritance. Thus the following configuration works fine, and you do not need to specify
-the constructor argument indexes and/or types explicitly in the `<constructor-arg/>`
+Assuming that `ThingTwo` and `ThingThree` classes are not related by inheritance, no potential
+ambiguity exists. Thus, the following configuration works fine, and you do not need to specify
+the constructor argument indexes or types explicitly in the `<constructor-arg/>`
 element.
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<beans>
-		<bean id="foo" class="x.y.Foo">
-			<constructor-arg ref="bar"/>
-			<constructor-arg ref="baz"/>
+		<bean id="thingOne" class="x.y.ThingOne">
+			<constructor-arg ref="thingTwo"/>
+			<constructor-arg ref="thingThree"/>
 		</bean>
 
-		<bean id="bar" class="x.y.Bar"/>
+		<bean id="thingTwo" class="x.y.ThingTwo"/>
 
-		<bean id="baz" class="x.y.Baz"/>
+		<bean id="thingThree" class="x.y.ThingThree"/>
 	</beans>
 ----
+====
 
 When another bean is referenced, the type is known, and matching can occur (as was the
 case with the preceding example). When a simple type is used, such as
 `<value>true</value>`, Spring cannot determine the type of the value, and so cannot match
 by type without help. Consider the following class:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -906,13 +962,15 @@ by type without help. Consider the following class:
 		}
 	}
 ----
+====
 
 .[[beans-factory-ctor-arguments-type]]Constructor argument type matching
 --
-In the preceding scenario, the container __can__ use type matching with simple types if
-you explicitly specify the type of the constructor argument using the `type` attribute.
-For example:
+In the preceding scenario, the container can use type matching with simple types if
+you explicitly specify the type of the constructor argument by using the `type` attribute.
+as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -921,13 +979,15 @@ For example:
 		<constructor-arg type="java.lang.String" value="42"/>
 	</bean>
 ----
+====
 --
 
 .[[beans-factory-ctor-arguments-index]]Constructor argument index
 --
-Use the `index` attribute to specify explicitly the index of constructor arguments. For
-example:
+You can use the `index` attribute to specify explicitly the index of constructor arguments,
+as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -936,16 +996,20 @@ example:
 		<constructor-arg index="1" value="42"/>
 	</bean>
 ----
+====
 
 In addition to resolving the ambiguity of multiple simple values, specifying an index
-resolves ambiguity where a constructor has two arguments of the same type. Note that the
-__index is 0 based__.
+resolves ambiguity where a constructor has two arguments of the same type.
+
+NOTE: The index is 0-based.
 --
 
 .[[beans-factory-ctor-arguments-name]]Constructor argument name
 --
-You can also use the constructor parameter name for value disambiguation:
+You can also use the constructor parameter name for value disambiguation, as the following
+example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -954,14 +1018,16 @@ You can also use the constructor parameter name for value disambiguation:
 		<constructor-arg name="ultimateAnswer" value="42"/>
 	</bean>
 ----
+====
 
-Keep in mind that to make this work out of the box your code must be compiled with the
+Keep in mind that, to make this work out of the box, your code must be compiled with the
 debug flag enabled so that Spring can look up the parameter name from the constructor.
-If you can't compile your code with debug flag (or don't want to) you can use
+If you cannot or do not want to compile your code with the debug flag, you can use
 http://download.oracle.com/javase/6/docs/api/java/beans/ConstructorProperties.html[@ConstructorProperties]
 JDK annotation to explicitly name your constructor arguments. The sample class would
 then have to look as follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -978,20 +1044,22 @@ then have to look as follows:
 		}
 	}
 ----
+====
 --
 
 
 [[beans-setter-injection]]
-==== Setter-based dependency injection
+==== Setter-based Dependency Injection
 
-__Setter-based__ DI is accomplished by the container calling setter methods on your
-beans after invoking a no-argument constructor or no-argument `static` factory method to
+Setter-based DI is accomplished by the container calling setter methods on your
+beans after invoking a no-argument constructor or a no-argument `static` factory method to
 instantiate your bean.
 
-The following example shows a class that can only be dependency-injected using pure
+The following example shows a class that can only be dependency-injected by using pure
 setter injection. This class is conventional Java. It is a POJO that has no dependencies
-on container specific interfaces, base classes or annotations.
+on container specific interfaces, base classes, or annotations.
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1008,31 +1076,32 @@ on container specific interfaces, base classes or annotations.
 		// business logic that actually uses the injected MovieFinder is omitted...
 	}
 ----
+====
 
 The `ApplicationContext` supports constructor-based and setter-based DI for the beans it
 manages. It also supports setter-based DI after some dependencies have already been
 injected through the constructor approach. You configure the dependencies in the form of
 a `BeanDefinition`, which you use in conjunction with `PropertyEditor` instances to
 convert properties from one format to another. However, most Spring users do not work
-with these classes directly (i.e., programmatically) but rather with XML `bean`
-definitions, annotated components (i.e., classes annotated with `@Component`,
-`@Controller`, etc.), or `@Bean` methods in Java-based `@Configuration` classes. These
-sources are then converted internally into instances of `BeanDefinition` and used to
+with these classes directly (that is, programmatically) but rather with XML `bean`
+definitions, annotated components (that is, classes annotated with `@Component`,
+`@Controller`, and so forth), or `@Bean` methods in Java-based `@Configuration` classes.
+These sources are then converted internally into instances of `BeanDefinition` and used to
 load an entire Spring IoC container instance.
 
 [[beans-constructor-vs-setter-injection]]
 .Constructor-based or setter-based DI?
 ****
 Since you can mix constructor-based and setter-based DI, it is a good rule of thumb to
-use constructors for _mandatory dependencies_ and setter methods or configuration methods
-for _optional dependencies_. Note that use of the <<beans-required-annotation,@Required>>
-annotation on a setter method can be used to make the property a required dependency.
+use constructors for mandatory dependencies and setter methods or configuration methods
+for optional dependencies. Note that use of the <<beans-required-annotation,@Required>>
+annotation on a setter method can be used to make the property be a required dependency.
 
-The Spring team generally advocates constructor injection as it enables one to implement
-application components as _immutable objects_ and to ensure that required dependencies
-are not `null`. Furthermore constructor-injected components are always returned to client
+The Spring team generally advocates constructor injection, as it lets you implement
+application components as immutable objects and ensures that required dependencies
+are not `null`. Furthermore, constructor-injected components are always returned to the client
 (calling) code in a fully initialized state. As a side note, a large number of constructor
-arguments is a _bad code smell_, implying that the class likely has too many
+arguments is a bad code smell, implying that the class likely has too many
 responsibilities and should be refactored to better address proper separation of concerns.
 
 Setter injection should primarily only be used for optional dependencies that can be
@@ -1050,32 +1119,32 @@ injection may be the only available form of DI.
 
 
 [[beans-dependency-resolution]]
-==== Dependency resolution process
+==== Dependency Resolution Process
 
 The container performs bean dependency resolution as follows:
 
 * The `ApplicationContext` is created and initialized with configuration metadata that
-  describes all the beans. Configuration metadata can be specified via XML, Java code, or
+  describes all the beans. Configuration metadata can be specified by XML, Java code, or
   annotations.
 * For each bean, its dependencies are expressed in the form of properties, constructor
-  arguments, or arguments to the static-factory method if you are using that instead of
-  a normal constructor. These dependencies are provided to the bean, __when the bean is
-  actually created__.
+  arguments, or arguments to the static-factory method( if you use that instead of
+  a normal constructor). These dependencies are provided to the bean, when the bean is
+  actually created.
 * Each property or constructor argument is an actual definition of the value to set, or
   a reference to another bean in the container.
-* Each property or constructor argument which is a value is converted from its specified
-  format to the actual type of that property or constructor argument. By default Spring
+* Each property or constructor argument that is a value is converted from its specified
+  format to the actual type of that property or constructor argument. By default, Spring
   can convert a value supplied in string format to all built-in types, such as `int`,
-  `long`, `String`, `boolean`, etc.
+  `long`, `String`, `boolean`, and so forth.
 
 The Spring container validates the configuration of each bean as the container is created.
-However, the bean properties themselves are not set until the bean __is actually created__.
+However, the bean properties themselves are not set until the bean is actually created.
 Beans that are singleton-scoped and set to be pre-instantiated (the default) are created
 when the container is created. Scopes are defined in <<beans-factory-scopes>>. Otherwise,
 the bean is created only when it is requested. Creation of a bean potentially causes a
 graph of beans to be created, as the bean's dependencies and its dependencies'
 dependencies (and so on) are created and assigned. Note that resolution mismatches among
-those dependencies may show up late, i.e. on first creation of the affected bean.
+those dependencies may show up late -- that is, on first creation of the affected bean.
 
 .Circular dependencies
 ****
@@ -1093,29 +1162,29 @@ setters rather than constructors. Alternatively, avoid constructor injection and
 setter injection only. In other words, although it is not recommended, you can configure
 circular dependencies with setter injection.
 
-Unlike the __typical__ case (with no circular dependencies), a circular dependency
+Unlike the typical case (with no circular dependencies), a circular dependency
 between bean A and bean B forces one of the beans to be injected into the other prior to
-being fully initialized itself (a classic chicken/egg scenario).
+being fully initialized itself (a classic chicken-and-egg scenario).
 ****
 
 You can generally trust Spring to do the right thing. It detects configuration problems,
 such as references to non-existent beans and circular dependencies, at container
 load-time. Spring sets properties and resolves dependencies as late as possible, when
-the bean is actually created. This means that a Spring container which has loaded
+the bean is actually created. This means that a Spring container that has loaded
 correctly can later generate an exception when you request an object if there is a
-problem creating that object or one of its dependencies. For example, the bean throws an
+problem creating that object or one of its dependencies -- for example, the bean throws an
 exception as a result of a missing or invalid property. This potentially delayed
 visibility of some configuration issues is why `ApplicationContext` implementations by
 default pre-instantiate singleton beans. At the cost of some upfront time and memory to
 create these beans before they are actually needed, you discover configuration issues
 when the `ApplicationContext` is created, not later. You can still override this default
-behavior so that singleton beans will lazy-initialize, rather than be pre-instantiated.
+behavior so that singleton beans initialize lazily, rather than being pre-instantiated.
 
 If no circular dependencies exist, when one or more collaborating beans are being
-injected into a dependent bean, each collaborating bean is __totally__ configured prior
-to being injected into the dependent bean. This means that if bean A has a dependency on
+injected into a dependent bean, each collaborating bean is totally configured prior
+to being injected into the dependent bean. This means that, if bean A has a dependency on
 bean B, the Spring IoC container completely configures bean B prior to invoking the
-setter method on bean A. In other words, the bean is instantiated (if not a
+setter method on bean A. In other words, the bean is instantiated (if it is not a
 pre-instantiated singleton), its dependencies are set, and the relevant lifecycle
 methods (such as a <<beans-factory-lifecycle-initializingbean,configured init method>>
 or the <<beans-factory-lifecycle-initializingbean,InitializingBean callback method>>)
@@ -1123,11 +1192,12 @@ are invoked.
 
 
 [[beans-some-examples]]
-==== Examples of dependency injection
+==== Examples of Dependency Injection
 
 The following example uses XML-based configuration metadata for setter-based DI. A small
-part of a Spring XML configuration file specifies some bean definitions:
+part of a Spring XML configuration file specifies some bean definitions as follows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1145,7 +1215,11 @@ part of a Spring XML configuration file specifies some bean definitions:
 	<bean id="anotherExampleBean" class="examples.AnotherBean"/>
 	<bean id="yetAnotherBean" class="examples.YetAnotherBean"/>
 ----
+====
 
+The following example shows the corresponding `ExampleBean` class:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1170,10 +1244,12 @@ part of a Spring XML configuration file specifies some bean definitions:
 		}
 	}
 ----
+====
 
 In the preceding example, setters are declared to match against the properties specified
 in the XML file. The following example uses constructor-based DI:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1192,7 +1268,11 @@ in the XML file. The following example uses constructor-based DI:
 	<bean id="anotherExampleBean" class="examples.AnotherBean"/>
 	<bean id="yetAnotherBean" class="examples.YetAnotherBean"/>
 ----
+====
 
+The following example shows the corresponding `ExampleBean` class:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1212,13 +1292,15 @@ in the XML file. The following example uses constructor-based DI:
 		}
 	}
 ----
+====
 
-The constructor arguments specified in the bean definition will be used as arguments to
+The constructor arguments specified in the bean definition are used as arguments to
 the constructor of the `ExampleBean`.
 
-Now consider a variant of this example, where instead of using a constructor, Spring is
+Now consider a variant of this example, where, instead of using a constructor, Spring is
 told to call a `static` factory method to return an instance of the object:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1231,7 +1313,11 @@ told to call a `static` factory method to return an instance of the object:
 	<bean id="anotherExampleBean" class="examples.AnotherBean"/>
 	<bean id="yetAnotherBean" class="examples.YetAnotherBean"/>
 ----
+====
 
+The following example shows the corresponding `ExampleBean` class:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1254,34 +1340,39 @@ told to call a `static` factory method to return an instance of the object:
 		}
 	}
 ----
+====
 
-Arguments to the `static` factory method are supplied via `<constructor-arg/>` elements,
+Arguments to the `static` factory method are supplied by `<constructor-arg/>` elements,
 exactly the same as if a constructor had actually been used. The type of the class being
 returned by the factory method does not have to be of the same type as the class that
-contains the `static` factory method, although in this example it is. An instance
-(non-static) factory method would be used in an essentially identical fashion (aside
-from the use of the `factory-bean` attribute instead of the `class` attribute), so
-details will not be discussed here.
+contains the `static` factory method (although, in this example, it is). An instance
+(non-static) factory method can be used in an essentially identical fashion (aside
+from the use of the `factory-bean` attribute instead of the `class` attribute), so we
+do not discuss those details here.
 
 
 
 [[beans-factory-properties-detailed]]
-=== Dependencies and configuration in detail
+=== Dependencies and Configuration in Detail
 
-As mentioned in the previous section, you can define bean properties and constructor
-arguments as references to other managed beans (collaborators), or as values defined
-inline. Spring's XML-based configuration metadata supports sub-element types within its
-`<property/>` and `<constructor-arg/>` elements for this purpose.
+As mentioned in the <<beans-factory-collaborators,previous section>>, you can define bean
+properties and constructor arguments as references to other managed beans (collaborators)
+or as values defined inline. Spring's XML-based configuration metadata supports
+sub-element types within its `<property/>` and `<constructor-arg/>` elements for this
+purpose.
+
 
 
 [[beans-value-element]]
-==== Straight values (primitives, Strings, and so on)
+==== Straight Values (Primitives, Strings, and so on)
 
 The `value` attribute of the `<property/>` element specifies a property or constructor
 argument as a human-readable string representation. Spring's
 <<core-convert-ConversionService-API, conversion service>> is used to convert these
 values from a `String` to the actual type of the property or argument.
+The following example shows various values being set:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1293,10 +1384,12 @@ values from a `String` to the actual type of the property or argument.
 		<property name="password" value="masterkaoli"/>
 	</bean>
 ----
+====
 
 The following example uses the <<beans-p-namespace,p-namespace>> for even more succinct
-XML configuration.
+XML configuration:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1315,15 +1408,17 @@ XML configuration.
 
 	</beans>
 ----
+====
 
-The preceding XML is more succinct; however, typos are discovered at runtime rather than
-design time, unless you use an IDE such as http://www.jetbrains.com/idea/[IntelliJ
-IDEA] or the https://spring.io/tools/sts[Spring Tool Suite] (STS)
-that support automatic property completion when you create bean definitions. Such IDE
+The preceding XML is more succinct. However, typos are discovered at runtime rather than
+design time, unless you use an IDE (such as http://www.jetbrains.com/idea/[IntelliJ
+IDEA] or the https://spring.io/tools/sts[Spring Tool Suite])
+that supports automatic property completion when you create bean definitions. Such IDE
 assistance is highly recommended.
 
-You can also configure a `java.util.Properties` instance as:
+You can also configure a `java.util.Properties` instance, as follows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1339,6 +1434,7 @@ You can also configure a `java.util.Properties` instance as:
 		</property>
 	</bean>
 ----
+====
 
 The Spring container converts the text inside the `<value/>` element into a
 `java.util.Properties` instance by using the JavaBeans `PropertyEditor` mechanism. This
@@ -1346,12 +1442,13 @@ is a nice shortcut, and is one of a few places where the Spring team do favor th
 the nested `<value/>` element over the `value` attribute style.
 
 [[beans-idref-element]]
-===== The idref element
+===== The `idref` element
 
-The `idref` element is simply an error-proof way to pass the __id__ (string value - not
+The `idref` element is simply an error-proof way to pass the `id` (a string value - not
 a reference) of another bean in the container to a `<constructor-arg/>` or `<property/>`
-element.
+element. The following example shows how to use it:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1363,10 +1460,12 @@ element.
 		</property>
 	</bean>
 ----
+====
 
-The above bean definition snippet is __exactly__ equivalent (at runtime) to the
+The preceding bean definition snippet is exactly equivalent (at runtime) to the
 following snippet:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1376,65 +1475,68 @@ following snippet:
 		<property name="targetName" value="theTargetBean"/>
 	</bean>
 ----
+====
 
-The first form is preferable to the second, because using the `idref` tag allows the
-container to validate __at deployment time__ that the referenced, named bean actually
+The first form is preferable to the second, because using the `idref` tag lets the
+container validate at deployment time that the referenced, named bean actually
 exists. In the second variation, no validation is performed on the value that is passed
 to the `targetName` property of the `client` bean. Typos are only discovered (with most
 likely fatal results) when the `client` bean is actually instantiated. If the `client`
 bean is a <<beans-factory-scopes,prototype>> bean, this typo and the resulting exception
 may only be discovered long after the container is deployed.
 
-[NOTE]
-====
-The `local` attribute on the `idref` element is no longer supported in the 4.0 beans xsd
-since it does not provide value over a regular `bean` reference anymore. Simply change
+NOTE: The `local` attribute on the `idref` element is no longer supported in the 4.0 beans
+XSD, since it does not provide value over a regular `bean` reference any more. Change
 your existing `idref local` references to `idref bean` when upgrading to the 4.0 schema.
-====
 
 A common place (at least in versions earlier than Spring 2.0) where the `<idref/>` element
 brings value is in the configuration of <<aop-pfb-1,AOP interceptors>> in a
 `ProxyFactoryBean` bean definition. Using `<idref/>` elements when you specify the
-interceptor names prevents you from misspelling an interceptor id.
+interceptor names prevents you from misspelling an interceptor ID.
 
 
 [[beans-ref-element]]
-==== References to other beans (collaborators)
+==== References to Other Beans (Collaborators)
 
 The `ref` element is the final element inside a `<constructor-arg/>` or `<property/>`
-definition element. Here you set the value of the specified property of a bean to be a
+definition element. Here, you set the value of the specified property of a bean to be a
 reference to another bean (a collaborator) managed by the container. The referenced bean
-is a dependency of the bean whose property will be set, and it is initialized on demand
+is a dependency of the bean whose property is to be set, and it is initialized on demand
 as needed before the property is set. (If the collaborator is a singleton bean, it may
-be initialized already by the container.) All references are ultimately a reference to
-another object. Scoping and validation depend on whether you specify the id/name of the
+already be initialized by the container.) All references are ultimately a reference to
+another object. Scoping and validation depend on whether you specify the ID or name of the
 other object through the `bean`, `local,` or `parent` attributes.
 
 Specifying the target bean through the `bean` attribute of the `<ref/>` tag is the most
-general form, and allows creation of a reference to any bean in the same container or
+general form and allows creation of a reference to any bean in the same container or
 parent container, regardless of whether it is in the same XML file. The value of the
-`bean` attribute may be the same as the `id` attribute of the target bean, or as one of
-the values in the `name` attribute of the target bean.
+`bean` attribute may be the same as the `id` attribute of the target bean or be the same
+as one of the values in the `name` attribute of the target bean. The following example
+shows how to use a `ref` element:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<ref bean="someBean"/>
 ----
+====
 
 Specifying the target bean through the `parent` attribute creates a reference to a bean
 that is in a parent container of the current container. The value of the `parent`
-attribute may be the same as either the `id` attribute of the target bean, or one of the
-values in the `name` attribute of the target bean, and the target bean must be in a
-parent container of the current one. You use this bean reference variant mainly when you
-have a hierarchy of containers and you want to wrap an existing bean in a parent
-container with a proxy that will have the same name as the parent bean.
+attribute may be the same as either the `id` attribute of the target bean or one of the
+values in the `name` attribute of the target bean. The target bean must be in a
+parent container of the current one. You should use this bean reference variant mainly
+when you have a hierarchy of containers and you want to wrap an existing bean in a parent
+container with a proxy that has the same name as the parent bean. The following pair of
+listings shows how to use the `parent` attribute:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<!-- in the parent context -->
-	<bean id="accountService" class="com.foo.SimpleAccountService">
+	<bean id="accountService" class="com.something.SimpleAccountService">
 		<!-- insert dependencies as required as here -->
 	</bean>
 ----
@@ -1451,21 +1553,21 @@ container with a proxy that will have the same name as the parent bean.
 		<!-- insert other configuration and dependencies as required here -->
 	</bean>
 ----
+====
 
-[NOTE]
-====
-The `local` attribute on the `ref` element is no longer supported in the 4.0 beans xsd
-since it does not provide value over a regular `bean` reference anymore. Simply change
+NOTE: The `local` attribute on the `ref` element is no longer supported in the 4.0 beans
+XSD, since it does not provide value over a regular `bean` reference any more. Change
 your existing `ref local` references to `ref bean` when upgrading to the 4.0 schema.
-====
+
 
 
 [[beans-inner-beans]]
-==== Inner beans
+==== Inner Beans
 
-A `<bean/>` element inside the `<property/>` or `<constructor-arg/>` elements defines a
-so-called __inner bean__.
+A `<bean/>` element inside the `<property/>` or `<constructor-arg/>` elements defines an
+inner bean, as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1479,27 +1581,30 @@ so-called __inner bean__.
 		</property>
 	</bean>
 ----
+====
 
-An inner bean definition does not require a defined id or name; if specified, the container
+An inner bean definition does not require a defined ID or name. If specified, the container
 does not use such a value as an identifier. The container also ignores the `scope` flag on
-creation: Inner beans are __always__ anonymous and they are __always__ created with the outer
-bean. It is __not__ possible to inject inner beans into collaborating beans other than into
-the enclosing bean or to access them independently.
+creation, because inner beans are always anonymous and are always created with the outer
+bean. It is not possible to access inner beans independently or to inject them into
+collaborating beans other than into the enclosing bean.
 
-As a corner case, it is possible to receive destruction callbacks from a custom scope, e.g.
-for a request-scoped inner bean contained within a singleton bean: The creation of the inner
-bean instance will be tied to its containing bean, but destruction callbacks allow it to
-participate in the request scope's lifecycle. This is not a common scenario; inner beans
+As a corner case, it is possible to receive destruction callbacks from a custom scope --
+for example, for a request-scoped inner bean contained within a singleton bean. The creation
+of the inner bean instance is tied to its containing bean, but destruction callbacks let it
+participate in the request scope's lifecycle. This is not a common scenario. Inner beans
 typically simply share their containing bean's scope.
+
 
 
 [[beans-collection-elements]]
 ==== Collections
 
-In the `<list/>`, `<set/>`, `<map/>`, and `<props/>` elements, you set the properties
+The `<list/>`, `<set/>`, `<map/>`, and `<props/>` elements set the properties
 and arguments of the Java `Collection` types `List`, `Set`, `Map`, and `Properties`,
-respectively.
+respectively. The following example shows how to use them:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1535,32 +1640,36 @@ respectively.
 		</property>
 	</bean>
 ----
+====
 
-__The value of a map key or value, or a set value, can also again be any of the
-following elements:__
+The value of a map key or value, or a set value, can also be any of the
+following elements:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	bean | ref | idref | list | set | map | props | value | null
 ----
+====
 
 [[beans-collection-elements-merging]]
-===== Collection merging
+===== Collection Merging
 
-The Spring container also supports the __merging__ of collections. An application
-developer can define a parent-style `<list/>`, `<map/>`, `<set/>` or `<props/>` element,
-and have child-style `<list/>`, `<map/>`, `<set/>` or `<props/>` elements inherit and
+The Spring container also supports merging collections. An application
+developer can define a parent `<list/>`, `<map/>`, `<set/>` or `<props/>` element
+and have child `<list/>`, `<map/>`, `<set/>` or `<props/>` elements inherit and
 override values from the parent collection. That is, the child collection's values are
 the result of merging the elements of the parent and child collections, with the child's
 collection elements overriding values specified in the parent collection.
 
-__This section on merging discusses the parent-child bean mechanism. Readers unfamiliar
+This section on merging discusses the parent-child bean mechanism. Readers unfamiliar
 with parent and child bean definitions may wish to read the
-<<beans-child-bean-definitions,relevant section>> before continuing.__
+<<beans-child-bean-definitions,relevant section>> before continuing.
 
 The following example demonstrates collection merging:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1584,13 +1693,16 @@ The following example demonstrates collection merging:
 		</bean>
 	<beans>
 ----
+====
 
 Notice the use of the `merge=true` attribute on the `<props/>` element of the
 `adminEmails` property of the `child` bean definition. When the `child` bean is resolved
 and instantiated by the container, the resulting instance has an `adminEmails`
-`Properties` collection that contains the result of the merging of the child's
-`adminEmails` collection with the parent's `adminEmails` collection.
+`Properties` collection that contains the result of merging the child's
+`adminEmails` collection with the parent's `adminEmails` collection. The following listing
+shows the result:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
@@ -1598,6 +1710,7 @@ administrator=administrator@example.com
 sales=sales@example.com
 support=support@example.co.uk
 ----
+====
 
 The child `Properties` collection's value set inherits all property elements from the
 parent `<props/>`, and the child's value for the `support` value overrides the value in
@@ -1605,35 +1718,41 @@ the parent collection.
 
 This merging behavior applies similarly to the `<list/>`, `<map/>`, and `<set/>`
 collection types. In the specific case of the `<list/>` element, the semantics
-associated with the `List` collection type, that is, the notion of an `ordered`
-collection of values, is maintained; the parent's values precede all of the child list's
+associated with the `List` collection type (that is, the notion of an `ordered`
+collection of values) is maintained. The parent's values precede all of the child list's
 values. In the case of the `Map`, `Set`, and `Properties` collection types, no ordering
-exists. Hence no ordering semantics are in effect for the collection types that underlie
+exists. Hence, no ordering semantics are in effect for the collection types that underlie
 the associated `Map`, `Set`, and `Properties` implementation types that the container
 uses internally.
 
-[[beans-collection-merge-limitations]]
-===== Limitations of collection merging
 
-You cannot merge different collection types (such as a `Map` and a `List`), and if you
-do attempt to do so an appropriate `Exception` is thrown. The `merge` attribute must be
-specified on the lower, inherited, child definition; specifying the `merge` attribute on
-a parent collection definition is redundant and will not result in the desired merging.
+
+[[beans-collection-merge-limitations]]
+===== Limitations of Collection Merging
+
+You cannot merge different collection types (such as a `Map` and a `List`). If you
+do attempt to do so, an appropriate `Exception` is thrown. The `merge` attribute must be
+specified on the lower, inherited, child definition. Specifying the `merge` attribute on
+a parent collection definition is redundant and does not result in the desired merging.
+
+
 
 [[beans-collection-elements-strongly-typed]]
 ===== Strongly-typed collection
 
 With the introduction of generic types in Java 5, you can use strongly typed collections.
 That is, it is possible to declare a `Collection` type such that it can only contain
-`String` elements (for example). If you are using Spring to dependency-inject a
+(for example) `String` elements. If you use Spring to dependency-inject a
 strongly-typed `Collection` into a bean, you can take advantage of Spring's
 type-conversion support such that the elements of your strongly-typed `Collection`
 instances are converted to the appropriate type prior to being added to the `Collection`.
+The following Java class and bean definition show how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
-	public class Foo {
+	public class SomeClass {
 
 		private Map<String, Float> accounts;
 
@@ -1647,7 +1766,7 @@ instances are converted to the appropriate type prior to being added to the `Col
 [subs="verbatim,quotes"]
 ----
 	<beans>
-		<bean id="foo" class="x.y.Foo">
+		<bean id="something" class="x.y.SomeClass">
 			<property name="accounts">
 				<map>
 					<entry key="one" value="9.99"/>
@@ -1658,21 +1777,24 @@ instances are converted to the appropriate type prior to being added to the `Col
 		</bean>
 	</beans>
 ----
+====
 
-When the `accounts` property of the `foo` bean is prepared for injection, the generics
+When the `accounts` property of the `something` bean is prepared for injection, the generics
 information about the element type of the strongly-typed `Map<String, Float>` is
-available by reflection. Thus Spring's type conversion infrastructure recognizes the
-various value elements as being of type `Float`, and the string values `9.99, 2.75`, and
-`3.99` are converted into an actual `Float` type.
+available by reflection. Thus, Spring's type conversion infrastructure recognizes the
+various value elements as being of type `Float`, and the string values (`9.99, 2.75`, and
+`3.99`) are converted into an actual `Float` type.
+
 
 
 [[beans-null-element]]
-==== Null and empty string values
+==== Null and Empty String Values
 
 Spring treats empty arguments for properties and the like as empty `Strings`. The
-following XML-based configuration metadata snippet sets the email property to the empty
+following XML-based configuration metadata snippet sets the `email` property to the empty
 `String` value ("").
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1680,17 +1802,21 @@ following XML-based configuration metadata snippet sets the email property to th
 		<property name="email" value=""/>
 	</bean>
 ----
+====
 
 The preceding example is equivalent to the following Java code:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	exampleBean.setEmail("");
 ----
+====
 
-The `<null/>` element handles `null` values. For example:
+The `<null/>` element handles `null` values. The following listing shows an example:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1700,31 +1826,35 @@ The `<null/>` element handles `null` values. For example:
 		</property>
 	</bean>
 ----
+====
 
-The above configuration is equivalent to the following Java code:
+The preceding configuration is equivalent to the following Java code:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	exampleBean.setEmail(null);
 ----
+====
+
 
 
 [[beans-p-namespace]]
-==== XML shortcut with the p-namespace
+==== XML Shortcut with the p-namespace
 
-The p-namespace enables you to use the `bean` element's attributes, instead of nested
-`<property/>` elements, to describe your property values and/or collaborating beans.
+The p-namespace lets you use the `bean` element's attributes (instead of nested
+`<property/>` elements) to describe your property values collaborating beans, or both.
 
-Spring supports extensible configuration formats
-<<core.adoc#xsd-schemas,with namespaces>>,
-which are based on an XML Schema definition. The `beans` configuration format discussed in this
-chapter is defined in an XML Schema document. However, the p-namespace is not defined in
-an XSD file and exists only in the core of Spring.
+Spring supports extensible configuration formats <<core.adoc#xsd-schemas,with namespaces>>,
+which are based on an XML Schema definition. The `beans` configuration format discussed in
+this chapter is defined in an XML Schema document. However, the p-namespace is not defined
+in an XSD file and exists only in the core of Spring.
 
-The following example shows two XML snippets that resolve to the same result: The first
-uses standard XML format and the second uses the p-namespace.
+The following example shows two XML snippets (the first uses
+standard XML format and the second uses the p-namespace) that resolve to the same result:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1735,15 +1865,16 @@ uses standard XML format and the second uses the p-namespace.
 			http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 		<bean name="classic" class="com.example.ExampleBean">
-			<property name="email" value="foo@bar.com"/>
+			<property name="email" value="someone@somewhere.com"/>
 		</bean>
 
 		<bean name="p-namespace" class="com.example.ExampleBean"
-			p:email="foo@bar.com"/>
+			p:email="someone@somewhere.com"/>
 	</beans>
 ----
+====
 
-The example shows an attribute in the p-namespace called email in the bean definition.
+The example shows an attribute in the p-namespace called `email` in the bean definition.
 This tells Spring to include a property declaration. As previously mentioned, the
 p-namespace does not have a schema definition, so you can set the name of the attribute
 to the property name.
@@ -1751,6 +1882,7 @@ to the property name.
 This next example includes two more bean definitions that both have a reference to
 another bean:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1775,34 +1907,35 @@ another bean:
 		</bean>
 	</beans>
 ----
+====
 
-As you can see, this example includes not only a property value using the p-namespace,
+This example includes not only a property value using the p-namespace
 but also uses a special format to declare property references. Whereas the first bean
 definition uses `<property name="spouse" ref="jane"/>` to create a reference from bean
 `john` to bean `jane`, the second bean definition uses `p:spouse-ref="jane"` as an
-attribute to do the exact same thing. In this case `spouse` is the property name,
+attribute to do the exact same thing. In this case, `spouse` is the property name,
 whereas the `-ref` part indicates that this is not a straight value but rather a
 reference to another bean.
 
-[NOTE]
-====
-The p-namespace is not as flexible as the standard XML format. For example, the format
+NOTE: The p-namespace is not as flexible as the standard XML format. For example, the format
 for declaring property references clashes with properties that end in `Ref`, whereas the
 standard XML format does not. We recommend that you choose your approach carefully and
-communicate this to your team members, to avoid producing XML documents that use all
+communicate this to your team members to avoid producing XML documents that use all
 three approaches at the same time.
-====
+
 
 
 [[beans-c-namespace]]
-==== XML shortcut with the c-namespace
+==== XML Shortcut with the c-namespace
 
-Similar to the <<beans-p-namespace>>, the __c-namespace__, newly introduced in Spring
-3.1, allows usage of inlined attributes for configuring the constructor arguments rather
+Similar to the <<beans-p-namespace>>, the c-namespace, introduced in Spring
+3.1, allows inlined attributes for configuring the constructor arguments rather
 then nested `constructor-arg` elements.
 
-Let's review the examples from <<beans-constructor-injection>> with the `c:` namespace:
+The following example uses the `c:` namespace to do the same thing as the from
+<<beans-constructor-injection>>:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1812,95 +1945,101 @@ Let's review the examples from <<beans-constructor-injection>> with the `c:` nam
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-		<bean id="bar" class="x.y.Bar"/>
-		<bean id="baz" class="x.y.Baz"/>
+		<bean id="thingOne" class="x.y.ThingTwo"/>
+		<bean id="thingTwo" class="x.y.ThingThree"/>
 
 		<!-- traditional declaration -->
-		<bean id="foo" class="x.y.Foo">
-			<constructor-arg ref="bar"/>
-			<constructor-arg ref="baz"/>
-			<constructor-arg value="foo@bar.com"/>
+		<bean id="thingOne" class="x.y.ThingOne">
+			<constructor-arg ref="thingTwo"/>
+			<constructor-arg ref="thingThree"/>
+			<constructor-arg value="something@somewhere.com"/>
 		</bean>
 
 		<!-- c-namespace declaration -->
-		<bean id="foo" class="x.y.Foo" c:bar-ref="bar" c:baz-ref="baz" c:email="foo@bar.com"/>
+		<bean id="thingOne" class="x.y.ThingOne" c:thingTwo-ref="thingTwo" c:thingThree-ref="thingThree" c:email="something@somewhere.com"/>
 
 	</beans>
 ----
+====
 
-The `c:` namespace uses the same conventions as the `p:` one (trailing `-ref` for bean
-references) for setting the constructor arguments by their names. And just as well, it
-needs to be declared even though it is not defined in an XSD schema (but it exists
+The `c:` namespace uses the same conventions as the `p:` one (a trailing `-ref` for bean
+references) for setting the constructor arguments by their names. Similarly, it
+needs to be declared even though it is not defined in an XSD schema (it exists
 inside the Spring core).
 
 For the rare cases where the constructor argument names are not available (usually if
-the bytecode was compiled without debugging information), one can use fallback to the
-argument indexes:
+the bytecode was compiled without debugging information), you can use fallback to the
+argument indexes, as follows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<!-- c-namespace index declaration -->
-	<bean id="foo" class="x.y.Foo" c:_0-ref="bar" c:_1-ref="baz"/>
+	<bean id="thingOne" class="x.y.ThingOne" c:_0-ref="thingTwo" c:_1-ref="thingThree"/>
 ----
+====
 
-[NOTE]
-====
-Due to the XML grammar, the index notation requires the presence of the leading `_` as
-XML attribute names cannot start with a number (even though some IDE allow it).
-====
+NOTE: Due to the XML grammar, the index notation requires the presence of the leading `_`,
+as XML attribute names cannot start with a number (even though some IDEs allow it).
 
 In practice, the constructor resolution
 <<beans-factory-ctor-arguments-resolution,mechanism>> is quite efficient in matching
-arguments so unless one really needs to, we recommend using the name notation
+arguments, so unless you really need to, we recommend using the name notation
 through-out your configuration.
 
 
+
 [[beans-compound-property-names]]
-==== Compound property names
+==== Compound Property Names
 
 You can use compound or nested property names when you set bean properties, as long as
 all components of the path except the final property name are not `null`. Consider the
-following bean definition.
+following bean definition:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="foo" class="foo.Bar">
+	<bean id="something" class="things.ThingOne">
 		<property name="fred.bob.sammy" value="123" />
 	</bean>
 ----
+====
 
-The `foo` bean has a `fred` property, which has a `bob` property, which has a `sammy`
-property, and that final `sammy` property is being set to the value `123`. In order for
-this to work, the `fred` property of `foo`, and the `bob` property of `fred` must not be
-`null` after the bean is constructed, or a `NullPointerException` is thrown.
+The `something` bean has a `fred` property, which has a `bob` property, which has a `sammy`
+property, and that final `sammy` property is being set to a value of `123`. In order for
+this to work, the `fred` property of `something` and the `bob` property of `fred` must not
+be `null` after the bean is constructed. Otherwise, a `NullPointerException` is thrown.
 
 
 
 [[beans-factory-dependson]]
-=== Using depends-on
+=== Using `depends-on`
 
-If a bean is a dependency of another that usually means that one bean is set as a
+If a bean is a dependency of another bean, that usually means that one bean is set as a
 property of another. Typically you accomplish this with the <<beans-ref-element, `<ref/>`
 element>> in XML-based configuration metadata. However, sometimes dependencies between
-beans are less direct; for example, a static initializer in a class needs to be
-triggered, such as database driver registration. The `depends-on` attribute can
+beans are less direct. An example is when a static initializer in a class needs to be
+triggered, such as for database driver registration. The `depends-on` attribute can
 explicitly force one or more beans to be initialized before the bean using this element
 is initialized. The following example uses the `depends-on` attribute to express a
 dependency on a single bean:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<bean id="beanOne" class="ExampleBean" depends-on="manager"/>
 	<bean id="manager" class="ManagerBean" />
 ----
+====
 
 To express a dependency on multiple beans, supply a list of bean names as the value of
-the `depends-on` attribute, with commas, whitespace and semicolons, used as valid
-delimiters:
+the `depends-on` attribute (commas, whitespace, and semicolons are valid
+delimiters):
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1911,52 +2050,54 @@ delimiters:
 	<bean id="manager" class="ManagerBean" />
 	<bean id="accountDao" class="x.y.jdbc.JdbcAccountDao" />
 ----
+====
 
-[NOTE]
-====
-The `depends-on` attribute in the bean definition can specify both an initialization
-time dependency and, in the case of <<beans-factory-scopes-singleton,singleton>> beans
-only, a corresponding destroy time dependency. Dependent beans that define a
+NOTE:
+The `depends-on` attribute in the bean definition can specify both an initialization-time
+dependency and, in the case of <<beans-factory-scopes-singleton,singleton>> beans
+only, a corresponding destroy-time dependency. Dependent beans that define a
 `depends-on` relationship with a given bean are destroyed first, prior to the given bean
-itself being destroyed. Thus `depends-on` can also control shutdown order.
-====
+itself being destroyed. Thus, `depends-on` can also control shutdown order.
 
 
 
 [[beans-factory-lazy-init]]
-=== Lazy-initialized beans
+=== Lazy-initialized Beans
 
 By default, `ApplicationContext` implementations eagerly create and configure all
 <<beans-factory-scopes-singleton,singleton>> beans as part of the initialization
 process. Generally, this pre-instantiation is desirable, because errors in the
 configuration or surrounding environment are discovered immediately, as opposed to hours
-or even days later. When this behavior is __not__ desirable, you can prevent
-pre-instantiation of a singleton bean by marking the bean definition as
+or even days later. When this behavior is not desirable, you can prevent
+pre-instantiation of a singleton bean by marking the bean definition as being
 lazy-initialized. A lazy-initialized bean tells the IoC container to create a bean
 instance when it is first requested, rather than at startup.
 
 In XML, this behavior is controlled by the `lazy-init` attribute on the `<bean/>`
-element; for example:
+element, as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="lazy" class="com.foo.ExpensiveToCreateBean" lazy-init="true"/>
-	<bean name="not.lazy" class="com.foo.AnotherBean"/>
+	<bean id="lazy" class="com.something.ExpensiveToCreateBean" lazy-init="true"/>
+	<bean name="not.lazy" class="com.something.AnotherBean"/>
 ----
+====
 
-When the preceding configuration is consumed by an `ApplicationContext`, the bean named
-`lazy` is not eagerly pre-instantiated when the `ApplicationContext` is starting up,
+When the preceding configuration is consumed by an `ApplicationContext`, the `lazy` bean
+is not eagerly pre-instantiated when the `ApplicationContext` starts,
 whereas the `not.lazy` bean is eagerly pre-instantiated.
 
 However, when a lazy-initialized bean is a dependency of a singleton bean that is
-__not__ lazy-initialized, the `ApplicationContext` creates the lazy-initialized bean at
+not lazy-initialized, the `ApplicationContext` creates the lazy-initialized bean at
 startup, because it must satisfy the singleton's dependencies. The lazy-initialized bean
 is injected into a singleton bean elsewhere that is not lazy-initialized.
 
 You can also control lazy-initialization at the container level by using the
-`default-lazy-init` attribute on the `<beans/>` element; for example:
+`default-lazy-init` attribute on the `<beans/>` element, a the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -1964,14 +2105,15 @@ You can also control lazy-initialization at the container level by using the
 		<!-- no beans will be pre-instantiated... -->
 	</beans>
 ----
+====
 
 
 
 [[beans-factory-autowire]]
-=== Autowiring collaborators
+=== Autowiring Collaborators
 
-The Spring container can __autowire__ relationships between collaborating beans. You can
-allow Spring to resolve collaborators (other beans) automatically for your bean by
+The Spring container can autowire relationships between collaborating beans. You can
+let Spring resolve collaborators (other beans) automatically for your bean by
 inspecting the contents of the `ApplicationContext`. Autowiring has the following
 advantages:
 
@@ -1985,54 +2127,57 @@ advantages:
   during development, without negating the option of switching to explicit wiring when
   the code base becomes more stable.
 
-When using XML-based configuration metadata footnote:[See
-pass:specialcharacters,macros[<<beans-factory-collaborators>>]], you specify autowire
+When using XML-based configuration metadata (see
+<<beans-factory-collaborators>>), you can specify autowire
 mode for a bean definition with the `autowire` attribute of the `<bean/>` element. The
-autowiring functionality has four modes. You specify autowiring __per__ bean and thus
-can choose which ones to autowire.
+autowiring functionality has four modes. You specify autowiring per bean and
+can thus choose which ones to autowire. The following table describes the four autowiring
+modes:
 
 [[beans-factory-autowiring-modes-tbl]]
 .Autowiring modes
 |===
 | Mode| Explanation
 
-| no
-| (Default) No autowiring. Bean references must be defined via a `ref` element. Changing
+| `no`
+| (Default) No autowiring. Bean references must be defined by `ref` elements. Changing
   the default setting is not recommended for larger deployments, because specifying
   collaborators explicitly gives greater control and clarity. To some extent, it
   documents the structure of a system.
 
-| byName
+| `byName`
 | Autowiring by property name. Spring looks for a bean with the same name as the
   property that needs to be autowired. For example, if a bean definition is set to
-  autowire by name, and it contains a __master__ property (that is, it has a
-  __setMaster(..)__ method), Spring looks for a bean definition named `master`, and uses
+  autowire by name and it contains a `master` property (that is, it has a
+  `setMaster(..)` method), Spring looks for a bean definition named `master` and uses
   it to set the property.
 
-| byType
-| Allows a property to be autowired if exactly one bean of the property type exists in
+| `byType`
+| Lets a property be autowired if exactly one bean of the property type exists in
   the container. If more than one exists, a fatal exception is thrown, which indicates
-  that you may not use __byType__ autowiring for that bean. If there are no matching
-  beans, nothing happens; the property is not set.
+  that you may not use `byType` autowiring for that bean. If there are no matching
+  beans, nothing happens (the property is not set).
 
-| constructor
-| Analogous to __byType__, but applies to constructor arguments. If there is not exactly
+| `constructor`
+| Analogous to `byType` but applies to constructor arguments. If there is not exactly
   one bean of the constructor argument type in the container, a fatal error is raised.
 |===
 
-With __byType__ or __constructor__ autowiring mode, you can wire arrays and
-typed-collections. In such cases __all__ autowire candidates within the container that
+With `byType` or `constructor` autowiring mode, you can wire arrays and
+typed collections. In such cases, all autowire candidates within the container that
 match the expected type are provided to satisfy the dependency. You can autowire
-strongly-typed Maps if the expected key type is `String`. An autowired Maps values will
-consist of all bean instances that match the expected type, and the Maps keys will
-contain the corresponding bean names.
+strongly-typed `Map` instances if the expected key type is `String`. An autowired `Map`
+instance's values consist of all bean instances that match the expected type, and the
+`Map` instance's keys contain the corresponding bean names.
 
 You can combine autowire behavior with dependency checking, which is performed after
 autowiring completes.
+// TODO Describe how to do so or provide a link to a section that describes how to do so.
+
 
 
 [[beans-autowired-exceptions]]
-==== Limitations and disadvantages of autowiring
+==== Limitations and Disadvantages of Autowiring
 
 Autowiring works best when it is used consistently across a project. If autowiring is
 not used in general, it might be confusing to developers to use it to wire only one or
@@ -2041,83 +2186,81 @@ two bean definitions.
 Consider the limitations and disadvantages of autowiring:
 
 * Explicit dependencies in `property` and `constructor-arg` settings always override
-  autowiring. You cannot autowire so-called __simple__ properties such as primitives,
+  autowiring. You cannot autowire simple properties such as primitives,
   `Strings`, and `Classes` (and arrays of such simple properties). This limitation is
   by-design.
-* Autowiring is less exact than explicit wiring. Although, as noted in the above table,
+* Autowiring is less exact than explicit wiring. Although, as noted in the earlier table,
   Spring is careful to avoid guessing in case of ambiguity that might have unexpected
-  results, the relationships between your Spring-managed objects are no longer
+  results. The relationships between your Spring-managed objects are no longer
   documented explicitly.
 * Wiring information may not be available to tools that may generate documentation from
   a Spring container.
 * Multiple bean definitions within the container may match the type specified by the
   setter method or constructor argument to be autowired. For arrays, collections, or
-  Maps, this is not necessarily a problem. However for dependencies that expect a single
-  value, this ambiguity is not arbitrarily resolved. If no unique bean definition is
-  available, an exception is thrown.
+  `Map` instances, this is not necessarily a problem. However, for dependencies that
+  expect a single value, this ambiguity is not arbitrarily resolved. If no unique bean
+  definition is available, an exception is thrown.
 
 In the latter scenario, you have several options:
 
 * Abandon autowiring in favor of explicit wiring.
 * Avoid autowiring for a bean definition by setting its `autowire-candidate` attributes
-  to `false` as described in the next section.
-* Designate a single bean definition as the __primary__ candidate by setting the
+  to `false`, as described in the <<beans-factory-autowire-candidate,next section>>.
+* Designate a single bean definition as the primary candidate by setting the
   `primary` attribute of its `<bean/>` element to `true`.
 * Implement the more fine-grained control available
   with annotation-based configuration, as described in <<beans-annotation-config>>.
 
 
+
 [[beans-factory-autowire-candidate]]
-==== Excluding a bean from autowiring
+==== Excluding a Bean from Autowiring
 
 On a per-bean basis, you can exclude a bean from autowiring. In Spring's XML format, set
-the `autowire-candidate` attribute of the `<bean/>` element to `false`; the container
+the `autowire-candidate` attribute of the `<bean/>` element to `false`. The container
 makes that specific bean definition unavailable to the autowiring infrastructure
 (including annotation style configurations such as <<beans-autowired-annotation,
 `@Autowired`>>).
 
-[NOTE]
-====
-The `autowire-candidate` attribute is designed to only affect type-based autowiring.
-It does not affect explicit references by name, which will get resolved even if the
+NOTE: The `autowire-candidate` attribute is designed to only affect type-based autowiring.
+It does not affect explicit references by name, which get resolved even if the
 specified bean is not marked as an autowire candidate. As a consequence, autowiring
-by name will nevertheless inject a bean if the name matches.
-====
+by name nevertheless injects a bean if the name matches.
 
 You can also limit autowire candidates based on pattern-matching against bean names. The
 top-level `<beans/>` element accepts one or more patterns within its
 `default-autowire-candidates` attribute. For example, to limit autowire candidate status
-to any bean whose name ends with __Repository,__ provide a value of *Repository. To
+to any bean whose name ends with `Repository`, provide a value of `*Repository`. To
 provide multiple patterns, define them in a comma-separated list. An explicit value of
-`true` or `false` for a bean definitions `autowire-candidate` attribute always takes
-precedence, and for such beans, the pattern matching rules do not apply.
+`true` or `false` for a bean definition's `autowire-candidate` attribute always takes
+precedence. For such beans, the pattern matching rules do not apply.
 
 These techniques are useful for beans that you never want to be injected into other
-beans by autowiring. It does not mean that an excluded bean cannot itself be configured
+beans by autowiring. It does not mean that an excluded bean cannot itself be configured by
 using autowiring. Rather, the bean itself is not a candidate for autowiring other beans.
 
 
 
-
 [[beans-factory-method-injection]]
-=== Method injection
+=== Method Injection
 
 In most application scenarios, most beans in the container are
 <<beans-factory-scopes-singleton,singletons>>. When a singleton bean needs to
-collaborate with another singleton bean, or a non-singleton bean needs to collaborate
+collaborate with another singleton bean or a non-singleton bean needs to collaborate
 with another non-singleton bean, you typically handle the dependency by defining one
 bean as a property of the other. A problem arises when the bean lifecycles are
 different. Suppose singleton bean A needs to use non-singleton (prototype) bean B,
-perhaps on each method invocation on A. The container only creates the singleton bean A
+perhaps on each method invocation on A. The container creates the singleton bean A only
 once, and thus only gets one opportunity to set the properties. The container cannot
 provide bean A with a new instance of bean B every time one is needed.
 
 A solution is to forego some inversion of control. You can <<beans-factory-aware,make
 bean A aware of the container>> by implementing the `ApplicationContextAware` interface,
-and by <<beans-factory-client,making a getBean("B") call to the container>> ask for (a
-typically new) bean B instance every time bean A needs it. The following is an example
-of this approach:
+and by <<beans-factory-client,making a `getBean("B")` call to the container>> ask for (a
+typically new) bean B instance every time bean A needs it. The following example
+shows this approach:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2152,10 +2295,11 @@ of this approach:
 		}
 	}
 ----
+====
 
 The preceding is not desirable, because the business code is aware of and coupled to the
 Spring Framework. Method Injection, a somewhat advanced feature of the Spring IoC
-container, allows this use case to be handled in a clean fashion.
+container, lets you handle this use case cleanly.
 
 ****
 You can read more about the motivation for Method Injection in
@@ -2163,35 +2307,37 @@ https://spring.io/blog/2004/08/06/method-injection/[this blog entry].
 ****
 
 
+
 [[beans-factory-lookup-method-injection]]
-==== Lookup method injection
+==== Lookup Method Injection
 
 Lookup method injection is the ability of the container to override methods on
-__container managed beans__, to return the lookup result for another named bean in the
-container. The lookup typically involves a prototype bean as in the scenario described
-in the preceding section. The Spring Framework implements this method injection by using
-bytecode generation from the CGLIB library to generate dynamically a subclass that
-overrides the method.
+container-managed beans and return the lookup result for another named bean in the
+container. The lookup typically involves a prototype bean, as in the scenario described
+in <<beans-factory-method-injection,the preceding section>>. The Spring Framework
+implements this method injection by using bytecode generation from the CGLIB library to
+dynamically generate a subclass that overrides the method.
 
 [NOTE]
 ====
-* For this dynamic subclassing to work, the class that the Spring bean container will
-  subclass cannot be `final`, and the method to be overridden cannot be `final` either.
+* For this dynamic subclassing to work, the class that the Spring bean container
+  subclasses cannot be `final`, and the method to be overridden cannot be `final`, either.
 * Unit-testing a class that has an `abstract` method requires you to subclass the class
   yourself and to supply a stub implementation of the `abstract` method.
-* Concrete methods are also necessary for component scanning which requires concrete
+* Concrete methods are also necessary for component scanning, which requires concrete
   classes to pick up.
-* A further key limitation is that lookup methods won't work with factory methods and
-  in particular not with `@Bean` methods in configuration classes, since the container
-  is not in charge of creating the instance in that case and therefore cannot create
+* A further key limitation is that lookup methods do not work with factory methods and
+  in particular not with `@Bean` methods in configuration classes, since, in that case,
+  the container is not in charge of creating the instance and therefore cannot create
   a runtime-generated subclass on the fly.
 ====
 
-Looking at the `CommandManager` class in the previous code snippet, you see that the
-Spring container will dynamically override the implementation of the `createCommand()`
-method. Your `CommandManager` class will not have any Spring dependencies, as can be
-seen in the reworked example:
+In the case of the `CommandManager` class in the previous code snippet, the
+Spring container dynamically overrides the implementation of the `createCommand()`
+method. The `CommandManager` class does not have any Spring dependencies, as
+the reworked example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2213,20 +2359,24 @@ seen in the reworked example:
 		protected abstract Command createCommand();
 	}
 ----
+====
 
-In the client class containing the method to be injected (the `CommandManager` in this
+In the client class that contains the method to be injected (the `CommandManager` in this
 case), the method to be injected requires a signature of the following form:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<public|protected> [abstract] <return-type> theMethodName(no-arguments);
 ----
+====
 
 If the method is `abstract`, the dynamically-generated subclass implements the method.
 Otherwise, the dynamically-generated subclass overrides the concrete method defined in
-the original class. For example:
+the original class. Consider the following example:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2240,16 +2390,18 @@ the original class. For example:
 		<lookup-method name="createCommand" bean="myCommand"/>
 	</bean>
 ----
+====
 
-The bean identified as __commandManager__ calls its own method `createCommand()`
-whenever it needs a new instance of the __myCommand__ bean. You must be careful to deploy
-the `myCommand` bean as a prototype, if that is actually what is needed. If it is
- as a <<beans-factory-scopes-singleton,singleton>>, the same instance of the `myCommand`
+The bean identified as `commandManager` calls its own `createCommand()` method
+whenever it needs a new instance of the `myCommand` bean. You must be careful to deploy
+the `myCommand` bean as a prototype if that is actually what is needed. If it is
+a <<beans-factory-scopes-singleton,singleton>>, the same instance of the `myCommand`
 bean is returned each time.
 
-Alternatively, within the annotation-based component model, you may declare a lookup
-method through the `@Lookup` annotation:
+Alternatively, within the annotation-based component model, you can declare a lookup
+method through the `@Lookup` annotation, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2265,10 +2417,12 @@ method through the `@Lookup` annotation:
 		protected abstract Command createCommand();
 	}
 ----
+====
 
-Or, more idiomatically, you may rely on the target bean getting resolved against the
+Or, more idiomatically, you can rely on the target bean getting resolved against the
 declared return type of the lookup method:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2284,33 +2438,36 @@ declared return type of the lookup method:
 		protected abstract MyCommand createCommand();
 	}
 ----
+====
 
-Note that you will typically declare such annotated lookup methods with a concrete
+Note that you should typically declare such annotated lookup methods with a concrete
 stub implementation, in order for them to be compatible with Spring's component
 scanning rules where abstract classes get ignored by default. This limitation does not
-apply in case of explicitly registered or explicitly imported bean classes.
+apply to explicitly registered or explicitly imported bean classes.
 
 [TIP]
 ====
 Another way of accessing differently scoped target beans is an `ObjectFactory`/
-`Provider` injection point. Check out <<beans-factory-scopes-other-injection>>.
+`Provider` injection point. See <<beans-factory-scopes-other-injection>>.
 
-The interested reader may also find the `ServiceLocatorFactoryBean` (in the
-`org.springframework.beans.factory.config` package) to be of use.
+You may also find the `ServiceLocatorFactoryBean` (in the
+`org.springframework.beans.factory.config` package) to be useful.
 ====
 
 
+
 [[beans-factory-arbitrary-method-replacement]]
-==== Arbitrary method replacement
+==== Arbitrary Method Replacement
 
 A less useful form of method injection than lookup method injection is the ability to
-replace arbitrary methods in a managed bean with another method implementation. Users
-may safely skip the rest of this section until the functionality is actually needed.
+replace arbitrary methods in a managed bean with another method implementation. You
+can safely skip the rest of this section until you actually need this functionality.
 
 With XML-based configuration metadata, you can use the `replaced-method` element to
 replace an existing method implementation with another, for a deployed bean. Consider
-the following class, with a method computeValue, which we want to override:
+the following class, which has a method called `computeValue` that we want to override:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2323,10 +2480,12 @@ the following class, with a method computeValue, which we want to override:
 		// some other methods...
 	}
 ----
+====
 
-A class implementing the `org.springframework.beans.factory.support.MethodReplacer`
-interface provides the new method definition.
+A class that implements the `org.springframework.beans.factory.support.MethodReplacer`
+interface provides the new method definition, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2344,10 +2503,12 @@ interface provides the new method definition.
 		}
 	}
 ----
+====
 
 The bean definition to deploy the original class and specify the method override would
-look like this:
+resemble the following example:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2360,14 +2521,16 @@ look like this:
 
 	<bean id="replacementComputeValue" class="a.b.c.ReplacementComputeValue"/>
 ----
+====
 
-You can use one or more contained `<arg-type/>` elements within the `<replaced-method/>`
+You can use one or more `<arg-type/>` elements within the `<replaced-method/>`
 element to indicate the method signature of the method being overridden. The signature
 for the arguments is necessary only if the method is overloaded and multiple variants
 exist within the class. For convenience, the type string for an argument may be a
 substring of the fully qualified type name. For example, the following all match
 `java.lang.String`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2375,33 +2538,33 @@ substring of the fully qualified type name. For example, the following all match
 	String
 	Str
 ----
+====
 
 Because the number of arguments is often enough to distinguish between each possible
-choice, this shortcut can save a lot of typing, by allowing you to type only the
-shortest string that will match an argument type.
-
+choice, this shortcut can save a lot of typing, by letting you type only the
+shortest string that matches an argument type.
 
 
 
 [[beans-factory-scopes]]
-== Bean scopes
+== Bean Scopes
 
-When you create a bean definition, you create a __recipe__ for creating actual instances
+When you create a bean definition, you create a recipe for creating actual instances
 of the class defined by that bean definition. The idea that a bean definition is a
 recipe is important, because it means that, as with a class, you can create many object
 instances from a single recipe.
 
 You can control not only the various dependencies and configuration values that are to
-be plugged into an object that is created from a particular bean definition, but also
-the __scope__ of the objects created from a particular bean definition. This approach is
-powerful and flexible in that you can __choose__ the scope of the objects you create
+be plugged into an object that is created from a particular bean definition but also control
+the scope of the objects created from a particular bean definition. This approach is
+powerful and flexible, because you can choose the scope of the objects you create
 through configuration instead of having to bake in the scope of an object at the Java
-class level. Beans can be defined to be deployed in one of a number of scopes: out of
-the box, the Spring Framework supports six scopes, four of which are available only if
-you use a web-aware `ApplicationContext`.
-
-The following scopes are supported out of the box. You can also create
+class level. Beans can be defined to be deployed in one of a number of scopes.
+The Spring Framework supports six scopes, four of which are available only if
+you use a web-aware `ApplicationContext`. You can also create
 <<beans-factory-scopes-custom,a custom scope.>>
+
+The following table describes the supported scopes:
 
 [[beans-factory-scopes-tbl]]
 .Bean scopes
@@ -2409,14 +2572,14 @@ The following scopes are supported out of the box. You can also create
 | Scope| Description
 
 | <<beans-factory-scopes-singleton,singleton>>
-| (Default) Scopes a single bean definition to a single object instance per Spring IoC
+| (Default) Scopes a single bean definition to a single object instance for each Spring IoC
   container.
 
 | <<beans-factory-scopes-prototype,prototype>>
 | Scopes a single bean definition to any number of object instances.
 
 | <<beans-factory-scopes-request,request>>
-| Scopes a single bean definition to the lifecycle of a single HTTP request; that is,
+| Scopes a single bean definition to the lifecycle of a single HTTP request. That is,
   each HTTP request has its own instance of a bean created off the back of a single bean
   definition. Only valid in the context of a web-aware Spring `ApplicationContext`.
 
@@ -2433,83 +2596,87 @@ The following scopes are supported out of the box. You can also create
   the context of a web-aware Spring `ApplicationContext`.
 |===
 
-[NOTE]
-====
-As of Spring 3.0, a __thread scope__ is available, but is not registered by default. For
+NOTE: As of Spring 3.0, a thread scope is available but is not registered by default. For
 more information, see the documentation for
 {api-spring-framework}/context/support/SimpleThreadScope.html[`SimpleThreadScope`].
 For instructions on how to register this or any other custom scope, see
 <<beans-factory-scopes-custom-using>>.
-====
 
 
 
 [[beans-factory-scopes-singleton]]
-=== The singleton scope
+=== The Singleton Scope
 
-Only one __shared__ instance of a singleton bean is managed, and all requests for beans
-with an id or ids matching that bean definition result in that one specific bean
+Only one shared instance of a singleton bean is managed, and all requests for beans
+with an ID or IDs that match that bean definition result in that one specific bean
 instance being returned by the Spring container.
 
 To put it another way, when you define a bean definition and it is scoped as a
-singleton, the Spring IoC container creates __exactly one__ instance of the object
+singleton, the Spring IoC container creates exactly one instance of the object
 defined by that bean definition. This single instance is stored in a cache of such
-singleton beans, and __all subsequent requests and references__ for that named bean
-return the cached object.
+singleton beans, and all subsequent requests and references for that named bean
+return the cached object. The following image shows how the singleton scope works:
 
 image::images/singleton.png[]
 
-Spring's concept of a singleton bean differs from the Singleton pattern as defined in
-the Gang of Four (GoF) patterns book. The GoF Singleton hard-codes the scope of an
-object such that one __and only one__ instance of a particular class is created __per
-ClassLoader__. The scope of the Spring singleton is best described as __per container
-and per bean__. This means that if you define one bean for a particular class in a
-single Spring container, then the Spring container creates one __and only one__ instance
-of the class defined by that bean definition. __The singleton scope is the default scope
-in Spring__. To define a bean as a singleton in XML, you would write, for example:
+Spring's concept of a singleton bean differs from the singleton pattern as defined in
+the Gang of Four (GoF) patterns book. The GoF singleton hard-codes the scope of an
+object such that one and only one instance of a particular class is created per
+ClassLoader. The scope of the Spring singleton is best described as being per-container
+and per-bean. This means that, if you define one bean for a particular class in a
+single Spring container, the Spring container creates one and only one instance
+of the class defined by that bean definition. The singleton scope is the default scope
+in Spring. To define a bean as a singleton in XML, you can define a bean as shown in the
+following example:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="accountService" class="com.foo.DefaultAccountService"/>
+	<bean id="accountService" class="com.something.DefaultAccountService"/>
 
 	<!-- the following is equivalent, though redundant (singleton scope is the default) -->
-	<bean id="accountService" class="com.foo.DefaultAccountService" scope="singleton"/>
+	<bean id="accountService" class="com.something.DefaultAccountService" scope="singleton"/>
 ----
+====
 
 
 
 [[beans-factory-scopes-prototype]]
-=== The prototype scope
+=== The Prototype Scope
 
-The non-singleton, prototype scope of bean deployment results in the __creation of a new
-bean instance__ every time a request for that specific bean is made. That is, the bean
+The non-singleton prototype scope of bean deployment results in the creation of a new
+bean instance every time a request for that specific bean is made. That is, the bean
 is injected into another bean or you request it through a `getBean()` method call on the
-container. As a rule, use the prototype scope for all stateful beans and the singleton
-scope for stateless beans.
+container. As a rule, you should use the prototype scope for all stateful beans and the
+singleton scope for stateless beans.
 
-The following diagram illustrates the Spring prototype scope. __A data access object
-(DAO) is not typically configured as a prototype, because a typical DAO does not hold
-any conversational state; it was just easier for this author to reuse the core of the
-singleton diagram.__
+The following diagram illustrates the Spring prototype scope:
 
 image::images/prototype.png[]
 
+(A data access object
+(DAO) is not typically configured as a prototype, because a typical DAO does not hold
+any conversational state. It was easier for us to reuse the core of the
+singleton diagram.)
+
 The following example defines a bean as a prototype in XML:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="accountService" class="com.foo.DefaultAccountService" scope="prototype"/>
+	<bean id="accountService" class="com.something.DefaultAccountService" scope="prototype"/>
 ----
+====
 
 In contrast to the other scopes, Spring does not manage the complete lifecycle of a
-prototype bean: the container instantiates, configures, and otherwise assembles a
-prototype object, and hands it to the client, with no further record of that prototype
-instance. Thus, although__ initialization__ lifecycle callback methods are called on all
-objects regardless of scope, in the case of prototypes, configured __destruction__
-lifecycle callbacks are __not__ called. The client code must clean up prototype-scoped
-objects and release expensive resources that the prototype bean(s) are holding. To get
+prototype bean. The container instantiates, configures, and otherwise assembles a
+prototype object and hands it to the client, with no further record of that prototype
+instance. Thus, although initialization lifecycle callback methods are called on all
+objects regardless of scope, in the case of prototypes, configured destruction
+lifecycle callbacks are not called. The client code must clean up prototype-scoped
+objects and release expensive resources that the prototype beans hold. To get
 the Spring container to release resources held by prototype-scoped beans, try using a
 custom <<beans-factory-extension-bpp,bean post-processor>>, which holds a reference to
 beans that need to be cleaned up.
@@ -2522,10 +2689,10 @@ container, see <<beans-factory-lifecycle>>.)
 
 
 [[beans-factory-scopes-sing-prot-interaction]]
-=== Singleton beans with prototype-bean dependencies
+=== Singleton Beans with Prototype-bean Dependencies
 
 When you use singleton-scoped beans with dependencies on prototype beans, be aware that
-__dependencies are resolved at instantiation time__. Thus if you dependency-inject a
+dependencies are resolved at instantiation time. Thus, if you dependency-inject a
 prototype-scoped bean into a singleton-scoped bean, a new prototype bean is instantiated
 and then dependency-injected into the singleton bean. The prototype instance is the sole
 instance that is ever supplied to the singleton-scoped bean.
@@ -2533,43 +2700,45 @@ instance that is ever supplied to the singleton-scoped bean.
 However, suppose you want the singleton-scoped bean to acquire a new instance of the
 prototype-scoped bean repeatedly at runtime. You cannot dependency-inject a
 prototype-scoped bean into your singleton bean, because that injection occurs only
-__once__, when the Spring container is instantiating the singleton bean and resolving
-and injecting its dependencies. If you need a new instance of a prototype bean at
+once, when the Spring container instantiates the singleton bean and resolves
+and injects its dependencies. If you need a new instance of a prototype bean at
 runtime more than once, see <<beans-factory-method-injection>>
 
 
 
 [[beans-factory-scopes-other]]
-=== Request, session, application, and WebSocket scopes
+=== Request, Session, Application, and WebSocket Scopes
 
-The `request`, `session`, `application`, and `websocket` scopes are __only__ available
+The `request`, `session`, `application`, and `websocket` scopes are available only
 if you use a web-aware Spring `ApplicationContext` implementation (such as
-`XmlWebApplicationContext`). If you use these scopes with regular Spring IoC containers
-such as the `ClassPathXmlApplicationContext`, an `IllegalStateException` will be thrown
-complaining about an unknown bean scope.
+`XmlWebApplicationContext`). If you use these scopes with regular Spring IoC containers,
+such as the `ClassPathXmlApplicationContext`, an `IllegalStateException` that complains
+about an unknown bean scope is thrown.
+
 
 
 [[beans-factory-scopes-other-web-configuration]]
-==== Initial web configuration
+==== Initial Web Configuration
 
 To support the scoping of beans at the `request`, `session`, `application`, and
 `websocket` levels (web-scoped beans), some minor initial configuration is
-required before you define your beans. (This initial setup is __not__ required
-for the standard scopes, `singleton` and `prototype`.)
+required before you define your beans. (This initial setup is not required
+for the standard scopes: `singleton` and `prototype`.)
 
 How you accomplish this initial setup depends on your particular Servlet environment.
 
 If you access scoped beans within Spring Web MVC, in effect, within a request that is
-processed by the Spring `DispatcherServlet`, then no special setup is necessary:
+processed by the Spring `DispatcherServlet`, no special setup is necessary.
 `DispatcherServlet` already exposes all relevant state.
 
 If you use a Servlet 2.5 web container, with requests processed outside of Spring's
 `DispatcherServlet` (for example, when using JSF or Struts), you need to register the
 `org.springframework.web.context.request.RequestContextListener` `ServletRequestListener`.
-For Servlet 3.0+, this can be done programmatically via the `WebApplicationInitializer`
+For Servlet 3.0+, this can be done programmatically by using the `WebApplicationInitializer`
 interface. Alternatively, or for older containers, add the following declaration to
 your web application's `web.xml` file:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2583,11 +2752,14 @@ your web application's `web.xml` file:
 		...
 	</web-app>
 ----
+====
 
 Alternatively, if there are issues with your listener setup, consider using Spring's
 `RequestContextFilter`. The filter mapping depends on the surrounding web
-application configuration, so you have to change it as appropriate.
+application configuration, so you have to change it as appropriate. The following listing
+shows the filter part of a web application:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2604,6 +2776,7 @@ application configuration, so you have to change it as appropriate.
 		...
 	</web-app>
 ----
+====
 
 `DispatcherServlet`, `RequestContextListener`, and `RequestContextFilter` all do exactly
 the same thing, namely bind the HTTP request object to the `Thread` that is servicing
@@ -2611,28 +2784,33 @@ that request. This makes beans that are request- and session-scoped available fu
 down the call chain.
 
 
+
 [[beans-factory-scopes-request]]
 ==== Request scope
 
 Consider the following XML configuration for a bean definition:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="loginAction" class="com.foo.LoginAction" scope="request"/>
+	<bean id="loginAction" class="com.something.LoginAction" scope="request"/>
 ----
+====
 
 The Spring container creates a new instance of the `LoginAction` bean by using the
 `loginAction` bean definition for each and every HTTP request. That is, the
 `loginAction` bean is scoped at the HTTP request level. You can change the internal
 state of the instance that is created as much as you want, because other instances
-created from the same `loginAction` bean definition will not see these changes in state;
-they are particular to an individual request. When the request completes processing, the
+created from the same `loginAction` bean definition do not see these changes in state.
+They are particular to an individual request. When the request completes processing, the
 bean that is scoped to the request is discarded.
 
-When using annotation-driven components or Java Config, the `@RequestScope` annotation
-can be used to assign a component to the `request` scope.
+When using annotation-driven components or Java configuration, the `@RequestScope` annotation
+can be used to assign a component to the `request` scope. The following example shows how
+to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2642,32 +2820,37 @@ can be used to assign a component to the `request` scope.
 		// ...
 	}
 ----
+====
+
 
 
 [[beans-factory-scopes-session]]
-==== Session scope
+==== Session Scope
 
 Consider the following XML configuration for a bean definition:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="userPreferences" class="com.foo.UserPreferences" scope="session"/>
+	<bean id="userPreferences" class="com.something.UserPreferences" scope="session"/>
 ----
+====
 
 The Spring container creates a new instance of the `UserPreferences` bean by using the
 `userPreferences` bean definition for the lifetime of a single HTTP `Session`. In other
 words, the `userPreferences` bean is effectively scoped at the HTTP `Session` level. As
-with `request-scoped` beans, you can change the internal state of the instance that is
+with request-scoped beans, you can change the internal state of the instance that is
 created as much as you want, knowing that other HTTP `Session` instances that are also
 using instances created from the same `userPreferences` bean definition do not see these
 changes in state, because they are particular to an individual HTTP `Session`. When the
 HTTP `Session` is eventually discarded, the bean that is scoped to that particular HTTP
 `Session` is also discarded.
 
-When using annotation-driven components or Java Config, the `@SessionScope` annotation
-can be used to assign a component to the `session` scope.
+When using annotation-driven components or Java configuration, you can use the
+`@SessionScope` annotation to assign a component to the `session` scope.
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2677,30 +2860,36 @@ can be used to assign a component to the `session` scope.
 		// ...
 	}
 ----
+====
+
 
 
 [[beans-factory-scopes-application]]
-==== Application scope
+==== Application Scope
 
 Consider the following XML configuration for a bean definition:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="appPreferences" class="com.foo.AppPreferences" scope="application"/>
+	<bean id="appPreferences" class="com.something.AppPreferences" scope="application"/>
 ----
+====
 
 The Spring container creates a new instance of the `AppPreferences` bean by using the
 `appPreferences` bean definition once for the entire web application. That is, the
-`appPreferences` bean is scoped at the `ServletContext` level, stored as a regular
+`appPreferences` bean is scoped at the `ServletContext` level and stored as a regular
 `ServletContext` attribute. This is somewhat similar to a Spring singleton bean but
 differs in two important ways: It is a singleton per `ServletContext`, not per Spring
 'ApplicationContext' (for which there may be several in any given web application),
 and it is actually exposed and therefore visible as a `ServletContext` attribute.
 
-When using annotation-driven components or Java Config, the `@ApplicationScope`
-annotation can be used to assign a component to the `application` scope.
+When using annotation-driven components or Java configuration, you can use the
+`@ApplicationScope` annotation to assign a component to the `application` scope. The
+following example shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2710,14 +2899,16 @@ annotation can be used to assign a component to the `application` scope.
 		// ...
 	}
 ----
+====
+
 
 
 [[beans-factory-scopes-other-injection]]
-==== Scoped beans as dependencies
+==== Scoped Beans as Dependencies
 
 The Spring IoC container manages not only the instantiation of your objects (beans),
 but also the wiring up of collaborators (or dependencies). If you want to inject (for
-example) an HTTP request scoped bean into another bean of a longer-lived scope, you may
+example) an HTTP request-scoped bean into another bean of a longer-lived scope, you may
 choose to inject an AOP proxy in place of the scoped bean. That is, you need to inject
 a proxy object that exposes the same public interface as the scoped object but that can
 also retrieve the real target object from the relevant scope (such as an HTTP request)
@@ -2730,26 +2921,27 @@ with the reference then going through an intermediate proxy that is serializable
 and therefore able to re-obtain the target singleton bean on deserialization.
 
 When declaring `<aop:scoped-proxy/>` against a bean of scope `prototype`, every method
-call on the shared proxy will lead to the creation of a new target instance which the
-call is then being forwarded to.
+call on the shared proxy leads to the creation of a new target instance to which the
+call is then being forwarded.
 
 Also, scoped proxies are not the only way to access beans from shorter scopes in a
-lifecycle-safe fashion. You may also simply declare your injection point (i.e. the
-constructor/setter argument or autowired field) as `ObjectFactory<MyTargetBean>`,
+lifecycle-safe fashion. You may also declare your injection point (that is, the
+constructor or setter argument or autowired field) as `ObjectFactory<MyTargetBean>`,
 allowing for a `getObject()` call to retrieve the current instance on demand every
-time it is needed - without holding on to the instance or storing it separately.
+time it is needed -- without holding on to the instance or storing it separately.
 
-As an extended variant, you may declare `ObjectProvider<MyTargetBean>` which delivers
+As an extended variant, you may declare `ObjectProvider<MyTargetBean>`, which delivers
 several additional access variants, including `getIfAvailable` and `getIfUnique`.
 
-The JSR-330 variant of this is called `Provider`, used with a `Provider<MyTargetBean>`
+The JSR-330 variant of this is called `Provider` and is used with a `Provider<MyTargetBean>`
 declaration and a corresponding `get()` call for every retrieval attempt.
 See <<beans-standard-annotations,here>> for more details on JSR-330 overall.
 ====
 
 The configuration in the following example is only one line, but it is important to
-understand the "why" as well as the "how" behind it.
+understand the "`why`" as well as the "`how`" behind it:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -2763,109 +2955,114 @@ understand the "why" as well as the "how" behind it.
 			http://www.springframework.org/schema/aop/spring-aop.xsd">
 
 		<!-- an HTTP Session-scoped bean exposed as a proxy -->
-		<bean id="userPreferences" class="com.foo.UserPreferences" scope="session">
+		<bean id="userPreferences" class="com.something.UserPreferences" scope="session">
 			<!-- instructs the container to proxy the surrounding bean -->
-			<aop:scoped-proxy/>
+			<aop:scoped-proxy/>                                                       <1>
 		</bean>
 
 		<!-- a singleton-scoped bean injected with a proxy to the above bean -->
-		<bean id="userService" class="com.foo.SimpleUserService">
+		<bean id="userService" class="com.something.SimpleUserService">
 			<!-- a reference to the proxied userPreferences bean -->
 			<property name="userPreferences" ref="userPreferences"/>
 		</bean>
 	</beans>
 ----
+<1> The line that defines the proxy.
+====
 
 To create such a proxy, you insert a child `<aop:scoped-proxy/>` element into a scoped
 bean definition (see <<beans-factory-scopes-other-injection-proxies>> and
 <<core.adoc#xsd-schemas, XML Schema-based configuration>>).
 Why do definitions of beans scoped at the `request`, `session` and custom-scope
 levels require the `<aop:scoped-proxy/>` element?
-Let's examine the following singleton bean definition and contrast it with
+Consider the following singleton bean definition and contrast it with
 what you need to define for the aforementioned scopes (note that the following
-`userPreferences` bean definition as it stands is __incomplete__).
+`userPreferences` bean definition as it stands is incomplete):
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="userPreferences" class="com.foo.UserPreferences" scope="session"/>
+	<bean id="userPreferences" class="com.something.UserPreferences" scope="session"/>
 
-	<bean id="userManager" class="com.foo.UserManager">
+	<bean id="userManager" class="com.something.UserManager">
 		<property name="userPreferences" ref="userPreferences"/>
 	</bean>
 ----
+====
 
-In the preceding example, the singleton bean `userManager` is injected with a reference
-to the HTTP `Session`-scoped bean `userPreferences`. The salient point here is that the
-`userManager` bean is a singleton: it will be instantiated __exactly once__ per
+In the preceding example, the singleton bean (`userManager`) is injected with a reference
+to the HTTP `Session`-scoped bean (`userPreferences`). The salient point here is that the
+`userManager` bean is a singleton: it is instantiated exactly once per
 container, and its dependencies (in this case only one, the `userPreferences` bean) are
-also injected only once. This means that the `userManager` bean will only operate on the
-exact same `userPreferences` object, that is, the one that it was originally injected
-with.
+also injected only once. This means that the `userManager` bean operates only on the
+exact same `userPreferences` object (that is, the one with which it was originally injected.
 
-This is __not__ the behavior you want when injecting a shorter-lived scoped bean into a
-longer-lived scoped bean, for example injecting an HTTP `Session`-scoped collaborating
-bean as a dependency into singleton bean. Rather, you need a single `userManager`
-object, and for the lifetime of an HTTP `Session`, you need a `userPreferences` object
-that is specific to said HTTP `Session`. Thus the container creates an object that
+This is not the behavior you want when injecting a shorter-lived scoped bean into a
+longer-lived scoped bean (for example, injecting an HTTP `Session`-scoped collaborating
+bean as a dependency into singleton bean). Rather, you need a single `userManager`
+object, and, for the lifetime of an HTTP `Session`, you need a `userPreferences` object
+that is specific to the HTTP `Session`. Thus, the container creates an object that
 exposes the exact same public interface as the `UserPreferences` class (ideally an
-object that __is a__ `UserPreferences` instance) which can fetch the real
-`UserPreferences` object from the scoping mechanism (HTTP request, `Session`, etc.). The
-container injects this proxy object into the `userManager` bean, which is unaware that
-this `UserPreferences` reference is a proxy. In this example, when a `UserManager`
-instance invokes a method on the dependency-injected `UserPreferences` object, it
-actually is invoking a method on the proxy. The proxy then fetches the real
-`UserPreferences` object from (in this case) the HTTP `Session`, and delegates the
+object that is a `UserPreferences` instance), which can fetch the real
+`UserPreferences` object from the scoping mechanism (HTTP request, `Session`, and so
+forth). The container injects this proxy object into the `userManager` bean, which is
+unaware that this `UserPreferences` reference is a proxy. In this example, when a
+`UserManager` instance invokes a method on the dependency-injected `UserPreferences`
+object, it is actually invoking a method on the proxy. The proxy then fetches the real
+`UserPreferences` object from (in this case) the HTTP `Session` and delegates the
 method invocation onto the retrieved real `UserPreferences` object.
 
-Thus you need the following, correct and complete, configuration when injecting
-`request-` and `session-scoped` beans into collaborating objects:
+Thus, you need the following (correct and complete) configuration when injecting
+`request-` and `session-scoped` beans into collaborating objects, as the following example
+shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<bean id="userPreferences" class="com.foo.UserPreferences" scope="session">
+	<bean id="userPreferences" class="com.something.UserPreferences" scope="session">
 		<aop:scoped-proxy/>
 	</bean>
 
-	<bean id="userManager" class="com.foo.UserManager">
+	<bean id="userManager" class="com.something.UserManager">
 		<property name="userPreferences" ref="userPreferences"/>
 	</bean>
 ----
+====
 
 [[beans-factory-scopes-other-injection-proxies]]
-===== Choosing the type of proxy to create
+===== Choosing the Type of Proxy to Create
 
 By default, when the Spring container creates a proxy for a bean that is marked up with
-the `<aop:scoped-proxy/>` element, __a CGLIB-based class proxy is created__.
+the `<aop:scoped-proxy/>` element, a CGLIB-based class proxy is created.
 
-[NOTE]
-====
-CGLIB proxies only intercept public method calls! Do not call non-public methods
-on such a proxy; they will not be delegated to the actual scoped target object.
-====
+NOTE: CGLIB proxies intercept only public method calls! Do not call non-public methods
+on such a proxy. They are not delegated to the actual scoped target object.
 
 Alternatively, you can configure the Spring container to create standard JDK
 interface-based proxies for such scoped beans, by specifying `false` for the value of
 the `proxy-target-class` attribute of the `<aop:scoped-proxy/>` element. Using JDK
 interface-based proxies means that you do not need additional libraries in your
-application classpath to effect such proxying. However, it also means that the class of
-the scoped bean must implement at least one interface, and __that all__ collaborators
+application classpath to affect such proxying. However, it also means that the class of
+the scoped bean must implement at least one interface and that all collaborators
 into which the scoped bean is injected must reference the bean through one of its
-interfaces.
+interfaces. The following example shows a proxy based on an interface:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<!-- DefaultUserPreferences implements the UserPreferences interface -->
-	<bean id="userPreferences" class="com.foo.DefaultUserPreferences" scope="session">
+	<bean id="userPreferences" class="com.stuff.DefaultUserPreferences" scope="session">
 		<aop:scoped-proxy proxy-target-class="false"/>
 	</bean>
 
-	<bean id="userManager" class="com.foo.UserManager">
+	<bean id="userManager" class="com.stuff.UserManager">
 		<property name="userPreferences" ref="userPreferences"/>
 	</bean>
 ----
+====
 
 For more detailed information about choosing class-based or interface-based proxying,
 see <<aop-proxying>>.
@@ -2873,119 +3070,137 @@ see <<aop-proxying>>.
 
 
 [[beans-factory-scopes-custom]]
-=== Custom scopes
+=== Custom Scopes
 
-The bean scoping mechanism is extensible; You can define your own
-scopes, or even redefine existing scopes, although the latter is considered bad practice
-and you __cannot__ override the built-in `singleton` and `prototype` scopes.
+The bean scoping mechanism is extensible. You can define your own
+scopes or even redefine existing scopes, although the latter is considered bad practice
+and you cannot override the built-in `singleton` and `prototype` scopes.
 
 
 [[beans-factory-scopes-custom-creating]]
-==== Creating a custom scope
+==== Creating a Custom Scope
 
-To integrate your custom scope(s) into the Spring container, you need to implement the
+To integrate your custom scopes into the Spring container, you need to implement the
 `org.springframework.beans.factory.config.Scope` interface, which is described in this
 section. For an idea of how to implement your own scopes, see the `Scope`
 implementations that are supplied with the Spring Framework itself and the
-{api-spring-framework}/beans/factory/config/Scope.html[`Scope` javadocs],
+{api-spring-framework}/beans/factory/config/Scope.html[`Scope` Javadoc],
 which explains the methods you need to implement in more detail.
 
 The `Scope` interface has four methods to get objects from the scope, remove them from
-the scope, and allow them to be destroyed.
+the scope, and let them be destroyed.
 
-The following method returns the object from the underlying scope. The session scope
-implementation, for example, returns the session-scoped bean (and if it does not exist,
+The session scope
+implementation, for example, returns the session-scoped bean (if it does not exist,
 the method returns a new instance of the bean, after having bound it to the session for
-future reference).
+future reference). The following method returns the object from the underlying scope:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	Object get(String name, ObjectFactory objectFactory)
 ----
+====
 
-The following method removes the object from the underlying scope. The session scope
-implementation for example, removes the session-scoped bean from the underlying session.
+The session scope
+implementation, for example, removes the session-scoped bean from the underlying session.
 The object should be returned, but you can return null if the object with the specified
-name is not found.
+name is not found. The following method removes the object from the underlying scope:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	Object remove(String name)
 ----
+====
 
 The following method registers the callbacks the scope should execute when it is
-destroyed or when the specified object in the scope is destroyed. Refer to the javadocs
-or a Spring scope implementation for more information on destruction callbacks.
+destroyed or when the specified object in the scope is destroyed:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	void registerDestructionCallback(String name, Runnable destructionCallback)
 ----
+====
 
-The following method obtains the conversation identifier for the underlying scope. This
-identifier is different for each scope. For a session scoped implementation, this
-identifier can be the session identifier.
+See the {api-spring-framework}/beans/factory/config/Scope.html#registerDestructionCallback[Javadoc]
+or a Spring scope implementation for more information on destruction callbacks.
 
+The following method obtains the conversation identifier for the underlying scope:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	String getConversationId()
 ----
+====
+
+This identifier is different for each scope. For a session scoped implementation, this
+identifier can be the session identifier.
+
 
 
 [[beans-factory-scopes-custom-using]]
-==== Using a custom scope
+==== Using a Custom Scope
 
 After you write and test one or more custom `Scope` implementations, you need to make
-the Spring container aware of your new scope(s). The following method is the central
+the Spring container aware of your new scopes. The following method is the central
 method to register a new `Scope` with the Spring container:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	void registerScope(String scopeName, Scope scope);
 ----
+====
 
 This method is declared on the `ConfigurableBeanFactory` interface, which is available
-on most of the concrete `ApplicationContext` implementations that ship with Spring via
-the BeanFactory property.
+through the `BeanFactory` property on most of the concrete `ApplicationContext`
+implementations that ship with Spring.
 
 The first argument to the `registerScope(..)` method is the unique name associated with
-a scope; examples of such names in the Spring container itself are `singleton` and
+a scope. Examples of such names in the Spring container itself are `singleton` and
 `prototype`. The second argument to the `registerScope(..)` method is an actual instance
 of the custom `Scope` implementation that you wish to register and use.
 
-Suppose that you write your custom `Scope` implementation, and then register it as below.
+Suppose that you write your custom `Scope` implementation, and then register it as shown
+in the next example.
 
-[NOTE]
-====
-The example below uses `SimpleThreadScope` which is included with Spring, but not
+NOTE: The next example uses `SimpleThreadScope`, which is included with Spring but is not
 registered by default. The instructions would be the same for your own custom `Scope`
 implementations.
-====
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	Scope threadScope = new SimpleThreadScope();
 	beanFactory.registerScope("thread", threadScope);
 ----
+====
 
-You then create bean definitions that adhere to the scoping rules of your custom `Scope`:
+You can then create bean definitions that adhere to the scoping rules of your custom
+`Scope`, as follows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<bean id="..." class="..." scope="thread">
 ----
+====
 
 With a custom `Scope` implementation, you are not limited to programmatic registration
-of the scope. You can also do the `Scope` registration declaratively, using the
-`CustomScopeConfigurer` class:
+of the scope. You can also do the `Scope` registration declaratively, by using the
+`CustomScopeConfigurer` class, as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3008,85 +3223,93 @@ of the scope. You can also do the `Scope` registration declaratively, using the
 			</property>
 		</bean>
 
-		<bean id="bar" class="x.y.Bar" scope="thread">
+		<bean id="thing2" class="x.y.Thing2" scope="thread">
 			<property name="name" value="Rick"/>
 			<aop:scoped-proxy/>
 		</bean>
 
-		<bean id="foo" class="x.y.Foo">
-			<property name="bar" ref="bar"/>
+		<bean id="thing1" class="x.y.Thing1">
+			<property name="thing2" ref="thing2"/>
 		</bean>
 
 	</beans>
 ----
-
-[NOTE]
 ====
-When you place `<aop:scoped-proxy/>` in a `FactoryBean` implementation, it is the factory
+
+NOTE: When you place `<aop:scoped-proxy/>` in a `FactoryBean` implementation, it is the factory
 bean itself that is scoped, not the object returned from `getObject()`.
-====
-
 
 
 
 [[beans-factory-nature]]
-== Customizing the nature of a bean
+== Customizing the Nature of a Bean
+
+The Spring Framework provides a number of interfaces you can use to customize the nature
+of a bean. This section groups them as follows:
+
+* <<beans-factory-lifecycle>>
+* <<beans-factory-aware>>
+* <<aware-list>>
 
 
 
 [[beans-factory-lifecycle]]
-=== Lifecycle callbacks
+=== Lifecycle Callbacks
 
 To interact with the container's management of the bean lifecycle, you can implement the
 Spring `InitializingBean` and `DisposableBean` interfaces. The container calls
-`afterPropertiesSet()` for the former and `destroy()` for the latter to allow the bean
-to perform certain actions upon initialization and destruction of your beans.
+`afterPropertiesSet()` for the former and `destroy()` for the latter to let the bean
+perform certain actions upon initialization and destruction of your beans.
 
 [TIP]
 ====
 The JSR-250 `@PostConstruct` and `@PreDestroy` annotations are generally considered best
 practice for receiving lifecycle callbacks in a modern Spring application. Using these
-annotations means that your beans are not coupled to Spring specific interfaces. For
-details see <<beans-postconstruct-and-predestroy-annotations>>.
+annotations means that your beans are not coupled to Spring-specific interfaces. For
+details, see <<beans-postconstruct-and-predestroy-annotations>>.
 
-If you don't want to use the JSR-250 annotations but you are still looking to remove
-coupling consider the use of init-method and destroy-method object definition metadata.
+If you do not want to use the JSR-250 annotations but you still want to remove
+coupling, consider using of `init-method` and `destroy-method` object definition metadata.
 ====
 
 Internally, the Spring Framework uses `BeanPostProcessor` implementations to process any
 callback interfaces it can find and call the appropriate methods. If you need custom
-features or other lifecycle behavior Spring does not offer out-of-the-box, you can
+features or other lifecycle behavior Spring does not by default offer, you can
 implement a `BeanPostProcessor` yourself. For more information, see
 <<beans-factory-extension>>.
 
 In addition to the initialization and destruction callbacks, Spring-managed objects may
 also implement the `Lifecycle` interface so that those objects can participate in the
-startup and shutdown process as driven by the container's own lifecycle.
+startup and shutdown process, as driven by the container's own lifecycle.
 
 The lifecycle callback interfaces are described in this section.
 
 
+
 [[beans-factory-lifecycle-initializingbean]]
-==== Initialization callbacks
+==== Initialization Callbacks
 
-The `org.springframework.beans.factory.InitializingBean` interface allows a bean to
-perform initialization work after all necessary properties on the bean have been set by
-the container. The `InitializingBean` interface specifies a single method:
+The `org.springframework.beans.factory.InitializingBean` interface lets a bean
+perform initialization work after the container has set all necessary properties on the
+bean. The `InitializingBean` interface specifies a single method:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	void afterPropertiesSet() throws Exception;
 ----
+====
 
-It is recommended that you do not use the `InitializingBean` interface because it
-unnecessarily couples the code to Spring. Alternatively, use
+We recommend that you do not use the `InitializingBean` interface, because it
+unnecessarily couples the code to Spring. Alternatively, we suggest using
 the <<beans-postconstruct-and-predestroy-annotations, `@PostConstruct`>> annotation or
-specify a POJO initialization method. In the case of XML-based configuration metadata,
-you use the `init-method` attribute to specify the name of the method that has a void
-no-argument signature. With Java config, you use the `initMethod` attribute of `@Bean`,
-see <<beans-java-lifecycle-callbacks>>. For example, the following:
+specifying a POJO initialization method. In the case of XML-based configuration metadata,
+you can use the `init-method` attribute to specify the name of the method that has a void
+no-argument signature. With Java configuration, you can use the `initMethod` attribute of
+`@Bean`. See <<beans-java-lifecycle-callbacks>>. Consider the following example:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3103,9 +3326,12 @@ see <<beans-java-lifecycle-callbacks>>. For example, the following:
 		}
 	}
 ----
+====
 
-...is exactly the same as...
+The preceding example has almost exactly the same effect as the following example (which
+consists of two listings):
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3122,31 +3348,35 @@ see <<beans-java-lifecycle-callbacks>>. For example, the following:
 		}
 	}
 ----
+====
 
-but does not couple the code to Spring.
+However, the second of the two preceding examples does not couple the code to Spring.
 
 
 [[beans-factory-lifecycle-disposablebean]]
-==== Destruction callbacks
+==== Destruction Callbacks
 
-Implementing the `org.springframework.beans.factory.DisposableBean` interface allows a
-bean to get a callback when the container containing it is destroyed. The
+Implementing the `org.springframework.beans.factory.DisposableBean` interface lets a
+bean get a callback when the container that contains it is destroyed. The
 `DisposableBean` interface specifies a single method:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	void destroy() throws Exception;
 ----
+====
 
-It is recommended that you do not use the `DisposableBean` callback interface because it
-unnecessarily couples the code to Spring. Alternatively, use
+We recommend that you do not use the `DisposableBean` callback interface, because it
+unnecessarily couples the code to Spring. Alternatively, we suggest using
 the <<beans-postconstruct-and-predestroy-annotations, `@PreDestroy`>> annotation or
-specify a generic method that is supported by bean definitions. With XML-based
-configuration metadata, you use the `destroy-method` attribute on the `<bean/>`.
-With Java config, you use the `destroyMethod` attribute of `@Bean`, see
-<<beans-java-lifecycle-callbacks>>. For example, the following definition:
+specifying a generic method that is supported by bean definitions. With XML-based
+configuration metadata, you can use the `destroy-method` attribute on the `<bean/>`.
+With Java configuration, you can use the `destroyMethod` attribute of `@Bean`. See
+<<beans-java-lifecycle-callbacks>>. Consider the following definition:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3163,9 +3393,11 @@ With Java config, you use the `destroyMethod` attribute of `@Bean`, see
 		}
 	}
 ----
+====
 
-is exactly the same as:
+The preceding definition has almost exactly the same effect as the following definition:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3182,23 +3414,21 @@ is exactly the same as:
 		}
 	}
 ----
-
-but does not couple the code to Spring.
-
-[TIP]
 ====
-The `destroy-method` attribute of a `<bean>` element can be assigned a special
-`(inferred)` value which instructs Spring to automatically detect a public `close` or
-`shutdown` method on the specific bean class (any class that implements
-`java.lang.AutoCloseable` or `java.io.Closeable` would therefore match). This special
-`(inferred)` value can also be set on the `default-destroy-method` attribute of a
+
+However, the second of the two preceding definitions does not couple the code to Spring.
+
+TIP: You can assign the `destroy-method` attribute of a `<bean>` element a special
+`(inferred)` value, which instructs Spring to automatically detect a public `close` or
+`shutdown` method on the specific bean class. (Any class that implements
+`java.lang.AutoCloseable` or `java.io.Closeable` would therefore match.) You can also set
+this special `(inferred)` value on the `default-destroy-method` attribute of a
 `<beans>` element to apply this behavior to an entire set of beans (see
 <<beans-factory-lifecycle-default-init-destroy-methods>>). Note that this is the
-default behavior with Java config.
-====
+default behavior with Java configuration.
 
 [[beans-factory-lifecycle-default-init-destroy-methods]]
-==== Default initialization and destroy methods
+==== Default Initialization and Destroy Methods
 
 When you write initialization and destroy method callbacks that do not use the
 Spring-specific `InitializingBean` and `DisposableBean` callback interfaces, you
@@ -3206,19 +3436,20 @@ typically write methods with names such as `init()`, `initialize()`, `dispose()`
 on. Ideally, the names of such lifecycle callback methods are standardized across a
 project so that all developers use the same method names and ensure consistency.
 
-You can configure the Spring container to `look` for named initialization and destroy
-callback method names on __every__ bean. This means that you, as an application
+You can configure the Spring container to "`look`" for named initialization and destroy
+callback method names on every bean. This means that you, as an application
 developer, can write your application classes and use an initialization callback called
 `init()`, without having to configure an `init-method="init"` attribute with each bean
 definition. The Spring IoC container calls that method when the bean is created (and in
-accordance with the standard lifecycle callback contract described previously). This
-feature also enforces a consistent naming convention for initialization and destroy
-method callbacks.
+accordance with the standard lifecycle callback contract <<beans-factory-lifecycle,
+described previously>>). This feature also enforces a consistent naming convention for
+initialization and destroy method callbacks.
 
-Suppose that your initialization callback methods are named `init()` and destroy
-callback methods are named `destroy()`. Your class will resemble the class in the
-following example.
+Suppose that your initialization callback methods are named `init()` and your destroy
+callback methods are named `destroy()`. Your class then resembles the class in the
+following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3238,83 +3469,90 @@ following example.
 		}
 	}
 ----
+====
 
+You could then use that class in a bean resembling the following:
+
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<beans default-init-method="init">
 
-		<bean id="blogService" class="com.foo.DefaultBlogService">
+		<bean id="blogService" class="com.something.DefaultBlogService">
 			<property name="blogDao" ref="blogDao" />
 		</bean>
 
 	</beans>
 ----
+====
 
 The presence of the `default-init-method` attribute on the top-level `<beans/>` element
-attribute causes the Spring IoC container to recognize a method called `init` on beans
-as the initialization method callback. When a bean is created and assembled, if the bean
-class has such a method, it is invoked at the appropriate time.
+attribute causes the Spring IoC container to recognize a method called `init` on the bean
+class as the initialization method callback. When a bean is created and assembled, if the
+bean class has such a method, it is invoked at the appropriate time.
 
-You configure destroy method callbacks similarly (in XML, that is) by using the
+You can configure destroy method callbacks similarly (in XML, that is) by using the
 `default-destroy-method` attribute on the top-level `<beans/>` element.
 
 Where existing bean classes already have callback methods that are named at variance
 with the convention, you can override the default by specifying (in XML, that is) the
-method name using the `init-method` and `destroy-method` attributes of the `<bean/>`
+method name by using the `init-method` and `destroy-method` attributes of the `<bean/>`
 itself.
 
 The Spring container guarantees that a configured initialization callback is called
-immediately after a bean is supplied with all dependencies. Thus the initialization
+immediately after a bean is supplied with all dependencies. Thus, the initialization
 callback is called on the raw bean reference, which means that AOP interceptors and so
-forth are not yet applied to the bean. A target bean is fully created __first__,
-__then__ an AOP proxy (for example) with its interceptor chain is applied. If the target
+forth are not yet applied to the bean. A target bean is fully created first and
+then an AOP proxy (for example) with its interceptor chain is applied. If the target
 bean and the proxy are defined separately, your code can even interact with the raw
 target bean, bypassing the proxy. Hence, it would be inconsistent to apply the
-interceptors to the init method, because doing so would couple the lifecycle of the
-target bean with its proxy/interceptors and leave strange semantics when your code
-interacts directly to the raw target bean.
+interceptors to the `init` method, because doing so would couple the lifecycle of the
+target bean to its proxy or interceptors and leave strange semantics when your code
+interacts directly with the raw target bean.
+
 
 
 [[beans-factory-lifecycle-combined-effects]]
-==== Combining lifecycle mechanisms
+==== Combining Lifecycle Mechanisms
 
-As of Spring 2.5, you have three options for controlling bean lifecycle behavior: the
-<<beans-factory-lifecycle-initializingbean, `InitializingBean`>> and
-<<beans-factory-lifecycle-disposablebean, `DisposableBean`>> callback interfaces; custom
-`init()` and `destroy()` methods; and the
-<<beans-postconstruct-and-predestroy-annotations, `@PostConstruct` and `@PreDestroy`
+As of Spring 2.5, you have three options for controlling bean lifecycle behavior:
+
+* The <<beans-factory-lifecycle-initializingbean, `InitializingBean`>> and
+<<beans-factory-lifecycle-disposablebean, `DisposableBean`>> callback interfaces
+* Custom `init()` and `destroy()` methods
+* The <<beans-postconstruct-and-predestroy-annotations, `@PostConstruct` and `@PreDestroy`
 annotations>>. You can combine these mechanisms to control a given bean.
 
-[NOTE]
-====
-If multiple lifecycle mechanisms are configured for a bean, and each mechanism is
+NOTE: If multiple lifecycle mechanisms are configured for a bean and each mechanism is
 configured with a different method name, then each configured method is executed in the
-order listed below. However, if the same method name is configured - for example,
-`init()` for an initialization method - for more than one of these lifecycle mechanisms,
-that method is executed once, as explained in the preceding section.
-====
+order listed after this note. However, if the same method name is configured -- for example,
+`init()` for an initialization method -- for more than one of these lifecycle mechanisms,
+that method is executed once, as explained in the
+<<beans-factory-lifecycle-default-init-destroy-methods,preceding section>>.
 
 Multiple lifecycle mechanisms configured for the same bean, with different
 initialization methods, are called as follows:
 
-* Methods annotated with `@PostConstruct`
-* `afterPropertiesSet()` as defined by the `InitializingBean` callback interface
-* A custom configured `init()` method
+. Methods annotated with `@PostConstruct`
+. `afterPropertiesSet()` as defined by the `InitializingBean` callback interface
+. A custom configured `init()` method
 
 Destroy methods are called in the same order:
 
-* Methods annotated with `@PreDestroy`
-* `destroy()` as defined by the `DisposableBean` callback interface
-* A custom configured `destroy()` method
+. Methods annotated with `@PreDestroy`
+. `destroy()` as defined by the `DisposableBean` callback interface
+. A custom configured `destroy()` method
+
 
 
 [[beans-factory-lifecycle-processor]]
-==== Startup and shutdown callbacks
+==== Startup and Shutdown Callbacks
 
 The `Lifecycle` interface defines the essential methods for any object that has its own
-lifecycle requirements (e.g. starts and stops some background process):
+lifecycle requirements (such as starting and stopping some background process):
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3327,12 +3565,15 @@ lifecycle requirements (e.g. starts and stops some background process):
 		boolean isRunning();
 	}
 ----
+====
 
-Any Spring-managed object may implement that interface. Then, when the
-`ApplicationContext` itself receives start and stop signals, e.g. for a stop/restart
-scenario at runtime, it will cascade those calls to all `Lifecycle` implementations
-defined within that context. It does this by delegating to a `LifecycleProcessor`:
+Any Spring-managed object may implement the `Lifecycle` interface. Then, when the
+`ApplicationContext` itself receives start and stop signals (for example, for a stop/restart
+scenario at runtime), it cascades those calls to all `Lifecycle` implementations
+defined within that context. It does this by delegating to a `LifecycleProcessor`, shown
+in the following listing:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3343,6 +3584,7 @@ defined within that context. It does this by delegating to a `LifecycleProcessor
 		void onClose();
 	}
 ----
+====
 
 Notice that the `LifecycleProcessor` is itself an extension of the `Lifecycle`
 interface. It also adds two other methods for reacting to the context being refreshed
@@ -3350,24 +3592,26 @@ and closed.
 
 [TIP]
 ====
-Note that the regular `org.springframework.context.Lifecycle` interface is just a plain
-contract for explicit start/stop notifications and does NOT imply auto-startup at context
-refresh time. Consider implementing `org.springframework.context.SmartLifecycle` instead
-for fine-grained control over auto-startup of a specific bean (including startup phases).
-Also, please note that stop notifications are not guaranteed to come before destruction:
-On regular shutdown, all `Lifecycle` beans will first receive a stop notification before
-the general destruction callbacks are being propagated; however, on hot refresh during a
-context's lifetime or on aborted refresh attempts, only destroy methods will be called.
+Note that the regular `org.springframework.context.Lifecycle` interface is a plain
+contract for explicit start and stop notifications and does not imply auto-startup at context
+refresh time. For fine-grained control over auto-startup of a specific bean (including startup phases),
+consider implementing `org.springframework.context.SmartLifecycle` instead.
+
+Also, please note that stop notifications are not guaranteed to come before destruction.
+On regular shutdown, all `Lifecycle` beans first receive a stop notification before
+the general destruction callbacks are being propagated. However, on hot refresh during a
+context's lifetime or on aborted refresh attempts, only destroy methods are called.
 ====
 
-The order of startup and shutdown invocations can be important. If a "depends-on"
-relationship exists between any two objects, the dependent side will start __after__ its
-dependency, and it will stop __before__ its dependency. However, at times the direct
+The order of startup and shutdown invocations can be important. If a "`depends-on`"
+relationship exists between any two objects, the dependent side starts after its
+dependency, and it stops before its dependency. However, at times, the direct
 dependencies are unknown. You may only know that objects of a certain type should start
 prior to objects of another type. In those cases, the `SmartLifecycle` interface defines
 another option, namely the `getPhase()` method as defined on its super-interface,
-`Phased`.
+`Phased`. The following listing shows the definition of the `Phased` interface:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3376,7 +3620,11 @@ another option, namely the `getPhase()` method as defined on its super-interface
 		int getPhase();
 	}
 ----
+====
 
+The following listing shows the definition of the `SmartLifecycle` interface:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3387,28 +3635,30 @@ another option, namely the `getPhase()` method as defined on its super-interface
 		void stop(Runnable callback);
 	}
 ----
+====
 
-When starting, the objects with the lowest phase start first, and when stopping, the
+When starting, the objects with the lowest phase start first. When stopping, the
 reverse order is followed. Therefore, an object that implements `SmartLifecycle` and
 whose `getPhase()` method returns `Integer.MIN_VALUE` would be among the first to start
 and the last to stop. At the other end of the spectrum, a phase value of
 `Integer.MAX_VALUE` would indicate that the object should be started last and stopped
 first (likely because it depends on other processes to be running). When considering the
-phase value, it's also important to know that the default phase for any "normal"
-`Lifecycle` object that does not implement `SmartLifecycle` would be 0. Therefore, any
-negative phase value would indicate that an object should start before those standard
-components (and stop after them), and vice versa for any positive phase value.
+phase value, it is also important to know that the default phase for any "`normal`"
+`Lifecycle` object that does not implement `SmartLifecycle` is `0`. Therefore, any
+negative phase value indicates that an object should start before those standard
+components (and stop after them). The reverse is true for any positive phase value.
 
-As you can see the stop method defined by `SmartLifecycle` accepts a callback. Any
-implementation __must__ invoke that callback's `run()` method after that implementation's
-shutdown process is complete. That enables asynchronous shutdown where necessary since
+The stop method defined by `SmartLifecycle` accepts a callback. Any
+implementation must invoke that callback's `run()` method after that implementation's
+shutdown process is complete. That enables asynchronous shutdown where necessary, since
 the default implementation of the `LifecycleProcessor` interface,
-`DefaultLifecycleProcessor`, will wait up to its timeout value for the group of objects
+`DefaultLifecycleProcessor`, waits up to its timeout value for the group of objects
 within each phase to invoke that callback. The default per-phase timeout is 30 seconds.
 You can override the default lifecycle processor instance by defining a bean named
-"lifecycleProcessor" within the context. If you only want to modify the timeout, then
-defining the following would be sufficient:
+`lifecycleProcessor` within the context. If you want only to modify the timeout,
+defining the following would suffice:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3417,41 +3667,40 @@ defining the following would be sufficient:
 		<property name="timeoutPerShutdownPhase" value="10000"/>
 	</bean>
 ----
+====
 
-As mentioned, the `LifecycleProcessor` interface defines callback methods for the
-refreshing and closing of the context as well. The latter will simply drive the shutdown
-process as if `stop()` had been called explicitly, but it will happen when the context is
-closing. The 'refresh' callback on the other hand enables another feature of
+As mentioned earlier, the `LifecycleProcessor` interface defines callback methods for the
+refreshing and closing of the context as well. The latter drives the shutdown
+process as if `stop()` had been called explicitly, but it happens when the context is
+closing. The 'refresh' callback, on the other hand, enables another feature of
 `SmartLifecycle` beans. When the context is refreshed (after all objects have been
-instantiated and initialized), that callback will be invoked, and at that point the
-default lifecycle processor will check the boolean value returned by each
-`SmartLifecycle` object's `isAutoStartup()` method. If "true", then that object will be
+instantiated and initialized), that callback is invoked. At that point, the
+default lifecycle processor checks the boolean value returned by each
+`SmartLifecycle` object's `isAutoStartup()` method. If `true`, that object is
 started at that point rather than waiting for an explicit invocation of the context's or
 its own `start()` method (unlike the context refresh, the context start does not happen
-automatically for a standard context implementation). The "phase" value as well as any
-"depends-on" relationships will determine the startup order in the same way as described
-above.
+automatically for a standard context implementation). The `phase` value and any
+"`depends-on`" relationships determine the startup order as described earlier.
+
 
 
 [[beans-factory-shutdown]]
-==== Shutting down the Spring IoC container gracefully in non-web applications
+==== Shutting Down the Spring IoC Container Gracefully in Non-web Applications
 
-[NOTE]
-====
-This section applies only to non-web applications. Spring's web-based
-`ApplicationContext` implementations already have code in place to shut down the Spring
-IoC container gracefully when the relevant web application is shut down.
-====
+NOTE: This section applies only to non-web applications. Spring's web-based
+`ApplicationContext` implementations already have code in place to gracefully shut down
+the Spring IoC container when the relevant web application is shut down.
 
-If you are using Spring's IoC container in a non-web application environment; for
-example, in a rich client desktop environment; you register a shutdown hook with the
+If you use Spring's IoC container in a non-web application environment (for
+example, in a rich client desktop environment), register a shutdown hook with the
 JVM. Doing so ensures a graceful shutdown and calls the relevant destroy methods on your
-singleton beans so that all resources are released. Of course, you must still configure
+singleton beans so that all resources are released. You must still configure
 and implement these destroy callbacks correctly.
 
-To register a shutdown hook, you call the `registerShutdownHook()` method that is
-declared on the `ConfigurableApplicationContext` interface:
+To register a shutdown hook, call the `registerShutdownHook()` method that is
+declared on the `ConfigurableApplicationContext` interface, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3472,16 +3721,19 @@ declared on the `ConfigurableApplicationContext` interface:
 		}
 	}
 ----
+====
 
 
 
 [[beans-factory-aware]]
-=== ApplicationContextAware and BeanNameAware
+=== `ApplicationContextAware` and `BeanNameAware`
 
 When an `ApplicationContext` creates an object instance that implements the
 `org.springframework.context.ApplicationContextAware` interface, the instance is provided
-with a reference to that `ApplicationContext`.
+with a reference to that `ApplicationContext`. The following listing shows the definition
+of the `ApplicationContextAware` interface:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3490,33 +3742,36 @@ with a reference to that `ApplicationContext`.
 		void setApplicationContext(ApplicationContext applicationContext) throws BeansException;
 	}
 ----
+====
 
-Thus beans can manipulate programmatically the `ApplicationContext` that created them,
-through the `ApplicationContext` interface, or by casting the reference to a known
-subclass of this interface, such as `ConfigurableApplicationContext`, which exposes
-additional functionality. One use would be the programmatic retrieval of other beans.
-Sometimes this capability is useful; however, in general you should avoid it, because it
+Thus, beans can programmatically manipulate the `ApplicationContext` that created them,
+through the `ApplicationContext` interface or by casting the reference to a known
+subclass of this interface (such as `ConfigurableApplicationContext`, which exposes
+additional functionality). One use would be the programmatic retrieval of other beans.
+Sometimes this capability is useful. However, in general, you should avoid it, because it
 couples the code to Spring and does not follow the Inversion of Control style, where
 collaborators are provided to beans as properties. Other methods of the
 `ApplicationContext` provide access to file resources, publishing application events, and
 accessing a `MessageSource`. These additional features are described in
-<<context-introduction>>
+<<context-introduction>>.
 
-As of Spring 2.5, autowiring is another alternative to obtain reference to the
-`ApplicationContext`. The "traditional" `constructor` and `byType` autowiring modes (as
+As of Spring 2.5, autowiring is another alternative to obtain a reference to the
+`ApplicationContext`. The "`traditional`" `constructor` and `byType` autowiring modes (as
 described in <<beans-factory-autowire>>) can provide a dependency of type
-`ApplicationContext` for a constructor argument or setter method parameter,
+`ApplicationContext` for a constructor argument or a setter method parameter,
 respectively. For more flexibility, including the ability to autowire fields and
 multiple parameter methods, use the new annotation-based autowiring features. If you do,
 the `ApplicationContext` is autowired into a field, constructor argument, or method
-parameter that is expecting the `ApplicationContext` type if the field, constructor, or
+parameter that expects the `ApplicationContext` type if the field, constructor, or
 method in question carries the `@Autowired` annotation. For more information, see
 <<beans-autowired-annotation>>.
 
 When an `ApplicationContext` creates a class that implements the
 `org.springframework.beans.factory.BeanNameAware` interface, the class is provided with
-a reference to the name defined in its associated object definition.
+a reference to the name defined in its associated object definition. The following listing
+shows the definition of the BeanNameAware interface:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3525,21 +3780,22 @@ a reference to the name defined in its associated object definition.
 		void setBeanName(String name) throws BeansException;
 	}
 ----
+====
 
 The callback is invoked after population of normal bean properties but before an
-initialization callback such as `InitializingBean` __afterPropertiesSet__ or a custom
+initialization callback such as `InitializingBean`, `afterPropertiesSet`, or a custom
 init-method.
 
 
 
 [[aware-list]]
-=== Other Aware interfaces
+=== Other `Aware` Interfaces
 
-Besides `ApplicationContextAware` and `BeanNameAware` discussed above, Spring offers a
-range of `Aware` interfaces that allow beans to indicate to the container that they
-require a certain __infrastructure__ dependency. The most important `Aware` interfaces
-are summarized below - as a general rule, the name is a good indication of the
-dependency type:
+Besides `ApplicationContextAware` and `BeanNameAware` (discussed
+<<beans-factory-aware,earlier>>), Spring offers a range of `Aware` interfaces that let
+beans indicate to the container that they require a certain infrastructure dependency. As
+a general rule, the name is a good indication of the dependency type. The following table
+summarizes the most important `Aware` interfaces:
 
 [[beans-factory-nature-aware-list]]
 .Aware interfaces
@@ -3547,11 +3803,11 @@ dependency type:
 | Name| Injected Dependency| Explained in...
 
 | `ApplicationContextAware`
-| Declaring `ApplicationContext`
+| Declaring `ApplicationContext`.
 | <<beans-factory-aware>>
 
 | `ApplicationEventPublisherAware`
-| Event publisher of the enclosing `ApplicationContext`
+| Event publisher of the enclosing `ApplicationContext`.
 | <<context-introduction>>
 
 | `BeanClassLoaderAware`
@@ -3559,70 +3815,71 @@ dependency type:
 | <<beans-factory-class>>
 
 | `BeanFactoryAware`
-| Declaring `BeanFactory`
+| Declaring `BeanFactory`.
 | <<beans-factory-aware>>
 
 | `BeanNameAware`
-| Name of the declaring bean
+| Name of the declaring bean.
 | <<beans-factory-aware>>
 
 | `BootstrapContextAware`
 | Resource adapter `BootstrapContext` the container runs in. Typically available only in
-  JCA aware ``ApplicationContext``s
+  JCA aware `ApplicationContext` instances.
 | <<integration.adoc#cci, JCA CCI>>
 
 | `LoadTimeWeaverAware`
-| Defined __weaver__ for processing class definition at load time
+| Defined weaver for processing class definition at load time.
 | <<aop-aj-ltw>>
 
 | `MessageSourceAware`
 | Configured strategy for resolving messages (with support for parametrization and
-  internationalization)
+  internationalization).
 | <<context-introduction>>
 
 | `NotificationPublisherAware`
-| Spring JMX notification publisher
+| Spring JMX notification publisher.
 | <<integration.adoc#jmx-notifications, Notifications>>
 
 | `ResourceLoaderAware`
-| Configured loader for low-level access to resources
+| Configured loader for low-level access to resources.
 | <<resources>>
 
 | `ServletConfigAware`
 | Current `ServletConfig` the container runs in. Valid only in a web-aware Spring
-  `ApplicationContext`
+  `ApplicationContext`.
 | <<web.adoc#mvc, Spring MVC>>
 
 | `ServletContextAware`
 | Current `ServletContext` the container runs in. Valid only in a web-aware Spring
-  `ApplicationContext`
+  `ApplicationContext`.
 | <<web.adoc#mvc, Spring MVC>>
 |===
 
-Note again that usage of these interfaces ties your code to the Spring API and does not
-follow the Inversion of Control style. As such, they are recommended for infrastructure
+Note again that using these interfaces ties your code to the Spring API and does not
+follow the Inversion of Control style. As a result, we recommend them for infrastructure
 beans that require programmatic access to the container.
 
 
 
-
 [[beans-child-bean-definitions]]
-== Bean definition inheritance
+== Bean Definition Inheritance
 
 A bean definition can contain a lot of configuration information, including constructor
-arguments, property values, and container-specific information such as initialization
-method, static factory method name, and so on. A child bean definition inherits
+arguments, property values, and container-specific information, such as the initialization
+method, a static factory method name, and so on. A child bean definition inherits
 configuration data from a parent definition. The child definition can override some
-values, or add others, as needed. Using parent and child bean definitions can save a lot
+values or add others as needed. Using parent and child bean definitions can save a lot
 of typing. Effectively, this is a form of templating.
 
 If you work with an `ApplicationContext` interface programmatically, child bean
 definitions are represented by the `ChildBeanDefinition` class. Most users do not work
-with them on this level, instead configuring bean definitions declaratively in something
-like the `ClassPathXmlApplicationContext`. When you use XML-based configuration
-metadata, you indicate a child bean definition by using the `parent` attribute,
-specifying the parent bean as the value of this attribute.
+with them on this level. Instead, they configure bean definitions declaratively in a class
+such as the `ClassPathXmlApplicationContext`. When you use XML-based configuration
+metadata, you can indicate a child bean definition by using the `parent` attribute,
+specifying the parent bean as the value of this attribute. The following example shows how
+to do so:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3634,28 +3891,32 @@ specifying the parent bean as the value of this attribute.
 
 	<bean id="inheritsWithDifferentClass"
 			class="org.springframework.beans.DerivedTestBean"
-			**parent="inheritedTestBean"** init-method="initialize">
+			parent="inheritedTestBean" init-method="initialize">  <1>
 		<property name="name" value="override"/>
 		<!-- the age property value of 1 will be inherited from parent -->
 	</bean>
 ----
+<1> Note the `parent` attribute.
+====
 
 A child bean definition uses the bean class from the parent definition if none is
-specified, but can also override it. In the latter case, the child bean class must be
-compatible with the parent, that is, it must accept the parent's property values.
+specified but can also override it. In the latter case, the child bean class must be
+compatible with the parent (that is, it must accept the parent's property values).
 
 A child bean definition inherits scope, constructor argument values, property values, and
 method overrides from the parent, with the option to add new values. Any scope, initialization
-method, destroy method, and/or `static` factory method settings that you specify will
+method, destroy method, or `static` factory method settings that you specify
 override the corresponding parent settings.
 
-The remaining settings are __always__ taken from the child definition: __depends on__,
-__autowire mode__, __dependency check__, __singleton__, __lazy init__.
+The remaining settings are always taken from the child definition: depends on,
+autowire mode, dependency check, singleton, and lazy init.
 
 The preceding example explicitly marks the parent bean definition as abstract by using
 the `abstract` attribute. If the parent definition does not specify a class, explicitly
-marking the parent bean definition as `abstract` is required, as follows:
+marking the parent bean definition as `abstract` is required, as the following example
+shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3670,25 +3931,22 @@ marking the parent bean definition as `abstract` is required, as follows:
 		<!-- age will inherit the value of 1 from the parent bean definition-->
 	</bean>
 ----
+====
 
 The parent bean cannot be instantiated on its own because it is incomplete, and it is
-also explicitly marked as `abstract`. When a definition is `abstract` like this, it is
+also explicitly marked as `abstract`. When a definition is `abstract`, it is
 usable only as a pure template bean definition that serves as a parent definition for
 child definitions. Trying to use such an `abstract` parent bean on its own, by referring
 to it as a ref property of another bean or doing an explicit `getBean()` call with the
-parent bean id, returns an error. Similarly, the container's internal
+parent bean ID returns an error. Similarly, the container's internal
 `preInstantiateSingletons()` method ignores bean definitions that are defined as
 abstract.
 
-[NOTE]
-====
-`ApplicationContext` pre-instantiates all singletons by default. Therefore, it is
+NOTE: `ApplicationContext` pre-instantiates all singletons by default. Therefore, it is
 important (at least for singleton beans) that if you have a (parent) bean definition
 which you intend to use only as a template, and this definition specifies a class, you
 must make sure to set the __abstract__ attribute to __true__, otherwise the application
 context will actually (attempt to) pre-instantiate the `abstract` bean.
-====
-
 
 
 
@@ -3703,120 +3961,120 @@ integration interfaces.
 
 
 [[beans-factory-extension-bpp]]
-=== Customizing beans using a BeanPostProcessor
+=== Customizing Beans by Using a `BeanPostProcessor`
 
-The `BeanPostProcessor` interface defines __callback methods__ that you can implement to
+The `BeanPostProcessor` interface defines callback methods that you can implement to
 provide your own (or override the container's default) instantiation logic,
 dependency-resolution logic, and so forth. If you want to implement some custom logic
 after the Spring container finishes instantiating, configuring, and initializing a bean,
 you can plug in one or more `BeanPostProcessor` implementations.
 
 You can configure multiple `BeanPostProcessor` instances, and you can control the order
-in which these ``BeanPostProcessor``s execute by setting the `order` property. You can
-set this property only if the `BeanPostProcessor` implements the `Ordered` interface; if
-you write your own `BeanPostProcessor` you should consider implementing the `Ordered`
-interface too. For further details, consult the javadocs of the `BeanPostProcessor` and
-`Ordered` interfaces. See also the note below on
+in which these `BeanPostProcessor` instances execute by setting the `order` property. You can
+set this property only if the `BeanPostProcessor` implements the `Ordered` interface. If
+you write your own `BeanPostProcessor`, you should consider implementing the `Ordered`
+interface, too. For further details, see the Javadoc of the {api-spring-framework}/beans/factory/config/BeanPostProcessor.html[`BeanPostProcessor`] and
+{api-spring-framework}/core/Ordered.html[`Ordered`] interfaces. See also the note on
 <<beans-factory-programmatically-registering-beanpostprocessors, programmatic
-registration of ``BeanPostProcessor``s>>.
+registration of `BeanPostProcessor` instances>>.
 
 [NOTE]
 ====
-``BeanPostProcessor``s operate on bean (or object) __instances__; that is to say, the
-Spring IoC container instantiates a bean instance and __then__ ``BeanPostProcessor``s do
+`BeanPostProcessor` instances operate on bean (or object) instances. That is, the
+Spring IoC container instantiates a bean instance and then `BeanPostProcessor` instances do
 their work.
 
-``BeanPostProcessor``s are scoped __per-container__. This is only relevant if you are
-using container hierarchies. If you define a `BeanPostProcessor` in one container, it
-will __only__ post-process the beans in that container. In other words, beans that are
+`BeanPostProcessor` instances are scoped per-container. This is relevant only if you
+use container hierarchies. If you define a `BeanPostProcessor` in one container, it
+post-processes only the beans in that container. In other words, beans that are
 defined in one container are not post-processed by a `BeanPostProcessor` defined in
 another container, even if both containers are part of the same hierarchy.
 
-To change the actual bean definition (i.e., the __blueprint__ that defines the bean),
-you instead need to use a `BeanFactoryPostProcessor` as described in
+To change the actual bean definition (that is, the blueprint that defines the bean),
+you instead need to use a `BeanFactoryPostProcessor`, as described in
 <<beans-factory-extension-factory-postprocessors>>.
 ====
 
 The `org.springframework.beans.factory.config.BeanPostProcessor` interface consists of
 exactly two callback methods. When such a class is registered as a post-processor with
 the container, for each bean instance that is created by the container, the
-post-processor gets a callback from the container both __before__ container
-initialization methods (such as InitializingBean's __afterPropertiesSet()__ and any
-declared init method) are called as well as __after__ any bean initialization callbacks.
+post-processor gets a callback from the container both before container
+initialization methods (such as `InitializingBean.afterPropertiesSet()`, after any
+declared `init` method) are called, and after any bean initialization callbacks.
 The post-processor can take any action with the bean instance, including ignoring the
-callback completely. A bean post-processor typically checks for callback interfaces or
+callback completely. A bean post-processor typically checks for callback interfaces, or it
 may wrap a bean with a proxy. Some Spring AOP infrastructure classes are implemented as
 bean post-processors in order to provide proxy-wrapping logic.
 
-An `ApplicationContext` __automatically detects__ any beans that are defined in the
-configuration metadata which implement the `BeanPostProcessor` interface. The
+An `ApplicationContext` automatically detects any beans that are defined in the
+configuration metadata that implements the `BeanPostProcessor` interface. The
 `ApplicationContext` registers these beans as post-processors so that they can be called
-later upon bean creation. Bean post-processors can be deployed in the container just
-like any other beans.
+later, upon bean creation. Bean post-processors can be deployed in the container in the
+same fashion as any other beans.
 
-Note that when declaring a `BeanPostProcessor` using an `@Bean` factory method on a
+Note that, when declaring a `BeanPostProcessor` by using an `@Bean` factory method on a
 configuration class, the return type of the factory method should be the implementation
 class itself or at least the `org.springframework.beans.factory.config.BeanPostProcessor`
 interface, clearly indicating the post-processor nature of that bean. Otherwise, the
-`ApplicationContext` won't be able to autodetect it by type before fully creating it.
+`ApplicationContext` cannot autodetect it by type before fully creating it.
 Since a `BeanPostProcessor` needs to be instantiated early in order to apply to the
 initialization of other beans in the context, this early type detection is critical.
 
 
+
 [[beans-factory-programmatically-registering-beanpostprocessors]]
-.Programmatically registering BeanPostProcessors
-[NOTE]
-====
-While the recommended approach for `BeanPostProcessor` registration is through
-`ApplicationContext` auto-detection (as described above), it is also possible to
-register them __programmatically__ against a `ConfigurableBeanFactory` using the
-`addBeanPostProcessor` method. This can be useful when needing to evaluate conditional
-logic before registration, or even for copying bean post processors across contexts in a
-hierarchy. Note however that ``BeanPostProcessor``s added programmatically __do not
-respect the `Ordered` interface__. Here it is the __order of registration__ that
-dictates the order of execution. Note also that ``BeanPostProcessor``s registered
+.Programmatically registering `BeanPostProcessor` instances
+NOTE: While the recommended approach for `BeanPostProcessor` registration is through
+`ApplicationContext` auto-detection (as described earlier), you can
+register them programmatically against a `ConfigurableBeanFactory` by using the
+`addBeanPostProcessor` method. This can be useful when you need to evaluate conditional
+logic before registration or even for copying bean post processors across contexts in a
+hierarchy. Note, however, that `BeanPostProcessor` instances added programmatically do not
+respect the `Ordered` interface. Here, it is the order of registration that
+dictates the order of execution. Note also that `BeanPostProcessor` instances registered
 programmatically are always processed before those registered through auto-detection,
 regardless of any explicit ordering.
-====
 
-.BeanPostProcessors and AOP auto-proxying
+.`BeanPostProcessor` instances and AOP auto-proxying
 [NOTE]
 ====
-Classes that implement the `BeanPostProcessor` interface are __special__ and are treated
-differently by the container. All ``BeanPostProcessor``s __and beans that they reference
-directly__ are instantiated on startup, as part of the special startup phase of the
-`ApplicationContext`. Next, all ``BeanPostProcessor``s are registered in a sorted fashion
+Classes that implement the `BeanPostProcessor` interface are special and are treated
+differently by the container. All `BeanPostProcessor` instances and beans that they directly reference
+are instantiated on startup, as part of the special startup phase of the
+`ApplicationContext`. Next, all `BeanPostProcessor` instances are registered in a sorted fashion
 and applied to all further beans in the container. Because AOP auto-proxying is
-implemented as a `BeanPostProcessor` itself, neither ``BeanPostProcessor``s nor the beans
-they reference directly are eligible for auto-proxying, and thus do not have aspects
+implemented as a `BeanPostProcessor` itself, neither `BeanPostProcessor` instances nor the beans
+they directly reference are eligible for auto-proxying and, thus, do not have aspects
 woven into them.
 
-For any such bean, you should see an informational log message: "__Bean foo is not
+For any such bean, you should see an informational log message: `Bean someBean is not
 eligible for getting processed by all BeanPostProcessor interfaces (for example: not
-eligible for auto-proxying)__".
+eligible for auto-proxying)`.
 
-Note that if you have beans wired into your `BeanPostProcessor` using autowiring or
+If you have beans wired into your `BeanPostProcessor` by using autowiring or
 `@Resource` (which may fall back to autowiring), Spring might access unexpected beans
-when searching for type-matching dependency candidates, and therefore make them
+when searching for type-matching dependency candidates and, therefore, make them
 ineligible for auto-proxying or other kinds of bean post-processing. For example, if you
-have a dependency annotated with `@Resource` where the field/setter name does not
-directly correspond to the declared name of a bean and no name attribute is used, then
-Spring will access other beans for matching them by type.
+have a dependency annotated with `@Resource` where the field or setter name does not
+directly correspond to the declared name of a bean and no name attribute is used,
+Spring accesses other beans for matching them by type.
 ====
 
-The following examples show how to write, register, and use ``BeanPostProcessor``s in an
-`ApplicationContext`.
+The following examples show how to write, register, and use `BeanPostProcessor` instances
+in an `ApplicationContext`.
+
 
 
 [[beans-factory-extension-bpp-examples-hw]]
-==== Example: Hello World, BeanPostProcessor-style
+==== Example: Hello World, `BeanPostProcessor`-style
 
 This first example illustrates basic usage. The example shows a custom
 `BeanPostProcessor` implementation that invokes the `toString()` method of each bean as
 it is created by the container and prints the resulting string to the system console.
 
-Find below the custom `BeanPostProcessor` implementation class definition:
+The following listing shows the custom `BeanPostProcessor` implementation class definition:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3837,7 +4095,11 @@ Find below the custom `BeanPostProcessor` implementation class definition:
 		}
 	}
 ----
+====
 
+The following `beans` element uses the `InstantiationTracingBeanPostProcessor`:
+
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3863,15 +4125,17 @@ Find below the custom `BeanPostProcessor` implementation class definition:
 
 	</beans>
 ----
+====
 
-Notice how the `InstantiationTracingBeanPostProcessor` is simply defined. It does not
-even have a name, and because it is a bean it can be dependency-injected just like any
+Notice how the `InstantiationTracingBeanPostProcessor` is merely defined. It does not
+even have a name, and, because it is a bean, it can be dependency-injected as you would any
 other bean. (The preceding configuration also defines a bean that is backed by a Groovy
 script. The Spring dynamic language support is detailed in the chapter entitled
-<<languages.adoc#dynamic-language, Dynamic language support>>.)
+<<languages.adoc#dynamic-language, Dynamic Language Support>>.)
 
-The following simple Java application executes the preceding code and configuration:
+The following Java application runs the preceding code and configuration:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -3889,110 +4153,107 @@ The following simple Java application executes the preceding code and configurat
 
 	}
 ----
+====
 
 The output of the preceding application resembles the following:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
 Bean 'messenger' created : org.springframework.scripting.groovy.GroovyMessenger@272961
 org.springframework.scripting.groovy.GroovyMessenger@272961
 ----
+====
+
 
 
 [[beans-factory-extension-bpp-examples-rabpp]]
-==== Example: The RequiredAnnotationBeanPostProcessor
+==== Example: The `RequiredAnnotationBeanPostProcessor`
 
 Using callback interfaces or annotations in conjunction with a custom
 `BeanPostProcessor` implementation is a common means of extending the Spring IoC
-container. An example is Spring's `RequiredAnnotationBeanPostProcessor` - a
-`BeanPostProcessor` implementation that ships with the Spring distribution which ensures
+container. An example is Spring's `RequiredAnnotationBeanPostProcessor` -- a
+`BeanPostProcessor` implementation that ships with the Spring distribution and that ensures
 that JavaBean properties on beans that are marked with an (arbitrary) annotation are
 actually (configured to be) dependency-injected with a value.
 
 
 
 [[beans-factory-extension-factory-postprocessors]]
-=== Customizing configuration metadata with a BeanFactoryPostProcessor
+=== Customizing Configuration Metadata with a `BeanFactoryPostProcessor`
 
-The next extension point that we will look at is the
+The next extension point that we look at is the
 `org.springframework.beans.factory.config.BeanFactoryPostProcessor`. The semantics of
 this interface are similar to those of the `BeanPostProcessor`, with one major
-difference: `BeanFactoryPostProcessor` operates on the __bean configuration metadata__;
-that is, the Spring IoC container allows a `BeanFactoryPostProcessor` to read the
-configuration metadata and potentially change it __before__ the container instantiates
-any beans other than ``BeanFactoryPostProcessor``s.
+difference: `BeanFactoryPostProcessor` operates on the bean configuration metadata.
+That is, the Spring IoC container lets a `BeanFactoryPostProcessor` read the
+configuration metadata and potentially change it _before_ the container instantiates
+any beans other than `BeanFactoryPostProcessor` instances.
 
-You can configure multiple ``BeanFactoryPostProcessor``s, and you can control the order in
-which these ``BeanFactoryPostProcessor``s execute by setting the `order` property.
+You can configure multiple `BeanFactoryPostProcessor` instances, and you can control the order in
+which these `BeanFactoryPostProcessor` instances run by setting the `order` property.
 However, you can only set this property if the `BeanFactoryPostProcessor` implements the
 `Ordered` interface. If you write your own `BeanFactoryPostProcessor`, you should
-consider implementing the `Ordered` interface too. Consult the javadocs of the
-`BeanFactoryPostProcessor` and `Ordered` interfaces for more details.
+consider implementing the `Ordered` interface, too. See the Javadoc of the
+{api-spring-framework}/beans/factory/config/BeanFactoryPostProcessor.html[`BeanFactoryPostProcessor`] and {api-spring-framework}/core/Ordered.html[`Ordered`] interfaces for more details.
 
 [NOTE]
 ====
-If you want to change the actual bean __instances__ (i.e., the objects that are created
+If you want to change the actual bean instances (that is, the objects that are created
 from the configuration metadata), then you instead need to use a `BeanPostProcessor`
-(described above in <<beans-factory-extension-bpp>>). While it is technically possible
-to work with bean instances within a `BeanFactoryPostProcessor` (e.g., using
+(described earlier in <<beans-factory-extension-bpp>>). While it is technically possible
+to work with bean instances within a `BeanFactoryPostProcessor` (for example, by using
 `BeanFactory.getBean()`), doing so causes premature bean instantiation, violating the
-standard container lifecycle. This may cause negative side effects such as bypassing
+standard container lifecycle. This may cause negative side effects, such as bypassing
 bean post processing.
 
-Also, ``BeanFactoryPostProcessor``s are scoped __per-container__. This is only relevant if
-you are using container hierarchies. If you define a `BeanFactoryPostProcessor` in one
-container, it will __only__ be applied to the bean definitions in that container. Bean
-definitions in one container will not be post-processed by ``BeanFactoryPostProcessor``s
+Also, `BeanFactoryPostProcessor` instances are scoped per-container. This is only relevant if
+you use container hierarchies. If you define a `BeanFactoryPostProcessor` in one
+container, it is applied only to the bean definitions in that container. Bean
+definitions in one container are not post-processed by `BeanFactoryPostProcessor` instances
 in another container, even if both containers are part of the same hierarchy.
 ====
 
-A bean factory post-processor is executed automatically when it is declared inside an
+A bean factory post-processor is automatically executed when it is declared inside an
 `ApplicationContext`, in order to apply changes to the configuration metadata that
 define the container. Spring includes a number of predefined bean factory
 post-processors, such as `PropertyOverrideConfigurer` and
-`PropertyPlaceholderConfigurer`. A custom `BeanFactoryPostProcessor` can also be used,
+`PropertyPlaceholderConfigurer`. You can also use a custom `BeanFactoryPostProcessor` --
 for example, to register custom property editors.
-
-[[null]]
 
 An `ApplicationContext` automatically detects any beans that are deployed into it that
 implement the `BeanFactoryPostProcessor` interface. It uses these beans as bean factory
 post-processors, at the appropriate time. You can deploy these post-processor beans as
 you would any other bean.
 
-[NOTE]
-====
-As with ``BeanPostProcessor``s , you typically do not want to configure
+NOTE: As with ``BeanPostProcessor``s , you typically do not want to configure
 ``BeanFactoryPostProcessor``s for lazy initialization. If no other bean references a
 `Bean(Factory)PostProcessor`, that post-processor will not get instantiated at all.
 Thus, marking it for lazy initialization will be ignored, and the
 `Bean(Factory)PostProcessor` will be instantiated eagerly even if you set the
 `default-lazy-init` attribute to `true` on the declaration of your `<beans />` element.
-====
+
 
 
 [[beans-factory-placeholderconfigurer]]
-==== Example: the Class name substitution PropertyPlaceholderConfigurer
+==== Example: The Class Name Substitution `PropertyPlaceholderConfigurer`
 
-You use the `PropertyPlaceholderConfigurer` to externalize property values from a bean
-definition in a separate file using the standard Java `Properties` format. Doing so
-enables the person deploying an application to customize environment-specific properties
+You can use the `PropertyPlaceholderConfigurer` to externalize property values from a bean
+definition in a separate file by using the standard Java `Properties` format. Doing so
+enables the person deploying an application to customize environment-specific properties,
 such as database URLs and passwords, without the complexity or risk of modifying the
 main XML definition file or files for the container.
 
 Consider the following XML-based configuration metadata fragment, where a `DataSource`
-with placeholder values is defined. The example shows properties configured from an
-external `Properties` file. At runtime, a `PropertyPlaceholderConfigurer` is applied to
-the metadata that will replace some properties of the DataSource. The values to replace
-are specified as __placeholders__ of the form `${property-name}` which follows the Ant /
-log4j / JSP EL style.
+with placeholder values is defined:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-		<property name="locations" value="classpath:com/foo/jdbc.properties"/>
+		<property name="locations" value="classpath:com/something/jdbc.properties"/>
 	</bean>
 
 	<bean id="dataSource" destroy-method="close"
@@ -4003,9 +4264,17 @@ log4j / JSP EL style.
 		<property name="password" value="${jdbc.password}"/>
 	</bean>
 ----
+====
+
+The example shows properties configured from an
+external `Properties` file. At runtime, a `PropertyPlaceholderConfigurer` is applied to
+the metadata that replaces some properties of the DataSource. The values to replace
+are specified as placeholders of the form `${property-name}`, which follows the Ant and
+log4j and JSP EL style.
 
 The actual values come from another file in the standard Java `Properties` format:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
@@ -4014,66 +4283,71 @@ jdbc.url=jdbc:hsqldb:hsql://production:9002
 jdbc.username=sa
 jdbc.password=root
 ----
+====
 
-Therefore, the string `${jdbc.username}` is replaced at runtime with the value 'sa', and
+Therefore, the `${jdbc.username}` string is replaced at runtime with the value, 'sa', and
 the same applies for other placeholder values that match keys in the properties file.
 The `PropertyPlaceholderConfigurer` checks for placeholders in most properties and
-attributes of a bean definition. Furthermore, the placeholder prefix and suffix can be
-customized.
+attributes of a bean definition. Furthermore, you can customize the placeholder prefix and suffix.
 
-With the `context` namespace introduced in Spring 2.5, it is possible to configure
-property placeholders with a dedicated configuration element. One or more locations can
-be provided as a comma-separated list in the `location` attribute.
+With the `context` namespace introduced in Spring 2.5, you can configure
+property placeholders with a dedicated configuration element. You can provide one or more locations
+as a comma-separated list in the `location` attribute, as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
-	<context:property-placeholder location="classpath:com/foo/jdbc.properties"/>
+	<context:property-placeholder location="classpath:com/something/jdbc.properties"/>
 ----
+====
 
 The `PropertyPlaceholderConfigurer` not only looks for properties in the `Properties`
-file you specify. By default it also checks against the Java `System` properties if it
-cannot find a property in the specified properties files. You can customize this
+file you specify. By default,  if it
+cannot find a property in the specified properties files, it also checks against the Java `System` properties. You can customize this
 behavior by setting the `systemPropertiesMode` property of the configurer with one of
 the following three supported integer values:
 
-* __never__ (0): Never check system properties
-* __fallback__ (1): Check system properties if not resolvable in the specified
+* `never` (0): Never check system properties.
+* `fallback` (1): Check system properties if not resolvable in the specified
   properties files. This is the default.
-* __override__ (2): Check system properties first, before trying the specified
-  properties files. This allows system properties to override any other property source.
+* `override` (2): Check system properties first, before trying the specified
+  properties files. This lets system properties override any other property source.
 
-Consult the `PropertyPlaceholderConfigurer` javadocs for more information.
+See the {api-spring-framework}/beans/factory/config/PropertyPlaceholderConfigurer.html[`PropertyPlaceholderConfigurer`] Javadoc for more information.
 
 [TIP]
-====
+=====
 You can use the `PropertyPlaceholderConfigurer` to substitute class names, which is
-sometimes useful when you have to pick a particular implementation class at runtime. For
-example:
+sometimes useful when you have to pick a particular implementation class at runtime. The
+following example shows how to do so:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="locations">
-			<value>classpath:com/foo/strategy.properties</value>
+			<value>classpath:com/something/strategy.properties</value>
 		</property>
 		<property name="properties">
-			<value>custom.strategy.class=com.foo.DefaultStrategy</value>
+			<value>custom.strategy.class=com.something.DefaultStrategy</value>
 		</property>
 	</bean>
 
 	<bean id="serviceStrategy" class="${custom.strategy.class}"/>
 ----
+====
 
 If the class cannot be resolved at runtime to a valid class, resolution of the bean
 fails when it is about to be created, which is during the `preInstantiateSingletons()`
 phase of an `ApplicationContext` for a non-lazy-init bean.
-====
+=====
+
 
 
 [[beans-factory-overrideconfigurer]]
-==== Example: the PropertyOverrideConfigurer
+==== Example: The `PropertyOverrideConfigurer`
 
 The `PropertyOverrideConfigurer`, another bean factory post-processor, resembles the
 `PropertyPlaceholderConfigurer`, but unlike the latter, the original definitions can
@@ -4081,67 +4355,71 @@ have default values or no values at all for bean properties. If an overriding
 `Properties` file does not have an entry for a certain bean property, the default
 context definition is used.
 
-Note that the bean definition is __not__ aware of being overridden, so it is not
+Note that the bean definition is not aware of being overridden, so it is not
 immediately obvious from the XML definition file that the override configurer is being
 used. In case of multiple `PropertyOverrideConfigurer` instances that define different
 values for the same bean property, the last one wins, due to the overriding mechanism.
 
-Properties file configuration lines take this format:
+Properties file configuration lines take the following format:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
 beanName.property=value
 ----
+====
 
-For example:
+The following listing shows an example of the format:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
 dataSource.driverClassName=com.mysql.jdbc.Driver
 dataSource.url=jdbc:mysql:mydb
 ----
+====
 
 This example file can be used with a container definition that contains a bean called
-__dataSource__, which has __driver__ and __url__ properties.
+`dataSource` that has `driver` and `url` properties.
 
 Compound property names are also supported, as long as every component of the path
 except the final property being overridden is already non-null (presumably initialized
-by the constructors). In this example...
+by the constructors). In the following example, the `sammy` property of the `bob` property of the `fred` property of the `tom` bean
+is set to the scalar value `123`:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
-foo.fred.bob.sammy=123
+tom.fred.bob.sammy=123
 ----
-
-... the `sammy` property of the `bob` property of the `fred` property of the `foo` bean
-is set to the scalar value `123`.
-
-[NOTE]
 ====
-Specified override values are always __literal__ values; they are not translated into
+
+
+NOTE: Specified override values are always literal values. They are not translated into
 bean references. This convention also applies when the original value in the XML bean
 definition specifies a bean reference.
-====
 
 With the `context` namespace introduced in Spring 2.5, it is possible to configure
-property overriding with a dedicated configuration element:
+property overriding with a dedicated configuration element, as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<context:property-override location="classpath:override.properties"/>
 ----
+====
 
 
 
 [[beans-factory-extension-factorybean]]
-=== Customizing instantiation logic with a FactoryBean
+=== Customizing Instantiation Logic with a `FactoryBean`
 
-Implement the `org.springframework.beans.factory.FactoryBean` interface for objects that
-__are themselves factories__.
+You can implement the `org.springframework.beans.factory.FactoryBean` interface for objects that
+are themselves factories.
 
 The `FactoryBean` interface is a point of pluggability into the Spring IoC container's
 instantiation logic. If you have complex initialization code that is better expressed in
@@ -4151,36 +4429,35 @@ custom `FactoryBean` into the container.
 
 The `FactoryBean` interface provides three methods:
 
-* `Object getObject()`: returns an instance of the object this factory creates. The
+* `Object getObject()`: Returns an instance of the object this factory creates. The
   instance can possibly be shared, depending on whether this factory returns singletons
   or prototypes.
-* `boolean isSingleton()`: returns `true` if this `FactoryBean` returns singletons,
+* `boolean isSingleton()`: Returns `true` if this `FactoryBean` returns singletons or
   `false` otherwise.
-* `Class getObjectType()`: returns the object type returned by the `getObject()` method
+* `Class getObjectType()`: Returns the object type returned by the `getObject()` method
   or `null` if the type is not known in advance.
 
 The `FactoryBean` concept and interface is used in a number of places within the Spring
-Framework; more than 50 implementations of the `FactoryBean` interface ship with Spring
+Framework. More than 50 implementations of the `FactoryBean` interface ship with Spring
 itself.
 
 When you need to ask a container for an actual `FactoryBean` instance itself instead of
-the bean it produces, preface the bean's id with the ampersand symbol ( `&`) when
-calling the `getBean()` method of the `ApplicationContext`. So for a given `FactoryBean`
-with an id of `myBean`, invoking `getBean("myBean")` on the container returns the
-product of the `FactoryBean`; whereas, invoking `getBean("&myBean")` returns the
+the bean it produces, preface the bean's `id` with the ampersand symbol (`&`) when
+calling the `getBean()` method of the `ApplicationContext`. So, for a given `FactoryBean`
+with an `id` of `myBean`, invoking `getBean("myBean")` on the container returns the
+product of the `FactoryBean`, whereas invoking `getBean("&myBean")` returns the
 `FactoryBean` instance itself.
 
 
 
-
 [[beans-annotation-config]]
-== Annotation-based container configuration
+== Annotation-based Container Configuration
 
 .Are annotations better than XML for configuring Spring?
 ****
-The introduction of annotation-based configurations raised the question of whether this
-approach is 'better' than XML. The short answer is __it depends__. The long answer is
-that each approach has its pros and cons, and usually it is up to the developer to
+The introduction of annotation-based configuration raised the question of whether this
+approach is "`better`" than XML. The short answer is "`it depends.`" The long answer is
+that each approach has its pros and cons, and, usually, it is up to the developer to
 decide which strategy suits them better. Due to the way they are defined, annotations
 provide a lot of context in their declaration, leading to shorter and more concise
 configuration. However, XML excels at wiring up components without touching their source
@@ -4189,39 +4466,37 @@ while others argue that annotated classes are no longer POJOs and, furthermore, 
 configuration becomes decentralized and harder to control.
 
 No matter the choice, Spring can accommodate both styles and even mix them together.
-It's worth pointing out that through its <<beans-java,JavaConfig>> option, Spring allows
-annotations to be used in a non-invasive way, without touching the target components
-source code and that in terms of tooling, all configuration styles are supported by the
+It is worth pointing out that through its <<beans-java,JavaConfig>> option, Spring lets
+annotations be used in a non-invasive way, without touching the target components
+source code and that, in terms of tooling, all configuration styles are supported by the
 https://spring.io/tools/sts[Spring Tool Suite].
 ****
 
-An alternative to XML setups is provided by annotation-based configuration which rely on
+An alternative to XML setup is provided by annotation-based configuration, which relies on
 the bytecode metadata for wiring up components instead of angle-bracket declarations.
 Instead of using XML to describe a bean wiring, the developer moves the configuration
 into the component class itself by using annotations on the relevant class, method, or
 field declaration. As mentioned in <<beans-factory-extension-bpp-examples-rabpp>>, using
 a `BeanPostProcessor` in conjunction with annotations is a common means of extending the
 Spring IoC container. For example, Spring 2.0 introduced the possibility of enforcing
-required properties with the <<beans-required-annotation,@Required>> annotation. Spring
+required properties with the <<beans-required-annotation,`@Required`>> annotation. Spring
 2.5 made it possible to follow that same general approach to drive Spring's dependency
 injection. Essentially, the `@Autowired` annotation provides the same capabilities as
 described in <<beans-factory-autowire>> but with more fine-grained control and wider
-applicability. Spring 2.5 also added support for JSR-250 annotations such as
-`@PostConstruct`, and `@PreDestroy`. Spring 3.0 added support for JSR-330 (Dependency
-Injection for Java) annotations contained in the javax.inject package such as `@Inject`
+applicability. Spring 2.5 also added support for JSR-250 annotations, such as
+`@PostConstruct` and `@PreDestroy`. Spring 3.0 added support for JSR-330 (Dependency
+Injection for Java) annotations contained in the `javax.inject` package such as `@Inject`
 and `@Named`. Details about those annotations can be found in the
 <<beans-standard-annotations,relevant section>>.
 
-[NOTE]
-====
-Annotation injection is performed __before__ XML injection, thus the latter
-configuration will override the former for properties wired through both approaches.
-====
+NOTE: Annotation injection is performed before XML injection. Thus, the XML
+configuration overrides the annotations for properties wired through both approaches.
 
 As always, you can register them as individual bean definitions, but they can also be
 implicitly registered by including the following tag in an XML-based Spring
 configuration (notice the inclusion of the `context` namespace):
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4238,22 +4513,20 @@ configuration (notice the inclusion of the `context` namespace):
 
 	</beans>
 ----
+====
 
 (The implicitly registered post-processors include
 {api-spring-framework}/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.html[`AutowiredAnnotationBeanPostProcessor`],
  {api-spring-framework}/context/annotation/CommonAnnotationBeanPostProcessor.html[`CommonAnnotationBeanPostProcessor`],
  {api-spring-framework}/orm/jpa/support/PersistenceAnnotationBeanPostProcessor.html[`PersistenceAnnotationBeanPostProcessor`],
-as well as the aforementioned
+and the aforementioned
 {api-spring-framework}/beans/factory/annotation/RequiredAnnotationBeanPostProcessor.html[`RequiredAnnotationBeanPostProcessor`].)
 
-[NOTE]
-====
-`<context:annotation-config/>` only looks for annotations on beans in the same
+NOTE: `<context:annotation-config/>` only looks for annotations on beans in the same
 application context in which it is defined. This means that, if you put
 `<context:annotation-config/>` in a `WebApplicationContext` for a `DispatcherServlet`,
 it only checks for `@Autowired` beans in your controllers, and not your services. See
 <<web.adoc#mvc-servlet, The DispatcherServlet>> for more information.
-====
 
 
 
@@ -4263,6 +4536,7 @@ it only checks for `@Autowired` beans in your controllers, and not your services
 The `@Required` annotation applies to bean property setter methods, as in the following
 example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4278,13 +4552,14 @@ example:
 		// ...
 	}
 ----
+====
 
-This annotation simply indicates that the affected bean property must be populated at
+This annotation indicates that the affected bean property must be populated at
 configuration time, through an explicit property value in a bean definition or through
 autowiring. The container throws an exception if the affected bean property has not been
-populated; this allows for eager and explicit failure, avoiding ``NullPointerException``s
-or the like later on. It is still recommended that you put assertions into the bean
-class itself, for example, into an init method. Doing so enforces those required
+populated. This allows for eager and explicit failure, avoiding `NullPointerException` instances
+or the like later on. We still recommend that you put assertions into the bean
+class itself (for example, into an init method). Doing so enforces those required
 references and values even when you use the class outside of a container.
 
 
@@ -4292,14 +4567,12 @@ references and values even when you use the class outside of a container.
 [[beans-autowired-annotation]]
 === @Autowired
 
-[NOTE]
-====
-JSR 330's `@Inject` annotation can be used in place of Spring's `@Autowired` annotation
-in the examples below. See <<beans-standard-annotations,here>> for more details.
-====
+NOTE: JSR 330's `@Inject` annotation can be used in place of Spring's `@Autowired` annotation
+in the examples included in this section. See <<beans-standard-annotations,here>> for more details.
 
-You can apply the `@Autowired` annotation to constructors:
+You can apply the `@Autowired` annotation to constructors, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4315,18 +4588,17 @@ You can apply the `@Autowired` annotation to constructors:
 		// ...
 	}
 ----
-
-[NOTE]
 ====
-As of Spring Framework 4.3, an `@Autowired` annotation on such a constructor is
-no longer necessary if the target bean only defines one constructor to begin with.
+
+NOTE: As of Spring Framework 4.3, an `@Autowired` annotation on such a constructor is
+no longer necessary if the target bean defines only one constructor to begin with.
 However, if several constructors are available, at least one must be annotated to
 teach the container which one to use.
+
+You can also apply the `@Autowired` annotation to "`traditional`" setter
+methods, as the following example shows:
+
 ====
-
-As expected, you can also apply the `@Autowired` annotation to "traditional" setter
-methods:
-
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4342,10 +4614,12 @@ methods:
 		// ...
 	}
 ----
+====
 
-You can also apply the annotation to methods with arbitrary names and/or multiple
-arguments:
+You can also apply the annotation to methods with arbitrary names and multiple
+arguments, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4365,9 +4639,12 @@ arguments:
 		// ...
 	}
 ----
+====
 
-You can apply `@Autowired` to fields as well and even mix it with constructors:
+You can apply `@Autowired` to fields as well and even mix it with constructors, as the
+following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4386,25 +4663,27 @@ You can apply `@Autowired` to fields as well and even mix it with constructors:
 		// ...
 	}
 ----
+====
 
 [TIP]
 ====
-Make sure that your target components (e.g. `MovieCatalog`, `CustomerPreferenceDao`)
-are consistently declared by the type that you are using for your `@Autowired`-annotated
-injection points. Otherwise injection may fail due to no type match found at runtime.
+Make sure that your target components (for example, `MovieCatalog` or `CustomerPreferenceDao`)
+are consistently declared by the type that you use for your `@Autowired`-annotated
+injection points. Otherwise, injection may fail due to no type match found at runtime.
 
 For XML-defined beans or component classes found through a classpath scan, the container
-usually knows the concrete type upfront. However, for `@Bean` factory methods, you need
+usually knows the concrete type up front. However, for `@Bean` factory methods, you need
 to make sure that the declared return type is sufficiently expressive. For components
-implementing several interfaces or for components potentially referred to by their
+that implement several interfaces or for components potentially referred to by their
 implementation type, consider declaring the most specific return type on your factory
 method (at least as specific as required by the injection points referring to your bean).
 ====
 
-It is also possible to provide __all__ beans of a particular type from the
+You can also provide all beans of a particular type from the
 `ApplicationContext` by adding the annotation to a field or method that expects an array
-of that type:
+of that type, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4416,9 +4695,11 @@ of that type:
 		// ...
 	}
 ----
+====
 
-The same applies for typed collections:
+The same applies for typed collections, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4434,29 +4715,31 @@ The same applies for typed collections:
 		// ...
 	}
 ----
+====
 
 [TIP]
 ====
 Your target beans can implement the `org.springframework.core.Ordered` interface or use
 the `@Order` or standard `@Priority` annotation if you want items in the array or list
-to be sorted in a specific order. Otherwise their order will follow the registration
+to be sorted in a specific order. Otherwise, their order follows the registration
 order of the corresponding target bean definitions in the container.
 
-The `@Order` annotation may be declared at target class level but also on `@Bean` methods,
-potentially being very individual per bean definition (in case of multiple definitions
-with the same bean class). `@Order` values may influence priorities at injection points,
-but please be aware that they do not influence singleton startup order which is an
+You can declare the `@Order` annotation at the target class level and on `@Bean` methods,
+potentially by individual bean definition (in case of multiple definitions that
+use the same bean class). `@Order` values may influence priorities at injection points,
+but be aware that they do not influence singleton startup order, which is an
 orthogonal concern determined by dependency relationships and `@DependsOn` declarations.
 
 Note that the standard `javax.annotation.Priority` annotation is not available at the
-`@Bean` level since it cannot be declared on methods. Its semantics can be modeled
-through `@Order` values in combination with `@Primary` on a single bean per type.
+`@Bean` level, since it cannot be declared on methods. Its semantics can be modeled
+through `@Order` values in combination with `@Primary` on a single bean for each type.
 ====
 
-Even typed Maps can be autowired as long as the expected key type is `String`. The Map
-values will contain all beans of the expected type, and the keys will contain the
-corresponding bean names:
+Even typed `Map` instances can be autowired as long as the expected key type is `String`. The Map
+values contain all beans of the expected type, and the keys contain the
+corresponding bean names, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4472,11 +4755,14 @@ corresponding bean names:
 		// ...
 	}
 ----
+====
 
-By default, the autowiring fails whenever __zero__ candidate beans are available; the
+By default, the autowiring fails whenever zero candidate beans are available. The
 default behavior is to treat annotated methods, constructors, and fields as
-indicating __required__ dependencies. This behavior can be changed as demonstrated below.
+indicating required dependencies. You can change this behavior as demonstrated, in the
+following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4492,24 +4778,26 @@ indicating __required__ dependencies. This behavior can be changed as demonstrat
 		// ...
 	}
 ----
+====
 
 [NOTE]
 ====
-Only __one annotated constructor per-class__ can be marked as __required__, but multiple
+Only one annotated constructor per-class can be marked as required, but multiple
 non-required constructors can be annotated. In that case, each is considered among the
-candidates and Spring uses the __greediest__ constructor whose dependencies can be
-satisfied, that is the constructor that has the largest number of arguments.
+candidates and Spring uses the greediest constructor whose dependencies can be
+satisfied -- that is, the constructor that has the largest number of arguments.
 
-The __required__ attribute of `@Autowired` is recommended over the `@Required` annotation.
-The __required__ attribute indicates that the property is not required for autowiring
-purposes, the property is ignored if it cannot be autowired. `@Required`, on the other
+The required attribute of `@Autowired` is recommended over the `@Required` annotation.
+The required attribute indicates that the property is not required for autowiring
+purposes. The property is ignored if it cannot be autowired. `@Required`, on the other
 hand, is stronger in that it enforces the property that was set by any means supported
 by the container. If no value is injected, a corresponding exception is raised.
 ====
 
-Alternatively, you may express the non-required nature of a particular dependency
-through Java 8's `java.util.Optional`:
+Alternatively, you can express the non-required nature of a particular dependency
+through Java 8's `java.util.Optional`, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4521,10 +4809,12 @@ through Java 8's `java.util.Optional`:
 		}
 	}
 ----
+====
 
-As of Spring Framework 5.0, you may also use an `@Nullable` annotation (of any kind
-in any package, e.g. `javax.annotation.Nullable` from JSR-305):
+As of Spring Framework 5.0, you can also use a `@Nullable` annotation (of any kind
+in any package -- for example, `javax.annotation.Nullable` from JSR-305):
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4536,12 +4826,14 @@ in any package, e.g. `javax.annotation.Nullable` from JSR-305):
 		}
 	}
 ----
+====
 
 You can also use `@Autowired` for interfaces that are well-known resolvable
 dependencies: `BeanFactory`, `ApplicationContext`, `Environment`, `ResourceLoader`,
 `ApplicationEventPublisher`, and `MessageSource`. These interfaces and their extended
 interfaces, such as `ConfigurableApplicationContext` or `ResourcePatternResolver`, are
-automatically resolved, with no special setup necessary.
+automatically resolved, with no special setup necessary. The following example autowires
+an `ApplicationContext` object:
 
 [source,java,indent=0]
 [subs="verbatim,quotes"]
@@ -4558,29 +4850,27 @@ automatically resolved, with no special setup necessary.
 	}
 ----
 
-[NOTE]
-====
-`@Autowired`, `@Inject`, `@Resource`, and `@Value` annotations are handled by Spring
-`BeanPostProcessor` implementations which in turn means that you __cannot__ apply these
+NOTE: The `@Autowired`, `@Inject`, `@Resource`, and `@Value` annotations are handled by Spring
+`BeanPostProcessor` implementations. This means that you cannot apply these
 annotations within your own `BeanPostProcessor` or `BeanFactoryPostProcessor` types (if
-any). These types must be 'wired up' explicitly via XML or using a Spring `@Bean` method.
-====
+any). These types must be 'wired up' explicitly by using XML or a Spring `@Bean` method.
 
 
 
 [[beans-autowired-annotation-primary]]
-=== Fine-tuning annotation-based autowiring with @Primary
+=== Fine-tuning Annotation-based Autowiring with `@Primary`
 
 Because autowiring by type may lead to multiple candidates, it is often necessary to have
 more control over the selection process. One way to accomplish this is with Spring's
 `@Primary` annotation. `@Primary` indicates that a particular bean should be given
 preference when multiple beans are candidates to be autowired to a single-valued
-dependency. If exactly one 'primary' bean exists among the candidates, it will be the
+dependency. If exactly one primary bean exists among the candidates, it becomes the
 autowired value.
 
-Let's assume we have the following configuration that defines `firstMovieCatalog` as the
-_primary_ `MovieCatalog`.
+Consider the following configuration that defines `firstMovieCatalog` as the
+primary `MovieCatalog`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4597,10 +4887,12 @@ _primary_ `MovieCatalog`.
 		// ...
 	}
 ----
+====
 
-With such configuration, the following `MovieRecommender` will be autowired with the
-`firstMovieCatalog`.
+With the preceding configuration, the following `MovieRecommender` is autowired with the
+`firstMovieCatalog`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4612,10 +4904,11 @@ With such configuration, the following `MovieRecommender` will be autowired with
 		// ...
 	}
 ----
+====
 
+The corresponding bean definitions follow:
 
-The corresponding bean definitions appear as follows.
-
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4642,18 +4935,21 @@ The corresponding bean definitions appear as follows.
 
 	</beans>
 ----
+====
 
 
 
 [[beans-autowired-annotation-qualifiers]]
-=== Fine-tuning annotation-based autowiring with qualifiers
+=== Fine-tuning Annotation-based Autowiring with Qualifiers
 
 `@Primary` is an effective way to use autowiring by type with several instances when one
-primary candidate can be determined. When more control over the selection process is
-required, Spring's `@Qualifier` annotation can be used. You can associate qualifier values
+primary candidate can be determined. When you need more control over the selection process,
+you can use Spring's `@Qualifier` annotation. You can associate qualifier values
 with specific arguments, narrowing the set of type matches so that a specific bean is
-chosen for each argument. In the simplest case, this can be a plain descriptive value:
+chosen for each argument. In the simplest case, this can be a plain descriptive value, as
+shown in the following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4666,10 +4962,12 @@ chosen for each argument. In the simplest case, this can be a plain descriptive 
 		// ...
 	}
 ----
+====
 
-The `@Qualifier` annotation can also be specified on individual constructor arguments or
-method parameters:
+You can also specify the `@Qualifier` annotation on individual constructor arguments or
+method parameters, as shown in the following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4689,10 +4987,11 @@ method parameters:
 		// ...
 	}
 ----
+====
 
-The corresponding bean definitions appear as follows. The bean with qualifier value
-"main" is wired with the constructor argument that is qualified with the same value.
+The following example shows corresponding bean definitions.
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4708,13 +5007,13 @@ The corresponding bean definitions appear as follows. The bean with qualifier va
 		<context:annotation-config/>
 
 		<bean class="example.SimpleMovieCatalog">
-			**<qualifier value="main"/>**
+			<qualifier value="main"/>                         <1>
 
 			<!-- inject any dependencies required by this bean -->
 		</bean>
 
 		<bean class="example.SimpleMovieCatalog">
-			**<qualifier value="action"/>**
+			<qualifier value="action"/>                       <2>
 
 			<!-- inject any dependencies required by this bean -->
 		</bean>
@@ -4723,71 +5022,77 @@ The corresponding bean definitions appear as follows. The bean with qualifier va
 
 	</beans>
 ----
+<1> The bean with the `main` qualifier value is wired with the constructor argument that
+is qualified with the same value.
+<2> The bean with the `action` qualifier value is wired with the constructor argument that
+is qualified with the same value.
+====
 
-For a fallback match, the bean name is considered a default qualifier value. Thus you
-can define the bean with an id "main" instead of the nested qualifier element, leading
+For a fallback match, the bean name is considered a default qualifier value. Thus, you
+can define the bean with an `id` of `main` instead of the nested qualifier element, leading
 to the same matching result. However, although you can use this convention to refer to
 specific beans by name, `@Autowired` is fundamentally about type-driven injection with
 optional semantic qualifiers. This means that qualifier values, even with the bean name
-fallback, always have narrowing semantics within the set of type matches; they do not
-semantically express a reference to a unique bean id. Good qualifier values are "main"
-or "EMEA" or "persistent", expressing characteristics of a specific component that are
+fallback, always have narrowing semantics within the set of type matches. They do not
+semantically express a reference to a unique bean `id`. Good qualifier values are `main`
+or `EMEA` or `persistent`, expressing characteristics of a specific component that are
 independent from the bean `id`, which may be auto-generated in case of an anonymous bean
-definition like the one in the preceding example.
+definition such as the one in the preceding example.
 
-Qualifiers also apply to typed collections, as discussed above, for example, to
-`Set<MovieCatalog>`. In this case, all matching beans according to the declared
-qualifiers are injected as a collection. This implies that qualifiers do not have to be
-unique; they rather simply constitute filtering criteria. For example, you can define
-multiple `MovieCatalog` beans with the same qualifier value "action", all of which would
-be injected into a `Set<MovieCatalog>` annotated with `@Qualifier("action")`.
+Qualifiers also apply to typed collections, as discussed earlier -- for example, to
+`Set<MovieCatalog>`. In this case, all matching beans, according to the declared
+qualifiers, are injected as a collection. This implies that qualifiers do not have to be
+unique. Rather, they constitute filtering criteria. For example, you can define
+multiple `MovieCatalog` beans with the same qualifier value "`action`", all of which are
+injected into a `Set<MovieCatalog>` annotated with `@Qualifier("action")`.
 
 [TIP]
 ====
 Letting qualifier values select against target bean names, within the type-matching
-candidates, doesn't even require a `@Qualifier` annotation at the injection point.
-If there is no other resolution indicator (e.g. a qualifier or a primary marker),
-for a non-unique dependency situation, Spring will match the injection point name
-(i.e. field name or parameter name) against the target bean names and choose the
+candidates, does not require a `@Qualifier` annotation at the injection point.
+If there is no other resolution indicator (such as a qualifier or a primary marker),
+for a non-unique dependency situation, Spring matches the injection point name
+(that is, the field name or parameter name) against the target bean names and choose the
 same-named candidate, if any.
 
 That said, if you intend to express annotation-driven injection by name, do not
-primarily use `@Autowired`, even if is capable of selecting by bean name among
+primarily use `@Autowired`, even if it is capable of selecting by bean name among
 type-matching candidates. Instead, use the JSR-250 `@Resource` annotation, which is
 semantically defined to identify a specific target component by its unique name, with
 the declared type being irrelevant for the matching process. `@Autowired` has rather
-different semantics: After selecting candidate beans by type, the specified String
-qualifier value will be considered within those type-selected candidates only, e.g.
-matching an "account" qualifier against beans marked with the same qualifier label.
+different semantics: After selecting candidate beans by type, the specified `String`
+qualifier value is considered within those type-selected candidates only (for example,
+matching an `account` qualifier against beans marked with the same qualifier label).
 
-For beans that are themselves defined as a collection/map or array type, `@Resource`
+For beans that are themselves defined as a collection, `Map`, or array type, `@Resource`
 is a fine solution, referring to the specific collection or array bean by unique name.
-That said, as of 4.3, collection/map and array types can be matched through Spring's
+That said, as of 4.3, collection, you can match `Map`, and array types through Spring's
 `@Autowired` type matching algorithm as well, as long as the element type information
 is preserved in `@Bean` return type signatures or collection inheritance hierarchies.
-In this case, qualifier values can be used to select among same-typed collections,
+In this case, you can use qualifier values to select among same-typed collections,
 as outlined in the previous paragraph.
 
-As of 4.3, `@Autowired` also considers self references for injection, i.e. references
-back to the bean that is currently injected. Note that self injection is a fallback;
-regular dependencies on other components always have precedence. In that sense, self
+As of 4.3, `@Autowired` also considers self references for injection (that is, references
+back to the bean that is currently injected). Note that self injection is a fallback.
+Regular dependencies on other components always have precedence. In that sense, self
 references do not participate in regular candidate selection and are therefore in
-particular never primary; on the contrary, they always end up as lowest precedence.
-In practice, use self references as a last resort only, e.g. for calling other methods
-on the same instance through the bean's transactional proxy: Consider factoring out
-the affected methods to a separate delegate bean in such a scenario. Alternatively,
-use `@Resource` which may obtain a proxy back to the current bean by its unique name.
+particular never primary. On the contrary, they always end up as lowest precedence.
+In practice, you should use self references as a last resort only (for example, for calling other methods
+on the same instance through the bean's transactional proxy). Consider factoring out
+the effected methods to a separate delegate bean in such a scenario. Alternatively, you
+can use `@Resource`, which may obtain a proxy back to the current bean by its unique name.
 
 `@Autowired` applies to fields, constructors, and multi-argument methods, allowing for
 narrowing through qualifier annotations at the parameter level. By contrast, `@Resource`
 is supported only for fields and bean property setter methods with a single argument.
-As a consequence, stick with qualifiers if your injection target is a constructor or a
+As a consequence, you should stick with qualifiers if your injection target is a constructor or a
 multi-argument method.
 ====
 
-You can create your own custom qualifier annotations. Simply define an annotation and
-provide the `@Qualifier` annotation within your definition:
+You can create your own custom qualifier annotations. To do so, define an annotation and
+provide the `@Qualifier` annotation within your definition, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4799,9 +5104,12 @@ provide the `@Qualifier` annotation within your definition:
 		String value();
 	}
 ----
+====
 
-Then you can provide the custom qualifier on autowired fields and parameters:
+Then you can provide the custom qualifier on autowired fields and parameters, as the
+following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4821,14 +5129,16 @@ Then you can provide the custom qualifier on autowired fields and parameters:
 		// ...
 	}
 ----
+====
 
-Next, provide the information for the candidate bean definitions. You can add
+Next, you can provide the information for the candidate bean definitions. You can add
 `<qualifier/>` tags as sub-elements of the `<bean/>` tag and then specify the `type` and
 `value` to match your custom qualifier annotations. The type is matched against the
-fully-qualified class name of the annotation. Or, as a convenience if no risk of
-conflicting names exists, you can use the short class name. Both approaches are
-demonstrated in the following example.
+fully-qualified class name of the annotation. Alternately, as a convenience if no risk of
+conflicting names exists, you can use the short class name. The following example
+demonstrates both approaches:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4857,16 +5167,18 @@ demonstrated in the following example.
 
 	</beans>
 ----
+====
 
-In <<beans-classpath-scanning>>, you will see an annotation-based alternative to
+In <<beans-classpath-scanning>>, you can see an annotation-based alternative to
 providing the qualifier metadata in XML. Specifically, see <<beans-scanning-qualifiers>>.
 
-In some cases, it may be sufficient to use an annotation without a value. This may be
+In some cases, using an annotation without a value may suffice. This can be
 useful when the annotation serves a more generic purpose and can be applied across
-several different types of dependencies. For example, you may provide an __offline__
-catalog that would be searched when no Internet connection is available. First define
-the simple annotation:
+several different types of dependencies. For example, you may provide an offline
+catalog that can be searched when no Internet connection is available. First, define
+the simple annotation, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4877,39 +5189,48 @@ the simple annotation:
 
 	}
 ----
+====
 
-Then add the annotation to the field or property to be autowired:
+Then add the annotation to the field or property to be autowired, as shown in the
+following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	public class MovieRecommender {
 
 		@Autowired
-		**@Offline**
+		@Offline                               <1>
 		private MovieCatalog offlineCatalog;
 
 		// ...
 	}
 ----
+<1> This line adds the `@Offline` annotation.
+====
 
-Now the bean definition only needs a qualifier `type`:
+Now the bean definition only needs a qualifier `type`, as shown in the following example:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
 	<bean class="example.SimpleMovieCatalog">
-		**<qualifier type="Offline"/>**
+		<qualifier type="Offline"/>              <1>
 		<!-- inject any dependencies required by this bean -->
 	</bean>
 ----
+<1> This element specifies the qualifier.
+====
 
 You can also define custom qualifier annotations that accept named attributes in
 addition to or instead of the simple `value` attribute. If multiple attribute values are
 then specified on a field or parameter to be autowired, a bean definition must match
-__all__ such attribute values to be considered an autowire candidate. As an example,
+all such attribute values to be considered an autowire candidate. As an example,
 consider the following annotation definition:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4923,9 +5244,11 @@ consider the following annotation definition:
 		Format format();
 	}
 ----
+====
 
-In this case `Format` is an enum:
+In this case `Format` is an enum, defined as follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4933,10 +5256,12 @@ In this case `Format` is an enum:
 		VHS, DVD, BLURAY
 	}
 ----
+====
 
 The fields to be autowired are annotated with the custom qualifier and include values
-for both attributes: `genre` and `format`.
+for both attributes: `genre` and `format`, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -4961,14 +5286,16 @@ for both attributes: `genre` and `format`.
 		// ...
 	}
 ----
+====
 
 Finally, the bean definitions should contain matching qualifier values. This example
-also demonstrates that bean __meta__ attributes may be used instead of the
-`<qualifier/>` sub-elements. If available, the `<qualifier/>` and its attributes take
+also demonstrates that you can use bean meta attributes instead of the
+`<qualifier/>` elements. If available, the `<qualifier/>` element and its attributes take
 precedence, but the autowiring mechanism falls back on the values provided within the
 `<meta/>` tags if no such qualifier is present, as in the last two bean definitions in
-the following example.
+the following example:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5013,16 +5340,18 @@ the following example.
 
 	</beans>
 ----
+====
 
 
 
 [[beans-generics-as-qualifiers]]
-=== Using generics as autowiring qualifiers
+=== Using Generics as Autowiring Qualifiers
 
-In addition to the `@Qualifier` annotation, it is also possible to use Java generic types
+In addition to the `@Qualifier` annotation, you can use Java generic types
 as an implicit form of qualification. For example, suppose you have the following
 configuration:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5040,11 +5369,13 @@ configuration:
 		}
 	}
 ----
+====
 
-Assuming that beans above implement a generic interface, i.e. `Store<String>` and
-`Store<Integer>`, you can `@Autowire` the `Store` interface and the __generic__ will
-be used as a qualifier:
+Assuming that the preceding beans implement a generic interface, (that is, `Store<String>` and
+`Store<Integer>`), you can `@Autowire` the `Store` interface and the generic is
+used as a qualifier, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5054,9 +5385,12 @@ be used as a qualifier:
 	@Autowired
 	private Store<Integer> s2; // <Integer> qualifier, injects the integerStore bean
 ----
+====
 
-Generic qualifiers also apply when autowiring Lists, Maps and Arrays:
+Generic qualifiers also apply when autowiring lists, `Map` instances and arrays. The
+following example autowires a generic `List`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5065,17 +5399,19 @@ Generic qualifiers also apply when autowiring Lists, Maps and Arrays:
 	@Autowired
 	private List<Store<Integer>> s;
 ----
+====
 
 
 
 [[beans-custom-autowire-configurer]]
-=== CustomAutowireConfigurer
+=== Using `CustomAutowireConfigurer`
 
-The
 {api-spring-framework}/beans/factory/annotation/CustomAutowireConfigurer.html[`CustomAutowireConfigurer`]
-is a `BeanFactoryPostProcessor` that enables you to register your own custom qualifier
-annotation types even if they are not annotated with Spring's `@Qualifier` annotation.
+is a `BeanFactoryPostProcessor` that lets you register your own custom qualifier
+annotation types, even if they are not annotated with Spring's `@Qualifier` annotation.
+The following example shows how to use `CustomAutowireConfigurer`:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5088,32 +5424,34 @@ annotation types even if they are not annotated with Spring's `@Qualifier` annot
 		</property>
 	</bean>
 ----
+====
 
 The `AutowireCandidateResolver` determines autowire candidates by:
 
-* the `autowire-candidate` value of each bean definition
-* any `default-autowire-candidates` pattern(s) available on the `<beans/>` element
-* the presence of `@Qualifier` annotations and any custom annotations registered
+* The `autowire-candidate` value of each bean definition
+* Any `default-autowire-candidates` patterns available on the `<beans/>` element
+* The presence of `@Qualifier` annotations and any custom annotations registered
 with the `CustomAutowireConfigurer`
 
-When multiple beans qualify as autowire candidates, the determination of a "primary" is
-the following: if exactly one bean definition among the candidates has a `primary`
-attribute set to `true`, it will be selected.
+When multiple beans qualify as autowire candidates, the determination of a "`primary`" is
+as follows: If exactly one bean definition among the candidates has a `primary`
+attribute set to `true`, it is selected.
 
 
 
 [[beans-resource-annotation]]
-=== @Resource
+=== Injection with `@Resource`
 
-Spring also supports injection using the JSR-250 `@Resource` annotation on fields or
-bean property setter methods. This is a common pattern in Java EE 5 and 6, for example
-in JSF 1.2 managed beans or JAX-WS 2.0 endpoints. Spring supports this pattern for
+Spring also supports injection by using the JSR-250 `@Resource` annotation on fields or
+bean property setter methods. This is a common pattern in Java EE 5 and 6 (for example,
+in JSF 1.2 managed beans or JAX-WS 2.0 endpoints). Spring supports this pattern for
 Spring-managed objects as well.
 
-`@Resource` takes a name attribute, and by default Spring interprets that value as the
-bean name to be injected. In other words, it follows __by-name__ semantics, as
-demonstrated in this example:
+`@Resource` takes a name attribute. By default, Spring interprets that value as the
+bean name to be injected. In other words, it follows by-name semantics, as
+demonstrated in the following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5121,18 +5459,21 @@ demonstrated in this example:
 
 		private MovieFinder movieFinder;
 
-		**@Resource(name="myMovieFinder")**
+		@Resource(name="myMovieFinder")                        <1>
 		public void setMovieFinder(MovieFinder movieFinder) {
 			this.movieFinder = movieFinder;
 		}
 	}
 ----
+<1> This line injects a `@Resource`.
+====
 
-If no name is specified explicitly, the default name is derived from the field name or
-setter method. In case of a field, it takes the field name; in case of a setter method,
-it takes the bean property name. So the following example is going to have the bean with
-name "movieFinder" injected into its setter method:
+If no name is explicitly specified, the default name is derived from the field name or
+setter method. In case of a field, it takes the field name. In case of a setter method,
+it takes the bean property name. The following example is going to have the bean
+named `movieFinder` injected into its setter method:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5146,28 +5487,26 @@ name "movieFinder" injected into its setter method:
 		}
 	}
 ----
-
-[NOTE]
 ====
-The name provided with the annotation is resolved as a bean name by the
+
+NOTE: The name provided with the annotation is resolved as a bean name by the
 `ApplicationContext` of which the `CommonAnnotationBeanPostProcessor` is aware. The
 names can be resolved through JNDI if you configure Spring's
 {api-spring-framework}/jndi/support/SimpleJndiBeanFactory.html[`SimpleJndiBeanFactory`]
-explicitly. However, it is recommended that you rely on the default behavior and simply
+explicitly. However, we recommend that you rely on the default behavior and
 use Spring's JNDI lookup capabilities to preserve the level of indirection.
-====
 
 In the exclusive case of `@Resource` usage with no explicit name specified, and similar
 to `@Autowired`, `@Resource` finds a primary type match instead of a specific named bean
-and resolves well-known resolvable dependencies: the `BeanFactory`,
+and resolves well known resolvable dependencies: the `BeanFactory`,
 `ApplicationContext`, `ResourceLoader`, `ApplicationEventPublisher`, and `MessageSource`
 interfaces.
 
-Thus in the following example, the `customerPreferenceDao` field first looks for a bean
-named customerPreferenceDao, then falls back to a primary type match for the type
-`CustomerPreferenceDao`. The "context" field is injected based on the known resolvable
-dependency type `ApplicationContext`.
+Thus, in the following example, the `customerPreferenceDao` field first looks for a bean
+named customerPreferenceDao and then falls back to a primary type match for the type
+`CustomerPreferenceDao`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5177,7 +5516,7 @@ dependency type `ApplicationContext`.
 		private CustomerPreferenceDao customerPreferenceDao;
 
 		@Resource
-		private ApplicationContext context;
+		private ApplicationContext context;                 <1>
 
 		public MovieRecommender() {
 		}
@@ -5185,23 +5524,27 @@ dependency type `ApplicationContext`.
 		// ...
 	}
 ----
+<1> The `context` field is injected based on the known resolvable dependency type:
+`ApplicationContext`.
+====
 
 
 
 [[beans-postconstruct-and-predestroy-annotations]]
-=== @PostConstruct and @PreDestroy
+=== Using `@PostConstruct` and `@PreDestroy`
 
 The `CommonAnnotationBeanPostProcessor` not only recognizes the `@Resource` annotation
-but also the JSR-250 __lifecycle__ annotations. Introduced in Spring 2.5, the support
+but also the JSR-250 lifecycle annotations. Introduced in Spring 2.5, the support
 for these annotations offers yet another alternative to those described in
 <<beans-factory-lifecycle-initializingbean,initialization callbacks>> and
 <<beans-factory-lifecycle-disposablebean,destruction callbacks>>. Provided that the
 `CommonAnnotationBeanPostProcessor` is registered within the Spring
 `ApplicationContext`, a method carrying one of these annotations is invoked at the same
 point in the lifecycle as the corresponding Spring lifecycle interface method or
-explicitly declared callback method. In the example below, the cache will be
-pre-populated upon initialization and cleared upon destruction.
+explicitly declared callback method. In the following example, the cache is
+pre-populated upon initialization and cleared upon destruction:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5218,96 +5561,94 @@ pre-populated upon initialization and cleared upon destruction.
 		}
 	}
 ----
-
-[NOTE]
 ====
-For details about the effects of combining various lifecycle mechanisms, see
+
+NOTE: For details about the effects of combining various lifecycle mechanisms, see
 <<beans-factory-lifecycle-combined-effects>>.
-====
-
 
 
 
 [[beans-classpath-scanning]]
-== Classpath scanning and managed components
+== Classpath Scanning and Managed Components
 
 Most examples in this chapter use XML to specify the configuration metadata that produces
 each `BeanDefinition` within the Spring container. The previous section
 (<<beans-annotation-config>>) demonstrates how to provide a lot of the configuration
-metadata through source-level annotations. Even in those examples, however, the "base"
-bean definitions are explicitly defined in the XML file, while the annotations only drive
+metadata through source-level annotations. Even in those examples, however, the "`base`"
+bean definitions are explicitly defined in the XML file, while the annotations drive only
 the dependency injection. This section describes an option for implicitly detecting the
-__candidate components__ by scanning the classpath. Candidate components are classes that
+candidate components by scanning the classpath. Candidate components are classes that
 match against a filter criteria and have a corresponding bean definition registered with
-the container. This removes the need to use XML to perform bean registration; instead you
-can use annotations (for example `@Component`), AspectJ type expressions, or your own
-custom filter criteria to select which classes will have bean definitions registered with
+the container. This removes the need to use XML to perform bean registration. Instead, you
+can use annotations (for example, `@Component`), AspectJ type expressions, or your own
+custom filter criteria to select which classes have bean definitions registered with
 the container.
 
-[NOTE]
-====
-Starting with Spring 3.0, many features provided by the Spring JavaConfig project are
+NOTE: Starting with Spring 3.0, many features provided by the Spring JavaConfig project are
 part of the core Spring Framework. This allows you to define beans using Java rather
 than using the traditional XML files. Take a look at the `@Configuration`, `@Bean`,
 `@Import`, and `@DependsOn` annotations for examples of how to use these new features.
-====
 
 
 
 [[beans-stereotype-annotations]]
-=== @Component and further stereotype annotations
+=== `@Component` and Further Stereotype Annotations
 
 The `@Repository` annotation is a marker for any class that fulfills the role or
-__stereotype__ of a repository (also known as Data Access Object or DAO). Among the uses
-of this marker is the automatic translation of exceptions as described in
-<<data-access.adoc#orm-exception-translation, Exception translation>>.
+stereotype of a repository (also known as Data Access Object or DAO). Among the uses
+of this marker is the automatic translation of exceptions, as described in
+<<data-access.adoc#orm-exception-translation, Exception Translation>>.
 
 Spring provides further stereotype annotations: `@Component`, `@Service`, and
 `@Controller`. `@Component` is a generic stereotype for any Spring-managed component.
 `@Repository`, `@Service`, and `@Controller` are specializations of `@Component` for
-more specific use cases, for example, in the persistence, service, and presentation
-layers, respectively. Therefore, you can annotate your component classes with
-`@Component`, but by annotating them with `@Repository`, `@Service`, or `@Controller`
+more specific use cases (in the persistence, service, and presentation
+layers, respectively). Therefore, you can annotate your component classes with
+`@Component`, but, by annotating them with `@Repository`, `@Service`, or `@Controller`
 instead, your classes are more properly suited for processing by tools or associating
 with aspects. For example, these stereotype annotations make ideal targets for
-pointcuts. It is also possible that `@Repository`, `@Service`, and `@Controller` may
+pointcuts. `@Repository`, `@Service`, and `@Controller` can also
 carry additional semantics in future releases of the Spring Framework. Thus, if you are
 choosing between using `@Component` or `@Service` for your service layer, `@Service` is
-clearly the better choice. Similarly, as stated above, `@Repository` is already
+clearly the better choice. Similarly, as stated earlier, `@Repository` is already
 supported as a marker for automatic exception translation in your persistence layer.
 
 
 
 [[beans-meta-annotations]]
-=== Meta-annotations
+=== Using Meta-annotations and Composed Annotations
 
-Many of the annotations provided by Spring can be used as __meta-annotations__ in your
-own code. A meta-annotation is simply an annotation that can be applied to another
-annotation. For example, the `@Service` annotation mentioned above is meta-annotated with
-`@Component`:
+Many of the annotations provided by Spring can be used as meta-annotations in your
+own code. A meta-annotation is an annotation that can be applied to another
+annotation. For example, the `@Service` annotation mentioned <<beans-stereotype-annotations,earlier>> is meta-annotated with
+`@Component`, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented
-	**@Component** // Spring will see this and treat @Service in the same way as @Component
+	@Component                         <1>
 	public @interface Service {
 
 		// ....
 	}
 ----
+<1> The `Component` causes `@Service` to be treated in the same way as `@Component`.
+====
 
-Meta-annotations can also be combined to create __composed annotations__. For example,
-the `@RestController` annotation from Spring MVC is __composed__ of `@Controller` and
+You can also combine meta-annotations to create "`composed annotations`". For example,
+the `@RestController` annotation from Spring MVC is composed of `@Controller` and
 `@ResponseBody`.
 
-In addition, composed annotations may optionally redeclare attributes from
-meta-annotations to allow user customization. This can be particularly useful when you
+In addition, composed annotations can optionally redeclare attributes from
+meta-annotations to allow customization. This can be particularly useful when you
 want to only expose a subset of the meta-annotation's attributes. For example, Spring's
 `@SessionScope` annotation hardcodes the scope name to `session` but still allows
-customization of the `proxyMode`.
+customization of the `proxyMode`. The following listing shows the definition of the
+`SessionScope` annotation:
 
 [source,java,indent=0]
 [subs="verbatim,quotes"]
@@ -5328,8 +5669,9 @@ customization of the `proxyMode`.
 	}
 ----
 
-`@SessionScope` can then be used without declaring the `proxyMode` as follows:
+You can then use `@SessionScope` without declaring the `proxyMode` as follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5339,9 +5681,11 @@ customization of the `proxyMode`.
 		// ...
 	}
 ----
+====
 
-Or with an overridden value for the `proxyMode` as follows:
+You can also override the value for the `proxyMode`, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5351,20 +5695,22 @@ Or with an overridden value for the `proxyMode` as follows:
 		// ...
 	}
 ----
+====
 
-For further details, consult the
+For further details, see the
 https://github.com/spring-projects/spring-framework/wiki/Spring-Annotation-Programming-Model[Spring Annotation Programming Model]
 wiki page.
 
 
 
 [[beans-scanning-autodetection]]
-=== Automatically detecting classes and registering bean definitions
+=== Automatically Detecting Classes and Registering Bean Definitions
 
 Spring can automatically detect stereotyped classes and register corresponding
-``BeanDefinition``s with the `ApplicationContext`. For example, the following two classes
+`BeanDefinition` instances with the `ApplicationContext`. For example, the following two classes
 are eligible for such autodetection:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5388,12 +5734,14 @@ are eligible for such autodetection:
 		// implementation elided for clarity
 	}
 ----
+====
 
 To autodetect these classes and register the corresponding beans, you need to add
 `@ComponentScan` to your `@Configuration` class, where the `basePackages` attribute
 is a common parent package for the two classes. (Alternatively, you can specify a
-comma/semicolon/space-separated list that includes the parent package of each class.)
+comma- or semicolon- or space-separated list that includes the parent package of each class.)
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5403,15 +5751,14 @@ comma/semicolon/space-separated list that includes the parent package of each cl
 		...
 	}
 ----
-
-[NOTE]
-====
-For concision, the above may have used the `value` attribute of the
-annotation, i.e. `@ComponentScan("org.example")`
 ====
 
-The following is an alternative using XML
+NOTE: For brevity, the preceding example could have used the `value` attribute of the
+annotation (that is, `@ComponentScan("org.example")`).
 
+The following alternative uses XML:
+
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5428,54 +5775,49 @@ The following is an alternative using XML
 
 	</beans>
 ----
-
-[TIP]
 ====
-The use of `<context:component-scan>` implicitly enables the functionality of
+
+TIP: The use of `<context:component-scan>` implicitly enables the functionality of
 `<context:annotation-config>`. There is usually no need to include the
 `<context:annotation-config>` element when using `<context:component-scan>`.
-====
 
 [NOTE]
 ====
 The scanning of classpath packages requires the presence of corresponding directory
-entries in the classpath. When you build JARs with Ant, make sure that you do __not__
+entries in the classpath. When you build JARs with Ant, make sure that you do not
 activate the files-only switch of the JAR task. Also, classpath directories may not
-get exposed based on security policies in some environments, e.g. standalone apps on
-JDK 1.7.0_45 and higher (which requires 'Trusted-Library' setup in your manifests; see
+be exposed based on security policies in some environments -- for example, standalone apps on
+JDK 1.7.0_45 and higher (which requires 'Trusted-Library' setup in your manifests -- see
 http://stackoverflow.com/questions/19394570/java-jre-7u45-breaks-classloader-getresources).
 
 On JDK 9's module path (Jigsaw), Spring's classpath scanning generally works as expected.
-However, please make sure that your component classes are exported in your `module-info`
-descriptors; if you expect Spring to invoke non-public members of your classes, make
-sure that they are 'opened' (i.e. using an `opens` declaration instead of an `exports`
+However, make sure that your component classes are exported in your `module-info`
+descriptors. If you expect Spring to invoke non-public members of your classes, make
+sure that they are 'opened' (that is, that they use an `opens` declaration instead of an `exports`
 declaration in your `module-info` descriptor).
 ====
 
 Furthermore, the `AutowiredAnnotationBeanPostProcessor` and
-`CommonAnnotationBeanPostProcessor` are both included implicitly when you use the
-component-scan element. That means that the two components are autodetected __and__
-wired together - all without any bean configuration metadata provided in XML.
+`CommonAnnotationBeanPostProcessor` are both implicitly included when you use the
+component-scan element. That means that the two components are autodetected and
+wired together -- all without any bean configuration metadata provided in XML.
 
-[NOTE]
-====
-You can disable the registration of `AutowiredAnnotationBeanPostProcessor` and
-`CommonAnnotationBeanPostProcessor` by including the __annotation-config__ attribute
+NOTE: You can disable the registration of `AutowiredAnnotationBeanPostProcessor` and
+`CommonAnnotationBeanPostProcessor` by including the annotation-config attribute
 with a value of `false`.
-====
 
 
 
 [[beans-scanning-filters]]
-=== Using filters to customize scanning
+=== Using Filters to Customize Scanning
 
 By default, classes annotated with `@Component`, `@Repository`, `@Service`,
 `@Controller`, or a custom annotation that itself is annotated with `@Component` are the
 only detected candidate components. However, you can modify and extend this behavior
-simply by applying custom filters. Add them as __includeFilters__ or __excludeFilters__
-parameters of the `@ComponentScan` annotation (or as __include-filter__ or __exclude-filter__
-sub-elements of the `component-scan` element). Each filter element requires the `type`
-and `expression` attributes. The following table describes the filtering options.
+by applying custom filters. Add them as `includeFilters` or `excludeFilters`
+parameters of the `@ComponentScan` annotation (or as `include-filter` or `exclude-filter`
+child elements of the `component-scan` element). Each filter element requires the `type`
+and `expression` attributes. The following table describes the filtering options:
 
 [[beans-scanning-filters-tbl]]
 .Filter Types
@@ -5488,7 +5830,7 @@ and `expression` attributes. The following table describes the filtering options
 
 | assignable
 | `org.example.SomeClass`
-| A class (or interface) that the target components are assignable to (extend/implement).
+| A class (or interface) that the target components are assignable to (extend or implement).
 
 | aspectj
 | `org.example..*Service+`
@@ -5504,9 +5846,9 @@ and `expression` attributes. The following table describes the filtering options
 |===
 
 The following example shows the configuration ignoring all `@Repository` annotations
-and using "stub" repositories instead.
+and using "`stub`" repositories instead:
 
-
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5518,9 +5860,11 @@ and using "stub" repositories instead.
 		...
 	}
 ----
+====
 
-and the equivalent using XML
+The following listing shows the equivalent XML:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5533,24 +5877,23 @@ and the equivalent using XML
 		</context:component-scan>
 	</beans>
 ----
+====
 
-[NOTE]
-====
-You can also disable the default filters by setting `useDefaultFilters=false` on the annotation or
-providing `use-default-filters="false"` as an attribute of the `<component-scan/>` element. This
-will in effect disable automatic detection of classes annotated with `@Component`, `@Repository`,
+NOTE: You can also disable the default filters by setting `useDefaultFilters=false` on the annotation or
+ by providing `use-default-filters="false"` as an attribute of the `<component-scan/>` element. This,
+in effect, disables automatic detection of classes annotated with `@Component`, `@Repository`,
 `@Service`, `@Controller`, or `@Configuration`.
-====
 
 
 
 [[beans-factorybeans-annotations]]
-=== Defining bean metadata within components
+=== Defining Bean Metadata within Components
 
-Spring components can also contribute bean definition metadata to the container. You do
+Spring components can also contribute bean definition metadata to the container. You can do
 this with the same `@Bean` annotation used to define bean metadata within `@Configuration`
-annotated classes. Here is a simple example:
+annotated classes. The following example show how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5568,24 +5911,23 @@ annotated classes. Here is a simple example:
 		}
 	}
 ----
+====
 
-This class is a Spring component that has application-specific code contained in its
+The preceding class is a Spring component that has application-specific code in its
 `doWork()` method. However, it also contributes a bean definition that has a factory
 method referring to the method `publicInstance()`. The `@Bean` annotation identifies the
 factory method and other bean definition properties, such as a qualifier value through
-the `@Qualifier` annotation. Other method level annotations that can be specified are
+the `@Qualifier` annotation. Other method-level annotations that can be specified are
 `@Scope`, `@Lazy`, and custom qualifier annotations.
 
-[TIP]
-====
-In addition to its role for component initialization, the `@Lazy` annotation may also be
-placed on injection points marked with `@Autowired` or `@Inject`. In this context, it
+TIP: In addition to its role for component initialization, you can also place the `@Lazy` annotation may
+on injection points marked with `@Autowired` or `@Inject`. In this context, it
 leads to the injection of a lazy-resolution proxy.
+
+Autowired fields and methods are supported, as previously discussed, with additional
+support for autowiring of `@Bean` methods. The following example shows how to do so:
+
 ====
-
-Autowired fields and methods are supported as previously discussed, with additional
-support for autowiring of `@Bean` methods:
-
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5623,6 +5965,7 @@ support for autowiring of `@Bean` methods:
 		}
 	}
 ----
+====
 
 The example autowires the `String` method parameter `country` to the value of the `age`
 property on another bean named `privateInstance`. A Spring Expression Language element
@@ -5631,15 +5974,17 @@ annotations, an expression resolver is preconfigured to look for bean names when
 resolving expression text.
 
 As of Spring Framework 4.3, you may also declare a factory method parameter of type
-`InjectionPoint` (or its more specific subclass `DependencyDescriptor`) in order to
+`InjectionPoint` (or its more specific subclass: `DependencyDescriptor`) to
 access the requesting injection point that triggers the creation of the current bean.
-Note that this will only apply to the actual creation of bean instances, not to the
+Note that this applies only to the actual creation of bean instances, not to the
 injection of existing instances. As a consequence, this feature makes most sense for
-beans of prototype scope. For other scopes, the factory method will only ever see the
-injection point which triggered the creation of a new bean instance in the given scope:
-for example, the dependency that triggered the creation of a lazy singleton bean.
-Use the provided injection point metadata with semantic care in such scenarios.
+beans of prototype scope. For other scopes, the factory method only ever sees the
+injection point that triggered the creation of a new bean instance in the given scope
+(for example, the dependency that triggered the creation of a lazy singleton bean).
+You can use the provided injection point metadata with semantic care in such scenarios.
+The following example shows how to do use `InjectionPoint`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5652,69 +5997,71 @@ Use the provided injection point metadata with semantic care in such scenarios.
 		}
 	}
 ----
+====
 
 The `@Bean` methods in a regular Spring component are processed differently than their
 counterparts inside a Spring `@Configuration` class. The difference is that `@Component`
 classes are not enhanced with CGLIB to intercept the invocation of methods and fields.
 CGLIB proxying is the means by which invoking methods or fields within `@Bean` methods
-in `@Configuration` classes creates bean metadata references to collaborating objects;
-such methods are __not__ invoked with normal Java semantics but rather go through the
+in `@Configuration` classes creates bean metadata references to collaborating objects.
+Such methods are not invoked with normal Java semantics but rather go through the
 container in order to provide the usual lifecycle management and proxying of Spring
-beans even when referring to other beans via programmatic calls to `@Bean` methods.
-In contrast, invoking a method or field in an `@Bean` method within a plain `@Component`
-class __has__ standard Java semantics, with no special CGLIB processing or other
+beans, even when referring to other beans through programmatic calls to `@Bean` methods.
+In contrast, invoking a method or field in a `@Bean` method within a plain `@Component`
+class has standard Java semantics, with no special CGLIB processing or other
 constraints applying.
 
 [NOTE]
 ====
 You may declare `@Bean` methods as `static`, allowing for them to be called without
 creating their containing configuration class as an instance. This makes particular
-sense when defining post-processor beans, e.g. of type `BeanFactoryPostProcessor` or
-`BeanPostProcessor`, since such beans will get initialized early in the container
+sense when defining post-processor beans (for example, of type `BeanFactoryPostProcessor` or
+`BeanPostProcessor`), since such beans get initialized early in the container
 lifecycle and should avoid triggering other parts of the configuration at that point.
 
-Note that calls to static `@Bean` methods will never get intercepted by the container,
-not even within `@Configuration` classes (see above). This is due to technical
-limitations: CGLIB subclassing can only override non-static methods. As a consequence,
-a direct call to another `@Bean` method will have standard Java semantics, resulting
+Calls to static `@Bean` methods never get intercepted by the container,
+not even within `@Configuration` classes (as described earlier in this section), due to technical
+limitations: CGLIB subclassing can override only non-static methods. As a consequence,
+a direct call to another `@Bean` method has standard Java semantics, resulting
 in an independent instance being returned straight from the factory method itself.
 
 The Java language visibility of `@Bean` methods does not have an immediate impact on
-the resulting bean definition in Spring's container. You may freely declare your
+the resulting bean definition in Spring's container. You can freely declare your
 factory methods as you see fit in non-`@Configuration` classes and also for static
 methods anywhere. However, regular `@Bean` methods in `@Configuration` classes need
-to be overridable, i.e. they must not be declared as `private` or `final`.
+to be overridable -- that is, they must not be declared as `private` or `final`.
 
-`@Bean` methods will also be discovered on base classes of a given component or
+`@Bean` methods are also discovered on base classes of a given component or
 configuration class, as well as on Java 8 default methods declared in interfaces
 implemented by the component or configuration class. This allows for a lot of
 flexibility in composing complex configuration arrangements, with even multiple
 inheritance being possible through Java 8 default methods as of Spring 4.2.
 
-Finally, note that a single class may hold multiple `@Bean` methods for the same
+Finally, a single class may hold multiple `@Bean` methods for the same
 bean, as an arrangement of multiple factory methods to use depending on available
-dependencies at runtime. This is the same algorithm as for choosing the "greediest"
+dependencies at runtime. This is the same algorithm as for choosing the "`greediest`"
 constructor or factory method in other configuration scenarios: The variant with
-the largest number of satisfiable dependencies will be picked at construction time,
+the largest number of satisfiable dependencies is picked at construction time,
 analogous to how the container selects between multiple `@Autowired` constructors.
 ====
 
 
 
 [[beans-scanning-name-generator]]
-=== Naming autodetected components
+=== Naming Autodetected Components
 
 When a component is autodetected as part of the scanning process, its bean name is
 generated by the `BeanNameGenerator` strategy known to that scanner. By default, any
 Spring stereotype annotation (`@Component`, `@Repository`, `@Service`, and
-`@Controller`) that contains a _name_ `value` will thereby provide that name to the
+`@Controller`) that contains a name `value` thereby provides that name to the
 corresponding bean definition.
 
-If such an annotation contains no _name_ `value` or for any other detected component
+If such an annotation contains no name `value` or for any other detected component
 (such as those discovered by custom filters), the default bean name generator returns
 the uncapitalized non-qualified class name. For example, if the following component
 classes were detected, the names would be `myMovieLister` and `movieFinderImpl`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5732,16 +6079,16 @@ classes were detected, the names would be `myMovieLister` and `movieFinderImpl`:
 		// ...
 	}
 ----
-
-[NOTE]
 ====
-If you do not want to rely on the default bean-naming strategy, you can provide a custom
+
+NOTE: If you do not want to rely on the default bean-naming strategy, you can provide a custom
 bean-naming strategy. First, implement the
 {api-spring-framework}/beans/factory/support/BeanNameGenerator.html[`BeanNameGenerator`]
 interface, and be sure to include a default no-arg constructor. Then, provide the
-fully-qualified class name when configuring the scanner:
-====
+fully qualified class name when configuring the scanner, as the following example annotation
+and bean definition show:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5760,6 +6107,7 @@ fully-qualified class name when configuring the scanner:
 			name-generator="org.example.MyNameGenerator" />
 	</beans>
 ----
+====
 
 As a general rule, consider specifying the name with the annotation whenever other
 components may be making explicit references to it. On the other hand, the
@@ -5768,13 +6116,14 @@ auto-generated names are adequate whenever the container is responsible for wiri
 
 
 [[beans-scanning-scope-resolver]]
-=== Providing a scope for autodetected components
+=== Providing a Scope for Autodetected Components
 
 As with Spring-managed components in general, the default and most common scope for
 autodetected components is `singleton`. However, sometimes you need a different scope
-which can be specified via the `@Scope` annotation. Simply provide the name of the
-scope within the annotation:
+that can be specified by the `@Scope` annotation. You can provide the name of the
+scope within the annotation, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5784,30 +6133,27 @@ scope within the annotation:
 		// ...
 	}
 ----
-
-[NOTE]
 ====
-`@Scope` annotations are only introspected on the concrete bean class (for annotated
+
+NOTE: `@Scope` annotations are only introspected on the concrete bean class (for annotated
 components) or the factory method (for `@Bean` methods). In contrast to XML bean
 definitions, there is no notion of bean definition inheritance, and inheritance
 hierarchies at the class level are irrelevant for metadata purposes.
-====
 
-For details on web-specific scopes such as "request"/"session" in a Spring context,
-see <<beans-factory-scopes-other>>. Like the pre-built annotations for those scopes,
-you may also compose your own scoping annotations using Spring's meta-annotation
-approach: e.g. a custom annotation meta-annotated with `@Scope("prototype")`,
+For details on web-specific scopes such as "`request`" or "`session`" in a Spring context,
+see <<beans-factory-scopes-other>>. As with the pre-built annotations for those scopes,
+you may also compose your own scoping annotations by using Spring's meta-annotation
+approach: for example, a custom annotation meta-annotated with `@Scope("prototype")`,
 possibly also declaring a custom scoped-proxy mode.
 
-[NOTE]
-====
-To provide a custom strategy for scope resolution rather than relying on the
-annotation-based approach, implement the
+NOTE: To provide a custom strategy for scope resolution rather than relying on the
+annotation-based approach, you can implement the
 {api-spring-framework}/context/annotation/ScopeMetadataResolver.html[`ScopeMetadataResolver`]
-interface, and be sure to include a default no-arg constructor. Then, provide the
-fully-qualified class name when configuring the scanner:
-====
+interface. Be sure to include a default no-arg constructor. Then you can provide the
+fully qualified class name when configuring the scanner, as the following example of both
+an annotation and a bean definition shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5825,13 +6171,15 @@ fully-qualified class name when configuring the scanner:
 		<context:component-scan base-package="org.example" scope-resolver="org.example.MyScopeResolver"/>
 	</beans>
 ----
+====
 
 When using certain non-singleton scopes, it may be necessary to generate proxies for the
 scoped objects. The reasoning is described in <<beans-factory-scopes-other-injection>>.
-For this purpose, a __scoped-proxy__ attribute is available on the component-scan
-element. The three possible values are: no, interfaces, and targetClass. For example,
-the following configuration will result in standard JDK dynamic proxies:
+For this purpose, a scoped-proxy attribute is available on the component-scan
+element. The three possible values are: `no`, `interfaces`, and `targetClass`. For example,
+the following configuration results in standard JDK dynamic proxies:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5849,22 +6197,24 @@ the following configuration will result in standard JDK dynamic proxies:
 		<context:component-scan base-package="org.example" scoped-proxy="interfaces"/>
 	</beans>
 ----
+====
 
 
 
 [[beans-scanning-qualifiers]]
-=== Providing qualifier metadata with annotations
+=== Providing Qualifier Metadata with Annotations
 
 The `@Qualifier` annotation is discussed in <<beans-autowired-annotation-qualifiers>>.
 The examples in that section demonstrate the use of the `@Qualifier` annotation and
 custom qualifier annotations to provide fine-grained control when you resolve autowire
 candidates. Because those examples were based on XML bean definitions, the qualifier
-metadata was provided on the candidate bean definitions using the `qualifier` or `meta`
-sub-elements of the `bean` element in the XML. When relying upon classpath scanning for
-autodetection of components, you provide the qualifier metadata with type-level
+metadata was provided on the candidate bean definitions by using the `qualifier` or `meta`
+child elements of the `bean` element in the XML. When relying upon classpath scanning for
+auto-detection of components, you can provide the qualifier metadata with type-level
 annotations on the candidate class. The following three examples demonstrate this
 technique:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5894,29 +6244,29 @@ technique:
 		// ...
 	}
 ----
+====
 
-[NOTE]
-====
-As with most annotation-based alternatives, keep in mind that the annotation metadata is
+NOTE: As with most annotation-based alternatives, keep in mind that the annotation metadata is
 bound to the class definition itself, while the use of XML allows for multiple beans
-__of the same type__ to provide variations in their qualifier metadata, because that
+of the same type to provide variations in their qualifier metadata, because that
 metadata is provided per-instance rather than per-class.
-====
 
 
 
 [[beans-scanning-index]]
-=== Generating an index of candidate components
+=== Generating an Index of Candidate Components
 
 While classpath scanning is very fast, it is possible to improve the startup performance
 of large applications by creating a static list of candidates at compilation time. In this
-mode, _all modules_ of the application must use this mechanism as, when the
-`ApplicationContext` detects such index, it will automatically use it rather than scanning
+mode, all modules of the application must use this mechanism as, when the
+`ApplicationContext` detects such an index, it automatically uses it rather than scanning
 the classpath.
 
-To generate the index, simply add an additional dependency to each module that contains
-components that are target for component scan directives:
+To generate the index, add an additional dependency to each module that contains
+components that are targets for component scan directives. The following example shows
+how to do so with Maven:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes,attributes"]
 ----
@@ -5929,9 +6279,11 @@ components that are target for component scan directives:
 		</dependency>
 	</dependencies>
 ----
+====
 
-Or, using Gradle:
+The following example shows how to do so with Gradle:
 
+====
 [source,groovy,indent=0]
 [subs="verbatim,quotes,attributes"]
 ----
@@ -5939,27 +6291,21 @@ Or, using Gradle:
 		compileOnly("org.springframework:spring-context-indexer:{spring-version}")
 	}
 ----
-
-That process will generate a `META-INF/spring.components` file that is going to be
-included in the jar.
-
-[NOTE]
 ====
-When working with this mode in your IDE, the `spring-context-indexer` must be registered
-as an annotation processor to make sure the index is up to date when candidate components
+
+That process generates a `META-INF/spring.components` file that is
+included in the jar file.
+
+NOTE: When working with this mode in your IDE, the `spring-context-indexer` must be registered
+as an annotation processor to make sure the index is up-to-date when candidate components
 are updated.
-====
 
-[TIP]
-====
-The index is enabled automatically when a `META-INF/spring.components` is found on the
+TIP: The index is enabled automatically when a `META-INF/spring.components` is found on the
 classpath. If an index is partially available for some libraries (or use cases) but
-couldn't be built for the whole application, you can fallback to a regular classpath
-arrangement (i.e. as no index was present at all) by setting `spring.index.ignore` to
+could not be built for the whole application, you can fallback to a regular classpath
+arrangement (as though no index was present at all) by setting `spring.index.ignore` to
 `true`, either as a system property or in a `spring.properties` file at the root of the
 classpath.
-====
-
 
 
 
@@ -5968,15 +6314,16 @@ classpath.
 
 Starting with Spring 3.0, Spring offers support for JSR-330 standard annotations
 (Dependency Injection). Those annotations are scanned in the same way as the Spring
-annotations. You just need to have the relevant jars in your classpath.
+annotations. To use them, you need to have the relevant jars in your classpath.
 
 [NOTE]
-====
-If you are using Maven, the `javax.inject` artifact is available in the standard Maven
+=====
+If you use Maven, the `javax.inject` artifact is available in the standard Maven
 repository (
 http://repo1.maven.org/maven2/javax/inject/javax.inject/1/[http://repo1.maven.org/maven2/javax/inject/javax.inject/1/]).
 You can add the following dependency to your file pom.xml:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -5987,14 +6334,16 @@ You can add the following dependency to your file pom.xml:
 	</dependency>
 ----
 ====
+=====
 
 
 
 [[beans-inject-named]]
-=== Dependency Injection with @Inject and @Named
+=== Dependency Injection with `@Inject` and `@Named`
 
-Instead of `@Autowired`, `@javax.inject.Inject` may be used as follows:
+Instead of `@Autowired`, you can use `@javax.inject.Inject` as follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6015,12 +6364,15 @@ Instead of `@Autowired`, `@javax.inject.Inject` may be used as follows:
 		}
 	}
 ----
+====
 
-As with `@Autowired`, it is possible to use `@Inject` at the field level, method level
+As with `@Autowired`, you can use `@Inject` at the field level, method level
 and constructor-argument level. Furthermore, you may declare your injection point as a
 `Provider`, allowing for on-demand access to beans of shorter scopes or lazy access to
-other beans through a `Provider.get()` call. As a variant of the example above:
+other beans through a `Provider.get()` call. The following example offers a variant of the
+preceding example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6042,10 +6394,12 @@ other beans through a `Provider.get()` call. As a variant of the example above:
 		}
 	}
 ----
+====
 
 If you would like to use a qualified name for the dependency that should be injected,
-you should use the `@Named` annotation as follows:
+you should use the `@Named` annotation, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6064,11 +6418,14 @@ you should use the `@Named` annotation as follows:
 		// ...
 	}
 ----
+====
 
-Like `@Autowired`, `@Inject` can also be used with `java.util.Optional` or
-`@Nullable`. This is even more applicable here since `@Inject` does not have
-a `required` attribute.
+As with `@Autowired`, `@Inject` can also be used with `java.util.Optional` or
+`@Nullable`. This is even more applicable here, since `@Inject` does not have
+a `required` attribute. The following pair of examples show how to use `@Inject` and
+`@Nullable`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6092,15 +6449,17 @@ a `required` attribute.
 		}
 	}
 ----
+====
 
 
 
 [[beans-named]]
-=== @Named and @ManagedBean: standard equivalents to the @Component annotation
+=== `@Named` and `@ManagedBean`: Standard Equivalents to the `@Component` Annotation
 
-Instead of `@Component`, `@javax.inject.Named` or `javax.annotation.ManagedBean` may be
-used as follows:
+Instead of `@Component`, you can use `@javax.inject.Named` or `javax.annotation.ManagedBean`,
+as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6120,10 +6479,12 @@ used as follows:
 		// ...
 	}
 ----
+====
 
 It is very common to use `@Component` without specifying a name for the component.
-`@Named` can be used in a similar fashion:
+`@Named` can be used in a similar fashion, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6143,10 +6504,12 @@ It is very common to use `@Component` without specifying a name for the componen
 		// ...
 	}
 ----
+====
 
-When using `@Named` or `@ManagedBean`, it is possible to use component scanning in the
-exact same way as when using Spring annotations:
+When you use `@Named` or `@ManagedBean`, you can use component scanning in the
+exact same way as when you use Spring annotations, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6156,34 +6519,32 @@ exact same way as when using Spring annotations:
 		...
 	}
 ----
+====
 
-[NOTE]
-====
-In contrast to `@Component`, the JSR-330 `@Named` and the JSR-250 `ManagedBean`
-annotations are not composable. Please use Spring's stereotype model for building custom
+NOTE: In contrast to `@Component`, the JSR-330 `@Named` and the JSR-250 `ManagedBean`
+annotations are not composable. You should use Spring's stereotype model for building custom
 component annotations.
-====
 
 
 
 [[beans-standard-annotations-limitations]]
-=== Limitations of JSR-330 standard annotations
+=== Limitations of JSR-330 Standard Annotations
 
-When working with standard annotations, it is important to know that some significant
-features are not available as shown in the table below:
+When you work with standard annotations, you should know that some significant
+features are not available, as the following table shows:
 
 [[annotations-comparison]]
-.Spring component model elements vs. JSR-330 variants
+.Spring component model elements versus JSR-330 variants
 |===
 | Spring| javax.inject.*| javax.inject restrictions / comments
 
 | @Autowired
 | @Inject
-| `@Inject` has no 'required' attribute; can be used with Java 8's `Optional` instead.
+| `@Inject` has no 'required' attribute. Can be used with Java 8's `Optional` instead.
 
 | @Component
 | @Named / @ManagedBean
-| JSR-330 does not provide a composable model, just a way to identify named components.
+| JSR-330 does not provide a composable model, only a way to identify named components.
 
 | @Scope("singleton")
 | @Singleton
@@ -6197,7 +6558,7 @@ features are not available as shown in the table below:
 | @Qualifier
 | @Qualifier / @Named
 | `javax.inject.Qualifier` is just a meta-annotation for building custom qualifiers.
-  Concrete String qualifiers (like Spring's `@Qualifier` with a value) can be associated
+  Concrete `String` qualifiers (like Spring's `@Qualifier` with a value) can be associated
   through `javax.inject.Named`.
 
 | @Value
@@ -6215,35 +6576,48 @@ features are not available as shown in the table below:
 | ObjectFactory
 | Provider
 | `javax.inject.Provider` is a direct alternative to Spring's `ObjectFactory`,
-  just with a shorter `get()` method name. It can also be used in combination with
+  only with a shorter `get()` method name. It can also be used in combination with
   Spring's `@Autowired` or with non-annotated constructors and setter methods.
 |===
 
 
 
-
 [[beans-java]]
-== Java-based container configuration
+== Java-based Container Configuration
+
+This section covers how to use annotations in your Java code to configure the Spring
+container. It includes the following topics:
+
+* <<beans-java-basic-concepts>>
+* <<beans-java-instantiating-container>>
+* <<beans-java-bean-annotation>>
+* <<beans-java-configuration-annotation>>
+* <<beans-java-composing-configuration-classes>>
+* <<beans-definition-profiles>>
+* <<beans-property-source-abstraction>>
+* <<beans-using-propertysource>>
+* <<beans-placeholder-resolution-in-statements>>
 
 
 
 [[beans-java-basic-concepts]]
-=== Basic concepts: @Bean and @Configuration
+=== Basic Concepts: `@Bean` and `@Configuration`
 
 The central artifacts in Spring's new Java-configuration support are
 `@Configuration`-annotated classes and `@Bean`-annotated methods.
 
-The `@Bean` annotation is used to indicate that a method instantiates, configures and
+The `@Bean` annotation is used to indicate that a method instantiates, configures, and
 initializes a new object to be managed by the Spring IoC container. For those familiar
-with Spring's `<beans/>` XML configuration the `@Bean` annotation plays the same role as
-the `<bean/>` element. You can use `@Bean` annotated methods with any Spring
-`@Component`, however, they are most often used with `@Configuration` beans.
+with Spring's `<beans/>` XML configuration, the `@Bean` annotation plays the same role as
+the `<bean/>` element. You can use `@Bean`-annotated methods with any Spring
+`@Component`. However, they are most often used with `@Configuration` beans.
 
 Annotating a class with `@Configuration` indicates that its primary purpose is as a
-source of bean definitions. Furthermore, `@Configuration` classes allow inter-bean
-dependencies to be defined by simply calling other `@Bean` methods in the same class.
-The simplest possible `@Configuration` class would read as follows:
+source of bean definitions. Furthermore, `@Configuration` classes let inter-bean
+dependencies be defined by calling other `@Bean` methods in the same class.
+The simplest possible `@Configuration` class reads as follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6256,9 +6630,11 @@ The simplest possible `@Configuration` class would read as follows:
 		}
 	}
 ----
+====
 
-The `AppConfig` class above would be equivalent to the following Spring `<beans/>` XML:
+The preceding `AppConfig` class is equivalent to the following Spring `<beans/>` XML:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6266,48 +6642,49 @@ The `AppConfig` class above would be equivalent to the following Spring `<beans/
 		<bean id="myService" class="com.acme.services.MyServiceImpl"/>
 	</beans>
 ----
+====
 
-.Full @Configuration vs 'lite' @Bean mode?
+.Full @Configuration vs "`lite`" @Bean mode?
 ****
-When `@Bean` methods are declared within classes that are __not__ annotated with
-`@Configuration` they are referred to as being processed in a 'lite' mode. Bean methods
-declared in a `@Component` or even in a __plain old class__ will be considered 'lite',
-with a different primary purpose of the containing class and an `@Bean` method just
+When `@Bean` methods are declared within classes that are not annotated with
+`@Configuration`, they are referred to as being processed in a "`lite`" mode. Bean methods
+declared in a `@Component` or even in a plain old class are considered to be "`lite`",
+with a different primary purpose of the containing class and a `@Bean` method
 being a sort of bonus there. For example, service components may expose management views
 to the container through an additional `@Bean` method on each applicable component class.
-In such scenarios, `@Bean` methods are a simple general-purpose factory method mechanism.
+In such scenarios, `@Bean` methods are a general-purpose factory method mechanism.
 
 Unlike full `@Configuration`, lite `@Bean` methods cannot declare inter-bean dependencies.
-Instead, they operate on their containing component's internal state and optionally on
-arguments that they may declare. Such an `@Bean` method should therefore not invoke other
-`@Bean` methods; each such method is literally just a factory method for a particular
+Instead, they operate on their containing component's internal state and, optionally, on
+arguments that they may declare. Such a `@Bean` method should therefore not invoke other
+`@Bean` methods. Each such method is literally only a factory method for a particular
 bean reference, without any special runtime semantics. The positive side-effect here is
 that no CGLIB subclassing has to be applied at runtime, so there are no limitations in
-terms of class design (i.e. the containing class may nevertheless be `final` etc).
+terms of class design (that is, the containing class may be `final` and so forth).
 
 In common scenarios, `@Bean` methods are to be declared within `@Configuration` classes,
-ensuring that 'full' mode is always used and that cross-method references will therefore
-get redirected to the container's lifecycle management. This will prevent the same
-`@Bean` method from accidentally being invoked through a regular Java call which helps
-to reduce subtle bugs that can be hard to track down when operating in 'lite' mode.
+ensuring that "`full`" mode is always used and that cross-method references therefore
+get redirected to the container's lifecycle management. This prevents the same
+`@Bean` method from accidentally being invoked through a regular Java call, which helps
+to reduce subtle bugs that can be hard to track down when operating in "`lite`" mode.
 ****
 
-The `@Bean` and `@Configuration` annotations will be discussed in depth in the sections
-below. First, however, we'll cover the various ways of creating a spring container using
+The `@Bean` and `@Configuration` annotations are discussed in depth in the following sections.
+First, however, we cover the various ways of creating a spring container using by
 Java-based configuration.
 
 
 
 [[beans-java-instantiating-container]]
-=== Instantiating the Spring container using AnnotationConfigApplicationContext
+=== Instantiating the Spring Container by Using `AnnotationConfigApplicationContext`
 
-The sections below document Spring's `AnnotationConfigApplicationContext`, new in Spring
+The following sections document Spring's `AnnotationConfigApplicationContext`, introduced in Spring
 3.0. This versatile `ApplicationContext` implementation is capable of accepting not only
-`@Configuration` classes as input, but also plain `@Component` classes and classes
+`@Configuration` classes as input but also plain `@Component` classes and classes
 annotated with JSR-330 metadata.
 
 When `@Configuration` classes are provided as input, the `@Configuration` class itself
-is registered as a bean definition, and all declared `@Bean` methods within the class
+is registered as a bean definition and all declared `@Bean` methods within the class
 are also registered as bean definitions.
 
 When `@Component` and JSR-330 classes are provided, they are registered as bean
@@ -6316,13 +6693,14 @@ used within those classes where necessary.
 
 
 [[beans-java-instantiating-container-contstructor]]
-==== Simple construction
+==== Simple Construction
 
 In much the same way that Spring XML files are used as input when instantiating a
-`ClassPathXmlApplicationContext`, `@Configuration` classes may be used as input when
+`ClassPathXmlApplicationContext`, you can use `@Configuration` classes as input when
 instantiating an `AnnotationConfigApplicationContext`. This allows for completely
-XML-free usage of the Spring container:
+XML-free usage of the Spring container, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6332,11 +6710,13 @@ XML-free usage of the Spring container:
 		myService.doStuff();
 	}
 ----
+====
 
-As mentioned above, `AnnotationConfigApplicationContext` is not limited to working only
+As mentioned earlier, `AnnotationConfigApplicationContext` is not limited to working only
 with `@Configuration` classes. Any `@Component` or JSR-330 annotated class may be supplied
-as input to the constructor. For example:
+as input to the constructor, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6346,18 +6726,21 @@ as input to the constructor. For example:
 		myService.doStuff();
 	}
 ----
+====
 
-The above assumes that `MyServiceImpl`, `Dependency1` and `Dependency2` use Spring
+The preceding example assumes that `MyServiceImpl`, `Dependency1`, and `Dependency2` use Spring
 dependency injection annotations such as `@Autowired`.
 
 
 [[beans-java-instantiating-container-register]]
-==== Building the container programmatically using register(Class<?>...)
+==== Building the Container Programmatically by Using `register(Class<?>...)`
 
-An `AnnotationConfigApplicationContext` may be instantiated using a no-arg constructor
-and then configured using the `register()` method. This approach is particularly useful
-when programmatically building an `AnnotationConfigApplicationContext`.
+You can instantiate an `AnnotationConfigApplicationContext` by using a no-arg constructor
+and then configure it by using the `register()` method. This approach is particularly useful
+when programmatically building an `AnnotationConfigApplicationContext`. The following
+example shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6370,28 +6753,34 @@ when programmatically building an `AnnotationConfigApplicationContext`.
 		myService.doStuff();
 	}
 ----
+====
+
 
 
 [[beans-java-instantiating-container-scan]]
-==== Enabling component scanning with scan(String...)
+==== Enabling Component Scanning with `scan(String...)`
 
-To enable component scanning, just annotate your `@Configuration` class as follows:
+To enable component scanning, you can annotate your `@Configuration` class as follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	@Configuration
-	@ComponentScan(basePackages = "com.acme")
+	@ComponentScan(basePackages = "com.acme") <1>
 	public class AppConfig  {
 		...
 	}
 ----
+<1> This annotation enables component scanning.
+====
 
 [TIP]
-====
-Experienced Spring users will be familiar with the XML declaration equivalent from
-Spring's `context:` namespace
+=====
+Experienced Spring users may be familiar with the XML declaration equivalent from
+Spring's `context:` namespace, shown in the following example:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6400,13 +6789,15 @@ Spring's `context:` namespace
 	</beans>
 ----
 ====
+=====
 
-
-In the example above, the `com.acme` package will be scanned, looking for any
-`@Component`-annotated classes, and those classes will be registered as Spring bean
+In the preceding example, the `com.acme` package is scanned to look for any
+`@Component`-annotated classes, and those classes are registered as Spring bean
 definitions within the container. `AnnotationConfigApplicationContext` exposes the
-`scan(String...)` method to allow for the same component-scanning functionality:
+`scan(String...)` method to allow for the same component-scanning functionality, as the
+following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6417,28 +6808,28 @@ definitions within the container. `AnnotationConfigApplicationContext` exposes t
 		MyService myService = ctx.getBean(MyService.class);
 	}
 ----
+====
 
-[NOTE]
-====
-Remember that `@Configuration` classes are <<beans-meta-annotations,meta-annotated>>
-with `@Component`, so they are candidates for component-scanning! In the example above,
+NOTE: Remember that `@Configuration` classes are <<beans-meta-annotations,meta-annotated>>
+with `@Component`, so they are candidates for component-scanning. In the preceding example,
 assuming that `AppConfig` is declared within the `com.acme` package (or any package
-underneath), it will be picked up during the call to `scan()`, and upon `refresh()` all
-its `@Bean` methods will be processed and registered as bean definitions within the
+underneath), it is picked up during the call to `scan()`. Upon `refresh()`, all
+its `@Bean` methods are processed and registered as bean definitions within the
 container.
-====
+
 
 
 [[beans-java-instantiating-container-web]]
-==== Support for web applications with AnnotationConfigWebApplicationContext
+==== Support for Web Applications with `AnnotationConfigWebApplicationContext`
 
 A `WebApplicationContext` variant of `AnnotationConfigApplicationContext` is available
-with `AnnotationConfigWebApplicationContext`. This implementation may be used when
+with `AnnotationConfigWebApplicationContext`. You can use this implementation when
 configuring the Spring `ContextLoaderListener` servlet listener, Spring MVC
-`DispatcherServlet`, etc. What follows is a `web.xml` snippet that configures a typical
-Spring MVC web application. Note the use of the `contextClass` context-param and
-init-param:
+`DispatcherServlet`, and so forth. The following `web.xml` snippet configures a typical
+Spring MVC web application (note the use of the `contextClass` context-param and
+init-param):
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6492,30 +6883,34 @@ init-param:
 		</servlet-mapping>
 	</web-app>
 ----
+====
 
 
 
 [[beans-java-bean-annotation]]
-=== Using the @Bean annotation
+=== Using the `@Bean` Annotation
 
 `@Bean` is a method-level annotation and a direct analog of the XML `<bean/>` element.
 The annotation supports some of the attributes offered by `<bean/>`, such as:
-<<beans-factory-lifecycle-initializingbean,init-method>>,
-<<beans-factory-lifecycle-disposablebean,destroy-method>>,
-<<beans-factory-autowire,autowiring>> and `name`.
+* <<beans-factory-lifecycle-initializingbean,init-method>>
+* <<beans-factory-lifecycle-disposablebean,destroy-method>>
+* <<beans-factory-autowire,autowiring>>
+* `name`.
 
 You can use the `@Bean` annotation in a `@Configuration`-annotated or in a
 `@Component`-annotated class.
 
 
+
 [[beans-java-declaring-a-bean]]
-==== Declaring a bean
+==== Declaring a Bean
 
-To declare a bean, simply annotate a method with the `@Bean` annotation. You use this
+To declare a bean, you can annotate a method with the `@Bean` annotation. You use this
 method to register a bean definition within an `ApplicationContext` of the type
-specified as the method's return value. By default, the bean name will be the same as
-the method name. The following is a simple example of a `@Bean` method declaration:
+specified as the method's return value. By default, the bean name is the same as
+the method name. The following example shows a `@Bean` method declaration:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6528,9 +6923,11 @@ the method name. The following is a simple example of a `@Bean` method declarati
 		}
 	}
 ----
+====
 
 The preceding configuration is exactly equivalent to the following Spring XML:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6538,19 +6935,24 @@ The preceding configuration is exactly equivalent to the following Spring XML:
 		<bean id="transferService" class="com.acme.TransferServiceImpl"/>
 	</beans>
 ----
+====
 
 Both declarations make a bean named `transferService` available in the
-`ApplicationContext`, bound to an object instance of type `TransferServiceImpl`:
+`ApplicationContext`, bound to an object instance of type `TransferServiceImpl`, as the
+following text image shows:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
 transferService -> com.acme.TransferServiceImpl
 ----
+====
 
-You may also declare your `@Bean` method with an interface (or base class)
-return type:
+You can also declare your `@Bean` method with an interface (or base class)
+return type, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6563,33 +6965,33 @@ return type:
 		}
 	}
 ----
+====
 
 However, this limits the visibility for advance type prediction to the specified
-interface type (`TransferService`) then, with the full type (`TransferServiceImpl`)
-only known to the container once the affected singleton bean has been instantiated.
+interface type (`TransferService`). Then, with the full type (`TransferServiceImpl`)
+known to the container only once, the affected singleton bean has been instantiated.
 Non-lazy singleton beans get instantiated according to their declaration order,
 so you may see different type matching results depending on when another component
-tries to match by a non-declared type (such as `@Autowired TransferServiceImpl`
-which will only resolve once the "transferService" bean has been instantiated).
+tries to match by a non-declared type (such as `@Autowired TransferServiceImpl`,
+which resolves only once the `transferService` bean has been instantiated).
 
-[TIP]
-====
-If you consistently refer to your types by a declared service interface, your
+TIP: If you consistently refer to your types by a declared service interface, your
 `@Bean` return types may safely join that design decision. However, for components
-implementing several interfaces or for components potentially referred to by their
+that implement several interfaces or for components potentially referred to by their
 implementation type, it is safer to declare the most specific return type possible
-(at least as specific as required by the injection points referring to your bean).
-====
+(at least as specific as required by the injection points that refer to your bean).
+
 
 
 [[beans-java-dependencies]]
-==== Bean dependencies
+==== Bean Dependencies
 
-A `@Bean` annotated method can have an arbitrary number of parameters describing the
-dependencies required to build that bean. For instance if our `TransferService`
-requires an `AccountRepository` we can materialize that dependency via a method
-parameter:
+A `@Bean`-annotated method can have an arbitrary number of parameters that describe the
+dependencies required to build that bean. For instance, if our `TransferService`
+requires an `AccountRepository`, we can materialize that dependency with a method
+parameter, as the followig example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6602,16 +7004,18 @@ parameter:
 		}
 	}
 ----
+====
 
 The resolution mechanism is pretty much identical to constructor-based dependency
-injection, see <<beans-constructor-injection,the relevant section>> for more details.
+injection. See <<beans-constructor-injection,the relevant section>> for more details.
+
 
 
 [[beans-java-lifecycle-callbacks]]
-==== Receiving lifecycle callbacks
+==== Receiving Lifecycle Callbacks
 
 Any classes defined with the `@Bean` annotation support the regular lifecycle callbacks
-and can use the `@PostConstruct` and `@PreDestroy` annotations from JSR-250, see
+and can use the `@PostConstruct` and `@PreDestroy` annotations from JSR-250. See
 <<beans-postconstruct-and-predestroy-annotations,JSR-250 annotations>> for further
 details.
 
@@ -6619,26 +7023,27 @@ The regular Spring <<beans-factory-nature,lifecycle>> callbacks are fully suppor
 well. If a bean implements `InitializingBean`, `DisposableBean`, or `Lifecycle`, their
 respective methods are called by the container.
 
-The standard set of `*Aware` interfaces such as <<beans-beanfactory,BeanFactoryAware>>,
+The standard set of `*Aware` interfaces (such as <<beans-beanfactory,BeanFactoryAware>>,
 <<beans-factory-aware,BeanNameAware>>,
 <<context-functionality-messagesource,MessageSourceAware>>,
-<<beans-factory-aware,ApplicationContextAware>>, and so on are also fully supported.
+<<beans-factory-aware,ApplicationContextAware>>, and so on) are also fully supported.
 
 The `@Bean` annotation supports specifying arbitrary initialization and destruction
 callback methods, much like Spring XML's `init-method` and `destroy-method` attributes
-on the `bean` element:
+on the `bean` element, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
-	public class Foo {
+	public class BeanOne {
 
 		public void init() {
 			// initialization logic
 		}
 	}
 
-	public class Bar {
+	public class BeanTwo {
 
 		public void cleanup() {
 			// destruction logic
@@ -6649,29 +7054,34 @@ on the `bean` element:
 	public class AppConfig {
 
 		@Bean(initMethod = "init")
-		public Foo foo() {
-			return new Foo();
+		public BeanOne beanOne() {
+			return new BeanOne();
 		}
 
 		@Bean(destroyMethod = "cleanup")
-		public Bar bar() {
-			return new Bar();
+		public BeanTwo beanTwo() {
+			return new BeanTwo();
 		}
 	}
 ----
+====
 
 [NOTE]
-====
-By default, beans defined using Java config that have a public `close` or `shutdown`
+=====
+By default, beans defined with Java configuration that have a public `close` or `shutdown`
 method are automatically enlisted with a destruction callback. If you have a public
 `close` or `shutdown` method and you do not wish for it to be called when the container
-shuts down, simply add `@Bean(destroyMethod="")` to your bean definition to disable the
+shuts down, you can add `@Bean(destroyMethod="")` to your bean definition to disable the
 default `(inferred)` mode.
 
-You may want to do that by default for a resource that you acquire via JNDI as its
+You may want to do that by default for a resource that you acquire with JNDI, as its
 lifecycle is managed outside the application. In particular, make sure to always do it
-for a `DataSource` as it is known to be problematic on Java EE application servers.
+for a `DataSource`, as it is known to be problematic on Java EE application servers.
 
+The following example shows how to prevent an automatic destruction callback for a
+`DataSource`:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6680,18 +7090,20 @@ for a `DataSource` as it is known to be problematic on Java EE application serve
 		return (DataSource) jndiTemplate.lookup("MyDS");
 	}
 ----
-
-Also, with `@Bean` methods, you will typically choose to use programmatic JNDI lookups:
-either using Spring's `JndiTemplate`/`JndiLocatorDelegate` helpers or straight JNDI
-`InitialContext` usage, but not the `JndiObjectFactoryBean` variant which would force
-you to declare the return type as the `FactoryBean` type instead of the actual target
-type, making it harder to use for cross-reference calls in other `@Bean` methods that
-intend to refer to the provided resource here.
 ====
 
-Of course, in the case of `Foo` above, it would be equally as valid to call the `init()`
-method directly during construction:
+Also, with `@Bean` methods, you typically use programmatic JNDI lookups,
+either by using Spring's `JndiTemplate` or `JndiLocatorDelegate` helpers or straight JNDI
+`InitialContext` usage but not the `JndiObjectFactoryBean` variant (which would force
+you to declare the return type as the `FactoryBean` type instead of the actual target
+type, making it harder to use for cross-reference calls in other `@Bean` methods that
+intend to refer to the provided resource here).
+=====
 
+In the case of `BeanOne` from the example above the preceding note, it would be equally valid to call the `init()`
+method directly during construction, as the following example shows:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6699,35 +7111,40 @@ method directly during construction:
 	public class AppConfig {
 
 		@Bean
-		public Foo foo() {
-			Foo foo = new Foo();
-			foo.init();
-			return foo;
+		public BeanOne beanOne() {
+			BeanOne beanOne = new BeanOne();
+			beanOne.init();
+			return beanOne;
 		}
 
 		// ...
 	}
 ----
+====
 
-[TIP]
-====
-When you work directly in Java, you can do anything you like with your objects and do
-not always need to rely on the container lifecycle!
-====
+TIP: When you work directly in Java, you can do anything you like with your objects and do
+not always need to rely on the container lifecycle.
+
 
 
 [[beans-java-specifying-bean-scope]]
-==== Specifying bean scope
+==== Specifying Bean Scope
+
+Spring includes the `@Scope` annotation so that you can specify the scope of a bean.
+
+
 
 [[beans-java-available-scopes]]
-===== Using the @Scope annotation
+===== Using the `@Scope` Annotation
 
 You can specify that your beans defined with the `@Bean` annotation should have a
 specific scope. You can use any of the standard scopes specified in the
 <<beans-factory-scopes,Bean Scopes>> section.
 
-The default scope is `singleton`, but you can override this with the `@Scope` annotation:
+The default scope is `singleton`, but you can override this with the `@Scope` annotation,
+as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6741,20 +7158,22 @@ The default scope is `singleton`, but you can override this with the `@Scope` an
 		}
 	}
 ----
+====
 
 [[beans-java-scoped-proxy]]
-===== @Scope and scoped-proxy
+===== `@Scope` and `scoped-proxy`
 
 Spring offers a convenient way of working with scoped dependencies through
 <<beans-factory-scopes-other-injection,scoped proxies>>. The easiest way to create such
 a proxy when using the XML configuration is the `<aop:scoped-proxy/>` element.
-Configuring your beans in Java with a @Scope annotation offers equivalent support with
-the proxyMode attribute. The default is no proxy ( `ScopedProxyMode.NO`), but you can
+Configuring your beans in Java with a `@Scope` annotation offers equivalent support with
+the `proxyMode` attribute. The default is no proxy ( `ScopedProxyMode.NO`), but you can
 specify `ScopedProxyMode.TARGET_CLASS` or `ScopedProxyMode.INTERFACES`.
 
-If you port the scoped proxy example from the XML reference documentation (see preceding
-link) to our `@Bean` using Java, it would look like the following:
+If you port the scoped proxy example from the XML reference documentation (see
+<<beans-factory-scopes-other-injection,scoped proxies>>) to our `@Bean` using Java, it resembles the following:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6773,35 +7192,43 @@ link) to our `@Bean` using Java, it would look like the following:
 		return service;
 	}
 ----
+====
+
 
 
 [[beans-java-customizing-bean-naming]]
-==== Customizing bean naming
+==== Customizing Bean Naming
 
 By default, configuration classes use a `@Bean` method's name as the name of the
-resulting bean. This functionality can be overridden, however, with the `name` attribute.
+resulting bean. This functionality can be overridden, however, with the `name` attribute,
+as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	@Configuration
 	public class AppConfig {
 
-		@Bean(name = "myFoo")
-		public Foo foo() {
-			return new Foo();
+		@Bean(name = "myThing")
+		public Thing thing() {
+			return new Thing();
 		}
 	}
 ----
+====
+
 
 
 [[beans-java-bean-aliasing]]
-==== Bean aliasing
+==== Bean Aliasing
 
 As discussed in <<beans-beanname>>, it is sometimes desirable to give a single bean
-multiple names, otherwise known as __bean aliasing__. The `name` attribute of the `@Bean`
-annotation accepts a String array for this purpose.
+multiple names, otherwise known as bean aliasing. The `name` attribute of the `@Bean`
+annotation accepts a String array for this purpose. The following example shows how to set
+a number of aliases for a bean:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6814,18 +7241,21 @@ annotation accepts a String array for this purpose.
 		}
 	}
 ----
+====
+
 
 
 [[beans-java-bean-description]]
-==== Bean description
+==== Bean Description
 
-Sometimes it is helpful to provide a more detailed textual description of a bean. This can
-be particularly useful when beans are exposed (perhaps via JMX) for monitoring purposes.
+Sometimes, it is helpful to provide a more detailed textual description of a bean. This can
+be particularly useful when beans are exposed (perhaps through JMX) for monitoring purposes.
 
-To add a description to a `@Bean` the
+To add a description to a `@Bean`, you can use the
 {api-spring-framework}/context/annotation/Description.html[`@Description`]
-annotation can be used:
+annotation, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6834,29 +7264,32 @@ annotation can be used:
 
 		@Bean
 		**@Description("Provides a basic example of a bean")**
-		public Foo foo() {
-			return new Foo();
+		public Thing thing() {
+			return new Thing();
 		}
 	}
 ----
+====
 
 
 
 [[beans-java-configuration-annotation]]
-=== Using the @Configuration annotation
+=== Using the `@Configuration` annotation
 
 `@Configuration` is a class-level annotation indicating that an object is a source of
-bean definitions. `@Configuration` classes declare beans via public `@Bean` annotated
+bean definitions. `@Configuration` classes declare beans through public `@Bean` annotated
 methods. Calls to `@Bean` methods on `@Configuration` classes can also be used to define
 inter-bean dependencies. See <<beans-java-basic-concepts>> for a general introduction.
 
 
+
 [[beans-java-injecting-dependencies]]
-==== Injecting inter-bean dependencies
+==== Injecting Inter-bean Dependencies
 
-When ``@Bean``s have dependencies on one another, expressing that dependency is as simple
-as having one bean method call another:
+When beans have dependencies on one another, expressing that dependency is as simple
+as having one bean method call another, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6864,36 +7297,37 @@ as having one bean method call another:
 	public class AppConfig {
 
 		@Bean
-		public Foo foo() {
-			return new Foo(bar());
+		public BeanOne beanOne() {
+			return new BeanOne(beanTwo());
 		}
 
 		@Bean
-		public Bar bar() {
-			return new Bar();
+		public BeanTwo beanTwo() {
+			return new BeanTwo();
 		}
 	}
 ----
+====
 
-In the example above, the `foo` bean receives a reference to `bar` via constructor
+In the preceding example, `beanOne` receives a reference to `beanTwo` through constructor
 injection.
 
-[NOTE]
-====
-This method of declaring inter-bean dependencies only works when the `@Bean` method is
+NOTE: This method of declaring inter-bean dependencies works only when the `@Bean` method is
 declared within a `@Configuration` class. You cannot declare inter-bean dependencies
-using plain `@Component` classes.
-====
+by using plain `@Component` classes.
+
 
 
 [[beans-java-method-injection]]
-==== Lookup method injection
+==== Lookup Method Injection
 
 As noted earlier, <<beans-factory-method-injection,lookup method injection>> is an
 advanced feature that you should use rarely. It is useful in cases where a
 singleton-scoped bean has a dependency on a prototype-scoped bean. Using Java for this
-type of configuration provides a natural means for implementing this pattern.
+type of configuration provides a natural means for implementing this pattern. The
+following example shows how to use lookup method injection:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6910,11 +7344,13 @@ type of configuration provides a natural means for implementing this pattern.
 		protected abstract Command createCommand();
 	}
 ----
+====
 
-Using Java-configuration support , you can create a subclass of `CommandManager` where
+By using Java configuration, you can create a subclass of `CommandManager` where
 the abstract `createCommand()` method is overridden in such a way that it looks up a new
-(prototype) command object:
+(prototype) command object. The following example shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6937,13 +7373,16 @@ the abstract `createCommand()` method is overridden in such a way that it looks 
 		}
 	}
 ----
+====
+
 
 
 [[beans-java-further-information-java-config]]
-==== Further information about how Java-based configuration works internally
+==== Further Information About How Java-based Configuration Works Internally
 
-The following example shows a `@Bean` annotated method being called twice:
+Consider the following example, which shows a `@Bean` annotated method being called twice:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -6970,50 +7409,54 @@ The following example shows a `@Bean` annotated method being called twice:
 		}
 	}
 ----
+====
 
 `clientDao()` has been called once in `clientService1()` and once in `clientService2()`.
 Since this method creates a new instance of `ClientDaoImpl` and returns it, you would
-normally expect having 2 instances (one for each service). That definitely would be
-problematic: in Spring, instantiated beans have a `singleton` scope by default. This is
+normally expect to have two instances (one for each service). That definitely would be
+problematic: In Spring, instantiated beans have a `singleton` scope by default. This is
 where the magic comes in: All `@Configuration` classes are subclassed at startup-time
 with `CGLIB`. In the subclass, the child method checks the container first for any
-cached (scoped) beans before it calls the parent method and creates a new instance. Note
-that as of Spring 3.2, it is no longer necessary to add CGLIB to your classpath because
+cached (scoped) beans before it calls the parent method and creates a new instance.
+
+NOTE: As of Spring 3.2, it is no longer necessary to add CGLIB to your classpath because
 CGLIB classes have been repackaged under `org.springframework.cglib` and included directly
 within the spring-core JAR.
 
-[NOTE]
-====
-The behavior could be different according to the scope of your bean. We are talking
+NOTE: The behavior could be different according to the scope of your bean. We are talking
 about singletons here.
-====
 
 [TIP]
 ====
 There are a few restrictions due to the fact that CGLIB dynamically adds features at
-startup-time, in particular that configuration classes must not be final. However, as
+startup-time. In particular, configuration classes must not be final. However, as
 of 4.3, any constructors are allowed on configuration classes, including the use of
 `@Autowired` or a single non-default constructor declaration for default injection.
 
 If you prefer to avoid any CGLIB-imposed limitations, consider declaring your `@Bean`
-methods on non-`@Configuration` classes, e.g. on plain `@Component` classes instead.
-Cross-method calls between `@Bean` methods won't get intercepted then, so you'll have
+methods on non-`@Configuration` classes (for example, on plain `@Component` classes instead).
+Cross-method calls between `@Bean` methods are not then intercepted, so you have
 to exclusively rely on dependency injection at the constructor or method level there.
 ====
 
 
 
 [[beans-java-composing-configuration-classes]]
-=== Composing Java-based configurations
+=== Composing Java-based Configurations
+
+Spring's Java-based configuration feature lets you compose annotations, which can reduce
+the complexity of your configuration.
+
 
 
 [[beans-java-using-import]]
-==== Using the @Import annotation
+==== Using the `@Import` Annotation
 
 Much as the `<import/>` element is used within Spring XML files to aid in modularizing
 configurations, the `@Import` annotation allows for loading `@Bean` definitions from
-another configuration class:
+another configuration class, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7036,10 +7479,13 @@ another configuration class:
 		}
 	}
 ----
+====
 
 Now, rather than needing to specify both `ConfigA.class` and `ConfigB.class` when
-instantiating the context, only `ConfigB` needs to be supplied explicitly:
+instantiating the context, only `ConfigB` needs to be supplied explicitly, as the
+following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7051,34 +7497,33 @@ instantiating the context, only `ConfigB` needs to be supplied explicitly:
 		B b = ctx.getBean(B.class);
 	}
 ----
+====
 
 This approach simplifies container instantiation, as only one class needs to be dealt
-with, rather than requiring the developer to remember a potentially large number of
+with, rather than requiring you to remember a potentially large number of
 `@Configuration` classes during construction.
 
-[TIP]
-====
-As of Spring Framework 4.2, `@Import` also supports references to regular component
+TIP: As of Spring Framework 4.2, `@Import` also supports references regular component
 classes, analogous to the `AnnotationConfigApplicationContext.register` method.
-This is particularly useful if you'd like to avoid component scanning, using a few
-configuration classes as entry points for explicitly defining all your components.
-====
+This is particularly useful if you want to avoid component scanning, by using a few
+configuration classes as entry points to explicitly define all your components.
 
 [[beans-java-injecting-imported-beans]]
-===== Injecting dependencies on imported @Bean definitions
+===== Injecting Dependencies on Imported `@Bean` Definitions
 
-The example above works, but is simplistic. In most practical scenarios, beans will have
+The preceding example works but is simplistic. In most practical scenarios, beans have
 dependencies on one another across configuration classes. When using XML, this is not an
-issue, per se, because there is no compiler involved, and one can simply declare
-`ref="someBean"` and trust that Spring will work it out during container initialization.
-Of course, when using `@Configuration` classes, the Java compiler places constraints on
+issue, because no compiler is involved, and you can declare
+`ref="someBean"` and trust Spring to work it out during container initialization.
+When using `@Configuration` classes, the Java compiler places constraints on
 the configuration model, in that references to other beans must be valid Java syntax.
 
 Fortunately, solving this problem is simple. As <<beans-java-dependencies,we already discussed>>,
-`@Bean` method can have an arbitrary number of parameters describing the bean
-dependencies. Let's consider a more real-world scenario with several `@Configuration`
+a `@Bean` method can have an arbitrary number of parameters that describe the bean
+dependencies. Consider the following more real-world scenario with several `@Configuration`
 classes, each depending on beans declared in the others:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7117,24 +7562,28 @@ classes, each depending on beans declared in the others:
 		transferService.transfer(100.00, "A123", "C456");
 	}
 ----
+====
 
 There is another way to achieve the same result. Remember that `@Configuration` classes are
-ultimately just another bean in the container: This means that they can take advantage of
-`@Autowired` and `@Value` injection etc just like any other bean!
+ultimately only another bean in the container: This means that they can take advantage of
+`@Autowired` and `@Value` injection and other features the same as any other bean.
 
 [WARNING]
 ====
 Make sure that the dependencies you inject that way are of the simplest kind only. `@Configuration`
-classes are processed quite early during the initialization of the context and forcing a dependency
+classes are processed quite early during the initialization of the context, and forcing a dependency
 to be injected this way may lead to unexpected early initialization. Whenever possible, resort to
-parameter-based injection as in the example above.
+parameter-based injection, as in the preceding example.
 
 Also, be particularly careful with `BeanPostProcessor` and `BeanFactoryPostProcessor` definitions
-via `@Bean`. Those should usually be declared as `static @Bean` methods, not triggering the
-instantiation of their containing configuration class. Otherwise, `@Autowired` and `@Value` won't
-work on the configuration class itself since it is being created as a bean instance too early.
+through `@Bean`. Those should usually be declared as `static @Bean` methods, not triggering the
+instantiation of their containing configuration class. Otherwise, `@Autowired` and `@Value` do not
+work on the configuration class itself, since it is being created as a bean instance too early.
 ====
 
+The following example shows how one bean can be autowired to another bean:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7183,31 +7632,30 @@ work on the configuration class itself since it is being created as a bean insta
 		transferService.transfer(100.00, "A123", "C456");
 	}
 ----
+====
 
-[TIP]
-====
-Constructor injection in `@Configuration` classes is only supported as of Spring
+TIP: Constructor injection in `@Configuration` classes is only supported as of Spring
 Framework 4.3. Note also that there is no need to specify `@Autowired` if the target
-bean defines only one constructor; in the example above, `@Autowired` is not necessary
+bean defines only one constructor. In the preceding example, `@Autowired` is not necessary
 on the `RepositoryConfig` constructor.
-====
 
 .[[beans-java-injecting-imported-beans-fq]]Fully-qualifying imported beans for ease of navigation
 --
-In the scenario above, using `@Autowired` works well and provides the desired
+In the preceding scenario, using `@Autowired` works well and provides the desired
 modularity, but determining exactly where the autowired bean definitions are declared is
 still somewhat ambiguous. For example, as a developer looking at `ServiceConfig`, how do
-you know exactly where the `@Autowired AccountRepository` bean is declared? It's not
+you know exactly where the `@Autowired AccountRepository` bean is declared? It is not
 explicit in the code, and this may be just fine. Remember that the
 https://spring.io/tools/sts[Spring Tool Suite] provides tooling that
-can render graphs showing how everything is wired up - that may be all you need. Also,
-your Java IDE can easily find all declarations and uses of the `AccountRepository` type,
-and will quickly show you the location of `@Bean` methods that return that type.
+can render graphs showing how everything is wired, which may be all you need. Also,
+your Java IDE can easily find all declarations and uses of the `AccountRepository` type
+and quickly show you the location of `@Bean` methods that return that type.
 
 In cases where this ambiguity is not acceptable and you wish to have direct navigation
 from within your IDE from one `@Configuration` class to another, consider autowiring the
-configuration classes themselves:
+configuration classes themselves. The following example shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7224,12 +7672,14 @@ configuration classes themselves:
 		}
 	}
 ----
+====
 
-In the situation above, it is completely explicit where `AccountRepository` is defined.
-However, `ServiceConfig` is now tightly coupled to `RepositoryConfig`; that's the
+In the preceding situation, where `AccountRepository` is defined is completely explicit.
+However, `ServiceConfig` is now tightly coupled to `RepositoryConfig`. That is the
 tradeoff. This tight coupling can be somewhat mitigated by using interface-based or
-abstract class-based `@Configuration` classes. Consider the following:
+abstract class-based `@Configuration` classes. Consider the following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7278,42 +7728,42 @@ abstract class-based `@Configuration` classes. Consider the following:
 		transferService.transfer(100.00, "A123", "C456");
 	}
 ----
+====
 
 Now `ServiceConfig` is loosely coupled with respect to the concrete
-`DefaultRepositoryConfig`, and built-in IDE tooling is still useful: it will be easy for
-the developer to get a type hierarchy of `RepositoryConfig` implementations. In this
+`DefaultRepositoryConfig`, and built-in IDE tooling is still useful: You can easily
+get a type hierarchy of `RepositoryConfig` implementations. In this
 way, navigating `@Configuration` classes and their dependencies becomes no different
 than the usual process of navigating interface-based code.
 --
 
-[TIP]
-====
-If you would like to influence the startup creation order of certain beans, consider
+TIP: If you want to influence the startup creation order of certain beans, consider
 declaring some of them as `@Lazy` (for creation on first access instead of on startup)
-or as `@DependsOn` on certain other beans (making sure that specific other beans will
-be created before the current bean, beyond what the latter's direct dependencies imply).
-====
+or as `@DependsOn` certain other beans (making sure that specific other beans are
+created before the current bean, beyond what the latter's direct dependencies imply).
+
 
 
 [[beans-java-conditional]]
-==== Conditionally include @Configuration classes or @Bean methods
+==== Conditionally Include `@Configuration` Classes or `@Bean` Methods
 
-It is often useful to conditionally enable or disable a complete `@Configuration` class,
+It is often useful to conditionally enable or disable a complete `@Configuration` class
 or even individual `@Bean` methods, based on some arbitrary system state. One common
 example of this is to use the `@Profile` annotation to activate beans only when a specific
 profile has been enabled in the Spring `Environment` (see <<beans-definition-profiles>>
 for details).
 
-The `@Profile` annotation is actually implemented using a much more flexible annotation
+The `@Profile` annotation is actually implemented by using a much more flexible annotation
 called {api-spring-framework}/context/annotation/Conditional.html[`@Conditional`].
 The `@Conditional` annotation indicates specific
 `org.springframework.context.annotation.Condition` implementations that should be
 consulted before a `@Bean` is registered.
 
-Implementations of the `Condition` interface simply provide a `matches(...)`
-method that returns `true` or `false`. For example, here is the actual
+Implementations of the `Condition` interface provide a `matches(...)`
+method that returns `true` or `false`. For example, the following listing shows the actual
 `Condition` implementation used for `@Profile`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7334,40 +7784,44 @@ method that returns `true` or `false`. For example, here is the actual
 		return true;
 	}
 ----
+====
 
 See the {api-spring-framework}/context/annotation/Conditional.html[
-`@Conditional` javadocs] for more detail.
+`@Conditional` Javadoc] for more detail.
 
 
 [[beans-java-combining]]
-==== Combining Java and XML configuration
+==== Combining Java and XML Configuration
 
 Spring's `@Configuration` class support does not aim to be a 100% complete replacement
-for Spring XML. Some facilities such as Spring XML namespaces remain an ideal way to
+for Spring XML. Some facilities, such as Spring XML namespaces, remain an ideal way to
 configure the container. In cases where XML is convenient or necessary, you have a
-choice: either instantiate the container in an "XML-centric" way using, for example,
-`ClassPathXmlApplicationContext`, or in a "Java-centric" fashion using
+choice: either instantiate the container in an "`XML-centric`" way by using, for example,
+`ClassPathXmlApplicationContext`, or instantiate it in a "`Java-centric`" way by using
 `AnnotationConfigApplicationContext` and the `@ImportResource` annotation to import XML
 as needed.
 
 [[beans-java-combining-xml-centric]]
-===== XML-centric use of @Configuration classes
+===== XML-centric Use of `@Configuration` Classes
 
 It may be preferable to bootstrap the Spring container from XML and include
 `@Configuration` classes in an ad-hoc fashion. For example, in a large existing codebase
-that uses Spring XML, it will be easier to create `@Configuration` classes on an
-as-needed basis and include them from the existing XML files. Below you'll find the
-options for using `@Configuration` classes in this kind of "XML-centric" situation.
+that uses Spring XML, it is easier to create `@Configuration` classes on an
+as-needed basis and include them from the existing XML files. Later in this section, we cover the
+options for using `@Configuration` classes in this kind of "`XML-centric`" situation.
 
-.[[beans-java-combining-xml-centric-declare-as-bean]]Declaring @Configuration classes as plain Spring `<bean/>` elements
+.[[beans-java-combining-xml-centric-declare-as-bean]]Declaring `@Configuration` classes as plain Spring `<bean/>` elements
 --
-Remember that `@Configuration` classes are ultimately just bean definitions in the
-container. In this example, we create a `@Configuration` class named `AppConfig` and
+Remember that `@Configuration` classes are ultimately bean definitions in the
+container. In this series examples, we create a `@Configuration` class named `AppConfig` and
 include it within `system-test-config.xml` as a `<bean/>` definition. Because
-`<context:annotation-config/>` is switched on, the container will recognize the
-`@Configuration` annotation and process the `@Bean` methods declared in `AppConfig`
+`<context:annotation-config/>` is switched on, the container recognizes the
+`@Configuration` annotation and processes the `@Bean` methods declared in `AppConfig`
 properly.
 
+The following example shows an ordinary configuration class in Java:
+
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7388,9 +7842,11 @@ properly.
 		}
 	}
 ----
+====
 
-*system-test-config.xml*:
+The following example shows part of a sample `system-test-config.xml` file:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7408,9 +7864,11 @@ properly.
 		</bean>
 	</beans>
 ----
+====
 
-*jdbc.properties*:
+The following example shows a possible `jdbc.properties` file:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
@@ -7428,28 +7886,27 @@ jdbc.password=
 		// ...
 	}
 ----
+====
 
-[NOTE]
-====
-In `system-test-config.xml` above, the `AppConfig` `<bean/>` does not declare an `id`
-element. While it would be acceptable to do so, it is unnecessary given that no other
-bean will ever refer to it, and it is unlikely that it will be explicitly fetched from
-the container by name. Likewise with the `DataSource` bean - it is only ever autowired
+NOTE: In `system-test-config.xml` file, the `AppConfig` `<bean/>` does not declare an `id`
+element. While it would be acceptable to do so, it is unnecessary, given that no other
+bean ever refers to it, and it is unlikely to be explicitly fetched from
+the container by name. Similarly, the `DataSource` bean is only ever autowired
 by type, so an explicit bean `id` is not strictly required.
-====
 --
 
 .[[beans-java-combining-xml-centric-component-scan]] Using <context:component-scan/> to pick up `@Configuration` classes
 --
 Because `@Configuration` is meta-annotated with `@Component`, `@Configuration`-annotated
 classes are automatically candidates for component scanning. Using the same scenario as
-above, we can redefine `system-test-config.xml` to take advantage of component-scanning.
-Note that in this case, we don't need to explicitly declare
+describe in the previous example, we can redefine `system-test-config.xml` to take advantage of component-scanning.
+Note that, in this case, we need not explicitly declare
 `<context:annotation-config/>`, because `<context:component-scan/>` enables the same
 functionality.
 
-*system-test-config.xml*:
+The following example shows the modified `system-test-config.xml` file:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7465,17 +7922,22 @@ functionality.
 		</bean>
 	</beans>
 ----
+====
 --
 
 [[beans-java-combining-java-centric]]
-===== @Configuration class-centric use of XML with @ImportResource
+===== `@Configuration` Class-centric Use of XML with `@ImportResource`
 
 In applications where `@Configuration` classes are the primary mechanism for configuring
-the container, it will still likely be necessary to use at least some XML. In these
-scenarios, simply use `@ImportResource` and define only as much XML as is needed. Doing
-so achieves a "Java-centric" approach to configuring the container and keeps XML to a
-bare minimum.
+the container, it is still likely necessary to use at least some XML. In these
+scenarios, you can use `@ImportResource` and define only as much XML as you need. Doing
+so achieves a "`Java-centric`" approach to configuring the container and keeps XML to a
+bare minimum. The following example (which includes a configuration class, an XML file
+that defines a bean, a properties file, and the `main` class) shows how to use
+the `@ImportResource` annotation to achieve "`Java-centric`" configuration that uses XML
+as needed:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7526,27 +7988,27 @@ jdbc.password=
 		// ...
 	}
 ----
-
+====
 
 
 
 [[beans-environment]]
-== Environment abstraction
+== Environment Abstraction
 
-The {api-spring-framework}/core/env/Environment.html[`Environment`]
+The {api-spring-framework}/core/env/Environment.html[`Environment`] interface
 is an abstraction integrated in the container that models two key
-aspects of the application environment: <<beans-definition-profiles,_profiles_>>
-and <<beans-property-source-abstraction,_properties_>>.
+aspects of the application environment: <<beans-definition-profiles,profiles>>
+and <<beans-property-source-abstraction,properties>>.
 
-A _profile_ is a named, logical group of bean definitions to be registered with the
+A profile is a named, logical group of bean definitions to be registered with the
 container only if the given profile is active. Beans may be assigned to a profile
-whether defined in XML or via annotations. The role of the `Environment` object with
+whether defined in XML or with annotations. The role of the `Environment` object with
 relation to profiles is in determining which profiles (if any) are currently active,
 and which profiles (if any) should be active by default.
 
-Properties play an important role in almost all applications, and may originate from
+Properties play an important role in almost all applications and may originate from
 a variety of sources: properties files, JVM system properties, system environment
-variables, JNDI, servlet context parameters, ad-hoc Properties objects, Maps, and so
+variables, JNDI, servlet context parameters, ad-hoc `Properties` objects, `Map` objects, and so
 on. The role of the `Environment` object with relation to properties is to provide the
 user with a convenient service interface for configuring property sources and resolving
 properties from them.
@@ -7554,23 +8016,24 @@ properties from them.
 
 
 [[beans-definition-profiles]]
-=== Bean definition profiles
+=== Bean Definition Profiles
 
-Bean definition profiles is a mechanism in the core container that allows for
-registration of different beans in different environments. The word _environment_
-can mean different things to different users and this feature can help with many
+Bean definition profiles provide a mechanism in the core container that allows for
+registration of different beans in different environments. The word, "`environment,`"
+can mean different things to different users, and this feature can help with many
 use cases, including:
 
-* working against an in-memory datasource in development vs looking up that same
-datasource from JNDI when in QA or production
-* registering monitoring infrastructure only when deploying an application into a
-performance environment
-* registering customized implementations of beans for customer A vs. customer
-B deployments
+* Working against an in-memory datasource in development versus looking up that same
+datasource from JNDI when in QA or production.
+* Registering monitoring infrastructure only when deploying an application into a
+performance environment.
+* Registering customized implementations of beans for customer A versus customer
+B deployments.
 
-Let's consider the first use case in a practical application that requires a
-`DataSource`. In a test environment, the configuration may look like this:
+Consider the first use case in a practical application that requires a
+`DataSource`. In a test environment, the configuration might resemble the following:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7583,12 +8046,14 @@ Let's consider the first use case in a practical application that requires a
 			.build();
 	}
 ----
+====
 
-Let's now consider how this application will be deployed into a QA or production
-environment, assuming that the datasource for the application will be registered
+Now consider how this application can be deployed into a QA or production
+environment, assuming that the datasource for the application is registered
 with the production application server's JNDI directory. Our `dataSource` bean
-now looks like this:
+now looks like the following listing:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7598,6 +8063,7 @@ now looks like this:
 		return (DataSource) ctx.lookup("java:comp/env/jdbc/datasource");
 	}
 ----
+====
 
 The problem is how to switch between using these two variations based on the
 current environment. Over time, Spring users have devised a number of ways to
@@ -7607,22 +8073,24 @@ to the correct configuration file path depending on the value of an environment
 variable. Bean definition profiles is a core container feature that provides a
 solution to this problem.
 
-If we generalize the example use case above of environment-specific bean
+If we generalize the use case shown in the preceding example of environment-specific bean
 definitions, we end up with the need to register certain bean definitions in
-certain contexts, while not in others. You could say that you want to register a
-certain profile of bean definitions in situation A, and a different profile in
-situation B. Let's first see how we can update our configuration to reflect
+certain contexts but not in others. You could say that you want to register a
+certain profile of bean definitions in situation A and a different profile in
+situation B. We start by updating our configuration to reflect
 this need.
 
 
+
 [[beans-definition-profiles-java]]
-==== @Profile
+==== Using `@Profile`
 
 The {api-spring-framework}/context/annotation/Profile.html[`@Profile`]
-annotation allows you to indicate that a component is eligible for registration
-when one or more specified profiles are active. Using our example above, we
+annotation lets you indicate that a component is eligible for registration
+when one or more specified profiles are active. Using our preceding example, we
 can rewrite the `dataSource` configuration as follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7655,36 +8123,32 @@ can rewrite the `dataSource` configuration as follows:
 		}
 	}
 ----
-
-[NOTE]
-====
-As mentioned before, with `@Bean` methods, you will typically choose to use programmatic
-JNDI lookups: either using Spring's `JndiTemplate`/`JndiLocatorDelegate` helpers or the
-straight JNDI `InitialContext` usage shown above, but not the `JndiObjectFactoryBean`
-variant which would force you to declare the return type as the `FactoryBean` type.
 ====
 
-The profile string may contain a simple profile name (for example `production`) or a
+NOTE: As mentioned earlier, with `@Bean` methods, you typically choose to use programmatic
+JNDI lookups, by using either Spring's `JndiTemplate`/`JndiLocatorDelegate` helpers or the
+straight JNDI `InitialContext` usage shown earlier but not the `JndiObjectFactoryBean`
+variant, which would force you to declare the return type as the `FactoryBean` type.
+
+The profile string may contain a simple profile name (for example, `production`) or a
 profile expression. A profile expression allows for more complicated profile logic to be
-expressed, for example `production & us-east`. The following operators are supported in
+expressed (for example, `production & us-east`). The following operators are supported in
 profile expressions:
 
-* `!` - A logical _not_ of the profile
-* `&` - A logical _and_ of the profiles
-* `|` - A logical _or_ of the profiles
+* `!`: A logical "`not`" of the profile
+* `&`: A logical "`and`" of the profiles
+* `|`_ A logical "`or`" of the profiles
 
-[NOTE]
-====
-The `&` and `|` operators may not be mixed without using parentheses. For example
-`production & us-east | eu-central` is not a valid expression; it must be expressed as
+NOTE: You cannot mix the `&` and `|` operators without using parentheses. For example,
+`production & us-east | eu-central` is not a valid expression. It must be expressed as
 `production & (us-east | eu-central)`.
-====
 
-`@Profile` can be used as a <<beans-meta-annotations,meta-annotation>> for the purpose
-of creating a custom _composed annotation_. The following example defines a custom
-`@Production` annotation that can be used as a drop-in replacement for
+You can use `@Profile` as a <<beans-meta-annotations,meta-annotation>> for the purpose
+of creating a custom composed annotation. The following example defines a custom
+`@Production` annotation that you can use as a drop-in replacement for
 `@Profile("production")`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7694,22 +8158,22 @@ of creating a custom _composed annotation_. The following example defines a cust
 	public @interface Production {
 	}
 ----
-
-[TIP]
 ====
-If a `@Configuration` class is marked with `@Profile`, all of the `@Bean` methods and
-`@Import` annotations associated with that class will be bypassed unless one or more of
+
+TIP: If a `@Configuration` class is marked with `@Profile`, all of the `@Bean` methods and
+`@Import` annotations associated with that class are bypassed unless one or more of
 the specified profiles are active. If a `@Component` or `@Configuration` class is marked
-with `@Profile({"p1", "p2"})`, that class will not be registered/processed unless
-profiles 'p1' and/or 'p2' have been activated. If a given profile is prefixed with the
-NOT operator (`!`), the annotated element will be registered if the profile is **not**
+with `@Profile({"p1", "p2"})`, that class is not registered or processed unless
+profiles 'p1' or 'p2' have been activated. If a given profile is prefixed with the
+NOT operator (`!`), the annotated element is registered only if the profile is not
 active. For example, given `@Profile({"p1", "!p2"})`, registration will occur if profile
 'p1' is active or if profile 'p2' is not active.
-====
 
 `@Profile` can also be declared at the method level to include only one particular bean
-of a configuration class, e.g. for alternative variants of a particular bean:
+of a configuration class (for example, for alternative variants of a particular bean), as
+the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7717,7 +8181,7 @@ of a configuration class, e.g. for alternative variants of a particular bean:
 	public class AppConfig {
 
 		@Bean("dataSource")
-		**@Profile("development")**
+		@Profile("development")                                               <1>
 		public DataSource standaloneDataSource() {
 			return new EmbeddedDatabaseBuilder()
 				.setType(EmbeddedDatabaseType.HSQL)
@@ -7734,33 +8198,37 @@ of a configuration class, e.g. for alternative variants of a particular bean:
 		}
 	}
 ----
+<1> The `standaloneDataSource` method is available only in the `development` profile.
+====
 
 [NOTE]
 ====
 With `@Profile` on `@Bean` methods, a special scenario may apply: In the case of
 overloaded `@Bean` methods of the same Java method name (analogous to constructor
-overloading), an `@Profile` condition needs to be consistently declared on all
+overloading), a `@Profile` condition needs to be consistently declared on all
 overloaded methods. If the conditions are inconsistent, only the condition on the
-first declaration among the overloaded methods will matter. `@Profile` can therefore
+first declaration among the overloaded methods matters. Therefore, `@Profile` can
 not be used to select an overloaded method with a particular argument signature over
-another; resolution between all factory methods for the same bean follows Spring's
+another. Resolution between all factory methods for the same bean follows Spring's
 constructor resolution algorithm at creation time.
 
-If you would like to define alternative beans with different profile conditions,
-use distinct Java method names pointing to the same bean name via the `@Bean` name
-attribute, as indicated in the example above. If the argument signatures are all
-the same (e.g. all of the variants have no-arg factory methods), this is the only
+If you want to define alternative beans with different profile conditions,
+use distinct Java method names that point to the same bean name by using the `@Bean` name
+attribute, as shown in the preceding example. If the argument signatures are all
+the same (for example, all of the variants have no-arg factory methods), this is the only
 way to represent such an arrangement in a valid Java class in the first place
 (since there can only be one method of a particular name and argument signature).
 ====
 
 
+
 [[beans-definition-profiles-xml]]
-==== XML bean definition profiles
+==== XML Bean Definition Profiles
 
-The XML counterpart is the `profile` attribute of the `<beans>` element. Our sample
-configuration above can be rewritten in two XML files as follows:
+The XML counterpart is the `profile` attribute of the `<beans>` element. Our preceding sample
+configuration can be rewritten in two XML files, as follows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7789,9 +8257,12 @@ configuration above can be rewritten in two XML files as follows:
 		<jee:jndi-lookup id="dataSource" jndi-name="java:comp/env/jdbc/datasource"/>
 	</beans>
 ----
+====
 
-It is also possible to avoid that split and nest `<beans/>` elements within the same file:
+It is also possible to avoid that split and nest `<beans/>` elements within the same file,
+as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7815,17 +8286,19 @@ It is also possible to avoid that split and nest `<beans/>` elements within the 
 		</beans>
 	</beans>
 ----
+====
 
 The `spring-bean.xsd` has been constrained to allow such elements only as the
 last ones in the file. This should help provide flexibility without incurring
 clutter in the XML files.
 
 [NOTE]
-====
-The XML counterpart does not support profile expressions described above. It is possible
-however to negate a profile using the `!` operator. It is also possible to apply a logical
-and by nesting the profiles:
+=====
+The XML counterpart does not support the profile expressions described earlier. It is possible,
+however, to negate a profile by using the `!` operator. It is also possible to apply a logical
+"`and`" by nesting the profiles, as the following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7844,14 +8317,15 @@ and by nesting the profiles:
 		</beans>
 	</beans>
 ----
-
-In the example above, the `dataSource` bean will be exposed if both the `production` and
-`us-east` profiles are active.
 ====
+
+In the preceding example, the `dataSource` bean is exposed if both the `production` and
+`us-east` profiles are active.
+=====
 
 
 [[beans-definition-profiles-enable]]
-==== Activating a profile
+==== Activating a Profile
 
 Now that we have updated our configuration, we still need to instruct Spring which
 profile is active. If we started our sample application right now, we would see
@@ -7859,9 +8333,10 @@ a `NoSuchBeanDefinitionException` thrown, because the container could not find
 the Spring bean named `dataSource`.
 
 Activating a profile can be done in several ways, but the most straightforward is to do
-it programmatically against the `Environment` API which is available via an
-`ApplicationContext`:
+it programmatically against the `Environment` API which is available through an
+`ApplicationContext`. The following example shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7870,40 +8345,49 @@ it programmatically against the `Environment` API which is available via an
 	ctx.register(SomeConfig.class, StandaloneDataConfig.class, JndiDataConfig.class);
 	ctx.refresh();
 ----
+====
 
-In addition, profiles may also be activated declaratively through the
-`spring.profiles.active` property which may be specified through system environment
+In addition, you can also declaratively activate profiles through the
+`spring.profiles.active` property, which may be specified through system environment
 variables, JVM system properties, servlet context parameters in `web.xml`, or even as an
 entry in JNDI (see <<beans-property-source-abstraction>>). In integration tests, active
-profiles can be declared via the `@ActiveProfiles` annotation in the `spring-test` module
+profiles can be declared by using the `@ActiveProfiles` annotation in the `spring-test` module
 (see <<testing.adoc#testcontext-ctx-management-env-profiles,
 Context configuration with environment profiles>>).
 
-Note that profiles are not an "either-or" proposition; it is possible to activate multiple
-profiles at once. Programmatically, simply provide multiple profile names to the
-`setActiveProfiles()` method, which accepts `String...` varargs:
+Note that profiles are not an "`either-or`" proposition. You can activate multiple
+profiles at once. Programmatically, you can provide multiple profile names to the
+`setActiveProfiles()` method, which accepts `String...` varargs. The following example
+activates multiple profiles:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	ctx.getEnvironment().setActiveProfiles("profile1", "profile2");
 ----
+====
 
-Declaratively, `spring.profiles.active` may accept a comma-separated list of profile names:
+Declaratively, `spring.profiles.active` may accept a comma-separated list of profile names,
+as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	-Dspring.profiles.active="profile1,profile2"
 ----
+====
+
 
 
 [[beans-definition-profiles-default]]
-==== Default profile
+==== Default Profile
 
-The _default_ profile represents the profile that is enabled by default. Consider the
-following:
+The default profile represents the profile that is enabled by default. Consider the
+following example:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7920,76 +8404,77 @@ following:
 		}
 	}
 ----
+====
 
-If no profile is active, the `dataSource` above will be created; this can be
-seen as a way to provide a _default_ definition for one or more beans. If any
-profile is enabled, the _default_ profile will not apply.
+If no profile is active, the `dataSource` is created. You can see this
+as a way to provide a default definition for one or more beans. If any
+profile is enabled, the default profile does not apply.
 
-The name of the default profile can be changed using `setDefaultProfiles()` on
-the `Environment` or declaratively using the `spring.profiles.default` property.
+You can change the name of the default profile by using `setDefaultProfiles()` on
+the `Environment` or ,declaratively, by using the `spring.profiles.default` property.
 
 
 
 [[beans-property-source-abstraction]]
-=== PropertySource abstraction
+=== `PropertySource` abstraction
 
 Spring's `Environment` abstraction provides search operations over a configurable
-hierarchy of property sources. To explain fully, consider the following:
+hierarchy of property sources. Consider the following listing:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 ApplicationContext ctx = new GenericApplicationContext();
 Environment env = ctx.getEnvironment();
-boolean containsFoo = env.containsProperty("foo");
-System.out.println("Does my environment contain the 'foo' property? " + containsFoo);
+boolean containsMyProperty = env.containsProperty("my-property");
+System.out.println("Does my environment contain the 'my-property' property? " + containsMyProperty);
 ----
+====
 
-In the snippet above, we see a high-level way of asking Spring whether the `foo` property is
+In the preceding snippet, we see a high-level way of asking Spring whether the `my-property` property is
 defined for the current environment. To answer this question, the `Environment` object performs
 a search over a set of {api-spring-framework}/core/env/PropertySource.html[`PropertySource`]
 objects. A `PropertySource` is a simple abstraction over any source of key-value pairs, and
 Spring's {api-spring-framework}/core/env/StandardEnvironment.html[`StandardEnvironment`]
 is configured with two PropertySource objects -- one representing the set of JVM system properties
-(_a la_ `System.getProperties()`) and one representing the set of system environment variables
-(_a la_ `System.getenv()`).
+(`System.getProperties()`) and one representing the set of system environment variables
+(`System.getenv()`).
 
-[NOTE]
-====
-These default property sources are present for `StandardEnvironment`, for use in standalone
+NOTE: These default property sources are present for `StandardEnvironment`, for use in standalone
 applications. {api-spring-framework}/web/context/support/StandardServletEnvironment.html[`StandardServletEnvironment`]
 is populated with additional default property sources including servlet config and servlet
 context parameters. It can optionally enable a {api-spring-framework}/jndi/JndiPropertySource.html[`JndiPropertySource`].
-See the javadocs for details.
-====
+See the Javadoc for details.
 
-Concretely, when using the `StandardEnvironment`, the call to `env.containsProperty("foo")`
-will return true if a `foo` system property or `foo` environment variable is present at
+Concretely, when you use the `StandardEnvironment`, the call to `env.containsProperty("my-property")`
+returns true if a `my-property` system property or `my-propertyi` environment variable is present at
 runtime.
 
 [TIP]
 ====
 The search performed is hierarchical. By default, system properties have precedence over
-environment variables, so if the `foo` property happens to be set in both places during
-a call to `env.getProperty("foo")`, the system property value will 'win' and be returned
-preferentially over the environment variable. Note that property values will not get merged
+environment variables. So, if the `my-property` property happens to be set in both places during
+a call to `env.getProperty("my-property")`, the system property value "`wins`" and is returned.
+Note that property values are not merged
 but rather completely overridden by a preceding entry.
 
-For a common `StandardServletEnvironment`, the full hierarchy looks as follows, with the
+For a common `StandardServletEnvironment`, the full hierarchy is as follows, with the
 highest-precedence entries at the top:
 
-* ServletConfig parameters (if applicable, e.g. in case of a `DispatcherServlet` context)
-* ServletContext parameters (web.xml context-param entries)
-* JNDI environment variables ("java:comp/env/" entries)
-* JVM system properties ("-D" command-line arguments)
-* JVM system environment (operating system environment variables)
+. ServletConfig parameters (if applicable -- for example, in case of a `DispatcherServlet` context)
+. ServletContext parameters (web.xml context-param entries)
+. JNDI environment variables (`java:comp/env/` entries)
+. JVM system properties (`-D` command-line arguments)
+. JVM system environment (operating system environment variables)
 ====
 
 Most importantly, the entire mechanism is configurable. Perhaps you have a custom source
-of properties that you'd like to integrate into this search. No problem -- simply implement
+of properties that you want to integrate into this search. To do so, implement
 and instantiate your own `PropertySource` and add it to the set of `PropertySources` for the
-current `Environment`:
+current `Environment`. The following example shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -7997,26 +8482,29 @@ ConfigurableApplicationContext ctx = new GenericApplicationContext();
 MutablePropertySources sources = ctx.getEnvironment().getPropertySources();
 sources.addFirst(new MyPropertySource());
 ----
+====
 
-In the code above, `MyPropertySource` has been added with highest precedence in the
-search. If it contains a  `foo` property, it will be detected and returned ahead of
-any `foo` property in any other `PropertySource`. The
+In the preceding code, `MyPropertySource` has been added with highest precedence in the
+search. If it contains a  `my-property` property, the property is detected and returned, in favor of
+any `my-property` property in any other `PropertySource`. The
 {api-spring-framework}/core/env/MutablePropertySources.html[`MutablePropertySources`]
 API exposes a number of methods that allow for precise manipulation of the set of
 property sources.
 
 
 
-=== @PropertySource
+[[beans-using-propertysource]]
+=== Using `@PropertySource`
 
 The {api-spring-framework}/context/annotation/PropertySource.html[`@PropertySource`]
 annotation provides a convenient and declarative mechanism for adding a `PropertySource`
 to Spring's `Environment`.
 
-Given a file "app.properties" containing the key/value pair `testbean.name=myTestBean`,
+Given a file called `app.properties` that contains the key-value pair `testbean.name=myTestBean`,
 the following `@Configuration` class uses `@PropertySource` in such a way that
-a call to `testBean.getName()` will return "myTestBean".
+a call to `testBean.getName()` returns `myTestBean`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8035,11 +8523,13 @@ a call to `testBean.getName()` will return "myTestBean".
 	   }
    }
 ----
+====
 
-Any `${...}` placeholders present in a `@PropertySource` resource location will
-be resolved against the set of property sources already registered against the
-environment. For example:
+Any `${...}` placeholders present in a `@PropertySource` resource location are
+resolved against the set of property sources already registered against the
+environment, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8058,37 +8548,37 @@ environment. For example:
 	   }
    }
 ----
+====
 
-Assuming that "my.placeholder" is present in one of the property sources already
-registered, e.g. system properties or environment variables, the placeholder will
-be resolved to the corresponding value. If not, then "default/path" will be used
+Assuming that `my.placeholder` is present in one of the property sources already
+registered (for example, system properties or environment variables), the placeholder is
+resolved to the corresponding value. If not, then `default/path` is used
 as a default. If no default is specified and a property cannot be resolved, an
-`IllegalArgumentException` will be thrown.
+`IllegalArgumentException` is thrown.
 
-[NOTE]
-====
-The `@PropertySource` annotation is repeatable according to Java 8 conventions.
+NOTE: The `@PropertySource` annotation is repeatable, according to Java 8 conventions.
 However, all such `@PropertySource` annotations need to be declared at the same
-level: either directly on the configuration class or as meta-annotations within the
-same custom annotation. Mixing of direct annotations and meta-annotations is not
-recommended since direct annotations will effectively override meta-annotations.
-====
+level, either directly on the configuration class or as meta-annotations within the
+same custom annotation. Mixing direct annotations and meta-annotations is not
+recommended, since direct annotations effectively override meta-annotations.
 
 
 
-=== Placeholder resolution in statements
+[[beans-placeholder-resolution-in-statements]]
+=== Placeholder Resolution in Statements
 
 Historically, the value of placeholders in elements could be resolved only against
-JVM system properties or environment variables. No longer is this the case. Because
-the Environment abstraction is integrated throughout the container, it's easy to
+JVM system properties or environment variables. This is no longer the case. Because
+the `Environment` abstraction is integrated throughout the container, it is easy to
 route resolution of placeholders through it. This means that you may configure the
-resolution process in any way you like: change the precedence of searching through
-system properties and environment variables, or remove them entirely; add your
-own property sources to the mix as appropriate.
+resolution process in any way you like. You can change the precedence of searching through
+system properties and environment variables or remove them entirely. You can also add your
+own property sources to the mix, as appropriate.
 
 Concretely, the following statement works regardless of where the `customer`
 property is defined, as long as it is available in the `Environment`:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8096,19 +8586,20 @@ property is defined, as long as it is available in the `Environment`:
 		<import resource="com/bank/service/${customer}-config.xml"/>
 	</beans>
 ----
-
+====
 
 
 
 [[context-load-time-weaver]]
-== Registering a LoadTimeWeaver
+== Registering a `LoadTimeWeaver`
 
 The `LoadTimeWeaver` is used by Spring to dynamically transform classes as they are
 loaded into the Java virtual machine (JVM).
 
-To enable load-time weaving add the `@EnableLoadTimeWeaving` to one of your
-`@Configuration` classes:
+To enable load-time weaving, you can add the `@EnableLoadTimeWeaving` to one of your
+`@Configuration` classes, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8117,9 +8608,11 @@ To enable load-time weaving add the `@EnableLoadTimeWeaving` to one of your
 	public class AppConfig {
 	}
 ----
+====
 
-Alternatively for XML configuration use the `context:load-time-weaver` element:
+Alternatively, for XML configuration, you can use the `context:load-time-weaver` element:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8127,52 +8620,52 @@ Alternatively for XML configuration use the `context:load-time-weaver` element:
 		<context:load-time-weaver/>
 	</beans>
 ----
+====
 
-Once configured for the `ApplicationContext`. Any bean within that `ApplicationContext`
+Once configured for the `ApplicationContext`, any bean within that `ApplicationContext`
 may implement `LoadTimeWeaverAware`, thereby receiving a reference to the load-time
 weaver instance. This is particularly useful in combination with
 <<data-access.adoc#orm-jpa,Spring's JPA support>> where load-time weaving may be necessary
 for JPA class transformation.
-Consult the `LocalContainerEntityManagerFactoryBean` javadocs for more detail. For more on
+Consult the {api-spring-framework}/orm/jpa/LocalContainerEntityManagerFactoryBean.html[`LocalContainerEntityManagerFactoryBean` Javadoc] for more detail. For more on
 AspectJ load-time weaving, see <<aop-aj-ltw>>.
 
 
 
-
 [[context-introduction]]
-== Additional capabilities of the ApplicationContext
+== Additional Capabilities of the `ApplicationContext`
 
-As was discussed in the chapter introduction, the `org.springframework.beans.factory`
+As discussed in the <<beans,chapter introduction>>, the `org.springframework.beans.factory`
 package provides basic functionality for managing and manipulating beans, including in a
 programmatic way. The `org.springframework.context` package adds the
 {api-spring-framework}/context/ApplicationContext.html[`ApplicationContext`]
 interface, which extends the `BeanFactory` interface, in addition to extending other
-interfaces to provide additional functionality in a more __application
-framework-oriented style__. Many people use the `ApplicationContext` in a completely
+interfaces to provide additional functionality in a more application
+framework-oriented style. Many people use the `ApplicationContext` in a completely
 declarative fashion, not even creating it programmatically, but instead relying on
 support classes such as `ContextLoader` to automatically instantiate an
 `ApplicationContext` as part of the normal startup process of a Java EE web application.
 
-To enhance `BeanFactory` functionality in a more framework-oriented style the context
+To enhance `BeanFactory` functionality in a more framework-oriented style, the context
 package also provides the following functionality:
 
-* __Access to messages in i18n-style__, through the `MessageSource` interface.
-* __Access to resources__, such as URLs and files, through the `ResourceLoader` interface.
-* __Event publication__ to namely beans implementing the `ApplicationListener` interface,
+* Access to messages in i18n-style, through the `MessageSource` interface.
+* Access to resources, such as URLs and files, through the `ResourceLoader` interface.
+* Event publication, namely to beans that implement the `ApplicationListener` interface,
   through the use of the `ApplicationEventPublisher` interface.
-* __Loading of multiple (hierarchical) contexts__, allowing each to be focused on one
+* Loading of multiple (hierarchical) contexts, letting each be focused on one
   particular layer, such as the web layer of an application, through the
   `HierarchicalBeanFactory` interface.
 
 
 
 [[context-functionality-messagesource]]
-=== Internationalization using MessageSource
+=== Internationalization using `MessageSource`
 
-The `ApplicationContext` interface extends an interface called `MessageSource`, and
-therefore provides internationalization (i18n) functionality. Spring also provides the
-interface `HierarchicalMessageSource`, which can resolve messages hierarchically.
-Together these interfaces provide the foundation upon which Spring effects message
+The `ApplicationContext` interface extends an interface called `MessageSource` and,
+therefore, provides internationalization ("`i18n`") functionality. Spring also provides the
+`HierarchicalMessageSource` interface, which can resolve messages hierarchically.
+Together, these interfaces provide the foundation upon which Spring effects message
 resolution. The methods defined on these interfaces include:
 
 * `String getMessage(String code, Object[] args, String default, Locale loc)`: The basic
@@ -8181,7 +8674,7 @@ resolution. The methods defined on these interfaces include:
   replacement values, using the `MessageFormat` functionality provided by the standard
   library.
 * `String getMessage(String code, Object[] args, Locale loc)`: Essentially the same as
-  the previous method, but with one difference: no default message can be specified; if
+  the previous method but with one difference: No default message can be specified. If
   the message cannot be found, a `NoSuchMessageException` is thrown.
 * `String getMessage(MessageSourceResolvable resolvable, Locale locale)`: All properties
   used in the preceding methods are also wrapped in a class named
@@ -8199,9 +8692,9 @@ methods defined above.
 Spring provides two `MessageSource` implementations, `ResourceBundleMessageSource` and
 `StaticMessageSource`. Both implement `HierarchicalMessageSource` in order to do nested
 messaging. The `StaticMessageSource` is rarely used but provides programmatic ways to
-add messages to the source. The `ResourceBundleMessageSource` is shown in the following
-example:
+add messages to the source. The following example shows `ResourceBundleMessageSource`:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8218,13 +8711,15 @@ example:
 		</bean>
 	</beans>
 ----
+====
 
-In the example it is assumed you have three resource bundles defined in your classpath
-called `format`, `exceptions` and `windows`. Any request to resolve a message will be
-handled in the JDK standard way of resolving messages through ResourceBundles. For the
+The example assumes that you have three resource bundles called `format`, `exceptions` and `windows`
+defined in your classpath. Any request to resolve a message is
+handled in the JDK-standard way of resolving messages through `ResourceBundle` objects. For the
 purposes of the example, assume the contents of two of the above resource bundle files
-are...
+are as follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8238,11 +8733,13 @@ are...
 	# in exceptions.properties
 	argument.required=The {0} argument is required.
 ----
+====
 
-A program to execute the `MessageSource` functionality is shown in the next example.
+The next example shows a program to execute the `MessageSource` functionality.
 Remember that all `ApplicationContext` implementations are also `MessageSource`
 implementations and so can be cast to the `MessageSource` interface.
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8252,25 +8749,29 @@ implementations and so can be cast to the `MessageSource` interface.
 		System.out.println(message);
 	}
 ----
+====
 
-The resulting output from the above program will be...
+The resulting output from the above program is as follows:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
 Alligators rock!
 ----
+====
 
-So to summarize, the `MessageSource` is defined in a file called `beans.xml`, which
+To summarize, the `MessageSource` is defined in a file called `beans.xml`, which
 exists at the root of your classpath. The `messageSource` bean definition refers to a
 number of resource bundles through its `basenames` property. The three files that are
 passed in the list to the `basenames` property exist as files at the root of your
 classpath and are called `format.properties`, `exceptions.properties`, and
-`windows.properties` respectively.
+`windows.properties`, respectively.
 
-The next example shows arguments passed to the message lookup; these arguments will be
-converted into Strings and inserted into placeholders in the lookup message.
+The next example shows arguments passed to the message lookup. These arguments are
+converted into `String` objects and inserted into placeholders in the lookup message.
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8282,7 +8783,7 @@ converted into Strings and inserted into placeholders in the lookup message.
 		</bean>
 
 		<!-- lets inject the above MessageSource into this POJO -->
-		<bean id="example" class="com.foo.Example">
+		<bean id="example" class="com.something.Example">
 			<property name="messages" ref="messageSource"/>
 		</bean>
 
@@ -8307,26 +8808,30 @@ converted into Strings and inserted into placeholders in the lookup message.
 		}
 	}
 ----
+====
 
-The resulting output from the invocation of the `execute()` method will be...
+The resulting output from the invocation of the `execute()` method is as follows:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
 The userDao argument is required.
 ----
+====
 
-With regard to internationalization (i18n), Spring's various `MessageSource`
+With regard to internationalization ("`i18n`"), Spring's various `MessageSource`
 implementations follow the same locale resolution and fallback rules as the standard JDK
 `ResourceBundle`. In short, and continuing with the example `messageSource` defined
 previously, if you want to resolve messages against the British (`en-GB`) locale, you
 would create files called `format_en_GB.properties`, `exceptions_en_GB.properties`, and
-`windows_en_GB.properties` respectively.
+`windows_en_GB.properties`, respectively.
 
 Typically, locale resolution is managed by the surrounding environment of the
-application. In this example, the locale against which (British) messages will be
-resolved is specified manually.
+application. In the following example, the locale against which (British) messages are
+resolved is specified manually:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
@@ -8344,52 +8849,49 @@ argument.required=Ebagum lad, the {0} argument is required, I say, required.
 		System.out.println(message);
 	}
 ----
+====
 
-The resulting output from the running of the above program will be...
+The resulting output from the running of the above program is as follows:
 
+====
 [literal]
 [subs="verbatim,quotes"]
 ----
 Ebagum lad, the 'userDao' argument is required, I say, required.
 ----
+====
 
 You can also use the `MessageSourceAware` interface to acquire a reference to any
 `MessageSource` that has been defined. Any bean that is defined in an
 `ApplicationContext` that implements the `MessageSourceAware` interface is injected with
 the application context's `MessageSource` when the bean is created and configured.
 
-[NOTE]
-====
-__As an alternative to `ResourceBundleMessageSource`, Spring provides a
+NOTE: As an alternative to `ResourceBundleMessageSource`, Spring provides a
 `ReloadableResourceBundleMessageSource` class. This variant supports the same bundle
 file format but is more flexible than the standard JDK based
-`ResourceBundleMessageSource` implementation.__ In particular, it allows for reading
-files from any Spring resource location (not just from the classpath) and supports hot
-reloading of bundle property files (while efficiently caching them in between). Check
-out the `ReloadableResourceBundleMessageSource` javadocs for details.
-====
+`ResourceBundleMessageSource` implementation. In particular, it allows for reading
+files from any Spring resource location (not only from the classpath) and supports hot
+reloading of bundle property files (while efficiently caching them in between).
+See the {api-spring-framework}/context/support/ReloadableResourceBundleMessageSource.html[`ReloadableResourceBundleMessageSource` Javadoc] for details.
 
 
 
 [[context-functionality-events]]
-=== Standard and custom events
+=== Standard and Custom Events
 
 Event handling in the `ApplicationContext` is provided through the `ApplicationEvent`
-class and `ApplicationListener` interface. If a bean that implements the
+class and the `ApplicationListener` interface. If a bean that implements the
 `ApplicationListener` interface is deployed into the context, every time an
 `ApplicationEvent` gets published to the `ApplicationContext`, that bean is notified.
-Essentially, this is the standard __Observer__ design pattern.
+Essentially, this is the standard Observer design pattern.
 
-[TIP]
-====
-As of Spring 4.2, the event infrastructure has been significantly improved and offer
+TIP: As of Spring 4.2, the event infrastructure has been significantly improved and offers
 an <<context-functionality-events-annotation,annotation-based model>> as well as the
-ability to publish any arbitrary event, that is an object that does not necessarily
-extend from `ApplicationEvent`. When such an object is published we wrap it in an
+ability to publish any arbitrary event (that is, an object that does not necessarily
+extend from `ApplicationEvent`). When such an object is published, we wrap it in an
 event for you.
-====
 
-Spring provides the following standard events:
+The following table describes the standard events that Spring provides:
 
 [[beans-ctx-events-tbl]]
 .Built-in Events
@@ -8397,44 +8899,45 @@ Spring provides the following standard events:
 | Event| Explanation
 
 | `ContextRefreshedEvent`
-| Published when the `ApplicationContext` is initialized or refreshed, for example,
-  using the `refresh()` method on the `ConfigurableApplicationContext` interface.
-  "Initialized" here means that all beans are loaded, post-processor beans are detected
+| Published when the `ApplicationContext` is initialized or refreshed (for example, by
+  using the `refresh()` method on the `ConfigurableApplicationContext` interface).
+  Here, "`initialized`" means that all beans are loaded, post-processor beans are detected
   and activated, singletons are pre-instantiated, and the `ApplicationContext` object is
   ready for use. As long as the context has not been closed, a refresh can be triggered
   multiple times, provided that the chosen `ApplicationContext` actually supports such
-  "hot" refreshes. For example, `XmlWebApplicationContext` supports hot refreshes, but
+  "`hot`" refreshes. For example, `XmlWebApplicationContext` supports hot refreshes, but
   `GenericApplicationContext` does not.
 
 | `ContextStartedEvent`
-| Published when the `ApplicationContext` is started, using the `start()` method on the
-  `ConfigurableApplicationContext` interface. "Started" here means that all `Lifecycle`
-  beans receive an explicit start signal. Typically this signal is used to restart beans
+| Published when the `ApplicationContext` is started by using the `start()` method on the
+  `ConfigurableApplicationContext` interface. Here, "`started`" means that all `Lifecycle`
+  beans receive an explicit start signal. Typically, this signal is used to restart beans
   after an explicit stop, but it may also be used to start components that have not been
-  configured for autostart , for example, components that have not already started on
-  initialization.
+  configured for autostart (for example, components that have not already started on
+  initialization).
 
 | `ContextStoppedEvent`
-| Published when the `ApplicationContext` is stopped, using the `stop()` method on the
-  `ConfigurableApplicationContext` interface. "Stopped" here means that all `Lifecycle`
+| Published when the `ApplicationContext` is stopped by using the `stop()` method on the
+  `ConfigurableApplicationContext` interface. Here, "`stopped`" means that all `Lifecycle`
   beans receive an explicit stop signal. A stopped context may be restarted through a
   `start()` call.
 
 | `ContextClosedEvent`
-| Published when the `ApplicationContext` is closed, using the `close()` method on the
-  `ConfigurableApplicationContext` interface. "Closed" here means that all singleton
-  beans are destroyed. A closed context reaches its end of life; it cannot be refreshed
+| Published when the `ApplicationContext` is closed by using the `close()` method on the
+  `ConfigurableApplicationContext` interface. Here, "`closed`" means that all singleton
+  beans are destroyed. A closed context reaches its end of life. It cannot be refreshed
   or restarted.
 
 | `RequestHandledEvent`
 | A web-specific event telling all beans that an HTTP request has been serviced. This
-  event is published __after__ the request is complete. This event is only applicable to
-  web applications using Spring's `DispatcherServlet`.
+  event is published after the request is complete. This event is only applicable to
+  web applications that use Spring's `DispatcherServlet`.
 |===
 
-You can also create and publish your own custom events. This example demonstrates a
+You can also create and publish your own custom events. The following example shows a
 simple class that extends Spring's `ApplicationEvent` base class:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8452,12 +8955,14 @@ simple class that extends Spring's `ApplicationEvent` base class:
 		// accessor and other methods...
 	}
 ----
+====
 
 To publish a custom `ApplicationEvent`, call the `publishEvent()` method on an
-`ApplicationEventPublisher`. Typically this is done by creating a class that implements
+`ApplicationEventPublisher`. Typically, this is done by creating a class that implements
 `ApplicationEventPublisherAware` and registering it as a Spring bean. The following
-example demonstrates such a class:
+example shows such a class:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8483,17 +8988,19 @@ example demonstrates such a class:
 		}
 	}
 ----
+====
 
-At configuration time, the Spring container will detect that `EmailService` implements
-`ApplicationEventPublisherAware` and will automatically call
-`setApplicationEventPublisher()`. In reality, the parameter passed in will be the Spring
-container itself; you're simply interacting with the application context via its
+At configuration time, the Spring container detects that `EmailService` implements
+`ApplicationEventPublisherAware` and automatically calls
+`setApplicationEventPublisher()`. In reality, the parameter passed in is the Spring
+container itself. You are interacting with the application context through its
 `ApplicationEventPublisher` interface.
 
-To receive the custom `ApplicationEvent`, create a class that implements
+To receive the custom `ApplicationEvent`, you can create a class that implements
 `ApplicationListener` and register it as a Spring bean. The following example
-demonstrates such a class:
+shows such a class:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8510,21 +9017,23 @@ demonstrates such a class:
 		}
 	}
 ----
+====
 
 Notice that `ApplicationListener` is generically parameterized with the type of your
-custom event, `BlackListEvent`. This means that the `onApplicationEvent()` method can
-remain type-safe, avoiding any need for downcasting. You may register as many event
-listeners as you wish, but note that by default event listeners receive events
-synchronously. This means the `publishEvent()` method blocks until all listeners have
+custom event (`BlackListEvent` in the preceding example). This means that the `onApplicationEvent()` method can
+remain type-safe, avoiding any need for downcasting. You can register as many event
+listeners as you wish, but note that, by default, event listeners receive events
+synchronously. This means that the `publishEvent()` method blocks until all listeners have
 finished processing the event. One advantage of this synchronous and single-threaded
-approach is that when a listener receives an event, it operates inside the transaction
+approach is that, when a listener receives an event, it operates inside the transaction
 context of the publisher if a transaction context is available. If another strategy for
-event publication becomes necessary, refer to the javadoc for Spring's
-`ApplicationEventMulticaster` interface.
+event publication becomes necessary, See the Javadoc for Spring's
+{api-spring-framework}/context/event/ApplicationEventMulticaster.html[`ApplicationEventMulticaster`] interface.
 
 The following example shows the bean definitions used to register and configure each of
 the classes above:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8542,32 +9051,32 @@ the classes above:
 		<property name="notificationAddress" value="blacklist@example.org"/>
 	</bean>
 ----
+====
 
 Putting it all together, when the `sendEmail()` method of the `emailService` bean is
-called, if there are any emails that should be blacklisted, a custom event of type
+called, if there are any email messages that should be blacklisted, a custom event of type
 `BlackListEvent` is published. The `blackListNotifier` bean is registered as an
-`ApplicationListener` and thus receives the `BlackListEvent`, at which point it can
+`ApplicationListener` and receives the `BlackListEvent`, at which point it can
 notify appropriate parties.
 
-[NOTE]
-====
-Spring's eventing mechanism is designed for simple communication between Spring beans
+NOTE: Spring's eventing mechanism is designed for simple communication between Spring beans
 within the same application context. However, for more sophisticated enterprise
-integration needs, the separately-maintained
+integration needs, the separately maintained
 http://projects.spring.io/spring-integration/[Spring Integration] project provides
 complete support for building lightweight,
 http://www.enterpriseintegrationpatterns.com[pattern-oriented], event-driven
 architectures that build upon the well-known Spring programming model.
-====
+
 
 
 [[context-functionality-events-annotation]]
-==== Annotation-based event listeners
+==== Annotation-based Event Listeners
 
-As of Spring 4.2, an event listener can be registered on any public method of a managed
-bean via the `EventListener` annotation. The `BlackListNotifier` can be rewritten as
+As of Spring 4.2, you can register an event listener on any public method of a managed
+bean by using the `EventListener` annotation. The `BlackListNotifier` can be rewritten as
 follows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8585,15 +9094,18 @@ follows:
 		}
 	}
 ----
+====
 
-As you can see above, the method signature once again declares the event type it listens to,
-but this time with a flexible name and without implementing a specific listener interface.
+The method signature once again declares the event type to which it listens,
+but, this time, with a flexible name and without implementing a specific listener interface.
 The event type can also be narrowed through generics as long as the actual event type
 resolves your generic parameter in its implementation hierarchy.
 
 If your method should listen to several events or if you want to define it with no
-parameter at all, the event type(s) can also be specified on the annotation itself:
+parameter at all, the event types can also be specified on the annotation itself. The
+following example shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8602,26 +9114,28 @@ parameter at all, the event type(s) can also be specified on the annotation itse
 		...
 	}
 ----
+====
 
-
-It is also possible to add additional runtime filtering via the `condition` attribute of the
-annotation that defines a <<expressions,`SpEL` expression>> that should match to actually
+It is also possible to add additional runtime filtering by using the `condition` attribute of the
+annotation that defines a <<expressions,`SpEL` expression>> , which should match to actually
 invoke the method for a particular event.
 
-For instance, our notifier can be rewritten to be only invoked if the `content` attribute
-of the event is equal to `foo`:
+The following example shows how our notifier can be rewritten to be invoked only if the `content` attribute
+of the event is equal to `my-event`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
-	@EventListener(condition = "#blEvent.content == 'foo'")
+	@EventListener(condition = "#blEvent.content == 'my-event'")
 	public void processBlackListEvent(BlackListEvent blEvent) {
 		// notify appropriate parties via notificationAddress...
 	}
 ----
+====
 
-Each `SpEL` expression evaluates against a dedicated context. The next table lists the
-items made available to the context so one can use them for conditional event processing:
+Each `SpEL` expression evaluates against a dedicated context. The following table lists the
+items made available to the context so that you can use them for conditional event processing:
 
 [[context-functionality-events-annotation-tbl]]
 .Event SpEL available metadata
@@ -8630,28 +9144,29 @@ items made available to the context so one can use them for conditional event pr
 
 | Event
 | root object
-| The actual `ApplicationEvent`
+| The actual `ApplicationEvent`.
 | `#root.event`
 
 | Arguments array
 | root object
-| The arguments (as array) used for invoking the target
+| The arguments (as array) used for invoking the target.
 | `#root.args[0]`
 
 | __Argument name__
 | evaluation context
-| Name of any of the method arguments. If for some reason the names are not available
-  (e.g. no debug information), the argument names are also available under the `#a<#arg>`
-  where __#arg__ stands for the argument index (starting from 0).
-| `#blEvent` or `#a0` (one can also use `#p0` or `#p<#arg>` notation as an alias).
+| The name of any of the method arguments. If, for some reason, the names are not available
+  (for example, because there is no debug information), the argument names are also available under the `#a<#arg>`
+  where `#arg` stands for the argument index (starting from 0).
+| `#blEvent` or `#a0` (you can also use `#p0` or `#p<#arg>` notation as an alias)
 |===
 
-Note that `#root.event` allows you to access to the underlying event, even if your method
+Note that `#root.event` gives you access to the underlying event, even if your method
 signature actually refers to an arbitrary object that was published.
 
-If you need to publish an event as the result of processing another, just change the
-method signature to return the event that should be published, something like:
+If you need to publish an event as the result of processing another event, you can change the
+method signature to return the event that should be published, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8661,21 +9176,25 @@ method signature to return the event that should be published, something like:
 		// then publish a ListUpdateEvent...
 	}
 ----
+====
 
 NOTE: This feature is not supported for <<context-functionality-events-async,asynchronous
 listeners>>.
 
-This new method will publish a new `ListUpdateEvent` for every `BlackListEvent` handled
-by the method above. If you need to publish several events, just return a `Collection` of
+This new method publishes a new `ListUpdateEvent` for every `BlackListEvent` handled
+by the method above. If you need to publish several events, you can return a `Collection` of
 events instead.
+
 
 
 [[context-functionality-events-async]]
 ==== Asynchronous Listeners
 
-If you want a particular listener to process events asynchronously, simply reuse the
-<<integration.adoc#scheduling-annotation-support-async,regular `@Async` support>>:
+If you want a particular listener to process events asynchronously, you can reuse the
+<<integration.adoc#scheduling-annotation-support-async,regular `@Async` support>>. The
+following example shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8685,22 +9204,25 @@ If you want a particular listener to process events asynchronously, simply reuse
 		// BlackListEvent is processed in a separate thread
 	}
 ----
+====
 
 Be aware of the following limitations when using asynchronous events:
 
-. If the event listener throws an `Exception` it will not be propagated to the caller,
-  check `AsyncUncaughtExceptionHandler` for more details.
-. Such event listener cannot send replies. If you need to send another event as the
-  result of the processing, inject `ApplicationEventPublisher` to send the event
+* If the event listener throws an `Exception`, it is not propagated to the caller
+  See `AsyncUncaughtExceptionHandler` for more details.
+* Such event listener cannot send replies. If you need to send another event as the
+  result of the processing, inject {api-spring-framework}/aop/interceptor/AsyncUncaughtExceptionHandler.html[`ApplicationEventPublisher`] to send the event
   manually.
 
 
+
 [[context-functionality-events-order]]
-==== Ordering listeners
+==== Ordering Listeners
 
-If you need the listener to be invoked before another one, just add the `@Order`
-annotation to the method declaration:
+If you need one listener to be invoked before another one, you can add the `@Order`
+annotation to the method declaration, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8710,16 +9232,19 @@ annotation to the method declaration:
 		// notify appropriate parties via notificationAddress...
 	}
 ----
+====
+
 
 
 [[context-functionality-events-generics]]
-==== Generic events
+==== Generic Events
 
-You may also use generics to further define the structure of your event. Consider an
-`EntityCreatedEvent<T>` where `T` is the type of the actual entity that got created. You
-can create the following listener definition to only receive `EntityCreatedEvent` for a
+You can also use generics to further define the structure of your event. Consider using an
+`EntityCreatedEvent<T>` where `T` is the type of the actual entity that got created. For example, you
+can create the following listener definition to receive only `EntityCreatedEvent` for a
 `Person`:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8728,17 +9253,18 @@ can create the following listener definition to only receive `EntityCreatedEvent
 		...
 	}
 ----
+====
 
-
-Due to type erasure, this will only work if the event that is fired resolves the generic
-parameter(s) on which the event listener filters on (that is something like
+Due to type erasure, this works only if the event that is fired resolves the generic
+parameters on which the event listener filters (that is, something like
 `class PersonCreatedEvent extends EntityCreatedEvent<Person> { ... }`).
 
 In certain circumstances, this may become quite tedious if all events follow the same
-structure (as it should be the case for the event above). In such a case, you can
-implement `ResolvableTypeProvider` to _guide_ the framework beyond what the runtime
-environment provides:
+structure (as should be the case for the event in the preceding example). In such a case, you can
+implement `ResolvableTypeProvider` to guide the framework beyond what the runtime
+environment provides. The following event shows how to do so:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8755,25 +9281,23 @@ environment provides:
 		}
 	}
 ----
+====
 
-[TIP]
-====
-This works not only for `ApplicationEvent` but any arbitrary object that you'd send as
+TIP: This works not only for `ApplicationEvent` but any arbitrary object that you send as
 an event.
-====
 
 
 
 [[context-functionality-resources]]
-=== Convenient access to low-level resources
+=== Convenient Access to Low-level Resources
 
-For optimal usage and understanding of application contexts, users should generally
-familiarize themselves with Spring's `Resource` abstraction, as described in the chapter
+For optimal usage and understanding of application contexts, you should
+familiarize yourself with Spring's `Resource` abstraction, as described in
 <<resources>>.
 
-An application context is a `ResourceLoader`, which can be used to load ``Resource``s. A
-`Resource` is essentially a more feature rich version of the JDK class `java.net.URL`,
-in fact, the implementations of the `Resource` wrap an instance of `java.net.URL` where
+An application context is a `ResourceLoader`, which can be used to load `Resource` objects. A
+`Resource` is essentially a more feature rich version of the JDK `java.net.URL` class.
+In fact, the implementations of the `Resource` wrap an instance of `java.net.URL`, where
 appropriate. A `Resource` can obtain low-level resources from almost any location in a
 transparent fashion, including from the classpath, a filesystem location, anywhere
 describable with a standard URL, and some other variations. If the resource location
@@ -8784,14 +9308,14 @@ You can configure a bean deployed into the application context to implement the 
 callback interface, `ResourceLoaderAware`, to be automatically called back at
 initialization time with the application context itself passed in as the
 `ResourceLoader`. You can also expose properties of type `Resource`, to be used to
-access static resources; they will be injected into it like any other properties. You
-can specify those `Resource` properties as simple String paths, and rely on a special
-JavaBean `PropertyEditor` that is automatically registered by the context, to convert
+access static resources. They are injected into it like any other properties. You
+can specify those `Resource` properties as simple `String` paths and rely on a special
+JavaBean `PropertyEditor` (which is automatically registered by the context) to convert
 those text strings to actual `Resource` objects when the bean is deployed.
 
 The location path or paths supplied to an `ApplicationContext` constructor are actually
-resource strings, and in simple form are treated appropriately to the specific context
-implementation. `ClassPathXmlApplicationContext` treats a simple location path as a
+resource strings and, in simple form, are treated appropriately according to the specific context
+implementation. For example `ClassPathXmlApplicationContext` treats a simple location path as a
 classpath location. You can also use location paths (resource strings) with special
 prefixes to force loading of definitions from the classpath or a URL, regardless of the
 actual context type.
@@ -8799,14 +9323,16 @@ actual context type.
 
 
 [[context-create]]
-=== Convenient ApplicationContext instantiation for web applications
+=== Convenient ApplicationContext Instantiation for Web Applications
 
 You can create `ApplicationContext` instances declaratively by using, for example, a
-`ContextLoader`. Of course you can also create `ApplicationContext` instances
+`ContextLoader`. Of course, you can also create `ApplicationContext` instances
 programmatically by using one of the `ApplicationContext` implementations.
 
-You can register an `ApplicationContext` using the `ContextLoaderListener` as follows:
+You can register an `ApplicationContext` by using the `ContextLoaderListener`, as the
+following example shows:
 
+====
 [source,xml,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8819,113 +9345,115 @@ You can register an `ApplicationContext` using the `ContextLoaderListener` as fo
 		<listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
 	</listener>
 ----
+====
 
 The listener inspects the `contextConfigLocation` parameter. If the parameter does not
 exist, the listener uses `/WEB-INF/applicationContext.xml` as a default. When the
-parameter __does__ exist, the listener separates the String by using predefined
-delimiters (comma, semicolon and whitespace) and uses the values as locations where
-application contexts will be searched. Ant-style path patterns are supported as well.
-Examples are `/WEB-INF/{asterisk}Context.xml` for all files with names ending with "Context.xml",
-residing in the "WEB-INF" directory, and `/WEB-INF/**/*Context.xml`, for all such files
-in any subdirectory of "WEB-INF".
+parameter does exist, the listener separates the `String` by using predefined
+delimiters (comma, semicolon, and whitespace) and uses the values as locations where
+application contexts are searched. Ant-style path patterns are supported as well.
+Examples are `/WEB-INF/{asterisk}Context.xml` (for all files with names that end with `Context.xml`
+and that reside in the `WEB-INF` directory) and `/WEB-INF/**/*Context.xml`( for all such files
+in any subdirectory of `WEB-INF`).
 
 
 
 [[context-deploy-rar]]
-=== Deploying a Spring ApplicationContext as a Java EE RAR file
+=== Deploying a Spring `ApplicationContext` as a Java EE RAR File
 
-It is possible to deploy a Spring ApplicationContext as a RAR file, encapsulating the
+It is possible to deploy a Spring `ApplicationContext` as a RAR file, encapsulating the
 context and all of its required bean classes and library JARs in a Java EE RAR deployment
-unit. This is the equivalent of bootstrapping a standalone ApplicationContext, just hosted
-in Java EE environment, being able to access the Java EE servers facilities. RAR deployment
-is  more natural alternative to scenario of deploying a headless WAR file, in effect, a WAR
+unit. This is the equivalent of bootstrapping a stand-alone `ApplicationContext` (only hosted
+in Java EE environment) being able to access the Java EE servers facilities. RAR deployment
+is a more natural alternative to a scenario of deploying a headless WAR file -- in effect, a WAR
 file without any HTTP entry points that is used only for bootstrapping a Spring
-ApplicationContext in a Java EE environment.
+`ApplicationContext` in a Java EE environment.
 
 RAR deployment is ideal for application contexts that do not need HTTP entry points but
 rather consist only of message endpoints and scheduled jobs. Beans in such a context can
 use application server resources such as the JTA transaction manager and JNDI-bound JDBC
-DataSources and JMS ConnectionFactory instances, and may also register with the
-platform's JMX server - all through Spring's standard transaction management and JNDI
+`DataSource` instances and JMS `ConnectionFactory` instances and can also register with the
+platform's JMX server -- all through Spring's standard transaction management and JNDI
 and JMX support facilities. Application components can also interact with the
-application server's JCA WorkManager through Spring's `TaskExecutor` abstraction.
+application server's JCA `WorkManager` through Spring's `TaskExecutor` abstraction.
 
-Check out the javadoc of the
+See the Javadoc of the
 {api-spring-framework}/jca/context/SpringContextResourceAdapter.html[`SpringContextResourceAdapter`]
 class for the configuration details involved in RAR deployment.
 
-__For a simple deployment of a Spring ApplicationContext as a Java EE RAR file:__ package
-all application classes into a RAR file, which is a standard JAR file with a different
-file extension. Add all required library JARs into the root of the RAR archive. Add a
-"META-INF/ra.xml" deployment descriptor (as shown in ``SpringContextResourceAdapter``s
-javadoc) and the corresponding Spring XML bean definition file(s) (typically
-"META-INF/applicationContext.xml"), and drop the resulting RAR file into your
+For a simple deployment of a Spring ApplicationContext as a Java EE RAR file:
+
+. Package
+all application classes into a RAR file (which is a standard JAR file with a different
+file extension).
+.Add all required library JARs into the root of the RAR archive.
+.Add a
+`META-INF/ra.xml` deployment descriptor (as shown in the {api-spring-framework}/jca/context/SpringContextResourceAdapter.html[Javadoc for `SpringContextResourceAdapter`])
+and the corresponding Spring XML bean definition file(s) (typically
+`META-INF/applicationContext.xml).
+. Drop the resulting RAR file into your
 application server's deployment directory.
 
-[NOTE]
-====
-Such RAR deployment units are usually self-contained; they do not expose components to
+NOTE: Such RAR deployment units are usually self-contained. They do not expose components to
 the outside world, not even to other modules of the same application. Interaction with a
-RAR-based ApplicationContext usually occurs through JMS destinations that it shares with
-other modules. A RAR-based ApplicationContext may also, for example, schedule some jobs,
-reacting to new files in the file system (or the like). If it needs to allow synchronous
-access from the outside, it could for example export RMI endpoints, which of course may
+RAR-based `ApplicationContext` usually occurs through JMS destinations that it shares with
+other modules. A RAR-based `ApplicationContext` may also, for example, schedule some jobs
+or react to new files in the file system (or the like). If it needs to allow synchronous
+access from the outside, it could (for example) export RMI endpoints, which may
 be used by other application modules on the same machine.
-====
-
 
 
 
 [[beans-beanfactory]]
-== The BeanFactory
+== The `BeanFactory`
 
 The `BeanFactory` API provides the underlying basis for Spring's IoC functionality.
 Its specific contracts are mostly used in integration with other parts of Spring and
 related third-party frameworks, and its `DefaultListableBeanFactory` implementation
 is a key delegate within the higher-level `GenericApplicationContext` container.
 
-`BeanFactory` and related interfaces such as `BeanFactoryAware`, `InitializingBean`,
-`DisposableBean` are important integration points for other framework components:
-not requiring any annotations or even reflection, they allow for very efficient
+`BeanFactory` and related interfaces (such as `BeanFactoryAware`, `InitializingBean`,
+`DisposableBean`) are important integration points for other framework components.
+By not requiring any annotations or even reflection, they allow for very efficient
 interaction between the container and its components. Application-level beans may
-use the same callback interfaces but will typically prefer declarative dependency
-injection instead, either via annotations or through programmatic configuration.
+use the same callback interfaces but typically prefer declarative dependency
+injection instead, either through annotations or through programmatic configuration.
 
 Note that the core `BeanFactory` API level and its `DefaultListableBeanFactory`
 implementation do not make assumptions about the configuration format or any
 component annotations to be used. All of these flavors come in through extensions
-such as `XmlBeanDefinitionReader` and `AutowiredAnnotationBeanPostProcessor`,
-operating on shared `BeanDefinition` objects as a core metadata representation.
+(such as `XmlBeanDefinitionReader` and `AutowiredAnnotationBeanPostProcessor`) and
+operate on shared `BeanDefinition` objects as a core metadata representation.
 This is the essence of what makes Spring's container so flexible and extensible.
-
-The following section explains the differences between the `BeanFactory` and
-`ApplicationContext` container levels and the implications on bootstrapping.
 
 
 
 [[context-introduction-ctx-vs-beanfactory]]
-=== BeanFactory or ApplicationContext?
+=== `BeanFactory` or `ApplicationContext`?
 
-Use an `ApplicationContext` unless you have a good reason for not doing so, with
+This section explains the differences between the `BeanFactory` and
+`ApplicationContext` container levels and the implications on bootstrapping.
+
+You should use an `ApplicationContext` unless you have a good reason for not doing so, with
 `GenericApplicationContext` and its subclass `AnnotationConfigApplicationContext`
 as the common implementations for custom bootstrapping. These are the primary entry
 points to Spring's core container for all common purposes: loading of configuration
 files, triggering a classpath scan, programmatically registering bean definitions
-and annotated classes, and as of 5.0 also registering functional bean definitions.
+and annotated classes, and (as of 5.0) registering functional bean definitions.
 
-Because an `ApplicationContext` includes all functionality of a `BeanFactory`, it is
-generally recommended over a plain `BeanFactory`, except for a scenarios where full
-control over bean processing is needed. Within an `ApplicationContext` such as the
-`GenericApplicationContext` implementation, several kinds of beans will be detected
-by convention (i.e. by bean name or by bean type), in particular post-processors,
-whereas a plain `DefaultListableBeanFactory` is agnostic about any special beans.
+Because an `ApplicationContext` includes all the functionality of a `BeanFactory`, it is
+generally recommended over a plain `BeanFactory`, except for scenarios where full
+control over bean processing is needed. Within an `ApplicationContext` (such as the
+`GenericApplicationContext` implementation), several kinds of beans are detected
+by convention (that is, by bean name or by bean type -- in particular, post-processors),
+while a plain `DefaultListableBeanFactory` is agnostic about any special beans.
 
-For many extended container features such as annotation processing and AOP proxying,
+For many extended container features, such as annotation processing and AOP proxying,
 the <<beans-factory-extension-bpp,`BeanPostProcessor` extension point>> is essential.
-If you use only a plain `DefaultListableBeanFactory`, such post-processors will not
-get detected and activated by default. This situation could be confusing because
-nothing is actually wrong with your bean configuration; it is rather the container
-which needs to be fully bootstrapped through additional setup in such a scenario.
+If you use only a plain `DefaultListableBeanFactory`, such post-processors do not
+get detected and activated by default. This situation could be confusing, because
+nothing is actually wrong with your bean configuration. Rather,  in such a scenario, the
+container needs to be fully bootstrapped through additional setup.
 
 The following table lists features provided by the `BeanFactory` and
 `ApplicationContext` interfaces and implementations.
@@ -8961,8 +9489,9 @@ The following table lists features provided by the `BeanFactory` and
 |===
 
 To explicitly register a bean post-processor with a `DefaultListableBeanFactory`,
-you need to programmatically call `addBeanPostProcessor`:
+you need to programmatically call `addBeanPostProcessor`, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8975,10 +9504,12 @@ you need to programmatically call `addBeanPostProcessor`:
 
 	// now start using the factory
 ----
+====
 
 To apply a `BeanFactoryPostProcessor` to a plain `DefaultListableBeanFactory`,
-you need to call its `postProcessBeanFactory` method:
+you need to call its `postProcessBeanFactory` method, as the following example shows:
 
+====
 [source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
@@ -8993,18 +9524,16 @@ you need to call its `postProcessBeanFactory` method:
 	// now actually do the replacement
 	cfg.postProcessBeanFactory(factory);
 ----
+====
 
 In both cases, the explicit registration steps are inconvenient, which is
 why the various `ApplicationContext` variants are preferred over a plain
 `DefaultListableBeanFactory` in Spring-backed applications, especially when
-relying on ``BeanFactoryPostProcessor``s and ``BeanPostProcessor``s for extended
+relying on `BeanFactoryPostProcessor` and `BeanPostProcessor` instances for extended
 container functionality in a typical enterprise setup.
 
-[NOTE]
-====
-An `AnnotationConfigApplicationContext` has all common annotation post-processors
-registered out of the box and may bring in additional processors underneath the
-covers through configuration annotations such as `@EnableTransactionManagement`.
+NOTE: An `AnnotationConfigApplicationContext` has all common annotation post-processors
+registered and may bring in additional processors underneath the
+covers through configuration annotations, such as `@EnableTransactionManagement`.
 At the abstraction level of Spring's annotation-based configuration model,
 the notion of bean post-processors becomes a mere internal container detail.
-====

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -4,9 +4,9 @@
 
 Welcome to the Spring Framework reference documentation!
 
-Please read the <<overview.adoc#overview,*Overview*>> for a quick introduction including brief history,
+Please read the <<overview.adoc#overview,*Overview*>> for a quick introduction, including a brief history,
 design philosophy, where to ask questions, and tips to get started. For information on
-"What's New", or "Migrating from previous versions", check the
+"`What's New`", or "`Migrating from previous versions`", check the
 https://github.com/spring-projects/spring-framework/wiki[*Github Wiki*].
 
 The reference documentation is divided into several sections:


### PR DESCRIPTION
I edited for spelling, punctuation, grammar, usage, and corporate voice. I also added cross-references and links to the Javadoc in a number of places.

I plan to add more commits to this PR as I work through more files.