### PR TITLE
URL Cleanup

### DIFF
--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-context.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-directPointcutEvents.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-directPointcutEvents.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:advisor advice-ref="countingAdvice" pointcut="within(org.springframework..*)"/>

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-pointcutEvents.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-pointcutEvents.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:pointcut id="myPointcut" expression="within(org.springframework..*)"/>

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-pointcutRefEvents.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerEventTests-pointcutRefEvents.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:pointcut id="pc" expression="within(org.springframework..*)"/>

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerPointcutErrorTests-pointcutDuplication.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerPointcutErrorTests-pointcutDuplication.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerPointcutErrorTests-pointcutMissing.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerPointcutErrorTests-pointcutMissing.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-aop/src/test/resources/org/springframework/aop/config/TopLevelAopTagTests-context.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/config/TopLevelAopTagTests-context.xml
@@ -1,6 +1,6 @@
 <config xmlns="http://www.springframework.org/schema/aop"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<pointcut id="testPointcut" expression="execution(* foo(..)) and within(springbank.dao.AccountDao+)"/>
 	<pointcut id="testPointcut1" expression="execution(* springbank.dao.AccountDao.foo(..))"/>

--- a/spring-aop/src/test/resources/org/springframework/aop/framework/PrototypeTargetTests-context.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/framework/PrototypeTargetTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-aop/src/test/resources/org/springframework/aop/interceptor/ExposeInvocationInterceptorTests-context.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/interceptor/ExposeInvocationInterceptorTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Tests for throws advice.

--- a/spring-aop/src/test/resources/org/springframework/aop/scope/ScopedProxyAutowireTests-scopedAutowireFalse.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/scope/ScopedProxyAutowireTests-scopedAutowireFalse.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd
+			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean id="scoped" class="org.springframework.aop.scope.ScopedProxyAutowireTests$TestBean" scope="prototype" autowire-candidate="false">
 		<aop:scoped-proxy/>

--- a/spring-aop/src/test/resources/org/springframework/aop/scope/ScopedProxyAutowireTests-scopedAutowireTrue.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/scope/ScopedProxyAutowireTests-scopedAutowireTrue.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd
+			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean id="scoped" class="org.springframework.aop.scope.ScopedProxyAutowireTests$TestBean" scope="singleton" autowire-candidate="true">
 		<aop:scoped-proxy/>

--- a/spring-aop/src/test/resources/org/springframework/aop/support/RegexpMethodPointcutAdvisorIntegrationTests-context.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/support/RegexpMethodPointcutAdvisorIntegrationTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-aspects/src/test/resources/org/springframework/aop/aspectj/autoproxy/ajcAutoproxyTests.xml
+++ b/spring-aspects/src/test/resources/org/springframework/aop/aspectj/autoproxy/ajcAutoproxyTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-aspects/src/test/resources/org/springframework/beans/factory/aspectj/beanConfigurerTests-beans.xml
+++ b/spring-aspects/src/test/resources/org/springframework/beans/factory/aspectj/beanConfigurerTests-beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean id="configuredBean" class="org.springframework.beans.factory.aspectj.ShouldBeConfiguredBySpring" lazy-init="true">
 		<property name="name" value="Rod"/>

--- a/spring-aspects/src/test/resources/org/springframework/beans/factory/aspectj/beanConfigurerTests.xml
+++ b/spring-aspects/src/test/resources/org/springframework/beans/factory/aspectj/beanConfigurerTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:spring-configured/>
 

--- a/spring-aspects/src/test/resources/org/springframework/beans/factory/aspectj/springConfigured.xml
+++ b/spring-aspects/src/test/resources/org/springframework/beans/factory/aspectj/springConfigured.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:spring-configured/>
 

--- a/spring-aspects/src/test/resources/org/springframework/cache/config/annotation-cache-aspectj.xml
+++ b/spring-aspects/src/test/resources/org/springframework/cache/config/annotation-cache-aspectj.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:cache="http://www.springframework.org/schema/cache"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 
 	<!--

--- a/spring-aspects/src/test/resources/org/springframework/cache/config/annotation-jcache-aspectj.xml
+++ b/spring-aspects/src/test/resources/org/springframework/cache/config/annotation-jcache-aspectj.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven mode="aspectj"/>
 

--- a/spring-aspects/src/test/resources/org/springframework/scheduling/aspectj/annotationDrivenContext.xml
+++ b/spring-aspects/src/test/resources/org/springframework/scheduling/aspectj/annotationDrivenContext.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   			http://www.springframework.org/schema/beans/spring-beans.xsd
+	   			https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/task
-				http://www.springframework.org/schema/task/spring-task.xsd">
+				https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<task:annotation-driven mode="aspectj" executor="testExecutor"
 							exception-handler="testExceptionHandler"/>

--- a/spring-aspects/src/test/resources/org/springframework/transaction/aspectj/TransactionAspectTests-context.xml
+++ b/spring-aspects/src/test/resources/org/springframework/transaction/aspectj/TransactionAspectTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-dependentBeans.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-dependentBeans.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean id="a" class="java.lang.Object" />
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-leaf.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-leaf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-middle.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-middle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-root.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-root.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/ConcurrentBeanFactoryTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/ConcurrentBeanFactoryTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanLookupTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanLookupTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="fooFactory" class="org.springframework.beans.factory.FooFactoryBean"/>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-abstract.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-abstract.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-circular.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-circular.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.springframework.org/schema/beans
-                       http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+                       https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
    <bean id="bean1" class="org.springframework.beans.factory.FactoryBeanTests$PassThroughFactoryBean" primary="true">
       <constructor-arg value="org.springframework.beans.factory.FactoryBeanTests$BeanImpl1"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-returnsNull.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-returnsNull.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-withAutowiring.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-withAutowiring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-lazy-init="true">
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/annotation/CustomAutowireConfigurerTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/annotation/CustomAutowireConfigurerTests-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.springframework.org/schema/beans
-                http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+                https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="resolver" class="org.springframework.beans.factory.annotation.CustomAutowireConfigurerTests$CustomResolver"/>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/config/FieldRetrievingFactoryBeanTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/config/FieldRetrievingFactoryBeanTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/config/ObjectFactoryCreatingFactoryBeanTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/config/ObjectFactoryCreatingFactoryBeanTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/config/PropertiesFactoryBeanTests-test.properties.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/config/PropertiesFactoryBeanTests-test.properties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<!DOCTYPE properties SYSTEM "https://java.sun.com/dtd/properties.dtd">
 
 <properties version="1.0">
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/config/PropertyPathFactoryBeanTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/config/PropertyPathFactoryBeanTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/config/PropertyResourceConfigurerTests-test.properties.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/config/PropertyResourceConfigurerTests-test.properties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<!DOCTYPE properties SYSTEM "https://java.sun.com/dtd/properties.dtd">
 
 <properties version="1.0">
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/config/SimpleScopeTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/config/SimpleScopeTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean id="usesScope" class="org.springframework.tests.sample.beans.TestBean" scope="myScope"/>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/parsing/CustomProblemReporterTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/parsing/CustomProblemReporterTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN"
-				"http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+				"https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/support/genericBeanTests.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/support/genericBeanTests.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 
@@ -64,7 +64,7 @@
   </bean>
 
   <bean id="setBean" class="org.springframework.beans.factory.support.BeanFactoryGenericsTests$UrlSet">
-    <property name="urlNames" value="http://www.springframework.org"/>
+    <property name="urlNames" value="https://www.springframework.org"/>
   </bean>
 
 </beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/support/lookupMethodTests.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/support/lookupMethodTests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 	<bean id="abstractBean" class="org.springframework.beans.factory.support.LookupMethodTests$AbstractBean">
 		<lookup-method name="get"/>  <!-- applying to overloaded methods, and based on return type since no bean name is given -->

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/support/security/callbacks.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/support/security/callbacks.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
 	default-lazy-init="true">
 
 	<bean name="spring-init" class="org.springframework.beans.factory.support.security.support.InitBean"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/DuplicateBeanIdTests-multiLevel-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/DuplicateBeanIdTests-multiLevel-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean">
 		<property name="name" value="topLevel"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/DuplicateBeanIdTests-sameLevel-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/DuplicateBeanIdTests-sameLevel-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean">
 		<property name="name" value="original"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-autowire-candidates-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-autowire-candidates-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 		default-autowire-candidates="foo*">
 
 	<bean id="fooRepository" class="java.lang.Object"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-autowire-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-autowire-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="foo" class="java.lang.Object"/>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-init-destroy-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-init-destroy-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	default-init-method="initMethod1"
 	default-destroy-method="destroyMethod1">
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-lazy-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-lazy-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<!-- lazy == false (based on default XSD values) -->
 	<bean id="foo" class="java.lang.Object"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-merge-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementAttributeRecursionTests-merge-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 		default-merge="false">
 
 	<bean id="abstractTestBean" class="org.springframework.tests.sample.beans.TestBean" abstract="true">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/NestedBeansElementTests-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="foo" class="java.lang.String"/>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-customDefaultProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-customDefaultProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<beans profile="custom-default">
 		<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-defaultAndDevProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-defaultAndDevProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="dev,default">
 		<!-- bean should be processed if dev OR no profile is defined -->
 		<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-defaultProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-defaultProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<beans profile="default">
 		<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-devProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-devProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="dev">
 
 	<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-multiProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-multiProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="dev,prod">
 
 	<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-multiProfileNegated.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-multiProfileNegated.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="!dev,!prod">
 
 	<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-multiProfileNotDev.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-multiProfileNotDev.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="!dev,prod">
 
 	<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-noProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-noProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="foo" class="java.lang.String"/>
 </beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-notDevProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-notDevProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="!dev">
 
 	<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-prodProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-prodProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="prod">
 
 	<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-spaceDelimitedProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-spaceDelimitedProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="dev prod">
 
 	<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-unknownProfile.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ProfileXmlBeanDefinitionTests-unknownProfile.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="unknown">
 
 	<bean id="foo" class="java.lang.String"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-constructor-with-exclusion.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-constructor-with-exclusion.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-exclusion.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-exclusion.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-inclusion.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-inclusion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd"
 		default-autowire-candidates="">
 
 	<bean id="rob" class="org.springframework.tests.sample.beans.TestBean" autowire="byType"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-selective-inclusion.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-selective-inclusion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd"
 		default-autowire-candidates="props*,*ly">
 
 	<bean id="rob" class="org.springframework.tests.sample.beans.TestBean" autowire="byType"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/beanEvents.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/beanEvents.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-lazy-init="true" default-autowire="constructor" default-merge="true"
 		default-init-method="myInit" default-destroy-method="myDestroy">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/beanEventsImported.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/beanEventsImported.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/beanNameGeneration.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/beanNameGeneration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/collectionMerging.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/collectionMerging.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/collections.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/collections.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.2.xsd">
 
 	<bean id="jenny" class="org.springframework.tests.sample.beans.TestBean">
 		<property name="name"><value>Jenny</value></property>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/collectionsWithDefaultTypes.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/collectionsWithDefaultTypes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean">
 		<property name="someList">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/defaultLifecycleMethods.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/defaultLifecycleMethods.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-init-method="init" default-destroy-method="destroy">
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/factory-methods.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/factory-methods.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="default" class="org.springframework.beans.factory.xml.FactoryMethods"
 			factory-method="defaultInstance">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ignoreDefaultLifecycleMethods.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/ignoreDefaultLifecycleMethods.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-init-method="foo" default-destroy-method="bar">
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/import.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/import.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/importPattern.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/importPattern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/invalidPerSchema.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/invalidPerSchema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<foobar/>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/schemaValidated.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/schemaValidated.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean xml:lang="en" id="testBean" class="org.springframework.tests.sample.beans.TestBean"/>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simpleConstructorNamespaceHandlerTests.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simpleConstructorNamespaceHandlerTests.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:c="http://www.springframework.org/schema/c"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
  <!--
 	<bean id="simple1" class="org.springframework.tests.sample.beans.DummyBean">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simpleConstructorNamespaceHandlerTestsWithErrors.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simpleConstructorNamespaceHandlerTestsWithErrors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="error" class="org.springframework.tests.sample.beans.TestBean" c:name="error-bean">
 		<constructor-arg name="name" value="error-bean"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simplePropertyNamespaceHandlerTests.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simplePropertyNamespaceHandlerTests.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:p="http://www.springframework.org/schema/p"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="rob" class="org.springframework.tests.sample.beans.TestBean" p:name="Rob Harrop" p:spouse-ref="sally">
 		<property name="age" value="24"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simplePropertyNamespaceHandlerTestsWithErrors.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simplePropertyNamespaceHandlerTestsWithErrors.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:p="http://www.springframework.org/schema/p"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="rob" class="org.springframework.tests.sample.beans.TestBean" p:name="Rob Harrop" p:spouse-ref="sally">
 		<property name="name" value="Rob Harrop"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/test.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/testUtilNamespace.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/testUtilNamespace.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:util="http://www.springframework.org/schema/util"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+				http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
 	<util:constant id="min" static-field="
 			java.lang.Integer.

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/validateWithDtd.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/validateWithDtd.xml
@@ -6,7 +6,7 @@ This is a top level block comment
 <!-- trying --> <!-- to trick --> <!--
 				the parser now --> <!-- <beans>
 				-->
