### PR TITLE
Remove duplicate assertion in AnnotatedElementUtilsTests

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotatedElementUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotatedElementUtilsTests.java
@@ -784,7 +784,6 @@ public class AnnotatedElementUtilsTests {
 	public void nullableAnnotationTypeViaFindMergedAnnotation() throws Exception {
 		Method method = TransactionalServiceImpl.class.getMethod("doIt");
 		assertThat(findMergedAnnotation(method, Resource.class)).isEqualTo(method.getAnnotation(Resource.class));
-		assertThat(findMergedAnnotation(method, Resource.class)).isEqualTo(method.getAnnotation(Resource.class));
 	}
 
 	@Test


### PR DESCRIPTION
This PR removes a duplicate assertion in `AnnotatedElementUtilsTests.nullableAnnotationTypeViaFindMergedAnnotation()`.