### PR TITLE
【infra 38】

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
@@ -282,10 +282,10 @@ public abstract class CollectionUtils {
 				candidate = elem;
 			}
 			else if (candidate != elem) {
-				return false;
+				return true;
 			}
 		}
-		return true;
+		return false;
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/util/CollectionUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/CollectionUtilsTests.java
@@ -210,6 +210,18 @@ public class CollectionUtilsTests {
 		assertThat(CollectionUtils.hasUniqueObject(list)).isFalse();
 	}
 
+	@Test
+    public void testHasUniqueObject2() {
+        List<Integer> list1 = new ArrayList<>();
+        list1.add(1);
+        list1.add(1);
+        System.out.println(CollectionUtils.hasUniqueObject(list1));
+
+        List<Integer> list2 = new ArrayList<>();
+        list2.add(1);
+        list2.add(2);
+        System.out.println(CollectionUtils.hasUniqueObject(list2));
+    }
 
 	private static final class Instance {
 

--- a/spring-core/src/test/java/org/springframework/util/CollectionUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/CollectionUtilsTests.java
@@ -214,7 +214,6 @@ public class CollectionUtilsTests {
     public void testHasUniqueObject2() {
         List<Integer> list1 = new ArrayList<>();
         list1.add(1);
-        list1.add(1);
         System.out.println(CollectionUtils.hasUniqueObject(list1));
 
         List<Integer> list2 = new ArrayList<>();


### PR DESCRIPTION
When using org.springframework.util.CollectionUtils#hasUniqueObject
such as 

public void test() {
    List<Integer> list = new ArrayList<>();
    list.add(1);
    list.add(2);
    System.out.println(CollectionUtils.hasUniqueObject(list));
}
From the function name, the result should be true,because there are different objects, but it is actually false.

another example

public void test() {
    List<Integer> list = new ArrayList<>();
    list.add(1);
    list.add(1);
    System.out.println(CollectionUtils.hasUniqueObject(list));
}
From the function name, the result should be false,because there are same*objects, but it is actually true.

I believe the author may reversed the return.
