### PR TITLE
Handle Optional<?> @RequestParam() when generating URL using MvcUriComponentsBuilder

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/DefaultConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/DefaultConversionService.java
@@ -97,6 +97,7 @@ public class DefaultConversionService extends GenericConversionService {
 		converterRegistry.addConverter(new IdToEntityConverter((ConversionService) converterRegistry));
 		converterRegistry.addConverter(new FallbackObjectToStringConverter());
 		converterRegistry.addConverter(new ObjectToOptionalConverter((ConversionService) converterRegistry));
+		converterRegistry.addConverter(new OptionalUnwrappingConverter((ConversionService) converterRegistry));
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/core/convert/support/OptionalUnwrappingConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/OptionalUnwrappingConverter.java
@@ -1,0 +1,64 @@
+package org.springframework.core.convert.support;
+
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+
+import java.util.*;
+
+final class OptionalUnwrappingConverter implements ConditionalGenericConverter {
+
+	private final ConversionService conversionService;
+
+	public OptionalUnwrappingConverter(final ConversionService conversionService)
+	{
+		this.conversionService = conversionService;
+	}
+
+	@Override
+	public Set<ConvertiblePair> getConvertibleTypes()
+	{
+		return null;
+	}
+
+	@Override
+	public boolean matches(final TypeDescriptor sourceType, final TypeDescriptor targetType)
+	{
+		if (!Optional.class.isAssignableFrom(sourceType.getObjectType())) {
+			return false;
+		}
+
+		if (!sourceType.getResolvableType().hasGenerics()) {
+			return false;
+		}
+
+		return conversionService.canConvert(new GenericTypeDescriptor(sourceType), targetType);
+	}
+
+	@Override
+	public Object convert(final Object source, final TypeDescriptor sourceType, final TypeDescriptor targetType)
+	{
+		if (source == null) {
+			return null;
+		}
+
+		Optional<?> optionalSource = Optional.class.cast(source);
+		if (!optionalSource.isPresent()) {
+			return null;
+		}
+
+		return conversionService.convert(optionalSource.get(), new GenericTypeDescriptor(sourceType), targetType);
+	}
+
+	@SuppressWarnings("serial")
+	private static class GenericTypeDescriptor extends TypeDescriptor
+	{
+
+		GenericTypeDescriptor(final TypeDescriptor typeDescriptor)
+		{
+			super(typeDescriptor.getResolvableType().getGeneric(), null, typeDescriptor.getAnnotations());
+		}
+
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
@@ -20,6 +20,7 @@ import java.beans.PropertyEditor;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.Part;
 
@@ -223,6 +224,9 @@ public class RequestParamMethodArgumentResolver extends AbstractNamedValueMethod
 				return;
 			}
 			builder.queryParam(name);
+		}
+		else if (value instanceof Optional && !((Optional) value).isPresent()) {
+			return;
 		}
 		else if (value instanceof Collection) {
 			for (Object element : (Collection<?>) value) {


### PR DESCRIPTION
Example of an action:

```java
@GetMapping("/{userId}")
public ModelAndView productGroups(
    @PathVariable @AssertUuid final String userId,
    @RequestParam("parentId") final Optional<@AssertUuid String> rawParentId,
    @PageableDefault(size = 100) final Pageable pageable
) throws ControllerException
```

this action validates, that the `parentId` is UUID, if it's present (which works great), but it also rejects the request completely, if it's not (with `400 BAD REQUEST`). Which means any of the following ends with `400` - `?parentId`, `?parentId=`, `?parentId=garbage`

-----

- Generating URL using `MvcUriComponentsBuilder.fromMethodCall` doesn't work without the `OptionalUnwrappingConverter` I've provided
- Without the fix in `RequestParamMethodArgumentResolver`, it generates empty query args - resulting in url with `?parentId` (without `=` and without value) - which is not valid and ends with `400`

I'm not sure if this is the correct way to fix this, so if you'll please give me some feedback on this, I'd be happy to add some tests.

-----

Related issue #16785  - it states that spring handles `Optional<?>` in handler arguments