### PR TITLE
modify-for-loop-mode

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
@@ -645,7 +645,7 @@ public class BeanDefinitionParserDelegate {
 
 	public void parseMetaElements(Element ele, BeanMetadataAttributeAccessor attributeAccessor) {
 		NodeList nl = ele.getChildNodes();
-		for (int i = 0; i < nl.getLength(); i++) {
+		for (int i = 0, j = nl.getLength(); i < j; i++) {
 			Node node = nl.item(i);
 			if (isCandidateElement(node) && nodeNameEquals(node, META_ELEMENT)) {
 				Element metaElement = (Element) node;


### PR DESCRIPTION
It modified the way of the for-loop in the method parseMetaElements 
of the class BeanDefinitionParserDelegate 
form for (int i = 0; i < nl.getLength(); i++) 
to for (int i = 0, j = nl.getLength(); i < j; i++).
It makes you only call the method nl.getLength() once no matter how many times the for-loop used.There are a lot of similar places in this code.
I think which should be optimised is:
1.The depth of VM stack can be reduced.
2.Some complicated methods would be waste time to calculate the length.
It also can be optimeised.I will modify the for-loop in the project if you identified the optimization