### PR TITLE
indexOf() expressions can be replaced with a call to the contains()

### DIFF
--- a/spring-aop/src/test/java/org/springframework/aop/target/HotSwappableTargetSourceTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/target/HotSwappableTargetSourceTests.java
@@ -132,7 +132,7 @@ public class HotSwappableTargetSourceTests {
 	@Test
 	public void testRejectsSwapToNull() {
 		IllegalArgumentException ex = testRejectsSwapToInvalidValue(null);
-		assertTrue(ex.getMessage().indexOf("null") != -1);
+		assertTrue(ex.getMessage().contains("null"));
 	}
 
 	// TODO test reject swap to wrong interface or class?

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperGenericsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperGenericsTests.java
@@ -84,7 +84,7 @@ public class BeanWrapperGenericsTests {
 			fail("Should have thrown TypeMismatchException");
 		}
 		catch (TypeMismatchException ex) {
-			assertTrue(ex.getMessage().indexOf("java.lang.Integer") != -1);
+			assertTrue(ex.getMessage().contains("java.lang.Integer"));
 		}
 	}
 

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/ServiceLocatorFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/ServiceLocatorFactoryBeanTests.java
@@ -198,7 +198,7 @@ public class ServiceLocatorFactoryBeanTests {
 		assertNotSame(testBean2, testBean4);
 		assertNotSame(testBean3, testBean4);
 
-		assertTrue(factory.toString().indexOf("TestServiceLocator3") != -1);
+		assertTrue(factory.toString().contains("TestServiceLocator3"));
 	}
 
 	@Ignore @Test // worked when using an ApplicationContext (see commented), fails when using BeanFactory

--- a/spring-context/src/test/java/org/springframework/aop/aspectj/OverloadedAdviceTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/aspectj/OverloadedAdviceTests.java
@@ -40,7 +40,7 @@ public class OverloadedAdviceTests {
 			Throwable cause = ex.getRootCause();
 			assertTrue("Should be IllegalArgumentException", cause instanceof IllegalArgumentException);
 			assertTrue("invalidAbsoluteTypeName should be detected by AJ",
-					cause.getMessage().indexOf("invalidAbsoluteTypeName") != -1);
+					cause.getMessage().contains("invalidAbsoluteTypeName"));
 		}
 	}
 
@@ -53,7 +53,7 @@ public class OverloadedAdviceTests {
 			Throwable cause = ex.getRootCause();
 			assertTrue("Should be IllegalArgumentException", cause instanceof IllegalArgumentException);
 			assertTrue("Cannot resolve method 'myBeforeAdvice' to a unique method",
-					cause.getMessage().indexOf("Cannot resolve method 'myBeforeAdvice' to a unique method") != -1);
+					cause.getMessage().contains("Cannot resolve method 'myBeforeAdvice' to a unique method"));
 		}
 	}
 

--- a/spring-context/src/test/java/org/springframework/aop/framework/AbstractAopProxyTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/AbstractAopProxyTests.java
@@ -736,7 +736,7 @@ public abstract class AbstractAopProxyTests {
 			fail("Shouldn't be able to add introduction interceptor except via introduction advice");
 		}
 		catch (AopConfigException ex) {
-			assertTrue(ex.getMessage().indexOf("ntroduction") > -1);
+			assertTrue(ex.getMessage().contains("ntroduction"));
 		}
 		// Check it still works: proxy factory state shouldn't have been corrupted
 		ITestBean proxied = (ITestBean) createProxy(pc);
@@ -849,7 +849,7 @@ public abstract class AbstractAopProxyTests {
 			fail("Shouldn't be able to add interceptor when frozen");
 		}
 		catch (AopConfigException ex) {
-			assertTrue(ex.getMessage().indexOf("frozen") > -1);
+			assertTrue(ex.getMessage().contains("frozen"));
 		}
 		// Check it still works: proxy factory state shouldn't have been corrupted
 		assertEquals(target.getAge(), proxied.getAge());

