### PR TITLE
Avoid calling other bean methods in web config

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
@@ -62,6 +62,7 @@ import org.springframework.web.servlet.handler.MappedInterceptor;
 import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.servlet.resource.ResourceUrlProvider;
 import org.springframework.web.servlet.support.SessionFlashMapManager;
 import org.springframework.web.servlet.theme.FixedThemeResolver;
 import org.springframework.web.servlet.view.DefaultRequestToViewNameTranslator;
@@ -374,7 +375,16 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 		wac.addBeans(this.controllers);
 		wac.addBeans(this.controllerAdvice);
 
-		RequestMappingHandlerMapping hm = config.getHandlerMapping();
+		FormattingConversionService mvcConversionService = config.mvcConversionService();
+		wac.addBean("mvcConversionService", mvcConversionService);
+		ResourceUrlProvider resourceUrlProvider = config.mvcResourceUrlProvider();
+		wac.addBean("mvcResourceUrlProvider", resourceUrlProvider);
+		ContentNegotiationManager mvcContentNegotiationManager = config.mvcContentNegotiationManager();
+		wac.addBean("mvcContentNegotiationManager", mvcContentNegotiationManager);
+		Validator mvcValidator = config.mvcValidator();
+		wac.addBean("mvcValidator", mvcValidator);
+
+		RequestMappingHandlerMapping hm = config.getHandlerMapping(mvcConversionService, resourceUrlProvider);
 		if (sc != null) {
 			hm.setServletContext(sc);
 		}
@@ -382,7 +392,8 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 		hm.afterPropertiesSet();
 		wac.addBean("requestMappingHandlerMapping", hm);
 
-		RequestMappingHandlerAdapter ha = config.requestMappingHandlerAdapter();
+		RequestMappingHandlerAdapter ha = config.requestMappingHandlerAdapter(mvcContentNegotiationManager,
+				mvcConversionService, mvcValidator);
 		if (sc != null) {
 			ha.setServletContext(sc);
 		}
@@ -390,7 +401,7 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 		ha.afterPropertiesSet();
 		wac.addBean("requestMappingHandlerAdapter", ha);
 
-		wac.addBean("handlerExceptionResolver", config.handlerExceptionResolver());
+		wac.addBean("handlerExceptionResolver", config.handlerExceptionResolver(mvcContentNegotiationManager));
 
 		wac.addBeans(initViewResolvers(wac));
 		wac.addBean(DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME, this.localeResolver);
