### PR TITLE
WebClient option with both URI template and UriBuilder

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -185,6 +185,12 @@ class DefaultWebClient implements WebClient {
 		}
 
 		@Override
+		public RequestBodySpec uri(String uriTemplate, Function<UriBuilder, URI> uriFunction) {
+			attribute(URI_TEMPLATE_ATTRIBUTE, uriTemplate);
+			return uri(uriFunction.apply(uriBuilderFactory.uriString(uriTemplate)));
+		}
+
+		@Override
 		public RequestBodySpec uri(Function<UriBuilder, URI> uriFunction) {
 			return uri(uriFunction.apply(uriBuilderFactory.builder()));
 		}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -350,7 +350,14 @@ public interface WebClient {
 
 		/**
 		 * Build the URI for the request using the {@link UriBuilderFactory}
+		 * configured for this client and initialized with the specified <code>uri</code>.
+		 */
+		S uri(String uri, Function<UriBuilder, URI> uriFunction);
+
+		/**
+		 * Build the URI for the request using the {@link UriBuilderFactory}
 		 * configured for this client.
+		 * @see #uri(String, Function)
 		 */
 		S uri(Function<UriBuilder, URI> uriFunction);
 	}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultWebClientTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultWebClientTests.java
@@ -84,6 +84,18 @@ public class DefaultWebClientTests {
 		assertEquals("/base/path?q=12", request.url().toString());
 	}
 
+
+	@Test
+	public void uriBuilderWithUriTemplate() {
+		this.builder.build().get()
+					.uri("/path/{id}", builder -> builder.queryParam("q", "12").build("identifier"))
+					.exchange().block(Duration.ofSeconds(10));
+
+		ClientRequest request = verifyAndGetRequest();
+		assertEquals("/base/path/identifier?q=12", request.url().toString());
+		assertEquals("/path/{id}", request.attribute(WebClient.class.getName() + ".uriTemplate").<String>get());
+	}
+
 	@Test
 	public void uriBuilderWithPathOverride() {
 		this.builder.build().get()


### PR DESCRIPTION
This pull request is related to #22371 opened issue.
It is basically implemented as discussed in the issue conversation and will allow to export metrics even when using UriBuilder to construct uri when using WebClient.