### PR TITLE
add TODOs to be done after migration to JDK 11

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/OpMultiply.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/OpMultiply.java
@@ -110,6 +110,8 @@ public class OpMultiply extends Operator {
 
 		if (leftOperand instanceof String && rightOperand instanceof Integer) {
 			int repeats = (Integer) rightOperand;
+			//todo after migration to Java 11 loop can be simplified to
+			// String result = ((String) leftOperand).repeat(Math.max(0, repeats));
 			StringBuilder result = new StringBuilder();
 			for (int i = 0; i < repeats; i++) {
 				result.append(leftOperand);

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/TypeReference.java
@@ -87,6 +87,7 @@ public class TypeReference extends SpelNodeImpl {
 	public String toStringAST() {
 		StringBuilder sb = new StringBuilder("T(");
 		sb.append(getChild(0).toStringAST());
+		//TODO replace loop with sb.append("[]".repeat(this.dimensions)) after migration to Java 11
 		for (int d = 0; d < this.dimensions; d++) {
 			sb.append("[]");
 		}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/incrementer/AbstractDataFieldMaxValueIncrementer.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/incrementer/AbstractDataFieldMaxValueIncrementer.java
@@ -133,6 +133,7 @@ public abstract class AbstractDataFieldMaxValueIncrementer implements DataFieldM
 		String s = Long.toString(getNextKey());
 		int len = s.length();
 		if (len < this.paddingLength) {
+			//TODO replace with s = "0".repeat(this.paddingLength - len) after migration to Java 11
 			StringBuilder sb = new StringBuilder(this.paddingLength);
 			for (int i = 0; i < this.paddingLength - len; i++) {
 				sb.append('0');

--- a/spring-web/src/main/java/org/springframework/web/util/pattern/PatternParseException.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/PatternParseException.java
@@ -68,6 +68,7 @@ public class PatternParseException extends IllegalArgumentException {
 	public String toDetailedString() {
 		StringBuilder buf = new StringBuilder();
 		buf.append(this.pattern).append('\n');
+		//TODO replace loop with buf.append(" ".repeat(this.position)) after migration to Java 11
 		for (int i = 0; i < this.position; i++) {
 			buf.append(' ');
 		}


### PR DESCRIPTION
In JDK 11 `String::repeat` becomes available and can be used to simplify code.