### PR TITLE
Add since tag for ClientResponse.Builder.request()

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientResponse.java
@@ -331,6 +331,7 @@ public interface ClientResponse {
 		 * Set the request associated with the response.
 		 * @param request the request
 		 * @return this builder
+		 * @since 5.2
 		 */
 		Builder request(HttpRequest request);
 


### PR DESCRIPTION
This PR adds Javadoc `@since` tag for `ClientResponse.Builder.request()`.