### PR TITLE
SPR-17248 - Add API to retrieve the body of a request as a flux

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -285,6 +285,16 @@ class DefaultWebTestClient implements WebTestClient {
 			WiretapConnector.Info info = wiretapConnector.claimRequest(this.requestId);
 			return new DefaultResponseSpec(info, clientResponse, this.uriTemplate, getTimeout());
 		}
+
+		@Override
+		public <T> Flux<T> retrieveBody(Class<T> elementType) {
+			return this.bodySpec.retrieve().bodyToFlux(elementType);
+		}
+
+		@Override
+		public <T> Flux<T> retrieveBody(ParameterizedTypeReference<T> typeReference) {
+			return this.bodySpec.retrieve().bodyToFlux(typeReference);
+		}
 	}
 
 

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -57,6 +57,7 @@ import org.springframework.web.server.WebHandler;
 import org.springframework.web.server.session.WebSessionManager;
 import org.springframework.web.util.UriBuilder;
 import org.springframework.web.util.UriBuilderFactory;
+import reactor.core.publisher.Flux;
 
 /**
  * Non-blocking, reactive client for testing web servers. It uses the reactive
@@ -599,6 +600,28 @@ public interface WebTestClient {
 		 * @return spec for decoding the response
 		 */
 		ResponseSpec exchange();
+
+		/**
+		 * Retrieve the response body without blocking the request. Useful for testing
+		 * a continuous, infinite stream (SSE).
+		 * @param typeReference a type reference describing the expected response body type
+		 * @param <T> the type of elements in the response
+		 * @return a flux containing the body, or a WebClientResponseException if the
+		 * status code is 4xx or 5xx
+		 *
+		 */
+		<T> Flux<T> retrieveBody(ParameterizedTypeReference<T> typeReference);
+
+		/**
+		 * Retrieve the response body without blocking the request. Useful for testing
+		 * a continuous, infinite stream (SSE)
+		 * @param typeReference a type reference describing the expected response body type
+		 * @param <T> the type of elements in the response
+		 * @return a flux containing the body, or a WebClientResponseException if the
+		 * status code is 4xx or 5xx
+		 *
+		 */
+		<T> Flux<T> retrieveBody(Class<T> typeReference);
 	}
 
 


### PR DESCRIPTION
This can be used to test SSE streams with the WebTestClient