### PR TITLE
Custom resolver should be first add in 

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -641,6 +641,11 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 	private List<HandlerMethodArgumentResolver> getDefaultArgumentResolvers() {
 		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
 
+		// Custom arguments
+		if (getCustomArgumentResolvers() != null) {
+			resolvers.addAll(getCustomArgumentResolvers());
+		}
+
 		// Annotation-based argument resolution
 		resolvers.add(new RequestParamMethodArgumentResolver(getBeanFactory(), false));
 		resolvers.add(new RequestParamMapMethodArgumentResolver());
@@ -669,10 +674,6 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 		resolvers.add(new SessionStatusMethodArgumentResolver());
 		resolvers.add(new UriComponentsBuilderMethodArgumentResolver());
 
-		// Custom arguments
-		if (getCustomArgumentResolvers() != null) {
-			resolvers.addAll(getCustomArgumentResolvers());
-		}
 
 		// Catch-all
 		resolvers.add(new RequestParamMethodArgumentResolver(getBeanFactory(), true));


### PR DESCRIPTION
Custom resolver should be first add in since they may want overwrite the default behavior,especially map resolver.
I want my @RequestParam Map<String,Object> contains some Integer value instead of all String value. I wrote my own resolver extends RequestParamMapMethodArgumentResolver  , but RequestParamMapMethodArgumentResolver will be the first resolver be detected, so my resolver won't work. So I add my own annotation and overwrite the  supportsParameter method , then MapMethodProcessor will be the first . I have no way to deal this solution. So I think it's better to add custom resolver first, then the default resolver.