### PR TITLE
Add a space in the documentation index file

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -9,7 +9,7 @@ https://github.com/spring-projects/spring-framework/wiki[*Github Wiki*].
 ****
 
 [horizontal]
-<<overview.adoc#overview, Overview>> :: history, design philosophy,feedback,
+<<overview.adoc#overview, Overview>> :: history, design philosophy, feedback,
 getting started.
 <<core.adoc#spring-core, Core>> :: IoC container, Events, Resources, i18n, Validation,
 Data Binding, Type Conversion, SpEL, AOP.


### PR DESCRIPTION
It just hurt my eyes, a missing space on the first page you see when you start reading the documentation.

Have a nice day :)