### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,22 +171,22 @@ configure(allprojects) { project ->
 	}
 
 	ext.javadocLinks = [
-		"http://docs.oracle.com/javase/8/docs/api/",
-		"http://docs.oracle.com/javaee/7/api/",
+		"https://docs.oracle.com/javase/8/docs/api/",
+		"https://docs.oracle.com/javaee/7/api/",
 		"https://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/",  // CommonJ
 		"https://www.ibm.com/support/knowledgecenter/SS7JFU_8.5.5/com.ibm.websphere.javadoc.doc/web/apidocs/",
-		"http://glassfish.java.net/nonav/docs/v3/api/",
-		"http://docs.jboss.org/jbossas/javadoc/4.0.5/connector/",
-		"http://docs.jboss.org/jbossas/javadoc/7.1.2.Final/",
-		"http://tiles.apache.org/tiles-request/apidocs/",
-		"http://tiles.apache.org/framework/apidocs/",
-		"http://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/",
-		"http://ehcache.org/apidocs/2.10.4",
+		"https://glassfish.java.net/nonav/docs/v3/api/",
+		"https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/",
+		"https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/",
+		"https://tiles.apache.org/tiles-request/apidocs/",
+		"https://tiles.apache.org/framework/apidocs/",
+		"https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/",
+		"https://www.ehcache.org/apidocs/2.10.4",
 		"https://www.quartz-scheduler.org/api/${quartzVersion}/package-list?",
-		"http://fasterxml.github.io/jackson-core/javadoc/2.9/",
-		"http://fasterxml.github.io/jackson-databind/javadoc/2.9/",
-		"http://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.9/",
-		"http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/",
+		"https://fasterxml.github.io/jackson-core/javadoc/2.9/",
+		"https://fasterxml.github.io/jackson-databind/javadoc/2.9/",
+		"https://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.9/",
+		"https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/",
 		"https://junit.org/junit4/javadoc/4.12/",
 		"https://junit.org/junit5/docs/${junit5Version}/api/"
 	] as String[]

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -72,10 +72,10 @@ dokka {
 		packageListUrl = new File(buildDir, "api/package-list").toURI().toURL()
 	}
 	externalDocumentationLink {
-		url = new URL("http://projectreactor.io/docs/core/release/api/")
+		url = new URL("https://projectreactor.io/docs/core/release/api/")
 	}
 	externalDocumentationLink {
-		url = new URL("http://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/")
+		url = new URL("https://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/")
 	}
 }
 
