### PR TITLE
Improve performance of ConcurrentReferenceHashMap creation

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
+++ b/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
@@ -179,10 +179,13 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 		int size = 1 << this.shift;
 		this.referenceType = referenceType;
 		int roundedUpSegmentCapacity = (int) ((initialCapacity + size - 1L) / size);
-		this.segments = (Segment[]) Array.newInstance(Segment.class, size);
-		for (int i = 0; i < this.segments.length; i++) {
-			this.segments[i] = new Segment(roundedUpSegmentCapacity);
+		int initialSize = 1 << calculateShift(roundedUpSegmentCapacity, MAXIMUM_SEGMENT_SIZE);
+		Segment[] segments = (Segment[]) Array.newInstance(Segment.class, size);
+		int resizeThreshold = (int) (initialSize * getLoadFactor());
+		for (int i = 0; i < segments.length; i++) {
+			segments[i] = new Segment(initialSize, resizeThreshold);
 		}
+		this.segments = segments;
 	}
 
 
@@ -481,11 +484,11 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 		 */
 		private int resizeThreshold;
 
-		public Segment(int initialCapacity) {
+		public Segment(int initialSize, int resizeThreshold) {
 			this.referenceManager = createReferenceManager();
-			this.initialSize = 1 << calculateShift(initialCapacity, MAXIMUM_SEGMENT_SIZE);
-			this.references = createReferenceArray(this.initialSize);
-			this.resizeThreshold = (int) (this.references.length * getLoadFactor());
+			this.initialSize = initialSize;
+			this.references = createReferenceArray(initialSize);
+			this.resizeThreshold = resizeThreshold;
 		}
 
 		@Nullable


### PR DESCRIPTION
I've discovered that on some workloads instantiation of CCRHM takes significant amount of time (e.g. loading interface-base projections in Spring Data JPA). Here's the patch that reduces map instantiation time:
```
//before
Benchmark                   Mode  Cnt    Score   Error  Units
concurrentReferenceHashMap  avgt  100  712,179 ± 7,233  ns/op

//after
Benchmark                   Mode  Cnt    Score   Error  Units
concurrentReferenceHashMap  avgt   50  496,598 ± 4,601  ns/op
```
Benchmark is very simple:
```java
@Benchmark
public ConcurrentReferenceHashMap concurrentReferenceHashMap() {
  return new ConcurrentReferenceHashMap();
}
```
Key ideas behind the changes:
- `initialSize` is the same at each loop iteration in constructor of `ConcurrentReferenceHashMap`, so expression `1 << calculateShift(initialCapacity, MAXIMUM_SEGMENT_SIZE);` can be hoisted out of constructor of `Segment` and then out of the loop
- same for `resizeThreshold` calculation
- `Segment.references` declared as `volatile` so I suspect when new segment is written into `ConcurrentReferenceHashMap.segments` array the field `segments` must be loaded at each iteration due to HB semantics, same for `this.segments.length`. To avoid this I propose to populate `ConcurrentReferenceHashMap.segments` as local var and the write it to the field. Event if my assumption about HB is wrong reduction of interaction with fields helps us in interpreter mode.