### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,27 +186,27 @@ configure(allprojects) { project ->
 	}
 
 	ext.javadocLinks = [
-		"http://docs.oracle.com/javase/8/docs/api/",
-		"http://docs.oracle.com/javaee/7/api/",
-		"http://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/",  // CommonJ
-		"http://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/",
-		"http://glassfish.java.net/nonav/docs/v3/api/",
-		"http://docs.jboss.org/jbossas/javadoc/4.0.5/connector/",
-		"http://docs.jboss.org/jbossas/javadoc/7.1.2.Final/",
-		"http://commons.apache.org/proper/commons-lang/javadocs/api-2.5/",
-		"http://commons.apache.org/proper/commons-codec/apidocs/",
-		"http://commons.apache.org/proper/commons-dbcp/apidocs/",
-		"http://portals.apache.org/pluto/portlet-2.0-apidocs/",
-		"http://tiles.apache.org/tiles-request/apidocs/",
-		"http://tiles.apache.org/framework/apidocs/",
-		"http://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/",
-		"http://ehcache.org/apidocs/${ehcacheVersion}",
-		"http://ehcache.org/apidocs/${ehcache3Version}",
-		"http://quartz-scheduler.org/api/2.2.1/",
-		"http://fasterxml.github.io/jackson-core/javadoc/2.8/",
-		"http://fasterxml.github.io/jackson-databind/javadoc/2.8/",
-		"http://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.8/",
-		"http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/",
+		"https://docs.oracle.com/javase/8/docs/api/",
+		"https://docs.oracle.com/javaee/7/api/",
+		"https://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/",  // CommonJ
+		"https://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/",
+		"https://glassfish.java.net/nonav/docs/v3/api/",
+		"https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/",
+		"https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/",
+		"https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/",
+		"https://commons.apache.org/proper/commons-codec/apidocs/",
+		"https://commons.apache.org/proper/commons-dbcp/apidocs/",
+		"https://portals.apache.org/pluto/portlet-2.0-apidocs/",
+		"https://tiles.apache.org/tiles-request/apidocs/",
+		"https://tiles.apache.org/framework/apidocs/",
+		"https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/",
+		"https://www.ehcache.org/apidocs/${ehcacheVersion}",
+		"https://www.ehcache.org/apidocs/${ehcache3Version}",
+		"https://www.quartz-scheduler.org/api/2.2.1/",
+		"https://fasterxml.github.io/jackson-core/javadoc/2.8/",
+		"https://fasterxml.github.io/jackson-databind/javadoc/2.8/",
+		"https://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.8/",
+		"https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/",
 		"https://junit.org/junit4/javadoc/${junitVersion}/"
 	] as String[]
 }
