### PR TITLE
Added configurable maxFramePayloadLength to ReactorNettyWebSocketClient

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/client/ReactorNettyWebSocketClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/client/ReactorNettyWebSocketClient.java
@@ -71,6 +71,20 @@ public class ReactorNettyWebSocketClient implements WebSocketClient {
 		return this.httpClient;
 	}
 
+	/**
+	 * Return the configured maxFramePayloadLength used by the configured {@link HttpClient}.
+	 * Default value of 65536 if not set.
+	 */
+	public int getMaxFramePayloadLength() {
+		return maxFramePayloadLength;
+	}
+
+	/**
+	 * Sets the maxFramePayloadLength to be used by the configured {@link HttpClient}.
+	 */
+	public void setMaxFramePayloadLength(int maxFramePayloadLength) {
+		this.maxFramePayloadLength = maxFramePayloadLength;
+	}
 
 	@Override
 	public Mono<Void> execute(URI url, WebSocketHandler handler) {
@@ -100,14 +114,6 @@ public class ReactorNettyWebSocketClient implements WebSocketClient {
 					}
 				})
 				.next();
-	}
-
-	public int getMaxFramePayloadLength() {
-		return maxFramePayloadLength;
-	}
-
-	public void setMaxFramePayloadLength(int maxFramePayloadLength) {
-		this.maxFramePayloadLength = maxFramePayloadLength;
 	}
 
 	private void setNettyHeaders(HttpHeaders httpHeaders, io.netty.handler.codec.http.HttpHeaders nettyHeaders) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/client/ReactorNettyWebSocketClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/client/ReactorNettyWebSocketClient.java
@@ -16,8 +16,12 @@
 
 package org.springframework.web.reactive.socket.client;
 
+import java.net.URI;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.websocket.WebsocketInbound;
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.Assert;
@@ -26,11 +30,6 @@ import org.springframework.web.reactive.socket.HandshakeInfo;
 import org.springframework.web.reactive.socket.WebSocketHandler;
 import org.springframework.web.reactive.socket.WebSocketSession;
 import org.springframework.web.reactive.socket.adapter.ReactorNettyWebSocketSession;
-import reactor.core.publisher.Mono;
-import reactor.netty.http.client.HttpClient;
-import reactor.netty.http.websocket.WebsocketInbound;
-
-import java.net.URI;
 
 /**
  * {@link WebSocketClient} implementation for use with Reactor Netty.

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/client/ReactorNettyWebSocketClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/client/ReactorNettyWebSocketClient.java
@@ -17,11 +17,13 @@
 package org.springframework.web.reactive.socket.client;
 
 import java.net.URI;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.websocket.WebsocketInbound;
+
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.Assert;
@@ -41,16 +43,10 @@ import org.springframework.web.reactive.socket.adapter.ReactorNettyWebSocketSess
 public class ReactorNettyWebSocketClient implements WebSocketClient {
 
 	private static final Log logger = LogFactory.getLog(ReactorNettyWebSocketClient.class);
+
 	private int maxFramePayloadLength = 65536;
 
 	private final HttpClient httpClient;
-
-	/**
-	 * Default constructor.
-	 */
-	public ReactorNettyWebSocketClient(int maxFramePayloadLength) {
-		this(HttpClient.create());
-	}
 
 	/**
 	 * Default constructor.


### PR DESCRIPTION
Currently the ReactorNettyWebSocketClient (RNWSC) doesn't allow for a configurable maxFramePayloadLength. The HttpClient used by the RNWSC allows for a configurable maxFramePayloadLength however, the method .websocket() used by the RNWSC ignores whatever is set by the HttpClient and uses a default value of 65536. As shown below:

**ReactorNettyWebSocketClient invokes .websocket()**

    .websocket(StringUtils.collectionToCommaDelimitedString(handler.getSubProtocols()))

**The method invoked on the HttpClient ignores the value you may have set in your HttpClient**

	public final WebsocketSender websocket(String subprotocols) {
		return websocket(subprotocols, 65536);
	}

I've solved the issue by using the overloaded .websocket() method on the HttpClient which takes a maxFramePayloadLength.

    .websocket(StringUtils.collectionToCommaDelimitedString(handler.getSubProtocols()), 
    getMaxFramePayloadLength())

The maxFramePayloadLength is now configurable in the RNWSC.