### PR TITLE
SPR-17037 Use ArrayList instead of LinkedList in ReflectionUtils::findConcreteMethodsOnInterfaces

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -697,7 +697,7 @@ public abstract class ReflectionUtils {
 			for (Method ifcMethod : ifc.getMethods()) {
 				if (!Modifier.isAbstract(ifcMethod.getModifiers())) {
 					if (result == null) {
-						result = new LinkedList<>();
+						result = new ArrayList<>();
 					}
 					result.add(ifcMethod);
 				}


### PR DESCRIPTION
The mentioned method always returns either null or non-empty list, so it's reasonable to use `ArrayList` instead of `LinkedList` in this case.