### PR TITLE
Fix ScriptUtils for MS Windows line ending

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -234,7 +234,7 @@ public abstract class ScriptUtils {
 								"Missing block comment end delimiter: " + blockCommentEndDelimiter, resource);
 					}
 				}
-				else if (c == ' ' || c == '\n' || c == '\t') {
+				else if (c == ' ' || c == '\n' || c == '\t' || c == '\r') {
 					// Avoid multiple adjacent whitespace characters
 					if (sb.length() > 0 && sb.charAt(sb.length() - 1) != ' ') {
 						c = ' ';

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/init/ScriptUtilsUnitTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/init/ScriptUtilsUnitTests.java
@@ -136,6 +136,25 @@ public class ScriptUtilsUnitTests {
 		assertEquals("statement 4 not split correctly", statement4, statements.get(3));
 	}
 
+	@Test
+	public void readAndSplitScriptContainingCommentsWithWindowsLineEnding() throws Exception {
+		String script = readScript("test-data-with-comments.sql").replaceAll("\n", "\r\n");
+		List<String> statements = new ArrayList<>();
+		splitSqlScript(script, ';', statements);
+
+		String statement1 = "insert into customer (id, name) values (1, 'Rod; Johnson'), (2, 'Adrian Collier')";
+		String statement2 = "insert into orders(id, order_date, customer_id) values (1, '2008-01-02', 2)";
+		String statement3 = "insert into orders(id, order_date, customer_id) values (1, '2008-01-02', 2)";
+		// Statement 4 addresses the error described in SPR-9982.
+		String statement4 = "INSERT INTO persons( person_id , name) VALUES( 1 , 'Name' )";
+
+		assertEquals("wrong number of statements", 4, statements.size());
+		assertEquals("statement 1 not split correctly", statement1, statements.get(0));
+		assertEquals("statement 2 not split correctly", statement2, statements.get(1));
+		assertEquals("statement 3 not split correctly", statement3, statements.get(2));
+		assertEquals("statement 4 not split correctly", statement4, statements.get(3));
+	}
+
 	@Test  // SPR-10330
 	public void readAndSplitScriptContainingCommentsWithLeadingTabs() throws Exception {
 		String script = readScript("test-data-with-comments-and-leading-tabs.sql");


### PR DESCRIPTION
Shamelessly copied from https://github.com/testcontainers/testcontainers-java/pull/1467

Since Testcontainers copied ScriptUtils from this repo, the same bug exists here too.