### PR TITLE
Update ValidationUtils.java

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/ValidationUtils.java
+++ b/spring-context/src/main/java/org/springframework/validation/ValidationUtils.java
@@ -76,7 +76,7 @@ public abstract class ValidationUtils {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Invoking validator [" + validator + "]");
 		}
-		if (!validator.supports(target.getClass())) {
+		if (target != null && !validator.supports(target.getClass())) {
 			throw new IllegalArgumentException(
 					"Validator [" + validator.getClass() + "] does not support [" + target.getClass() + "]");
 		}


### PR DESCRIPTION
before using object, check for null is necessary.  Till spring 4.3.x we have this check and in spring 5.x.x its missing