### PR TITLE
Abort early in PropertyPlaceholderHelper if no placeholder exists

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/PropertyPlaceholderHelper.java
+++ b/spring-core/src/main/java/org/springframework/util/PropertyPlaceholderHelper.java
@@ -121,15 +121,20 @@ public class PropertyPlaceholderHelper {
 	 */
 	public String replacePlaceholders(String value, PlaceholderResolver placeholderResolver) {
 		Assert.notNull(value, "'value' must not be null");
+		if (!value.contains(this.placeholderPrefix)) {
+			return value;
+		}
 		return parseStringValue(value, placeholderResolver, new HashSet<>());
 	}
 
 	protected String parseStringValue(
 			String value, PlaceholderResolver placeholderResolver, Set<String> visitedPlaceholders) {
+		int startIndex = value.indexOf(this.placeholderPrefix);
+		if (startIndex == -1) {
+			return value;
+		}
 
 		StringBuilder result = new StringBuilder(value);
-
-		int startIndex = value.indexOf(this.placeholderPrefix);
 		while (startIndex != -1) {
 			int endIndex = findPlaceholderEndIndex(result, startIndex);
 			if (endIndex != -1) {


### PR DESCRIPTION
Hi,

I am currently working on https://github.com/spring-projects/spring-boot/issues/16401 and investigate performance issues in the binding context. I noticed a small optimization opportunity in PropertyPlaceholderHelper if no placeholders exist. We can early out in those cases and thus save the allocations coming from the StringBuilder (and the HashSet).
To be fair: this is not a major performance bottleneck at all (there are ~5000 StringBuilder/HashSet allocations that we could save), but every little helps and who knows what other people might be doing with that class.

Cheers,
Christoph