### PR TITLE
Fix */* in Javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
@@ -28,7 +28,7 @@ import org.springframework.util.StreamUtils;
 /**
  * Implementation of {@link HttpMessageConverter} that can read and write byte arrays.
  *
- * <p>By default, this converter supports all media types ({@code &#42;&#47;&#42;}), and
+ * <p>By default, this converter supports all media types (<code>&#42;/&#42;</code>), and
  * writes with a {@code Content-Type} of {@code application/octet-stream}. This can be
  * overridden by setting the {@link #setSupportedMediaTypes supportedMediaTypes} property.
  *

--- a/spring-web/src/main/java/org/springframework/http/converter/StringHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/StringHttpMessageConverter.java
@@ -33,7 +33,7 @@ import org.springframework.util.StreamUtils;
 /**
  * Implementation of {@link HttpMessageConverter} that can read and write strings.
  *
- * <p>By default, this converter supports all media types ({@code &#42;&#47;&#42;}),
+ * <p>By default, this converter supports all media types (<code>&#42;/&#42;</code>),
  * and writes with a {@code Content-Type} of {@code text/plain}. This can be overridden
  * by setting the {@link #setSupportedMediaTypes supportedMediaTypes} property.
  *


### PR DESCRIPTION
> {@code}
> 
>     {@code text }
> 
> Equivalent to <code>{@literal text }</code>.
> 
> Displays text in code font without interpreting the text as HTML markup or nested Javadoc tags.

https://docs.oracle.com/en/java/javase/12/docs/specs/doc-comment-spec.html

This is why `{@code &#42;&#47;&#42;}` isn't rendered as <code>&#42;/&#42;</code> as expected.

@pivotal-issuemaster This is an Obvious Fix.