--- a/spring-context/src/test/java/org/springframework/aop/framework/ProxyFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/ProxyFactoryBeanTests.java
@@ -145,7 +145,7 @@ public class ProxyFactoryBeanTests {
 		catch (BeanCreationException ex) {
 			// Root cause of the problem must be an AOP exception
 			AopConfigException aex = (AopConfigException) ex.getCause();
-			assertTrue(aex.getMessage().indexOf("TargetSource") != -1);
+			assertTrue(aex.getMessage().contains("TargetSource"));
 		}
 	}
 

--- a/spring-context/src/test/java/org/springframework/beans/factory/xml/XmlBeanFactoryTests.java
+++ b/spring-context/src/test/java/org/springframework/beans/factory/xml/XmlBeanFactoryTests.java
@@ -482,7 +482,7 @@ public class XmlBeanFactoryTests {
 		}
 		catch (BeanDefinitionStoreException ex) {
 			// check exception message contains the name
-			assertTrue(ex.getMessage().indexOf("bogusParent") != -1);
+			assertTrue(ex.getMessage().contains("bogusParent"));
 			assertTrue(ex.getCause() instanceof NoSuchBeanDefinitionException);
 		}
 	}
@@ -678,7 +678,7 @@ public class XmlBeanFactoryTests {
 			fail();
 		}
 		catch (BeanCreationException ex) {
-			assertTrue(ex.getResourceDescription().indexOf("initializers.xml") != -1);
+			assertTrue(ex.getResourceDescription().contains("initializers.xml"));
 			assertEquals("init-method2", ex.getBeanName());
 			assertTrue(ex.getCause() instanceof IOException);
 		}
@@ -694,9 +694,9 @@ public class XmlBeanFactoryTests {
 		}
 		catch (FatalBeanException ex) {
 			// check message is helpful
-			assertTrue(ex.getMessage().indexOf("initializers.xml") != -1);
-			assertTrue(ex.getMessage().indexOf("init-method3") != -1);
-			assertTrue(ex.getMessage().indexOf("init") != -1);
+			assertTrue(ex.getMessage().contains("initializers.xml"));
+			assertTrue(ex.getMessage().contains("init-method3"));
+			assertTrue(ex.getMessage().contains("init"));
 		}
 	}
 
@@ -934,7 +934,7 @@ public class XmlBeanFactoryTests {
 			xbf.getBean("rod2Accessor");
 		}
 		catch (BeanCreationException ex) {
-			assertTrue(ex.toString().indexOf("touchy") != -1);
+			assertTrue(ex.toString().contains("touchy"));
 			ex.printStackTrace();
 			assertNull(ex.getRelatedCauses());
 		}
@@ -1115,7 +1115,7 @@ public class XmlBeanFactoryTests {
 			fail("Must have thrown a CannotLoadBeanClassException");
 		}
 		catch (CannotLoadBeanClassException ex) {
-			assertTrue(ex.getResourceDescription().indexOf("classNotFound.xml") != -1);
+			assertTrue(ex.getResourceDescription().contains("classNotFound.xml"));
 			assertTrue(ex.getCause() instanceof ClassNotFoundException);
 		}
 	}
@@ -1367,7 +1367,7 @@ public class XmlBeanFactoryTests {
 		}
 		catch (BeanDefinitionStoreException ex) {
 			// Check that the bogus method name was included in the error message
-			assertTrue("Bogus method name correctly reported", ex.getMessage().indexOf("bogusMethod") != -1);
+			assertTrue("Bogus method name correctly reported", ex.getMessage().contains("bogusMethod"));
 		}
 	}
 

--- a/spring-context/src/test/java/org/springframework/context/BeanThatBroadcasts.java
+++ b/spring-context/src/test/java/org/springframework/context/BeanThatBroadcasts.java
@@ -29,7 +29,7 @@ public class BeanThatBroadcasts implements ApplicationContextAware {
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
-		if (applicationContext.getDisplayName().indexOf("listener") != -1) {
+		if (applicationContext.getDisplayName().contains("listener")) {
 			applicationContext.getBean("listener");
 		}
 	}

--- a/spring-context/src/test/java/org/springframework/context/support/PropertyResourceConfigurerIntegrationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/support/PropertyResourceConfigurerIntegrationTests.java
@@ -65,7 +65,7 @@ public class PropertyResourceConfigurerIntegrationTests {
 			if (userDir.startsWith("/")) {
 				userDir = userDir.substring(1);
 			}
-			assertTrue(ex.getMessage().indexOf(userDir) != -1);
+			assertTrue(ex.getMessage().contains(userDir));
 		}
 	}
 