@@ -137,7 +137,7 @@ task docsZip(type: Zip, dependsOn: ['api', 'asciidoctor', 'dokka']) {
 	baseName = "spring-framework"
 	classifier = "docs"
 	description = "Builds -${classifier} archive containing api and reference " +
-			"for deployment at http://docs.spring.io/spring-framework/docs."
+			"for deployment at https://docs.spring.io/spring-framework/docs."
 
 	from("src/dist") {
 		include "changelog.txt"
@@ -165,7 +165,7 @@ task schemaZip(type: Zip) {
 	baseName = "spring-framework"
 	classifier = "schema"
 	description = "Builds -${classifier} archive containing all " +
-			"XSDs for deployment at http://springframework.org/schema."
+			"XSDs for deployment at https://springframework.org/schema."
 	duplicatesStrategy 'exclude'
 	moduleProjects.each { subproject ->
 		def Properties schemas = new Properties();

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -11,7 +11,7 @@ eclipse.jdt {
 }
 
 // Replace classpath entries with project dependencies (GRADLE-1116)
-// http://issues.gradle.org/browse/GRADLE-1116
+// https://issues.gradle.org/browse/GRADLE-1116
 eclipse.classpath.file.whenMerged { classpath ->
 	def regexp = /.*?\/([^\/]+)\/build\/([^\/]+\/)+(?:main|test)/ // only match those that end in main or test (avoids removing necessary entries like build/classes/jaxb)
 	def projectOutputDependencies = classpath.entries.findAll { entry -> entry.path =~ regexp }

--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -30,12 +30,12 @@ def customizePom(pom, gradleProject) {
 			url = "https://github.com/spring-projects/spring-framework"
 			organization {
 				name = "Spring IO"
-				url = "http://projects.spring.io/spring-framework"
+				url = "https://projects.spring.io/spring-framework"
 			}
 			licenses {
 				license {
 					name "Apache License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0"
+					url "https://www.apache.org/licenses/LICENSE-2.0"
 					distribution "repo"
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortner).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://docs.jboss.org/jbossas/javadoc/4.0.5/connector/ migrated to:  
  https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/ ([https](https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/) result 200).
* http://docs.jboss.org/jbossas/javadoc/7.1.2.Final/ migrated to:  
  https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/ ([https](https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/) result 200).
* http://docs.oracle.com/javaee/7/api/ migrated to:  
  https://docs.oracle.com/javaee/7/api/ ([https](https://docs.oracle.com/javaee/7/api/) result 200).
* http://docs.oracle.com/javase/8/docs/api/ migrated to:  
  https://docs.oracle.com/javase/8/docs/api/ ([https](https://docs.oracle.com/javase/8/docs/api/) result 200).
* http://fasterxml.github.io/jackson-core/javadoc/2.9/ migrated to:  
  https://fasterxml.github.io/jackson-core/javadoc/2.9/ ([https](https://fasterxml.github.io/jackson-core/javadoc/2.9/) result 200).
* http://fasterxml.github.io/jackson-databind/javadoc/2.9/ migrated to:  
  https://fasterxml.github.io/jackson-databind/javadoc/2.9/ ([https](https://fasterxml.github.io/jackson-databind/javadoc/2.9/) result 200).
* http://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.9/ migrated to:  
  https://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.9/ ([https](https://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.9/) result 200).
* http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/ migrated to:  
  https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/ ([https](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/) result 200).
* http://issues.gradle.org/browse/GRADLE-1116 migrated to:  
  https://issues.gradle.org/browse/GRADLE-1116 ([https](https://issues.gradle.org/browse/GRADLE-1116) result 200).
* http://projectreactor.io/docs/core/release/api/ migrated to:  
  https://projectreactor.io/docs/core/release/api/ ([https](https://projectreactor.io/docs/core/release/api/) result 200).
* http://tiles.apache.org/framework/apidocs/ migrated to:  
  https://tiles.apache.org/framework/apidocs/ ([https](https://tiles.apache.org/framework/apidocs/) result 200).
* http://tiles.apache.org/tiles-request/apidocs/ migrated to:  
  https://tiles.apache.org/tiles-request/apidocs/ ([https](https://tiles.apache.org/tiles-request/apidocs/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/ migrated to:  
  https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/ ([https](https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/) result 200).
* http://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/ migrated to:  
  https://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/ ([https](https://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/) result 200).
* http://docs.spring.io/spring-framework/docs migrated to:  
  https://docs.spring.io/spring-framework/docs ([https](https://docs.spring.io/spring-framework/docs) result 301).
* http://glassfish.java.net/nonav/docs/v3/api/ migrated to:  
  https://glassfish.java.net/nonav/docs/v3/api/ ([https](https://glassfish.java.net/nonav/docs/v3/api/) result 301).
* http://projects.spring.io/spring-framework migrated to:  
  https://projects.spring.io/spring-framework ([https](https://projects.spring.io/spring-framework) result 301).
* http://springframework.org/schema migrated to:  
  https://springframework.org/schema ([https](https://springframework.org/schema) result 301).
* http://ehcache.org/apidocs/2.10.4 (301) migrated to:  
  https://www.ehcache.org/apidocs/2.10.4 ([https](https://ehcache.org/apidocs/2.10.4) result 301).