### PR TITLE
Release cached item in ChannelSendOperator also in case of error from writeFunction

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ChannelSendOperator.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ChannelSendOperator.java
@@ -394,7 +394,12 @@ public class ChannelSendOperator<T> extends Mono<Void> implements Scannable {
 
 		@Override
 		public void onError(Throwable ex) {
-			this.completionSubscriber.onError(ex);
+			try {
+				this.completionSubscriber.onError(ex);
+			}
+			finally {
+				this.writeBarrier.releaseCachedItem();
+			}
 		}
 
 		@Override


### PR DESCRIPTION
A follow-up fix for gh-22720.