--- a/spring-context/src/test/java/org/springframework/context/support/StaticMessageSourceTests.java
+++ b/spring-context/src/test/java/org/springframework/context/support/StaticMessageSourceTests.java
@@ -109,8 +109,8 @@ public class StaticMessageSourceTests extends AbstractApplicationContextTests {
 
 		// Now msg better be as expected
 		assertTrue("2nd search within MsgFormat cache returned expected message for Locale.US",
-				sac.getMessage("message.format.example1", arguments, Locale.US).indexOf(
-						"there was \"a disturbance in the Force\" on planet 7.") != -1);
+				sac.getMessage("message.format.example1", arguments, Locale.US).
+						contains("there was \"a disturbance in the Force\" on planet 7."));
 
 		Object[] newArguments = {
 			new Integer(8), new Date(System.currentTimeMillis()),
@@ -119,8 +119,8 @@ public class StaticMessageSourceTests extends AbstractApplicationContextTests {
 
 		// Now msg better be as expected even with different args
 		assertTrue("2nd search within MsgFormat cache with different args returned expected message for Locale.US",
-				sac.getMessage("message.format.example1", newArguments, Locale.US)
-				.indexOf("there was \"a disturbance in the Force\" on planet 8.") != -1);
+				sac.getMessage("message.format.example1", newArguments, Locale.US).
+						contains("there was \"a disturbance in the Force\" on planet 8."));
 	}
 
 	/**
@@ -142,13 +142,13 @@ public class StaticMessageSourceTests extends AbstractApplicationContextTests {
 		 minutes of the time might not be the same.
 		 */
 		assertTrue("msg from staticMsgSource for Locale.US substituting args for placeholders is as expected",
-				sac.getMessage("message.format.example1", arguments, Locale.US)
-				.indexOf("there was \"a disturbance in the Force\" on planet 7.") != -1);
+				sac.getMessage("message.format.example1", arguments, Locale.US).
+						contains("there was \"a disturbance in the Force\" on planet 7."));
 
 		// Try with Locale.UK
 		assertTrue("msg from staticMsgSource for Locale.UK substituting args for placeholders is as expected",
-				sac.getMessage("message.format.example1", arguments, Locale.UK)
-				.indexOf("there was \"a disturbance in the Force\" on station number 7.") != -1);
+				sac.getMessage("message.format.example1", arguments, Locale.UK).
+						contains("there was \"a disturbance in the Force\" on station number 7."));
 
 		// Try with Locale.US - Use a different test msg that requires no args
 		assertTrue("msg from staticMsgSource for Locale.US that requires no args is as expected",

--- a/spring-context/src/test/java/org/springframework/jndi/JndiObjectFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/jndi/JndiObjectFactoryBeanTests.java
@@ -396,7 +396,7 @@ public class JndiObjectFactoryBeanTests {
 			fail("Should have thrown NamingException");
 		}
 		catch (NamingException ex) {
-			assertTrue(ex.getMessage().indexOf("org.springframework.tests.sample.beans.DerivedTestBean") != -1);
+			assertTrue(ex.getMessage().contains("org.springframework.tests.sample.beans.DerivedTestBean"));
 		}
 	}
 

--- a/spring-core/src/test/java/org/springframework/util/PropertiesPersisterTests.java
+++ b/spring-core/src/test/java/org/springframework/util/PropertiesPersisterTests.java
@@ -125,10 +125,10 @@ public class PropertiesPersisterTests {
 			propCopy = new String(propOut.toByteArray());
 		}
 		if (header != null) {
-			assertTrue(propCopy.indexOf(header) != -1);
+			assertTrue(propCopy.contains(header));
 		}
-		assertTrue(propCopy.indexOf("\ncode1=message1") != -1);
-		assertTrue(propCopy.indexOf("\ncode2=message2") != -1);
+		assertTrue(propCopy.contains("\ncode1=message1"));
+		assertTrue(propCopy.contains("\ncode2=message2"));
 		return propCopy;
 	}
 

