### PR TITLE
Support arrays of `AnnotatedElement` with `MergedAnnotations.from`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java
@@ -78,6 +78,30 @@ abstract class AnnotationsScanner {
 	}
 
 	/**
+	 * Scan the the specified elements using {@link SearchStrategy#DIRECT} for
+	 * relevant annotations and call the processor as required.
+	 * @param context an optional context object that will be passed back to the
+	 * processor
+	 * @param sources the element sources to scan
+	 * @param processor the processor that receives the annotations
+	 * @return the result of {@link AnnotationsProcessor#finish(Object)}
+	 */
+	@Nullable
+	static <C, R> R scan(C context, AnnotatedElement[] sources,
+			AnnotationsProcessor<C, R> processor) {
+
+		for (AnnotatedElement source : sources) {
+			if (source != null) {
+				R result = process(context, source, SearchStrategy.DIRECT, processor, null);
+				if (result != null) {
+					return processor.finish(result);
+				}
+			}
+		}
+		return processor.finish(null);
+	}
+
+	/**
 	 * Scan the hierarchy of the specified element for relevant annotations and
 	 * call the processor as required.
 	 * @param context an optional context object that will be passed back to the

--- a/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotations.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotations.java
@@ -288,8 +288,21 @@ public interface MergedAnnotations extends Iterable<MergedAnnotation<Annotation>
 	 * @return a {@link MergedAnnotations} instance containing the element's
 	 * annotations
 	 */
-	static MergedAnnotations from(AnnotatedElement element) {
+	static MergedAnnotations from(@Nullable AnnotatedElement element) {
 		return from(element, SearchStrategy.DIRECT);
+	}
+
+	/**
+	 * Create a new {@link MergedAnnotations} instance containing all
+	 * annotations and meta-annotations from the specified elements using
+	 * {@link SearchStrategy#DIRECT}.
+	 * @param elements the source elements (elements of the array can be
+	 * {@code null})
+	 * @return a {@link MergedAnnotations} instance containing the element's
+	 * annotations
+	 */
+	static MergedAnnotations from(AnnotatedElement... elements) {
+		return TypeMappedAnnotations.from(elements);
 	}
 
 	/**
@@ -301,7 +314,7 @@ public interface MergedAnnotations extends Iterable<MergedAnnotation<Annotation>
 	 * @return a {@link MergedAnnotations} instance containing the merged
 	 * element annotations
 	 */
-	static MergedAnnotations from(AnnotatedElement element, SearchStrategy searchStrategy) {
+	static MergedAnnotations from(@Nullable AnnotatedElement element, SearchStrategy searchStrategy) {
 		return from(element, searchStrategy, RepeatableContainers.standardRepeatables(), AnnotationFilter.PLAIN);
 	}
 
@@ -318,7 +331,7 @@ public interface MergedAnnotations extends Iterable<MergedAnnotation<Annotation>
 	 * @return a {@link MergedAnnotations} instance containing the merged
 	 * element annotations
 	 */
-	static MergedAnnotations from(AnnotatedElement element, SearchStrategy searchStrategy,
+	static MergedAnnotations from(@Nullable AnnotatedElement element, SearchStrategy searchStrategy,
 			RepeatableContainers repeatableContainers, AnnotationFilter annotationFilter) {
 
 		return TypeMappedAnnotations.from(element, searchStrategy, repeatableContainers, annotationFilter);


### PR DESCRIPTION
Provide an overloaded version of `MergedAnnotations.from` that takes
an array of elements. This shortcut is particularly useful in property
situations where an annotation may be used on a getter, setter or field.

Closes gh-23327