### PR TITLE
Avoid possible memory leak in ResolvableType

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -935,7 +935,7 @@ public class ResolvableType implements Serializable {
 		if (this == NONE) {
 			return null;
 		}
-		return new DefaultVariableResolver();
+		return new DefaultVariableResolver(this);
 	}
 
 	/**
@@ -1452,17 +1452,23 @@ public class ResolvableType implements Serializable {
 
 
 	@SuppressWarnings("serial")
-	private class DefaultVariableResolver implements VariableResolver {
+	private static class DefaultVariableResolver implements VariableResolver {
+
+		private final ResolvableType source;
+
+		DefaultVariableResolver(ResolvableType resolvableType) {
+			this.source = resolvableType;
+		}
 
 		@Override
 		@Nullable
 		public ResolvableType resolveVariable(TypeVariable<?> variable) {
-			return ResolvableType.this.resolveVariable(variable);
+			return this.source.resolveVariable(variable);
 		}
 
 		@Override
 		public Object getSource() {
-			return ResolvableType.this;
+			return this.source;
 		}
 	}
 


### PR DESCRIPTION
Hi,

in recent profiling sessions of Spring-Boot apps, I noticed that instances of ResolvableType are retained by their `DefaultVariableResolver`:
![grafik](https://user-images.githubusercontent.com/6304496/56597829-91daba80-65f3-11e9-9f63-694f520ae553.png)
Until now I've not seen any critical leaks but I thought better be safe than sorry.

Let me know what you think.
Cheers,
Christoph