### PR TITLE
Use AtomicInteger instead of unsafe increment on volatile fields

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/support/ControlFlowPointcut.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/ControlFlowPointcut.java
@@ -18,6 +18,7 @@ package org.springframework.aop.support;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.aop.ClassFilter;
 import org.springframework.aop.MethodMatcher;
@@ -43,7 +44,7 @@ public class ControlFlowPointcut implements Pointcut, ClassFilter, MethodMatcher
 	@Nullable
 	private String methodName;
 
-	private volatile int evaluations;
+	private final AtomicInteger evaluations = new AtomicInteger(0);
 
 
 	/**
@@ -92,7 +93,7 @@ public class ControlFlowPointcut implements Pointcut, ClassFilter, MethodMatcher
 
 	@Override
 	public boolean matches(Method method, Class<?> targetClass, Object... args) {
-		this.evaluations++;
+		this.evaluations.incrementAndGet();
 
 		for (StackTraceElement element : new Throwable().getStackTrace()) {
 			if (element.getClassName().equals(this.clazz.getName()) &&
@@ -107,7 +108,7 @@ public class ControlFlowPointcut implements Pointcut, ClassFilter, MethodMatcher
 	 * It's useful to know how many times we've fired, for optimization.
 	 */
 	public int getEvaluations() {
-		return this.evaluations;
+		return this.evaluations.get();
 	}
 
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/SpelExpression.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/SpelExpression.java
@@ -34,6 +34,8 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * A {@code SpelExpression} represents a parsed (valid) expression that is ready to be
  * evaluated in a specified context. An expression can be evaluated standalone or in a
@@ -69,7 +71,7 @@ public class SpelExpression implements Expression {
 
 	// Count of many times as the expression been interpreted - can trigger compilation
 	// when certain limit reached
-	private volatile int interpretedCount = 0;
+	private final AtomicInteger interpretedCount = new AtomicInteger(0);
 
 	// The number of times compilation was attempted and failed - enables us to eventually
 	// give up trying to compile it when it just doesn't seem to be possible.
@@ -124,7 +126,7 @@ public class SpelExpression implements Expression {
 			catch (Throwable ex) {
 				// If running in mixed mode, revert to interpreted
 				if (this.configuration.getCompilerMode() == SpelCompilerMode.MIXED) {
-					this.interpretedCount = 0;
+					this.interpretedCount.set(0);
 					this.compiledAst = null;
 				}
 				else {
@@ -159,7 +161,7 @@ public class SpelExpression implements Expression {
 			catch (Throwable ex) {
 				// If running in mixed mode, revert to interpreted
 				if (this.configuration.getCompilerMode() == SpelCompilerMode.MIXED) {
-					this.interpretedCount = 0;
+					this.interpretedCount.set(0);
 					this.compiledAst = null;
 				}
 				else {
@@ -186,7 +188,7 @@ public class SpelExpression implements Expression {
 			catch (Throwable ex) {
 				// If running in mixed mode, revert to interpreted
 				if (this.configuration.getCompilerMode() == SpelCompilerMode.MIXED) {
-					this.interpretedCount = 0;
+					this.interpretedCount.set(0);
 					this.compiledAst = null;
 				}
 				else {
@@ -221,7 +223,7 @@ public class SpelExpression implements Expression {
 			catch (Throwable ex) {
 				// If running in mixed mode, revert to interpreted
 				if (this.configuration.getCompilerMode() == SpelCompilerMode.MIXED) {
-					this.interpretedCount = 0;
+					this.interpretedCount.set(0);
 					this.compiledAst = null;
 				}
 				else {
@@ -251,7 +253,7 @@ public class SpelExpression implements Expression {
 			catch (Throwable ex) {
 				// If running in mixed mode, revert to interpreted
 				if (this.configuration.getCompilerMode() == SpelCompilerMode.MIXED) {
-					this.interpretedCount = 0;
+					this.interpretedCount.set(0);
 					this.compiledAst = null;
 				}
 				else {
@@ -286,7 +288,7 @@ public class SpelExpression implements Expression {
 			catch (Throwable ex) {
 				// If running in mixed mode, revert to interpreted
 				if (this.configuration.getCompilerMode() == SpelCompilerMode.MIXED) {
-					this.interpretedCount = 0;
+					this.interpretedCount.set(0);
 					this.compiledAst = null;
 				}
 				else {
@@ -314,7 +316,7 @@ public class SpelExpression implements Expression {
 			catch (Throwable ex) {
 				// If running in mixed mode, revert to interpreted
 				if (this.configuration.getCompilerMode() == SpelCompilerMode.MIXED) {
-					this.interpretedCount = 0;
+					this.interpretedCount.set(0);
 					this.compiledAst = null;
 				}
 				else {
@@ -351,7 +353,7 @@ public class SpelExpression implements Expression {
 			catch (Throwable ex) {
 				// If running in mixed mode, revert to interpreted
 				if (this.configuration.getCompilerMode() == SpelCompilerMode.MIXED) {
-					this.interpretedCount = 0;
+					this.interpretedCount.set(0);
 					this.compiledAst = null;
 				}
 				else {
@@ -473,17 +475,17 @@ public class SpelExpression implements Expression {
 	 * @param expressionState the expression state used to determine compilation mode
 	 */
 	private void checkCompile(ExpressionState expressionState) {
-		this.interpretedCount++;
+		this.interpretedCount.incrementAndGet();
 		SpelCompilerMode compilerMode = expressionState.getConfiguration().getCompilerMode();
 		if (compilerMode != SpelCompilerMode.OFF) {
 			if (compilerMode == SpelCompilerMode.IMMEDIATE) {
-				if (this.interpretedCount > 1) {
+				if (this.interpretedCount.get() > 1) {
 					compileExpression();
 				}
 			}
 			else {
 				// compilerMode = SpelCompilerMode.MIXED
-				if (this.interpretedCount > INTERPRETED_COUNT_THRESHOLD) {
+				if (this.interpretedCount.get() > INTERPRETED_COUNT_THRESHOLD) {
 					compileExpression();
 				}
 			}
@@ -524,7 +526,7 @@ public class SpelExpression implements Expression {
 	 */
 	public void revertToInterpreted() {
 		this.compiledAst = null;
-		this.interpretedCount = 0;
+		this.interpretedCount.set(0);
 		this.failedAttempts = 0;
 	}
 


### PR DESCRIPTION
I've found several cases where we increment numeric field declared `volatile`. Such explicit increment may bring incorrect behaviour, as increment operation itself is not atomic.