### PR TITLE
Generalize ServerResponse and WebClient body methods

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -273,8 +273,27 @@ class DefaultWebTestClient implements WebTestClient {
 		}
 
 		@Override
+		public RequestHeadersSpec<?> body(Object producer, Class<?> elementClass) {
+			this.bodySpec.body(producer, elementClass);
+			return this;
+		}
+
+		@Override
+		public RequestHeadersSpec<?> body(Object producer, ParameterizedTypeReference<?> elementTypeRef) {
+			this.bodySpec.body(producer, elementTypeRef);
+			return this;
+		}
+
+		@Override
+		@Deprecated
 		public RequestHeadersSpec<?> syncBody(Object body) {
 			this.bodySpec.syncBody(body);
+			return this;
+		}
+
+		@Override
+		public RequestHeadersSpec<?> body(Object body) {
+			this.bodySpec.body(body);
 			return this;
 		}
 

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.reactivestreams.Publisher;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -46,6 +47,7 @@ import org.springframework.web.reactive.config.PathMatchConfigurer;
 import org.springframework.web.reactive.config.ViewResolverRegistry;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
 import org.springframework.web.reactive.function.BodyInserter;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -643,6 +645,28 @@ public interface WebTestClient {
 		<T, S extends Publisher<T>> RequestHeadersSpec<?> body(S publisher, Class<T> elementClass);
 
 		/**
+		 * Set the body of the request to the given producer.
+		 * @param producer the source of payload data value(s). This must be a
+		 * {@link Publisher} or another producer adaptable to a
+		 * {@code Publisher} via {@link ReactiveAdapterRegistry}
+		 * @param elementClass the class of elements contained in the producer
+		 * @return spec for decoding the response
+		 * @since 5.2
+		 */
+		RequestHeadersSpec<?> body(Object producer, Class<?> elementClass);
+
+		/**
+		 * Set the body of the request to the given producer.
+		 * @param producer the source of payload data value(s). This must be a
+		 * {@link Publisher} or another producer adaptable to a
+		 * {@code Publisher} via {@link ReactiveAdapterRegistry}
+		 * @param elementTypeRef the type reference of elements contained in the producer
+		 * @return spec for decoding the response
+		 * @since 5.2
+		 */
+		RequestHeadersSpec<?> body(Object producer, ParameterizedTypeReference<?> elementTypeRef);
+
+		/**
 		 * Set the body of the request to the given synchronous {@code Object} and
 		 * perform the request.
 		 * <p>This method is a convenient shortcut for:
@@ -658,8 +682,48 @@ public interface WebTestClient {
 		 * conveniently using
 		 * @param body the {@code Object} to write to the request
 		 * @return a {@code Mono} with the response
+		 * @deprecated as of Spring Framework 5.2 in favor of {@link #body(Object)}
 		 */
+		@Deprecated
 		RequestHeadersSpec<?> syncBody(Object body);
+
+		/**
+		 * A shortcut for {@link #body(BodyInserter)} with an
+		 * {@linkplain BodyInserters#fromObject Object inserter}.
+		 *
+		 * <p>The body of the request can be one of the following:
+		 * <ul>
+		 * <li>Concrete value
+		 * <li>{@link Publisher} of value(s)
+		 * <li>Any other producer of value(s) that can be adapted to a
+		 * {@link Publisher} via {@link ReactiveAdapterRegistry}
+		 * </ul>.
+
+		 * For example:
+		 * <p><pre class="code">
+		 * Person person = ... ;
+		 *
+		 * Mono&lt;Void&gt; result = client.post()
+		 *     .uri("/persons/{id}", id)
+		 *     .contentType(MediaType.APPLICATION_JSON)
+		 *     .body(person)
+		 *     .retrieve()
+		 *     .bodyToMono(Void.class);
+		 * </pre>
+		 *
+		 * <p>For multipart requests, provide a
+		 * {@link org.springframework.util.MultiValueMap MultiValueMap}. The
+		 * values in the {@code MultiValueMap} can be any Object representing
+		 * the body of the part, or an
+		 * {@link org.springframework.http.HttpEntity HttpEntity} representing
+		 * a part with body and headers. The {@code MultiValueMap} can be built
+		 * with {@link org.springframework.http.client.MultipartBodyBuilder
+		 * MultipartBodyBuilder}.
+		 * @param body the body to write to the request
+		 * @return spec for decoding the response
+		 * @since 5.2
+		 */
+		RequestHeadersSpec<?> body(Object body);
 	}
 
 

