### PR TITLE
Extend MultipartBodyBuilder methods so they accept a filename parameter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
@@ -32,6 +32,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 
 /**
  * A mutable builder for multipart form bodies. For example:
@@ -124,7 +125,7 @@ public final class MultipartBodyBuilder {
 		Object partBody;
 		HttpHeaders partHeaders = new HttpHeaders();
 
-		if (filename != null) {
+		if (StringUtils.hasLength(filename)) {
 			partHeaders.setContentDispositionFormData(name, filename);
 		}
 

--- a/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
@@ -78,7 +78,7 @@ public final class MultipartBodyBuilder {
 	 * Add a part from an Object.
 	 * @param name the name of the part to add
 	 * @param part the part data
-	 * @param contentType MediaType which is used to determine how to encode the part
+	 * @param contentType used to determine how to encode the part
 	 * @return builder that allows for further customization of part headers
 	 */
 	public PartBuilder part(String name, Object part, MediaType contentType) {


### PR DESCRIPTION
This fix allows passing a filename to MultipartBodyBuilder methods and
sets the proper value of the content disposition header based on it.

Closes gh-22616