### PR TITLE
Fix duplicate invoke method of transformedBeanName

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -1648,7 +1648,7 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 				return beanInstance;
 			}
 			if (!(beanInstance instanceof FactoryBean)) {
-				throw new BeanIsNotAFactoryException(transformedBeanName(name), beanInstance.getClass());
+                throw new BeanIsNotAFactoryException(beanName, beanInstance.getClass());
 			}
 		}
 


### PR DESCRIPTION
 The first sentence of `doGetBean` method of `AbstractBeanFactory` class already invoke `transformedBeanName`method to convert `name` to `beanName` and `beanName` is passed as a parameter to the method of `getObjectForBeanInstance`.
So, I think there is no necessary to twice invoke `transformedBeanName`.


