### PR TITLE
Simplification in constructor of MvcUriComponentsBuilder.MethodArgumentBuilder

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilder.java
@@ -852,9 +852,6 @@ public class MvcUriComponentsBuilder {
 			this.controllerType = controllerType;
 			this.method = method;
 			this.argumentValues = new Object[method.getParameterCount()];
-			for (int i = 0; i < this.argumentValues.length; i++) {
-				this.argumentValues[i] = null;
-			}
 		}
 
 		private static String getPath() {


### PR DESCRIPTION
Accodring to JLS newly created array is populated with default values for array's type. In case of reference type it is `null` so manual population of array is pointeless in this case.