### PR TITLE
Modify the javadoc of @EnableWebFlux annotation

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/EnableWebFlux.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/EnableWebFlux.java
@@ -47,10 +47,17 @@ import org.springframework.context.annotation.Import;
  * &#064;EnableWebFlux
  * &#064;ComponentScan(basePackageClasses = MyConfiguration.class)
  * public class MyConfiguration implements WebFluxConfigurer {
+ * 
+ * 	   private ObjectMapper objectMapper;
  *
  * 	   &#064;Override
- * 	   public void configureMessageWriters(List&lt;HttpMessageWriter&lt;?&gt&gt messageWriters) {
- *         messageWriters.add(new MyHttpMessageWriter());
+ * 	   public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
+ *         configurer.defaultCodecs().jackson2JsonEncoder(
+ *             new Jackson2JsonEncoder(objectMapper)
+ *         );
+ *         configurer.defaultCodecs().jackson2JsonDecoder(
+ *             new Jackson2JsonDecoder(objectMapper)
+ *         );
  * 	   }
  *
  * 	   // ...


### PR DESCRIPTION
Previously the Javadoc of EnableWebFlux referred to `configureMessageWriters()` method in `WebFluxConfigurer` which wasn't there. Now it has been modified to give an example of the `configureHttpMessageCodecs()` method which is present

This fixes the [issue 23452](https://github.com/spring-projects/spring-framework/issues/23452)