### PR TITLE
SPR-17606 @Profile mishandles "not" operand mixed with "&"

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/ProfilesParser.java
+++ b/spring-core/src/main/java/org/springframework/core/env/ProfilesParser.java
@@ -66,12 +66,11 @@ final class ProfilesParser {
 			}
 			switch (token) {
 				case "(":
-					Profiles contents = parseTokens(expression, tokens);
+					Profiles contents = parseTokens(expression, tokens, Context.BRACKET);
 					if (context == Context.INVERT) {
 						return contents;
-					}else {
-						elements.add(contents);
 					}
+					elements.add(contents);
 					break;
 				case "&":
 					assertWellFormed(expression, operator == null || operator == Operator.AND);
@@ -86,6 +85,9 @@ final class ProfilesParser {
 					break;
 				case ")":
 					Profiles merged = merge(expression, elements, operator);
+					if (context == Context.BRACKET) {
+						return merged;
+					}
 					elements.clear();
 					elements.add(merged);
 					operator = null;
@@ -94,9 +96,8 @@ final class ProfilesParser {
 					Profiles value = equals(token);
 					if (context == Context.INVERT) {
 						return value;
-					} else {
-						elements.add(value);
 					}
+					elements.add(value);
 			}
 		}
 		return merge(expression, elements, operator);
@@ -137,7 +138,9 @@ final class ProfilesParser {
 
 
 	private enum Operator {AND, OR}
-	private enum Context {NONE, INVERT}
+
+
+	private enum Context {NONE, INVERT, BRACKET}
 
 
 	private static class ParsedProfiles implements Profiles {

--- a/spring-core/src/test/java/org/springframework/core/env/ProfilesTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/ProfilesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,10 +194,28 @@ public class ProfilesTests {
 		assertFalse(profiles.matches(activeProfiles("spring", "framework")));
 		assertTrue(profiles.matches(activeProfiles("java")));
 	}
-	
+
 	@Test
 	public void ofAndExpressionWithInvertedSingleElement() {
 		Profiles profiles = Profiles.of("!spring & framework");
+		assertOfAndExpressionWithInvertedSingleElement(profiles);
+	}
+
+	@Test
+	public void ofAndExpressionWithInBracketsInvertedSingleElement() {
+		Profiles profiles = Profiles.of("(!spring) & framework");
+		assertOfAndExpressionWithInvertedSingleElement(profiles);
+	}
+
+	@Test
+	public void ofAndExpressionWithInvertedSingleElementInBrackets() {
+		Profiles profiles = Profiles.of("! (spring) & framework");
+		assertOfAndExpressionWithInvertedSingleElement(profiles);
+	}
+
+	@Test
+	public void ofAndExpressionWithInvertedSingleElementInBracketsWithoutSpaces() {
+		Profiles profiles = Profiles.of("!(spring)&framework");
 		assertOfAndExpressionWithInvertedSingleElement(profiles);
 	}
 

--- a/spring-core/src/test/java/org/springframework/core/env/ProfilesTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/ProfilesTests.java
@@ -194,6 +194,38 @@ public class ProfilesTests {
 		assertFalse(profiles.matches(activeProfiles("spring", "framework")));
 		assertTrue(profiles.matches(activeProfiles("java")));
 	}
+	
+	@Test
+	public void ofAndExpressionWithInvertedSingleElement() {
+		Profiles profiles = Profiles.of("!spring & framework");
+		assertOfAndExpressionWithInvertedSingleElement(profiles);
+	}
+
+	@Test
+	public void ofAndExpressionWithInvertedSingleElementWithoutSpaces() {
+		Profiles profiles = Profiles.of("!spring&framework");
+		assertOfAndExpressionWithInvertedSingleElement(profiles);
+	}
+
+	private void assertOfAndExpressionWithInvertedSingleElement(Profiles profiles) {
+		assertTrue(profiles.matches(activeProfiles("framework")));
+		assertFalse(profiles.matches(activeProfiles("java")));
+		assertFalse(profiles.matches(activeProfiles("spring", "framework")));
+		assertFalse(profiles.matches(activeProfiles("spring")));
+	}
+
+	@Test
+	public void ofOrExpressionWithInvertedSingleElementWithoutSpaces() {
+		Profiles profiles = Profiles.of("!spring|framework");
+		assertOfOrExpressionWithInvertedSingleElement(profiles);
+	}
+
+	private void assertOfOrExpressionWithInvertedSingleElement(Profiles profiles) {
+		assertTrue(profiles.matches(activeProfiles("framework")));
+		assertTrue(profiles.matches(activeProfiles("java")));
+		assertTrue(profiles.matches(activeProfiles("spring", "framework")));
+		assertFalse(profiles.matches(activeProfiles("spring")));
+	}
 
 	@Test
 	public void ofNotOrExpression() {


### PR DESCRIPTION
The root cause of the [issue](https://jira.spring.io/browse/SPR-17606) was that single-element inversions (not operator, '!) were greedy and consumed the whole expression prior to inverting it.

This fix provides some contextual information to the parsing method about currently processed element and based on it, returns to previous parsing context.

During the investigation, it turned out that brackets work in similar way (greedy) and some fix was provided as well.