### PR TITLE
Cannot enhance @Configuration bean definition

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
@@ -405,13 +405,17 @@ public class ConfigurationClassPostProcessor implements BeanDefinitionRegistryPo
 					throw new BeanDefinitionStoreException("Cannot enhance @Configuration bean definition '" +
 							beanName + "' since it is not stored in an AbstractBeanDefinition subclass");
 				}
-				else if (logger.isInfoEnabled() && beanFactory.containsSingleton(beanName)) {
-					logger.info("Cannot enhance @Configuration bean definition '" + beanName +
-							"' since its singleton instance has been created too early. The typical cause " +
-							"is a non-static @Bean method with a BeanDefinitionRegistryPostProcessor " +
-							"return type: Consider declaring such methods as 'static'.");
+				else if (beanFactory.containsSingleton(beanName)) {
+					if (logger.isInfoEnabled()) {
+						logger.info("Cannot enhance @Configuration bean definition '" + beanName +
+								"' since its singleton instance has been created too early. The typical cause " +
+								"is a non-static @Bean method with a BeanDefinitionRegistryPostProcessor " +
+								"return type: Consider declaring such methods as 'static'.");
+					}
 				}
-				configBeanDefs.put(beanName, (AbstractBeanDefinition) beanDef);
+				else {
+					configBeanDefs.put(beanName, (AbstractBeanDefinition) beanDef);
+				}
 			}
 		}
 		if (configBeanDefs.isEmpty()) {

--- a/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassPostProcessorTests.java
@@ -34,11 +34,8 @@ import org.springframework.aop.scope.ScopedObject;
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
-import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.beans.factory.BeanDefinitionStoreException;
-import org.springframework.beans.factory.FactoryBean;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
 import org.springframework.beans.factory.annotation.Lookup;
@@ -1118,6 +1115,16 @@ public class ConfigurationClassPostProcessorTests {
 		assertTrue(ctx.getBean("myTestBean") instanceof TestBean);
 	}
 
+	@Test
+	public void testBeanDefinitionRegistryPostProcessorImplementation() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(PostProcessorConfiguration.class);
+		ConfigurableListableBeanFactory testBeanFactory = ctx.getBeanFactory();
+		PostProcessorConfigurationUser user = (PostProcessorConfigurationUser) ctx.getBean("postProcessorConfigurationUser");
+		assertEquals(user.getClass().getName(),
+				testBeanFactory.getBeanDefinition("postProcessorConfigurationUser").getBeanClassName());
+		assertEquals(user.postProcessorConfiguration.getClass().getName(),
+				testBeanFactory.getBeanDefinition("configurationClassPostProcessorTests.PostProcessorConfiguration").getBeanClassName());
+	}
 
 	// -------------------------------------------------------------------------
 
@@ -2003,6 +2010,23 @@ public class ConfigurationClassPostProcessorTests {
 				}
 			};
 		}
+	}
+
+	@Configuration
+	static class PostProcessorConfiguration implements BeanDefinitionRegistryPostProcessor {
+		@Override
+		public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+			registry.registerBeanDefinition("postProcessorConfigurationUser", new RootBeanDefinition(PostProcessorConfigurationUser.class));
+		}
+		@Override
+		public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		}
+	}
+
+	static class PostProcessorConfigurationUser {
+		@Autowired
+		PostProcessorConfiguration postProcessorConfiguration;
+
 	}
 
 }


### PR DESCRIPTION
Cannot enhance @Configuration bean definition if its singleton instance has been created too early.
Add the corresponding testcase.
Fix #22990.