### PR TITLE
Get all the aliases at getPropertyNames

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/JOptCommandLinePropertySource.java
+++ b/spring-core/src/main/java/org/springframework/core/env/JOptCommandLinePropertySource.java
@@ -88,10 +88,19 @@ public class JOptCommandLinePropertySource extends CommandLinePropertySource<Opt
 	public String[] getPropertyNames() {
 		List<String> names = new ArrayList<>();
 		for (OptionSpec<?> spec : this.source.specs()) {
-			String lastOption = CollectionUtils.lastElement(spec.options());
-			if (lastOption != null) {
-				// Only the longest name is used for enumerating
-				names.add(lastOption);
+			List<String> aliases = new ArrayList<>(spec.options());
+			String longestAliase = "";
+			for (String aliase : aliases) {
+				if (aliase.length() > longestAliase.length()) {
+					// Only the longest name is used for enumerating.
+					// If more than one name have the same longest length,
+					// the first one(alphabetically) will be used.
+					longestAliase = aliase;
+				}
+			}
+			if (!"".equals(longestAliase) && !names.contains(longestAliase)) {
+				// The names are not added repeatedly.
+				names.add(longestAliase);
 			}
 		}
 		return StringUtils.toStringArray(names);

--- a/spring-core/src/test/java/org/springframework/core/env/JOptCommandLinePropertySourceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/JOptCommandLinePropertySourceTests.java
@@ -88,6 +88,7 @@ public class JOptCommandLinePropertySourceTests {
 		CommandLinePropertySource<?> ps = new JOptCommandLinePropertySource(options);
 		assertEquals(Arrays.asList("bar","baz","biz"), ps.getOptionValues("foo"));
 		assertThat(ps.getProperty("foo"), equalTo("bar,baz,biz"));
+		assertEquals(1, ps.getPropertyNames().length);
 	}
 
 	@Test
@@ -158,6 +159,19 @@ public class JOptCommandLinePropertySourceTests {
 		assertThat(ps.containsProperty("o2"), is(true));
 		String nonOptionArgs = ps.getProperty("NOA");
 		assertThat(nonOptionArgs, equalTo("noa1,noa2"));
+	}
+
+	@Test
+	public void withMultipleOptionAliases() {
+		OptionParser parser = new OptionParser();
+		parser.acceptsAll(Arrays.asList("u", "username", "user"));
+		parser.acceptsAll(Arrays.asList( "MN", "NM"));
+		parser.acceptsAll(Arrays.asList("A", "CBA", "B", "ABC", "BCA", "AB", "BA"));
+
+		OptionSet optionSet = parser.parse("-u", "-ABC", "-MN");
+		EnumerablePropertySource<?> ps = new JOptCommandLinePropertySource(optionSet);
+
+		assertArrayEquals(new String[]{"username", "ABC", "MN"},  ps.getPropertyNames());
 	}
 
 	@Test


### PR DESCRIPTION
At present, the `JOptCommandLinePropertySource.getPropertyNames` get the last element in the result of `spec.options()`. But the comment says `Only the longest name is used for enumerating`. It is a contradiction and one of the two(code or comment) has to be changed.

I change the code according the comment because I think the longest name is more useful. And if more than one name have the same longest length, the first one(alphabetically) will be used in my solution.

Fix #22168.