--- a/spring-web/src/test/java/org/springframework/remoting/httpinvoker/HttpInvokerTests.java
+++ b/spring-web/src/test/java/org/springframework/remoting/httpinvoker/HttpInvokerTests.java
@@ -463,8 +463,8 @@ public class HttpInvokerTests {
 		ITestBean proxy = (ITestBean) pfb.getObject();
 
 		// shouldn't go through to remote service
-		assertTrue(proxy.toString().indexOf("HTTP invoker") != -1);
-		assertTrue(proxy.toString().indexOf(serviceUrl) != -1);
+		assertTrue(proxy.toString().contains("HTTP invoker"));
+		assertTrue(proxy.toString().contains(serviceUrl));
 		assertEquals(proxy.hashCode(), proxy.hashCode());
 		assertTrue(proxy.equals(proxy));
 

--- a/spring-webmvc/src/test/java/org/springframework/context/BeanThatBroadcasts.java
+++ b/spring-webmvc/src/test/java/org/springframework/context/BeanThatBroadcasts.java
@@ -29,7 +29,7 @@ public class BeanThatBroadcasts implements ApplicationContextAware {
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
-		if (applicationContext.getDisplayName().indexOf("listener") != -1) {
+		if (applicationContext.getDisplayName().contains("listener")) {
 			applicationContext.getBean("listener");
 		}
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
@@ -564,7 +564,7 @@ public class DispatcherServletTests {
 		}
 		catch (ServletException ex) {
 			// expected
-			assertTrue(ex.getMessage().indexOf("No adapter for handler") != -1);
+			assertTrue(ex.getMessage().contains("No adapter for handler"));
 		}
 	}
 
@@ -584,7 +584,7 @@ public class DispatcherServletTests {
 		}
 		catch (ServletException ex) {
 			// expected
-			assertTrue(ex.getMessage().indexOf("failed0") != -1);
+			assertTrue(ex.getMessage().contains("failed0"));
 		}
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/BindTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/BindTagTests.java
@@ -561,7 +561,7 @@ public class BindTagTests extends AbstractTagTests {
 		BindStatus status = (BindStatus) pc.getAttribute(BindTag.STATUS_VARIABLE_NAME, PageContext.REQUEST_SCOPE);
 		assertEquals("doctor", status.getExpression());
 		assertTrue(status.getValue() instanceof NestedTestBean);
-		assertTrue(status.getDisplayValue().indexOf("juergen&amp;eva") != -1);
+		assertTrue(status.getDisplayValue().contains("juergen&amp;eva"));
 	}
 
 	@Test

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/RadioButtonTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/RadioButtonTagTests.java
@@ -255,11 +255,11 @@ public class RadioButtonTagTests extends AbstractFormTagTests {
 	}
 
 	private void assertTagOpened(String output) {
-		assertTrue(output.indexOf("<input ") > -1);
+		assertTrue(output.contains("<input "));
 	}
 
 	private void assertTagClosed(String output) {
-		assertTrue(output.indexOf("/>") > -1);
+		assertTrue(output.contains("/>"));
 	}
 
 	private Float getFloat() {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/xslt/XsltViewTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/xslt/XsltViewTests.java
@@ -133,7 +133,7 @@ public class XsltViewTests {
 		model.put("someKey", getProductDataResource());
 		model.put("title", "Product List");
 		doTestWithModel(model);
-		assertTrue(this.response.getContentAsString().indexOf("Product List") > -1);
+		assertTrue(this.response.getContentAsString().contains("Product List"));
 	}
 
 	@Test
@@ -148,7 +148,7 @@ public class XsltViewTests {
 
 		view.render(model, this.request, this.response);
 		assertHtmlOutput(this.response.getContentAsString());
-		assertTrue(this.response.getContentAsString().indexOf("Product List") > -1);
+		assertTrue(this.response.getContentAsString().contains("Product List"));
 
 	}
 


### PR DESCRIPTION
indexOf() expressions can be replaced with a call to the contains() method available in Java 5 and newer.