### PR TITLE
References of CountingBeforeAdvice target its previous location

### DIFF
--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-context.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-context.xml
@@ -16,9 +16,9 @@
 		</aop:aspect>
 	</aop:config>
 
-	<bean id="getNameCounter" class="org.springframework.aop.framework.CountingBeforeAdvice"/>
+	<bean id="getNameCounter" class="org.springframework.tests.aop.advice.CountingBeforeAdvice"/>
 
-	<bean id="getAgeCounter" class="org.springframework.aop.framework.CountingBeforeAdvice"/>
+	<bean id="getAgeCounter" class="org.springframework.tests.aop.advice.CountingBeforeAdvice"/>
 
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean"/>
 

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-directPointcutEvents.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-directPointcutEvents.xml
@@ -9,6 +9,6 @@
 		<aop:advisor advice-ref="countingAdvice" pointcut="within(org.springframework..*)"/>
 	</aop:config>
 
-	<bean id="countingAdvice" class="org.springframework.aop.framework.CountingBeforeAdvice"/>
+	<bean id="countingAdvice" class="org.springframework.tests.aop.advice.CountingBeforeAdvice"/>
 
 </beans>

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-pointcutRefEvents.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-pointcutRefEvents.xml
@@ -10,6 +10,6 @@
 		<aop:advisor advice-ref="countingAdvice" pointcut-ref="pc"/>
 	</aop:config>
 
-	<bean id="countingAdvice" class="org.springframework.aop.framework.CountingBeforeAdvice"/>
+	<bean id="countingAdvice" class="org.springframework.tests.aop.advice.CountingBeforeAdvice"/>
 
 </beans>

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerPointcutErrorTests-pointcutDuplication.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerPointcutErrorTests-pointcutDuplication.xml
@@ -12,7 +12,7 @@
 		</aop:aspect>
 	</aop:config>
 
-	<bean id="getAgeCounter" class="org.springframework.aop.framework.CountingBeforeAdvice"/>
+	<bean id="getAgeCounter" class="org.springframework.tests.aop.advice.CountingBeforeAdvice"/>
 
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean"/>
 

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerPointcutErrorTests-pointcutMissing.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerPointcutErrorTests-pointcutMissing.xml
@@ -12,7 +12,7 @@
 		</aop:aspect>
 	</aop:config>
 
-	<bean id="getAgeCounter" class="org.springframework.aop.framework.CountingBeforeAdvice"/>
+	<bean id="getAgeCounter" class="org.springframework.tests.aop.advice.CountingBeforeAdvice"/>
 
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean"/>
 


### PR DESCRIPTION
I have some questions about AOP. So I research the source codes.

I want to debug the test source codes of AOP. I found the references of `CountingBeforeAdvice` was missed, and I found `org.springframework.tests.aop.advice.CountingBeforeAdvice` is in the repo.

Maybe the reference of `CountingBeforeAdvice` is incorrect. Please check it. Thanks a lot.