### PR TITLE
Add constants for application/cbor to MediaType

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -74,6 +74,18 @@ public class MediaType extends MimeType implements Serializable {
 	public static final String APPLICATION_ATOM_XML_VALUE = "application/atom+xml";
 
 	/**
+	 * Public constant media type for {@code application/cbor}.
+	 * @since 5.2
+	 */
+	public static final MediaType APPLICATION_CBOR;
+
+	/**
+	 * A String equivalent of {@link MediaType#APPLICATION_CBOR}.
+	 * @since 5.2
+	 */
+	public static final String APPLICATION_CBOR_VALUE = "application/cbor";
+
+	/**
 	 * Public constant media type for {@code application/x-www-form-urlencoded}.
 	 */
 	public static final MediaType APPLICATION_FORM_URLENCODED;
@@ -338,6 +350,7 @@ public class MediaType extends MimeType implements Serializable {
 		// Not using "valueOf' to avoid static init cost
 		ALL = new MediaType("*", "*");
 		APPLICATION_ATOM_XML = new MediaType("application", "atom+xml");
+		APPLICATION_CBOR = new MediaType("application", "cbor");
 		APPLICATION_FORM_URLENCODED = new MediaType("application", "x-www-form-urlencoded");
 		APPLICATION_JSON = new MediaType("application", "json");
 		APPLICATION_JSON_UTF8 = new MediaType("application", "json", StandardCharsets.UTF_8);

--- a/spring-web/src/main/java/org/springframework/http/codec/cbor/Jackson2CborDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/cbor/Jackson2CborDecoder.java
@@ -43,7 +43,7 @@ import org.springframework.util.MimeType;
 public class Jackson2CborDecoder extends AbstractJackson2Decoder {
 
 	public Jackson2CborDecoder() {
-		this(Jackson2ObjectMapperBuilder.cbor().build(), new MediaType("application", "cbor"));
+		this(Jackson2ObjectMapperBuilder.cbor().build(), MediaType.APPLICATION_CBOR);
 	}
 
 	public Jackson2CborDecoder(ObjectMapper mapper, MimeType... mimeTypes) {

--- a/spring-web/src/main/java/org/springframework/http/codec/cbor/Jackson2CborEncoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/cbor/Jackson2CborEncoder.java
@@ -44,7 +44,7 @@ import org.springframework.util.MimeType;
 public class Jackson2CborEncoder extends AbstractJackson2Encoder {
 
 	public Jackson2CborEncoder() {
-		this(Jackson2ObjectMapperBuilder.cbor().build(), new MediaType("application", "cbor"));
+		this(Jackson2ObjectMapperBuilder.cbor().build(), MediaType.APPLICATION_CBOR);
 	}
 
 	public Jackson2CborEncoder(ObjectMapper mapper, MimeType... mimeTypes) {

--- a/spring-web/src/main/java/org/springframework/http/converter/cbor/MappingJackson2CborHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/cbor/MappingJackson2CborHttpMessageConverter.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
  * <a href="https://github.com/FasterXML/jackson-dataformats-binary/tree/master/cbor">
  * the dedicated Jackson 2.x extension</a>.
  *
- * <p>By default, this converter supports {@code "application/cbor"} media type. This can be
+ * <p>By default, this converter supports {@value MediaType#APPLICATION_CBOR_VALUE} media type. This can be
  * overridden by setting the {@link #setSupportedMediaTypes supportedMediaTypes} property.
  *
  * <p>The default constructor uses the default configuration provided by {@link Jackson2ObjectMapperBuilder}.
@@ -57,7 +57,7 @@ public class MappingJackson2CborHttpMessageConverter extends AbstractJackson2Htt
 	 * @see Jackson2ObjectMapperBuilder#cbor()
 	 */
 	public MappingJackson2CborHttpMessageConverter(ObjectMapper objectMapper) {
-		super(objectMapper, new MediaType("application", "cbor"));
+		super(objectMapper, MediaType.APPLICATION_CBOR);
 		Assert.isInstanceOf(CBORFactory.class, objectMapper.getFactory(), "CBORFactory required");
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParser.java
@@ -450,7 +450,7 @@ class AnnotationDrivenBeanDefinitionParser implements BeanDefinitionParser {
 			defaultMediaTypes.put("smile", "application/x-jackson-smile");
 		}
 		if (jackson2CborPresent) {
-			defaultMediaTypes.put("cbor", "application/cbor");
+			defaultMediaTypes.put("cbor", MediaType.APPLICATION_CBOR_VALUE);
 		}
 		return defaultMediaTypes;
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -427,7 +427,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 			map.put("smile", MediaType.valueOf("application/x-jackson-smile"));
 		}
 		if (jackson2CborPresent) {
-			map.put("cbor", MediaType.valueOf("application/cbor"));
+			map.put("cbor", MediaType.APPLICATION_CBOR);
 		}
 		return map;
 	}


### PR DESCRIPTION
This PR adds constants for `application/cbor` to `MediaType` and changes to use them where possible.