--- a/spring-test/src/main/kotlin/org/springframework/test/web/reactive/server/WebTestClientExtensions.kt
+++ b/spring-test/src/main/kotlin/org/springframework/test/web/reactive/server/WebTestClientExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.test.web.reactive.server
 
 import org.reactivestreams.Publisher
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.test.util.AssertionErrors.assertEquals
 import org.springframework.test.web.reactive.server.WebTestClient.*
 
@@ -28,7 +29,17 @@ import org.springframework.test.web.reactive.server.WebTestClient.*
  * @since 5.0
  */
 inline fun <reified T : Any, S : Publisher<T>> RequestBodySpec.body(publisher: S): RequestHeadersSpec<*>
-		= body(publisher, T::class.java)
+		= body(publisher, object : ParameterizedTypeReference<T>() {})
+
+/**
+ * Extension for [RequestBodySpec.body] providing a variant without explicit class
+ * parameter thanks to Kotlin reified type parameters.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.2
+ */
+inline fun <reified T : Any> RequestBodySpec.body(producer: Any): RequestHeadersSpec<*>
+		= body(producer, object : ParameterizedTypeReference<T>() {})
 
 /**
  * Extension for [ResponseSpec.expectBody] providing an `expectBody<Foo>()` variant and

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/ApplicationContextSpecTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/ApplicationContextSpecTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class ApplicationContextSpecTests {
 					.GET("/sessionClassName", request ->
 							request.session().flatMap(session -> {
 								String className = session.getClass().getSimpleName();
-								return ServerResponse.ok().syncBody(className);
+								return ServerResponse.ok().body(className);
 							}))
 					.build();
 		}

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/bind/HttpServerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/bind/HttpServerTests.java
@@ -45,7 +45,7 @@ public class HttpServerTests {
 	@Before
 	public void start() throws Exception {
 		HttpHandler httpHandler = RouterFunctions.toHttpHandler(
-				route(GET("/test"), request -> ServerResponse.ok().syncBody("It works!")));
+				route(GET("/test"), request -> ServerResponse.ok().body("It works!")));
 
 		this.server = new ReactorHttpServer();
 		this.server.setHandler(httpHandler);

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/bind/RouterFunctionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/bind/RouterFunctionTests.java
@@ -41,7 +41,7 @@ public class RouterFunctionTests {
 	public void setUp() throws Exception {
 
 		RouterFunction<?> route = route(GET("/test"), request ->
-				ServerResponse.ok().syncBody("It works!"));
+				ServerResponse.ok().body("It works!"));
 
 		this.testClient = WebTestClient.bindToRouterFunction(route).build();
 	}

--- a/spring-test/src/test/kotlin/org/springframework/test/web/reactive/server/WebTestClientExtensionsTests.kt
+++ b/spring-test/src/test/kotlin/org/springframework/test/web/reactive/server/WebTestClientExtensionsTests.kt
@@ -21,6 +21,7 @@ import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.reactivestreams.Publisher
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.web.reactive.function.server.router
 
 /**
@@ -38,8 +39,8 @@ class WebTestClientExtensionsTests {
 	@Test
 	fun `RequestBodySpec#body with Publisher and reified type parameters`() {
 		val body = mockk<Publisher<Foo>>()
-		requestBodySpec.body(body)
-		verify { requestBodySpec.body(body, Foo::class.java) }
+		requestBodySpec.body<Foo>(body)
+		verify { requestBodySpec.body(body as Any, object : ParameterizedTypeReference<Foo>() {}) }
 	}
 
 	@Test
@@ -51,7 +52,7 @@ class WebTestClientExtensionsTests {
 	@Test
 	fun `KotlinBodySpec#isEqualTo`() {
 		WebTestClient
-				.bindToRouterFunction( router { GET("/") { ok().syncBody("foo") } } )
+				.bindToRouterFunction( router { GET("/") { ok().body("foo") } } )
 				.build()
 				.get().uri("/").exchange().expectBody<String>().isEqualTo("foo")
 	}
@@ -59,7 +60,7 @@ class WebTestClientExtensionsTests {
 	@Test
 	fun `KotlinBodySpec#consumeWith`() {
 		WebTestClient
-				.bindToRouterFunction( router { GET("/") { ok().syncBody("foo") } } )
+				.bindToRouterFunction( router { GET("/") { ok().body("foo") } } )
 				.build()
 				.get().uri("/").exchange().expectBody<String>().consumeWith { assertEquals("foo", it.responseBody) }
 	}
@@ -67,7 +68,7 @@ class WebTestClientExtensionsTests {
 	@Test
 	fun `KotlinBodySpec#returnResult`() {
 		WebTestClient
-				.bindToRouterFunction( router { GET("/") { ok().syncBody("foo") } } )
+				.bindToRouterFunction( router { GET("/") { ok().body("foo") } } )
 				.build()
 				.get().uri("/").exchange().expectBody<String>().returnResult().apply { assertEquals("foo", responseBody) }
 	}

--- a/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
@@ -41,7 +41,7 @@ import org.springframework.util.MultiValueMap;
 /**
  * Builder for the body of a multipart request, producing
  * {@code MultiValueMap<String, HttpEntity>}, which can be provided to the
- * {@code WebClient} through the {@code syncBody} method.
+ * {@code WebClient} through the {@code body} method.
  *
  * Examples:
  * <pre class="code">
@@ -67,7 +67,7 @@ import org.springframework.util.MultiValueMap;
  *
  * Mono&lt;Void&gt; result = webClient.post()
  *     .uri("...")
- *     .syncBody(multipartBody)
+ *     .body(multipartBody)
  *     .retrieve()
  *     .bodyToMono(Void.class)
  * </pre>

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ final class DefaultClientRequestBuilder implements ClientRequest.Builder {
 
 	@Override
 	public <S, P extends Publisher<S>> ClientRequest.Builder body(P publisher, Class<S> elementClass) {
-		this.body = BodyInserters.fromPublisher(publisher, elementClass);
+		this.body = BodyInserters.fromObject(publisher, elementClass);
 		return this;
 	}
 
@@ -134,7 +134,7 @@ final class DefaultClientRequestBuilder implements ClientRequest.Builder {
 	public <S, P extends Publisher<S>> ClientRequest.Builder body(
 			P publisher, ParameterizedTypeReference<S> typeReference) {
 
-		this.body = BodyInserters.fromPublisher(publisher, typeReference);
+		this.body = BodyInserters.fromObject(publisher, typeReference);
 		return this;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -61,6 +61,7 @@ import org.springframework.web.util.UriBuilderFactory;
  *
  * @author Rossen Stoyanchev
  * @author Brian Clozel
+ * @author Sebastien Deleuze
  * @since 5.0
  */
 class DefaultWebClient implements WebClient {
@@ -299,20 +300,39 @@ class DefaultWebClient implements WebClient {
 		public <T, P extends Publisher<T>> RequestHeadersSpec<?> body(
 				P publisher, ParameterizedTypeReference<T> typeReference) {
 
-			this.inserter = BodyInserters.fromPublisher(publisher, typeReference);
+			this.inserter = BodyInserters.fromObject(publisher, typeReference);
 			return this;
 		}
 
 		@Override
 		public <T, P extends Publisher<T>> RequestHeadersSpec<?> body(P publisher, Class<T> elementClass) {
-			this.inserter = BodyInserters.fromPublisher(publisher, elementClass);
+			this.inserter = BodyInserters.fromObject(publisher, elementClass);
 			return this;
 		}
 
 		@Override
+		@Deprecated
 		public RequestHeadersSpec<?> syncBody(Object body) {
 			Assert.isTrue(!(body instanceof Publisher),
 					"Please specify the element class by using body(Publisher, Class)");
+			this.inserter = BodyInserters.fromObject(body);
+			return this;
+		}
+
+		@Override
+		public RequestHeadersSpec<?> body(Object producer, Class<?> elementClass) {
+			this.inserter = BodyInserters.fromObject(producer, elementClass);
+			return this;
+		}
+
+		@Override
+		public RequestHeadersSpec<?> body(Object producer, ParameterizedTypeReference<?> typeReference) {
+			this.inserter = BodyInserters.fromObject(producer, typeReference);
+			return this;
+		}
+
+		@Override
+		public RequestHeadersSpec<?> body(Object body) {
 			this.inserter = BodyInserters.fromObject(body);
 			return this;
 		}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/EntityResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/EntityResponse.java
@@ -80,6 +80,7 @@ public interface EntityResponse<T> extends ServerResponse {
 	 * @param <P> the type of the {@code Publisher}
 	 * @return the created builder
 	 */
+	@Deprecated
 	static <T, P extends Publisher<T>> Builder<P> fromPublisher(P publisher, Class<T> elementClass) {
 		return new DefaultEntityResponseBuilder<>(publisher,
 				BodyInserters.fromPublisher(publisher, elementClass));
@@ -93,6 +94,7 @@ public interface EntityResponse<T> extends ServerResponse {
 	 * @param <P> the type of the {@code Publisher}
 	 * @return the created builder
 	 */
+	@Deprecated
 	static <T, P extends Publisher<T>> Builder<P> fromPublisher(P publisher,
 			ParameterizedTypeReference<T> typeReference) {
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/ServerResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/ServerResponse.java
@@ -30,6 +30,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -387,7 +388,7 @@ public interface ServerResponse {
 		/**
 		 * Set the body of the response to the given asynchronous {@code Publisher} and return it.
 		 * This convenience method combines {@link #body(BodyInserter)} and
-		 * {@link BodyInserters#fromPublisher(Publisher, Class)}.
+		 * {@link BodyInserters#fromObject(Object, Class)}.
 		 * @param publisher the {@code Publisher} to write to the response
 		 * @param elementClass the class of elements contained in the publisher
 		 * @param <T> the type of the elements contained in the publisher
@@ -399,7 +400,20 @@ public interface ServerResponse {
 		/**
 		 * Set the body of the response to the given asynchronous {@code Publisher} and return it.
 		 * This convenience method combines {@link #body(BodyInserter)} and
-		 * {@link BodyInserters#fromPublisher(Publisher, Class)}.
+		 * {@link BodyInserters#fromObject(Object, Class)}.
+		 * @param producer the source of payload data value(s). This must be a
+		 * {@link Publisher} or another producer adaptable to a
+		 * {@code Publisher} via {@link ReactiveAdapterRegistry}
+		 * @param elementClass the class of elements contained in the producer
+		 * @return the built response
+		 * @since 5.2
+		 */
+		Mono<ServerResponse> body(Object producer, Class<?> elementClass);
+
+		/**
+		 * Set the body of the response to the given asynchronous {@code Publisher} and return it.
+		 * This convenience method combines {@link #body(BodyInserter)} and
+		 * {@link BodyInserters#fromObject(Object, ParameterizedTypeReference)}.
 		 * @param publisher the {@code Publisher} to write to the response
 		 * @param typeReference a type reference describing the elements contained in the publisher
 		 * @param <T> the type of the elements contained in the publisher
@@ -410,6 +424,19 @@ public interface ServerResponse {
 				ParameterizedTypeReference<T> typeReference);
 
 		/**
+		 * Set the body of the response to the given asynchronous {@code Publisher} and return it.
+		 * This convenience method combines {@link #body(BodyInserter)} and
+		 * {@link BodyInserters#fromObject(Object, ParameterizedTypeReference)}.
+		 * @param producer the source of payload data value(s). This must be a
+		 * {@link Publisher} or another producer adaptable to a
+		 * {@code Publisher} via {@link ReactiveAdapterRegistry}
+		 * @param typeReference a type reference describing the elements contained in the producer
+		 * @return the built response
+		 * @since 5.2
+		 */
+		Mono<ServerResponse> body(Object producer, ParameterizedTypeReference<?> typeReference);
+
+		/**
 		 * Set the body of the response to the given synchronous {@code Object} and return it.
 		 * This convenience method combines {@link #body(BodyInserter)} and
 		 * {@link BodyInserters#fromObject(Object)}.
@@ -417,8 +444,25 @@ public interface ServerResponse {
 		 * @return the built response
 		 * @throws IllegalArgumentException if {@code body} is a {@link Publisher}, for which
 		 * {@link #body(Publisher, Class)} should be used.
+		 * @deprecated as of Spring Framework 5.2 in favor of {@link #body(Object)}
 		 */
+		@Deprecated
 		Mono<ServerResponse> syncBody(Object body);
+
+		/**
+		 * Set the body of the response to the given {@code Object} and return it.
+		 * The body can be one of the following:
+		 * <ul>
+		 * <li>Concrete value
+		 * <li>{@link Publisher} of value(s)
+		 * <li>Any other producer of value(s) that can be adapted to a
+		 * {@link Publisher} via {@link ReactiveAdapterRegistry}
+		 * </ul>
+		 * @param body the body of the response
+		 * @return the built response
+		 * @since 5.2
+		 */
+		Mono<ServerResponse> body(Object body);
 
 		/**
 		 * Set the body of the response to the given {@code BodyInserter} and return it.

--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.reactive.flow.asFlow
-import kotlinx.coroutines.reactive.flow.asPublisher
 import kotlinx.coroutines.reactor.mono
 import org.reactivestreams.Publisher
 import org.springframework.core.ParameterizedTypeReference
@@ -39,6 +38,7 @@ import reactor.core.publisher.Mono
  * @author Sebastien Deleuze
  * @since 5.0
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 inline fun <reified T : Any, S : Publisher<T>> RequestBodySpec.body(publisher: S): RequestHeadersSpec<*> =
 		body(publisher, object : ParameterizedTypeReference<T>() {})
 
@@ -50,9 +50,9 @@ inline fun <reified T : Any, S : Publisher<T>> RequestBodySpec.body(publisher: S
  * @author Sebastien Deleuze
  * @since 5.2
  */
-@FlowPreview
-inline fun <reified T : Any, S : Flow<T>> RequestBodySpec.body(flow: S): RequestHeadersSpec<*> =
-		body(flow.asPublisher(), object : ParameterizedTypeReference<T>() {})
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Any> RequestBodySpec.body(producer: Any): RequestHeadersSpec<*> =
+		body(producer, object : ParameterizedTypeReference<T>() {})
 
 /**
  * Extension for [WebClient.ResponseSpec.bodyToMono] providing a `bodyToMono<Foo>()` variant
@@ -106,6 +106,7 @@ suspend fun RequestHeadersSpec<out RequestHeadersSpec<*>>.awaitExchange(): Clien
  * @author Sebastien Deleuze
  * @since 5.2
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 inline fun <reified T: Any> RequestBodySpec.body(crossinline supplier: suspend () -> T)
 		= body(GlobalScope.mono(Dispatchers.Unconfined) { supplier.invoke() })
 

--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerResponseExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerResponseExtensions.kt
@@ -16,25 +16,35 @@
 
 package org.springframework.web.reactive.function.server
 
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.reactive.flow.asPublisher
 import org.reactivestreams.Publisher
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
 import reactor.core.publisher.Mono
 
 /**
- * Extension for [ServerResponse.BodyBuilder.body] providing a `body(Publisher<T>)`
- * variant. This extension is not subject to type erasure and retains actual generic
- * type arguments.
+ * Extension for [ServerResponse.BodyBuilder.body] providing a variant leveraging Kotlin
+ * reified type parameters. This extension is not subject to type erasure and retains
+ * actual generic type arguments.
  *
  * @author Sebastien Deleuze
  * @since 5.0
  */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 inline fun <reified T : Any> ServerResponse.BodyBuilder.body(publisher: Publisher<T>): Mono<ServerResponse> =
 		body(publisher, object : ParameterizedTypeReference<T>() {})
+
+/**
+ * Extension for [ServerResponse.BodyBuilder.body] providing a variant leveraging Kotlin
+ * reified type parameters. This extension is not subject to type erasure and retains
+ * actual generic type arguments.
+ *
+ * @author Sebastien Deleuze
+ * @since 5.2
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Any> ServerResponse.BodyBuilder.body(producer: Any): Mono<ServerResponse> =
+		body(producer, object : ParameterizedTypeReference<T>() {})
 
 /**
  * Extension for [ServerResponse.BodyBuilder.body] providing a
@@ -86,29 +96,16 @@ suspend fun ServerResponse.HeadersBuilder<out ServerResponse.HeadersBuilder<*>>.
 		build().awaitSingle()
 
 /**
- * Coroutines [Flow] based extension for [ServerResponse.BodyBuilder.body] providing a
- * `bodyFlowAndAwait(Flow<T>)` variant. This extension is not subject to type erasure and retains
- * actual generic type arguments.
+ * Coroutines variant of [ServerResponse.BodyBuilder.body].
  *
  * @author Sebastien Deleuze
  * @since 5.2
  */
-@FlowPreview
-suspend inline fun <reified T : Any> ServerResponse.BodyBuilder.bodyFlowAndAwait(flow: Flow<T>): ServerResponse =
-		body(flow.asPublisher(), object : ParameterizedTypeReference<T>() {}).awaitSingle()
+suspend inline fun <reified T : Any> ServerResponse.BodyBuilder.bodyAndAwait(body: Any): ServerResponse =
+		body<T>(body).awaitSingle()
 
 /**
- * Coroutines variant of [ServerResponse.BodyBuilder.syncBody].
- *
- * @author Sebastien Deleuze
- * @since 5.2
- */
-suspend fun ServerResponse.BodyBuilder.bodyAndAwait(body: Any): ServerResponse =
-		syncBody(body).awaitSingle()
-
-/**
- * Coroutines variant of [ServerResponse.BodyBuilder.syncBody] without the sync prefix since it is ok to use it within
- * another suspendable function.
+ * Coroutines variant of [ServerResponse.BodyBuilder.render].
  *
  * @author Sebastien Deleuze
  * @since 5.2
@@ -117,8 +114,7 @@ suspend fun ServerResponse.BodyBuilder.renderAndAwait(name: String, vararg model
 		render(name, *modelAttributes).awaitSingle()
 
 /**
- * Coroutines variant of [ServerResponse.BodyBuilder.syncBody] without the sync prefix since it is ok to use it within
- * another suspendable function.
+ * Coroutines variant of [ServerResponse.BodyBuilder.render].
  *
  * @author Sebastien Deleuze
  * @since 5.2

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/BodyInsertersTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/BodyInsertersTests.java
@@ -36,6 +36,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.codec.ByteBufferEncoder;
 import org.springframework.core.codec.CharSequenceEncoder;
 import org.springframework.core.io.ClassPathResource;
@@ -155,6 +156,48 @@ public class BodyInsertersTests {
 
 		StepVerifier.create(response.getBodyAsString())
 				.expectNext("{\"username\":\"foo\"}")
+				.expectComplete()
+				.verify();
+	}
+
+	@Test
+	public void ofObjectWithPublisher() {
+		Mono<User> body = Mono.just(new User("foo", "bar"));
+		BodyInserter<Mono<User>, ReactiveHttpOutputMessage> inserter = BodyInserters.fromObject(body);
+
+		MockServerHttpResponse response = new MockServerHttpResponse();
+		Mono<Void> result = inserter.insert(response, this.context);
+		StepVerifier.create(result).expectComplete().verify();
+		StepVerifier.create(response.getBodyAsString())
+				.expectNext("{\"username\":\"foo\",\"password\":\"bar\"}")
+				.expectComplete()
+				.verify();
+	}
+
+	@Test
+	public void ofObjectWithPublisherAndClass() {
+		Mono<User> body = Mono.just(new User("foo", "bar"));
+		BodyInserter<Mono<User>, ReactiveHttpOutputMessage> inserter = BodyInserters.fromObject(body, User.class);
+
+		MockServerHttpResponse response = new MockServerHttpResponse();
+		Mono<Void> result = inserter.insert(response, this.context);
+		StepVerifier.create(result).expectComplete().verify();
+		StepVerifier.create(response.getBodyAsString())
+				.expectNext("{\"username\":\"foo\",\"password\":\"bar\"}")
+				.expectComplete()
+				.verify();
+	}
+
+	@Test
+	public void ofObjectWithPublisherAndTypeReference() {
+		Mono<User> body = Mono.just(new User("foo", "bar"));
+		BodyInserter<Mono<User>, ReactiveHttpOutputMessage> inserter = BodyInserters.fromObject(body, new ParameterizedTypeReference<User>() {});
+
+		MockServerHttpResponse response = new MockServerHttpResponse();
+		Mono<Void> result = inserter.insert(response, this.context);
+		StepVerifier.create(result).expectComplete().verify();
+		StepVerifier.create(response.getBodyAsString())
+				.expectNext("{\"username\":\"foo\",\"password\":\"bar\"}")
 				.expectComplete()
 				.verify();
 	}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/MultipartIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/MultipartIntegrationTests.java
@@ -169,7 +169,7 @@ public class MultipartIntegrationTests extends AbstractRouterFunctionIntegration
 							Path tempFile = Files.createTempFile("MultipartIntegrationTests", null);
 							return part.transferTo(tempFile)
 									.then(ServerResponse.ok()
-											.syncBody(tempFile.toString()));
+											.body(tempFile.toString()));
 						}
 						catch (Exception e) {
 							return Mono.error(e);

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/DefaultServerResponseBuilderTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/DefaultServerResponseBuilderTests.java
@@ -308,7 +308,7 @@ public class DefaultServerResponseBuilderTests {
 	public void copyCookies() {
 		Mono<ServerResponse> serverResponse = ServerResponse.ok()
 				.cookie(ResponseCookie.from("foo", "bar").build())
-				.syncBody("body");
+				.body("body");
 
 		assertThat(serverResponse.block().cookies().isEmpty()).isFalse();
 
@@ -360,7 +360,7 @@ public class DefaultServerResponseBuilderTests {
 		Mono<Void> mono = Mono.empty();
 
 		assertThatIllegalArgumentException().isThrownBy(() ->
-				ServerResponse.ok().syncBody(mono));
+				ServerResponse.ok().body(mono));
 	}
 
 	@Test
@@ -368,7 +368,7 @@ public class DefaultServerResponseBuilderTests {
 		String etag = "\"foo\"";
 		ServerResponse responseMono = ServerResponse.ok()
 				.eTag(etag)
-				.syncBody("bar")
+				.body("bar")
 				.block();
 
 		MockServerHttpRequest request = MockServerHttpRequest.get("https://example.com")
@@ -392,7 +392,7 @@ public class DefaultServerResponseBuilderTests {
 
 		ServerResponse responseMono = ServerResponse.ok()
 				.lastModified(oneMinuteBeforeNow)
-				.syncBody("bar")
+				.body("bar")
 				.block();
 
 		MockServerHttpRequest request = MockServerHttpRequest.get("https://example.com")

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/InvalidHttpMethodIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/InvalidHttpMethodIntegrationTests.java
@@ -33,8 +33,8 @@ public class InvalidHttpMethodIntegrationTests extends AbstractRouterFunctionInt
 	@Override
 	protected RouterFunction<?> routerFunction() {
 		return RouterFunctions.route(RequestPredicates.GET("/"),
-				request -> ServerResponse.ok().syncBody("FOO"))
-				.andRoute(RequestPredicates.all(), request -> ServerResponse.ok().syncBody("BAR"));
+				request -> ServerResponse.ok().body("FOO"))
+				.andRoute(RequestPredicates.all(), request -> ServerResponse.ok().body("BAR"));
 	}
 
 	@Test

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/NestedRouteIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/NestedRouteIntegrationTests.java
@@ -125,7 +125,7 @@ public class NestedRouteIntegrationTests extends AbstractRouterFunctionIntegrati
 
 		public Mono<ServerResponse> pattern(ServerRequest request) {
 			String pattern = matchingPattern(request).getPatternString();
-			return ServerResponse.ok().syncBody(pattern);
+			return ServerResponse.ok().body(pattern);
 		}
 
 		@SuppressWarnings("unchecked")

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/client/WebClientExtensionsTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/client/WebClientExtensionsTests.kt
@@ -43,16 +43,16 @@ class WebClientExtensionsTests {
 	@Test
 	fun `RequestBodySpec#body with Publisher and reified type parameters`() {
 		val body = mockk<Publisher<List<Foo>>>()
-		requestBodySpec.body(body)
-		verify { requestBodySpec.body(body, object : ParameterizedTypeReference<List<Foo>>() {}) }
+		requestBodySpec.body<List<Foo>>(body)
+		verify { requestBodySpec.body(ofType<Any>(), object : ParameterizedTypeReference<List<Foo>>() {}) }
 	}
 
 	@Test
 	@FlowPreview
 	fun `RequestBodySpec#body with Flow and reified type parameters`() {
 		val body = mockk<Flow<List<Foo>>>()
-		requestBodySpec.body(body)
-		verify { requestBodySpec.body(ofType<Publisher<List<Foo>>>(), object : ParameterizedTypeReference<List<Foo>>() {}) }
+		requestBodySpec.body<List<Foo>>(body)
+		verify { requestBodySpec.body(ofType<Any>(), object : ParameterizedTypeReference<List<Foo>>() {}) }
 	}
 
 	@Test
@@ -89,7 +89,7 @@ class WebClientExtensionsTests {
 		val supplier: suspend () -> String = mockk()
 		every { requestBodySpec.body(ofType<Mono<String>>()) } returns headerSpec
 		runBlocking {
-			requestBodySpec.body(supplier)
+			requestBodySpec.body<String>(supplier)
 		}
 		verify {
 			requestBodySpec.body(ofType<Mono<String>>())

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/ServerResponseExtensionsTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/ServerResponseExtensionsTests.kt
@@ -42,7 +42,7 @@ class ServerResponseExtensionsTests {
 	@Test
 	fun `BodyBuilder#body with Publisher and reified type parameters`() {
 		val body = mockk<Publisher<List<Foo>>>()
-		bodyBuilder.body(body)
+		bodyBuilder.body<List<Foo>>(body)
 		verify { bodyBuilder.body(body, object : ParameterizedTypeReference<List<Foo>>() {}) }
 	}
 
@@ -84,25 +84,25 @@ class ServerResponseExtensionsTests {
 	fun `bodyAndAwait with object parameter`() {
 		val response = mockk<ServerResponse>()
 		val body = "foo"
-		every { bodyBuilder.syncBody(ofType<String>()) } returns Mono.just(response)
+		every { bodyBuilder.body<String>(ofType<String>()) } returns Mono.just(response)
 		runBlocking {
-			bodyBuilder.bodyAndAwait(body)
+			bodyBuilder.bodyAndAwait<String>(body)
 		}
 		verify {
-			bodyBuilder.syncBody(ofType<String>())
+			bodyBuilder.body<String>(ofType<String>())
 		}
 	}
 
 	@Test
 	@FlowPreview
-	fun bodyFlowAndAwait() {
+	fun `bodyAndAwait with flow parameter`() {
 		val response = mockk<ServerResponse>()
 		val body = mockk<Flow<List<Foo>>>()
-		every { bodyBuilder.body(ofType<Publisher<List<Foo>>>()) } returns Mono.just(response)
+		every { bodyBuilder.body<List<Foo>>(ofType<Flow<List<Foo>>>()) } returns Mono.just(response)
 		runBlocking {
-			bodyBuilder.bodyFlowAndAwait(body)
+			bodyBuilder.bodyAndAwait<List<Foo>>(body)
 		}
-		verify { bodyBuilder.body(ofType<Publisher<List<Foo>>>(), object : ParameterizedTypeReference<List<Foo>>() {}) }
+		verify { bodyBuilder.body(ofType<Flow<List<Foo>>>(), object : ParameterizedTypeReference<List<Foo>>() {}) }
 	}
 
 	@Test

--- a/src/docs/asciidoc/web/webflux-webclient.adoc
+++ b/src/docs/asciidoc/web/webflux-webclient.adoc
@@ -318,7 +318,8 @@ is closed and is not placed back in the pool.
 [[webflux-client-body]]
 == Request Body
 
-The request body can be encoded from an `Object`, as the following example shows:
+The request body can be encoded from an `Object`, a Reactive Streams `Publisher` like `Mono`
+or `Flux`, or any Reactive type supported by , as the following example shows:
 
 [source,java,intent=0]
 [subs="verbatim,quotes"]
@@ -348,7 +349,7 @@ You can also have a stream of objects be encoded, as the following example shows
 			.bodyToMono(Void.class);
 ----
 
-Alternatively, if you have the actual value, you can use the `syncBody` shortcut method,
+Alternatively, if you have the actual value, you can use the `body` shortcut method,
 as the following example shows:
 
 [source,java,intent=0]
@@ -359,7 +360,7 @@ as the following example shows:
 	Mono<Void> result = client.post()
 			.uri("/persons/{id}", id)
 			.contentType(MediaType.APPLICATION_JSON)
-			.syncBody(person)
+			.body(person)
 			.retrieve()
 			.bodyToMono(Void.class);
 ----
@@ -380,7 +381,7 @@ content is automatically set to `application/x-www-form-urlencoded` by the
 
 	Mono<Void> result = client.post()
 			.uri("/path", id)
-			.syncBody(formData)
+			.body(formData)
 			.retrieve()
 			.bodyToMono(Void.class);
 ----
@@ -428,7 +429,7 @@ explicitly provide the `MediaType` to use for each part through one of the overl
 builder `part` methods.
 
 Once a `MultiValueMap` is prepared, the easiest way to pass it to the the `WebClient` is
-through the `syncBody` method, as the following example shows:
+through the `body` method, as the following example shows:
 
 [source,java,intent=0]
 [subs="verbatim,quotes"]
@@ -437,7 +438,7 @@ through the `syncBody` method, as the following example shows:
 
 	Mono<Void> result = client.post()
 			.uri("/path", id)
-			.syncBody(builder.build())
+			.body(builder.build())
 			.retrieve()
 			.bodyToMono(Void.class);
 ----


### PR DESCRIPTION
The commit is a follow-up of d6b5c2005849e0676781ec1086bf8fc994e1a2c4
which applies the same principle to ServerResponse,
WebClient.RequestBodySpec and WebTestClient.RequestBodySpec body
methods.

It introduces a body(Object) method where the parameter can be:
 - Concrete value
 - Publisher of value(s)
 - Any other producer of value(s) that can be adapted to a
   Publisher via ReactiveAdapterRegistry

Variants with Class and ParameterizedTypeReference parameters are also
provided and syncBody(Object) is deprecated.

With this change, in Kotlin it is now mandatory to specify explicitly
the generic type (for example body<List<Foo>>(body)) in order to
invoke the ParameterizedTypeReference shortcut. If it is not specified,
the extension is shadowed by the Java body(Object) method which is not
able to use Kotlin type inference to resolve the generic type.