### PR TITLE
Add Javadoc since for Jaxb2XmlDecoder(MimeType...)

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/xml/Jaxb2XmlDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/xml/Jaxb2XmlDecoder.java
@@ -91,6 +91,11 @@ public class Jaxb2XmlDecoder extends AbstractDecoder<Object> {
 		super(MimeTypeUtils.APPLICATION_XML, MimeTypeUtils.TEXT_XML);
 	}
 
+	/**
+	 * Create a {@code Jaxb2XmlDecoder} with the specified MIME types.
+	 * @param supportedMimeTypes supported MIME types
+	 * @since 5.1.9
+	 */
 	public Jaxb2XmlDecoder(MimeType... supportedMimeTypes) {
 		super(supportedMimeTypes);
 	}


### PR DESCRIPTION
This PR adds Javadoc `@since` tag for the `Jaxb2XmlDecoder(MimeType...)` constructor.