### PR TITLE
 Fix doCleanupAfterCompletion invocation and replace signal materialization

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/AbstractReactiveTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/AbstractReactiveTransactionManager.java
@@ -676,17 +676,18 @@ public abstract class AbstractReactiveTransactionManager implements ReactiveTran
 			if (status.isNewSynchronization()) {
 				synchronizationManager.clear();
 			}
+			Mono<Void> cleanup = Mono.empty();
 			if (status.isNewTransaction()) {
-				doCleanupAfterCompletion(synchronizationManager, status.getTransaction());
+				cleanup = doCleanupAfterCompletion(synchronizationManager, status.getTransaction());
 			}
 			if (status.getSuspendedResources() != null) {
 				if (status.isDebug()) {
 					logger.debug("Resuming suspended transaction after completion of inner transaction");
 				}
 				Object transaction = (status.hasTransaction() ? status.getTransaction() : null);
-				return resume(synchronizationManager, transaction, (SuspendedResourcesHolder) status.getSuspendedResources());
+				return cleanup.then(resume(synchronizationManager, transaction, (SuspendedResourcesHolder) status.getSuspendedResources()));
 			}
-			return Mono.empty();
+			return cleanup;
 		});
 	}
 

--- a/spring-tx/src/test/java/org/springframework/transaction/reactive/ReactiveTestTransactionManager.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/reactive/ReactiveTestTransactionManager.java
@@ -44,6 +44,8 @@ class ReactiveTestTransactionManager extends AbstractReactiveTransactionManager 
 
 	protected boolean rollbackOnly = false;
 
+	protected boolean cleanup = false;
+
 
 	ReactiveTestTransactionManager(boolean existingTransaction, boolean canCreateTransaction) {
 		this.existingTransaction = existingTransaction;
@@ -96,4 +98,8 @@ class ReactiveTestTransactionManager extends AbstractReactiveTransactionManager 
 		return Mono.fromRunnable(() -> this.rollbackOnly = true);
 	}
 
+	@Override
+	protected Mono<Void> doCleanupAfterCompletion(TransactionSynchronizationManager synchronizationManager, Object transaction) {
+		return Mono.fromRunnable(() -> this.cleanup = true);
+	}
 }

--- a/spring-tx/src/test/java/org/springframework/transaction/reactive/ReactiveTransactionSupportTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/reactive/ReactiveTransactionSupportTests.java
@@ -95,6 +95,7 @@ public class ReactiveTransactionSupportTests {
 		assertHasCommitted(tm);
 		assertHasNoRollback(tm);
 		assertHasNotSetRollbackOnly(tm);
+		assertHasCleanedUp(tm);
 	}
 
 	@Test
@@ -108,6 +109,7 @@ public class ReactiveTransactionSupportTests {
 		assertHasNotCommitted(tm);
 		assertHasRolledBack(tm);
 		assertHasNotSetRollbackOnly(tm);
+		assertHasCleanedUp(tm);
 	}
 
 	@Test
@@ -122,6 +124,7 @@ public class ReactiveTransactionSupportTests {
 		assertHasNotCommitted(tm);
 		assertHasRolledBack(tm);
 		assertHasNotSetRollbackOnly(tm);
+		assertHasCleanedUp(tm);
 	}
 
 	@Test
@@ -135,6 +138,7 @@ public class ReactiveTransactionSupportTests {
 		assertHasNotCommitted(tm);
 		assertHasNoRollback(tm);
 		assertHasNotSetRollbackOnly(tm);
+		assertHasNotCleanedUp(tm);
 	}
 
 	@Test
@@ -148,6 +152,7 @@ public class ReactiveTransactionSupportTests {
 		assertHasNotCommitted(tm);
 		assertHasNoRollback(tm);
 		assertHasSetRollbackOnly(tm);
+		assertHasNotCleanedUp(tm);
 	}
 
 	@Test
@@ -161,6 +166,7 @@ public class ReactiveTransactionSupportTests {
 		assertHasNotCommitted(tm);
 		assertHasNoRollback(tm);
 		assertHasSetRollbackOnly(tm);
+		assertHasNotCleanedUp(tm);
 	}
 
 	@Test
@@ -177,6 +183,7 @@ public class ReactiveTransactionSupportTests {
 		assertHasCommitted(tm);
 		assertHasNoRollback(tm);
 		assertHasNotSetRollbackOnly(tm);
+		assertHasCleanedUp(tm);
 	}
 
 	@Test
@@ -194,6 +201,7 @@ public class ReactiveTransactionSupportTests {
 		assertHasNotCommitted(tm);
 		assertHasRolledBack(tm);
 		assertHasNotSetRollbackOnly(tm);
+		assertHasCleanedUp(tm);
 	}
 
 	private void assertHasBegan(ReactiveTestTransactionManager actual) {
@@ -226,6 +234,14 @@ assertFalse("Expected to not call <ReactiveTransactionManager.rollback()> but wa
 
 	private void assertHasNotSetRollbackOnly(ReactiveTestTransactionManager actual) {
 		assertFalse("Expected to not call <ReactiveTransactionManager.setRollbackOnly()> but was <setRollbackOnly()> was called", actual.rollbackOnly);
+	}
+
+	private void assertHasCleanedUp(ReactiveTestTransactionManager actual) {
+		assertTrue("Expected <ReactiveTransactionManager.doCleanupAfterCompletion()> but was <doCleanupAfterCompletion()> was not invoked", actual.cleanup);
+	}
+
+	private void assertHasNotCleanedUp(ReactiveTestTransactionManager actual) {
+		assertFalse("Expected to not call <ReactiveTransactionManager.doCleanupAfterCompletion()> but was <doCleanupAfterCompletion()> was called", actual.cleanup);
 	}
 
 }

--- a/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
@@ -59,9 +59,9 @@ public class TransactionalOperatorTests {
 	@Test
 	public void commitWithFlux() {
 		TransactionalOperator operator = TransactionalOperator.create(tm, new DefaultTransactionDefinition());
-		Flux.just(true).as(operator::transactional)
+		Flux.just(1, 2, 3, 4).as(operator::transactional)
 				.as(StepVerifier::create)
-				.expectNext(true)
+				.expectNextCount(4)
 				.verifyComplete();
 		assertTrue(tm.commit);
 		assertFalse(tm.rollback);


### PR DESCRIPTION
`doCleanupAfterCompletion` gets now subscribed to when processing cleanup after a new transaction.

We now use `Flux.usingWhen()` instead materialize/dematerialize operators to reuse Reactor's resource closure.

Until usingWhen() accepts a BiFunction to consume error signals, we need to map error signals outside of `usingWhen` which requires re-wrapping of the `ReactiveTransaction` object.

See also reactor/reactor-core#1687