### PR TITLE
Update HTTP status code for PRECONDITION_FAILED

### DIFF
--- a/src/docs/asciidoc/web/webmvc.adoc
+++ b/src/docs/asciidoc/web/webmvc.adoc
@@ -3904,7 +3904,7 @@ as the following example shows:
 There are three variants for checking conditional requests against `eTag` values, `lastModified`
 values, or both. For conditional `GET` and `HEAD` requests, you can set the response to
 304 (NOT_MODIFIED). For conditional `POST`, `PUT`, and `DELETE`, you can instead set the response
-to 409 (PRECONDITION_FAILED), to prevent concurrent modification.
+to 412 (PRECONDITION_FAILED), to prevent concurrent modification.
 
 
 


### PR DESCRIPTION
PRECONDITION_FAILED is 412 https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
And I think it is code typo instead of description typo. I am backed by this piece of code in ServletWebRequest.java: 

https://github.com/spring-projects/spring-framework/blob/f7e53a071b8613ce9312d282770b29211da219b7/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java#L243