@@ -430,13 +441,15 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 	/** Using the MVC Java configuration as the starting point for the "standalone" setup. */
 	private class StandaloneConfiguration extends WebMvcConfigurationSupport {
 
-		public RequestMappingHandlerMapping getHandlerMapping() {
+		public RequestMappingHandlerMapping getHandlerMapping(
+				FormattingConversionService mvcConversionService,
+				ResourceUrlProvider mvcResourceUrlProvider) {
 			RequestMappingHandlerMapping handlerMapping = handlerMappingFactory.get();
 			handlerMapping.setEmbeddedValueResolver(new StaticStringValueResolver(placeholderValues));
 			handlerMapping.setUseSuffixPatternMatch(useSuffixPatternMatch);
 			handlerMapping.setUseTrailingSlashMatch(useTrailingSlashPatternMatch);
 			handlerMapping.setOrder(0);
-			handlerMapping.setInterceptors(getInterceptors());
+			handlerMapping.setInterceptors(getInterceptors(mvcConversionService, mvcResourceUrlProvider));
 			if (removeSemicolonContent != null) {
 				handlerMapping.setRemoveSemicolonContent(removeSemicolonContent);
 			}
@@ -506,7 +519,7 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 			}
 			for (HandlerExceptionResolver resolver : handlerExceptionResolvers) {
 				if (resolver instanceof ApplicationContextAware) {
-					ApplicationContext applicationContext  = getApplicationContext();
+					ApplicationContext applicationContext = getApplicationContext();
 					if (applicationContext != null) {
 						((ApplicationContextAware) resolver).setApplicationContext(applicationContext);
 					}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/DelegatingWebFluxConfiguration.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/DelegatingWebFluxConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurationSupport.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,10 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	@Nullable
 	private ApplicationContext applicationContext;
 
+	@Nullable
+	public final ApplicationContext getApplicationContext() {
+		return this.applicationContext;
+	}
 
 	@Override
 	public void setApplicationContext(@Nullable ApplicationContext applicationContext) {
@@ -102,12 +106,6 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 						"e.g. via @EnableWebMvc and @EnableWebFlux, in the same application.");
 		}
 	}
-
-	@Nullable
-	public final ApplicationContext getApplicationContext() {
-		return this.applicationContext;
-	}
-
 
 	@Bean
 	public DispatcherHandler webHandler() {
@@ -121,10 +119,11 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	}
 
 	@Bean
-	public RequestMappingHandlerMapping requestMappingHandlerMapping() {
+	public RequestMappingHandlerMapping requestMappingHandlerMapping(
+			RequestedContentTypeResolver webFluxContentTypeResolver) {
 		RequestMappingHandlerMapping mapping = createRequestMappingHandlerMapping();
 		mapping.setOrder(0);
-		mapping.setContentTypeResolver(webFluxContentTypeResolver());
+		mapping.setContentTypeResolver(webFluxContentTypeResolver);
 		mapping.setCorsConfigurations(getCorsConfigurations());
 
 		PathMatchConfigurer configurer = getPathMatchConfigurer();
@@ -203,10 +202,10 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	}
 
 	@Bean
-	public RouterFunctionMapping routerFunctionMapping() {
+	public RouterFunctionMapping routerFunctionMapping(ServerCodecConfigurer serverCodecConfigurer) {
 		RouterFunctionMapping mapping = createRouterFunctionMapping();
 		mapping.setOrder(-1); // go before RequestMappingHandlerMapping
-		mapping.setMessageReaders(serverCodecConfigurer().getReaders());
+		mapping.setMessageReaders(serverCodecConfigurer.getReaders());
 		mapping.setCorsConfigurations(getCorsConfigurations());
 
 		return mapping;
@@ -225,13 +224,13 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	 * {@link #addResourceHandlers}.
 	 */
 	@Bean
-	public HandlerMapping resourceHandlerMapping() {
+	public HandlerMapping resourceHandlerMapping(ResourceUrlProvider resourceUrlProvider) {
 		ResourceLoader resourceLoader = this.applicationContext;
 		if (resourceLoader == null) {
 			resourceLoader = new DefaultResourceLoader();
 		}
 		ResourceHandlerRegistry registry = new ResourceHandlerRegistry(resourceLoader);
-		registry.setResourceUrlProvider(resourceUrlProvider());
+		registry.setResourceUrlProvider(resourceUrlProvider);
 		addResourceHandlers(registry);
 
 		AbstractHandlerMapping handlerMapping = registry.getHandlerMapping();
@@ -265,11 +264,15 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	}
 
 	@Bean
-	public RequestMappingHandlerAdapter requestMappingHandlerAdapter() {
+	public RequestMappingHandlerAdapter requestMappingHandlerAdapter(
+			ReactiveAdapterRegistry webFluxAdapterRegistry,
+			ServerCodecConfigurer serverCodecConfigurer,
+			FormattingConversionService webFluxConversionService,
+			Validator webfluxValidator) {
 		RequestMappingHandlerAdapter adapter = createRequestMappingHandlerAdapter();
-		adapter.setMessageReaders(serverCodecConfigurer().getReaders());
-		adapter.setWebBindingInitializer(getConfigurableWebBindingInitializer());
-		adapter.setReactiveAdapterRegistry(webFluxAdapterRegistry());
+		adapter.setMessageReaders(serverCodecConfigurer.getReaders());
+		adapter.setWebBindingInitializer(getConfigurableWebBindingInitializer(webFluxConversionService, webfluxValidator));
+		adapter.setReactiveAdapterRegistry(webFluxAdapterRegistry);
 
 		ArgumentResolverConfigurer configurer = new ArgumentResolverConfigurer();
 		configureArgumentResolvers(configurer);
@@ -325,10 +328,12 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	 * Return the {@link ConfigurableWebBindingInitializer} to use for
 	 * initializing all {@link WebDataBinder} instances.
 	 */
-	protected ConfigurableWebBindingInitializer getConfigurableWebBindingInitializer() {
+	protected ConfigurableWebBindingInitializer getConfigurableWebBindingInitializer(
+			FormattingConversionService webFluxConversionService,
+			Validator webFluxValidator) {
 		ConfigurableWebBindingInitializer initializer = new ConfigurableWebBindingInitializer();
-		initializer.setConversionService(webFluxConversionService());
-		initializer.setValidator(webFluxValidator());
+		initializer.setConversionService(webFluxConversionService);
+		initializer.setValidator(webFluxValidator);
 		MessageCodesResolver messageCodesResolver = getMessageCodesResolver();
 		if (messageCodesResolver != null) {
 			initializer.setMessageCodesResolver(messageCodesResolver);
@@ -420,33 +425,42 @@ public class WebFluxConfigurationSupport implements ApplicationContextAware {
 	}
 
 	@Bean
-	public ResponseEntityResultHandler responseEntityResultHandler() {
-		return new ResponseEntityResultHandler(serverCodecConfigurer().getWriters(),
-				webFluxContentTypeResolver(), webFluxAdapterRegistry());
+	public ResponseEntityResultHandler responseEntityResultHandler(
+			ReactiveAdapterRegistry webFluxAdapterRegistry,
+			ServerCodecConfigurer serverCodecConfigurer,
+			RequestedContentTypeResolver webFluxContentTypeResolver) {
+		return new ResponseEntityResultHandler(serverCodecConfigurer.getWriters(),
+				webFluxContentTypeResolver, webFluxAdapterRegistry);
 	}
 
 	@Bean
-	public ResponseBodyResultHandler responseBodyResultHandler() {
-		return new ResponseBodyResultHandler(serverCodecConfigurer().getWriters(),
-				webFluxContentTypeResolver(), webFluxAdapterRegistry());
+	public ResponseBodyResultHandler responseBodyResultHandler(
+			ReactiveAdapterRegistry webFluxAdapterRegistry,
+			ServerCodecConfigurer serverCodecConfigurer,
+			RequestedContentTypeResolver webFluxContentTypeResolver) {
+		return new ResponseBodyResultHandler(serverCodecConfigurer.getWriters(),
+				webFluxContentTypeResolver, webFluxAdapterRegistry);
 	}
 
 	@Bean
-	public ViewResolutionResultHandler viewResolutionResultHandler() {
+	public ViewResolutionResultHandler viewResolutionResultHandler(
+			ReactiveAdapterRegistry webFluxAdapterRegistry,
+			RequestedContentTypeResolver webFluxContentTypeResolver) {
 		ViewResolverRegistry registry = getViewResolverRegistry();
 		List<ViewResolver> resolvers = registry.getViewResolvers();
 		ViewResolutionResultHandler handler = new ViewResolutionResultHandler(
-				resolvers, webFluxContentTypeResolver(), webFluxAdapterRegistry());
+				resolvers, webFluxContentTypeResolver, webFluxAdapterRegistry);
 		handler.setDefaultViews(registry.getDefaultViews());
 		handler.setOrder(registry.getOrder());
 		return handler;
 	}
 
 	@Bean
-	public ServerResponseResultHandler serverResponseResultHandler() {
+	public ServerResponseResultHandler serverResponseResultHandler(
+			ServerCodecConfigurer serverCodecConfigurer) {
 		List<ViewResolver> resolvers = getViewResolverRegistry().getViewResolvers();
 		ServerResponseResultHandler handler = new ServerResponseResultHandler();
-		handler.setMessageWriters(serverCodecConfigurer().getWriters());
+		handler.setMessageWriters(serverCodecConfigurer.getWriters());
 		handler.setViewResolvers(resolvers);
 		return handler;
 	}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/config/DelegatingWebFluxConfigurationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/config/DelegatingWebFluxConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.format.support.FormattingConversionService;
 import org.springframework.http.codec.HttpMessageWriter;
 import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.validation.Validator;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.bind.support.ConfigurableWebBindingInitializer;
 import org.springframework.web.reactive.accept.RequestedContentTypeResolverBuilder;
@@ -72,7 +75,7 @@ public class DelegatingWebFluxConfigurationTests {
 	@Test
 	public void requestMappingHandlerMapping() throws Exception {
 		delegatingConfig.setConfigurers(Collections.singletonList(webFluxConfigurer));
-		delegatingConfig.requestMappingHandlerMapping();
+		delegatingConfig.requestMappingHandlerMapping(delegatingConfig.webFluxContentTypeResolver());
 
 		verify(webFluxConfigurer).configureContentTypeResolver(any(RequestedContentTypeResolverBuilder.class));
 		verify(webFluxConfigurer).addCorsMappings(any(CorsRegistry.class));
@@ -82,9 +85,14 @@ public class DelegatingWebFluxConfigurationTests {
 	@Test
 	public void requestMappingHandlerAdapter() throws Exception {
 		delegatingConfig.setConfigurers(Collections.singletonList(webFluxConfigurer));
+		ReactiveAdapterRegistry reactiveAdapterRegistry = delegatingConfig.webFluxAdapterRegistry();
+		ServerCodecConfigurer serverCodecConfigurer = delegatingConfig.serverCodecConfigurer();
+		FormattingConversionService formattingConversionService = delegatingConfig.webFluxConversionService();
+		Validator validator = delegatingConfig.webFluxValidator();
 
 		ConfigurableWebBindingInitializer initializer = (ConfigurableWebBindingInitializer)
-				this.delegatingConfig.requestMappingHandlerAdapter().getWebBindingInitializer();
+				this.delegatingConfig.requestMappingHandlerAdapter(reactiveAdapterRegistry, serverCodecConfigurer,
+						formattingConversionService, validator).getWebBindingInitializer();
 
 		verify(webFluxConfigurer).configureHttpMessageCodecs(codecsConfigurer.capture());
 		verify(webFluxConfigurer).getValidator();
@@ -107,7 +115,7 @@ public class DelegatingWebFluxConfigurationTests {
 			return null;
 		}).when(webFluxConfigurer).addResourceHandlers(any(ResourceHandlerRegistry.class));
 
-		delegatingConfig.resourceHandlerMapping();
+		delegatingConfig.resourceHandlerMapping(delegatingConfig.resourceUrlProvider());
 		verify(webFluxConfigurer).addResourceHandlers(any(ResourceHandlerRegistry.class));
 		verify(webFluxConfigurer).configurePathMatching(any(PathMatchConfigurer.class));
 	}
@@ -115,7 +123,10 @@ public class DelegatingWebFluxConfigurationTests {
 	@Test
 	public void responseBodyResultHandler() throws Exception {
 		delegatingConfig.setConfigurers(Collections.singletonList(webFluxConfigurer));
-		delegatingConfig.responseBodyResultHandler();
+		delegatingConfig.responseBodyResultHandler(
+				delegatingConfig.webFluxAdapterRegistry(),
+				delegatingConfig.serverCodecConfigurer(),
+				delegatingConfig.webFluxContentTypeResolver());
 
 		verify(webFluxConfigurer).configureHttpMessageCodecs(codecsConfigurer.capture());
 		verify(webFluxConfigurer).configureContentTypeResolver(any(RequestedContentTypeResolverBuilder.class));
@@ -124,7 +135,8 @@ public class DelegatingWebFluxConfigurationTests {
 	@Test
 	public void viewResolutionResultHandler() throws Exception {
 		delegatingConfig.setConfigurers(Collections.singletonList(webFluxConfigurer));
-		delegatingConfig.viewResolutionResultHandler();
+		delegatingConfig.viewResolutionResultHandler(delegatingConfig.webFluxAdapterRegistry(),
+				delegatingConfig.webFluxContentTypeResolver());
 
 		verify(webFluxConfigurer).configureViewResolvers(any(ViewResolverRegistry.class));
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfiguration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfigurationTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfigurationTests.java
@@ -97,7 +97,9 @@ public class DelegatingWebMvcConfigurationTests {
 	@Test
 	public void requestMappingHandlerAdapter() throws Exception {
 		delegatingConfig.setConfigurers(Collections.singletonList(webMvcConfigurer));
-		RequestMappingHandlerAdapter adapter = this.delegatingConfig.requestMappingHandlerAdapter();
+		RequestMappingHandlerAdapter adapter = this.delegatingConfig.requestMappingHandlerAdapter(
+				this.delegatingConfig.mvcContentNegotiationManager(), this.delegatingConfig.mvcConversionService(),
+				this.delegatingConfig.mvcValidator());
 
 		ConfigurableWebBindingInitializer initializer =
 				(ConfigurableWebBindingInitializer) adapter.getWebBindingInitializer();
@@ -128,6 +130,7 @@ public class DelegatingWebMvcConfigurationTests {
 			public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
 				converters.add(stringConverter);
 			}
+
 			@Override
 			public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
 				converters.add(0, customConverter);
@@ -136,7 +139,9 @@ public class DelegatingWebMvcConfigurationTests {
 		delegatingConfig = new DelegatingWebMvcConfiguration();
 		delegatingConfig.setConfigurers(configurers);
 
-		RequestMappingHandlerAdapter adapter = delegatingConfig.requestMappingHandlerAdapter();
+		RequestMappingHandlerAdapter adapter = delegatingConfig.requestMappingHandlerAdapter(
+				this.delegatingConfig.mvcContentNegotiationManager(), this.delegatingConfig.mvcConversionService(),
+				this.delegatingConfig.mvcValidator());
 		assertEquals("Only one custom converter should be registered", 2, adapter.getMessageConverters().size());
 		assertSame(customConverter, adapter.getMessageConverters().get(0));
 		assertSame(stringConverter, adapter.getMessageConverters().get(1));
@@ -165,7 +170,7 @@ public class DelegatingWebMvcConfigurationTests {
 	@Test
 	public void handlerExceptionResolver() throws Exception {
 		delegatingConfig.setConfigurers(Collections.singletonList(webMvcConfigurer));
-		delegatingConfig.handlerExceptionResolver();
+		delegatingConfig.handlerExceptionResolver(delegatingConfig.mvcContentNegotiationManager());
 
 		verify(webMvcConfigurer).configureMessageConverters(converters.capture());
 		verify(webMvcConfigurer).configureContentNegotiation(contentNegotiationConfigurer.capture());
@@ -190,7 +195,8 @@ public class DelegatingWebMvcConfigurationTests {
 		delegatingConfig.setConfigurers(configurers);
 
 		HandlerExceptionResolverComposite composite =
-				(HandlerExceptionResolverComposite) delegatingConfig.handlerExceptionResolver();
+				(HandlerExceptionResolverComposite) delegatingConfig
+						.handlerExceptionResolver(delegatingConfig.mvcContentNegotiationManager());
 		assertEquals("Only one custom converter is expected", 1, composite.getExceptionResolvers().size());
 	}
 
@@ -211,7 +217,9 @@ public class DelegatingWebMvcConfigurationTests {
 		});
 		delegatingConfig.setConfigurers(configurers);
 
-		RequestMappingHandlerMapping handlerMapping = delegatingConfig.requestMappingHandlerMapping();
+		RequestMappingHandlerMapping handlerMapping = delegatingConfig.requestMappingHandlerMapping(
+				delegatingConfig.mvcContentNegotiationManager(), delegatingConfig.mvcConversionService(),
+				delegatingConfig.mvcResourceUrlProvider());
 		assertNotNull(handlerMapping);
 		assertEquals("PathMatchConfigurer should configure RegisteredSuffixPatternMatch",
 				true, handlerMapping.useRegisteredSuffixPatternMatch());


### PR DESCRIPTION
This commit changes the main configuration classes for Spring MVC and
Spring WebFlux to not call other bean methods when setting up the web
infrastructure. This allows the `DelegatingWebFluxConfiguration` and
`DelegatingWebMvcConfiguration` to opt-in the lite-mode, as introduced
in gh-22461.