### PR TITLE
SPR-17194 - Change the type of parameters for expires and lastModified to long

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/HeaderAssertions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/HeaderAssertions.java
@@ -181,14 +181,14 @@ public class HeaderAssertions {
 	/**
 	 * Expect an "Expires" header with the given value.
 	 */
-	public WebTestClient.ResponseSpec expires(int expires) {
+	public WebTestClient.ResponseSpec expires(long expires) {
 		return assertHeader("Expires", expires, getHeaders().getExpires());
 	}
 
 	/**
 	 * Expect a "Last-Modified" header with the given value.
 	 */
-	public WebTestClient.ResponseSpec lastModified(int lastModified) {
+	public WebTestClient.ResponseSpec lastModified(long lastModified) {
 		return assertHeader("Last-Modified", lastModified, getHeaders().getLastModified());
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/HeaderAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/HeaderAssertionTests.java
@@ -17,6 +17,8 @@
 package org.springframework.test.web.reactive.server;
 
 import java.net.URI;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -217,6 +219,39 @@ public class HeaderAssertionTests {
 		}
 	}
 
+	@Test
+	public void expires() {
+		HttpHeaders headers = new HttpHeaders();
+		ZonedDateTime expires = ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0,
+				ZoneId.of("UTC"));
+		headers.setExpires(expires);
+		HeaderAssertions assertions = headerAssertions(headers);
+		assertions.expires(expires.toInstant().toEpochMilli());
+		try {
+			assertions.expires(expires.toInstant().toEpochMilli() + 1);
+			fail("Wrong value expected");
+		}
+		catch (AssertionError error) {
+			// Expected
+		}
+	}
+
+	@Test
+	public void lastModified() {
+		HttpHeaders headers = new HttpHeaders();
+		ZonedDateTime lastModified = ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0,
+				ZoneId.of("UTC"));
+		headers.setLastModified(lastModified.toInstant().toEpochMilli());
+		HeaderAssertions assertions = headerAssertions(headers);
+		assertions.lastModified(lastModified.toInstant().toEpochMilli());
+		try {
+			assertions.lastModified(lastModified.toInstant().toEpochMilli() + 1);
+			fail("Wrong value expected");
+		}
+		catch (AssertionError error) {
+			// Expected
+		}
+	}
 
 	private HeaderAssertions headerAssertions(HttpHeaders responseHeaders) {
 		MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("/"));


### PR DESCRIPTION
This commit changes the type of parameters so that HeaderAssertions
can assert expires and lastModified properly.

Issue: SPR-17194