### PR TITLE
SPR-17459 Catering for comma being part of the media/mime type as double quoted

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -37,6 +37,7 @@ import org.springframework.util.MimeType.SpecificityComparator;
  *
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
+ * @author Dimitrios Liapis
  * @since 4.0
  */
 public abstract class MimeTypeUtils {
@@ -257,12 +258,20 @@ public abstract class MimeTypeUtils {
 		if (!StringUtils.hasLength(mimeTypes)) {
 			return Collections.emptyList();
 		}
-		String[] tokens = StringUtils.tokenizeToStringArray(mimeTypes, ",");
-		List<MimeType> result = new ArrayList<>(tokens.length);
-		for (String token : tokens) {
-			result.add(parseMimeType(token));
+		boolean isQuoted = false;
+		int nextBeginIndex = 0;
+		List<MimeType> tokens = new ArrayList<>();
+		for(int i = 0; i < mimeTypes.length() - 1; i++) {
+			if(mimeTypes.charAt(i) == ',' && !isQuoted) {
+				tokens.add(parseMimeType(mimeTypes.substring(nextBeginIndex,i)));
+				nextBeginIndex = i + 1;
+			} else if(mimeTypes.charAt(i) == '"') {
+				isQuoted = !isQuoted;
+			}
 		}
-		return result;
+		//either the last part of the tokenization or the original string
+		tokens.add(parseMimeType(mimeTypes.substring(nextBeginIndex)));
+		return tokens;
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -266,7 +266,7 @@ public abstract class MimeTypeUtils {
 			if(mimeTypes.charAt(i) == ',' && !isQuoted) {
 				tokens.add(parseMimeType(mimeTypes.substring(nextBeginIndex,i)));
 				nextBeginIndex = i + 1;
-				//ignoring escaped double quote within double quotes
+			//ignoring escaped double quote within double quotes
 			} else if(isQuoted && mimeTypes.charAt(i) == '"' && mimeTypes.charAt(i-1) == '\\') {
 				continue;
 			} else if(mimeTypes.charAt(i) == '"') {

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -267,7 +267,7 @@ public abstract class MimeTypeUtils {
 				tokens.add(parseMimeType(mimeTypes.substring(nextBeginIndex,i)));
 				nextBeginIndex = i + 1;
 				//ignoring escaped double quote within double quotes
-			} else if(isQuoted && mimeTypes.charAt(i) == '"' && i > 0 && mimeTypes.charAt(i-1) == '\\') {
+			} else if(isQuoted && mimeTypes.charAt(i) == '"' && mimeTypes.charAt(i-1) == '\\') {
 				continue;
 			} else if(mimeTypes.charAt(i) == '"') {
 				isQuoted = !isQuoted;

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -262,9 +262,13 @@ public abstract class MimeTypeUtils {
 		int nextBeginIndex = 0;
 		List<MimeType> tokens = new ArrayList<>();
 		for(int i = 0; i < mimeTypes.length() - 1; i++) {
+			//tokenizing on commas that are not within double quotes
 			if(mimeTypes.charAt(i) == ',' && !isQuoted) {
 				tokens.add(parseMimeType(mimeTypes.substring(nextBeginIndex,i)));
 				nextBeginIndex = i + 1;
+				//ignoring escaped double quote within double quotes
+			} else if(isQuoted && mimeTypes.charAt(i) == '"' && i > 0 && mimeTypes.charAt(i-1) == '\\') {
+				continue;
 			} else if(mimeTypes.charAt(i) == '"') {
 				isQuoted = !isQuoted;
 			}

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -304,6 +304,15 @@ public class MimeTypeTests {
 		assertEquals("Comma should be part of the mime type", "foo/bar;param=\"s,\"", mimeTypes.get(0).toString());
 	}
 
+	// SPR-17459
+	@Test
+	public void parseMimeTypesIgnoreEscapedDoubleQuoteWithinDoubleQuotes() {
+		String s = "foo/bar;param=\"a\\\"b,c\"";
+		List<MimeType> mimeTypes = MimeTypeUtils.parseMimeTypes(s);
+		assertEquals("Invalid amount of mime types", 1, mimeTypes.size());
+		assertEquals("Escaped quote within quotes should be ignored when considering comma tokenization", s, mimeTypes.get(0).toString());
+	}
+
 	@Test
 	public void compareTo() {
 		MimeType audioBasic = new MimeType("audio", "basic");

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.*;
  * @author Arjen Poutsma
  * @author Juergen Hoeller
  * @author Sam Brannen
+ * @author Dimitrios Liapis
  */
 public class MimeTypeTests {
 
@@ -274,6 +275,33 @@ public class MimeTypeTests {
 		mimeTypes = MimeTypeUtils.parseMimeTypes(null);
 		assertNotNull("No mime types returned", mimeTypes);
 		assertEquals("Invalid amount of mime types", 0, mimeTypes.size());
+	}
+
+	// SPR-17459
+	@Test
+	public void parseMimeTypesWithOddNumberOfDoubleQuotedCommas() {
+		String s = "foo/bar;param=\",\"";
+		List<MimeType> mimeTypes = MimeTypeUtils.parseMimeTypes(s);
+		assertEquals("Invalid amount of mime types", 1, mimeTypes.size());
+		assertEquals("Comma should be part of the mime type", s, mimeTypes.get(0).toString());
+	}
+
+	// SPR-17459
+	@Test
+	public void parseMimeTypesWithEvenNumberOfDoubleQuotedCommas() {
+		String s = "foo/bar;param=\"s,a,\"";
+		List<MimeType> mimeTypes = MimeTypeUtils.parseMimeTypes(s);
+		assertEquals("Invalid amount of mime types", 1, mimeTypes.size());
+		assertEquals("Comma should be part of the mime type", s, mimeTypes.get(0).toString());
+	}
+
+	// SPR-17459
+	@Test
+	public void parseMimeTypesWithAndWithoutDoubleQuotedCommas() {
+		String s = "foo/bar;param=\"s,\", text/x-c";
+		List<MimeType> mimeTypes = MimeTypeUtils.parseMimeTypes(s);
+		assertEquals("Invalid amount of mime types", 2, mimeTypes.size());
+		assertEquals("Comma should be part of the mime type", "foo/bar;param=\"s,\"", mimeTypes.get(0).toString());
 	}
 
 	@Test

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -313,6 +313,20 @@ public class MimeTypeTests {
 		assertEquals("Escaped quote within quotes should be ignored when considering comma tokenization", s, mimeTypes.get(0).toString());
 	}
 
+	// SPR-17459
+	@Test
+	public void parseMimeTypesIgnoreEscapedBackslash() {
+		String s = "foo/bar;param=\"\\\\\"";
+		List<MimeType> mimeTypes = MimeTypeUtils.parseMimeTypes(s);
+		assertEquals("Invalid amount of mime types", 1, mimeTypes.size());
+		assertEquals("Escaped backslash should be ignored when considering comma tokenization", s, mimeTypes.get(0).toString());
+
+		s = "foo/bar;param=\"\\,\\\"";
+		mimeTypes = MimeTypeUtils.parseMimeTypes(s);
+		assertEquals("Invalid amount of mime types", 1, mimeTypes.size());
+		assertEquals("Escaped backslash should be ignored when considering comma tokenization", s, mimeTypes.get(0).toString());
+	}
+
 	@Test
 	public void compareTo() {
 		MimeType audioBasic = new MimeType("audio", "basic");

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -557,9 +557,13 @@ public class MediaType extends MimeType implements Serializable {
 		int nextBeginIndex = 0;
 		List<MediaType> tokens = new ArrayList<>();
 		for(int i = 0; i < mediaTypes.length() - 1; i++) {
+			//tokenizing on commas that are not within double quotes
 			if(mediaTypes.charAt(i) == ',' && !isQuoted) {
-				tokens.add(parseMediaType(mediaTypes.substring(nextBeginIndex,i)));
+				tokens.add(parseMediaType(mediaTypes.substring(nextBeginIndex, i)));
 				nextBeginIndex = i + 1;
+			//ignoring escaped double quote within double quotes
+			} else if(isQuoted && mediaTypes.charAt(i) == '"' && i > 0 && mediaTypes.charAt(i-1) == '\\') {
+				continue;
 			} else if(mediaTypes.charAt(i) == '"') {
 				isQuoted = !isQuoted;
 			}

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -552,12 +552,21 @@ public class MediaType extends MimeType implements Serializable {
 		if (!StringUtils.hasLength(mediaTypes)) {
 			return Collections.emptyList();
 		}
-		String[] tokens = StringUtils.tokenizeToStringArray(mediaTypes, ",");
-		List<MediaType> result = new ArrayList<>(tokens.length);
-		for (String token : tokens) {
-			result.add(parseMediaType(token));
+		boolean isQuoted = false;
+		int nextBeginIndex = 0;
+		List<MediaType> tokens = new ArrayList<>();
+		for(int i = 0; i < mediaTypes.length() - 1; i++) {
+			if(mediaTypes.charAt(i) == ',' && !isQuoted) {
+				tokens.add(parseMediaType(mediaTypes.substring(nextBeginIndex,i)));
+				nextBeginIndex = i + 1;
+			} else if(mediaTypes.charAt(i) == '"') {
+				isQuoted = !isQuoted;
+			}
 		}
-		return result;
+		//either the last part of the tokenization or the original string
+		//itself if not found any commas that are not double quoted.
+		tokens.add(parseMediaType(mediaTypes.substring(nextBeginIndex)));
+		return tokens;
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -562,7 +562,7 @@ public class MediaType extends MimeType implements Serializable {
 				tokens.add(parseMediaType(mediaTypes.substring(nextBeginIndex, i)));
 				nextBeginIndex = i + 1;
 			//ignoring escaped double quote within double quotes
-			} else if(isQuoted && mediaTypes.charAt(i) == '"' && i > 0 && mediaTypes.charAt(i-1) == '\\') {
+			} else if(isQuoted && mediaTypes.charAt(i) == '"' && mediaTypes.charAt(i-1) == '\\') {
 				continue;
 			} else if(mediaTypes.charAt(i) == '"') {
 				isQuoted = !isQuoted;

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Rossen Stoyanchev
  * @author Sebastien Deleuze
  * @author Kazuki Shimizu
+ * @author Dimitrios Liapis
  * @since 3.0
  * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.1.1">
  *     HTTP 1.1: Semantics and Content, section 3.1.1.1</a>
@@ -564,7 +565,6 @@ public class MediaType extends MimeType implements Serializable {
 			}
 		}
 		//either the last part of the tokenization or the original string
-		//itself if not found any commas that are not double quoted.
 		tokens.add(parseMediaType(mediaTypes.substring(nextBeginIndex)));
 		return tokens;
 	}

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -552,58 +552,12 @@ public class MediaType extends MimeType implements Serializable {
 		if (!StringUtils.hasLength(mediaTypes)) {
 			return Collections.emptyList();
 		}
-		String[] tokens = isAnyCommaDoubleQuotedInString(mediaTypes) ?
-				tokenizeOnCommasIgnoringDoubleQuotedCommas(mediaTypes) :
-				StringUtils.tokenizeToStringArray(mediaTypes, ",");
+		String[] tokens = StringUtils.tokenizeToStringArray(mediaTypes, ",");
 		List<MediaType> result = new ArrayList<>(tokens.length);
 		for (String token : tokens) {
 			result.add(parseMediaType(token));
 		}
 		return result;
-	}
-
-	private static String[] tokenizeOnCommasIgnoringDoubleQuotedCommas(String string) {
-		List<Integer> indices = indicesOfNonDoubleQuotedCommasInString(string);
-		int beginIndex = 0;
-		ArrayList<String> tokens = new ArrayList<>(indices.size()+1);
-		for(int commaIndex : indices) {
-			tokens.add(string.substring(beginIndex, commaIndex));
-			beginIndex = commaIndex + 1;
-		}
-		//either 0 indices or the last part of the tokenization
-		tokens.add(string.substring(beginIndex));
-		return tokens.toArray(new String[0]);
-	}
-
-	private static List<Integer> indicesOfNonDoubleQuotedCommasInString(String string) {
-		boolean isQuoted = false;
-		int totalCommaOccurences = string.length() - string.replace(",", "").length();
-		if(totalCommaOccurences == 0) {
-			return Collections.emptyList();
-		}
-		List<Integer> indicesOfNonDoubleQuotedCommas = new ArrayList<>(totalCommaOccurences);
-		for(int i=0; i < string.length(); i++) {
-			char currentStringChar = string.charAt(i);
-			if(currentStringChar == ',' && !isQuoted) {
-				indicesOfNonDoubleQuotedCommas.add(i);
-			} else if(currentStringChar == '"') {
-				isQuoted = !isQuoted;
-			}
-		}
-		return indicesOfNonDoubleQuotedCommas;
-	}
-
-	private static boolean isAnyCommaDoubleQuotedInString(String string) {
-		boolean isQuoted = false;
-		for(int i=0; i<string.length(); i++) {
-			char currentStringChar = string.charAt(i);
-			if(currentStringChar == ',') {
-				return isQuoted;
-			} else if(currentStringChar == '"') {
-				isQuoted = !isQuoted;
-			}
-		}
-		return false;
 	}
 
 	/**

--- a/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
+++ b/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
@@ -144,6 +144,30 @@ public class MediaTypeTests {
 	}
 
 	@Test
+	public void parseMediaTypesWithOddNumberOfDoubleQuotedCommas() {
+		String s = "foo/bar;param=\",\"";
+		List<MediaType> mediaTypes = MediaType.parseMediaTypes(s);
+		assertEquals("Invalid amount of media types", 1, mediaTypes.size());
+		assertEquals("Comma should be part of the media type", s, mediaTypes.get(0).toString());
+	}
+
+	@Test
+	public void parseMediaTypesWithEvenNumberOfDoubleQuotedCommas() {
+		String s = "foo/bar;param=\"s,a,\"";
+		List<MediaType> mediaTypes = MediaType.parseMediaTypes(s);
+		assertEquals("Invalid amount of media types", 1, mediaTypes.size());
+		assertEquals("Comma should be part of the media type", s, mediaTypes.get(0).toString());
+	}
+
+	@Test
+	public void parseMediaTypesWithAndWithoutDoubleQuotedCommas() {
+		String s = "foo/bar;param=\"s,\", text/x-c";
+		List<MediaType> mediaTypes = MediaType.parseMediaTypes(s);
+		assertEquals("Invalid amount of media types", 2, mediaTypes.size());
+		assertEquals("Comma should be part of the media type", "foo/bar;param=\"s,\"", mediaTypes.get(0).toString());
+	}
+
+	@Test
 	public void compareTo() {
 		MediaType audioBasic = new MediaType("audio", "basic");
 		MediaType audio = new MediaType("audio");

--- a/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
+++ b/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
@@ -180,6 +180,20 @@ public class MediaTypeTests {
 		assertEquals("Escaped quote within quotes should be ignored when considering comma tokenization", s, mediaTypes.get(0).toString());
 	}
 
+	// SPR-17459
+	@Test
+	public void parseMediaTypesIgnoreEscapedBackslash() {
+		String s = "foo/bar;param=\"\\\\\"";
+		List<MediaType> mediaTypes = MediaType.parseMediaTypes(s);
+		assertEquals("Invalid amount of media types", 1, mediaTypes.size());
+		assertEquals("Escaped quote within quotes should be ignored when considering comma tokenization", s, mediaTypes.get(0).toString());
+
+		s = "foo/bar;param=\"\\,\\\"";
+		mediaTypes = MediaType.parseMediaTypes(s);
+		assertEquals("Invalid amount of media types", 1, mediaTypes.size());
+		assertEquals("Escaped quote within quotes should be ignored when considering comma tokenization", s, mediaTypes.get(0).toString());
+	}
+
 	@Test
 	public void compareTo() {
 		MediaType audioBasic = new MediaType("audio", "basic");

--- a/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
+++ b/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
@@ -143,6 +143,7 @@ public class MediaTypeTests {
 		assertEquals("Invalid amount of media types", 0, mediaTypes.size());
 	}
 
+	// SPR-17459
 	@Test
 	public void parseMediaTypesWithOddNumberOfDoubleQuotedCommas() {
 		String s = "foo/bar;param=\",\"";
@@ -151,6 +152,7 @@ public class MediaTypeTests {
 		assertEquals("Comma should be part of the media type", s, mediaTypes.get(0).toString());
 	}
 
+	// SPR-17459
 	@Test
 	public void parseMediaTypesWithEvenNumberOfDoubleQuotedCommas() {
 		String s = "foo/bar;param=\"s,a,\"";
@@ -159,6 +161,7 @@ public class MediaTypeTests {
 		assertEquals("Comma should be part of the media type", s, mediaTypes.get(0).toString());
 	}
 
+	// SPR-17459
 	@Test
 	public void parseMediaTypesWithAndWithoutDoubleQuotedCommas() {
 		String s = "foo/bar;param=\"s,\", text/x-c";

--- a/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
+++ b/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import static org.junit.Assert.*;
 /**
  * @author Arjen Poutsma
  * @author Juergen Hoeller
+ * @author Dimitrios Liapis
  */
 public class MediaTypeTests {
 

--- a/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
+++ b/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
@@ -171,6 +171,15 @@ public class MediaTypeTests {
 		assertEquals("Comma should be part of the media type", "foo/bar;param=\"s,\"", mediaTypes.get(0).toString());
 	}
 
+	// SPR-17459
+	@Test
+	public void parseMediaTypesIgnoreEscapedDoubleQuoteWithinDoubleQuotes() {
+		String s = "foo/bar;param=\"a\\\"b,c\"";
+		List<MediaType> mediaTypes = MediaType.parseMediaTypes(s);
+		assertEquals("Invalid amount of media types", 1, mediaTypes.size());
+		assertEquals("Escaped quote within quotes should be ignored when considering comma tokenization", s, mediaTypes.get(0).toString());
+	}
+
 	@Test
 	public void compareTo() {
 		MediaType audioBasic = new MediaType("audio", "basic");


### PR DESCRIPTION
Adding functionality to: 

1. detect if double quoted comma provided
2. if not, then flow continues exactly as before (tokenization on commas)
3. if yes, then calculate the indexes of of commas ignoring the double quoted ones
4. tokenize on the above comma indexes and proceed as before