### PR TITLE
Extract Method::getParameterTypes out of the loop where possible

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
@@ -363,8 +363,10 @@ class CglibAopProxy implements AopProxy, Serializable {
 	 * Check whether the given method is declared on any of the given interfaces.
 	 */
 	private static boolean implementsInterface(Method method, Set<Class<?>> ifcs) {
+		String methodName = method.getName();
+		Class<?>[] methodParameterTypes = method.getParameterTypes();
 		for (Class<?> ifc : ifcs) {
-			if (ClassUtils.hasMethod(ifc, method.getName(), method.getParameterTypes())) {
+			if (ClassUtils.hasMethod(ifc, methodName, methodParameterTypes)) {
 				return true;
 			}
 		}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
@@ -116,9 +116,11 @@ abstract class AutowireUtils {
 		Method setter = pd.getWriteMethod();
 		if (setter != null) {
 			Class<?> targetClass = setter.getDeclaringClass();
+			String setterName = setter.getName();
+			Class<?>[] setterParameterTypes = setter.getParameterTypes();
 			for (Class<?> ifc : interfaces) {
 				if (ifc.isAssignableFrom(targetClass) &&
-						ClassUtils.hasMethod(ifc, setter.getName(), setter.getParameterTypes())) {
+						ClassUtils.hasMethod(ifc, setterName, setterParameterTypes)) {
 					return true;
 				}
 			}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/ReplaceOverride.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/ReplaceOverride.java
@@ -43,7 +43,7 @@ public class ReplaceOverride extends MethodOverride {
 
 	/**
 	 * Construct a new ReplaceOverride.
-	 * @param methodName the name of the method to override
+	 * @param methodName             the name of the method to override
 	 * @param methodReplacerBeanName the bean name of the MethodReplacer
 	 */
 	public ReplaceOverride(String methodName, String methodReplacerBeanName) {
@@ -82,9 +82,12 @@ public class ReplaceOverride extends MethodOverride {
 		if (this.typeIdentifiers.size() != method.getParameterCount()) {
 			return false;
 		}
+
+		Class<?>[] parameterTypes = method.getParameterTypes();
+
 		for (int i = 0; i < this.typeIdentifiers.size(); i++) {
 			String identifier = this.typeIdentifiers.get(i);
-			if (!method.getParameterTypes()[i].getName().contains(identifier)) {
+			if (!parameterTypes[i].getName().contains(identifier)) {
 				return false;
 			}
 		}

--- a/spring-context/src/main/java/org/springframework/jmx/export/assembler/InterfaceBasedMBeanInfoAssembler.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/assembler/InterfaceBasedMBeanInfoAssembler.java
@@ -228,10 +228,13 @@ public class InterfaceBasedMBeanInfoAssembler extends AbstractConfigurableMBeanI
 			}
 		}
 
+		String methodName = method.getName();
+		Class<?>[] methodParameterTypes = method.getParameterTypes();
+
 		for (Class<?> ifc : ifaces) {
 			for (Method ifcMethod : ifc.getMethods()) {
-				if (ifcMethod.getName().equals(method.getName()) &&
-						Arrays.equals(ifcMethod.getParameterTypes(), method.getParameterTypes())) {
+				if (ifcMethod.getName().equals(methodName) &&
+						Arrays.equals(ifcMethod.getParameterTypes(), methodParameterTypes)) {
 					return true;
 				}
 			}

--- a/spring-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
@@ -235,8 +235,8 @@ public final class BridgeMethodResolver {
 		if (bridgeMethod == bridgedMethod) {
 			return true;
 		}
-		return (Arrays.equals(bridgeMethod.getParameterTypes(), bridgedMethod.getParameterTypes()) &&
-				bridgeMethod.getReturnType().equals(bridgedMethod.getReturnType()));
+		return bridgeMethod.getReturnType().equals(bridgedMethod.getReturnType()) &&
+				Arrays.equals(bridgeMethod.getParameterTypes(), bridgedMethod.getParameterTypes());
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -1289,11 +1289,13 @@ public abstract class ClassUtils {
 	public static Method getInterfaceMethodIfPossible(Method method) {
 		if (Modifier.isPublic(method.getModifiers()) && !method.getDeclaringClass().isInterface()) {
 			Class<?> current = method.getDeclaringClass();
+			String methodName = method.getName();
+			Class<?>[] methodParameterTypes = method.getParameterTypes();
 			while (current != null && current != Object.class) {
 				Class<?>[] ifcs = current.getInterfaces();
 				for (Class<?> ifc : ifcs) {
 					try {
-						return ifc.getMethod(method.getName(), method.getParameterTypes());
+						return ifc.getMethod(methodName, methodParameterTypes);
 					}
 					catch (NoSuchMethodException ex) {
 						// ignore

--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -626,9 +626,11 @@ public abstract class ReflectionUtils {
 		doWithMethods(leafClass, method -> {
 			boolean knownSignature = false;
 			Method methodBeingOverriddenWithCovariantReturnType = null;
+			String methodName = method.getName();
+			Class<?>[] methodParameterTypes = method.getParameterTypes();
 			for (Method existingMethod : methods) {
-				if (method.getName().equals(existingMethod.getName()) &&
-						Arrays.equals(method.getParameterTypes(), existingMethod.getParameterTypes())) {
+				if (methodName.equals(existingMethod.getName()) &&
+						Arrays.equals(methodParameterTypes, existingMethod.getParameterTypes())) {
 					// Is this a covariant return type situation?
 					if (existingMethod.getReturnType() != method.getReturnType() &&
 							existingMethod.getReturnType().isAssignableFrom(method.getReturnType())) {


### PR DESCRIPTION
Method::getParameterTypes returns copy of Method.parameterTypes.
Often this can be extracted out of the loop