### PR TITLE
Improve spring-context-indexer documentation

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -5958,7 +5958,7 @@ The following example shows how to do so with Gradle:
 [subs="verbatim,quotes,attributes"]
 ----
 	dependencies {
-		compileOnly("org.springframework:spring-context-indexer:{spring-version}")
+		annotationProcessor("org.springframework:spring-context-indexer:{spring-version}")
 	}
 ----
 


### PR DESCRIPTION
The reference manual currently has the following snippet as an example of how to enable `spring-context-indexer` in Gradle based build:

```groovy
dependencies {
    compileOnly("org.springframework:spring-context-indexer:5.1.4.RELEASE")
}
```

This doesn't produce `spring.components` file using recent Gradle releases (I've verified with `4.10.3` and `5.1.1`), since `annotationProcessor` configuration should be used instead.

Possibly related to #22338.