### PR TITLE
Spelling fix in `core-expressions.adoc`

### DIFF
--- a/src/docs/asciidoc/core/core-expressions.adoc
+++ b/src/docs/asciidoc/core/core-expressions.adoc
@@ -1212,7 +1212,7 @@ The following listing shows A more complex example:
 
 [NOTE]
 =====
-You can use the Elvis operator to apply default values in expressions. The folloiwng
+You can use the Elvis operator to apply default values in expressions. The following
 example shows how to use the Elvis operator in a `@Value` expression:
 
 [source,java,indent=0]


### PR DESCRIPTION
Obvious Fix