### PR TITLE
Fix CompletableFuture exception handling

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/DeferredResultMethodReturnValueHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/DeferredResultMethodReturnValueHandler.java
@@ -16,6 +16,7 @@
 
 package org.springframework.web.servlet.mvc.method.annotation;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 
@@ -93,6 +94,9 @@ public class DeferredResultMethodReturnValueHandler implements HandlerMethodRetu
 		DeferredResult<Object> result = new DeferredResult<>();
 		future.handle((BiFunction<Object, Throwable, Object>) (value, ex) -> {
 			if (ex != null) {
+				if (ex instanceof CompletionException) {
+					ex = ex.getCause();
+				}
 				result.setErrorResult(ex);
 			}
 			else {


### PR DESCRIPTION
CompletableFuture exceptions are always wrapped into CompletionException.
We need to unwrap CompletionException to properly handle exceptions in MVC handlers that return CompletableFuture.
See https://stackoverflow.com/questions/49676889/spring-controller-advice-does-not-correctly-handle-a-completablefuture-completed

#22475