### PR TITLE
Introduce @SingletonScope and @PrototypeScope composed annotations

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/PrototypeScope.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/PrototypeScope.java
@@ -1,0 +1,34 @@
+package org.springframework.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+
+/**
+ * {@code @PrototypeScope} is a specialization of {@link Scope @Scope} for a
+ * standard prototype scope: "prototype".
+ *
+ * <p>Specifically, {@code @PrototypeScope} is a <em>composed annotation</em> that
+ * acts as a shortcut for {@code @Scope("prototype")}.
+ *
+ * <p>{@code @PrototypeScope} may be used as a meta-annotation to create custom
+ * composed annotations.
+ *
+ * @author Bojan Vukasovic
+ * @since 5.1
+ * @see SingletonScope
+ * @see org.springframework.context.annotation.Scope
+ * @see ConfigurableBeanFactory#SCOPE_PROTOTYPE
+ * @see org.springframework.stereotype.Component
+ * @see org.springframework.context.annotation.Bean
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public @interface PrototypeScope {
+}

--- a/spring-context/src/main/java/org/springframework/context/annotation/SingletonScope.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/SingletonScope.java
@@ -1,0 +1,34 @@
+package org.springframework.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+
+/**
+ * {@code @SingletonScope} is a specialization of {@link Scope @Scope} for a
+ * standard singleton scope: "singleton".
+ *
+ * <p>Specifically, {@code @SingletonScope} is a <em>composed annotation</em> that
+ * acts as a shortcut for {@code @Scope("singleton")}.
+ *
+ * <p>{@code @SingletonScope} may be used as a meta-annotation to create custom
+ * composed annotations.
+ *
+ * @author Bojan Vukasovic
+ * @since 5.1
+ * @see PrototypeScope
+ * @see org.springframework.context.annotation.Scope
+ * @see ConfigurableBeanFactory#SCOPE_SINGLETON
+ * @see org.springframework.stereotype.Component
+ * @see org.springframework.context.annotation.Bean
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
+public @interface SingletonScope {
+}


### PR DESCRIPTION
Since there are already: @ApplicationScope, @RequestScope and @SessionScope ([here](https://github.com/spring-projects/spring-framework/tree/master/spring-web/src/main/java/org/springframework/web/context/annotation)). In order to be consistent, I guess it would be nice to include this 2 core annotations?