### PR TITLE
Fix data access documentation typo

### DIFF
--- a/src/docs/asciidoc/data-access.adoc
+++ b/src/docs/asciidoc/data-access.adoc
@@ -5737,7 +5737,7 @@ generic or customized to various platforms (such as Tomcat, JBoss and WebSphere)
 
 As described in <<core.adoc#aop-aj-ltw-spring, Spring configuration>>, you can configure
 a context-wide `LoadTimeWeaver` by using the `@EnableLoadTimeWeaving` annotation of the
-`context:load-time-weaver` XML element. Such a global weaver is automatically picked u
+`context:load-time-weaver` XML element. Such a global weaver is automatically picked up
 by all JPA `LocalContainerEntityManagerFactoryBean` instances. The following example
 shows the preferred way of setting up a load-time weaver, delivering auto-detection
 of the platform (e.g. Tomcat's weaving-capable class loader or Spring's JVM agent)


### PR DESCRIPTION
There was missing 'p' letter