### PR TITLE
Remove duplicate assertion in matchWithNullPath()

### DIFF
--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -136,7 +136,6 @@ public class AntPathMatcherTests {
 	public void matchWithNullPath() {
 		assertThat(pathMatcher.match("/test", null)).isFalse();
 		assertThat(pathMatcher.match("/", null)).isFalse();
-		assertThat(pathMatcher.match("/", null)).isFalse();
 		assertThat(pathMatcher.match(null, null)).isFalse();
 	}
 


### PR DESCRIPTION
This PR removes a duplicate assertion in `AntPathMatcherTests.matchWithNullPath()`.