### PR TITLE
The name of the parameter is misleading

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java
@@ -213,7 +213,7 @@ public class StompSubProtocolHandler implements SubProtocolHandler, ApplicationE
 	 * Handle incoming WebSocket messages from clients.
 	 */
 	public void handleMessageFromClient(WebSocketSession session,
-			WebSocketMessage<?> webSocketMessage, MessageChannel outputChannel) {
+			WebSocketMessage<?> webSocketMessage, MessageChannel inboundChannel) {
 
 		List<Message<byte[]>> messages;
 		try {
@@ -262,7 +262,7 @@ public class StompSubProtocolHandler implements SubProtocolHandler, ApplicationE
 				headerAccessor.setSessionAttributes(session.getAttributes());
 				headerAccessor.setUser(getUser(session));
 				headerAccessor.setHeader(SimpMessageHeaderAccessor.HEART_BEAT_HEADER, headerAccessor.getHeartbeat());
-				if (!detectImmutableMessageInterceptor(outputChannel)) {
+				if (!detectImmutableMessageInterceptor(inboundChannel)) {
 					headerAccessor.setImmutable();
 				}
 
@@ -281,7 +281,7 @@ public class StompSubProtocolHandler implements SubProtocolHandler, ApplicationE
 
 				try {
 					SimpAttributesContextHolder.setAttributesFromMessage(message);
-					boolean sent = outputChannel.send(message);
+					boolean sent = inboundChannel.send(message);
 
 					if (sent) {
 						if (isConnect) {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/SubProtocolHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/SubProtocolHandler.java
@@ -51,9 +51,9 @@ public interface SubProtocolHandler {
 	 * Handle the given {@link WebSocketMessage} received from a client.
 	 * @param session the client session
 	 * @param message the client message
-	 * @param outputChannel an output channel to send messages to
+	 * @param inboundChannel an inbound channel to send messages to this application.
 	 */
-	void handleMessageFromClient(WebSocketSession session, WebSocketMessage<?> message, MessageChannel outputChannel)
+	void handleMessageFromClient(WebSocketSession session, WebSocketMessage<?> message, MessageChannel inboundChannel)
 			throws Exception;
 
 	/**


### PR DESCRIPTION
This method sends a message to the application through the  inboundChannel instead of outChannel. This parameter is confusing to developers who read the source code. Thank you for your contribution.