### PR TITLE
RSocketRequester.ResponseSpec Kotlin extensions issue

### DIFF
--- a/spring-messaging/src/main/kotlin/org/springframework/messaging/rsocket/RSocketRequesterExtensions.kt
+++ b/spring-messaging/src/main/kotlin/org/springframework/messaging/rsocket/RSocketRequesterExtensions.kt
@@ -64,7 +64,7 @@ suspend fun RSocketRequester.Builder.connectWebSocketAndAwait(uri: URI): RSocket
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 @FlowPreview
-fun <T : Any> RSocketRequester.RequestSpec.data(producer: Any): RSocketRequester.ResponseSpec =
+inline fun <reified T : Any> RSocketRequester.RequestSpec.data(producer: Any): RSocketRequester.ResponseSpec =
 		data(producer, object : ParameterizedTypeReference<T>() {})
 
 /**
@@ -83,7 +83,7 @@ suspend fun RSocketRequester.ResponseSpec.sendAndAwait() {
  * @author Sebastien Deleuze
  * @since 5.2
  */
-suspend fun <T : Any> RSocketRequester.ResponseSpec.retrieveAndAwait(): T =
+suspend inline fun <reified T : Any> RSocketRequester.ResponseSpec.retrieveAndAwait(): T =
 		retrieveMono(object : ParameterizedTypeReference<T>() {}).awaitSingle()
 
 /**
@@ -93,7 +93,7 @@ suspend fun <T : Any> RSocketRequester.ResponseSpec.retrieveAndAwait(): T =
  * @since 5.2
  */
 @FlowPreview
-fun <T : Any> RSocketRequester.ResponseSpec.retrieveFlow(batchSize: Int = 1): Flow<T> =
+inline fun <reified T : Any> RSocketRequester.ResponseSpec.retrieveFlow(batchSize: Int = 1): Flow<T> =
 		retrieveFlux(object : ParameterizedTypeReference<T>() {}).asFlow(batchSize)
 
 /**
@@ -104,7 +104,7 @@ fun <T : Any> RSocketRequester.ResponseSpec.retrieveFlow(batchSize: Int = 1): Fl
  * @author Sebastien Deleuze
  * @since 5.2
  */
-fun <T : Any> RSocketRequester.ResponseSpec.retrieveMono(): Mono<T> =
+inline fun <reified T : Any> RSocketRequester.ResponseSpec.retrieveMono(): Mono<T> =
 		retrieveMono(object : ParameterizedTypeReference<T>() {})
 
 
@@ -116,5 +116,5 @@ fun <T : Any> RSocketRequester.ResponseSpec.retrieveMono(): Mono<T> =
  * @author Sebastien Deleuze
  * @since 5.2
  */
-fun <T : Any> RSocketRequester.ResponseSpec.retrieveFlux(): Flux<T> =
+inline fun <reified T : Any> RSocketRequester.ResponseSpec.retrieveFlux(): Flux<T> =
 		retrieveFlux(object : ParameterizedTypeReference<T>() {})

--- a/spring-messaging/src/test/kotlin/org/springframework/messaging/rsocket/RSocketRequesterExtensionsTests.kt
+++ b/spring-messaging/src/test/kotlin/org/springframework/messaging/rsocket/RSocketRequesterExtensionsTests.kt
@@ -3,7 +3,6 @@ package org.springframework.messaging.rsocket
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals

--- a/spring-messaging/src/test/kotlin/org/springframework/messaging/rsocket/RSocketRequesterExtensionsTests.kt
+++ b/spring-messaging/src/test/kotlin/org/springframework/messaging/rsocket/RSocketRequesterExtensionsTests.kt
@@ -3,6 +3,7 @@ package org.springframework.messaging.rsocket
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -20,6 +21,8 @@ import reactor.core.publisher.Mono
  */
 @FlowPreview
 class RSocketRequesterExtensionsTests {
+
+	private val stringTypeRefMatcher: (ParameterizedTypeReference<*>) -> Boolean  = { it.type == String::class.java }
 
 	@Test
 	fun connectAndAwait() {
@@ -56,7 +59,7 @@ class RSocketRequesterExtensionsTests {
 	fun dataFlowWithType() {
 		val requestSpec = mockk<RSocketRequester.RequestSpec>()
 		val responseSpec = mockk<RSocketRequester.ResponseSpec>()
-		every { requestSpec.data(any<Publisher<String>>(), any<ParameterizedTypeReference<String>>()) } returns responseSpec
+		every { requestSpec.data(any<Publisher<String>>(), match<ParameterizedTypeReference<*>>(stringTypeRefMatcher)) } returns responseSpec
 		assertEquals(responseSpec, requestSpec.data<String>(mockk()))
 	}
 
@@ -81,16 +84,16 @@ class RSocketRequesterExtensionsTests {
 	fun retrieveAndAwait() {
 		val response = "foo"
 		val responseSpec = mockk<RSocketRequester.ResponseSpec>()
-		every { responseSpec.retrieveMono(any<ParameterizedTypeReference<String>>()) } returns Mono.just("foo")
+		every { responseSpec.retrieveMono(match<ParameterizedTypeReference<*>>(stringTypeRefMatcher)) } returns Mono.just("foo")
 		runBlocking {
-			assertEquals(response, responseSpec.retrieveAndAwait())
+			assertEquals(response, responseSpec.retrieveAndAwait<String>())
 		}
 	}
 
 	@Test
 	fun retrieveFlow() {
 		val responseSpec = mockk<RSocketRequester.ResponseSpec>()
-		every { responseSpec.retrieveFlux(any<ParameterizedTypeReference<String>>()) } returns Flux.just("foo", "bar")
+		every { responseSpec.retrieveFlux(match<ParameterizedTypeReference<*>>(stringTypeRefMatcher)) } returns Flux.just("foo", "bar")
 		runBlocking {
 			assertEquals(listOf("foo", "bar"), responseSpec.retrieveFlow<String>().toList())
 		}
@@ -99,7 +102,7 @@ class RSocketRequesterExtensionsTests {
 	@Test
 	fun retrieveMono() {
 		val responseSpec = mockk<RSocketRequester.ResponseSpec>()
-		every { responseSpec.retrieveMono(any<ParameterizedTypeReference<String>>()) } returns Mono.just("foo")
+		every { responseSpec.retrieveMono(match<ParameterizedTypeReference<*>>(stringTypeRefMatcher)) } returns Mono.just("foo")
 		runBlocking {
 			assertEquals("foo", responseSpec.retrieveMono<String>().block())
 		}
@@ -108,7 +111,7 @@ class RSocketRequesterExtensionsTests {
 	@Test
 	fun retrieveFlux() {
 		val responseSpec = mockk<RSocketRequester.ResponseSpec>()
-		every { responseSpec.retrieveFlux(any<ParameterizedTypeReference<String>>()) } returns Flux.just("foo", "bar")
+		every { responseSpec.retrieveFlux(match<ParameterizedTypeReference<*>>(stringTypeRefMatcher)) } returns Flux.just("foo", "bar")
 		runBlocking {
 			assertEquals(listOf("foo", "bar"), responseSpec.retrieveFlux<String>().collectList().block())
 		}


### PR DESCRIPTION
Extension functions need to use reified types to create 
ParameterizedTypeReference

Closes gh-23185