### PR TITLE
SPR-17195 Fix unusable assertions in HeaderAssertions

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/HeaderAssertions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/HeaderAssertions.java
@@ -182,14 +182,14 @@ public class HeaderAssertions {
 	 * Expect an "Expires" header with the given value.
 	 */
 	public WebTestClient.ResponseSpec expires(int expires) {
-		return assertHeader("Expires", expires, getHeaders().getExpires());
+		return assertHeader("Expires", (long)expires, getHeaders().getExpires());
 	}
 
 	/**
 	 * Expect a "Last-Modified" header with the given value.
 	 */
 	public WebTestClient.ResponseSpec lastModified(int lastModified) {
-		return assertHeader("Last-Modified", lastModified, getHeaders().getLastModified());
+		return assertHeader("Last-Modified", (long)lastModified, getHeaders().getLastModified());
 	}
 
 

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/HeaderAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/HeaderAssertionTests.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Rossen Stoyanchev
  * @author Sam Brannen
+ * @author Konrad Czajka
  * @since 5.0
  */
 public class HeaderAssertionTests {
@@ -217,6 +218,37 @@ public class HeaderAssertionTests {
 		}
 	}
 
+	@Test
+	public void lastModifiedWhenHeaderSpecified() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLastModified(1500000000);
+		HeaderAssertions assertions = headerAssertions(headers);
+
+		assertions.lastModified(1500000000);
+	}
+
+	@Test
+	public void lastModifiedWhenHeaderIsNotSpecified() {
+		HeaderAssertions assertions = headerAssertions(new HttpHeaders());
+
+		assertions.lastModified(-1);
+	}
+
+	@Test
+	public void expiresWhenHeaderSpecified() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setExpires(1500000000);
+		HeaderAssertions assertions = headerAssertions(headers);
+
+		assertions.expires(1500000000);
+	}
+
+	@Test
+	public void expiresWhenHeaderIsNotSpecified() {
+		HeaderAssertions assertions = headerAssertions(new HttpHeaders());
+
+		assertions.expires(-1);
+	}
 
 	private HeaderAssertions headerAssertions(HttpHeaders responseHeaders) {
 		MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("/"));


### PR DESCRIPTION
Two header assertions (expires, lastModified) accept int parameter
whereas HttpHeaders class stores those headers as long.
It makes them always fail as Object::equals is used for comparing.

The change casts incoming values to long.