### PR TITLE
Remove redundant 'String.substring()' call

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityDecoder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ class HtmlCharacterEntityDecoder {
 			int skipUntilIndex = (this.nextPotentialReferencePosition != -1 ?
 					this.nextPotentialReferencePosition : this.originalMessage.length());
 			if (skipUntilIndex - this.currentPosition > 3) {
-				this.decodedMessage.append(this.originalMessage.substring(this.currentPosition, skipUntilIndex));
+				this.decodedMessage.append(this.originalMessage, this.currentPosition, skipUntilIndex);
 				this.currentPosition = skipUntilIndex;
 			}
 			else {


### PR DESCRIPTION
Call to 'String.substring()' making a String instance, but if we call to 'StringBuilder append(CharSequence s, int start, int end)' directly, the String instance can be avoided.