### PR TITLE
query(PSC, PSS RSE) missing from JdbcOperations

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcOperations.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcOperations.java
@@ -300,6 +300,23 @@ public interface JdbcOperations {
 	<T> T execute(String sql, PreparedStatementCallback<T> action) throws DataAccessException;
 
 	/**
+	 * Query using a prepared statement, allowing for a PreparedStatementCreator
+	 * and a PreparedStatementSetter. Most other query methods use this method,
+	 * but application code will always work with either a creator or a setter.
+	 * @param psc the Callback handler that can create a PreparedStatement given a
+	 * Connection
+	 * @param pss object that knows how to set values on the prepared statement.
+	 * If this is null, the SQL will be assumed to contain no bind parameters.
+	 * @param rse object that will extract results.
+	 * @return an arbitrary result object, as returned by the ResultSetExtractor
+	 * @throws DataAccessException if there is any problem
+	 */
+	@Nullable
+	public <T> T query(
+			PreparedStatementCreator psc, @Nullable PreparedStatementSetter pss, ResultSetExtractor<T> rse)
+			throws DataAccessException;
+
+	/**
 	 * Query using a prepared statement, reading the ResultSet with a
 	 * ResultSetExtractor.
 	 * <p>A PreparedStatementCreator can either be implemented directly or

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -646,18 +646,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 		return execute(new SimplePreparedStatementCreator(sql), action);
 	}
 
-	/**
-	 * Query using a prepared statement, allowing for a PreparedStatementCreator
-	 * and a PreparedStatementSetter. Most other query methods use this method,
-	 * but application code will always work with either a creator or a setter.
-	 * @param psc the Callback handler that can create a PreparedStatement given a
-	 * Connection
-	 * @param pss object that knows how to set values on the prepared statement.
-	 * If this is null, the SQL will be assumed to contain no bind parameters.
-	 * @param rse object that will extract results.
-	 * @return an arbitrary result object, as returned by the ResultSetExtractor
-	 * @throws DataAccessException if there is any problem
-	 */
+	@Override
 	@Nullable
 	public <T> T query(
 			PreparedStatementCreator psc, @Nullable final PreparedStatementSetter pss, final ResultSetExtractor<T> rse)


### PR DESCRIPTION
JdbcTemplate.query(PSC, PSS RSE) is the only public query method on
JdbcTemplate that is not on JdbcOperations.