### PR TITLE
Allow configuration of Jetty WebSocket's max receive packet size

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/WebSocketMessage.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/WebSocketMessage.java
@@ -158,7 +158,7 @@ public class WebSocketMessage {
 		/**
 		 * WebSocket pong.
 		 */
-		PONG;
+		PONG
 	}
 
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/adapter/NettyWebSocketSessionSupport.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/adapter/NettyWebSocketSessionSupport.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import org.springframework.util.ObjectUtils;
@@ -50,6 +51,9 @@ public abstract class NettyWebSocketSessionSupport<T> extends AbstractWebSocketS
 	protected static final int DEFAULT_FRAME_MAX_SIZE = 64 * 1024;
 
 
+	@Value("${spring.web.reactive.socket.receiveFrameMaxSize:0}")
+	private int receiveFrameMaxSize;
+
 	private static final Map<Class<?>, WebSocketMessage.Type> messageTypes;
 
 	static {
@@ -71,6 +75,9 @@ public abstract class NettyWebSocketSessionSupport<T> extends AbstractWebSocketS
 		return (NettyDataBufferFactory) super.bufferFactory();
 	}
 
+	protected int receiveFrameMaxSize() {
+		return this.receiveFrameMaxSize > 0 ? this.receiveFrameMaxSize : DEFAULT_FRAME_MAX_SIZE;
+	}
 
 	protected WebSocketMessage toMessage(WebSocketFrame frame) {
 		DataBuffer payload = bufferFactory().wrap(frame.content());

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/adapter/ReactorNettyWebSocketSession.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/adapter/ReactorNettyWebSocketSession.java
@@ -43,7 +43,6 @@ import org.springframework.web.reactive.socket.WebSocketSession;
 public class ReactorNettyWebSocketSession
 		extends NettyWebSocketSessionSupport<ReactorNettyWebSocketSession.WebSocketConnection> {
 
-
 	public ReactorNettyWebSocketSession(WebsocketInbound inbound, WebsocketOutbound outbound,
 			HandshakeInfo info, NettyDataBufferFactory bufferFactory) {
 
@@ -54,7 +53,7 @@ public class ReactorNettyWebSocketSession
 	@Override
 	public Flux<WebSocketMessage> receive() {
 		return getDelegate().getInbound()
-				.aggregateFrames(DEFAULT_FRAME_MAX_SIZE)
+				.aggregateFrames(receiveFrameMaxSize())
 				.receiveFrames()
 				.map(super::toMessage)
 				.doOnNext(message -> {


### PR DESCRIPTION
Currently, Jetty's WebSocket packet size for receive direction is limited by a constant (DEFAULT_FRAME_MAX_SIZE = 64Kb). This causes a problem while receiving e.g. multimedia contents such as jpg images. The pull requests tries to provide a configuration of this max packet size.

Honesty, I am not sure if it is the best idea using @Value annotation. But at least, this pull request shows the demand for a proper configuration.