### PR TITLE
SPR-8335: fixed default-lazy-init processing when xsd validation is disabled

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
@@ -98,6 +98,8 @@ public class BeanDefinitionParserDelegate {
 
 	public static final String DEFAULT_VALUE = "default";
 
+	private static final String EMPTY_STRING = "";
+
 	public static final String DESCRIPTION_ELEMENT = "description";
 
 	public static final String AUTOWIRE_NO_VALUE = "no";
@@ -320,21 +322,21 @@ public class BeanDefinitionParserDelegate {
 	 */
 	protected void populateDefaults(DocumentDefaultsDefinition defaults, @Nullable DocumentDefaultsDefinition parentDefaults, Element root) {
 		String lazyInit = root.getAttribute(DEFAULT_LAZY_INIT_ATTRIBUTE);
-		if (DEFAULT_VALUE.equals(lazyInit)) {
+		if (isDefault(lazyInit)) {
 			// Potentially inherited from outer <beans> sections, otherwise falling back to false.
 			lazyInit = (parentDefaults != null ? parentDefaults.getLazyInit() : FALSE_VALUE);
 		}
 		defaults.setLazyInit(lazyInit);
 
 		String merge = root.getAttribute(DEFAULT_MERGE_ATTRIBUTE);
-		if (DEFAULT_VALUE.equals(merge)) {
+		if (isDefault(merge)) {
 			// Potentially inherited from outer <beans> sections, otherwise falling back to false.
 			merge = (parentDefaults != null ? parentDefaults.getMerge() : FALSE_VALUE);
 		}
 		defaults.setMerge(merge);
 
 		String autowire = root.getAttribute(DEFAULT_AUTOWIRE_ATTRIBUTE);
-		if (DEFAULT_VALUE.equals(autowire)) {
+		if (isDefault(autowire)) {
 			// Potentially inherited from outer <beans> sections, otherwise falling back to 'no'.
 			autowire = (parentDefaults != null ? parentDefaults.getAutowire() : AUTOWIRE_NO_VALUE);
 		}
@@ -572,7 +574,7 @@ public class BeanDefinitionParserDelegate {
 		}
 
 		String lazyInit = ele.getAttribute(LAZY_INIT_ATTRIBUTE);
-		if (DEFAULT_VALUE.equals(lazyInit)) {
+		if (isDefault(lazyInit)) {
 			lazyInit = this.defaults.getLazyInit();
 		}
 		bd.setLazyInit(TRUE_VALUE.equals(lazyInit));
@@ -586,7 +588,7 @@ public class BeanDefinitionParserDelegate {
 		}
 
 		String autowireCandidate = ele.getAttribute(AUTOWIRE_CANDIDATE_ATTRIBUTE);
-		if ("".equals(autowireCandidate) || DEFAULT_VALUE.equals(autowireCandidate)) {
+		if (isDefault(autowireCandidate)) {
 			String candidatePattern = this.defaults.getAutowireCandidates();
 			if (candidatePattern != null) {
 				String[] patterns = StringUtils.commaDelimitedListToStringArray(candidatePattern);
@@ -661,7 +663,7 @@ public class BeanDefinitionParserDelegate {
 	@SuppressWarnings("deprecation")
 	public int getAutowireMode(String attValue) {
 		String att = attValue;
-		if (DEFAULT_VALUE.equals(att)) {
+		if (isDefault(att)) {
 			att = this.defaults.getAutowire();
 		}
 		int autowire = AbstractBeanDefinition.AUTOWIRE_NO;
@@ -681,6 +683,9 @@ public class BeanDefinitionParserDelegate {
 		return autowire;
 	}
 
+	private boolean isDefault(String value) {
+		return (DEFAULT_VALUE.equals(value) || EMPTY_STRING.equals(value));
+	}
 	/**
 	 * Parse constructor-arg sub-elements of the given bean element.
 	 */
@@ -1341,7 +1346,7 @@ public class BeanDefinitionParserDelegate {
 	 */
 	public boolean parseMergeAttribute(Element collectionElement) {
 		String value = collectionElement.getAttribute(MERGE_ATTRIBUTE);
-		if (DEFAULT_VALUE.equals(value)) {
+		if (isDefault(value)) {
 			value = this.defaults.getMerge();
 		}
 		return TRUE_VALUE.equals(value);

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests.java
@@ -41,6 +41,10 @@ public class NestedBeansElementAttributeRecursionTests {
 		new XmlBeanDefinitionReader(bf).loadBeanDefinitions(
 				new ClassPathResource("NestedBeansElementAttributeRecursionTests-lazy-context.xml", this.getClass()));
 
+		assertLazyInits(bf);
+	}
+
+	private void assertLazyInits(DefaultListableBeanFactory bf) {
 		BeanDefinition foo = bf.getBeanDefinition("foo");
 		BeanDefinition bar = bf.getBeanDefinition("bar");
 		BeanDefinition baz = bf.getBeanDefinition("baz");
@@ -55,12 +59,39 @@ public class NestedBeansElementAttributeRecursionTests {
 	}
 
 	@Test
+	public void defaultLazyInitWithNonValidatingParser() {
+		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(bf);
+		xmlBeanDefinitionReader.setValidating(false);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource("NestedBeansElementAttributeRecursionTests-lazy-context.xml", this.getClass()));
+
+		assertLazyInits(bf);
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	public void defaultMerge() {
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
 		new XmlBeanDefinitionReader(bf).loadBeanDefinitions(
 				new ClassPathResource("NestedBeansElementAttributeRecursionTests-merge-context.xml", this.getClass()));
 
+		assertMerge(bf);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void defaultMergeWithNonValidatingParser() {
+		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(bf);
+		xmlBeanDefinitionReader.setValidating(false);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource("NestedBeansElementAttributeRecursionTests-merge-context.xml", this.getClass()));
+
+		assertMerge(bf);
+	}
+
+	private void assertMerge(DefaultListableBeanFactory bf) {
 		TestBean topLevel = bf.getBean("topLevelConcreteTestBean", TestBean.class);
 		// has the concrete child bean values
 		assertThat((Iterable<String>) topLevel.getSomeList(), hasItems("charlie", "delta"));
@@ -74,7 +105,7 @@ public class NestedBeansElementAttributeRecursionTests {
 
 		TestBean secondLevel = bf.getBean("secondLevelNestedTestBean", TestBean.class);
 		// merges all values
-		assertThat((Iterable<String>)secondLevel.getSomeList(),
+		assertThat((Iterable<String>) secondLevel.getSomeList(),
 				hasItems("charlie", "delta", "echo", "foxtrot", "golf", "hotel"));
 	}
 
@@ -84,6 +115,21 @@ public class NestedBeansElementAttributeRecursionTests {
 		new XmlBeanDefinitionReader(bf).loadBeanDefinitions(
 				new ClassPathResource("NestedBeansElementAttributeRecursionTests-autowire-candidates-context.xml", this.getClass()));
 
+		assertAutowireCandidates(bf);
+	}
+
+	@Test
+	public void defaultAutowireCandidatesWithNonValidatingParser() {
+		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+		XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(bf);
+		xmlBeanDefinitionReader.setValidating(false);
+		xmlBeanDefinitionReader.loadBeanDefinitions(
+				new ClassPathResource("NestedBeansElementAttributeRecursionTests-autowire-candidates-context.xml", this.getClass()));
+
+		assertAutowireCandidates(bf);
+	}
+
+	private void assertAutowireCandidates(DefaultListableBeanFactory bf) {
 		assertThat(bf.getBeanDefinition("fooService").isAutowireCandidate(), is(true));
 		assertThat(bf.getBeanDefinition("fooRepository").isAutowireCandidate(), is(true));
 		assertThat(bf.getBeanDefinition("other").isAutowireCandidate(), is(false));


### PR DESCRIPTION
The xml parser does not fill in defaults provided in the xsd when validation is disabled. 

As a result, attributes like default-lazy-init will not receive the value "default" but an empty
string value. This also applies for other default attributes in the root or parent elements.

The BeanDefinitionParserDelegate did not take this into account. So, we should also check on an empty string value, which is semantically the same as the value "default".

Issues: SPR-8335