### PR TITLE
Clarify behaviour of AnnotationBeanNameGenerator with acronyms

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/AnnotationBeanNameGenerator.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/AnnotationBeanNameGenerator.java
@@ -48,10 +48,11 @@ import org.springframework.util.StringUtils;
  *
  * <p>If the annotation's value doesn't indicate a bean name, an appropriate
  * name will be built based on the short name of the class (with the first
- * letter lower-cased). For example:
+ * letter lower-cased). If two first letters of class name are uppercase, bean name will be unchanged. For example:
  *
  * <pre class="code">com.xyz.FooServiceImpl -&gt; fooServiceImpl</pre>
- *
+ * <pre class="code">com.xyz.URLFooServiceImpl -&gt; URLFooServiceImpl</pre>
+ * 
  * @author Juergen Hoeller
  * @author Mark Fisher
  * @since 2.5


### PR DESCRIPTION
Name transformation is delegated java.beans.Introspector#decapitalize. It says "but in the (unusual) special  case when there is more than one character and both the first and second characters are upper case, we leave it alone.". It should be reflected in documentation