### PR TITLE
Fix groupId for spring-framework-bom

### DIFF
--- a/spring-framework-bom/spring-framework-bom.gradle
+++ b/spring-framework-bom/spring-framework-bom.gradle
@@ -1,4 +1,5 @@
 description = "Spring Framework (Bill of Materials)"
+group = "org.springframework"
 
 apply plugin: "java"
 apply plugin: "maven"


### PR DESCRIPTION
Hi,

the recent changes to the Gradle builds seem to have caused the BOM to be published with a wrong groupId. E.g. it is `<groupId>spring</groupId>` now while it was (and probably should be) `<groupId>org.springframework</groupId>`

This PR is an attempt to fix this by applying the group as in [build.gradle#L53](https://github.com/spring-projects/spring-framework/blob/master/build.gradle#L53).

Cheers,
Christoph