### PR TITLE
Updated referenced dependency on project reactor to working version

### DIFF
--- a/src/docs/asciidoc/web/websocket.adoc
+++ b/src/docs/asciidoc/web/websocket.adoc
@@ -1595,7 +1595,7 @@ messages to it, and then forwards all messages received
 from the broker to clients through their WebSocket sessions. Essentially,
 it acts as a "`relay`" that forwards messages in both directions.
 
-NOTE: Add `io.projectreactor.netty:reactor-netty` and `io.netty:netty-all`
+NOTE: Add `io.projectreactor.ipc:reactor-netty` and `io.netty:netty-all`
 dependencies to your project for TCP connection management.
 
 Furthermore, application components (such as HTTP request handling methods,


### PR DESCRIPTION
Tried to use the referenced `io.projectreactor.netty:reactor-netty` however the dependency was not found. Changing it to `io.projectreactor.netty:reactor-netty:0.8.0.RELEASE` leads to the dependency being found but getting a `ClassNotFoundException` at runtime.

After switching to: `io.projectreactor.ipc:reactor-netty` everything started working. 