### PR TITLE
Exclude jdk package in ShadowingClassLoader

### DIFF
--- a/spring-context/src/main/java/org/springframework/instrument/classloading/ShadowingClassLoader.java
+++ b/spring-context/src/main/java/org/springframework/instrument/classloading/ShadowingClassLoader.java
@@ -48,7 +48,7 @@ public class ShadowingClassLoader extends DecoratingClassLoader {
 
 	/** Packages that are excluded by default. */
 	public static final String[] DEFAULT_EXCLUDED_PACKAGES =
-			new String[] {"java.", "javax.", "sun.", "oracle.", "com.sun.", "com.ibm.", "COM.ibm.",
+			new String[] {"java.", "javax.", "jdk.", "sun.", "oracle.", "com.sun.", "com.ibm.", "COM.ibm.",
 					"org.w3c.", "org.xml.", "org.dom4j.", "org.eclipse", "org.aspectj.", "net.sf.cglib",
 					"org.springframework.cglib", "org.apache.xerces.", "org.apache.commons.logging."};
 


### PR DESCRIPTION
Many Java 11 internal classes are located in the jdk package. ShadowingClassLoader should not load them, because it can cause errors, e.g. java.lang.IllegalAccessError: class jdk.internal.reflect.ConstructorAccessorImpl loaded by org.springframework.instrument.classloading.ShadowingClassLoader @2bea5ab4 cannot access jdk/internal/reflect superclass jdk.internal.reflect.MagicAccessorImpl