### PR TITLE
Add missing break statements to stop looping when result is known

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/ExtendedBeanInfoTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/ExtendedBeanInfoTests.java
@@ -754,6 +754,7 @@ public class ExtendedBeanInfoTests {
 		for (PropertyDescriptor pd : ebi.getPropertyDescriptors()) {
 			if (pd.getName().equals("foo")) {
 				found = true;
+				break;
 			}
 		}
 		assertThat(found, is(true));

--- a/spring-context/src/main/java/org/springframework/scripting/support/StandardScriptFactory.java
+++ b/spring-context/src/main/java/org/springframework/scripting/support/StandardScriptFactory.java
@@ -151,6 +151,7 @@ public class StandardScriptFactory implements ScriptFactory, BeanClassLoaderAwar
 				if (script instanceof Class ? !requestedIfc.isAssignableFrom((Class<?>) script) :
 						!requestedIfc.isInstance(script)) {
 					adaptationRequired = true;
+					break;
 				}
 			}
 			if (adaptationRequired) {

--- a/spring-core/src/test/java/org/springframework/core/io/support/PathMatchingResourcePatternResolverTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/support/PathMatchingResourcePatternResolverTests.java
@@ -89,7 +89,7 @@ public class PathMatchingResourcePatternResolverTests {
 				noCloverResources.add(resource);
 			}
 		}
-		resources = noCloverResources.toArray(new Resource[noCloverResources.size()]);
+		resources = noCloverResources.toArray(new Resource[0]);
 		assertProtocolAndFilenames(resources, "file",
 				StringUtils.concatenateStringArrays(CLASSES_IN_CORE_IO_SUPPORT, TEST_CLASSES_IN_CORE_IO_SUPPORT));
 	}
@@ -113,6 +113,7 @@ public class PathMatchingResourcePatternResolverTests {
 		for (Resource resource : resources) {
 			if (resource.getFilename().equals("aspectj_1_5_0.dtd")) {
 				found = true;
+				break;
 			}
 		}
 		assertTrue("Could not find aspectj_1_5_0.dtd in the root of the aspectjweaver jar", found);


### PR DESCRIPTION
Assuming 
- raise-the-flag loop raises the flag 
- `if` statement has not side effects requiring iteration up to the end
We can add break right after the flag is raised.