### PR TITLE
Optimize `CharSequence` writing to `DataBuffer` instances

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/codec/CharSequenceEncoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/CharSequenceEncoder.java
@@ -19,6 +19,8 @@ package org.springframework.core.codec;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -48,6 +50,9 @@ public final class CharSequenceEncoder extends AbstractEncoder<CharSequence> {
 	 */
 	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
+	private final ConcurrentMap<Charset, Float> charsetToMaxBytesPerChar =
+			new ConcurrentHashMap<>(3);
+
 
 	private CharSequenceEncoder(MimeType... mimeTypes) {
 		super(mimeTypes);
@@ -75,7 +80,8 @@ public final class CharSequenceEncoder extends AbstractEncoder<CharSequence> {
 				});
 			}
 			boolean release = true;
-			DataBuffer dataBuffer = bufferFactory.allocateBuffer();
+			int capacity = calculateCapacity(charSequence, charset);
+			DataBuffer dataBuffer = bufferFactory.allocateBuffer(capacity);
 			try {
 				dataBuffer.write(charSequence, charset);
 				release = false;
@@ -90,6 +96,13 @@ public final class CharSequenceEncoder extends AbstractEncoder<CharSequence> {
 			}
 			return dataBuffer;
 		});
+	}
+
+	private int calculateCapacity(CharSequence sequence, Charset charset) {
+		float maxBytesPerChar = this.charsetToMaxBytesPerChar
+				.computeIfAbsent(charset, cs -> cs.newEncoder().maxBytesPerChar());
+		float maxBytesForSequence = sequence.length() * maxBytesPerChar;
+		return (int) Math.ceil(maxBytesForSequence);
 	}
 
 	private Charset getCharset(@Nullable MimeType mimeType) {

--- a/spring-core/src/main/java/org/springframework/core/codec/CharSequenceEncoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/CharSequenceEncoder.java
@@ -16,8 +16,6 @@
 
 package org.springframework.core.codec;
 
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -28,6 +26,7 @@ import reactor.core.publisher.Flux;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.core.log.LogFormatUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.MimeType;
@@ -75,9 +74,21 @@ public final class CharSequenceEncoder extends AbstractEncoder<CharSequence> {
 					return Hints.getLogPrefix(hints) + "Writing " + formatted;
 				});
 			}
-			CharBuffer charBuffer = CharBuffer.wrap(charSequence);
-			ByteBuffer byteBuffer = charset.encode(charBuffer);
-			return bufferFactory.wrap(byteBuffer);
+			boolean release = true;
+			DataBuffer dataBuffer = bufferFactory.allocateBuffer();
+			try {
+				dataBuffer.write(charSequence, charset);
+				release = false;
+			}
+			catch (IllegalStateException ex) {
+				throw new EncodingException("String encoding error: " + ex.getMessage(), ex);
+			}
+			finally {
+				if (release) {
+					DataBufferUtils.release(dataBuffer);
+				}
+			}
+			return dataBuffer;
 		});
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DataBuffer.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DataBuffer.java
@@ -19,7 +19,14 @@ package org.springframework.core.io.buffer;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.util.function.IntPredicate;
+
+import org.springframework.util.Assert;
 
 /**
  * Basic abstraction over byte buffers.
@@ -45,6 +52,7 @@ import java.util.function.IntPredicate;
  * can also be used on non-Netty platforms (i.e. Servlet containers).
  *
  * @author Arjen Poutsma
+ * @author Brian Clozel
  * @since 5.0
  * @see DataBufferFactory
  */