-<!-- more trickery-->  <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd"><!-- some nasty stuff -->
+<!-- more trickery-->  <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd"><!-- some nasty stuff -->
 
 <beans>
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/validateWithXsd.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/validateWithXsd.xml
@@ -6,6 +6,6 @@ This is a top level block comment
 <!-- trying --> <!-- to trick --> <!--
 				the parser now --> <!-- <beans>
 				-->
-<!-- more trickery--><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd"><!-- end -->
+<!-- more trickery--><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd"><!-- end -->
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean"/>
 </beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/withMeta.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/withMeta.xml
@@ -2,7 +2,7 @@
 <spring:beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:spring="http://www.springframework.org/schema/beans"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<spring:bean id="testBean1" class="org.springframework.tests.sample.beans.TestBean">
 		<spring:meta key="foo" value="bar"/>

--- a/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheNamespaceDriven-resolver.xml
+++ b/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheNamespaceDriven-resolver.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
        		http://www.springframework.org/schema/cache
-       		http://www.springframework.org/schema/cache/spring-cache.xsd">
+       		https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven cache-manager="cacheManager" cache-resolver="cacheResolver"/>
 

--- a/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheNamespaceDriven.xml
+++ b/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheNamespaceDriven.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd
        		http://www.springframework.org/schema/cache
-       		http://www.springframework.org/schema/cache/spring-cache.xsd">
+       		https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven proxy-target-class="false" order="0" error-handler="errorHandler"/>
 

--- a/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheStandaloneConfig.xml
+++ b/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheStandaloneConfig.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   		https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator"/>
 

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/databasePersistence.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/databasePersistence.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="scheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="triggers" ref="trigger" />

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/job-scheduling-data.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/job-scheduling-data.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <job-scheduling-data xmlns="http://www.quartz-scheduler.org/xml/JobSchedulingData"
 					 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-					 xsi:schemaLocation="http://www.quartz-scheduler.org/xml/JobSchedulingData http://www.quartz-scheduler.org/xml/job_scheduling_data_1_8.xsd"
+					 xsi:schemaLocation="http://www.quartz-scheduler.org/xml/JobSchedulingData https://www.quartz-scheduler.org/xml/job_scheduling_data_1_8.xsd"
 					 version="1.8">
 	<schedule>
 		<job>

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/multipleAnonymousMethodInvokingJobDetailFB.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/multipleAnonymousMethodInvokingJobDetailFB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/multipleSchedulers.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/multipleSchedulers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/multipleSchedulersWithQuartzProperties.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/multipleSchedulersWithQuartzProperties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/quartzSchedulerLifecycleTests.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/quartzSchedulerLifecycleTests.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd">
+        https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="otherSchedulerWithDefaultShutdownOrder" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="autoStartup" value="false"/>

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/schedulerAccessorBean.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/schedulerAccessorBean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/schedulerRepositoryExposure.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/schedulerRepositoryExposure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AfterAdviceBindingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AfterAdviceBindingTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="afterAdviceBindingTests" ref="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AfterReturningAdviceBindingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AfterReturningAdviceBindingTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="afterReturningAdviceBindingTests" ref="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AfterThrowingAdviceBindingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AfterThrowingAdviceBindingTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AroundAdviceBindingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AroundAdviceBindingTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="beforeAdviceBindingTests" ref="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AroundAdviceCircularTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AroundAdviceCircularTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="beforeAdviceBindingTests" ref="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AspectAndAdvicePrecedenceTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AspectAndAdvicePrecedenceTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:aop="http://www.springframework.org/schema/aop"
-			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AspectJExpressionPointcutAdvisorTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AspectJExpressionPointcutAdvisorTests.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/BeanNamePointcutAtAspectTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/BeanNamePointcutAtAspectTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/BeanNamePointcutTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/BeanNamePointcutTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="beanNameMatchingTest" ref="counterAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/BeforeAdviceBindingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/BeforeAdviceBindingTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="beforeAdviceBindingTests" ref="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/DeclarationOrderIndependenceTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/DeclarationOrderIndependenceTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xmlns:aop="http://www.springframework.org/schema/aop"
-     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+     xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
   <bean id="topsyTurvyAspect" class="org.springframework.aop.aspectj.TopsyTurvyAspect"/>
  

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/DeclareParentsDelegateRefTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/DeclareParentsDelegateRefTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-	   		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+	   		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
 
 	<aop:config>
 		<aop:aspect id="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/DeclareParentsTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/DeclareParentsTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-	   		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+	   		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="beforeAdviceBindingTests" ref="introduction">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ImplicitJPArgumentMatchingAtAspectJTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ImplicitJPArgumentMatchingAtAspectJTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean">
 		<property name="name" value="aTestBean"/>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ImplicitJPArgumentMatchingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ImplicitJPArgumentMatchingTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config proxy-target-class="true">
 		<aop:aspect ref="counterAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/OverloadedAdviceTests-ambiguous.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/OverloadedAdviceTests-ambiguous.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/OverloadedAdviceTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/OverloadedAdviceTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ProceedTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ProceedTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="aspectOne" ref="firstTestAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-after.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-after.xml
@@ -3,8 +3,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect ref="monitoringAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-atAspectJ-after.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-atAspectJ-after.xml
@@ -3,8 +3,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="counter" class="org.springframework.aop.aspectj.Counter"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-atAspectJ-before.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-atAspectJ-before.xml
@@ -3,8 +3,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-before.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-before.xml
@@ -3,8 +3,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="counter" class="org.springframework.aop.aspectj.Counter"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/SharedPointcutWithArgsMismatchTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/SharedPointcutWithArgsMismatchTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/SubtypeSensitiveMatchingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/SubtypeSensitiveMatchingTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/TargetPointcutSelectionTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/TargetPointcutSelectionTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ThisAndTargetSelectionOnlyPointcutsAtAspectJTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ThisAndTargetSelectionOnlyPointcutsAtAspectJTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy proxy-target-class="false"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ThisAndTargetSelectionOnlyPointcutsTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ThisAndTargetSelectionOnlyPointcutsTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AnnotationBindingTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AnnotationBindingTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="annotationBindingAspect" ref="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AnnotationPointcutTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AnnotationPointcutTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:advisor advice-ref="testInterceptor" pointcut-ref="myPointcut"/>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectImplementingInterfaceTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectImplementingInterfaceTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect ref="interfaceExtendingAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorAndLazyInitTargetSourceTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorAndLazyInitTargetSourceTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean class="org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator">
 		<property name="customTargetSourceCreators">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspects.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspects.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<!--
 	<bean class="org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator"/>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsPlusAdvisor.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsPlusAdvisor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithAbstractBean.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithAbstractBean.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd"
 	   default-lazy-init="true">
 
 	<aop:aspectj-autoproxy/>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithCGLIB.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithCGLIB.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
 
     
     <!--

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithOrdering.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithOrdering.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<!--
 	<bean class="org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator" />

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-pertarget.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-pertarget.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-perthis.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-perthis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-retryAspect.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-retryAspect.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<aop:aspectj-autoproxy proxy-target-class="true"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-twoAdviceAspect.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-twoAdviceAspect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-twoAdviceAspectPrototype.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-twoAdviceAspectPrototype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-twoAdviceAspectSingleton.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-twoAdviceAspectSingleton.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-usesInclude.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-usesInclude.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy>
 	  <aop:include name="aspectOne"/>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-usesJoinPointAspect.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-usesJoinPointAspect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-withBeanNameAutoProxyCreator.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-withBeanNameAutoProxyCreator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean class="org.springframework.aop.framework.autoproxy.BeanNameAutoProxyCreator">
 		<property name="beanNames" value="adrian"/>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AtAspectJAfterThrowingTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AtAspectJAfterThrowingTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AtAspectJAnnotationBindingTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AtAspectJAnnotationBindingTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/benchmark/BenchmarkTests-aspectj.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/benchmark/BenchmarkTests-aspectj.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
     
     <!--

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/benchmark/BenchmarkTests-springAop.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/benchmark/BenchmarkTests-springAop.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<!--
 	<bean class="org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator" />

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/spr3064/SPR3064Tests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/spr3064/SPR3064Tests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/generic/AfterReturningGenericTypeMatchingTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/generic/AfterReturningGenericTypeMatchingTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/beans"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/generic/GenericBridgeMethodMatchingClassProxyTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/generic/GenericBridgeMethodMatchingClassProxyTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/beans"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy proxy-target-class="true"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/generic/GenericBridgeMethodMatchingTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/generic/GenericBridgeMethodMatchingTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/beans"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy proxy-target-class="false"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/generic/GenericParameterMatchingTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/generic/GenericParameterMatchingTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/beans"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerAdviceTypeTests-error.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerAdviceTypeTests-error.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerAdviceTypeTests-ok.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerAdviceTypeTests-ok.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerArgNamesTests-error.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerArgNamesTests-error.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerArgNamesTests-ok.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerArgNamesTests-ok.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerProxyTargetClassTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerProxyTargetClassTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
 
 	<aop:config proxy-target-class="true" expose-proxy="true">
 		<aop:pointcut id="getNameCalls" expression="execution(* getName(..)) and within(*..ITestBean+)"/>

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerReturningTests-error.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerReturningTests-error.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerReturningTests-ok.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerReturningTests-ok.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:pointcut id="getNameCalls" expression="execution(* getName(..)) and within(*..ITestBean+)"/>

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerThrowingTests-error.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerThrowingTests-error.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerThrowingTests-ok.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerThrowingTests-ok.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="countAgeCalls" ref="countingAdvice">

--- a/spring-context/src/test/resources/org/springframework/aop/config/PrototypeProxyTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/config/PrototypeProxyTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="service" class="org.springframework.tests.sample.beans.TestBean" scope="prototype"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/CglibProxyTests-with-dependency-checking.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/CglibProxyTests-with-dependency-checking.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ObjenesisProxyTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ObjenesisProxyTests-context.xml
@@ -3,10 +3,10 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
 	<context:component-scan base-package="org.springframework.aop.framework" />
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-autowiring.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-autowiring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-double-targetsource.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-double-targetsource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Tests for misconfiguring the proxy factory bean using a target source in the

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-frozen.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-frozen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-inner-bean-target.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-inner-bean-target.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Test that inner bean for target means that we can use

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-invalid.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-invalid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-notlast-targetsource.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-notlast-targetsource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Tests for misconfiguring the proxy factory bean using a target source in the

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-prototype.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-prototype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Tests for independent prototype behavior.

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-serialization.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-serialization.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Tests for independent prototype behaviour.

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-targetsource.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-targetsource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Tests for independent prototype behaviour.

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-throws-advice.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-throws-advice.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Tests for throws advice.

--- a/spring-context/src/test/resources/org/springframework/aop/framework/adapter/AdvisorAdapterRegistrationTests-with-bpp.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/adapter/AdvisorAdapterRegistrationTests-with-bpp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/adapter/AdvisorAdapterRegistrationTests-without-bpp.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/adapter/AdvisorAdapterRegistrationTests-without-bpp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorTests-common-interceptors.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorTests-common-interceptors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Shows common interceptor along with advisor.

--- a/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorTests-custom-targetsource.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorTests-custom-targetsource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorTests-optimized.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorTests-optimized.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorTests-quick-targetsource.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorTests-quick-targetsource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/BeanNameAutoProxyCreatorInitTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/BeanNameAutoProxyCreatorInitTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/BeanNameAutoProxyCreatorTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/autoproxy/BeanNameAutoProxyCreatorTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/aop/scope/ScopedProxyTests-list.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/scope/ScopedProxyTests-list.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="scopedList" class="java.util.ArrayList" scope="request">
 		<aop:scoped-proxy/>

--- a/spring-context/src/test/resources/org/springframework/aop/scope/ScopedProxyTests-map.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/scope/ScopedProxyTests-map.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="singletonMap" class="java.util.Collections" factory-method="singletonMap" scope="prototype">
 		<aop:scoped-proxy/>

--- a/spring-context/src/test/resources/org/springframework/aop/scope/ScopedProxyTests-override.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/scope/ScopedProxyTests-override.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
 
 	<bean id="testBean" class="org.springframework.tests.sample.beans.TestBean" scope="request">
 		<aop:scoped-proxy proxy-target-class="false"/>

