### PR TITLE
Reintroduce author list and copyright notice

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -24,3 +24,17 @@ WebSocket.
 <<integration.adoc#spring-integration, Integration>> :: Remoting, JMS, JCA, JMX,
 Email, Tasks, Scheduling, Caching.
 <<languages.adoc#languages, Languages>> :: Kotlin, Groovy, Dynamic Languages.
+
+Rod Johnson, Juergen Hoeller, Keith Donald, Colin Sampaleanu, Rob Harrop, Thomas Risberg,
+Alef Arendsen, Darren Davison, Dmitriy Kopylenko, Mark Pollack, Thierry Templier,
+Erwin Vervaet, Portia Tung, Ben Hale, Adrian Colyer, John Lewis, Costin Leau, Mark Fisher,
+Sam Brannen, Ramnivas Laddad, Arjen Poutsma, Chris Beams, Tareq Abedrabbo, Andy Clement,
+Dave Syer, Oliver Gierke, Rossen Stoyanchev, Phillip Webb, Rob Winch, Brian Clozel, 
+Stephane Nicoll, Sebastien Deleuze, Jay Bryant
+
+Copyright © 2002 - 2019 Pivotal, Inc. All Rights Reserved.
+
+Copies of this document may be made for your own use and for
+distribution to others, provided that you do not charge any fee for such
+copies and further provided that each copy contains this Copyright
+Notice, whether distributed in print or electronically.


### PR DESCRIPTION
Sam Brannen noticed that we had lost the author list and the copyright notice. I have replaced that content by re-creating it from the most recent author list and copyright notice that I could find. Thanks for noticing, Sam.