### PR TITLE
Ensure indexer gracefully handle missing meta annotations

### DIFF
--- a/spring-context-indexer/spring-context-indexer.gradle
+++ b/spring-context-indexer/spring-context-indexer.gradle
@@ -4,5 +4,6 @@ dependencies {
 	testCompile(project(":spring-context"))
 	testCompile("javax.inject:javax.inject:1")
 	testCompile("javax.annotation:javax.annotation-api:1.3.2")
+	testCompile("javax.transaction:javax.transaction-api:1.3")
 	testCompile("org.eclipse.persistence:javax.persistence:2.2.0")
 }

--- a/spring-context-indexer/src/main/java/org/springframework/context/index/processor/TypeHelper.java
+++ b/spring-context-indexer/src/main/java/org/springframework/context/index/processor/TypeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.context.index.processor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -110,7 +111,12 @@ class TypeHelper {
 	}
 
 	public List<? extends AnnotationMirror> getAllAnnotationMirrors(Element e) {
-		return this.env.getElementUtils().getAllAnnotationMirrors(e);
+		try {
+			return this.env.getElementUtils().getAllAnnotationMirrors(e);
+		}
+		catch (Throwable ex) {
+			return Collections.emptyList();
+		}
 	}
 
 }

--- a/spring-context-indexer/src/test/java/org/springframework/context/index/processor/CandidateComponentsIndexerTests.java
+++ b/spring-context-indexer/src/test/java/org/springframework/context/index/processor/CandidateComponentsIndexerTests.java
@@ -25,6 +25,7 @@ import javax.persistence.Converter;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.MappedSuperclass;
+import javax.transaction.Transactional;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,6 +45,7 @@ import org.springframework.context.index.sample.SampleRepository;
 import org.springframework.context.index.sample.SampleService;
 import org.springframework.context.index.sample.cdi.SampleManagedBean;
 import org.springframework.context.index.sample.cdi.SampleNamed;
+import org.springframework.context.index.sample.cdi.SampleTransactional;
 import org.springframework.context.index.sample.jpa.SampleConverter;
 import org.springframework.context.index.sample.jpa.SampleEmbeddable;
 import org.springframework.context.index.sample.SampleEmbedded;
@@ -67,6 +69,7 @@ import static org.springframework.context.index.processor.Metadata.*;
  * Tests for {@link CandidateComponentsIndexer}.
  *
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  */
 public class CandidateComponentsIndexerTests {
 
@@ -140,6 +143,11 @@ public class CandidateComponentsIndexerTests {
 	@Test
 	public void cdiNamed() {
 		testSingleComponent(SampleNamed.class, Named.class);
+	}
+
+	@Test
+	public void cdiTransactional() {
+		testSingleComponent(SampleTransactional.class, Transactional.class);
 	}
 
 	@Test

--- a/spring-context-indexer/src/test/java/org/springframework/context/index/sample/cdi/SampleTransactional.java
+++ b/spring-context-indexer/src/test/java/org/springframework/context/index/sample/cdi/SampleTransactional.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.index.sample.cdi;
+
+import javax.transaction.Transactional;
+
+/**
+ * Test candidate for {@link Transactional}.
+ *
+ * @author Vedran Pavic
+ */
+@Transactional
+public class SampleTransactional {
+}


### PR DESCRIPTION
If `spring-context-indexer` is used in an application that uses `@javax.transaction.Transactional`, compilation will fail due to `javax.interceptor.InterceptorBinding` not being available.

This can be easily reproduced with a project as simple as:

```gradle
plugins {
    id 'java'
    id 'io.spring.dependency-management' version '1.0.6.RELEASE'
    id 'org.springframework.boot' version '2.1.2.RELEASE'
}

sourceCompatibility = '1.8'

repositories {
    mavenCentral()
}

dependencies {
    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
    implementation 'com.h2database:h2'
    annotationProcessor 'org.springframework:spring-context-indexer'
    testImplementation 'org.springframework.boot:spring-boot-starter-test'
}
```

```java
@SpringBootApplication
@javax.transaction.Transactional
public class DemoApplication {

    public static void main(String[] args) {
        SpringApplication.run(DemoApplication.class, args);
    }

}
```

```bash
$ ./gradlew compileJava 

> Task :compileJava FAILED
error: cannot access InterceptorBinding
  class file for javax.interceptor.InterceptorBinding not found
  Consult the following stack trace for details.
  com.sun.tools.javac.code.Symbol$CompletionFailure: class file for javax.interceptor.InterceptorBinding not found
1 error

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
1 actionable task: 1 executed
```

This PR addresses the problem by adding a classpath presence check for annotation before proceeding to collect its stereotypes.