### PR TITLE
Fix casing for GitHub in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you have a question, check StackOverflow using
 Find an existing discussion or start a new one if necessary.
 
 If you suspect an issue, perform a search in the
-[Github issue tracker](https://github.com/spring-projects/spring-framework/issues), using a few different keywords.
+[GitHub issue tracker](https://github.com/spring-projects/spring-framework/issues), using a few different keywords.
 When you find related issues and discussions, prior or current, it helps you to learn and
 it helps us to make a decision.
 
@@ -42,7 +42,7 @@ Before you create a ticket, please take the time to [research first](#discuss).
 
 If creating a ticket after a discussion on StackOverflow, please provide a self-sufficient description in the ticket, independent of the details on StackOverview. We understand this is extra work but the issue tracker is an important place of record for design discussions and decisions that can often be referenced long after the fix version, for example to revisit decisions, to understand the origin of a feature, and so on.
 
-When ready create a ticket in the [Github issue tracker](https://github.com/spring-projects/spring-framework/issues).
+When ready create a ticket in the [GitHub issue tracker](https://github.com/spring-projects/spring-framework/issues).
 
 #### Ticket Lifecycle
 


### PR DESCRIPTION
This PR fixes casing for GitHub in the contributing guide.