### PR TITLE
Fix truncation of response body in AbstractMessageConverterMethodProcessor

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
@@ -284,7 +284,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 					if (body != null) {
 						Object theBody = body;
 						LogFormatUtils.traceDebug(logger, traceOn ->
-								"Writing [" + LogFormatUtils.formatValue(theBody, traceOn) + "]");
+								"Writing [" + LogFormatUtils.formatValue(theBody, !traceOn) + "]");
 						addContentDispositionHeader(inputMessage, outputMessage);
 						if (genericConverter != null) {
 							genericConverter.write(body, targetType, selectedMediaType, outputMessage);


### PR DESCRIPTION
It seems to be minor mistakes from SPR-17254.

Second parameter of LogFormatUtils.formatValue is (boolean limitLength). It should be false at TRACE. So !traceOn is correct. Other code that call formatValue method are all !traceOn

related issue : [SPR-17254] #21787