### PR TITLE
SPR-17299 - Fix javadoc error

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Autowired.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Autowired.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Autowired.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Autowired.java
@@ -26,9 +26,15 @@ import java.lang.annotation.Target;
  * Marks a constructor, field, setter method or config method as to be autowired
  * by Spring's dependency injection facilities.
  *
- * <p>Only one constructor (at max) of any given bean class may carry this annotation,
- * indicating the constructor to autowire when used as a Spring bean. Such a
- * constructor does not have to be public.
+ * <p>Only one constructor (at max) of any given bean class may carry this
+ * annotation with the 'required' parameter set to {@code true},
+ * indicating <i>the</i> constructor to autowire when used as a Spring bean.
+ * If multiple <i>non-required</i> constructors carry the annotation, they
+ * will be considered as candidates for autowiring. The constructor with
+ * the greatest number of dependencies that can be satisfied by matching
+ * beans in the Spring container will be chosen. If none of the candidates
+ * can be satisfied, then a default constructor (if present) will be used.
+ * An annotated constructor does not have to be public.
  *
  * <p>Fields are injected right after construction of a bean, before any config
  * methods are invoked. Such a config field does not have to be public.


### PR DESCRIPTION
Comments on applying the annotation Autowired to constructor are error, we can refer to the javadoc of class AutowiredAnnotationBeanPostProcessor for correct description.

Issue: SPR-17299