### PR TITLE
Fix DefaultHandlerExceptionResolver Javadoc comments to match behaviour

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
@@ -88,7 +88,7 @@ import org.springframework.web.servlet.handler.AbstractHandlerExceptionResolver;
  * </tr>
  * <tr class="altColor">
  * <td><p>MissingServletRequestParameterException</p></td>
- * <td><p>500 (SC_INTERNAL_SERVER_ERROR)</p></td>
+ * <td><p>400 (SC_BAD_REQUEST)</p></td>
  * </tr>
  * <tr class="rowColor">
  * <td><p>ServletRequestBindingException</p></td>
@@ -364,7 +364,8 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	/**
 	 * Handle the case when a {@link org.springframework.web.bind.WebDataBinder} conversion cannot occur.
 	 * <p>The default implementation sends an HTTP 500 error, and returns an empty {@code ModelAndView}.
-	 * Alternatively, a fallback view could be chosen, or the TypeMismatchException could be rethrown as-is.
+	 * Alternatively, a fallback view could be chosen, or the ConversionNotSupportedException could be
+	 * rethrown as-is.
 	 * @param ex the ConversionNotSupportedException to be handled
 	 * @param request current HTTP request
 	 * @param response current HTTP response
@@ -401,7 +402,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	 * Handle the case where a {@linkplain org.springframework.http.converter.HttpMessageConverter message converter}
 	 * cannot read from a HTTP request.
 	 * <p>The default implementation sends an HTTP 400 error, and returns an empty {@code ModelAndView}.
-	 * Alternatively, a fallback view could be chosen, or the HttpMediaTypeNotSupportedException could be
+	 * Alternatively, a fallback view could be chosen, or the HttpMessageNotReadableException could be
 	 * rethrown as-is.
 	 * @param ex the HttpMessageNotReadableException to be handled
 	 * @param request current HTTP request
@@ -422,7 +423,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	 * {@linkplain org.springframework.http.converter.HttpMessageConverter message converter}
 	 * cannot write to a HTTP request.
 	 * <p>The default implementation sends an HTTP 500 error, and returns an empty {@code ModelAndView}.
-	 * Alternatively, a fallback view could be chosen, or the HttpMediaTypeNotSupportedException could
+	 * Alternatively, a fallback view could be chosen, or the HttpMessageNotWritableException could
 	 * be rethrown as-is.
 	 * @param ex the HttpMessageNotWritableException to be handled
 	 * @param request current HTTP request


### PR DESCRIPTION
An "obvious fix". 

Most notably, a `MissingServletRequestParameterException` actually results in a 400 response, not 500.