### PR TITLE
RestTemplate adds duplicate accept header information 

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -767,7 +768,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 				if (this.responseType instanceof Class) {
 					responseClass = (Class<?>) this.responseType;
 				}
-				List<MediaType> allSupportedMediaTypes = new ArrayList<MediaType>();
+				Set<MediaType> allSupportedMediaTypes = new LinkedHashSet<MediaType>();
 				for (HttpMessageConverter<?> converter : getMessageConverters()) {
 					if (responseClass != null) {
 						if (converter.canRead(responseClass, null)) {
@@ -782,11 +783,12 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 					}
 				}
 				if (!allSupportedMediaTypes.isEmpty()) {
-					MediaType.sortBySpecificity(allSupportedMediaTypes);
+					List<MediaType> result = new ArrayList<MediaType>(allSupportedMediaTypes);
+					MediaType.sortBySpecificity(result);
 					if (logger.isDebugEnabled()) {
 						logger.debug("Setting request Accept header to " + allSupportedMediaTypes);
 					}
-					request.getHeaders().setAccept(allSupportedMediaTypes);
+					request.getHeaders().setAccept(result);
 				}
 			}
 		}


### PR DESCRIPTION
Hi :)

In 4.3.x version, I found a bug that caused the `Accept` header to be duplicated. 
I have added a validation test and fixed the bug, if you could review this PR then I appreciate it.

It seems to have been fixed in 5.0.x and above. It appears to be occurring in versions below 4.3.x.

If this PR is not in the correct format, please let me know. I will fix it.
Thank you.