### PR TITLE
Fix typo in websocket.adoc

### DIFF
--- a/src/docs/asciidoc/web/websocket.adoc
+++ b/src/docs/asciidoc/web/websocket.adoc
@@ -1783,7 +1783,7 @@ as the following example shows:
 [subs="verbatim,quotes"]
 ----
 	@Controller
-	@MessageMapping("erd")
+	@MessageMapping("red")
 	public class RedController {
 
 		@MessageMapping("blue.{green}")


### PR DESCRIPTION
Obvious Fix typo from '@MessageMapping("erd")' to '@MessageMapping("red")'