--- a/spring-context/src/test/resources/org/springframework/aop/scope/ScopedProxyTests-testbean.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/scope/ScopedProxyTests-testbean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/LookupMethodWrappedByCglibProxyTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/LookupMethodWrappedByCglibProxyTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/QualifierAnnotationTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/QualifierAnnotationTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:annotation-config/>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-autowire.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-autowire.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-child.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-child.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-classNotFound.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-classNotFound.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN"
-		"http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+		"https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
 
 	<bean id="classNotFound" class="WhatALotOfRubbish"/>

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-collections.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-collections.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="jenny" class="org.springframework.tests.sample.beans.TestBean">
 		<property name="name"><value>Jenny</value></property>

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-complexFactoryCircle.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-complexFactoryCircle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-constructorArg.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-constructorArg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="rod1" class="org.springframework.beans.factory.xml.ConstructorDependenciesBean">
 		<constructor-arg><ref bean="kerry2"/></constructor-arg>

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-constructorOverrides.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-constructorOverrides.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-defaultAutowire.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-defaultAutowire.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-autowire="byType">
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-defaultLazyInit.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-defaultLazyInit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-lazy-init="true">
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-delegationOverrides.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-delegationOverrides.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<!--
 		Not yet in use: illustration of possible approach

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depCarg.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depCarg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depCargAutowire.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depCargAutowire.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depCargInner.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depCargInner.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depDependsOn.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depDependsOn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depDependsOnInner.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depDependsOnInner.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depMaterializeThis.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depMaterializeThis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depProp.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depProp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depPropAutowireByName.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depPropAutowireByName.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depPropAutowireByType.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depPropAutowireByType.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depPropInTheMiddle.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depPropInTheMiddle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depPropInner.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-depPropInner.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-factoryCircle.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-factoryCircle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-initializers.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-initializers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-invalid.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-invalid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-invalidOverridesNoSuchMethod.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-invalidOverridesNoSuchMethod.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-localCollectionsUsingXsd.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-localCollectionsUsingXsd.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	     xmlns:util="http://www.springframework.org/schema/util"
-	     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd">
+	     xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+           http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.0.xsd">
 
 	<!-- just ensures that one can use <ref bean=""/> to refer to the various <util:collections/> types -->
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-noSuchFactoryMethod.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-noSuchFactoryMethod.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-overrides.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-overrides.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-parent.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-parent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-recursiveImport.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-recursiveImport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-resourceImport.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-resourceImport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-testWithDuplicateNameInAlias.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-testWithDuplicateNameInAlias.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-testWithDuplicateNames.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-testWithDuplicateNames.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/simplePropertyNamespaceHandlerWithExpressionLanguageTests.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/simplePropertyNamespaceHandlerWithExpressionLanguageTests.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:p="http://www.springframework.org/schema/p"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="foo" class="org.springframework.tests.sample.beans.TestBean" p:name="Baz"/>
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/support/CustomNamespaceHandlerTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/support/CustomNamespaceHandlerTests-context.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:test="http://www.springframework.org/schema/beans/test"
 	   xmlns:util="http://www.springframework.org/schema/util"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.0.xsd
-       http://www.springframework.org/schema/beans/test http://www.springframework.org/schema/beans/factory/xml/support/CustomNamespaceHandlerTests.xsd"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+       http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.0.xsd
+       http://www.springframework.org/schema/beans/test https://www.springframework.org/schema/beans/factory/xml/support/CustomNamespaceHandlerTests.xsd"
 	default-lazy-init="true">
 
 	<test:testBean id="testBean" name="Rob Harrop" age="23"/>

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheConfig.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheConfig.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<bean id="apc" class="org.springframework.aop.framework.autoproxy.InfrastructureAdvisorAutoProxyCreator"/>
 

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace-manager-resolver.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace-manager-resolver.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns:p="http://www.springframework.org/schema/p"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven cache-manager="customCacheManager"
 							 cache-resolver="cacheResolver"/>

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace-resolver.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace-resolver.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns:p="http://www.springframework.org/schema/p"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven cache-resolver="cacheResolver"/>
 

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace.xml
@@ -3,9 +3,9 @@
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-       		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven proxy-target-class="false" order="0"
 							 key-generator="keyGenerator" error-handler="errorHandler"/>

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice-invalid.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice-invalid.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<import resource="cache-advice.xml"/>
 

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
@@ -3,9 +3,9 @@
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns:p="http://www.springframework.org/schema/p"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-       		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:advice id="cacheAdviceInterface" cache-manager="cacheManager">
 		<cache:caching cache="testCache">

--- a/spring-context/src/test/resources/org/springframework/context/access/ContextJndiBeanFactoryLocatorTests-collections.xml
+++ b/spring-context/src/test/resources/org/springframework/context/access/ContextJndiBeanFactoryLocatorTests-collections.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="jenny" class="org.springframework.tests.sample.beans.TestBean">
 		<property name="name"><value>Jenny</value></property>

--- a/spring-context/src/test/resources/org/springframework/context/access/ContextJndiBeanFactoryLocatorTests-parent.xml
+++ b/spring-context/src/test/resources/org/springframework/context/access/ContextJndiBeanFactoryLocatorTests-parent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/access/ContextSingletonBeanFactoryLocatorTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/access/ContextSingletonBeanFactoryLocatorTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!-- We are only using one definition file for the purposes of this test, since we do not have multiple
 	classloaders available in the environment to allow combining multiple files of the same name, but

--- a/spring-context/src/test/resources/org/springframework/context/annotation/DestroyMethodInferenceTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/DestroyMethodInferenceTests-context.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	                    http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	                    https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="x1"
 	      class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithLocalCloseMethod"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/EnableLoadTimeWeavingTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/EnableLoadTimeWeavingTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<context:load-time-weaver weaver-class="org.springframework.instrument.classloading.SimpleLoadTimeWeaver"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/Spr6602Tests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/Spr6602Tests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="foo" class="org.springframework.context.annotation.Spr6602Tests$Foo">
 		<constructor-arg ref="barFactory" />

--- a/spring-context/src/test/resources/org/springframework/context/annotation/aspectjTypeFilterTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/aspectjTypeFilterTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable" use-default-filters="false" annotation-config="false">
         <context:include-filter type="aspectj" expression="example.scannable.Stub*"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/aspectjTypeFilterTestsWithPlaceholders.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/aspectjTypeFilterTestsWithPlaceholders.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="${basePackage}" use-default-filters="false" annotation-config="false">
         <context:include-filter type="aspectj" expression="example.scannable.Stub*"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/componentScanRespectsProfileAnnotationTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/componentScanRespectsProfileAnnotationTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-				http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+				https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 				http://www.springframework.org/schema/context
-				http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+				https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:component-scan base-package="example.profilescan"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/componentScanWithAutowiredQualifierTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/componentScanWithAutowiredQualifierTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-				http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 				http://www.springframework.org/schema/context
-				http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+				https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<bean id="fooService" class="example.scannable.AutowiredQualifierFooService"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/AutowiredConfigurationTests-custom.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/AutowiredConfigurationTests-custom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util">
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/AutowiredConfigurationTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/AutowiredConfigurationTests.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd"
 	xmlns:context="http://www.springframework.org/schema/context">
 
 	<context:annotation-config/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/ImportXmlConfig-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/ImportXmlConfig-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="xmlDeclaredBean" class="org.springframework.tests.sample.beans.TestBean">
 		<constructor-arg value="xml.declared"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/ImportXmlWithAopNamespace-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/ImportXmlWithAopNamespace-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="proxiedXmlBean" class="org.springframework.tests.sample.beans.TestBean"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/ImportXmlWithConfigurationClass-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/ImportXmlWithConfigurationClass-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="otherConfigClass" class="org.springframework.context.annotation.configuration.ImportResourceTests$ImportXmlConfig"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/SecondLevelSubConfig-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/SecondLevelSubConfig-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="secondLevelXmlDeclaredBean" class="java.lang.Object"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/ValueInjectionTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/ValueInjectionTests.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd"
 	xmlns:context="http://www.springframework.org/schema/context">
 
 	<context:annotation-config/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/annotation-config.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/annotation-config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd"
 	xmlns:context="http://www.springframework.org/schema/context">
 
 	<context:annotation-config/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/configuration/aspectj-autoproxy-config.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/configuration/aspectj-autoproxy-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+	   xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
 		>
 
 	<aop:aspectj-autoproxy proxy-target-class="true"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/customAnnotationUsedForBothComponentScanAndQualifierTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/customAnnotationUsedForBothComponentScanAndQualifierTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-				http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 				http://www.springframework.org/schema/context
-				http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+				https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation" use-default-filters="false">
 		<context:include-filter type="annotation" expression="org.springframework.context.annotation.ComponentScanParserTests$CustomAnnotation"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/customNameGeneratorTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/customNameGeneratorTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="test, example.scannable"
 	    name-generator="org.springframework.context.annotation.TestBeanNameGenerator"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/customScopeResolverTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/customScopeResolverTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable"
 	    scope-resolver="org.springframework.context.annotation.TestScopeMetadataResolver"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/customTypeFilterTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/customTypeFilterTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-				http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 				http://www.springframework.org/schema/context
-				http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+				https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation" use-default-filters="false">
 		<context:include-filter type="custom" expression="org.springframework.context.annotation.ComponentScanParserTests$CustomTypeFilter"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireByNameTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireByNameTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
         default-autowire="byName">
 
 	<context:component-scan base-package="org.springframework.context.annotation"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireByTypeTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireByTypeTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
         default-autowire="byType">
 
 	<context:component-scan base-package="org.springframework.context.annotation"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireConstructorTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireConstructorTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
         default-autowire="constructor">
 
 	<context:component-scan base-package="org.springframework.context.annotation"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireNoTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireNoTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
         default-autowire="no">
 
 	<context:component-scan base-package="org.springframework.context.annotation"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultInitAndDestroyMethodsTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultInitAndDestroyMethodsTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
     default-init-method="init" default-destroy-method="destroy">
 
 	<context:component-scan base-package="org.springframework.context.annotation"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultLazyInitFalseTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultLazyInitFalseTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
         default-lazy-init="false">
 
 	<context:component-scan base-package="org.springframework.context.annotation"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultLazyInitTrueTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultLazyInitTrueTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
         default-lazy-init="true">
 
 	<context:component-scan base-package="org.springframework.context.annotation"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultNonExistingInitAndDestroyMethodsTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultNonExistingInitAndDestroyMethodsTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:context="http://www.springframework.org/schema/context"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
     default-init-method="myInit" default-destroy-method="myDestroy">
 
 	<context:component-scan base-package="org.springframework.context.annotation"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultWithNoOverridesTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultWithNoOverridesTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
             use-default-filters="false"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/doubleScanTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/doubleScanTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/invalidClassNameScopeResolverTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/invalidClassNameScopeResolverTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
 	    scope-resolver="not.a.valid.classname"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/invalidConstructorNameGeneratorTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/invalidConstructorNameGeneratorTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
 	    name-generator="org.springframework.context.annotation.InvalidConstructorBeanNameGenerator"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/matchingResourcePatternTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/matchingResourcePatternTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example."
                             resource-pattern="**/scannable/*.class"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/multipleConstructors.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/multipleConstructors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.context.annotation.Spr16022Tests.MultipleConstructorsTestBean" name="bean1">
 		<constructor-arg value="0" type="int" />

--- a/spring-context/src/test/resources/org/springframework/context/annotation/nonMatchingResourcePatternTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/nonMatchingResourcePatternTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework."
                             resource-pattern="**/thispackagedoesnotexist/*.class"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyDefaultTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyDefaultTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable" use-default-filters="false">
 		<context:include-filter type="assignable" expression="example.scannable.ScopedProxyTestBean"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyInterfacesTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyInterfacesTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable" use-default-filters="false" scoped-proxy="interfaces">
 		<context:include-filter type="assignable" expression="example.scannable.ScopedProxyTestBean"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyInvalidConfigTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyInvalidConfigTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
 			use-default-filters="false" scoped-proxy="interfaces"

--- a/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyNoTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyNoTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable"
 			use-default-filters="false" scoped-proxy="no">

--- a/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyTargetClassTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/scopedProxyTargetClassTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable" use-default-filters="false" scoped-proxy="targetClass">
 		<context:include-filter type="assignable" expression="example.scannable.ScopedProxyTestBean"/>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/simpleConfigTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/simpleConfigTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:annotation-config/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/simpleScanTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/simpleScanTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/annotation/spr10546/importedResource.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/spr10546/importedResource.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="myBean" class="java.lang.String" c:_0="myBean"/>
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-location-placeholder.xml
+++ b/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-location-placeholder.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.3.xsd">
 
 	<context:property-placeholder location="${properties}" file-encoding="ISO-8859-1" trim-values="true"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-location.xml