@@ -1246,7 +1246,7 @@ configure(rootProject) {
 		baseName = "spring-framework"
 		classifier = "docs"
 		description = "Builds -${classifier} archive containing api and reference " +
-			"for deployment at http://static.springframework.org/spring-framework/docs."
+			"for deployment at https://docs.spring.io/spring-framework/docs."
 
 		from("src/dist") {
 			include "changelog.txt"
@@ -1266,7 +1266,7 @@ configure(rootProject) {
 		baseName = "spring-framework"
 		classifier = "schema"
 		description = "Builds -${classifier} archive containing all " +
-			"XSDs for deployment at http://springframework.org/schema."
+			"XSDs for deployment at https://springframework.org/schema."
 		duplicatesStrategy 'exclude'
 		moduleProjects.each { subproject ->
 			def Properties schemas = new Properties();

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -11,7 +11,7 @@ eclipse.jdt {
 }
 
 // Replace classpath entries with project dependencies (GRADLE-1116)
-// http://issues.gradle.org/browse/GRADLE-1116
+// https://issues.gradle.org/browse/GRADLE-1116
 eclipse.classpath.file.whenMerged { classpath ->
 	def regexp = /.*?\/([^\/]+)\/build\/[^\/]+\/(?:main|test)/ // only match those that end in main or test (avoids removing necessary entries like build/classes/jaxb)
 	def projectOutputDependencies = classpath.entries.findAll { entry -> entry.path =~ regexp }

--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -25,12 +25,12 @@ def customizePom(pom, gradleProject) {
 			url = "https://github.com/spring-projects/spring-framework"
 			organization {
 				name = "Spring IO"
-				url = "http://projects.spring.io/spring-framework"
+				url = "https://projects.spring.io/spring-framework"
 			}
 			licenses {
 				license {
 					name "Apache License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0"
+					url "https://www.apache.org/licenses/LICENSE-2.0"
 					distribution "repo"
 				}
 			}

--- a/import-into-eclipse.bat
+++ b/import-into-eclipse.bat
@@ -17,7 +17,7 @@ echo been tested against STS %STS_TEST_VERSION%), but at the minimum you will
 echo need Eclipse + AJDT.
 echo.
 echo If you need to download and install STS, please do that now by
-echo visiting http://spring.io/tools/sts/all 
+echo visiting https://spring.io/tools/sts/all 
 echo.
 echo Otherwise, press enter and we'll begin.
 

--- a/import-into-eclipse.sh
+++ b/import-into-eclipse.sh
@@ -19,9 +19,9 @@ This script has been tested against:
 If you need to download and install Eclipse or STS, please do that now
 by visiting one of the following sites:
 
-- Eclipse downloads: http://download.eclipse.org/eclipse/downloads
-- STS downloads: http://spring.io/tools/sts/all
-- STS nightly builds: http://dist.springsource.com/snapshot/STS/nightly-distributions.html
+- Eclipse downloads: https://download.eclipse.org/eclipse/downloads
+- STS downloads: https://spring.io/tools/sts/all
+- STS nightly builds: https://dist.springsource.com/snapshot/STS/nightly-distributions.html
 
 If you need to install a recent CI build for AJDT (i.e., so that the
 spring-aspects module properly compiles in Eclipse/STS), click on the


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://quartz-scheduler.org/api/2.2.1/ (301) migrated to:  
  https://www.quartz-scheduler.org/api/2.2.1/ ([https](https://quartz-scheduler.org/api/2.2.1/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://commons.apache.org/proper/commons-codec/apidocs/ migrated to:  
  https://commons.apache.org/proper/commons-codec/apidocs/ ([https](https://commons.apache.org/proper/commons-codec/apidocs/) result 200).
* http://commons.apache.org/proper/commons-dbcp/apidocs/ migrated to:  
  https://commons.apache.org/proper/commons-dbcp/apidocs/ ([https](https://commons.apache.org/proper/commons-dbcp/apidocs/) result 200).
* http://commons.apache.org/proper/commons-lang/javadocs/api-2.5/ migrated to:  
  https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/ ([https](https://commons.apache.org/proper/commons-lang/javadocs/api-2.5/) result 200).
* http://dist.springsource.com/snapshot/STS/nightly-distributions.html migrated to:  
  https://dist.springsource.com/snapshot/STS/nightly-distributions.html ([https](https://dist.springsource.com/snapshot/STS/nightly-distributions.html) result 200).
* http://docs.jboss.org/jbossas/javadoc/4.0.5/connector/ migrated to:  
  https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/ ([https](https://docs.jboss.org/jbossas/javadoc/4.0.5/connector/) result 200).
* http://docs.jboss.org/jbossas/javadoc/7.1.2.Final/ migrated to:  
  https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/ ([https](https://docs.jboss.org/jbossas/javadoc/7.1.2.Final/) result 200).
* http://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/ migrated to:  
  https://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/ ([https](https://docs.oracle.com/cd/E13222_01/wls/docs90/javadocs/) result 200).
* http://docs.oracle.com/javaee/7/api/ migrated to:  
  https://docs.oracle.com/javaee/7/api/ ([https](https://docs.oracle.com/javaee/7/api/) result 200).
* http://docs.oracle.com/javase/8/docs/api/ migrated to:  
  https://docs.oracle.com/javase/8/docs/api/ ([https](https://docs.oracle.com/javase/8/docs/api/) result 200).
* http://fasterxml.github.io/jackson-core/javadoc/2.8/ migrated to:  
  https://fasterxml.github.io/jackson-core/javadoc/2.8/ ([https](https://fasterxml.github.io/jackson-core/javadoc/2.8/) result 200).
* http://fasterxml.github.io/jackson-databind/javadoc/2.8/ migrated to:  
  https://fasterxml.github.io/jackson-databind/javadoc/2.8/ ([https](https://fasterxml.github.io/jackson-databind/javadoc/2.8/) result 200).
* http://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.8/ migrated to:  
  https://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.8/ ([https](https://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.8/) result 200).
* http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/ migrated to:  
  https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/ ([https](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/) result 200).
* http://issues.gradle.org/browse/GRADLE-1116 migrated to:  
  https://issues.gradle.org/browse/GRADLE-1116 ([https](https://issues.gradle.org/browse/GRADLE-1116) result 200).
* http://portals.apache.org/pluto/portlet-2.0-apidocs/ migrated to:  
  https://portals.apache.org/pluto/portlet-2.0-apidocs/ ([https](https://portals.apache.org/pluto/portlet-2.0-apidocs/) result 200).
* http://tiles.apache.org/framework/apidocs/ migrated to:  
  https://tiles.apache.org/framework/apidocs/ ([https](https://tiles.apache.org/framework/apidocs/) result 200).
* http://tiles.apache.org/tiles-request/apidocs/ migrated to:  
  https://tiles.apache.org/tiles-request/apidocs/ ([https](https://tiles.apache.org/tiles-request/apidocs/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/ migrated to:  
  https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/ ([https](https://www.eclipse.org/aspectj/doc/released/aspectj5rt-api/) result 200).
* http://ehcache.org/apidocs/ (301) migrated to:  
  https://www.ehcache.org/apidocs/ ([https](https://ehcache.org/apidocs/) result 200).
* http://static.springframework.org/spring-framework/docs (301) migrated to:  
  https://docs.spring.io/spring-framework/docs ([https](https://static.springframework.org/spring-framework/docs) result 301).
* http://download.eclipse.org/eclipse/downloads migrated to:  
  https://download.eclipse.org/eclipse/downloads ([https](https://download.eclipse.org/eclipse/downloads) result 301).
* http://glassfish.java.net/nonav/docs/v3/api/ migrated to:  
  https://glassfish.java.net/nonav/docs/v3/api/ ([https](https://glassfish.java.net/nonav/docs/v3/api/) result 301).
* http://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/ migrated to:  
  https://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/ ([https](https://pic.dhe.ibm.com/infocenter/wasinfo/v7r0/topic/com.ibm.websphere.javadoc.doc/web/apidocs/) result 301).
* http://projects.spring.io/spring-framework migrated to:  
  https://projects.spring.io/spring-framework ([https](https://projects.spring.io/spring-framework) result 301).
* http://springframework.org/schema migrated to:  
  https://springframework.org/schema ([https](https://springframework.org/schema) result 301).
* http://spring.io/tools/sts/all migrated to:  
  https://spring.io/tools/sts/all ([https](https://spring.io/tools/sts/all) result 302).