### PR TITLE
Allow sending headers with the disconnect frame

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
@@ -360,9 +360,17 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 
 	@Override
 	public void disconnect() {
+		disconnect(null);
+	}
+
+	@Override
+	public void disconnect(@Nullable StompHeaders headers) {
 		this.closing = true;
 		try {
 			StompHeaderAccessor accessor = createHeaderAccessor(StompCommand.DISCONNECT);
+			if (headers != null) {
+				accessor.addNativeHeaders(headers);
+			}
 			Message<byte[]> message = createMessage(accessor, EMPTY_PAYLOAD);
 			execute(message);
 		}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompSession.java
@@ -116,6 +116,12 @@ public interface StompSession {
 	 */
 	void disconnect();
 
+	/**
+	 * Disconnect the session by sending a DISCONNECT frame.
+	 * @param headers the headers for the disconnect message frame
+	 */
+	void disconnect(StompHeaders headers);
+
 
 	/**
 	 * A handle to use to track receipts.

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/DefaultStompSessionTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/DefaultStompSessionTests.java
@@ -636,4 +636,25 @@ public class DefaultStompSessionTests {
 		verifyNoMoreInteractions(this.sessionHandler);
 	}
 
+	@Test
+	public void disconnectWithHeaders() {
+		this.session.afterConnected(this.connection);
+		assertTrue(this.session.isConnected());
+
+		StompHeaders headers = new StompHeaders();
+		headers.add("foo", "bar");
+
+		this.session.disconnect(headers);
+
+		Message<byte[]> message = this.messageCaptor.getValue();
+		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+		headers = StompHeaders.readOnlyStompHeaders(accessor.getNativeHeaders());
+		assertEquals(headers.toString(), 1, headers.size());
+		assertEquals(headers.get("foo").size(), 1);
+		assertEquals(headers.get("foo").get(0), "bar");
+
+		assertFalse(this.session.isConnected());
+		verifyNoMoreInteractions(this.sessionHandler);
+	}
+
 }


### PR DESCRIPTION
The `disconnect` method of `StompSession` does not allow sending custom `headers`. This is something that is possible in other libraries and there does not seem to be a good reason to not support this.

This pull request is related to #16222 but does not limit itself to the receipt header.