### PR TITLE
Ignore null HttpMessageConverter in RestTemplate and HttpMessageConverterExtractor

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/HttpMessageConverterExtractor.java
+++ b/spring-web/src/main/java/org/springframework/web/client/HttpMessageConverterExtractor.java
@@ -103,7 +103,7 @@ public class HttpMessageConverterExtractor<T> implements ResponseExtractor<T> {
 					}
 				}
 				if (this.responseClass != null) {
-					if (messageConverter.canRead(this.responseClass, contentType)) {
+					if (messageConverter != null && messageConverter.canRead(this.responseClass, contentType)) {
 						if (logger.isDebugEnabled()) {
 							String className = this.responseClass.getName();
 							logger.debug("Reading to [" + className + "] as \"" + contentType + "\"");

--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -844,6 +845,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 		public void doWithRequest(ClientHttpRequest request) throws IOException {
 			if (this.responseType != null) {
 				List<MediaType> allSupportedMediaTypes = getMessageConverters().stream()
+						.filter(Objects::nonNull)
 						.filter(converter -> canReadResponse(this.responseType, converter))
 						.flatMap(this::getSupportedMediaTypes)
 						.distinct()
@@ -940,7 +942,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 							return;
 						}
 					}
-					else if (messageConverter.canWrite(requestBodyClass, requestContentType)) {
+					else if (messageConverter != null && messageConverter.canWrite(requestBodyClass, requestContentType)) {
 						if (!requestHeaders.isEmpty()) {
 							requestHeaders.forEach((key, values) -> httpHeaders.put(key, new LinkedList<>(values)));
 						}

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
@@ -379,6 +379,12 @@ public class RestTemplateTests {
 		verify(response).close();
 	}
 
+	@Test // Issue #23123 (method postForObject in RestTemplate causes NPE)
+	public void postForObjectWithNullMessageConverter() throws Exception {
+		template.setMessageConverters(Arrays.asList(null, converter));
+		postForObject();
+	}
+
 	@Test
 	public void postForEntity() throws Exception {
 		mockTextPlainHttpMessageConverter();


### PR DESCRIPTION
Prior to this commit, if a `null` `HttpMessageConverter` was configured
in the `RestTemplate`, this would lead to a `NullPointerException` once
the list of converters was accessed.

This commit avoids such exceptions by ignoring `null` converters.

See gh-23123