+++ b/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-location.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.3.xsd">
 
 	<context:property-placeholder
 			location="classpath*:/org/springframework/context/config/test-*.properties,classpath*:/org/springframework/context/config/empty-*.properties,classpath*:/org/springframework/context/config/missing-*.properties"

--- a/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-override.xml
+++ b/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-override.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xmlns:util="http://www.springframework.org/schema/util" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd">
+	   xmlns:util="http://www.springframework.org/schema/util" xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.2.xsd
+				http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-4.2.xsd">
 
 	<util:properties id="overrideProps">
 		<prop key="date.minutes">42</prop>

--- a/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-replace-ignore.xml
+++ b/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-replace-ignore.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:util="http://www.springframework.org/schema/util"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.2.xsd
+				http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-4.2.xsd">
 
 	<util:properties id="placeholderProps">
 		<prop key="foo">bar</prop>

--- a/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-replace.xml
+++ b/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-replace.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:util="http://www.springframework.org/schema/util"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.2.xsd
+				http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-4.2.xsd">
 
 	<util:properties id="placeholderProps">
 		<prop key="foo">bar</prop>

--- a/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-system.xml
+++ b/spring-context/src/test/resources/org/springframework/context/config/contextNamespaceHandlerTests-system.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.2.xsd
+				http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-4.2.xsd">
 
 	<util:properties id="placeholderProps">
 		<prop key="foo">bar</prop>

--- a/spring-context/src/test/resources/org/springframework/context/conversionservice/conversionService.xml
+++ b/spring-context/src/test/resources/org/springframework/context/conversionservice/conversionService.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean">
 		<property name="converters">

--- a/spring-context/src/test/resources/org/springframework/context/event/simple-event-configuration.xml
+++ b/spring-context/src/test/resources/org/springframework/context/event/simple-event-configuration.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/context
-	   http://www.springframework.org/schema/context/spring-context.xsd">
+	   https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:annotation-config/>
 

--- a/spring-context/src/test/resources/org/springframework/context/groovy/test.xml
+++ b/spring-context/src/test/resources/org/springframework/context/groovy/test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="foo" class="java.lang.String">
 		<constructor-arg value="hello"/>

--- a/spring-context/src/test/resources/org/springframework/context/support/ClassPathXmlApplicationContextTests-resource.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/ClassPathXmlApplicationContextTests-resource.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<import resource="ClassPathXmlApplicationContextTests-resourceIm*.xml"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/ClassPathXmlApplicationContextTests-resourceImport.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/ClassPathXmlApplicationContextTests-resourceImport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/GenericXmlApplicationContextTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/GenericXmlApplicationContextTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="testBean" class="java.lang.Object"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/aliasForParent.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/aliasForParent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/aliasThatOverridesParent.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/aliasThatOverridesParent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/childWithProxy.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/childWithProxy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/classWithPlaceholder.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/classWithPlaceholder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/conversionService.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/conversionService.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/conversionServiceWithResourceOverriding.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/conversionServiceWithResourceOverriding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/invalidClass.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/invalidClass.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/invalidValueType.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/invalidValueType.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/lifecycleTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/lifecycleTests.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+        https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
   <bean id="bean4" class="org.springframework.context.support.LifecycleTestBean" depends-on="bean2"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/messages_de_DE.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/messages_de_DE.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<!DOCTYPE properties SYSTEM "https://java.sun.com/dtd/properties.dtd">
 
 <properties version="1.0">
 

--- a/spring-context/src/test/resources/org/springframework/context/support/simpleContext.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/simpleContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/simpleThreadScopeTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/simpleThreadScopeTests.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+                https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean class="org.springframework.beans.factory.config.CustomScopeConfigurer">
 		<property name="scopes">

--- a/spring-context/src/test/resources/org/springframework/context/support/spr7283.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/spr7283.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:util="http://www.springframework.org/schema/util"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
 	<bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/spr7816.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/spr7816.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/test/aliased-contextC.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/test/aliased-contextC.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:property-placeholder location="org/springframework/context/support/placeholder.properties"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/test/contextA.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/test/contextA.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<import resource="import1.xml"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/test/contextB.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/test/contextB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/test/contextC.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/test/contextC.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:property-placeholder location="org/springframework/context/support/placeholder.properties"/>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/test/import1.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/test/import1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/context/support/test/subtest/import2.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/test/subtest/import2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/ejb/config/jeeNamespaceHandlerTests.xml
+++ b/spring-context/src/test/resources/org/springframework/ejb/config/jeeNamespaceHandlerTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:util="http://www.springframework.org/schema/util"
 		xmlns:jee="http://www.springframework.org/schema/jee"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-				http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-				http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.1.xsd"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+				http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+				http://www.springframework.org/schema/jee https://www.springframework.org/schema/jee/spring-jee-3.1.xsd"
 		default-lazy-init="true">
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">

--- a/spring-context/src/test/resources/org/springframework/jmx/applicationContext.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/applicationContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/annotation/annotations.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/annotation/annotations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/annotation/componentScan.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/annotation/componentScan.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:mbean-export server="server" />
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/annotation/lazyAssembling.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/annotation/lazyAssembling.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:mbean-export server="server" registration="replaceExisting"/>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/annotation/lazyNaming.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/annotation/lazyNaming.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:mbean-export server="server"/>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/interfaceAssembler.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/interfaceAssembler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/interfaceAssemblerCustom.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/interfaceAssemblerCustom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/interfaceAssemblerMapped.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/interfaceAssemblerMapped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/metadata-autodetect.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/metadata-autodetect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/metadataAssembler.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/metadataAssembler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodExclusionAssembler.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodExclusionAssembler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodExclusionAssemblerCombo.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodExclusionAssemblerCombo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodExclusionAssemblerMapped.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodExclusionAssemblerMapped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodExclusionAssemblerNotMapped.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodExclusionAssemblerNotMapped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodNameAssembler.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodNameAssembler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodNameAssemblerMapped.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/methodNameAssemblerMapped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/reflectiveAssembler.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/reflectiveAssembler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
 	<bean class="org.springframework.jmx.export.MBeanExporter" autowire="byName">
 		<property name="beans">

--- a/spring-context/src/test/resources/org/springframework/jmx/export/autodetectLazyMBeans.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/autodetectLazyMBeans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+ <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/autodetectMBeans.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/autodetectMBeans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+ <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/autodetectNoMBeans.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/autodetectNoMBeans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+ <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/customConfigurer.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/customConfigurer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+ <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/excludedBeans.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/excludedBeans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+ <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/lazyInit.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/lazyInit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/notificationPublisherLazyTests.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/notificationPublisherLazyTests.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/notificationPublisherTests.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/notificationPublisherTests.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/propertyPlaceholderConfigurer.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/propertyPlaceholderConfigurer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/scheduling/annotation/taskNamespaceTests.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/annotation/taskNamespaceTests.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:task="http://www.springframework.org/schema/task"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 
-				http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-4.1.xsd">
+				http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task-4.1.xsd">
 
 	<!--
 	<context:load-time-weaver aspectj-weaving="on"/>

--- a/spring-context/src/test/resources/org/springframework/scheduling/config/annotationDrivenContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/config/annotationDrivenContext.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   			http://www.springframework.org/schema/beans/spring-beans.xsd
+	   			https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/task
-				http://www.springframework.org/schema/task/spring-task.xsd">
+				https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<task:annotation-driven executor="testExecutor" scheduler="testScheduler"
 							exception-handler="testExceptionHandler"/>

--- a/spring-context/src/test/resources/org/springframework/scheduling/config/executorContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/config/executorContext.xml
@@ -4,10 +4,10 @@
 	xmlns:task="http://www.springframework.org/schema/task"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd"
 	default-lazy-init="true">
 
 	<task:executor id="default"/>

--- a/spring-context/src/test/resources/org/springframework/scheduling/config/lazyScheduledTasksContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/config/lazyScheduledTasksContext.xml
@@ -3,8 +3,8 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:task="http://www.springframework.org/schema/task"
 		xsi:schemaLocation="
-			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-			http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd"
+			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd"
 		default-lazy-init="true">
 
 	<task:scheduled-tasks>

--- a/spring-context/src/test/resources/org/springframework/scheduling/config/scheduledTasksContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/config/scheduledTasksContext.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   			http://www.springframework.org/schema/beans/spring-beans.xsd
+	   			https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/task
-				http://www.springframework.org/schema/task/spring-task.xsd">
+				https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<task:scheduled-tasks scheduler="testScheduler">
 		<task:scheduled ref="testBean" method="test" fixed-rate="1000"/>

--- a/spring-context/src/test/resources/org/springframework/scheduling/config/schedulerContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/config/schedulerContext.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   			http://www.springframework.org/schema/beans/spring-beans.xsd
+	   			https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/task
-				http://www.springframework.org/schema/task/spring-task.xsd">
+				https://www.springframework.org/schema/task/spring-task.xsd">
 
 	<task:scheduler id="defaultScheduler"/>
 

--- a/spring-context/src/test/resources/org/springframework/scripting/bsh/bsh-with-xsd.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/bsh/bsh-with-xsd.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:lang="http://www.springframework.org/schema/lang"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-2.5.xsd">
 
 	<lang:bsh id="messenger" script-source="classpath:org/springframework/scripting/bsh/Messenger.bsh"
 			script-interfaces="org.springframework.scripting.Messenger"

--- a/spring-context/src/test/resources/org/springframework/scripting/bsh/bshBrokenContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/bsh/bshBrokenContext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN"
-				"http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+				"https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/bsh/bshContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/bsh/bshContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-lazy-init="true">
 

--- a/spring-context/src/test/resources/org/springframework/scripting/bsh/bshRefreshableContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/bsh/bshRefreshableContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-lazy-init="true">
 

--- a/spring-context/src/test/resources/org/springframework/scripting/config/scriptingDefaultsProxyTargetClassTests.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/config/scriptingDefaultsProxyTargetClassTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:lang="http://www.springframework.org/schema/lang"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-				http://www.springframework.org/schema/beans/spring-beans.xsd
+				https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/lang
-				http://www.springframework.org/schema/lang/spring-lang-3.1.xsd"
+				https://www.springframework.org/schema/lang/spring-lang-3.1.xsd"
 		default-autowire="byName"
 		default-init-method="startup"
 		default-destroy-method="shutdown">

--- a/spring-context/src/test/resources/org/springframework/scripting/config/scriptingDefaultsTests.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/config/scriptingDefaultsTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:lang="http://www.springframework.org/schema/lang"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-				http://www.springframework.org/schema/beans/spring-beans.xsd
+				https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/lang
-				http://www.springframework.org/schema/lang/spring-lang-3.0.xsd"
+				https://www.springframework.org/schema/lang/spring-lang-3.0.xsd"
 		default-autowire="byName"
 		default-init-method="startup"
 		default-destroy-method="shutdown">

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-dynamic-context.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-dynamic-context.xml
@@ -3,9 +3,9 @@
 	   xmlns:lang="http://www.springframework.org/schema/lang"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-						http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-						http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+						http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+						http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
 
     <aop:config >
        <aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-interface-context.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-interface-context.xml
@@ -3,9 +3,9 @@
 	   xmlns:lang="http://www.springframework.org/schema/lang"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-						http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-						http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+						http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+						http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
 
     <aop:config >
        <aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-proxy-target-class-context.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-proxy-target-class-context.xml
