### PR TITLE
Replace nested conditional with guard clauses

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AnnotationBeanWiringInfoResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AnnotationBeanWiringInfoResolver.java
@@ -55,16 +55,12 @@ public class AnnotationBeanWiringInfoResolver implements BeanWiringInfoResolver 
 		if (!Autowire.NO.equals(annotation.autowire())) {
 			return new BeanWiringInfo(annotation.autowire().value(), annotation.dependencyCheck());
 		}
-		else {
-			if (!"".equals(annotation.value())) {
-				// explicitly specified bean name
-				return new BeanWiringInfo(annotation.value(), false);
-			}
-			else {
-				// default bean name
-				return new BeanWiringInfo(getDefaultBeanName(beanInstance), true);
-			}
+		if (!"".equals(annotation.value())) {
+			// explicitly specified bean name
+			return new BeanWiringInfo(annotation.value(), false);
 		}
+		// default bean name
+		return new BeanWiringInfo(getDefaultBeanName(beanInstance), true);
 	}
 
 	/**


### PR DESCRIPTION
The method has conditionals that do make difficult to follow the path of execution.

Solution:

Uses guard clauses to improve readability.