### PR TITLE
Resolve generic type in more complex scenarios

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/GenericTypeResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/GenericTypeResolver.java
@@ -199,8 +199,13 @@ public final class GenericTypeResolver {
 	private static ResolvableType resolveVariable(TypeVariable<?> typeVariable, ResolvableType contextType) {
 		ResolvableType resolvedType;
 		if (contextType.hasGenerics()) {
-			resolvedType = ResolvableType.forType(typeVariable, contextType);
-			if (resolvedType.resolve() != null) {
+			ResolvableType.VariableResolver variableResolver = contextType.asVariableResolver();
+			if (variableResolver == null) {
+				return ResolvableType.NONE;
+			}
+
+			resolvedType = variableResolver.resolveVariable(typeVariable);
+			if (resolvedType != null) {
 				return resolvedType;
 			}
 		}
@@ -208,16 +213,17 @@ public final class GenericTypeResolver {
 		ResolvableType superType = contextType.getSuperType();
 		if (superType != ResolvableType.NONE) {
 			resolvedType = resolveVariable(typeVariable, superType);
-			if (resolvedType.resolve() != null) {
+			if (resolvedType != ResolvableType.NONE) {
 				return resolvedType;
 			}
 		}
 		for (ResolvableType ifc : contextType.getInterfaces()) {
 			resolvedType = resolveVariable(typeVariable, ifc);
-			if (resolvedType.resolve() != null) {
+			if (resolvedType != ResolvableType.NONE) {
 				return resolvedType;
 			}
 		}
+
 		return ResolvableType.NONE;
 	}
 

--- a/spring-core/src/test/java/org/springframework/core/GenericTypeResolverTests.java
+++ b/spring-core/src/test/java/org/springframework/core/GenericTypeResolverTests.java
@@ -172,6 +172,19 @@ class GenericTypeResolverTests {
 		assertThat(resolved[1]).isEqualTo(Long.class);
 	}
 
+	@Test
+	public void resolvePartiallySpecializedTypeVariables() {
+		Type resolved = resolveType(BiGenericClass.class.getTypeParameters()[0], TypeFixedBiGenericClass.class);
+		assertThat(resolved).isNotNull();
+		assertThat(D.class).isEqualTo(resolved);
+	}
+
+	@Test
+	public void resolveTransitiveTypeVariableWithDifferentName() {
+		Type resolved = resolveType(BiGenericClass.class.getTypeParameters()[1], TypeFixedBiGenericClass.class);
+		assertThat(resolved).isNotNull();
+		assertThat(E.class).isEqualTo(resolved);
+	}
 
 	public interface MyInterfaceType<T> {
 	}
@@ -292,10 +305,22 @@ class GenericTypeResolverTests {
 
 	class B<T>{}
 
+	class C extends A {}
+
+	class D extends B<Long> {}
+
+	class E extends C {}
+
 	class TestIfc<T>{}
 
 	class TestImpl<I extends A, T extends B<I>> extends TestIfc<T>{
 	}
+
+	static abstract class BiGenericClass<T extends B<?>, V extends A> {}
+
+	static abstract class SpecializedBiGenericClass<U extends C> extends BiGenericClass<D, U>{}
+
+	static class TypeFixedBiGenericClass extends SpecializedBiGenericClass<E> {}
 
 	static class TopLevelClass<T> {
 		class Nested<X> {


### PR DESCRIPTION
The spring-core GenericTypeResolver does not resolve generic type variables correctly in more complex scenarios like renamed transitive type variables and partial specialization of classes.