### PR TITLE
SPR-17600 Vararg based methods in MessageSource

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/MessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/MessageSource.java
@@ -83,4 +83,41 @@ public interface MessageSource {
 	 */
 	String getMessage(MessageSourceResolvable resolvable, Locale locale) throws NoSuchMessageException;
 
+	/**
+	 * Try to resolve the message. Return default message if no message was found.
+	 * @param code the code to lookup up, such as 'calculator.noRateSet'. Users of
+	 * this class are encouraged to base message names on the relevant fully
+	 * qualified class name, thus avoiding conflict and ensuring maximum clarity.
+	 * @param defaultMessage a default message to return if the lookup fails
+	 * @param locale the locale in which to do the lookup
+	 * @param args a vararg of arguments that will be filled in for params within
+	 * the message (params look like "{0}", "{1,date}", "{2,time}" within a message).
+	 * @return the resolved message if the lookup was successful;
+	 * otherwise the default message passed as a parameter
+	 * @see java.text.MessageFormat
+	 * @since 5.1.4
+	 * @author Ankur Pathak
+	 */
+	@Nullable
+	default String getMessage(String code, @Nullable String defaultMessage, Locale locale, Object... args){
+		return getMessage(code, args, defaultMessage, locale);
+	}
+
+	/**
+	 * Try to resolve the message. Treat as an error if the message can't be found.
+	 * @param code the code to lookup up, such as 'calculator.noRateSet'
+	 * @param locale the locale in which to do the lookup
+	 * @param args a vararg of arguments that will be filled in for params within
+	 * the message (params look like "{0}", "{1,date}", "{2,time}" within a message).
+	 * @return the resolved message
+	 * @throws NoSuchMessageException if the message wasn't found
+	 * @see java.text.MessageFormat
+	 * @since 5.1.4
+	 * @author Ankur Pathak
+	 */
+	default String getMessage(String code, Locale locale, Object... args) throws NoSuchMessageException{
+		return getMessage(code, args, locale);
+	}
+
+
 }


### PR DESCRIPTION
It adds a vararg based getMessage methods
in MessageSource. The methods are added using
Java 8 Interface Default Methods so doesn't
need any implementation in any concrete
MessageSource.