### PR TITLE
convertList method added

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
@@ -18,6 +18,7 @@ package org.springframework.core.convert.support;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.springframework.core.DecoratingProxy;
 import org.springframework.core.ResolvableType;
@@ -170,18 +172,39 @@ public class GenericConversionService implements ConfigurableConversionService {
 	@SuppressWarnings("unchecked")
 	@Nullable
 	public <S, T> List<T> convertList(@Nullable List<S> sourceList, Class<T> targetClass) {
+		return (List<T>) convertCollection(sourceList, TypeDescriptor.valueOf(targetClass), ArrayList::new);
+	}
 
-		if (sourceList == null) {
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public <S, T> List<T> convertList(@Nullable List<S> sourceList, TypeDescriptor targetType) {
+		return (List<T>) convertCollection(sourceList, targetType, ArrayList::new);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public <S, T> Collection<T> convertCollection(
+		@Nullable Collection<S> sourceCollection, Class<T> targetClass, Supplier<Collection<T>> supplier) {
+
+		return convertCollection(sourceCollection, TypeDescriptor.valueOf(targetClass), supplier);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public <S, T> Collection<T> convertCollection(
+		@Nullable Collection<S> sourceCollection, TypeDescriptor targetType, Supplier<Collection<T>> supplier) {
+
+		if (sourceCollection == null) {
 			return null;
 		}
 
-		if (sourceList.isEmpty()) {
+		if (sourceCollection.isEmpty()) {
 			return Collections.emptyList();
 		}
 
-		return sourceList.stream()
-			.map(source -> convert(source, targetClass))
-			.collect(Collectors.toList());
+		return sourceCollection.stream()
+			.map(source -> (T) convert(source, targetType))
+			.collect(Collectors.toCollection(supplier));
 	}
 
 	@Override

--- a/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
@@ -169,14 +169,14 @@ public class GenericConversionService implements ConfigurableConversionService {
 
 	@SuppressWarnings("unchecked")
 	@Nullable
-	public <S, T> List<T> convertList(final @Nullable List<S> sourceList, final Class<T> targetClass) {
+	public <S, T> List<T> convertList(@Nullable List<S> sourceList, Class<T> targetClass) {
 
 		if (sourceList == null) {
 			return null;
 		}
 
 		if (sourceList.isEmpty()) {
-			return new ArrayList<>();
+			return Collections.emptyList();
 		}
 
 		return sourceList.stream()

--- a/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import org.springframework.core.DecoratingProxy;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionException;
@@ -164,6 +165,23 @@ public class GenericConversionService implements ConfigurableConversionService {
 		}
 		GenericConverter converter = getConverter(sourceType, targetType);
 		return (converter == NO_OP_CONVERTER);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public <S, T> List<T> convertList(final @Nullable List<S> sourceList, final Class<T> targetClass) {
+
+		if (sourceList == null) {
+			return null;
+		}
+
+		if (sourceList.isEmpty()) {
+			return new ArrayList<>();
+		}
+
+		return sourceList.stream()
+			.map(source -> convert(source, targetClass))
+			.collect(Collectors.toList());
 	}
 
 	@Override

--- a/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/GenericConversionService.java
@@ -199,7 +199,7 @@ public class GenericConversionService implements ConfigurableConversionService {
 		}
 
 		if (sourceCollection.isEmpty()) {
-			return Collections.emptyList();
+			return supplier.get();
 		}
 
 		return sourceCollection.stream()

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -106,6 +106,14 @@ public class GenericConversionServiceTests {
 	}
 
 	@Test
+	public void convertList() {
+		conversionService.addConverterFactory(new StringToNumberConverterFactory());
+		assertThat(
+				conversionService.convertList(Arrays.asList("3", "4", "5"), Integer.class)
+		).isEqualTo(Arrays.asList(3, 4, 5));
+	}
+
+	@Test
 	public void convert() {
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
 		assertThat(conversionService.convert("3", Integer.class)).isEqualTo((int) Integer.valueOf(3));

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -114,6 +114,23 @@ public class GenericConversionServiceTests {
 	}
 
 	@Test
+	public void convertEmptyCollection() {
+		conversionService.addConverterFactory(new StringToNumberConverterFactory());
+		assertThat(
+				conversionService.convertCollection(Collections.emptySet(), Integer.class, HashSet::new)
+		).isEqualTo(Collections.emptySet());
+	}
+
+	@Test
+	public void convertCollection() {
+		conversionService.addConverterFactory(new StringToNumberConverterFactory());
+
+		assertThat(
+				conversionService.convertCollection(new HashSet<>(Arrays.asList("3", "4", "5")), Integer.class, HashSet::new)
+		).isEqualTo(new HashSet<>(Arrays.asList(3, 4, 5)));
+	}
+
+	@Test
 	public void convert() {
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
 		assertThat(conversionService.convert("3", Integer.class)).isEqualTo((int) Integer.valueOf(3));

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import java.util.function.Supplier;
 import org.junit.Test;
 
 import org.springframework.core.convert.ConversionFailedException;
@@ -108,26 +109,33 @@ public class GenericConversionServiceTests {
 	@Test
 	public void convertList() {
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
-		assertThat(
-				conversionService.convertList(Arrays.asList("3", "4", "5"), Integer.class)
-		).isEqualTo(Arrays.asList(3, 4, 5));
+
+		List<Integer> numbers = conversionService.convertList(Arrays.asList("3", "4", "5"), Integer.class);
+		assertThat(numbers).isEqualTo(Arrays.asList(3, 4, 5));
 	}
 
 	@Test
 	public void convertEmptyCollection() {
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
-		assertThat(
-				conversionService.convertCollection(Collections.emptySet(), Integer.class, HashSet::new)
-		).isEqualTo(Collections.emptySet());
+
+		Set<Integer> numbers = conversionService.convertCollection(Collections.emptySet(), Integer.class, HashSet::new);
+		assertThat(numbers).isEqualTo(Collections.emptySet());
 	}
 
 	@Test
 	public void convertCollection() {
 		conversionService.addConverterFactory(new StringToNumberConverterFactory());
 
-		assertThat(
-				conversionService.convertCollection(new HashSet<>(Arrays.asList("3", "4", "5")), Integer.class, HashSet::new)
-		).isEqualTo(new HashSet<>(Arrays.asList(3, 4, 5)));
+		Set<Integer> numbers = conversionService.convertCollection(new HashSet<>(Arrays.asList("3", "4", "5")), Integer.class, HashSet::new);
+		assertThat(numbers).isEqualTo(new HashSet<>(Arrays.asList(3, 4, 5)));
+	}
+
+	@Test
+	public void convertCollectionWithTypeDescriptor() {
+		conversionService.addConverterFactory(new StringToNumberConverterFactory());
+
+		Set<Integer> numbers = conversionService.convertCollection(new HashSet<>(Arrays.asList("3", "4", "5")), TypeDescriptor.valueOf(Integer.class), HashSet::new);
+		assertThat(numbers).isEqualTo(new HashSet<>(Arrays.asList(3, 4, 5)));
 	}
 
 	@Test


### PR DESCRIPTION
Implementation for #23254

A simple method for converting lists in an iterative way. Considered to get converter outside of the loop but getConverter method uses a cache mechanism and fetches from a HashMap this means. it's already O(1).