### PR TITLE
Fix Javadoc for HttpHeaders.setContentLanguage()

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -886,7 +886,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the {@link Locale} of the content language,
 	 * as specified by the {@literal Content-Language} header.
-	 * <p>Use {@code set(CONTENT_LANGUAGE, list)} if you need
+	 * <p>Use {@code addAll(CONTENT_LANGUAGE, list)} if you need
 	 * to set multiple content languages.</p>
 	 * @since 5.0
 	 */


### PR DESCRIPTION
This PR changes `set()` to `addAll()` in Javadoc for `HttpHeaders.setContentLanguage()` as `set()` for the parameter types doesn't seem to exist and `addAll()` seems most suitable to the following description around available methods.