### PR TITLE
ForwardedHeaderTransformer preserves escape sequences when applying X-Forwarded-Prefix

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java
@@ -96,7 +96,7 @@ public class ForwardedHeaderTransformer implements Function<ServerHttpRequest, S
 				builder.uri(uri);
 				String prefix = getForwardedPrefix(request);
 				if (prefix != null) {
-					builder.path(prefix + uri.getPath());
+					builder.path(prefix + uri.getRawPath());
 					builder.contextPath(prefix);
 				}
 			}

--- a/spring-web/src/test/java/org/springframework/web/server/adapter/ForwardedHeaderTransformerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/adapter/ForwardedHeaderTransformerTests.java
@@ -91,6 +91,22 @@ public class ForwardedHeaderTransformerTests {
 	}
 
 	@Test
+	public void emptyXForwardedPrefixShouldNotLeadToDecodedPath() throws Exception {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("X-Forwarded-Prefix", "");
+		ServerHttpRequest request = MockServerHttpRequest
+				.method(HttpMethod.GET, new URI("https://example.com/a%20b?q=a%2Bb"))
+				.headers(headers)
+				.build();
+
+		request = this.requestMutator.apply(request);
+
+		assertThat(request.getURI()).isEqualTo(new URI("https://example.com/a%20b?q=a%2Bb"));
+		assertThat(request.getPath().value()).isEqualTo("/a%20b");
+		assertForwardedHeadersRemoved(request);
+	}
+
+	@Test
 	public void xForwardedPrefixTrailingSlash() throws Exception {
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("X-Forwarded-Prefix", "/prefix////");


### PR DESCRIPTION
See #23306 for the cause.