@@ -105,6 +113,16 @@ public interface DataBuffer {
 	 * @return this buffer
 	 */
 	DataBuffer capacity(int capacity);
+
+	/**
+	 * Ensure that the current buffer has enough {@link #writableByteCount()}
+	 * to write the amount of data given as an argument. If not, the missing
+	 * capacity will be added to the buffer.
+	 * @param capacity the writable capacity to check for
+	 * @return this buffer
+	 * @since 5.1.4
+	 */
+	DataBuffer ensureCapacity(int capacity);
 
 	/**
 	 * Return the position from which this buffer will read.
@@ -181,7 +199,7 @@ public interface DataBuffer {
 	DataBuffer write(byte b);
 
 	/**
-	 * Write the given source into this buffer, startin at the current writing position
+	 * Write the given source into this buffer, starting at the current writing position
 	 * of this buffer.
 	 * @param source the bytes to be written into this buffer
 	 * @return this buffer
@@ -214,6 +232,44 @@ public interface DataBuffer {
 	 * @return this buffer
 	 */
 	DataBuffer write(ByteBuffer... buffers);
+
+	/**
+	 * Write the given {@code CharSequence} using the given {@code Charset},
+	 * starting at the current writing position.
+	 * @param charSequence the char sequence to write into this buffer
+	 * @param charset the charset to encode the char sequence with
+	 * @return this buffer
+	 * @since 5.1.4
+	 */
+	default DataBuffer write(CharSequence charSequence, Charset charset) {
+		Assert.notNull(charSequence, "'charSequence' must not be null");
+		Assert.notNull(charset, "'charset' must not be null");
+		CharsetEncoder charsetEncoder = charset.newEncoder()
+				.onMalformedInput(CodingErrorAction.REPLACE)
+				.onUnmappableCharacter(CodingErrorAction.REPLACE);
+		CharBuffer inBuffer = CharBuffer.wrap(charSequence);
+		int estimatedSize = (int) (inBuffer.remaining() * charsetEncoder.averageBytesPerChar());
+		ByteBuffer outBuffer = ensureCapacity(estimatedSize)
+				.asByteBuffer(writePosition(), writableByteCount());
+		for (; ; ) {
+			CoderResult cr = inBuffer.hasRemaining() ?
+					charsetEncoder.encode(inBuffer, outBuffer, true) : CoderResult.UNDERFLOW;
+			if (cr.isUnderflow()) {
+				cr = charsetEncoder.flush(outBuffer);
+			}
+			if (cr.isUnderflow()) {
+				break;
+			}
+			if (cr.isOverflow()) {
+				writePosition(outBuffer.position());
+				int maximumSize = (int) (inBuffer.remaining() * charsetEncoder.maxBytesPerChar());
+				ensureCapacity(maximumSize);
+				outBuffer = asByteBuffer(writePosition(), writableByteCount());
+			}
+		}
+		writePosition(outBuffer.position());
+		return this;
+	}
 
 	/**
 	 * Create a new {@code DataBuffer} whose contents is a shared subsequence of this

--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DefaultDataBuffer.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DefaultDataBuffer.java
@@ -215,6 +215,15 @@ public class DefaultDataBuffer implements DataBuffer {
 		return this;
 	}
 
+	@Override
+	public DataBuffer ensureCapacity(int length) {
+		if (length > writableByteCount()) {
+			int newCapacity = calculateCapacity(this.writePosition + length);
+			capacity(newCapacity);
+		}
+		return this;
+	}
+
 	private static ByteBuffer allocate(int capacity, boolean direct) {
 		return direct ? ByteBuffer.allocateDirect(capacity) : ByteBuffer.allocate(capacity);
 	}
@@ -369,13 +378,6 @@ public class DefaultDataBuffer implements DataBuffer {
 		return new DefaultDataBufferOutputStream();
 	}
 
-	private void ensureCapacity(int length) {
-		if (length <= writableByteCount()) {
-			return;
-		}
-		int newCapacity = calculateCapacity(this.writePosition + length);
-		capacity(newCapacity);
-	}
 
 	/**
 	 * Calculate the capacity of the buffer.

--- a/spring-core/src/test/java/org/springframework/core/codec/CharSequenceEncoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/CharSequenceEncoderTests.java
@@ -63,8 +63,6 @@ public class CharSequenceEncoderTests
 				.consumeNextWith(expectString(this.foo))
 				.consumeNextWith(expectString(this.bar))
 				.verifyComplete());
-
-
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/io/buffer/DataBufferTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/buffer/DataBufferTests.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -147,6 +148,70 @@ public class DataBufferTests extends AbstractDataBufferAllocatingTestCase {
 
 		assertArrayEquals(new byte[]{'b', 'c', 'd', 'e'}, result);
 
+		release(buffer);
+	}
+
+	@Test
+	public void writeNullString() {
+		DataBuffer buffer = createDataBuffer(1);
+		try {
+			buffer.write(null, StandardCharsets.UTF_8);
+			fail("IllegalArgumentException expected");
+		}
+		catch (IllegalArgumentException exc) {
+		}
+		finally {
+			release(buffer);
+		}
+	}
+
+	@Test
+	public void writeNullCharset() {
+		DataBuffer buffer = createDataBuffer(1);
+		try {
+			buffer.write("test", null);
+			fail("IllegalArgumentException expected");
+		}
+		catch (IllegalArgumentException exc) {
+		}
+		finally {
+			release(buffer);
+		}
+	}
+
+	@Test
+	public void writeUtf8String() {
+		DataBuffer buffer = createDataBuffer(6);
+		buffer.write("Spring", StandardCharsets.UTF_8);
+
+		byte[] result = new byte[6];
+		buffer.read(result);
+
+		assertArrayEquals("Spring".getBytes(StandardCharsets.UTF_8), result);
+		release(buffer);
+	}
+
+	@Test
+	public void writeUtf8StringOutGrowsCapacity() {
+		DataBuffer buffer = createDataBuffer(5);
+		buffer.write("Spring €", StandardCharsets.UTF_8);
+
+		byte[] result = new byte[10];
+		buffer.read(result);
+
+		assertArrayEquals("Spring €".getBytes(StandardCharsets.UTF_8), result);
+		release(buffer);
+	}
+
+	@Test
+	public void writeIsoString() {
+		DataBuffer buffer = createDataBuffer(3);
+		buffer.write("\u00A3", StandardCharsets.ISO_8859_1);
+
+		byte[] result = new byte[1];
+		buffer.read(result);
+
+		assertArrayEquals("\u00A3".getBytes(StandardCharsets.ISO_8859_1), result);
 		release(buffer);
 	}
 

--- a/spring-core/src/test/java/org/springframework/core/io/buffer/LeakAwareDataBuffer.java
+++ b/spring-core/src/test/java/org/springframework/core/io/buffer/LeakAwareDataBuffer.java
@@ -19,6 +19,7 @@ package org.springframework.core.io.buffer;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.function.IntPredicate;
 
 import org.springframework.util.Assert;
@@ -140,6 +141,11 @@ class LeakAwareDataBuffer implements PooledDataBuffer {
 	}
 
 	@Override
+	public DataBuffer ensureCapacity(int capacity) {
+		return this.delegate.ensureCapacity(capacity);
+	}
+
+	@Override
 	public byte getByte(int index) {
 		return this.delegate.getByte(index);
 	}
@@ -182,6 +188,11 @@ class LeakAwareDataBuffer implements PooledDataBuffer {
 	@Override
 	public DataBuffer write(ByteBuffer... byteBuffers) {
 		return this.delegate.write(byteBuffers);
+	}
+
+	@Override
+	public DataBuffer write(CharSequence charSequence, Charset charset) {
+		return this.delegate.write(charSequence, charset);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpRequest.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.function.IntPredicate;
 import javax.net.ssl.SSLSession;
 
@@ -295,6 +296,11 @@ class UndertowServerHttpRequest extends AbstractServerHttpRequest {
 		}
 
 		@Override
+		public DataBuffer ensureCapacity(int capacity) {
+			return this.dataBuffer.ensureCapacity(capacity);
+		}
+
+		@Override
 		public byte getByte(int index) {
 			return this.dataBuffer.getByte(index);
 		}
@@ -341,6 +347,11 @@ class UndertowServerHttpRequest extends AbstractServerHttpRequest {
 		public DataBuffer write(
 				ByteBuffer... byteBuffers) {
 			return this.dataBuffer.write(byteBuffers);
+		}
+
+		@Override
+		public DataBuffer write(CharSequence charSequence, Charset charset) {
+			return this.dataBuffer.write(charSequence, charset);
 		}
 
 		@Override

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/BodyInsertersTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/BodyInsertersTests.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
@@ -44,6 +45,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.core.io.buffer.DefaultDataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.core.io.buffer.support.DataBufferTestUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRange;
 import org.springframework.http.ReactiveHttpOutputMessage;
@@ -121,10 +123,11 @@ public class BodyInsertersTests {
 		MockServerHttpResponse response = new MockServerHttpResponse();
 		Mono<Void> result = inserter.insert(response, this.context);
 		StepVerifier.create(result).expectComplete().verify();
-
-		DataBuffer buffer = new DefaultDataBufferFactory().wrap(body.getBytes(UTF_8));
 		StepVerifier.create(response.getBody())
-				.expectNext(buffer)
+				.consumeNextWith(buf -> {
+					String actual = DataBufferTestUtils.dumpString(buf, UTF_8);
+					Assert.assertEquals("foo", actual);
+				})
 				.expectComplete()
 				.verify();
 	}
@@ -166,11 +169,11 @@ public class BodyInsertersTests {
 		MockServerHttpResponse response = new MockServerHttpResponse();
 		Mono<Void> result = inserter.insert(response, this.context);
 		StepVerifier.create(result).expectComplete().verify();
-
-		ByteBuffer byteBuffer = ByteBuffer.wrap("foo".getBytes(UTF_8));
-		DataBuffer buffer = new DefaultDataBufferFactory().wrap(byteBuffer);
 		StepVerifier.create(response.getBody())
-				.expectNext(buffer)
+				.consumeNextWith(buf -> {
+					String actual = DataBufferTestUtils.dumpString(buf, UTF_8);
+					Assert.assertEquals("foo", actual);
+				})
 				.expectComplete()
 				.verify();
 	}


### PR DESCRIPTION
As explained in [SPR-17558](https://jira.spring.io/browse/SPR-17558), our current implementation doesn't use optimized variants provided by `DataBuffer` implementations, like Netty's.

This PR aims at introducing a new feature in `DataBuffer` to do that.