### PR TITLE
Add a link to Kotlin Sample w/ Spring Cloud GCP

### DIFF
--- a/src/docs/asciidoc/languages/kotlin.adoc
+++ b/src/docs/asciidoc/languages/kotlin.adoc
@@ -755,6 +755,7 @@ The following Github projects offer examples that you can learn from and possibl
 * https://github.com/sdeleuze/spring-kotlin-fullstack[spring-kotlin-fullstack]: WebFlux Kotlin fullstack example with Kotlin2js for frontend instead of JavaScript or TypeScript
 * https://github.com/spring-petclinic/spring-petclinic-kotlin[spring-petclinic-kotlin]: Kotlin version of the Spring PetClinic Sample Application
 * https://github.com/sdeleuze/spring-kotlin-deepdive[spring-kotlin-deepdive]: A step-by-step migration guide for Boot 1.0 and Java to Boot 2.0 and Kotlin
+* https://github.com/spring-cloud/spring-cloud-gcp/tree/master/spring-cloud-gcp-kotlin-samples/spring-cloud-gcp-kotlin-app-sample[spring-cloud-gcp-kotlin-app-sample]: Spring Boot with Google Cloud Platform Integrations
 
 
 


### PR DESCRIPTION
This add a Kotlin Spring Boot sample demonstrating integrations with Google Cloud Platform.

Hi, just to clarify - I work with the [Spring Cloud GCP](https://github.com/spring-cloud/spring-cloud-gcp) team at Google; we work with Pivotal to build integrations for Spring and Google Cloud. This PR is just to add a plug to a Kotlin sample application that integrates with Google Cloud. Not sure if this example fits within your docs but figured it s worth a shot.

cc/ @meltsufin