@@ -3,9 +3,9 @@
 	   xmlns:lang="http://www.springframework.org/schema/lang"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-						http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-						http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+						http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+						http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
 
     <aop:config >
        <aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-java-context.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-java-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-						http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+						http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
 
     <aop:config >
        <aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/calculators-with-xsd.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/calculators-with-xsd.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:lang="http://www.springframework.org/schema/lang"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-2.0.xsd">
 
 	<lang:groovy id="calculator"
 		script-source="classpath:org/springframework/scripting/groovy/Calculator.groovy"

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/calculators.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/calculators.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-multiple-properties.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-multiple-properties.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:lang="http://www.springframework.org/schema/lang"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-2.5.xsd">
 
 	<lang:groovy id="bean" script-source="classpath:org/springframework/scripting/groovy/ScriptBean.groovy" autowire="byType">
 		<lang:property name="name" value="Sophie Marceau"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-with-xsd-jsr223.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-with-xsd-jsr223.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:lang="http://www.springframework.org/schema/lang"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-4.2.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-4.2.xsd">
 
 	<lang:std id="messenger" script-source="classpath:org/springframework/scripting/groovy/Messenger.groovy">
 		<lang:property name="message" value="Hello World!"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-with-xsd-proxy-target-class.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-with-xsd-proxy-target-class.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:lang="http://www.springframework.org/schema/lang"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
 
 	<lang:groovy id="refreshableMessenger" refresh-check-delay="5000" proxy-target-class="true"
 			script-source="classpath:org/springframework/scripting/groovy/Messenger.groovy">

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-with-xsd.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-with-xsd.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:lang="http://www.springframework.org/schema/lang"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-				http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+				http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-2.5.xsd">
 
 	<aop:config>
 		<aop:aspect ref="getMessageAspect">

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyBrokenContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyBrokenContext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN"
-				"http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+				"https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyContext.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:lang="http://www.springframework.org/schema/lang"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-				http://www.springframework.org/schema/beans/spring-beans.xsd
+				https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/lang
-				http://www.springframework.org/schema/lang/spring-lang.xsd"
+				https://www.springframework.org/schema/lang/spring-lang.xsd"
  		default-lazy-init="true">
 
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyContextWithJsr223.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyContextWithJsr223.xml
@@ -3,7 +3,7 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:lang="http://www.springframework.org/schema/lang"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-				http://www.springframework.org/schema/beans/spring-beans.xsd"
+				https://www.springframework.org/schema/beans/spring-beans.xsd"
  		default-lazy-init="true">
 
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyRefreshableContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyRefreshableContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans default-lazy-init="true">
 

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/lwspBadGroovyContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/lwspBadGroovyContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
 
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/twoClassesCorrectOneFirst.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/twoClassesCorrectOneFirst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
 
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/twoClassesWrongOneFirst.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/twoClassesWrongOneFirst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
 
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/support/groovyReferences.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/support/groovyReferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/scripting/support/jsr223-with-xsd.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/support/jsr223-with-xsd.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:lang="http://www.springframework.org/schema/lang"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-4.2.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-4.2.xsd">
 
 	<lang:std id="messengerWithInterface" script-source="classpath:org/springframework/scripting/support/Messenger.js"
 			  script-interfaces="org.springframework.scripting.Messenger"/>

--- a/spring-core/src/test/resources/org/springframework/core/io/example.xml
+++ b/spring-core/src/test/resources/org/springframework/core/io/example.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<!DOCTYPE properties SYSTEM "https://java.sun.com/dtd/properties.dtd">
 <properties version="1.0">
 	<entry key="foo">bar</entry>
 </properties>

--- a/spring-jdbc/src/main/resources/org/springframework/jdbc/support/sql-error-codes.xml
+++ b/spring-jdbc/src/main/resources/org/springframework/jdbc/support/sql-error-codes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	- Default SQL error codes for well-known databases.
@@ -83,7 +83,7 @@
 		</property>
 	</bean>
 
-	<!-- http://help.sap.com/saphelp_hanaplatform/helpdata/en/20/a78d3275191014b41bae7c4a46d835/content.htm -->
+	<!-- https://help.sap.com/saphelp_hanaplatform/helpdata/en/20/a78d3275191014b41bae7c4a46d835/content.htm -->
 	<bean id="HDB" name="Hana" class="org.springframework.jdbc.support.SQLErrorCodes">
 		<property name="databaseProductNames">
 			<list>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-custom-separator.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-custom-separator.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.3.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.3.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL" separator="@@">
 		<jdbc:script location="classpath:org/springframework/jdbc/config/db-schema.sql" separator=";"/>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-db-name-default-and-anonymous-datasource.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-db-name-default-and-anonymous-datasource.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
 
 	<jdbc:embedded-database>
 		<jdbc:script location="classpath:org/springframework/jdbc/config/db-schema.sql" />

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-db-name-explicit.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-db-name-explicit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns:beans="http://www.springframework.org/schema/beans" xmlns="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
 
 	<embedded-database id="dataSource" database-name="customDbName">
 		<script location="classpath:org/springframework/jdbc/config/db-schema.sql" />

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-db-name-generated.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-db-name-generated.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns:beans="http://www.springframework.org/schema/beans" xmlns="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
 
 	<embedded-database id="dataSource" database-name="shouldBeOverriddenByGeneratedName" generate-name="true">
 		<script location="classpath:org/springframework/jdbc/config/db-schema.sql" />

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-db-name-implicit.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-db-name-implicit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns:beans="http://www.springframework.org/schema/beans" xmlns="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
 
 	<embedded-database id="dataSource">
 		<script location="classpath:org/springframework/jdbc/config/db-schema.sql" />

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-multiple-datasources.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-multiple-datasources.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<jdbc:embedded-database id="firstDataSource" />
 	<jdbc:embedded-database id="secondDataSource" />

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-pattern.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-pattern.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL">
 		<jdbc:script location="classpath:org/springframework/jdbc/config/db-schema.sql"/>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL">
 		<jdbc:script location="classpath:org/springframework/jdbc/config/db-schema.sql" />

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-nested-config-h2.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-nested-config-h2.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="H2">
 		<jdbc:script location="classpath:org/springframework/jdbc/config/db-schema.sql" execution="INIT"/>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-nested-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-nested-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL">
 		<jdbc:script location="classpath:org/springframework/jdbc/config/db-schema.sql" execution="INIT"/>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-cache-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-cache-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-custom-separator.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-custom-separator.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.3.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.3.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-endings-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-endings-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-endings-nested-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-endings-nested-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL">
 		<jdbc:script location="classpath:org/springframework/jdbc/config/db-schema.sql" encoding="ISO-8859-1"/>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-expression-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-expression-config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL" />
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-fail-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-fail-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-pattern-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-pattern-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-placeholder-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-placeholder-config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="HSQL" />
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/object/GenericSqlQueryTests-context.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/object/GenericSqlQueryTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.5.xsd">
 
 	<bean id="dataSource" class="org.springframework.jdbc.datasource.TestDataSourceWrapper"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/object/GenericStoredProcedureTests-context.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/object/GenericStoredProcedureTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.5.xsd">
 
 	<bean id="dataSource" class="org.springframework.jdbc.datasource.TestDataSourceWrapper"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/support/custom-error-codes.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/support/custom-error-codes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/support/test-custom-translators-context.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/support/test-custom-translators-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="H2"/>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/support/test-error-codes.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/support/test-error-codes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/support/wildcard-error-codes.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/support/wildcard-error-codes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-custom-container-factory.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-custom-container-factory.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
 
 	<jms:annotation-driven container-factory="simpleFactory"/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-custom-handler-method-factory.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-custom-handler-method-factory.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
 
 	<jms:annotation-driven handler-method-factory="customMessageHandlerMethodFactory"/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-custom-registry.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-custom-registry.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
 
 	<jms:annotation-driven registry="customRegistry"/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-default-container-factory.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-default-container-factory.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
 
 	<jms:annotation-driven/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-full-config.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-full-config.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
 
 	<jms:annotation-driven/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-full-configurable-config.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-full-configurable-config.xml
@@ -4,11 +4,11 @@
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd
 	   http://www.springframework.org/schema/context
-	   http://www.springframework.org/schema/context/spring-context.xsd">
+	   https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<jms:annotation-driven/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-jms-listener-repeatable.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-jms-listener-repeatable.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
 
 	<jms:annotation-driven/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-jms-listeners.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-jms-listeners.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
 
 	<jms:annotation-driven/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-sample-config.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/annotation/annotation-driven-sample-config.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:jms="http://www.springframework.org/schema/jms"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/jms
-	   http://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
+	   https://www.springframework.org/schema/jms/spring-jms-4.1.xsd">
 
 	<jms:annotation-driven/>
 

--- a/spring-jms/src/test/resources/org/springframework/jms/config/jmsNamespaceHandlerTests.xml
+++ b/spring-jms/src/test/resources/org/springframework/jms/config/jmsNamespaceHandlerTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:jms="http://www.springframework.org/schema/jms"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/jms http://www.springframework.org/schema/jms/spring-jms-4.2.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/jms https://www.springframework.org/schema/jms/spring-jms-4.2.xsd">
 
 	<jms:listener-container factory-id="testJmsFactory"
 			connection-factory="testConnectionFactory" task-executor="testTaskExecutor"

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/domain/persistence-context.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/domain/persistence-context.xml
@@ -1,5 +1,5 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="Person" transaction-type="RESOURCE_LOCAL">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/domain/persistence-multi.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/domain/persistence-multi.xml
@@ -1,5 +1,5 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="Drivers" transaction-type="RESOURCE_LOCAL">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/domain/persistence.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/domain/persistence.xml
@@ -1,5 +1,5 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="Person" transaction-type="RESOURCE_LOCAL">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/eclipselink/eclipselink-manager.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/eclipselink/eclipselink-manager.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/hibernate-manager-multi.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/hibernate-manager-multi.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:annotation-config/>
 

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/hibernate-manager-native.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/hibernate-manager-native.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="entityManagerFactory" name="Person" class="org.springframework.orm.hibernate5.LocalSessionFactoryBean" primary="true">
 		<property name="annotatedClasses">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/hibernate-manager.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/hibernate-manager.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean" primary="true">
 		<property name="persistenceXmlLocation" value="org/springframework/orm/jpa/domain/persistence-context.xml"/>

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/inject-hibernate-spring-bean-container-tests.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/inject-hibernate-spring-bean-container-tests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<bean id="single" class="org.springframework.orm.jpa.hibernate.beans.SinglePrototypeInSpringContextTestBean" scope="prototype">
 		<property name="source" value="SPRING" />

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/inject.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/inject.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:annotation-config/>
 

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/memdb.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/memdb.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/multi-jpa-emf.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/multi-jpa-emf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-complex.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-complex.xml
@@ -1,6 +1,6 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="pu1" transaction-type="RESOURCE_LOCAL">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example1.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example1.xml
@@ -1,7 +1,7 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
-          http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+          https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="OrderManagement" />

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example2.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example2.xml
@@ -1,6 +1,6 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="OrderManagement2">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example3.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example3.xml
@@ -1,6 +1,6 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="OrderManagement3">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example4.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example4.xml
@@ -1,6 +1,6 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="OrderManagement4"

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example5.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example5.xml
@@ -1,6 +1,6 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="OrderManagement5">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example6.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example6.xml
@@ -1,6 +1,6 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="pu">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-exclude-1.0.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-exclude-1.0.xml
@@ -1,7 +1,7 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
-          http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+          https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 			 version="1.0">
 
 	<persistence-unit name="NoExcludeElement" />

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-exclude-2.0.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-exclude-2.0.xml
@@ -1,7 +1,7 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
-          http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+          https://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
 			 version="2.0">
 
 	<persistence-unit name="NoExcludeElement" />

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-invalid.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-invalid.xml
@@ -1,6 +1,6 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit/>

--- a/spring-oxm/src/test/resources/org/springframework/oxm/config/oxmNamespaceHandlerTest.xml
+++ b/spring-oxm/src/test/resources/org/springframework/oxm/config/oxmNamespaceHandlerTest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oxm="http://www.springframework.org/schema/oxm"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/oxm http://www.springframework.org/schema/oxm/spring-oxm.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/oxm https://www.springframework.org/schema/oxm/spring-oxm.xsd">
 
 	<!-- JAXB2 -->
 	<oxm:jaxb2-marshaller id="jaxb2ContextPathMarshaller" context-path="org.springframework.oxm.jaxb.test"/>

--- a/spring-test/src/test/resources/META-INF/web-resources/WEB-INF/layouts/tiles.xml
+++ b/spring-test/src/test/resources/META-INF/web-resources/WEB-INF/layouts/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN" "http://tiles.apache.org/dtds/tiles-config_3_0.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN" "https://tiles.apache.org/dtds/tiles-config_3_0.dtd">
 <tiles-definitions>
 	<definition name="standardLayout" templateExpression="/WEB-INF/layouts/standardLayout.jsp"/>
 </tiles-definitions>

--- a/spring-test/src/test/resources/META-INF/web-resources/WEB-INF/views/tiles.xml
+++ b/spring-test/src/test/resources/META-INF/web-resources/WEB-INF/views/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN" "http://tiles.apache.org/dtds/tiles-config_3_0.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN" "https://tiles.apache.org/dtds/tiles-config_3_0.dtd">
 <tiles-definitions>
 	<definition name="home" extends="standardLayout">
 		<put-attribute name="main" value="/WEB-INF/views/home.jsp" />

--- a/spring-test/src/test/resources/org/springframework/test/context/expression/ExpressionUsageTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/expression/ExpressionUsageTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="properties"
 		class="org.springframework.beans.factory.config.PropertiesFactoryBean">

--- a/spring-test/src/test/resources/org/springframework/test/context/groovy/DefaultScriptDetectionXmlSupersedesGroovySpringContextTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/groovy/DefaultScriptDetectionXmlSupersedesGroovySpringContextTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="foo" class="java.lang.String">
 		<constructor-arg value="Foo" />

