### PR TITLE
LinkedMultiValueMap.getFirst - check that values is not empty

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/LinkedMultiValueMap.java
+++ b/spring-core/src/main/java/org/springframework/util/LinkedMultiValueMap.java
@@ -81,7 +81,7 @@ public class LinkedMultiValueMap<K, V> implements MultiValueMap<K, V>, Serializa
 	@Nullable
 	public V getFirst(K key) {
 		List<V> values = this.targetMap.get(key);
-		return (values != null ? values.get(0) : null);
+		return (values != null && !values.isEmpty() ? values.get(0) : null);
 	}
 
 	@Override


### PR DESCRIPTION
To avoid situation when values is Empty and we trying get first element without checking that this element exists