### PR TITLE
Simplify String concatenation

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -168,11 +168,11 @@ public class MockHttpServletResponse implements HttpServletResponse {
 
 	private void updateContentTypeHeader() {
 		if (this.contentType != null) {
-			StringBuilder sb = new StringBuilder(this.contentType);
-			if (!this.contentType.toLowerCase().contains(CHARSET_PREFIX) && this.charset) {
-				sb.append(";").append(CHARSET_PREFIX).append(this.characterEncoding);
+			String value = this.contentType;
+			if (this.charset && !this.contentType.toLowerCase().contains(CHARSET_PREFIX)) {
+				value = value + ';' + CHARSET_PREFIX + this.characterEncoding;
 			}
-			doAddHeaderValue(HttpHeaders.CONTENT_TYPE, sb.toString(), true);
+			doAddHeaderValue(HttpHeaders.CONTENT_TYPE, value, true);
 		}
 	}
 


### PR DESCRIPTION
As it follows from 
http://alblue.bandlem.com/2016/04/jmh-stringbuffer-stringbuilder.html
and 
https://habr.com/ru/post/330220/
chained `StringBuilder::append` is much faster than conventional `sb.append(); sb.append()`.

Assyming that expression like `String str = str1 + str2 + str3;` at runtime will behave as chained `StringBuilder::append` we can simplify usage of `StringBuilder` in particular cases like the one of this PR.

Here we have 2 cases:
- `if` expression is false
- `if` expression is true

In the first case we don't need SB at all, as resulting expression produced by `sb.toString()` equals `this.contentType`.
And in the opposite case we have non-interrupted `StringBuilder::append` chain (later simplifiable to String concatenation with `+`) and thus more simple code and better performance.