### PR TITLE
Option to create Exception response to MockRestResponseCreators

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
@@ -16,6 +16,7 @@
 
 package org.springframework.test.web.client.response;
 
+import java.io.IOException;
 import java.net.URI;
 
 import org.springframework.core.io.Resource;
@@ -114,6 +115,17 @@ public abstract class MockRestResponseCreators {
 	 */
 	public static DefaultResponseCreator withStatus(HttpStatus status) {
 		return new DefaultResponseCreator(status);
+	}
+
+	/**
+	 * {@code ResponseCreator} with an internal application {@code IOException}. For example,
+	 * one could use this to simulate a {@code SocketTimeoutException}.
+	 * @param e the {@code Exception} to be thrown at HTTP call time.
+	 */
+	public static ResponseCreator withException(IOException e) {
+		return request -> {
+			throw e;
+		};
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
@@ -129,7 +129,7 @@ public class ResponseCreatorsTests {
 	@Test(expected = SocketTimeoutException.class)
 	public void withException() throws Exception {
 		ResponseCreator responseCreator = MockRestResponseCreators.withException(new SocketTimeoutException());
-		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+		responseCreator.createResponse(null);
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.test.web.client.response;
 
+import java.net.SocketTimeoutException;
 import java.net.URI;
 
 import org.junit.Test;
@@ -23,6 +24,7 @@ import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.springframework.test.web.client.ResponseCreator;
 import org.springframework.util.StreamUtils;
 
 import static org.junit.Assert.*;
@@ -122,6 +124,12 @@ public class ResponseCreatorsTests {
 		assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
 		assertTrue(response.getHeaders().isEmpty());
 		assertEquals(0, StreamUtils.copyToByteArray(response.getBody()).length);
+	}
+
+	@Test(expected = SocketTimeoutException.class)
+	public void withException() throws Exception {
+		ResponseCreator responseCreator = MockRestResponseCreators.withException(new SocketTimeoutException());
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
 	}
 
 }


### PR DESCRIPTION
Issue: [SPR-14458](https://jira.spring.io/browse/SPR-14458). This accommodates for a `SocketTimeoutException` happening during calling of the `RestTemplate` that has a `MockRestServiceServer` bound to it. The only other way that I could find to do this is by doing the following:

```java
RestTemplate restTemplate = new RestTemplate();
restTemplate.setInterceptors(Collections.singletonList(new MyWhackoPersonalInterceptor()));
SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
requestFactory.setConnectTimeout(1);
requestFactory.setReadTimeout(1);
restTemplate.setRequestFactory(requestFactory);
MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate)
    .build();
mockServer.expect(requestTo("/something")).andRespond(
    request -> {
        try {
            Thread.sleep(5000);
        } catch (InterruptedException e) {}
        return new MockClientHttpResponse("{}".getBytes(), HttpStatus.OK);
    }
);
 restTemplate.getForEntity("/something", String.class);
```

which would contain considerable redundancy between this declaration and potential future declarations. Do you have any thoughts on this change?