### PR TITLE
Fix code example for validation on functional endpoints

### DIFF
--- a/src/docs/asciidoc/web/webflux-functional.adoc
+++ b/src/docs/asciidoc/web/webflux-functional.adoc
@@ -253,8 +253,8 @@ public class PersonHandler {
 	}
 
 	private void validate(Person person) {
-		Errors errors = new BeanPropertyBindingResult(body, "person");
-		validator.validate(body, errors);
+		Errors errors = new BeanPropertyBindingResult(person, "person");
+		validator.validate(person, errors);
 		if (errors.hasErrors) {
 			throw new ServerWebInputException(errors.toString()); <3>
 		}


### PR DESCRIPTION
There is an error on code example provided. The validate function uses the `body` parameter instead of `person`, thus making the code invalid. 