### PR TITLE
Typo in javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/UnsupportedMediaTypeStatusException.java
+++ b/spring-web/src/main/java/org/springframework/web/server/UnsupportedMediaTypeStatusException.java
@@ -25,7 +25,7 @@ import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
 
 /**
- * Exception for errors that fit response status 416 (unsupported media type).
+ * Exception for errors that fit response status 415 (unsupported media type).
  *
  * @author Rossen Stoyanchev
  * @since 5.0


### PR DESCRIPTION
Response status 415 (unsupported media type) reported as of 416 (which is Range Not Satisfiable), mismatching with superclass constructor parameter `HttpStatus.UNSUPPORTED_MEDIA_TYPE`