### PR TITLE
Update links to issue tracker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you have a question, check StackOverflow using
 Find an existing discussion or start a new one if necessary.
 
 If you suspect an issue, perform a search in the
-[JIRA issue tracker](https://jira.spring.io/browse/SPR), using a few different keywords.
+[Github issue tracker](https://github.com/spring-projects/spring-framework/issues), using a few different keywords.
 When you find related issues and discussions, prior or current, it helps you to learn and
 it helps us to make a decision.
 
@@ -42,7 +42,7 @@ Before you create a ticket, please take the time to [research first](#discuss).
 
 If creating a ticket after a discussion on StackOverflow, please provide a self-sufficient description in the ticket, independent of the details on StackOverview. We understand this is extra work but the issue tracker is an important place of record for design discussions and decisions that can often be referenced long after the fix version, for example to revisit decisions, to understand the origin of a feature, and so on.
 
-When ready create a ticket in the [JIRA issue tracker](https://jira.spring.io/browse/SPR).
+When ready create a ticket in the [Github issue tracker](https://github.com/spring-projects/spring-framework/issues).
 
 #### Ticket Lifecycle
 
@@ -66,7 +66,7 @@ automatically when you submit a pull request.
 
 1. For all but the most trivial of contributions, please [create a ticket](#create-a-ticket).
 The purpose of the ticket is to understand and discuss the underlying issue or feature.
-We use the JIRA issue tracker as the preferred place of record for conversations and
+We use the Github issue tracker as the preferred place of record for conversations and
 conclusions. In that sense discussions directly under a PR are more implementation detail
 oriented and transient in nature.
 
@@ -75,7 +75,7 @@ oriented and transient in nature.
 Backports to prior versions will be considered on a case-by-case basis and reflected as
 the fix version in the issue tracker.
 
-1. Use short branch names, preferably based on the JIRA issue (e.g. `SPR-1234`), or
+1. Use short branch names, preferably based on the Github issue (e.g. `SPR-1234`), or
 otherwise using succinct, lower-case, dash (-) delimited names, such as `fix-warnings`.
 
 1. Choose the granularity of your commits consciously and squash commits that represent
@@ -89,7 +89,7 @@ See the
 [Commit Guidelines section of Pro Git](http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines)
 for best practices around commit messages and use `git log` to see some examples.
 
-1. List the JIRA issue number in the PR description.
+1. List the Github issue number in the PR description.
 
 If accepted, your contribution may be heavily modified as needed prior to merging.
 You will likely retain author attribution for your Git commits granted that the bulk of

--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -52,8 +52,8 @@ def customizePom(pom, gradleProject) {
 				}
 			}
 			issueManagement {
-				system = "Jira"
-				url = "https://jira.springsource.org/browse/SPR"
+				system = "Github"
+				url = "https://github.com/spring-projects/spring-framework/issues"
 			}
 		}
 	}


### PR DESCRIPTION
Issues of Spring framework have recently been moved from Jira to Github.
This PR updates the links to issue tracker.