### PR TITLE
Fix construction of NullSafeComparator in nullsLow

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/comparator/Comparators.java
+++ b/spring-core/src/main/java/org/springframework/util/comparator/Comparators.java
@@ -52,7 +52,7 @@ public abstract class Comparators {
 	 * @see NullSafeComparator#NullSafeComparator(boolean)
 	 */
 	public static <T> Comparator<T> nullsLow(Comparator<T> comparator) {
-		return new NullSafeComparator<>(comparator, false);
+		return new NullSafeComparator<>(comparator, true);
 	}
 
 	/**


### PR DESCRIPTION
Previously, both nullsLow(Comparator<T>) and nullsHigh(Comparator<T>) returned a NullSafeComparator which treated nulls as being high. This commit corrects the typo in nullsLow.