### PR TITLE
Refactor the handle null value method

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractNamedValueArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractNamedValueArgumentResolver.java
@@ -255,16 +255,18 @@ public abstract class AbstractNamedValueArgumentResolver extends HandlerMethodAr
 	 */
 	@Nullable
 	private Object handleNullValue(String name, @Nullable Object value, Class<?> paramType) {
-		if (value == null) {
-			if (Boolean.TYPE.equals(paramType)) {
-				return Boolean.FALSE;
-			}
-			else if (paramType.isPrimitive()) {
-				throw new IllegalStateException("Optional " + paramType.getSimpleName() +
-						" parameter '" + name + "' is present but cannot be translated into a" +
-						" null value due to being declared as a primitive type. " +
-						"Consider declaring it as object wrapper for the corresponding primitive type.");
-			}
+		if (value != null) {
+			return value;
+		}
+
+		if (Boolean.TYPE.equals(paramType)) {
+			return Boolean.FALSE;
+		}
+		else if (paramType.isPrimitive()) {
+			throw new IllegalStateException("Optional " + paramType.getSimpleName() +
+					" parameter '" + name + "' is present but cannot be translated into a" +
+					" null value due to being declared as a primitive type. " +
+					"Consider declaring it as object wrapper for the corresponding primitive type.");
 		}
 		return value;
 	}


### PR DESCRIPTION
Instead of nesting all the logic inside an if when the value is null, now a guard against not null values will cause an early return, improving the readability by removing that indentation.