### PR TITLE
Treat null path as non-matching pattern in AntPathMatcher

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -169,6 +169,9 @@ public class AntPathMatcher implements PathMatcher {
 
 	@Override
 	public boolean isPattern(String path) {
+		if(path == null) {
+			return false;
+		}
 		boolean uriVar = false;
 		for (int i = 0; i < path.length(); i++) {
 			char c = path.charAt(i);
@@ -207,7 +210,7 @@ public class AntPathMatcher implements PathMatcher {
 	protected boolean doMatch(String pattern, String path, boolean fullMatch,
 			@Nullable Map<String, String> uriTemplateVariables) {
 
-		if (path.startsWith(this.pathSeparator) != pattern.startsWith(this.pathSeparator)) {
+		if (path == null || path.startsWith(this.pathSeparator) != pattern.startsWith(this.pathSeparator)) {
 			return false;
 		}
 

--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -130,6 +130,11 @@ public class AntPathMatcherTests {
 		assertThat(pathMatcher.match("", "")).isTrue();
 
 		assertThat(pathMatcher.match("/{bla}.*", "/testing.html")).isTrue();
+
+		assertThat(pathMatcher.match("/test", null)).isFalse();
+		assertThat(pathMatcher.match("/", null)).isFalse();
+		assertThat(pathMatcher.match("/", null)).isFalse();
+		assertThat(pathMatcher.match(null, null)).isFalse();
 	}
 
 	// SPR-14247
@@ -688,6 +693,7 @@ public class AntPathMatcherTests {
 		assertThat(pathMatcher.isPattern("/test/{name}")).isTrue();
 		assertThat(pathMatcher.isPattern("/test/name")).isFalse();
 		assertThat(pathMatcher.isPattern("/test/foo{bar")).isFalse();
+		assertThat(pathMatcher.isPattern(null)).isFalse();
 	}
 
 }

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/result/MockMvcResultMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/result/MockMvcResultMatchersTests.java
@@ -43,6 +43,18 @@ public class MockMvcResultMatchersTests {
 	}
 
 	@Test
+	public void redirectNonMatching() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				redirectedUrl("/resource/2").match(getRedirectedUrlStubMvcResult("/resource/1")));
+	}
+
+	@Test
+	public void redirectNonMatchingBecauseNotRedirect() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				redirectedUrl("/resource/1").match(getForwardedUrlStubMvcResult("/resource/1")));
+	}
+
+	@Test
 	public void redirectWithUrlTemplate() throws Exception {
 		redirectedUrlTemplate("/orders/{orderId}/items/{itemId}", 1, 2).match(getRedirectedUrlStubMvcResult("/orders/1/items/2"));
 	}
@@ -59,8 +71,26 @@ public class MockMvcResultMatchersTests {
 	}
 
 	@Test
+	public void redirectWithNonMatchingPatternBecauseNotRedirect() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				redirectedUrlPattern("/resource/*").match(getForwardedUrlStubMvcResult("/resource/1")));
+	}
+
+	@Test
 	public void forward() throws Exception {
 		forwardedUrl("/api/resource/1").match(getForwardedUrlStubMvcResult("/api/resource/1"));
+	}
+
+	@Test
+	public void forwardNonMatching() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				forwardedUrlPattern("api/resource/2").match(getForwardedUrlStubMvcResult("api/resource/1")));
+	}
+
+	@Test
+	public void forwardNonMatchingBecauseNotForward() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				forwardedUrlPattern("api/resource/1").match(getRedirectedUrlStubMvcResult("api/resource/1")));
 	}
 
 	@Test
@@ -82,6 +112,12 @@ public class MockMvcResultMatchersTests {
 	public void forwardWithNonMatchingPattern() throws Exception {
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
 				forwardedUrlPattern("/resource/").match(getForwardedUrlStubMvcResult("/resource/1")));
+	}
+
+	@Test
+	public void forwardWithNonMatchingPatternBecauseNotForward() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				forwardedUrlPattern("/resource/*").match(getRedirectedUrlStubMvcResult("/resource/1")));
 	}
 
 	private StubMvcResult getRedirectedUrlStubMvcResult(String redirectUrl) throws Exception {


### PR DESCRIPTION
This PR supersedes gh-943.

I noticed that the MVC Test `redirectedUrl` matcher fails with a `NullPointerException` if there happens to be no "Redirected URL" on the response (the test should still fail, but with a proper assertion error).

One way to fix this would be to `assertNotNull` in the respective `MockMvcResultMatchers` method before calling the `AntPathMatcher`, but I thought it would be more appropriate to fix the underlying null-safety issues. You may disagree.
