### PR TITLE
Use HttpHeaders constants where possible

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
@@ -32,6 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
@@ -49,16 +50,6 @@ import org.springframework.web.util.WebUtils;
  * @since 2.0
  */
 public class ServletWebRequest extends ServletRequestAttributes implements NativeWebRequest {
-
-	private static final String ETAG = "ETag";
-
-	private static final String IF_MODIFIED_SINCE = "If-Modified-Since";
-
-	private static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
-
-	private static final String IF_NONE_MATCH = "If-None-Match";
-
-	private static final String LAST_MODIFIED = "Last-Modified";
 
 	private static final List<String> SAFE_METHODS = Arrays.asList("GET", "HEAD");
 
@@ -244,11 +235,11 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 						HttpStatus.NOT_MODIFIED.value() : HttpStatus.PRECONDITION_FAILED.value());
 			}
 			if (isHttpGetOrHead) {
-				if (lastModifiedTimestamp > 0 && parseDateValue(response.getHeader(LAST_MODIFIED)) == -1) {
-					response.setDateHeader(LAST_MODIFIED, lastModifiedTimestamp);
+				if (lastModifiedTimestamp > 0 && parseDateValue(response.getHeader(HttpHeaders.LAST_MODIFIED)) == -1) {
+					response.setDateHeader(HttpHeaders.LAST_MODIFIED, lastModifiedTimestamp);
 				}
-				if (StringUtils.hasLength(etag) && response.getHeader(ETAG) == null) {
-					response.setHeader(ETAG, padEtagIfNecessary(etag));
+				if (StringUtils.hasLength(etag) && response.getHeader(HttpHeaders.ETAG) == null) {
+					response.setHeader(HttpHeaders.ETAG, padEtagIfNecessary(etag));
 				}
 			}
 		}
@@ -260,7 +251,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 		if (lastModifiedTimestamp < 0) {
 			return false;
 		}
-		long ifUnmodifiedSince = parseDateHeader(IF_UNMODIFIED_SINCE);
+		long ifUnmodifiedSince = parseDateHeader(HttpHeaders.IF_UNMODIFIED_SINCE);
 		if (ifUnmodifiedSince == -1) {
 			return false;
 		}
@@ -276,7 +267,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 
 		Enumeration<String> ifNoneMatch;
 		try {
-			ifNoneMatch = getRequest().getHeaders(IF_NONE_MATCH);
+			ifNoneMatch = getRequest().getHeaders(HttpHeaders.IF_NONE_MATCH);
 		}
 		catch (IllegalArgumentException ex) {
 			return false;
@@ -319,7 +310,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 		if (lastModifiedTimestamp < 0) {
 			return false;
 		}
-		long ifModifiedSince = parseDateHeader(IF_MODIFIED_SINCE);
+		long ifModifiedSince = parseDateHeader(HttpHeaders.IF_MODIFIED_SINCE);
 		if (ifModifiedSince == -1) {
 			return false;
 		}

--- a/spring-web/src/main/java/org/springframework/web/filter/ShallowEtagHeaderFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/ShallowEtagHeaderFilter.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.util.Assert;
 import org.springframework.util.DigestUtils;
@@ -52,12 +53,6 @@ import org.springframework.web.util.WebUtils;
  * @since 3.0
  */
 public class ShallowEtagHeaderFilter extends OncePerRequestFilter {
-
-	private static final String HEADER_ETAG = "ETag";
-
-	private static final String HEADER_IF_NONE_MATCH = "If-None-Match";
-
-	private static final String HEADER_CACHE_CONTROL = "Cache-Control";
 
 	private static final String DIRECTIVE_NO_STORE = "no-store";
 
@@ -124,8 +119,8 @@ public class ShallowEtagHeaderFilter extends OncePerRequestFilter {
 		}
 		else if (isEligibleForEtag(request, responseWrapper, statusCode, responseWrapper.getContentInputStream())) {
 			String responseETag = generateETagHeaderValue(responseWrapper.getContentInputStream(), this.writeWeakETag);
-			rawResponse.setHeader(HEADER_ETAG, responseETag);
-			String requestETag = request.getHeader(HEADER_IF_NONE_MATCH);
+			rawResponse.setHeader(HttpHeaders.ETAG, responseETag);
+			String requestETag = request.getHeader(HttpHeaders.IF_NONE_MATCH);
 			if (requestETag != null && ("*".equals(requestETag) || compareETagHeaderValue(requestETag, responseETag))) {
 				rawResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 			}
@@ -157,7 +152,7 @@ public class ShallowEtagHeaderFilter extends OncePerRequestFilter {
 
 		String method = request.getMethod();
 		if (responseStatusCode >= 200 && responseStatusCode < 300 && HttpMethod.GET.matches(method)) {
-			String cacheControl = response.getHeader(HEADER_CACHE_CONTROL);
+			String cacheControl = response.getHeader(HttpHeaders.CACHE_CONTROL);
 			return (cacheControl == null || !cacheControl.contains(DIRECTIVE_NO_STORE));
 		}
 		return false;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletInvocableHandlerMethod.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletInvocableHandlerMethod.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -167,7 +168,7 @@ public class ServletInvocableHandlerMethod extends InvocableHandlerMethod {
 		if (!isRequestNotModified(webRequest)) {
 			HttpServletResponse response = webRequest.getNativeResponse(HttpServletResponse.class);
 			Assert.notNull(response, "Expected HttpServletResponse");
-			if (StringUtils.hasText(response.getHeader("ETag"))) {
+			if (StringUtils.hasText(response.getHeader(HttpHeaders.ETAG))) {
 				HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 				Assert.notNull(request, "Expected HttpServletRequest");
 				ShallowEtagHeaderFilter.disableContentCaching(request);


### PR DESCRIPTION
This PR changes to use `HttpHeaders` constants where possible.