--- a/spring-test/src/test/resources/org/springframework/test/context/groovy/contextB.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/groovy/contextB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="employee" class="org.springframework.tests.sample.beans.Employee">
 		<property name="name" value="Dilbert" />

--- a/spring-test/src/test/resources/org/springframework/test/context/hierarchies/standard/SingleTestClassWithTwoLevelContextHierarchyAndMixedConfigTypesTests-ChildConfig.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/hierarchies/standard/SingleTestClassWithTwoLevelContextHierarchyAndMixedConfigTypesTests-ChildConfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="bar" class="java.lang.String" c:_="bar" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/hierarchies/standard/TestHierarchyLevelTwoWithSingleLevelContextHierarchyAndMixedConfigTypesTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/hierarchies/standard/TestHierarchyLevelTwoWithSingleLevelContextHierarchyAndMixedConfigTypesTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="foo" class="java.lang.String" c:_="foo-level-2" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/hierarchies/web/DispatcherWacRootWacEarTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/hierarchies/web/DispatcherWacRootWacEarTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="dispatcher" class="java.lang.String" c:_="dispatcher" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/ConcreteTransactionalJUnit4SpringContextTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/ConcreteTransactionalJUnit4SpringContextTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="transactionalTests-context.xml" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/FailingBeforeAndAfterMethodsTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/FailingBeforeAndAfterMethodsTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<jdbc:embedded-database id="dataSource" generate-name="true" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/MultipleResourcesSpringJUnit4ClassRunnerAppCtxTests-context1.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/MultipleResourcesSpringJUnit4ClassRunnerAppCtxTests-context1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="employee" class="org.springframework.tests.sample.beans.Employee">
 		<property name="name" value="John Smith" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/MultipleResourcesSpringJUnit4ClassRunnerAppCtxTests-context2.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/MultipleResourcesSpringJUnit4ClassRunnerAppCtxTests-context2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="pet" class="org.springframework.tests.sample.beans.Pet">
 		<constructor-arg value="Fido" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/MultipleResourcesSpringJUnit4ClassRunnerAppCtxTests-context3.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/MultipleResourcesSpringJUnit4ClassRunnerAppCtxTests-context3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="foo" class="java.lang.String">
 		<constructor-arg value="Foo" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/ParameterizedDependencyInjectionTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/ParameterizedDependencyInjectionTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="employee1" class="org.springframework.tests.sample.beans.Employee">
 		<property name="name" value="John Smith" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/SpringJUnit4ClassRunnerAppCtxTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/SpringJUnit4ClassRunnerAppCtxTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="employee" class="org.springframework.tests.sample.beans.Employee">
 		<property name="name" value="John Smith" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/aci/xml/MultipleInitializersXmlConfigTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/aci/xml/MultipleInitializersXmlConfigTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="foo" class="java.lang.String">
 		<constructor-arg value="foo" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/hybrid/HybridContextLoaderTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/hybrid/HybridContextLoaderTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="fooFromXml" class="java.lang.String" c:_="XML" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/orm/HibernateSessionFlushingTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/orm/HibernateSessionFlushingTests-context.xml
@@ -3,10 +3,10 @@
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
 	<context:component-scan base-package="org.springframework.test.context.junit4.orm"/>
 

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/orm/domain/DriversLicense.hbm.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/orm/domain/DriversLicense.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
-		"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+		"https://hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping auto-import="true" default-lazy="false">
 

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/orm/domain/Person.hbm.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/orm/domain/Person.hbm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
-		"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+		"https://hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping auto-import="true" default-lazy="false">
 

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/profile/importresource/import.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/profile/importresource/import.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<beans profile="dev">
 		<bean id="employee" class="org.springframework.tests.sample.beans.Employee">

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/profile/xml/DefaultProfileXmlConfigTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/profile/xml/DefaultProfileXmlConfigTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="pet" class="org.springframework.tests.sample.beans.Pet">
 		<constructor-arg value="Fido" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/spr3896/BeanOverridingDefaultLocationsInheritedTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/spr3896/BeanOverridingDefaultLocationsInheritedTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="employee" class="org.springframework.tests.sample.beans.Employee">
 		<property name="name" value="Yoda" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/spr3896/DefaultLocationsBaseTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/spr3896/DefaultLocationsBaseTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="employee" class="org.springframework.tests.sample.beans.Employee">
 		<property name="name" value="John Smith" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/spr3896/DefaultLocationsInheritedTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/spr3896/DefaultLocationsInheritedTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="pet" class="org.springframework.tests.sample.beans.Pet">
 		<constructor-arg value="Fido" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/spr6128/AutowiredQualifierTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/spr6128/AutowiredQualifierTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean id="foo" class="java.lang.String">
 		<constructor-arg value="normal" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/spr8849/datasource-config-with-auto-generated-db-name.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/spr8849/datasource-config-with-auto-generated-db-name.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
 
 	<jdbc:embedded-database id="dataSource" generate-name="true">
 		<jdbc:script location="classpath:/org/springframework/test/context/junit4/spr8849/spr8849-schema.sql" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/spr8849/datasource-config.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/spr8849/datasource-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd">
 
 	<jdbc:embedded-database id="dataSource" database-name="#{T(java.util.UUID).randomUUID().toString()}">
 		<jdbc:script location="classpath:/org/springframework/test/context/junit4/spr8849/spr8849-schema.sql" />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/spr9799/Spr9799XmlConfigTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/spr9799/Spr9799XmlConfigTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<mvc:annotation-driven />
 	<mvc:default-servlet-handler />

--- a/spring-test/src/test/resources/org/springframework/test/context/junit4/transactionalTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/junit4/transactionalTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<jdbc:embedded-database id="dataSource" generate-name="true">
 		<jdbc:script location="classpath:/org/springframework/test/jdbc/schema.sql"/>

--- a/spring-test/src/test/resources/org/springframework/test/context/support/AbstractContextConfigurationUtilsTests$BareAnnotations-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/support/AbstractContextConfigurationUtilsTests$BareAnnotations-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<!-- intentionally empty: only needed so that the ContextLoader can find this file -->
 

--- a/spring-test/src/test/resources/org/springframework/test/context/support/CustomizedGenericXmlContextLoaderTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/support/CustomizedGenericXmlContextLoaderTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<!-- intentionally empty: only needed so that the ContextLoader can load a file -->
 

--- a/spring-test/src/test/resources/org/springframework/test/context/support/DelegatingSmartContextLoaderTests$ImproperDuplicateDefaultXmlAndConfigClassTestCase-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/support/DelegatingSmartContextLoaderTests$ImproperDuplicateDefaultXmlAndConfigClassTestCase-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<!-- intentionally empty: we just need the file to be present to fail the test -->
 

--- a/spring-test/src/test/resources/org/springframework/test/context/support/DelegatingSmartContextLoaderTests$XmlTestCase-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/support/DelegatingSmartContextLoaderTests$XmlTestCase-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="foo" class="java.lang.String" c:_="foo" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/support/GenericXmlContextLoaderResourceLocationsTests$1ClasspathExistentDefaultLocationsTestCase-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/support/GenericXmlContextLoaderResourceLocationsTests$1ClasspathExistentDefaultLocationsTestCase-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<!-- intentionally empty: only needed so that the ContextLoader can find this file -->
 

--- a/spring-test/src/test/resources/org/springframework/test/context/testng/ConcreteTransactionalTestNGSpringContextTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/testng/ConcreteTransactionalTestNGSpringContextTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
 	<bean id="employee" class="org.springframework.tests.sample.beans.Employee" p:name="John Smith" p:age="42"
 		p:company="Acme Widgets, Inc." />

--- a/spring-test/src/test/resources/org/springframework/test/context/testng/DirtiesContextTransactionalTestNGSpringContextTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/testng/DirtiesContextTransactionalTestNGSpringContextTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
 	<jdbc:embedded-database id="dataSource" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/testng/FailingBeforeAndAfterMethodsTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/testng/FailingBeforeAndAfterMethodsTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
 	<jdbc:embedded-database id="dataSource" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/testng/TimedTransactionalTestNGSpringContextTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/testng/TimedTransactionalTestNGSpringContextTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
 	<jdbc:embedded-database id="dataSource" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/testng/transaction/ejb/testng-package.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/testng/transaction/ejb/testng-package.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 
 <suite name="EJB-TX-Package" verbose="1">
 	<test name="Package">

--- a/spring-test/src/test/resources/org/springframework/test/context/testng/transaction/ejb/testng-test-separate.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/testng/transaction/ejb/testng-test-separate.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 
 <suite name="EJB-TX-Separate" verbose="1">
 	<test name="RollbackForRequiredEjbTxDaoTestNGTests">

--- a/spring-test/src/test/resources/org/springframework/test/context/testng/transaction/ejb/testng-test-together.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/testng/transaction/ejb/testng-test-together.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 
 <suite name="EJB-TX-Together" verbose="1">
 	<test name="Together">

--- a/spring-test/src/test/resources/org/springframework/test/context/transaction/ejb/common-config.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/transaction/ejb/common-config.xml
@@ -2,10 +2,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" default-lazy-init="true" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 
 	<context:annotation-config />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/transaction/ejb/required-tx-config.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/transaction/ejb/required-tx-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="common-config.xml" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/transaction/ejb/requires-new-tx-config.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/transaction/ejb/requires-new-tx-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="common-config.xml" />
 

--- a/spring-test/src/test/resources/org/springframework/test/context/web/BasicXmlWacTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/web/BasicXmlWacTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:c="http://www.springframework.org/schema/c" xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="foo" class="java.lang.String" c:_="bar">
 		<qualifier value="foo" />

--- a/spring-test/src/test/resources/org/springframework/test/context/web/RequestAndSessionScopedBeansWacTests-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/context/web/RequestAndSessionScopedBeansWacTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="requestScopedTestBean" class="org.springframework.tests.sample.beans.TestBean" scope="request">
 		<property name="name" value="#{request.contextPath}" />

--- a/spring-test/src/test/resources/org/springframework/test/web/servlet/samples/context/root-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/web/servlet/samples/context/root-context.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="
 		http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="personDao" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.test.web.servlet.samples.context.PersonDao" />

--- a/spring-test/src/test/resources/org/springframework/test/web/servlet/samples/context/servlet-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/web/servlet/samples/context/servlet-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mvc="http://www.springframework.org/schema/mvc"
     xsi:schemaLocation="
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
     <mvc:annotation-driven />
 

--- a/spring-test/src/test/webapp/WEB-INF/layouts/tiles.xml
+++ b/spring-test/src/test/webapp/WEB-INF/layouts/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "https://tiles.apache.org/dtds/tiles-config_2_1.dtd">
 
 <tiles-definitions>
 

--- a/spring-test/src/test/webapp/WEB-INF/views/tiles.xml
+++ b/spring-test/src/test/webapp/WEB-INF/views/tiles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN" "https://tiles.apache.org/dtds/tiles-config_2_1.dtd">
 
 <tiles-definitions>
 

--- a/spring-tx/src/main/resources/org/springframework/jca/context/ra.xml
+++ b/spring-tx/src/main/resources/org/springframework/jca/context/ra.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <connector xmlns="http://java.sun.com/xml/ns/j2ee"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd"
+		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee https://java.sun.com/xml/ns/j2ee/connector_1_5.xsd"
 		version="1.5">
 	<vendor-name>Spring Framework</vendor-name>
 	<eis-type>Spring Connector</eis-type>

--- a/spring-tx/src/test/resources/org/springframework/transaction/annotation/annotationTransactionNamespaceHandlerTests.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/annotation/annotationTransactionNamespaceHandlerTests.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:tx="http://www.springframework.org/schema/tx"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+       http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
 
 	<tx:annotation-driven order="#{ T(java.lang.Integer).MAX_VALUE }"/>
 

--- a/spring-tx/src/test/resources/org/springframework/transaction/config/annotationDrivenConfigurationClassTests.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/config/annotationDrivenConfigurationClassTests.xml
@@ -3,10 +3,10 @@
        xmlns:aop="http://www.springframework.org/schema/aop"
 	   xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-       		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-       		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
-       		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+       		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+       		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd
+       		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
 
 	<context:annotation-config/>
 

--- a/spring-tx/src/test/resources/org/springframework/transaction/config/annotationDrivenProxyTargetClassTests.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/config/annotationDrivenProxyTargetClassTests.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
 
 	<tx:annotation-driven proxy-target-class="true" order="0"/>
 

--- a/spring-tx/src/test/resources/org/springframework/transaction/interceptor/noTransactionAttributeSource.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/interceptor/noTransactionAttributeSource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-tx/src/test/resources/org/springframework/transaction/interceptor/transactionalBeanFactory.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/interceptor/transactionalBeanFactory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-tx/src/test/resources/org/springframework/transaction/txNamespaceHandlerTests.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/txNamespaceHandlerTests.xml
@@ -3,9 +3,9 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
 		xmlns:tx="http://www.springframework.org/schema/tx"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-				http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+				http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
 
 	<aop:config>
 		<aop:advisor pointcut="execution(* *..ITestBean.*(..))" advice-ref="txAdvice"/>

