### PR TITLE
Add no-op TransactionOperations implementation

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/support/NoOpTransactionOperations.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/NoOpTransactionOperations.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.transaction.support;
+
+import org.springframework.transaction.TransactionException;
+
+/**
+ * A basic, no operation {@link TransactionOperations} implementation suitable for
+ * disabling transaction management.
+ *
+ * @author Vedran Pavic
+ * @since 5.2.0
+ */
+public class NoOpTransactionOperations implements TransactionOperations {
+
+	@Override
+	public <T> T execute(TransactionCallback<T> action) throws TransactionException {
+		return action.doInTransaction(new SimpleTransactionStatus(false));
+	}
+
+}

--- a/spring-tx/src/test/java/org/springframework/transaction/support/NoOpTransactionOperationsTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/support/NoOpTransactionOperationsTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.transaction.support;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link NoOpTransactionOperations}.
+ *
+ * @author Vedran Pavic
+ */
+public class NoOpTransactionOperationsTests {
+
+	private final TransactionOperations transactionOperations = new NoOpTransactionOperations();
+
+	@Test
+	public void execute() {
+		assertThat(this.transactionOperations.<String>execute(status -> {
+			assertThat(status.isNewTransaction()).isFalse();
+			return "test";
+		})).isEqualTo("test");
+	}
+
+}


### PR DESCRIPTION
A no-op implementation can be useful for:

- having `TransactionOperations` consuming code switch to non-transactional behavior by injecting `NoOpTransactionOperations` instead of `TransactionTemplate`
- testing purposes

For first point we have a use case in Spring Session's `JdbcOperationsSessionRepository`. I've used similar approach in a number of other projects so having Framework provide it OOTB would be nice. Also note that `TransactionOperations` isn't parameterized, but `TransactionOperations#execute` is which makes it impossible to have no-op implementation as lambda expression.