### PR TITLE
Issue-13568: Make PropertySourcesPlaceholderConfigurer call a convert…

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/support/PropertySourcesPlaceholderConfigurerTests.java
+++ b/spring-context/src/test/java/org/springframework/context/support/PropertySourcesPlaceholderConfigurerTests.java
@@ -388,6 +388,30 @@ public class PropertySourcesPlaceholderConfigurerTests {
 		assertThat(bf.getBean(OptionalTestBean.class).getName()).isEqualTo(Optional.empty());
 	}
 
+	@Test
+	public void convertPropertyImplemented() {
+		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
+		bf.registerBeanDefinition("testBean",
+				genericBeanDefinition(TestBean.class)
+					.addPropertyValue("name", "Hello ${my.name}")
+					.getBeanDefinition());
+
+		MockEnvironment env = new MockEnvironment();
+		env.setProperty("my.name", "encoded-val");
+
+		PropertySourcesPlaceholderConfigurer ppc = new PropertySourcesPlaceholderConfigurer() {
+			@Override
+			protected Object convertProperty(String propertyName, Object propertyValue) {
+				if ("encoded-val".equals(propertyValue)) {
+					return "decoded-val";
+				}
+				return propertyValue;
+			}
+		};
+		ppc.setEnvironment(env);
+		ppc.postProcessBeanFactory(bf);
+		assertThat(bf.getBean(TestBean.class).getName()).isEqualTo("Hello decoded-val");
+	}
 
 	private static class OptionalTestBean {
 


### PR DESCRIPTION
…perty method when resolving properties

See https://github.com/spring-projects/spring-framework/issues/13568.

The idea here is to provide a new `convertProperty` method for people to implement as a replacement for the ones in `PropertyResourceConfigurer`. The methods in that class are a poor fit for `PropertySourcesPlaceholderConfigurer`, as they only support String-type values.

This PR implements and deprecates the methods that should not be used, and provides a new `convertProperty` that the configurer will actually call.

I think a cleaner way to do this would be to make `PropertySourcesPlaceholderConfigurer` not subclass `PropertyResourceConfigurer`, but I did it this way to avoid breaking the API.