--- a/spring-web/src/main/resources/META-INF/web-fragment.xml
+++ b/spring-web/src/main/resources/META-INF/web-fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <web-fragment xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd"
 	version="3.0" metadata-complete="true">
 
 	<name>spring_web</name>

--- a/spring-web/src/test/resources/org/springframework/http/converter/feed/atom.xml
+++ b/spring-web/src/test/resources/org/springframework/http/converter/feed/atom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.w3.org/2005/Atom http://www.kbcafe.com/rss/atom.xsd.xml">
+      xsi:schemaLocation="http://www.w3.org/2005/Atom https://www.kbcafe.com/rss/atom.xsd.xml">
     <title>title</title>
     <subtitle>subtitle</subtitle>
     <entry>

--- a/spring-web/src/test/resources/org/springframework/http/converter/feed/rss.xml
+++ b/spring-web/src/test/resources/org/springframework/http/converter/feed/rss.xml
@@ -2,7 +2,7 @@
 <rss version="2.0">
     <channel>
         <title>title</title>
-        <link>http://example.com</link>
+        <link>https://example.com</link>
         <description>description</description>
         <item>
             <title>title1</title>

--- a/spring-web/src/test/resources/org/springframework/web/context/request/requestScopeTests.xml
+++ b/spring-web/src/test/resources/org/springframework/web/context/request/requestScopeTests.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+                https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean id="requestScopedObject" class="org.springframework.tests.sample.beans.TestBean" scope="request">
         <property name="name" value="#{request.contextPath}"/>

--- a/spring-web/src/test/resources/org/springframework/web/context/request/requestScopedProxyTests.xml
+++ b/spring-web/src/test/resources/org/springframework/web/context/request/requestScopedProxyTests.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="requestScopedObject" class="org.springframework.tests.sample.beans.TestBean" scope="request">
 		<aop:scoped-proxy/>

--- a/spring-web/src/test/resources/org/springframework/web/context/request/sessionScopeTests.xml
+++ b/spring-web/src/test/resources/org/springframework/web/context/request/sessionScopeTests.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webflux/src/test/resources/org/springframework/web/reactive/handler/map.xml
+++ b/spring-webflux/src/test/resources/org/springframework/web/reactive/handler/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">	
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">	
 	
 	<bean id="mapping" class="org.springframework.web.reactive.handler.SimpleUrlHandlerMapping">
 		<property name="mappings">

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/ContextLoaderTests-acc-context.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/ContextLoaderTests-acc-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.tests.sample.beans.TestBean">
 		<constructor-arg value="${name}"/>

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/applicationContext.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/applicationContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd" [
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd" [
 <!ENTITY contextInclude SYSTEM "org/springframework/web/context/WEB-INF/contextInclude.xml">
 ]>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/context-addition.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/context-addition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/empty-context.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/empty-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 </beans>

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/empty-servlet.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/empty-servlet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/fail.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/fail.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/resources/messageSource.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/resources/messageSource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/resources/themeSource.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/resources/themeSource.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/sessionContext.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/sessionContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/test-servlet.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/test-servlet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/testNamespace.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/testNamespace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/beans1.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/beans1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Id: beans1.xml,v 1.3 2006/08/20 19:08:40 jhoeller Exp $ -->
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/ref1.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/ref1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!-- We are only using one definition file for the purposes of this test, since we do not have multiple
 	classloaders available in the environment to allow combining multiple files of the same name, but

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/annotation/WEB-INF/tiles.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/annotation/WEB-INF/tiles.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN" "http://tiles.apache.org/dtds/tiles-config_3_0.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN" "https://tiles.apache.org/dtds/tiles-config_3_0.dtd">
 
 <tiles-definitions>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-argument-resolvers.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-argument-resolvers.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:argument-resolvers>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-async-support.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-async-support.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:async-support default-timeout="2500" task-executor="executor">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-bean-decoration.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-bean-decoration.xml
@@ -3,8 +3,8 @@
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven />
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-content-negotiation-manager.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-content-negotiation-manager.xml
@@ -3,8 +3,8 @@
 	   xmlns:mvc="http://www.springframework.org/schema/mvc"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 
 	<mvc:annotation-driven content-negotiation-manager="mvcContentNegotiationManager" />

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-cors-minimal.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-cors-minimal.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<!-- <mvc:cors /> element before <mvc:annotation-driven /> one -->
 	<mvc:cors>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-cors.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-cors.xml
@@ -2,18 +2,18 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven />
 
 	<mvc:cors>
 
-		<mvc:mapping path="/api/**" allowed-origins="http://domain1.com, http://domain2.com"
+		<mvc:mapping path="/api/**" allowed-origins="https://domain1.com, https://domain2.com"
 					 allowed-methods="GET, PUT" allowed-headers="header1, header2, header3"
 					 exposed-headers="header1, header2" allow-credentials="false" max-age="123" />
 
-		<mvc:mapping path="/resources/**" allowed-origins="http://domain1.com" />
+		<mvc:mapping path="/resources/**" allowed-origins="https://domain1.com" />
 
 	</mvc:cors>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-conversion-service.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-conversion-service.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven conversion-service="conversionService" />
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-validator.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-validator.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven validator="validator"
 		ignore-default-model-on-redirect="true" enable-matrix-variables="true" />

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-default-servlet-optional-attrs.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-default-servlet-optional-attrs.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:default-servlet-handler default-servlet-name="custom" />
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-default-servlet.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-default-servlet.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:default-servlet-handler />
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-interceptors.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-interceptors.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven />
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-codes-resolver.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-codes-resolver.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven message-codes-resolver="messageCodesResolver"/>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-converters-defaults-off.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-converters-defaults-off.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:message-converters register-defaults="false">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-converters.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-converters.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:message-converters>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-path-matching-mappings.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-path-matching-mappings.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
     <mvc:resources mapping="/resources/**" location="/, classpath:/META-INF/" />
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-path-matching.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-path-matching.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
     <mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
         <mvc:path-matching

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-chain-no-auto.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-chain-no-auto.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:resources mapping="/resources/**" location="/, classpath:/META-INF/">
 		<mvc:cache-control max-age="3600" s-maxage="1800" cache-public="true"/>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-chain.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-chain.xml
@@ -18,8 +18,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="properties">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-optional-attrs.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-optional-attrs.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:resources mapping="/resources/**" location="/, classpath:/META-INF/" cache-period="3600" order="5"/>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven />
 	<mvc:resources mapping="/resources/**" location="/, classpath:/META-INF/" />

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-return-value-handlers.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-return-value-handlers.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:return-value-handlers>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-controllers-minimal.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-controllers-minimal.xml
@@ -3,8 +3,8 @@
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:view-controller path="/path" view-name="home"/>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-controllers.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-controllers.xml
@@ -3,8 +3,8 @@
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven/>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution-content-negotiation.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution-content-negotiation.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xsi:schemaLocation="
-	   	http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
+	   	http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
 
 	<!--
 		View resolution finds the ContentNegotiationManager created by or

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution-custom-order.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution-custom-order.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<mvc:view-resolvers order="123">
 		<mvc:bean-name/>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
 
 	<mvc:view-resolvers>
 		<mvc:bean-name/>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven />
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/handler/map1.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/handler/map1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/handler/map2.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/handler/map2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/handler/map2err.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/handler/map2err.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/handler/map3.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/handler/map3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/resource/tiles/tiles1.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/resource/tiles/tiles1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE tiles-definitions PUBLIC
        "-//Apache Software Foundation//DTD Tiles Configuration 2.0//EN"
-       "http://tiles.apache.org/dtds/tiles-config_2_0.dtd">
+       "https://tiles.apache.org/dtds/tiles-config_2_0.dtd">
 <tiles-definitions>
 	<definition name="base.definition"
 		template="/WEB-INF/jsp/layout.jsp">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/resource/tiles/tiles2.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/resource/tiles/tiles2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE tiles-definitions PUBLIC
        "-//Apache Software Foundation//DTD Tiles Configuration 2.0//EN"
-       "http://tiles.apache.org/dtds/tiles-config_2_0.dtd">
+       "https://tiles.apache.org/dtds/tiles-config_2_0.dtd">
 <tiles-definitions>
 	<definition name="base.definition"
 		template="/WEB-INF/jsp/layout.jsp">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/tiles3/tiles-definitions.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/tiles3/tiles-definitions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE tiles-definitions PUBLIC
 		"-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN"
-		"http://tiles.apache.org/dtds/tiles-config_3_0.dtd">
+		"https://tiles.apache.org/dtds/tiles-config_3_0.dtd">
 
 <tiles-definitions>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/views.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/views.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-converters-defaults-off.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-converters-defaults-off.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker>
 

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-converters.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-converters.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker>
 

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-custom-argument-and-return-value-types.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-custom-argument-and-return-value-types.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker application-destination-prefix="/app" user-destination-prefix="/personal">
 		<websocket:stomp-endpoint path="/foo,/bar">

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-customchannels-default-executor.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-customchannels-default-executor.xml
@@ -2,8 +2,8 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker>
 		<websocket:stomp-endpoint path="/foo"/>

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-customchannels.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-customchannels.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker application-destination-prefix="/app" user-destination-prefix="/personal" validator="myValidator">
 		<websocket:stomp-endpoint path="/foo,/bar">

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-relay.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-relay.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker order="2" preserve-publish-order="true">
 		<websocket:stomp-endpoint path="/foo">

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-simple.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-simple.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker application-destination-prefix="/app"
 							  user-destination-prefix="/personal"
@@ -17,7 +17,7 @@
 			</websocket:decorator-factories>
 		</websocket:transport>
 
-		<websocket:stomp-endpoint path=" /foo,/bar" allowed-origins="http://mydomain1.com,http://mydomain2.com">
+		<websocket:stomp-endpoint path=" /foo,/bar" allowed-origins="https://mydomain1.com,http://mydomain2.com">
 			<websocket:handshake-handler ref="myHandler"/>
 			<websocket:handshake-interceptors>
 				<bean class="org.springframework.web.socket.config.FooTestInterceptor"/>
@@ -25,7 +25,7 @@
 			</websocket:handshake-interceptors>
 		</websocket:stomp-endpoint>
 
-		<websocket:stomp-endpoint path="/test,/sockjs" allowed-origins="http://mydomain3.com,http://mydomain4.com">
+		<websocket:stomp-endpoint path="/test,/sockjs" allowed-origins="https://mydomain3.com,http://mydomain4.com">
 			<websocket:handshake-handler ref="myHandler"/>
 			<websocket:handshake-interceptors>
 				<bean class="org.springframework.web.socket.config.FooTestInterceptor"/>

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-attributes.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-attributes.xml
@@ -2,10 +2,10 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
-	<websocket:handlers order="2" allowed-origins="http://mydomain1.com, http://mydomain2.com">
+	<websocket:handlers order="2" allowed-origins="https://mydomain1.com, https://mydomain2.com">
 		<websocket:mapping path="/foo" handler="fooHandler"/>
 		<websocket:mapping path="/test" handler="testHandler"/>
 		<websocket:handshake-handler ref="testHandshakeHandler"/>

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs-attributes.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs-attributes.xml
@@ -2,10 +2,10 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
-	<websocket:handlers allowed-origins="http://mydomain1.com, http://mydomain2.com">
+	<websocket:handlers allowed-origins="https://mydomain1.com, https://mydomain2.com">
 		<websocket:mapping path="/test" handler="testHandler"/>
 		<websocket:sockjs name="testSockJsService" scheduler="testTaskScheduler" websocket-enabled="false"
 						  session-cookie-needed="false" stream-bytes-limit="2048" disconnect-delay="256"

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs.xml
@@ -2,8 +2,8 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:handlers>
 		<websocket:mapping path="/test" handler="testHandler"/>

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers.xml
@@ -2,8 +2,8 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:handlers>
 		<websocket:mapping path="/foo,/bar" handler="fooHandler"/>

--- a/src/test/resources/com/foo/component-config.xml
+++ b/src/test/resources/com/foo/component-config.xml
@@ -3,7 +3,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:foo="http://www.foo.com/schema/component"
       xsi:schemaLocation="
-http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 http://www.foo.com/schema/component http://www.foo.com/schema/component/component.xsd">
 
    <foo:component id="bionic-family" name="Bionic-1">

--- a/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerScopeIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/aop/config/AopNamespaceHandlerScopeIntegrationTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:advisor advice-ref="advice" pointcut="execution(* *..ITestBean.*(..))"/>

