### PR TITLE
Use StringJoiner where possible to simplify String joining

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/propertyeditors/ClassArrayEditor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/propertyeditors/ClassArrayEditor.java
@@ -17,6 +17,7 @@
 package org.springframework.beans.propertyeditors;
 
 import java.beans.PropertyEditorSupport;
+import java.util.StringJoiner;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
@@ -82,14 +83,11 @@ public class ClassArrayEditor extends PropertyEditorSupport {
 		if (ObjectUtils.isEmpty(classes)) {
 			return "";
 		}
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < classes.length; ++i) {
-			if (i > 0) {
-				sb.append(",");
-			}
-			sb.append(ClassUtils.getQualifiedName(classes[i]));
+		StringJoiner sj = new StringJoiner(",");
+		for (Class<?> klass : classes) {
+			sj.add(ClassUtils.getQualifiedName(klass));
 		}
-		return sb.toString();
+		return sj.toString();
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
 
@@ -1298,14 +1299,11 @@ public abstract class StringUtils {
 			return ObjectUtils.nullSafeToString(arr[0]);
 		}
 
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < arr.length; i++) {
-			if (i > 0) {
-				sb.append(delim);
-			}
-			sb.append(arr[i]);
+		StringJoiner sj = new StringJoiner(delim);
+		for (Object o : arr) {
+			sj.add(String.valueOf(o));
 		}
-		return sb.toString();
+		return sj.toString();
 	}
 
 	/**

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/CompoundExpression.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/CompoundExpression.java
@@ -24,6 +24,8 @@ import org.springframework.expression.spel.ExpressionState;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.lang.Nullable;
 
+import java.util.StringJoiner;
+
 /**
  * Represents a DOT separated expression sequence, such as
  * {@code 'property1.property2.methodOne()'}.
@@ -104,14 +106,11 @@ public class CompoundExpression extends SpelNodeImpl {
 
 	@Override
 	public String toStringAST() {
-		StringBuilder sb = new StringBuilder();
+		StringJoiner sj = new StringJoiner(".");
 		for (int i = 0; i < getChildCount(); i++) {
-			if (i > 0) {
-				sb.append(".");
-			}
-			sb.append(getChild(i).toStringAST());
+			sj.add(getChild(i).toStringAST());
 		}
-		return sb.toString();
+		return sj.toString();
 	}
 
 	@Override

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/FormatHelper.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/FormatHelper.java
@@ -17,6 +17,7 @@
 package org.springframework.expression.spel.ast;
 
 import java.util.List;
+import java.util.StringJoiner;
 
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.lang.Nullable;
@@ -36,22 +37,16 @@ abstract class FormatHelper {
 	 * @return a nicely formatted representation, e.g. {@code foo(String,int)}
 	 */
 	public static String formatMethodForMessage(String name, List<TypeDescriptor> argumentTypes) {
-		StringBuilder sb = new StringBuilder(name);
-		sb.append("(");
-		for (int i = 0; i < argumentTypes.size(); i++) {
-			if (i > 0) {
-				sb.append(",");
-			}
-			TypeDescriptor typeDescriptor = argumentTypes.get(i);
+		StringJoiner sj = new StringJoiner(",", "(", ")");
+		for (TypeDescriptor typeDescriptor : argumentTypes) {
 			if (typeDescriptor != null) {
-				sb.append(formatClassNameForMessage(typeDescriptor.getType()));
+				sj.add(formatClassNameForMessage(typeDescriptor.getType()));
 			}
 			else {
-				sb.append(formatClassNameForMessage(null));
+				sj.add(formatClassNameForMessage(null));
 			}
 		}
-		sb.append(")");
-		return sb.toString();
+		return name + sj.toString();
 	}
 
 	/**

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/FunctionReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/FunctionReference.java
@@ -18,6 +18,7 @@ package org.springframework.expression.spel.ast;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.StringJoiner;
 
 import org.springframework.asm.MethodVisitor;
 import org.springframework.core.MethodParameter;
@@ -139,16 +140,11 @@ public class FunctionReference extends SpelNodeImpl {
 
 	@Override
 	public String toStringAST() {
-		StringBuilder sb = new StringBuilder("#").append(this.name);
-		sb.append("(");
+		StringJoiner sj = new StringJoiner(",", "(", ")");
 		for (int i = 0; i < getChildCount(); i++) {
-			if (i > 0) {
-				sb.append(",");
-			}
-			sb.append(getChild(i).toStringAST());
+			sj.add(getChild(i).toStringAST());
 		}
-		sb.append(")");
-		return sb.toString();
+		return '#' + this.name + sj.toString();
 	}
 
 	/**

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 
 import org.springframework.asm.MethodVisitor;
 import org.springframework.core.convert.TypeDescriptor;
@@ -320,15 +321,11 @@ public class Indexer extends SpelNodeImpl {
 
 	@Override
 	public String toStringAST() {
-		StringBuilder sb = new StringBuilder("[");
+		StringJoiner sj = new StringJoiner(",", "[", "]");
 		for (int i = 0; i < getChildCount(); i++) {
-			if (i > 0) {
-				sb.append(",");
-			}
-			sb.append(getChild(i).toStringAST());
+			sj.add(getChild(i).toStringAST());
 		}
-		sb.append("]");
-		return sb.toString();
+		return sj.toString();
 	}
 
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/MethodReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/MethodReference.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.StringJoiner;
 
 import org.springframework.asm.Label;
 import org.springframework.asm.MethodVisitor;
@@ -259,16 +260,11 @@ public class MethodReference extends SpelNodeImpl {
 
 	@Override
 	public String toStringAST() {
-		StringBuilder sb = new StringBuilder(this.name);
-		sb.append("(");
+		StringJoiner sj = new StringJoiner(",", "(", ")");
 		for (int i = 0; i < getChildCount(); i++) {
-			if (i > 0) {
-				sb.append(",");
-			}
-			sb.append(getChild(i).toStringAST());
+			sj.add(getChild(i).toStringAST());
 		}
-		sb.append(")");
-		return sb.toString();
+		return this.name + sj.toString();
 	}
 
 	/**

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -17,6 +17,7 @@
 package org.springframework.jdbc.core.metadata;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -304,12 +305,8 @@ public class TableMetaDataContext {
 						getTableName() + "' so an insert statement can't be generated");
 			}
 		}
-		for (int i = 0; i < columnCount; i++) {
-			if (i > 0) {
-				insertStatement.append(", ");
-			}
-			insertStatement.append("?");
-		}
+		String params = String.join(", ", Collections.nCopies(columnCount, "?"));
+		insertStatement.append(params);
 		insertStatement.append(")");
 		return insertStatement.toString();
 	}


### PR DESCRIPTION
Employment of `StringJoiner` greatly simplifies code by dropping `if` statement and subsequence simplification of `fori` to `foreach`.

As of performance currently (JDK 8) `StringJoiner` is splightly slower than `StringBuilder`, but much faster (and meory-saving) on JDK 11.