### PR TITLE
SPR-17338. Do not throw ServerWebInputException when mandatory request parameter is present

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractNamedValueArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractNamedValueArgumentResolver.java
@@ -205,23 +205,18 @@ public abstract class AbstractNamedValueArgumentResolver extends HandlerMethodAr
 	 */
 	private Mono<Object> getDefaultValue(NamedValueInfo namedValueInfo, MethodParameter parameter,
 			BindingContext bindingContext, Model model, ServerWebExchange exchange) {
-
-		Object value = null;
-		try {
+		return Mono.fromSupplier(() -> {
+			Object value = null;
 			if (namedValueInfo.defaultValue != null) {
 				value = resolveStringValue(namedValueInfo.defaultValue);
-			}
-			else if (namedValueInfo.required && !parameter.isOptional()) {
+			} else if (namedValueInfo.required && !parameter.isOptional()) {
 				handleMissingValue(namedValueInfo.name, parameter, exchange);
 			}
 			value = handleNullValue(namedValueInfo.name, value, parameter.getNestedParameterType());
 			value = applyConversion(value, namedValueInfo, parameter, bindingContext, exchange);
 			handleResolvedValue(value, namedValueInfo.name, parameter, model, exchange);
-			return Mono.justOrEmpty(value);
-		}
-		catch (Throwable ex) {
-			return Mono.error(ex);
-		}
+			return value;
+		});
 	}
 
 	/**


### PR DESCRIPTION
ServerWebInputException is throw each time Http request with mandatory request parameters is handled in AbstractNamedValueArgumentResolver. Even though this does not brake request handling flow, exception (and stack trace)  is generated each time and it has performance impact. 

The solution: Default value should be evaluated only if request parameter is empty: 

[JIAR ticket](https://jira.spring.io/browse/SPR-17338)