### PR TITLE
Rename PathPatternRouteMatcherTest to PathPatternRouteMatcherTests

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/util/pattern/PathPatternRouteMatcherTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/pattern/PathPatternRouteMatcherTests.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for the {@link PathPatternRouteMatcher}
  * @author Brian Clozel
  */
-public class PathPatternRouteMatcherTest {
+public class PathPatternRouteMatcherTests {
 
 	PathPatternRouteMatcher routeMatcher = new PathPatternRouteMatcher(new PathPatternParser());
 


### PR DESCRIPTION
This PR renames `PathPatternRouteMatcherTest` to `PathPatternRouteMatcherTests` to align its name with the names of the other test classes.