### PR TITLE
Refactor String#replaceAll

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/StringLiteral.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/StringLiteral.java
@@ -16,6 +16,8 @@
 
 package org.springframework.expression.spel.ast;
 
+import java.util.regex.Pattern;
+
 import org.springframework.asm.MethodVisitor;
 import org.springframework.expression.TypedValue;
 import org.springframework.expression.spel.CodeFlow;
@@ -29,13 +31,18 @@ import org.springframework.expression.spel.CodeFlow;
  */
 public class StringLiteral extends Literal {
 
+	private static final Pattern SINGLE_QUOTES_PATTERN = Pattern.compile("''");
+
+	private static final Pattern DOUBLE_QUOTES_PATTERN = Pattern.compile("\"\"");
+
 	private final TypedValue value;
 
 
 	public StringLiteral(String payload, int pos, String value) {
 		super(payload,pos);
 		value = value.substring(1, value.length() - 1);
-		this.value = new TypedValue(value.replaceAll("''", "'").replaceAll("\"\"", "\""));
+		value = SINGLE_QUOTES_PATTERN.matcher(value).replaceAll("'");
+		this.value = new TypedValue(DOUBLE_QUOTES_PATTERN.matcher(value).replaceAll("\""));
 		this.exitTypeDescriptor = "Ljava/lang/String";
 	}
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/SpelCompiler.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/SpelCompiler.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -73,6 +74,8 @@ public final class SpelCompiler implements Opcodes {
 	// A compiler is created for each classloader, it manages a child class loader of that
 	// classloader and the child is used to load the compiled expressions.
 	private static final Map<ClassLoader, SpelCompiler> compilers = new ConcurrentReferenceHashMap<>();
+
+	private static final Pattern SLASH_PATTERN = Pattern.compile("/");
 
 	// The child ClassLoader used to load the compiled expression classes
 	private ChildClassLoader ccl;
@@ -181,7 +184,7 @@ public final class SpelCompiler implements Opcodes {
 		byte[] data = cw.toByteArray();
 		// TODO need to make this conditionally occur based on a debug flag
 		// dump(expressionToCompile.toStringAST(), clazzName, data);
-		return loadClass(clazzName.replaceAll("/", "."), data);
+		return loadClass(SLASH_PATTERN.matcher(clazzName).replaceAll("."), data);
 	}
 
 	/**

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -76,6 +77,8 @@ import org.springframework.util.StringUtils;
  * @param <T> the result type
  */
 public class BeanPropertyRowMapper<T> implements RowMapper<T> {
+
+	private static final Pattern SPACE_PATTERN = Pattern.compile(" ");
 
 	/** Logger available to subclasses. */
 	protected final Log logger = LogFactory.getLog(getClass());
@@ -292,7 +295,7 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
 
 		for (int index = 1; index <= columnCount; index++) {
 			String column = JdbcUtils.lookupColumnName(rsmd, index);
-			String field = lowerCaseName(column.replaceAll(" ", ""));
+			String field = lowerCaseName(SPACE_PATTERN.matcher(column).replaceAll(""));
 			PropertyDescriptor pd = (this.mappedFields != null ? this.mappedFields.get(field) : null);
 			if (pd != null) {
 				try {

--- a/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageWriter.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -53,6 +54,7 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 
 	private static final List<MediaType> WRITABLE_MEDIA_TYPES = Collections.singletonList(MediaType.TEXT_EVENT_STREAM);
 
+	private static final Pattern LINE_FEED_PATTERN = Pattern.compile("\\n");
 
 	@Nullable
 	private final Encoder<?> encoder;
@@ -135,7 +137,7 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 				writeField("retry", retry.toMillis(), sb);
 			}
 			if (comment != null) {
-				sb.append(':').append(comment.replaceAll("\\n", "\n:")).append("\n");
+				sb.append(':').append(LINE_FEED_PATTERN.matcher(comment).replaceAll("\n:")).append("\n");
 			}
 			if (data != null) {
 				sb.append("data:");
@@ -164,7 +166,7 @@ public class ServerSentEventHttpMessageWriter implements HttpMessageWriter<Objec
 
 		if (data instanceof String) {
 			String text = (String) data;
-			return Flux.from(encodeText(text.replaceAll("\\n", "\ndata:") + "\n", mediaType, factory));
+			return Flux.from(encodeText(LINE_FEED_PATTERN.matcher(text).replaceAll("\ndata:") + "\n", mediaType, factory));
 		}
 
 		if (this.encoder == null) {

--- a/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
@@ -80,6 +80,8 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 
 	private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
 
+	private static final Pattern WEAK_PATTERN = Pattern.compile("^W/");
+
 	private boolean notModified = false;
 
 
@@ -293,7 +295,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 			// Compare weak/strong ETags as per https://tools.ietf.org/html/rfc7232#section-2.3
 			while (etagMatcher.find()) {
 				if (StringUtils.hasLength(etagMatcher.group()) &&
-						etag.replaceFirst("^W/", "").equals(etagMatcher.group(3))) {
+						WEAK_PATTERN.matcher(etag).replaceFirst("").equals(etagMatcher.group(3))) {
 					this.notModified = true;
 					break;
 				}

--- a/spring-web/src/main/java/org/springframework/web/filter/ShallowEtagHeaderFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/ShallowEtagHeaderFilter.java
@@ -19,6 +19,7 @@ package org.springframework.web.filter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.regex.Pattern;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
@@ -62,6 +63,8 @@ public class ShallowEtagHeaderFilter extends OncePerRequestFilter {
 	private static final String DIRECTIVE_NO_STORE = "no-store";
 
 	private static final String STREAMING_ATTRIBUTE = ShallowEtagHeaderFilter.class.getName() + ".STREAMING";
+
+	private static final Pattern WEAK_PATTERN = Pattern.compile("^W/");
 
 
 	private boolean writeWeakETag = false;
@@ -127,7 +130,7 @@ public class ShallowEtagHeaderFilter extends OncePerRequestFilter {
 			rawResponse.setHeader(HEADER_ETAG, responseETag);
 			String requestETag = request.getHeader(HEADER_IF_NONE_MATCH);
 			if (requestETag != null && ("*".equals(requestETag) || responseETag.equals(requestETag) ||
-					responseETag.replaceFirst("^W/", "").equals(requestETag.replaceFirst("^W/", "")))) {
+					WEAK_PATTERN.matcher(responseETag).replaceFirst("").equals(WEAK_PATTERN.matcher(requestETag).replaceFirst("")))) {
 				rawResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 			}
 			else {

--- a/spring-web/src/main/java/org/springframework/web/server/adapter/DefaultServerWebExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/DefaultServerWebExchange.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import reactor.core.publisher.Mono;
 
@@ -75,6 +76,8 @@ public class DefaultServerWebExchange implements ServerWebExchange {
 	private static final Mono<MultiValueMap<String, Part>> EMPTY_MULTIPART_DATA =
 			Mono.just(CollectionUtils.unmodifiableMultiValueMap(new LinkedMultiValueMap<String, Part>(0)))
 					.cache();
+
+	private static final Pattern WEAK_PATTERN = Pattern.compile("^W/");
 
 
 	private final ServerHttpRequest request;
@@ -321,7 +324,7 @@ public class DefaultServerWebExchange implements ServerWebExchange {
 		for (String clientETag : ifNoneMatch) {
 			// Compare weak/strong ETags as per https://tools.ietf.org/html/rfc7232#section-2.3
 			if (StringUtils.hasLength(clientETag) &&
-					clientETag.replaceFirst("^W/", "").equals(etag.replaceFirst("^W/", ""))) {
+					WEAK_PATTERN.matcher(clientETag).replaceFirst("").equals(WEAK_PATTERN.matcher(etag).replaceFirst(""))) {
 				this.notModified = true;
 				break;
 			}


### PR DESCRIPTION
If we repeatedly call String#replaceAll, we internally repeatedly call the regular expression pattern compilation every time as following:
```java
    public String replaceAll(String regex, String replacement) {
        return Pattern.compile(regex).matcher(this).replaceAll(replacement);
    }
```
The modifications are to keep the compiled pattern.
Therefore, compiling a relatively expensive regular expression pattern does not have to be done every time.