### PR TITLE
Update postProcessBeforeInstantiation comment

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/InstantiationAwareBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/InstantiationAwareBeanPostProcessor.java
@@ -54,7 +54,7 @@ public interface InstantiationAwareBeanPostProcessor extends BeanPostProcessor {
 	 * {@link #postProcessAfterInitialization} callback from the configured
 	 * {@link BeanPostProcessor BeanPostProcessors}.
 	 * <p>This callback will only be applied to bean definitions with a bean class.
-	 * In particular, it will not be applied to beans with a "factory-method".
+	 * It will also be applied to beans with a "factory-method".
 	 * <p>Post-processors may implement the extended
 	 * {@link SmartInstantiationAwareBeanPostProcessor} interface in order
 	 * to predict the type of the bean object that they are going to return here.


### PR DESCRIPTION
Since 4.1.x, `postProcessBeforeInstantiation` has started to support "factory-method": 
we can see that the `determineTargetType` method has been added to support "factory-method" in `org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory#resolveBeforeInstantiation`