### PR TITLE
SPR-16886 Provide two mechanisms for SQL Server sequence incrementers.

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/incrementer/SqlServerSequenceMaxValueIncrementer.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/incrementer/SqlServerSequenceMaxValueIncrementer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.support.incrementer;
+
+import javax.sql.DataSource;
+
+/**
+ * {@link DataFieldMaxValueIncrementer} that retrieves the next value of a given MS SQL Server sequence.
+ *
+ * <p>This incrementer should be used with SQL Server versions 2012 and newer to take advantage of native
+ * database sequences introduced in SQL Server 2012. For older versions of SQL Server (2008 and older,) the
+ * {@link SqlServerMaxValueIncrementer} can be used to generate values from a dedicated sequence table.
+ *
+ * @author Tyler Van Gorder
+ */
+public class SqlServerSequenceMaxValueIncrementer extends AbstractSequenceMaxValueIncrementer {
+
+	/**
+	 * Default constructor for bean property style usage.
+	 * @see #setDataSource
+	 * @see #setIncrementerName
+	 */
+	public SqlServerSequenceMaxValueIncrementer() {
+	}
+
+	/**
+	 * Convenience constructor.
+	 * @param dataSource the DataSource to use
+	 * @param incrementerName the name of the sequence/table to use
+	 */
+	public SqlServerSequenceMaxValueIncrementer(DataSource dataSource, String incrementerName) {
+		super(dataSource, incrementerName);
+	}
+
+	@Override
+	protected String getSequenceQuery() {
+		return "select NEXT VALUE for " + getIncrementerName();
+	}
+}


### PR DESCRIPTION
This PR is to address a deadlocking issue with MS SQL Server and is related to https://jira.spring.io/browse/SPR-16886. Please see that issue for details.

I tried to ensure that this fix does not break downstream projects that leverage the incrementer on SQL Server.

This means that all versions of SQL Server are still going to use a sequence table with the difference being that the incrementer uses a reaper interval to delete records out of the sequence table.

I have also included an incrementer that can leverage native database sequences in 2012 and higher. It will be at the discretion of each downstream project as to when/if they want to leverage the new incrementer.

I am open to any feedback or changes you might want to make. I had toyed with requiring a platform transaction manager being injected into the incrementer (and creating a new transaction when the reaping interval was reached) as an alternative to using a thread, but I felt that was a more invasive change to downstream projects.

I have also updated my little test harness to use "copies" of the incrementers I have submitted in this pull request: https://github.com/tkvangorder/jdbc-sqlserver-incrementer