### PR TITLE
Leverage ObjectProvider instead of autowired containers

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/adapter/WebHttpHandlerBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/WebHttpHandlerBuilder.java
@@ -18,13 +18,11 @@ package org.springframework.web.server.adapter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.http.codec.ServerCodecConfigurer;
@@ -158,12 +156,16 @@ public final class WebHttpHandlerBuilder {
 		WebHttpHandlerBuilder builder = new WebHttpHandlerBuilder(
 				context.getBean(WEB_HANDLER_BEAN_NAME, WebHandler.class), context);
 
-		// Autowire lists for @Bean + @Order
-
-		SortedBeanContainer container = new SortedBeanContainer();
-		context.getAutowireCapableBeanFactory().autowireBean(container);
-		builder.filters(filters -> filters.addAll(container.getFilters()));
-		builder.exceptionHandlers(handlers -> handlers.addAll(container.getExceptionHandlers()));
+		List<WebFilter> webFilters = context
+				.getBeanProvider(WebFilter.class)
+				.orderedStream()
+				.collect(Collectors.toList());
+		builder.filters(filters -> filters.addAll(webFilters));
+		List<WebExceptionHandler> exceptionHandlers = context
+				.getBeanProvider(WebExceptionHandler.class)
+				.orderedStream()
+				.collect(Collectors.toList());
+		builder.exceptionHandlers(handlers -> handlers.addAll(exceptionHandlers));
 
 		try {
 			builder.sessionManager(
@@ -387,32 +389,6 @@ public final class WebHttpHandlerBuilder {
 	@Override
 	public WebHttpHandlerBuilder clone() {
 		return new WebHttpHandlerBuilder(this);
-	}
-
-
-	private static class SortedBeanContainer {
-
-		private List<WebFilter> filters = Collections.emptyList();
-
-		private List<WebExceptionHandler> exceptionHandlers = Collections.emptyList();
-
-		@Autowired(required = false)
-		public void setFilters(List<WebFilter> filters) {
-			this.filters = filters;
-		}
-
-		public List<WebFilter> getFilters() {
-			return this.filters;
-		}
-
-		@Autowired(required = false)
-		public void setExceptionHandlers(List<WebExceptionHandler> exceptionHandlers) {
-			this.exceptionHandlers = exceptionHandlers;
-		}
-
-		public List<WebExceptionHandler> getExceptionHandlers() {
-			return this.exceptionHandlers;
-		}
 	}
 
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/RouterFunctionMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/RouterFunctionMapping.java
@@ -18,11 +18,11 @@ package org.springframework.web.reactive.function.server.support;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.lang.Nullable;
@@ -111,9 +111,11 @@ public class RouterFunctionMapping extends AbstractHandlerMapping implements Ini
 	}
 
 	private List<RouterFunction<?>> routerFunctions() {
-		SortedRouterFunctionsContainer container = new SortedRouterFunctionsContainer();
-		obtainApplicationContext().getAutowireCapableBeanFactory().autowireBean(container);
-		List<RouterFunction<?>> functions = container.routerFunctions;
+		List<RouterFunction<?>> functions = this.getApplicationContext()
+				.getBeanProvider(RouterFunction.class)
+				.orderedStream()
+				.map(router -> (RouterFunction<?>)router)
+				.collect(Collectors.toList());
 		return (!CollectionUtils.isEmpty(functions) ? functions : Collections.emptyList());
 	}
 
@@ -145,18 +147,6 @@ public class RouterFunctionMapping extends AbstractHandlerMapping implements Ini
 		}
 		else {
 			return Mono.empty();
-		}
-	}
-
-
-	private static class SortedRouterFunctionsContainer {
-
-		@Nullable
-		private List<RouterFunction<?>> routerFunctions;
-
-		@Autowired(required = false)
-		public void setRouterFunctions(List<RouterFunction<?>> routerFunctions) {
-			this.routerFunctions = routerFunctions;
 		}
 	}
 


### PR DESCRIPTION
In order to be able to leverage WebFlux configuration in a functional way, `WebHttpHandlerBuilder` and `RouterFunctionMapping` should leverage new `ObjectProvider` capabilities to get a sorted list of beans by type instead of using autowired containers.

@bclozel @jhoeller After a second look, it is not required to refactor [`DelegatingWebFluxConfiguration`](https://github.com/spring-projects/spring-framework/blob/master/spring-webflux/src/main/java/org/springframework/web/reactive/config/DelegatingWebFluxConfiguration.java) since in functional mode the autowired setter can be called externally using `ObjectProvider` capabilities + I don't think we could reach consistent design via a constructor approach.

@poutsma Are you ok with these changes?

Issue: [SPR-17327](https://jira.spring.io/browse/SPR-17327)