### PR TITLE
 XpathResultMatcher supports Hamcrest Matcher NodeList

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/util/XpathExpectationsHelper.java
+++ b/spring-test/src/main/java/org/springframework/test/util/XpathExpectationsHelper.java
@@ -102,6 +102,18 @@ public class XpathExpectationsHelper {
 		MatcherAssert.assertThat("XPath " + this.expression, node, matcher);
 	}
 
+    /**
+     * Parse the content, evaluate the XPath expression as a {@link NodeList},
+     * and assert it with the given {@code Matcher<NodeList>}.
+     */
+    public void assertNodeList(byte[] content, @Nullable String encoding, final Matcher<? super NodeList> matcher)
+            throws Exception {
+
+        Document document = parseXmlByteArray(content, encoding);
+        NodeList nodeList = evaluateXpath(document, XPathConstants.NODESET, NodeList.class);
+        MatcherAssert.assertThat("XPath " + this.getXpathExpression(), nodeList, matcher);
+    }
+
 	/**
 	 * Apply the XPath expression and assert the resulting content exists.
 	 * @throws Exception if content parsing or expression evaluation fails

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/XpathResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/XpathResultMatchers.java
@@ -21,6 +21,7 @@ import javax.xml.xpath.XPathExpressionException;
 
 import org.hamcrest.Matcher;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import org.springframework.lang.Nullable;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -67,6 +68,17 @@ public class XpathResultMatchers {
 			this.xpathHelper.assertNode(response.getContentAsByteArray(), getDefinedEncoding(response), matcher);
 		};
 	}
+
+    /**
+     * Evaluate the XPath and assert the {@link NodeList} content found with the
+     * given Hamcrest {@link Matcher}.
+     */
+    public ResultMatcher nodeList(final Matcher<? super NodeList> matcher) {
+        return result -> {
+            MockHttpServletResponse response = result.getResponse();
+            this.xpathHelper.assertNodeList(response.getContentAsByteArray(), getDefinedEncoding(response), matcher);
+        };
+    }
 
 	/**
 	 * Get the response encoding if explicitly defined in the response, {code null} otherwise.

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/result/XpathResultMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/result/XpathResultMatchersTests.java
@@ -46,6 +46,16 @@ public class XpathResultMatchersTests {
 	}
 
 	@Test
+	public void nodeList() throws Exception {
+		new XpathResultMatchers("/foo/bar", null).nodeList(Matchers.notNullValue()).match(getStubMvcResult());
+	}
+
+	@Test(expected = AssertionError.class)
+	public void nodeListNoMatch() throws Exception {
+		new XpathResultMatchers("/foo/bar", null).nodeList(Matchers.nullValue()).match(getStubMvcResult());
+	}
+
+	@Test
 	public void exists() throws Exception {
 		new XpathResultMatchers("/foo/bar", null).exists().match(getStubMvcResult());
 	}


### PR DESCRIPTION
See SPR-17529 XpathResultMatchers to support Hamcrest Matcher<NodeList>