### PR TITLE
Fix deprecated property in MBeanExporter documentation

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -3440,33 +3440,32 @@ The following table summarizes these registration behaviors:
 |===
 | Registration behavior | Explanation
 
-| `REGISTRATION_FAIL_ON_EXISTING`
+| `FAIL_ON_EXISTING`
 | This is the default registration behavior. If an `MBean` instance has already been
   registered under the same `ObjectName`, the `MBean` that is being registered is not
   registered, and an `InstanceAlreadyExistsException` is thrown. The existing
   `MBean` is unaffected.
 
-| `REGISTRATION_IGNORE_EXISTING`
+| `IGNORE_EXISTING`
 | If an `MBean` instance has already been registered under the same `ObjectName`, the
   `MBean` that is being registered is not registered. The existing `MBean` is
   unaffected, and no `Exception` is thrown. This is useful in settings where
   multiple applications want to share a common `MBean` in a shared `MBeanServer`.
 
-| `REGISTRATION_REPLACE_EXISTING`
+| `REPLACE_EXISTING`
 | If an `MBean` instance has already been registered under the same `ObjectName`, the
   existing `MBean` that was previously registered is unregistered, and the new
   `MBean` is registered in its place (the new `MBean` effectively replaces the
   previous instance).
 |===
 
-The values in the preceding table are defined as constants on the `MBeanRegistrationSupport` class (the
-`MBeanExporter` class derives from this superclass). If you want to change the default
-registration behavior, you need to set the value of the
-`registrationBehaviorName` property on your `MBeanExporter` definition to one of those
+The values in the preceding table are defined as enums on the `RegistrationPolicy` class. 
+If you want to change the default registration behavior, you need to set the value of the
+`registrationPolicy` property on your `MBeanExporter` definition to one of those
 values.
 
 The following example shows how to change from the default registration
-behavior to the `REGISTRATION_REPLACE_EXISTING` behavior:
+behavior to the `REPLACE_EXISTING` behavior:
 
 ====
 [source,xml,indent=0]
@@ -3480,7 +3479,7 @@ behavior to the `REGISTRATION_REPLACE_EXISTING` behavior:
 					<entry key="bean:name=testBean1" value-ref="testBean"/>
 				</map>
 			</property>
-			<property name="registrationBehaviorName" value="REGISTRATION_REPLACE_EXISTING"/>
+			<property name="registrationPolicy" value="REPLACE_EXISTING"/>
 		</bean>
 
 		<bean id="testBean" class="org.springframework.jmx.JmxTestBean">


### PR DESCRIPTION
The documentation still pointed to the deprecated property `registrationBehaviorName`.
The property was removed in Spring 5 by this commit: b5db5d3aac39ca7cff4ccca491652d9490a1d175