### PR TITLE
Fix MockHttpServletRequest.setCookies to produce single Cookie header

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -41,6 +41,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 import javax.servlet.AsyncContext;
 import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
@@ -58,6 +59,7 @@ import javax.servlet.http.Part;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedCaseInsensitiveMap;
@@ -973,12 +975,18 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	public void setCookies(@Nullable Cookie... cookies) {
 		this.cookies = (ObjectUtils.isEmpty(cookies) ? null : cookies);
-		this.headers.remove(HttpHeaders.COOKIE);
-		if (this.cookies != null) {
-			Arrays.stream(this.cookies)
-					.map(c -> c.getName() + '=' + (c.getValue() == null ? "" : c.getValue()))
-					.forEach(value -> doAddHeaderValue(HttpHeaders.COOKIE, value, false));
+		if (this.cookies == null) {
+			removeHeader(HttpHeaders.COOKIE);
 		}
+		else {
+			doAddHeaderValue(HttpHeaders.COOKIE, encodeCookies(this.cookies), true);
+		}
+	}
+
+	private static String encodeCookies(@NonNull Cookie... cookies) {
+		return Arrays.stream(cookies)
+				.map(c -> c.getName() + '=' + (c.getValue() == null ? "" : c.getValue()))
+				.collect(Collectors.joining("; "));
 	}
 
 	@Override

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
@@ -279,15 +279,20 @@ public class MockHttpServletRequestTests {
 		Cookie cookie2 = new Cookie("baz", "qux");
 		request.setCookies(cookie1, cookie2);
 
-		Cookie[] cookies = request.getCookies();
-		List<String> cookieHeaders = Collections.list(request.getHeaders("Cookie"));
+		assertThat(request.getCookies())
+				.describedAs("Raw cookies stored as is")
+				.hasSize(2)
+				.satisfies(subject -> {
+					assertThat(subject[0].getName()).isEqualTo("foo");
+					assertThat(subject[0].getValue()).isEqualTo("bar");
+					assertThat(subject[1].getName()).isEqualTo("baz");
+					assertThat(subject[1].getValue()).isEqualTo("qux");
+				});
 
-		assertThat(cookies.length).isEqualTo(2);
-		assertThat(cookies[0].getName()).isEqualTo("foo");
-		assertThat(cookies[0].getValue()).isEqualTo("bar");
-		assertThat(cookies[1].getName()).isEqualTo("baz");
-		assertThat(cookies[1].getValue()).isEqualTo("qux");
-		assertThat(cookieHeaders).isEqualTo(Arrays.asList("foo=bar", "baz=qux"));
+		assertThat(Collections.list(request.getHeaders(HttpHeaders.COOKIE)))
+				.describedAs("Cookies -> Header conversion works as expected per RFC6265")
+				.hasSize(1)
+				.hasOnlyOneElementSatisfying(header -> assertThat(header).isEqualTo("foo=bar; baz=qux"));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #23029 