### PR TITLE
Update Scheduled.java Javadoc to explicitly include cron element order

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -66,9 +66,15 @@ public @interface Scheduled {
 
 	/**
 	 * A cron-like expression, extending the usual UN*X definition to include triggers
-	 * on the second as well as minute, hour, day of month, month and day of week.
+	 * on the second, minute, hour, day of month, month and day of week.
 	 * <p>E.g. {@code "0 * * * * MON-FRI"} means once per minute on weekdays
-	 * (at the top of the minute - the 0th second).
+	 * (at the top of the minute - the 0th second). The order read from left to right is:
+	 * <li>second
+	 * <li>minute
+	 * <li>hour
+	 * <li>day of month
+	 * <li>month
+	 * <li>day of week
 	 * <p>The special value {@link #CRON_DISABLED "-"} indicates a disabled cron trigger,
 	 * primarily meant for externally specified values resolved by a ${...} placeholder.
 	 * @return an expression that can be parsed to a cron schedule

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -69,12 +69,14 @@ public @interface Scheduled {
 	 * on the second, minute, hour, day of month, month and day of week.
 	 * <p>E.g. {@code "0 * * * * MON-FRI"} means once per minute on weekdays
 	 * (at the top of the minute - the 0th second). The order read from left to right is:
-	 * <li>second
-	 * <li>minute
-	 * <li>hour
-	 * <li>day of month
-	 * <li>month
-	 * <li>day of week
+	 * <ul>
+	 * <li>second</li>
+	 * <li>minute</li>
+	 * <li>hour</li>
+	 * <li>day of month</li>
+	 * <li>month</li>
+	 * <li>day of week</li>
+	 * </ul>
 	 * <p>The special value {@link #CRON_DISABLED "-"} indicates a disabled cron trigger,
 	 * primarily meant for externally specified values resolved by a ${...} placeholder.
 	 * @return an expression that can be parsed to a cron schedule


### PR DESCRIPTION
When stumbling upon
https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/scheduling/annotation/Scheduled.html
I realised that the order is quite difficult to parse for the human eye.

Thus I shortened the initial/first sentence and added the explicit order of the elements for easier reference.