### PR TITLE
SPR-17458 Documentation explicit Executor usage on @Async section

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -3413,7 +3413,7 @@ The following table summarizes these registration behaviors:
   previous instance).
 |===
 
-The values in the preceding table are defined as enums on the `RegistrationPolicy` class. 
+The values in the preceding table are defined as enums on the `RegistrationPolicy` class.
 If you want to change the default registration behavior, you need to set the value of the
 `registrationPolicy` property on your `MBeanExporter` definition to one of those
 values.
@@ -6680,8 +6680,35 @@ in combination with a custom pointcut.
 [[scheduling-annotation-support-qualification]]
 ==== Executor Qualification with `@Async`
 
-By default, when specifying `@Async` on a method, the executor that is used is the
-one supplied to the "`annotation-driven`" element, as described earlier. However, you can use the `value`
+As seen previously, you can enable the `@Async` annotation by adding `@EnableAsync` to any of your
+`@Configuration` classes:
+
+====
+[source,java,indent=0]
+[subs="verbatim,quotes"]
+----
+	@Configuration
+	@EnableAsync
+	public class AppConfig {
+	}
+----
+====
+
+Or in the case of XML configuration:
+
+====
+[source,xml,indent=0]
+[subs="verbatim,quotes"]
+----
+	<task:annotation-driven executor="myExecutor" scheduler="myScheduler"/>
+	<task:executor id="myExecutor" pool-size="5"/>
+	<task:scheduler id="myScheduler" pool-size="10"/>
+----
+====
+
+In the above XML configuration example in particular, the `"myExecutor"` executor
+we are registering is the one that is getting used by default when specifying `@Async` on a method.
+However, you can use the `value`
 attribute of the `@Async` annotation when you need to indicate that an
 executor other than the default should be used when executing a given method.
 The following example shows how to do so:


### PR DESCRIPTION
Making more explicit the reference to the Executor usage for `@Async`.