### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,28 +84,28 @@ configure(allprojects) { project ->
 	}
 
 	ext.javadocLinks = [
-		"http://docs.oracle.com/javase/7/docs/api/",
-		"http://docs.oracle.com/javaee/6/api/",
-		"http://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/", // CommonJ
-		"http://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/",
-		"http://glassfish.java.net/nonav/docs/v3/api/",
-		"http://docs.jboss.org/jbossas/javadoc/4.0.5/connector/",
-		"http://docs.jboss.org/jbossas/javadoc/7.1.2.Final/",
-		"http://commons.apache.org/proper/commons-lang/javadocs/api-2.5/",
-		"http://commons.apache.org/proper/commons-codec/apidocs/",
-		"http://commons.apache.org/proper/commons-dbcp/apidocs/",
-		"http://portals.apache.org/pluto/portlet-2.0-apidocs/",
-		"http://tiles.apache.org/tiles-request/apidocs/",
-		"http://tiles.apache.org/framework/apidocs/",
+		"https://docs.oracle.com/javase/7/docs/api/",
+		"https://docs.oracle.com/javaee/6/api/",
+		"https://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/", // CommonJ
+		"https://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/",
+		"https://glassfish.java.net/nonav/docs/v3/api/",
+		"https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/",
+		"https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/",
+		"https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/",
+		"https://commons.apache.org/proper/commons-codec/apidocs/",
+		"https://commons.apache.org/proper/commons-dbcp/apidocs/",
+		"https://portals.apache.org/pluto/portlet-2.0-apidocs/",
+		"https://tiles.apache.org/tiles-request/apidocs/",
+		"https://tiles.apache.org/framework/apidocs/",
 		"http://aopalliance.sourceforge.net/doc/",
-		"http://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/",
-		"http://ehcache.org/apidocs/",
-		"http://quartz-scheduler.org/api/2.2.0/",
-		"http://jackson.codehaus.org/1.9.4/javadoc/",
-		"http://fasterxml.github.com/jackson-core/javadoc/2.3.0/",
-		"http://fasterxml.github.com/jackson-databind/javadoc/2.3.0/",
-		"http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs",
-		"http://ibatis.apache.org/docs/java/dev/"
+		"https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/",
+		"https://www.ehcache.org/apidocs/",
+		"https://www.quartz-scheduler.org/api/2.2.0/",
+		"https://jackson.codehaus.org/1.9.4/javadoc/",
+		"https://fasterxml.github.com/jackson-core/javadoc/2.3.0/",
+		"https://fasterxml.github.com/jackson-databind/javadoc/2.3.0/",
+		"https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs",
+		"https://ibatis.apache.org/docs/java/dev/"
 	] as String[]
 }
 
