### PR TITLE
Adds isNotEmpty to StringUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -90,6 +90,15 @@ public abstract class StringUtils {
 	}
 
 	/**
+	 * Check whether the given {@code String} is not empty.
+	 * @param str the candidate String
+	 * @see #isEmpty(String)
+	 */
+	public static boolean isNotEmpty(@Nullable Object str) {
+		return !isEmpty(str);
+	}
+
+	/**
 	 * Check that the given {@code CharSequence} is neither {@code null} nor
 	 * of length 0.
 	 * <p>Note: this method returns {@code true} for a {@code CharSequence}

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -32,6 +32,13 @@ import static org.junit.Assert.*;
 public class StringUtilsTests {
 
 	@Test
+	public void testIsNotEmpty() {
+		assertEquals(false, StringUtils.isNotEmpty(null));
+		assertEquals(false, StringUtils.isNotEmpty(""));
+		assertEquals(true, StringUtils.isNotEmpty("a"));
+	}
+
+	@Test
 	public void testHasTextBlank() {
 		String blank = "          ";
 		assertEquals(false, StringUtils.hasText(blank));


### PR DESCRIPTION
Quite a few times, the code is execution when the string value exists. In such cases, we always check `StringUtils.isEmpty(str)` and then negate it like below.

```
if (!StringUtils.isEmpty(str)) {
   ....
}
```

Having a `StringUtils.isNotEmpty()` would simplify the code readability and also chances of somebody ignore the `!` mark.