### PR TITLE
Allow alternative JdbcOperations implementations

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcCall.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SqlParameter;
@@ -77,6 +78,14 @@ public class SimpleJdbcCall extends AbstractJdbcCall implements SimpleJdbcCallOp
 	 * @see org.springframework.jdbc.core.JdbcTemplate#setDataSource
 	 */
 	public SimpleJdbcCall(JdbcTemplate jdbcTemplate) {
+		super(jdbcTemplate);
+	}
+
+	/**
+	 * Alternative Constructor that takes one parameter with the JdbcOperations to be used.
+	 * @param jdbcTemplate the {@code JdbcOperations} to use
+	 */
+	public SimpleJdbcCall(JdbcOperations jdbcTemplate) {
 		super(jdbcTemplate);
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsert.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsert.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.KeyHolder;
@@ -66,6 +67,14 @@ public class SimpleJdbcInsert extends AbstractJdbcInsert implements SimpleJdbcIn
 	 * @see org.springframework.jdbc.core.JdbcTemplate#setDataSource
 	 */
 	public SimpleJdbcInsert(JdbcTemplate jdbcTemplate) {
+		super(jdbcTemplate);
+	}
+
+	/**
+	 * Alternative Constructor that takes one parameter with the JdbcTemplate to be used.
+	 * @param jdbcTemplate the {@code JdbcOperations} to use
+	 */
+	public SimpleJdbcInsert(JdbcOperations jdbcTemplate) {
 		super(jdbcTemplate);
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/JdbcBeanDefinitionReader.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/support/JdbcBeanDefinitionReader.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -50,7 +51,7 @@ public class JdbcBeanDefinitionReader {
 	private final org.springframework.beans.factory.support.PropertiesBeanDefinitionReader propReader;
 
 	@Nullable
-	private JdbcTemplate jdbcTemplate;
+	private JdbcOperations jdbcTemplate;
 
 
 	/**
@@ -92,6 +93,15 @@ public class JdbcBeanDefinitionReader {
 	public void setJdbcTemplate(JdbcTemplate jdbcTemplate) {
 		Assert.notNull(jdbcTemplate, "JdbcTemplate must not be null");
 		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	/**
+	 * Set the JdbcTemplate to be used by this bean factory.
+	 * Contains settings for DataSource, SQLExceptionTranslator, etc.
+	 */
+	public void setJdbcOperations(JdbcOperations jdbcOperations) {
+		Assert.notNull(jdbcOperations, "JdbcOperations must not be null");
+		this.jdbcTemplate = jdbcOperations;
 	}
 
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/object/StoredProcedure.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/object/StoredProcedure.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ParameterMapper;
 import org.springframework.jdbc.core.SqlParameter;
@@ -64,6 +65,16 @@ public abstract class StoredProcedure extends SqlCall {
 	 */
 	protected StoredProcedure(JdbcTemplate jdbcTemplate, String name) {
 		setJdbcTemplate(jdbcTemplate);
+		setSql(name);
+	}
+
+	/**
+	 * Create a new object wrapper for a stored procedure.
+	 * @param jdbcTemplate the JdbcTemplate which wraps DataSource
+	 * @param name name of the stored procedure in the database
+	 */
+	protected StoredProcedure(JdbcOperations jdbcTemplate, String name) {
+		setJdbcOperations(jdbcTemplate);
 		setSql(name);
 	}
 


### PR DESCRIPTION
Change various JDBC abstraction classes to allow them to work with
JdbcOperations instead of JdbcTemplate. This allows the usage of
custom JdbcOperations that for example perform additional logging.

The following classes have been updated

- AbstractJdbcCall
- SimpleJdbcCall
- AbstractJdbcInsert
- SimpleJdbcInsert
- JdbcBeanDefinitionReader
- RdbmsOperation
- StoredProcedure

This is a backwards compatible change. All existing JdbcTemplate
methods are kept.

Closes gh-23065