### PR TITLE
Updated Javadoc: date format patterns SPR-17366

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/annotation/DateTimeFormat.java
+++ b/spring-context/src/main/java/org/springframework/format/annotation/DateTimeFormat.java
@@ -97,13 +97,13 @@ public @interface DateTimeFormat {
 		DATE,
 
 		/**
-		 * The most common ISO Time Format {@code HH:mm:ss.SSSZ},
+		 * The most common ISO Time Format {@code HH:mm:ss.SSSXXX},
 		 * e.g. "01:30:00.000-05:00".
 		 */
 		TIME,
 
 		/**
-		 * The most common ISO DateTime Format {@code yyyy-MM-dd'T'HH:mm:ss.SSSZ},
+		 * The most common ISO DateTime Format {@code yyyy-MM-dd'T'HH:mm:ss.SSSXXX},
 		 * e.g. "2000-10-31T01:30:00.000-05:00".
 		 * <p>This is the default if no annotation value is specified.
 		 */


### PR DESCRIPTION
The javadoc here: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/format/annotation/DateTimeFormat.ISO.html#DATE_TIME

states that the ISO DATE_TIME format uses the pattern `yyyy-MM-dd'T'HH:mm:ss.SSSZ`

but in fact the pattern is `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`

The change was made by this commit:

https://github.com/spring-projects/spring-framework/commit/bb94ba6e3ff8dfc053c5808d337289e8df37e935#diff-4e8b86c8c802560c74bf5647b9c91bb6

The javadoc needs to be changed to reflect the reality. The same also applies for the TIME format.

The actual difference is in the colon in the time zone offset. It was added in the commit mentioned above, and the examples in the documentation are correct. But not the pattern and it might be confusing.