### PR TITLE
Support both view and filters for Jackson 2

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -269,15 +269,12 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 			if (type != null && TypeUtils.isAssignable(type, value.getClass())) {
 				javaType = getJavaType(type, null);
 			}
-			ObjectWriter objectWriter;
+			ObjectWriter objectWriter = this.objectMapper.writer();
 			if (serializationView != null) {
-				objectWriter = this.objectMapper.writerWithView(serializationView);
+				objectWriter = objectWriter.withView(serializationView);
 			}
-			else if (filters != null) {
-				objectWriter = this.objectMapper.writer(filters);
-			}
-			else {
-				objectWriter = this.objectMapper.writer();
+			if (filters != null) {
+				objectWriter = objectWriter.with(filters);
 			}
 			if (javaType != null && javaType.isContainerType()) {
 				objectWriter = objectWriter.forType(javaType);


### PR DESCRIPTION
Adds support for combining view and filters in
AbstractJackson2HttpMessageConverter instead of only using view if both
are defined.

Issue: SPR-17209