### PR TITLE
Support target type in MockMvcResultMatchers.jsonPath()

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/MockMvcResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/MockMvcResultMatchers.java
@@ -205,6 +205,20 @@ public abstract class MockMvcResultMatchers {
 	}
 
 	/**
+	 * An overloaded variant of {@link #jsonPath(String, Matcher)} (Matcher)} that also accepts
+	 * a target type for the resulting value that the matcher can work reliably against.
+	 * <p> This can be useful for matching numbers reliably &mdash; for example,
+	 * to coerce an integer into a double.</p>
+	 *
+	 * @param expression the JSON path expression
+	 * @param targetClass the target class to coerce the matching type into.
+	 * @param matcher a matcher for the value expected at the JSON path
+	 */
+	public static <T> ResultMatcher jsonPath(String expression, Class<T> targetClass, Matcher<T> matcher) {
+		return new JsonPathResultMatchers(expression).value(matcher, targetClass);
+	}
+
+	/**
 	 * Access to response body assertions using an XPath expression to
 	 * inspect a specific subset of the body.
 	 * <p>The XPath expression can be a parameterized string using formatting

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/comics/Person.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/comics/Person.java
@@ -24,8 +24,19 @@ package org.springframework.test.context.junit.jupiter.comics;
  */
 public class Person extends Character {
 
+	private final long id;
+
 	public Person(String name) {
+		this(0, name);
+	}
+
+	public Person(long id, String name) {
 		super(name);
+		this.id = id;
+	}
+
+	public long getId() {
+		return id;
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/web/MultipleWebRequestsSpringExtensionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/web/MultipleWebRequestsSpringExtensionTests.java
@@ -68,6 +68,20 @@ class MultipleWebRequestsSpringExtensionTests {
 	}
 
 	@Test
+	void getPerson1() throws Exception {
+		// Tests for #23121 (Target type in jsonPath method of MockMvcResultMatchers) coercing into Long
+		this.mockMvc.perform(get("/person/1").accept(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.id", Long.class, is(1L)));
+	}
+
+	@Test
+	void getPerson2() throws Exception {
+		// Tests for #23121 (Target type in jsonPath method of MockMvcResultMatchers) coercing into String
+		this.mockMvc.perform(get("/person/2").accept(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.id", String.class, is("2")));
+	}
+
+	@Test
 	void getPerson99() throws Exception {
 		this.mockMvc.perform(get("/person/99").accept(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.name", is("Wally")));

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/web/PersonController.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/web/PersonController.java
@@ -31,9 +31,9 @@ class PersonController {
 	@GetMapping("/person/{id}")
 	Person getPerson(@PathVariable long id) {
 		if (id == 42) {
-			return new Person("Dilbert");
+			return new Person(id, "Dilbert");
 		}
-		return new Person("Wally");
+		return new Person(id, "Wally");
 	}
 
 }


### PR DESCRIPTION
This introduces an helper method to specify a type to coerce into
for MockMvcResultMatchers.
New signature:
MockMvcResultMatchers#jsonPath(String, Class<T>, Matcher<T>)

Solves #23121

Signed-off-by: RustyTheClone <21066051+rustytheclone@users.noreply.github.com>