### PR TITLE
Avoid storing unnecessary beanName in ApplicationListenerDetector

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/ApplicationListenerDetector.java
+++ b/spring-context/src/main/java/org/springframework/context/support/ApplicationListenerDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,9 @@ class ApplicationListenerDetector implements DestructionAwareBeanPostProcessor, 
 
 	@Override
 	public void postProcessMergedBeanDefinition(RootBeanDefinition beanDefinition, Class<?> beanType, String beanName) {
-		this.singletonNames.put(beanName, beanDefinition.isSingleton());
+		if (ApplicationListener.class.isAssignableFrom(beanType)) {
+			this.singletonNames.put(beanName, beanDefinition.isSingleton());
+		}
 	}
 
 	@Override


### PR DESCRIPTION
it would store name that implementation of the **ApplicationListener** rather than store all names