### PR TITLE
@ExceptionHandler to keep nesting beyond the first cause

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java
@@ -134,7 +134,7 @@ public class ExceptionHandlerMethodResolver {
 		if (method == null) {
 			Throwable cause = exception.getCause();
 			if (cause != null) {
-				method = resolveMethodByExceptionType(cause.getClass());
+				method = resolveMethodByThrowable(cause);
 			}
 		}
 		return method;

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
@@ -78,6 +78,20 @@ public class ExceptionHandlerMethodResolverTests {
 	}
 
 	@Test
+	public void resolveMethodExceptionCause() {
+		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(ExceptionController.class);
+		IOException ioException = new FileNotFoundException();
+
+		SocketException bindException = new BindException();
+		bindException.initCause(ioException);
+
+		Exception nestedException = new Exception(bindException);
+		Exception exception = new Exception(nestedException);
+
+		assertThat(resolver.resolveMethod(exception).getName()).isEqualTo("handleSocketException");
+	}
+
+	@Test
 	public void resolveMethodInherited() {
 		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(InheritedController.class);
 		IOException exception = new IOException();


### PR DESCRIPTION
spring-web exception handling considers only the first cause of an exception to determine the applicable `@ExceptionHandler`.
This patch makes the resolver search through the full exception hierarchy.