### PR TITLE
Use String::isEmpty instead of "".equals(arg) when arg is not null

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -194,7 +194,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 		this.wrappedObject = ObjectUtils.unwrapOptional(object);
 		Assert.notNull(this.wrappedObject, "Target object must not be null");
 		this.nestedPath = (nestedPath != null ? nestedPath : "");
-		this.rootObject = (!"".equals(this.nestedPath) ? rootObject : this.wrappedObject);
+		this.rootObject = (!this.nestedPath.isEmpty() ? rootObject : this.wrappedObject);
 		this.nestedPropertyAccessors = null;
 		this.typeConverterDelegate = new TypeConverterDelegate(this, this.wrappedObject);
 	}

--- a/spring-beans/src/main/java/org/springframework/beans/TypeConverterDelegate.java
+++ b/spring-beans/src/main/java/org/springframework/beans/TypeConverterDelegate.java
@@ -247,7 +247,7 @@ class TypeConverterDelegate {
 						}
 					}
 					String trimmedValue = ((String) convertedValue).trim();
-					if (requiredType.isEnum() && "".equals(trimmedValue)) {
+					if (requiredType.isEnum() && trimmedValue.isEmpty()) {
 						// It's an empty enum identifier: reset the enum value to null.
 						return null;
 					}

--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/SpringValidatorAdapter.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/SpringValidatorAdapter.java
@@ -162,7 +162,7 @@ public class SpringValidatorAdapter implements SmartValidator, javax.validation.
 						// as necessary for Hibernate Validator compatibility (non-indexed set path in field)
 						BindingResult bindingResult = (BindingResult) errors;
 						String nestedField = bindingResult.getNestedPath() + field;
-						if ("".equals(nestedField)) {
+						if (nestedField.isEmpty()) {
 							String[] errorCodes = bindingResult.resolveMessageCodes(errorCode);
 							ObjectError error = new ObjectError(
 									errors.getObjectName(), errorCodes, errorArgs, violation.getMessage());

--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToBooleanConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToBooleanConverter.java
@@ -49,7 +49,7 @@ final class StringToBooleanConverter implements Converter<String, Boolean> {
 	@Override
 	public Boolean convert(String source) {
 		String value = source.trim();
-		if ("".equals(value)) {
+		if (value.isEmpty()) {
 			return null;
 		}
 		value = value.toLowerCase();

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -571,8 +571,8 @@ public class AntPathMatcher implements PathMatcher {
 		int dotPos2 = pattern2.indexOf('.');
 		String file2 = (dotPos2 == -1 ? pattern2 : pattern2.substring(0, dotPos2));
 		String ext2 = (dotPos2 == -1 ? "" : pattern2.substring(dotPos2));
-		boolean ext1All = (ext1.equals(".*") || ext1.equals(""));
-		boolean ext2All = (ext2.equals(".*") || ext2.equals(""));
+		boolean ext1All = (ext1.equals(".*") || ext1.isEmpty());
+		boolean ext2All = (ext2.equals(".*") || ext2.isEmpty());
 		if (!ext1All && !ext2All) {
 			throw new IllegalArgumentException("Cannot combine patterns: " + pattern1 + " vs " + pattern2);
 		}

--- a/spring-core/src/main/java/org/springframework/util/PatternMatchUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/PatternMatchUtils.java
@@ -52,7 +52,7 @@ public abstract class PatternMatchUtils {
 				return str.endsWith(pattern.substring(1));
 			}
 			String part = pattern.substring(1, nextIndex);
-			if ("".equals(part)) {
+			if (part.isEmpty()) {
 				return simpleMatch(pattern.substring(nextIndex), str);
 			}
 			int partIndex = str.indexOf(part);

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -821,7 +821,7 @@ public abstract class StringUtils {
 			}
 		}
 
-		if ("".equals(variant) && country.startsWith("#")) {
+		if (variant.isEmpty() && country.startsWith("#")) {
 			variant = country;
 			country = "";
 		}
@@ -1192,7 +1192,7 @@ public abstract class StringUtils {
 		}
 
 		List<String> result = new ArrayList<>();
-		if ("".equals(delimiter)) {
+		if (delimiter.isEmpty()) {
 			for (int i = 0; i < str.length(); i++) {
 				result.add(deleteAny(str.substring(i, i + 1), charsToDelete));
 			}

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/support/PersistenceAnnotationBeanPostProcessor.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/support/PersistenceAnnotationBeanPostProcessor.java
@@ -468,7 +468,7 @@ public class PersistenceAnnotationBeanPostProcessor
 	protected EntityManagerFactory getPersistenceUnit(@Nullable String unitName) {
 		if (this.persistenceUnits != null) {
 			String unitNameForLookup = (unitName != null ? unitName : "");
-			if ("".equals(unitNameForLookup)) {
+			if (unitNameForLookup.isEmpty()) {
 				unitNameForLookup = this.defaultPersistenceUnitName;
 			}
 			String jndiName = this.persistenceUnits.get(unitNameForLookup);
@@ -501,7 +501,7 @@ public class PersistenceAnnotationBeanPostProcessor
 		Map<String, String> contexts = (extended ? this.extendedPersistenceContexts : this.persistenceContexts);
 		if (contexts != null) {
 			String unitNameForLookup = (unitName != null ? unitName : "");
-			if ("".equals(unitNameForLookup)) {
+			if (unitNameForLookup.isEmpty()) {
 				unitNameForLookup = this.defaultPersistenceUnitName;
 			}
 			String jndiName = contexts.get(unitNameForLookup);
@@ -533,10 +533,10 @@ public class PersistenceAnnotationBeanPostProcessor
 			throws NoSuchBeanDefinitionException {
 
 		String unitNameForLookup = (unitName != null ? unitName : "");
-		if ("".equals(unitNameForLookup)) {
+		if (unitNameForLookup.isEmpty()) {
 			unitNameForLookup = this.defaultPersistenceUnitName;
 		}
-		if (!"".equals(unitNameForLookup)) {
+		if (!unitNameForLookup.isEmpty()) {
 			return findNamedEntityManagerFactory(unitNameForLookup, requestingBeanName);
 		}
 		else {


### PR DESCRIPTION
```java
boolean b = "".equals(arg);
```
can be replaced with 
```java
boolean b = arg.isEmpty();
```
where `arg` is proven to be not null. This is shorter, more readable and slightly faster.