### PR TITLE
Avoid String concatenation for lookup in StaticMessageSource

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/StaticMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/StaticMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 package org.springframework.context.support;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -37,20 +39,20 @@ import org.springframework.util.Assert;
 public class StaticMessageSource extends AbstractMessageSource {
 
 	/** Map from 'code + locale' keys to message Strings. */
-	private final Map<String, String> messages = new HashMap<>();
+	private final Map<List<?>, String> messages = new HashMap<>();
 
-	private final Map<String, MessageFormat> cachedMessageFormats = new HashMap<>();
+	private final Map<List<?>, MessageFormat> cachedMessageFormats = new HashMap<>();
 
 
 	@Override
 	protected String resolveCodeWithoutArguments(String code, Locale locale) {
-		return this.messages.get(code + '_' + locale.toString());
+		return this.messages.get(Arrays.asList(code, locale));
 	}
 
 	@Override
 	@Nullable
 	protected MessageFormat resolveCode(String code, Locale locale) {
-		String key = code + '_' + locale.toString();
+		List<?> key = Arrays.asList(code, locale);
 		String msg = this.messages.get(key);
 		if (msg == null) {
 			return null;
@@ -75,7 +77,7 @@ public class StaticMessageSource extends AbstractMessageSource {
 		Assert.notNull(code, "Code must not be null");
 		Assert.notNull(locale, "Locale must not be null");
 		Assert.notNull(msg, "Message must not be null");
-		this.messages.put(code + '_' + locale.toString(), msg);
+		this.messages.put(Arrays.asList(code, locale), msg);
 		if (logger.isDebugEnabled()) {
 			logger.debug("Added message [" + msg + "] for code [" + code + "] and Locale [" + locale + "]");
 		}


### PR DESCRIPTION
Currently StaticMessageSource employs String composed of key and stringified Locale as key in map:
```java
public class StaticMessageSource extends AbstractMessageSource {

	/** Map from 'code + locale' keys to message Strings. */
	private final Map<String, String> messages = new HashMap<>();

	private final Map<String, MessageFormat> cachedMessageFormats = new HashMap<>();

        //...
}
```
As a result at each call to `Map::get`/`Map::put` we have to concat Strings resulting in allocations of  `StringBuilder` and copying `char[]`. Instead I propose to use separately defined immutable Key.

I've tested behaviour with benchmark

```java
@State(Scope.Thread)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
public class LocaleToStringBenchmark {

  @Benchmark
  public Object concatenation(Data data) {
    return data.code + '_' + data.locale;
  }

  @Benchmark
  public Object compositeKey(Data data) {
    return new Key(data.code, data.locale);
  }

  @Benchmark
  public int hashCodeCompositeString(Data data) {
    return data.compositeString.hashCode();
  }

  @Benchmark
  public int hashCodeCompositeKey(Data data) {
    return data.compositeKey.hashCode();
  }

  @Benchmark
  public boolean equalsCompositeString(Data data) {
    return data.compositeString.equals(data.anotherCompositeString);
  }

  @Benchmark
  public boolean equalsCompositeKey(Data data) {
    return data.compositeKey.equals(data.anotherCompositeKey);
  }

  @State(Scope.Thread)
  public static class Data {
    private final String code = "code1";
    private final Locale locale = Locale.getDefault();

    private final Key compositeKey = new Key(code, locale);
    private final String compositeString = code + '_' + locale;

    private final Key anotherCompositeKey = new Key(code, locale);
    private final String anotherCompositeString = code + '_' + locale;
  }

  private static final class Key {
    private final String code;
    private final Locale locale;

    private Key(String code, Locale locale) {
      this.code = code;
      this.locale = locale;
    }

    @Override
    public boolean equals(Object o) {
      if (this == o) return true;
      if (o == null || getClass() != o.getClass()) return false;

      Key key = (Key) o;

      if (!code.equals(key.code)) return false;
      return locale.equals(key.locale);
    }

    @Override
    public int hashCode() {
      return 31 * code.hashCode() + locale.hashCode();
    }
  }
}
```
Patched consumes much less memory on key allocation and does it faster, performance of equals/hashCode is mostly the same (tested at work on i7-7700):
```
JDK 8
                                             Mode  Cnt     Score     Error   Units

compositeKey                                 avgt   25     5,134 ±   0,274   ns/op
concatenation                                avgt   25    67,999 ±   5,872   ns/op

compositeKey:·gc.alloc.rate.norm             avgt   25    24,000 ±   0,001    B/op
concatenation:·gc.alloc.rate.norm            avgt   25   224,000 ±   0,001    B/op

equalsCompositeKey                           avgt   25     3,229 ±   0,161   ns/op
equalsCompositeString                        avgt   25     6,447 ±   0,448   ns/op

hashCodeCompositeKey                         avgt   25     2,584 ±   0,054   ns/op
hashCodeCompositeString                      avgt   25     2,069 ±   0,028   ns/op

JDK 11
                                             Mode  Cnt     Score    Error   Units

compositeKey                                 avgt   25     5,851 ±  0,271   ns/op
concatenation                                avgt   25    61,900 ±  4,406   ns/op

compositeKey:·gc.alloc.rate.norm             avgt   25    24,000 ±  0,001    B/op
concatenation:·gc.alloc.rate.norm            avgt   25   168,000 ±  0,001    B/op

equalsCompositeKey                           avgt   25     3,177 ±  0,254   ns/op
equalsCompositeString                        avgt   25     5,787 ±  0,305   ns/op

hashCodeCompositeKey                         avgt   25     2,947 ±  0,105   ns/op
hashCodeCompositeString                      avgt   25     2,187 ±  0,083   ns/op
```