### PR TITLE
DRY: use existing method Type::getInternalName in Type::appendDescriptor

### DIFF
--- a/spring-core/src/main/java/org/springframework/asm/Type.java
+++ b/spring-core/src/main/java/org/springframework/asm/Type.java
@@ -632,12 +632,7 @@ public final class Type {
       stringBuilder.append(descriptor);
     } else {
       stringBuilder.append('L');
-      String name = currentClass.getName();
-      int nameLength = name.length();
-      for (int i = 0; i < nameLength; ++i) {
-        char car = name.charAt(i);
-        stringBuilder.append(car == '.' ? '/' : car);
-      }
+      stringBuilder.append(getInternalName(currentClass));
       stringBuilder.append(';');
     }
   }


### PR DESCRIPTION
```java
String name = currentClass.getName();
int nameLength = name.length();
for (int i = 0; i < nameLength; ++i) {
  char car = name.charAt(i);
  stringBuilder.append(car == '.' ? '/' : car);
}
```
this code appends the name of `currentClass` having all dots replaced with `'/'`. However the same class already contains method doing exactly the same
```java
public static String getInternalName(final Class<?> clazz) {
  return clazz.getName().replace('.', '/');
}
```
This one is not only more readable and likely to be faster as it yields the whole String at once instead of appending char by char inflating original StringBuilder.
