### PR TITLE
Performance improvement in RequestMappingInfo

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ReadOnlyHttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/ReadOnlyHttpHeaders.java
@@ -40,6 +40,9 @@ class ReadOnlyHttpHeaders extends HttpHeaders {
 	@Nullable
 	private MediaType cachedContentType;
 
+	@Nullable
+	private MediaType cachedAccept;
+
 	ReadOnlyHttpHeaders(HttpHeaders headers) {
 		super(headers.headers);
 	}
@@ -53,6 +56,18 @@ class ReadOnlyHttpHeaders extends HttpHeaders {
 			MediaType contentType = super.getContentType();
 			this.cachedContentType = contentType;
 			return contentType;
+		}
+	}
+
+	@Override
+	public List<MediaType> getAccept() {
+		if (this.cachedAccept != null) {
+			return this.cachedAccept;
+		}
+		else {
+			List<MediaType> accept = super.getAccept();
+			this.cachedAccept = accept;
+			return accept;
 		}
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfo.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfo.java
@@ -218,15 +218,20 @@ public final class RequestMappingInfo implements RequestCondition<RequestMapping
 		RequestMethodsRequestCondition methods = this.methodsCondition.getMatchingCondition(exchange);
 		ParamsRequestCondition params = this.paramsCondition.getMatchingCondition(exchange);
 		HeadersRequestCondition headers = this.headersCondition.getMatchingCondition(exchange);
-		ConsumesRequestCondition consumes = this.consumesCondition.getMatchingCondition(exchange);
-		ProducesRequestCondition produces = this.producesCondition.getMatchingCondition(exchange);
 
-		if (methods == null || params == null || headers == null || consumes == null || produces == null) {
+		if (methods == null || params == null || headers == null) {
 			return null;
 		}
 
 		PatternsRequestCondition patterns = this.patternsCondition.getMatchingCondition(exchange);
 		if (patterns == null) {
+			return null;
+		}
+
+		ConsumesRequestCondition consumes = this.consumesCondition.getMatchingCondition(exchange);
+		ProducesRequestCondition produces = this.producesCondition.getMatchingCondition(exchange);
+
+		if (consumes == null || produces == null) {
 			return null;
 		}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfo.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfo.java
@@ -216,25 +216,29 @@ public final class RequestMappingInfo implements RequestCondition<RequestMapping
 	@Nullable
 	public RequestMappingInfo getMatchingCondition(ServerWebExchange exchange) {
 		RequestMethodsRequestCondition methods = this.methodsCondition.getMatchingCondition(exchange);
-		ParamsRequestCondition params = this.paramsCondition.getMatchingCondition(exchange);
-		HeadersRequestCondition headers = this.headersCondition.getMatchingCondition(exchange);
-
-		if (methods == null || params == null || headers == null) {
+		if (methods == null) {
 			return null;
 		}
-
+		ParamsRequestCondition params = this.paramsCondition.getMatchingCondition(exchange);
+		if (params == null) {
+			return null;
+		}
+		HeadersRequestCondition headers = this.headersCondition.getMatchingCondition(exchange);
+		if (headers == null) {
+			return null;
+		}
 		PatternsRequestCondition patterns = this.patternsCondition.getMatchingCondition(exchange);
 		if (patterns == null) {
 			return null;
 		}
-
 		ConsumesRequestCondition consumes = this.consumesCondition.getMatchingCondition(exchange);
-		ProducesRequestCondition produces = this.producesCondition.getMatchingCondition(exchange);
-
-		if (consumes == null || produces == null) {
+		if (consumes == null) {
 			return null;
 		}
-
+		ProducesRequestCondition produces = this.producesCondition.getMatchingCondition(exchange);
+		if (produces == null) {
+			return null;
+		}
 		RequestConditionHolder custom = this.customConditionHolder.getMatchingCondition(exchange);
 		if (custom == null) {
 			return null;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
@@ -217,25 +217,29 @@ public final class RequestMappingInfo implements RequestCondition<RequestMapping
 	@Nullable
 	public RequestMappingInfo getMatchingCondition(HttpServletRequest request) {
 		RequestMethodsRequestCondition methods = this.methodsCondition.getMatchingCondition(request);
-		ParamsRequestCondition params = this.paramsCondition.getMatchingCondition(request);
-		HeadersRequestCondition headers = this.headersCondition.getMatchingCondition(request);
-
-		if (methods == null || params == null || headers == null) {
+		if (methods == null) {
 			return null;
 		}
-
+		ParamsRequestCondition params = this.paramsCondition.getMatchingCondition(request);
+		if (params == null) {
+			return null;
+		}
+		HeadersRequestCondition headers = this.headersCondition.getMatchingCondition(request);
+		if (headers == null) {
+			return null;
+		}
 		PatternsRequestCondition patterns = this.patternsCondition.getMatchingCondition(request);
 		if (patterns == null) {
 			return null;
 		}
-
 		ConsumesRequestCondition consumes = this.consumesCondition.getMatchingCondition(request);
-		ProducesRequestCondition produces = this.producesCondition.getMatchingCondition(request);
-
-		if (consumes == null || produces == null) {
+		if (consumes == null) {
 			return null;
 		}
-
+		ProducesRequestCondition produces = this.producesCondition.getMatchingCondition(request);
+		if (produces == null) {
+			return null;
+		}
 		RequestConditionHolder custom = this.customConditionHolder.getMatchingCondition(request);
 		if (custom == null) {
 			return null;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
@@ -219,15 +219,20 @@ public final class RequestMappingInfo implements RequestCondition<RequestMapping
 		RequestMethodsRequestCondition methods = this.methodsCondition.getMatchingCondition(request);
 		ParamsRequestCondition params = this.paramsCondition.getMatchingCondition(request);
 		HeadersRequestCondition headers = this.headersCondition.getMatchingCondition(request);
-		ConsumesRequestCondition consumes = this.consumesCondition.getMatchingCondition(request);
-		ProducesRequestCondition produces = this.producesCondition.getMatchingCondition(request);
 
-		if (methods == null || params == null || headers == null || consumes == null || produces == null) {
+		if (methods == null || params == null || headers == null) {
 			return null;
 		}
 
 		PatternsRequestCondition patterns = this.patternsCondition.getMatchingCondition(request);
 		if (patterns == null) {
+			return null;
+		}
+
+		ConsumesRequestCondition consumes = this.consumesCondition.getMatchingCondition(request);
+		ProducesRequestCondition produces = this.producesCondition.getMatchingCondition(request);
+
+		if (consumes == null || produces == null) {
 			return null;
 		}
 


### PR DESCRIPTION
We are using `spring-cloud-gateway` integrated with `spring-boot-starter-actuator`,  we run a load test on it(using jmeter, and my gateway program runs on a linux server with 4 cores/2GB) and found that `RequestMappingInfo` have some performance problem.

Scene 1: We added a `Http Header Manager` into `jmeter` with the header `Accept:text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8`,(default value of chrome) 
then I run jmeter and let my gateway program run  to 2000 qps, the cpu usage is about 60%:
![image](https://user-images.githubusercontent.com/3961789/54422559-bff1f280-4749-11e9-82a1-61dd80095d32.png)

Scene 2: We added a `Http Header Manager` into `jmeter` with the header `Accept:`, then I run jmeter and let my gateway program run  to 2000 qps, the cpu usage is about 35%:
![image](https://user-images.githubusercontent.com/3961789/54424256-73a8b180-474d-11e9-8046-5505e913f8f7.png)

As you can see, the performance is affected by the length of `Accept` header,  maybe hackers can use this performance problem to make ddos attack easier.

I use `async-profiler`(https://github.com/jvm-profiling-tools/async-profiler) to profile my program, and this is the result:
[aaa.txt](https://github.com/spring-projects/spring-framework/files/2970632/aaa.txt)
there are many stacktraces like the following costs too much cpu:

```
Total: 2777057399 (3.74%)  samples: 2766
  [ 0] java.util.HashMap.putVal
  [ 1] java.util.HashMap.put
  [ 2] org.springframework.util.MimeTypeUtils.parseMimeType
  [ 3] org.springframework.http.MediaType.parseMediaType
  [ 4] org.springframework.http.MediaType.parseMediaTypes
  [ 5] org.springframework.http.MediaType.parseMediaTypes
  [ 6] org.springframework.http.HttpHeaders.getAccept
  [ 7] org.springframework.web.reactive.accept.HeaderContentTypeResolver.resolveMediaTypes
  [ 8] org.springframework.web.reactive.result.condition.ProducesRequestCondition.getAcceptedMediaTypes
  [ 9] org.springframework.web.reactive.result.condition.ProducesRequestCondition.access$000
  [10] org.springframework.web.reactive.result.condition.ProducesRequestCondition$ProduceMediaTypeExpression.matchMediaType
  [11] org.springframework.web.reactive.result.condition.AbstractMediaTypeExpression.match
  [12] org.springframework.web.reactive.result.condition.ProducesRequestCondition.lambda$getMatchingCondition$0
  [13] org.springframework.web.reactive.result.condition.ProducesRequestCondition$$Lambda$656.1800605879.test
  [14] java.util.Collection.removeIf
  [15] org.springframework.web.reactive.result.condition.ProducesRequestCondition.getMatchingCondition
  [16] org.springframework.web.reactive.result.method.RequestMappingInfo.getMatchingCondition
  [17] org.springframework.web.reactive.result.method.RequestMappingInfoHandlerMapping.getMatchingMapping
  [18] org.springframework.web.reactive.result.method.RequestMappingInfoHandlerMapping.getMatchingMapping
  [19] org.springframework.web.reactive.result.method.AbstractHandlerMethodMapping.addMatchingMappings
  [20] org.springframework.web.reactive.result.method.AbstractHandlerMethodMapping.lookupHandlerMethod
  [21] org.springframework.web.reactive.result.method.AbstractHandlerMethodMapping.getHandlerInternal
  [22] org.springframework.web.reactive.handler.AbstractHandlerMapping.getHandler
  [23] org.springframework.web.reactive.DispatcherHandler.lambda$handle$0
  [24] org.springframework.web.reactive.DispatcherHandler$$Lambda$653.1915333739.apply
  [25] reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.drain
  [26] reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.onSubscribe
  [27] reactor.core.publisher.FluxIterable.subscribe
  [28] reactor.core.publisher.FluxIterable.subscribe
  [29] reactor.core.publisher.FluxConcatMap.subscribe
  [30] reactor.core.publisher.MonoNext.subscribe
  [31] reactor.core.publisher.MonoSwitchIfEmpty.subscribe
  [32] reactor.core.publisher.MonoFlatMap.subscribe
  [33] reactor.core.publisher.MonoFlatMap.subscribe
  [34] reactor.core.publisher.MonoDefer.subscribe
  [35] reactor.core.publisher.MonoDefer.subscribe
  [36] reactor.core.publisher.MonoPeekTerminal.subscribe
  [37] reactor.core.publisher.MonoDefer.subscribe
  [38] reactor.core.publisher.MonoPeekTerminal.subscribe
  [39] reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext
  [40] reactor.core.publisher.Operators$MonoSubscriber.complete
  [41] reactor.core.publisher.MonoZip$ZipCoordinator.signal
  [42] reactor.core.publisher.MonoZip$ZipInner.onNext
  [43] reactor.core.publisher.Operators$ScalarSubscription.request
  [44] reactor.core.publisher.MonoZip$ZipInner.onSubscribe
  [45] reactor.core.publisher.MonoJust.subscribe
  [46] reactor.core.publisher.Mono.subscribe
  [47] reactor.core.publisher.MonoZip.subscribe
  [48] reactor.core.publisher.MonoFlatMap.subscribe
  [49] reactor.core.publisher.MonoDefer.subscribe
  [50] reactor.core.publisher.MonoDefer.subscribe
  [51] reactor.core.publisher.MonoDefer.subscribe
  [52] reactor.core.publisher.MonoDefer.subscribe
  [53] reactor.core.publisher.MonoDefer.subscribe
  [54] reactor.core.publisher.MonoDefer.subscribe
  [55] reactor.core.publisher.MonoDefer.subscribe
  [56] reactor.core.publisher.MonoDefer.subscribe
  [57] reactor.core.publisher.MonoDefer.subscribe
  [58] reactor.core.publisher.MonoOnErrorResume.subscribe
  [59] reactor.core.publisher.MonoOnErrorResume.subscribe
  [60] reactor.core.publisher.MonoOnErrorResume.subscribe
  [61] reactor.core.publisher.Mono.subscribe
  [62] reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.drain
  [63] reactor.core.publisher.MonoIgnoreThen.subscribe
  [64] reactor.core.publisher.MonoPeekFuseable.subscribe
  [65] reactor.core.publisher.MonoPeekTerminal.subscribe
  [66] reactor.ipc.netty.channel.ChannelOperations.applyHandler
  [67] reactor.ipc.netty.http.server.HttpServerOperations.onHandlerStart
  [68] reactor.ipc.netty.channel.ContextHandler$$Lambda$633.1255094246.run
  [69] io.netty.util.concurrent.AbstractEventExecutor.safeExecute
  [70] io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks
  [71] io.netty.channel.epoll.EpollEventLoop.run
  [72] io.netty.util.concurrent.SingleThreadEventExecutor$5.run
  [73] java.lang.Thread.run
```



I found that the key point is that `MediaType.parseMediaType` is invoked too many times(more than 400) in one http request, this will cost too much cpu, so I change the order of the code, and test it again(also run to 2000 qps), this time the cpu usage is no more than 35%, the cpu usage will not be affected by the length of `Accept` header any more.