@@ -376,7 +376,7 @@ project("spring-oxm") {
 
 	compileTestJava {
 		// necessary to avoid java.lang.VerifyError on jibx compilation
-		// see http://jira.codehaus.org/browse/JIBX-465
+		// see https://jira.codehaus.org/browse/JIBX-465
 		sourceCompatibility=1.6
 		targetCompatibility=1.6
 	}
@@ -929,7 +929,7 @@ configure(rootProject) {
 		baseName = "spring-framework"
 		classifier = "docs"
 		description = "Builds -${classifier} archive containing api and reference " +
-			"for deployment at http://static.springframework.org/spring-framework/docs."
+			"for deployment at https://docs.spring.io/spring-framework/docs."
 
 		from("src/dist") {
 			include "changelog.txt"
@@ -949,7 +949,7 @@ configure(rootProject) {
 		baseName = "spring-framework"
 		classifier = "schema"
 		description = "Builds -${classifier} archive containing all " +
-			"XSDs for deployment at http://springframework.org/schema."
+			"XSDs for deployment at https://springframework.org/schema."
 		duplicatesStrategy 'exclude'
 		moduleProjects.each { subproject ->
 			def Properties schemas = new Properties();

--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -25,12 +25,12 @@ def customizePom(pom, gradleProject) {
 			url = "https://github.com/SpringSource/spring-framework"
 			organization {
 				name = "SpringSource"
-				url = "http://springsource.org/spring-framework"
+				url = "https://projects.spring.io/spring-framework"
 			}
 			licenses {
 				license {
 					name "The Apache Software License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+					url "https://www.apache.org/licenses/LICENSE-2.0.txt"
 					distribution "repo"
 				}
 			}

--- a/import-into-eclipse.bat
+++ b/import-into-eclipse.bat
@@ -17,7 +17,7 @@ echo been tested against STS %STS_TEST_VERSION%), but at the minimum you will
 echo need Eclipse + AJDT.
 echo.
 echo If you need to download and install STS, please do that now by
-echo visiting http://springsource.org/downloads/sts
+echo visiting https://spring.io/projectss/sts
 echo.
 echo Otherwise, press enter and we'll begin.
 

--- a/import-into-eclipse.sh
+++ b/import-into-eclipse.sh
@@ -14,7 +14,7 @@ been tested against STS $STS_TEST_VERSION), but at the minimum you will
 need Eclipse + AJDT.
 
 If you need to download and install STS, please do that now by
-visiting http://springsource.org/downloads/sts
+visiting https://spring.io/projectss/sts
 
 Otherwise, press enter and we'll begin.
 EOM


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://aopalliance.sourceforge.net/doc/ (200) migrated to:  
  http://aopalliance.sourceforge.net/doc/ ([https](https://aopalliance.sourceforge.net/doc/) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://jackson.codehaus.org/1.9.4/javadoc/ (UnknownHostException) migrated to:  
  https://jackson.codehaus.org/1.9.4/javadoc/ ([https](https://jackson.codehaus.org/1.9.4/javadoc/) result UnknownHostException).
* http://jira.codehaus.org/browse/JIBX-465 (UnknownHostException) migrated to:  
  https://jira.codehaus.org/browse/JIBX-465 ([https](https://jira.codehaus.org/browse/JIBX-465) result UnknownHostException).
* http://springsource.org/downloads/sts (302) migrated to:  
  https://spring.io/projectss/sts ([https](https://springsource.org/downloads/sts) result 404).
* http://quartz-scheduler.org/api/2.2.0/ (301) migrated to:  
  https://www.quartz-scheduler.org/api/2.2.0/ ([https](https://quartz-scheduler.org/api/2.2.0/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://commons.apache.org/proper/commons-codec/apidocs/ migrated to:  
  https://commons.apache.org/proper/commons-codec/apidocs/ ([https](https://commons.apache.org/proper/commons-codec/apidocs/) result 200).
* http://commons.apache.org/proper/commons-dbcp/apidocs/ migrated to:  
  https://commons.apache.org/proper/commons-dbcp/apidocs/ ([https](https://commons.apache.org/proper/commons-dbcp/apidocs/) result 200).
* http://commons.apache.org/proper/commons-lang/javadocs/api-2.5/ migrated to:  
  https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/ ([https](https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/) result 200).
* http://docs.jboss.org/jbossas/javadoc/4.0.5/connector/ migrated to:  
  https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/ ([https](https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/) result 200).
* http://docs.jboss.org/jbossas/javadoc/7.1.2.Final/ migrated to:  
  https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/ ([https](https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/) result 200).
* http://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/ migrated to:  
  https://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/ ([https](https://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/) result 200).
* http://docs.oracle.com/javaee/6/api/ migrated to:  
  https://docs.oracle.com/javaee/6/api/ ([https](https://docs.oracle.com/javaee/6/api/) result 200).
* http://docs.oracle.com/javase/7/docs/api/ migrated to:  
  https://docs.oracle.com/javase/7/docs/api/ ([https](https://docs.oracle.com/javase/7/docs/api/) result 200).
* http://ibatis.apache.org/docs/java/dev/ migrated to:  
  https://ibatis.apache.org/docs/java/dev/ ([https](https://ibatis.apache.org/docs/java/dev/) result 200).
* http://portals.apache.org/pluto/portlet-2.0-apidocs/ migrated to:  
  https://portals.apache.org/pluto/portlet-2.0-apidocs/ ([https](https://portals.apache.org/pluto/portlet-2.0-apidocs/) result 200).
* http://tiles.apache.org/framework/apidocs/ migrated to:  
  https://tiles.apache.org/framework/apidocs/ ([https](https://tiles.apache.org/framework/apidocs/) result 200).
* http://tiles.apache.org/tiles-request/apidocs/ migrated to:  
  https://tiles.apache.org/tiles-request/apidocs/ ([https](https://tiles.apache.org/tiles-request/apidocs/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/ migrated to:  
  https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/ ([https](https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/) result 200).
* http://ehcache.org/apidocs/ (301) migrated to:  
  https://www.ehcache.org/apidocs/ ([https](https://ehcache.org/apidocs/) result 200).
* http://static.springframework.org/spring-framework/docs (301) migrated to:  
  https://docs.spring.io/spring-framework/docs ([https](https://static.springframework.org/spring-framework/docs) result 301).
* http://fasterxml.github.com/jackson-core/javadoc/2.3.0/ migrated to:  
  https://fasterxml.github.com/jackson-core/javadoc/2.3.0/ ([https](https://fasterxml.github.com/jackson-core/javadoc/2.3.0/) result 301).
* http://fasterxml.github.com/jackson-databind/javadoc/2.3.0/ migrated to:  
  https://fasterxml.github.com/jackson-databind/javadoc/2.3.0/ ([https](https://fasterxml.github.com/jackson-databind/javadoc/2.3.0/) result 301).
* http://glassfish.java.net/nonav/docs/v3/api/ migrated to:  
  https://glassfish.java.net/nonav/docs/v3/api/ ([https](https://glassfish.java.net/nonav/docs/v3/api/) result 301).
* http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs migrated to:  
  https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs ([https](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs) result 301).
* http://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/ migrated to:  
  https://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/ ([https](https://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/) result 301).
* http://springsource.org/spring-framework (301) migrated to:  
  https://projects.spring.io/spring-framework ([https](https://springsource.org/spring-framework) result 301).
* http://springframework.org/schema migrated to:  
  https://springframework.org/schema ([https](https://springframework.org/schema) result 301).