### PR TITLE
Adding the ability to blacklist the logging of certain headers in the

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
@@ -123,11 +123,9 @@ public class RequestLoggingFilterTests {
 
 	@Test
 	public void includeHeadersWithBlacklist() throws Exception {
-		Set<String> headersBlacklist = new HashSet<>();
-		headersBlacklist.add("Authorization");
 
 		filter.setIncludeHeaders(true);
-		filter.setHeadersBlacklist(headersBlacklist);
+		filter.setBlacklistPredicate(key -> key.equals("Authorization"));
 
 		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();

--- a/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
@@ -17,8 +17,6 @@
 package org.springframework.web.filter;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -125,7 +123,7 @@ public class RequestLoggingFilterTests {
 	public void includeHeadersWithBlacklist() throws Exception {
 
 		filter.setIncludeHeaders(true);
-		filter.setBlacklistPredicate(key -> key.equals("Authorization"));
+		filter.setBlacklistPredicate(key -> "Authorization".equals(key));
 
 		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
AbstractRequestLoggingFilter class in spring-web

Issue: #22244 [Issue Link](https://github.com/spring-projects/spring-framework/issues/22244)

> So issue SPR-14245 requested the ability to log all headers coming in with a request be added to AbstractRequestLoggingFilter.

>There are sometime headers that it would be beneficial not to log. Such as Authorization headers containing jwt tokens.

>It would be useful to be able to provide a blacklist of some headers which are then not appended to the log message builder.