### PR TITLE
Add a new RequestEntity$HeadersBuilder method

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/RequestEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/RequestEntity.java
@@ -316,6 +316,15 @@ public class RequestEntity<T> extends HttpEntity<T> {
 		B header(String headerName, String... headerValues);
 
 		/**
+		 * Copy the given headers into the entity's headers map.
+		 * @param headers the existing MultiValueMap to copy from
+		 * @return this builder
+		 * @since 5.2.0
+		 * @see HttpHeaders#add(String, String)
+		 */
+		B headers(@Nullable MultiValueMap<String, String> headers);
+
+		/**
 		 * Set the list of acceptable {@linkplain MediaType media types}, as
 		 * specified by the {@code Accept} header.
 		 * @param acceptableMediaTypes the acceptable media types
@@ -426,6 +435,14 @@ public class RequestEntity<T> extends HttpEntity<T> {
 		public BodyBuilder header(String headerName, String... headerValues) {
 			for (String headerValue : headerValues) {
 				this.headers.add(headerName, headerValue);
+			}
+			return this;
+		}
+
+		@Override
+		public BodyBuilder headers(@Nullable MultiValueMap<String, String> headers) {
+			if (headers != null) {
+				this.headers.putAll(headers);
 			}
 			return this;
 		}

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -326,12 +326,12 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 
 		/**
 		 * Copy the given headers into the entity's headers map.
-		 * @param headers the existing HttpHeaders to copy from
+		 * @param headers the existing MultiValueMap to copy from
 		 * @return this builder
 		 * @since 4.1.2
 		 * @see HttpHeaders#add(String, String)
 		 */
-		B headers(@Nullable HttpHeaders headers);
+		B headers(@Nullable MultiValueMap<String, String> headers);
 
 		/**
 		 * Set the set of allowed {@link HttpMethod HTTP methods}, as specified
@@ -474,7 +474,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 		}
 
 		@Override
-		public BodyBuilder headers(@Nullable HttpHeaders headers) {
+		public BodyBuilder headers(@Nullable MultiValueMap<String, String> headers) {
 			if (headers != null) {
 				this.headers.putAll(headers);
 			}

--- a/spring-web/src/test/java/org/springframework/http/RequestEntityTests.java
+++ b/spring-web/src/test/java/org/springframework/http/RequestEntityTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.util.UriTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,6 +120,29 @@ public class RequestEntityTests {
 		assertThat(responseHeaders.getFirst("If-None-Match")).isEqualTo(ifNoneMatch);
 		assertThat(responseHeaders.getFirst("Content-Length")).isEqualTo(String.valueOf(contentLength));
 		assertThat(responseHeaders.getFirst("Content-Type")).isEqualTo(contentType.toString());
+
+		assertThat(responseEntity.getBody()).isNull();
+	}
+
+	@Test
+	public void headersMap() throws URISyntaxException {
+		String key = "key";
+		String value = "value";
+		String key2 = "key2";
+		List<String> values2 = Arrays.asList("value2", "value3");
+		LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		map.add(key, value);
+		map.addAll(key2, values2);
+
+		RequestEntity<Void> responseEntity = RequestEntity.post(new URI("https://example.com")).
+				headers(map).
+				build();
+
+		assertThat(responseEntity).isNotNull();
+		HttpHeaders responseHeaders = responseEntity.getHeaders();
+
+		assertThat(responseHeaders.getFirst(key)).isEqualTo(value);
+		assertThat(responseHeaders.get(key2)).isEqualTo(values2);
 
 		assertThat(responseEntity.getBody()).isNull();
 	}


### PR DESCRIPTION
New `headers(MultiValueMap headers)` in RequestEntity$HeadersBuilder.
Just like in ResponseEntity$HeadersBuilder.

In addition, made wider argument type: `headers(MultiValueMap headers)`
instead of `headers(HttpHeaders headers)` on both Builders, for better polymorphism.

Issue: #23404 