--- a/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/aop/framework/autoproxy/AdvisorAutoProxyCreatorIntegrationTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	Common bean definitions for auto proxy creator tests.

--- a/src/test/resources/org/springframework/context/annotation/ltw/ComponentScanningWithLTWTests.xml
+++ b/src/test/resources/org/springframework/context/annotation/ltw/ComponentScanningWithLTWTests.xml
@@ -4,8 +4,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation=
-		"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+		"http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd"
 	default-autowire="byType">
 
 	<context:component-scan base-package="org.springframework.context.annotation">

--- a/src/test/resources/org/springframework/core/env/EnvironmentSystemIntegrationTests-context-dev.xml
+++ b/src/test/resources/org/springframework/core/env/EnvironmentSystemIntegrationTests-context-dev.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="dev">
 
 	<bean id="devBean" class="java.lang.Object"/>

--- a/src/test/resources/org/springframework/core/env/EnvironmentSystemIntegrationTests-context-prod.xml
+++ b/src/test/resources/org/springframework/core/env/EnvironmentSystemIntegrationTests-context-prod.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd"
 	profile="prod">
 
 	<bean id="prodBean" class="java.lang.Object"/>

--- a/src/test/resources/org/springframework/core/env/EnvironmentSystemIntegrationTests-context.xml
+++ b/src/test/resources/org/springframework/core/env/EnvironmentSystemIntegrationTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="envAwareBean" class="org.springframework.core.env.EnvironmentSystemIntegrationTests$EnvironmentAwareBean"/>
 

--- a/src/test/resources/org/springframework/transaction/annotation/enable-caching.xml
+++ b/src/test/resources/org/springframework/transaction/annotation/enable-caching.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:cache="http://www.springframework.org/schema/cache"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven/>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.foo.com/schema/component/component.xsd (404) with 1 occurrences could not be migrated:  
   ([https](https://www.foo.com/schema/component/component.xsd) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.kbcafe.com/rss/atom.xsd.xml (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.kbcafe.com/rss/atom.xsd.xml ([https](https://www.kbcafe.com/rss/atom.xsd.xml) result ConnectTimeoutException).
* http://domain1.com (UnknownHostException) with 2 occurrences migrated to:  
  https://domain1.com ([https](https://domain1.com) result UnknownHostException).
* http://domain2.com (UnknownHostException) with 1 occurrences migrated to:  
  https://domain2.com ([https](https://domain2.com) result UnknownHostException).
* http://mydomain1.com,http://mydomain2.com (UnknownHostException) with 1 occurrences migrated to:  
  https://mydomain1.com,http://mydomain2.com ([https](https://mydomain1.com,https://mydomain2.com) result UnknownHostException).
* http://mydomain2.com (UnknownHostException) with 2 occurrences migrated to:  
  https://mydomain2.com ([https](https://mydomain2.com) result UnknownHostException).
* http://mydomain3.com,http://mydomain4.com (UnknownHostException) with 1 occurrences migrated to:  
  https://mydomain3.com,http://mydomain4.com ([https](https://mydomain3.com,https://mydomain4.com) result UnknownHostException).
* http://www.springframework.org/schema/beans/factory/xml/support/CustomNamespaceHandlerTests.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/factory/xml/support/CustomNamespaceHandlerTests.xsd ([https](https://www.springframework.org/schema/beans/factory/xml/support/CustomNamespaceHandlerTests.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://example.com with 1 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd (301) with 2 occurrences migrated to:  
  https://hibernate.org/dtd/hibernate-mapping-3.0.dtd ([https](https://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd) result 200).
* http://testng.org/testng-1.0.dtd with 3 occurrences migrated to:  
  https://testng.org/testng-1.0.dtd ([https](https://testng.org/testng-1.0.dtd) result 200).
* http://tiles.apache.org/dtds/tiles-config_2_0.dtd with 2 occurrences migrated to:  
  https://tiles.apache.org/dtds/tiles-config_2_0.dtd ([https](https://tiles.apache.org/dtds/tiles-config_2_0.dtd) result 200).
* http://tiles.apache.org/dtds/tiles-config_2_1.dtd with 2 occurrences migrated to:  
  https://tiles.apache.org/dtds/tiles-config_2_1.dtd ([https](https://tiles.apache.org/dtds/tiles-config_2_1.dtd) result 200).
* http://tiles.apache.org/dtds/tiles-config_3_0.dtd with 4 occurrences migrated to:  
  https://tiles.apache.org/dtds/tiles-config_3_0.dtd ([https](https://tiles.apache.org/dtds/tiles-config_3_0.dtd) result 200).
* http://www.quartz-scheduler.org/xml/job_scheduling_data_1_8.xsd with 1 occurrences migrated to:  
  https://www.quartz-scheduler.org/xml/job_scheduling_data_1_8.xsd ([https](https://www.quartz-scheduler.org/xml/job_scheduling_data_1_8.xsd) result 200).
* http://www.springframework.org/dtd/spring-beans-2.0.dtd with 168 occurrences migrated to:  
  https://www.springframework.org/dtd/spring-beans-2.0.dtd ([https](https://www.springframework.org/dtd/spring-beans-2.0.dtd) result 200).
* http://www.springframework.org/schema/aop/spring-aop-2.0.xsd with 68 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-2.0.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-2.0.xsd) result 200).
* http://www.springframework.org/schema/aop/spring-aop-2.5.xsd with 11 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-2.5.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-2.5.xsd) result 200).
* http://www.springframework.org/schema/aop/spring-aop-3.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-3.0.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-3.0.xsd) result 200).
* http://www.springframework.org/schema/aop/spring-aop.xsd with 7 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop.xsd ([https](https://www.springframework.org/schema/aop/spring-aop.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.0.xsd with 112 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.5.xsd with 46 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.5.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.5.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 33 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.2.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.2.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-4.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-4.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-4.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-4.1.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-4.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-4.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-4.2.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-4.2.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-4.2.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-4.3.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-4.3.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-4.3.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 142 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/cache/spring-cache.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/cache/spring-cache.xsd ([https](https://www.springframework.org/schema/cache/spring-cache.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-2.5.xsd with 41 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-2.5.xsd ([https](https://www.springframework.org/schema/context/spring-context-2.5.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.1.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.2.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.2.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-4.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-4.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-4.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-4.2.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-4.2.xsd ([https](https://www.springframework.org/schema/context/spring-context-4.2.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-4.3.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-4.3.xsd ([https](https://www.springframework.org/schema/context/spring-context-4.3.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 10 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd with 9 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd with 9 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc-4.2.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc-4.3.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc-4.3.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc-4.3.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc.xsd with 8 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc.xsd) result 200).
* http://www.springframework.org/schema/jee/spring-jee-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jee/spring-jee-3.1.xsd ([https](https://www.springframework.org/schema/jee/spring-jee-3.1.xsd) result 200).
* http://www.springframework.org/schema/jms/spring-jms-4.1.xsd with 9 occurrences migrated to:  
  https://www.springframework.org/schema/jms/spring-jms-4.1.xsd ([https](https://www.springframework.org/schema/jms/spring-jms-4.1.xsd) result 200).
* http://www.springframework.org/schema/jms/spring-jms-4.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jms/spring-jms-4.2.xsd ([https](https://www.springframework.org/schema/jms/spring-jms-4.2.xsd) result 200).
* http://www.springframework.org/schema/lang/spring-lang-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/lang/spring-lang-2.0.xsd ([https](https://www.springframework.org/schema/lang/spring-lang-2.0.xsd) result 200).
* http://www.springframework.org/schema/lang/spring-lang-2.5.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/lang/spring-lang-2.5.xsd ([https](https://www.springframework.org/schema/lang/spring-lang-2.5.xsd) result 200).
* http://www.springframework.org/schema/lang/spring-lang-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/lang/spring-lang-3.0.xsd ([https](https://www.springframework.org/schema/lang/spring-lang-3.0.xsd) result 200).
* http://www.springframework.org/schema/lang/spring-lang-3.1.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/lang/spring-lang-3.1.xsd ([https](https://www.springframework.org/schema/lang/spring-lang-3.1.xsd) result 200).
* http://www.springframework.org/schema/lang/spring-lang-4.2.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/lang/spring-lang-4.2.xsd ([https](https://www.springframework.org/schema/lang/spring-lang-4.2.xsd) result 200).
* http://www.springframework.org/schema/lang/spring-lang.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/lang/spring-lang.xsd ([https](https://www.springframework.org/schema/lang/spring-lang.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc.xsd with 26 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc.xsd) result 200).
* http://www.springframework.org/schema/oxm/spring-oxm.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/oxm/spring-oxm.xsd ([https](https://www.springframework.org/schema/oxm/spring-oxm.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task-4.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task-4.1.xsd ([https](https://www.springframework.org/schema/task/spring-task-4.1.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx-2.5.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx-2.5.xsd ([https](https://www.springframework.org/schema/tx/spring-tx-2.5.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx-4.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx-4.0.xsd ([https](https://www.springframework.org/schema/tx/spring-tx-4.0.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx.xsd ([https](https://www.springframework.org/schema/tx/spring-tx.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-2.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-2.0.xsd ([https](https://www.springframework.org/schema/util/spring-util-2.0.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-2.5.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-2.5.xsd ([https](https://www.springframework.org/schema/util/spring-util-2.5.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-3.0.xsd ([https](https://www.springframework.org/schema/util/spring-util-3.0.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-3.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-3.1.xsd ([https](https://www.springframework.org/schema/util/spring-util-3.1.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-4.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-4.1.xsd ([https](https://www.springframework.org/schema/util/spring-util-4.1.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-4.2.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-4.2.xsd ([https](https://www.springframework.org/schema/util/spring-util-4.2.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* http://www.springframework.org/schema/websocket/spring-websocket.xsd with 11 occurrences migrated to:  
  https://www.springframework.org/schema/websocket/spring-websocket.xsd ([https](https://www.springframework.org/schema/websocket/spring-websocket.xsd) result 200).
* http://mydomain1.com with 2 occurrences migrated to:  
  https://mydomain1.com ([https](https://mydomain1.com) result 301).
* http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* http://help.sap.com/saphelp_hanaplatform/helpdata/en/20/a78d3275191014b41bae7c4a46d835/content.htm with 1 occurrences migrated to:  
  https://help.sap.com/saphelp_hanaplatform/helpdata/en/20/a78d3275191014b41bae7c4a46d835/content.htm ([https](https://help.sap.com/saphelp_hanaplatform/helpdata/en/20/a78d3275191014b41bae7c4a46d835/content.htm) result 302).
* http://java.sun.com/dtd/properties.dtd with 4 occurrences migrated to:  
  https://java.sun.com/dtd/properties.dtd ([https](https://java.sun.com/dtd/properties.dtd) result 302).
* http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/connector_1_5.xsd ([https](https://java.sun.com/xml/ns/j2ee/connector_1_5.xsd) result 302).
* http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd ([https](https://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd) result 302).
* http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd with 12 occurrences migrated to:  
  https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd ([https](https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd) result 302).
* http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/persistence/persistence_2_0.xsd ([https](https://java.sun.com/xml/ns/persistence/persistence_2_0.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/j2ee with 2 occurrences
* http://java.sun.com/xml/ns/javaee with 2 occurrences
* http://java.sun.com/xml/ns/persistence with 27 occurrences
* http://localhost:8080 with 3 occurrences
* http://samples.springframework.org/flight with 3 occurrences
* http://www.foo.com/schema/component with 2 occurrences
* http://www.greeting.com/goodbye/ with 1 occurrences
* http://www.greeting.com/hello/ with 1 occurrences
* http://www.quartz-scheduler.org/xml/JobSchedulingData with 2 occurrences
* http://www.springframework.org/schema/aop with 176 occurrences
* http://www.springframework.org/schema/beans with 715 occurrences
* http://www.springframework.org/schema/beans/test with 2 occurrences
* http://www.springframework.org/schema/c with 9 occurrences
* http://www.springframework.org/schema/cache with 20 occurrences
* http://www.springframework.org/schema/context with 126 occurrences
* http://www.springframework.org/schema/jdbc with 66 occurrences
* http://www.springframework.org/schema/jee with 2 occurrences
* http://www.springframework.org/schema/jms with 20 occurrences
* http://www.springframework.org/schema/lang with 27 occurrences
* http://www.springframework.org/schema/mvc with 58 occurrences
* http://www.springframework.org/schema/oxm with 2 occurrences
* http://www.springframework.org/schema/p with 16 occurrences
* http://www.springframework.org/schema/task with 14 occurrences
* http://www.springframework.org/schema/tx with 12 occurrences
* http://www.springframework.org/schema/util with 28 occurrences
* http://www.springframework.org/schema/websocket with 22 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 375 occurrences
* http://www.w3.org/2005/Atom with 2 occurrences