### PR TITLE
fix exception chain loss

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -552,7 +552,7 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 			catch (BeansException ex) {
 				if (logger.isWarnEnabled()) {
 					logger.warn("Exception encountered during context initialization - " +
-							"cancelling refresh attempt: " + ex);
+							"cancelling refresh attempt: ",ex);
 				}
 
 				// Destroy already created singletons to avoid dangling resources.


### PR DESCRIPTION
When the application initialization fails, the wrong log method call causes exception chain loss.