### PR TITLE
SPR-17492: FastByteArrayOutputStream.read byte-to-int conversion

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/FastByteArrayOutputStream.java
+++ b/spring-core/src/main/java/org/springframework/util/FastByteArrayOutputStream.java
@@ -367,7 +367,7 @@ public class FastByteArrayOutputStream extends OutputStream {
 			else {
 				if (this.nextIndexInCurrentBuffer < this.currentBufferLength) {
 					this.totalBytesRead++;
-					return this.currentBuffer[this.nextIndexInCurrentBuffer++];
+					return this.currentBuffer[this.nextIndexInCurrentBuffer++] & 0xFF;
 				}
 				else {
 					if (this.buffersIterator.hasNext()) {

--- a/spring-core/src/test/java/org/springframework/util/FastByteArrayOutputStreamTests.java
+++ b/spring-core/src/test/java/org/springframework/util/FastByteArrayOutputStreamTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.util;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -135,6 +136,15 @@ public class FastByteArrayOutputStreamTests {
 		assertEquals(inputStream.read(), this.helloBytes[1]);
 		assertEquals(inputStream.read(), this.helloBytes[2]);
 		assertEquals(inputStream.read(), this.helloBytes[3]);
+	}
+
+	@Test
+	public void getInputStreamReadBytePromotion() throws Exception {
+		byte[] bytes = new byte[] { -1 };
+		this.os.write(bytes);
+		InputStream inputStream = this.os.getInputStream();
+		ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+		assertEquals(bais.read(), inputStream.read());
 	}
 
 	@Test


### PR DESCRIPTION
While evaluating FastByteArrayOutputStream I have noticed that it doesn't behave correctly when negative bytes are encountered in the read() method.

Quoting from InputStream javadoc:

> The value byte is returned as an int in the range 0 to 255

To make the situation more obvious in the test I have deliberately used another InputStream implementation to make the situation clear and avoided using constant that could be confusing.