### PR TITLE
Use the 'io.freefair.aspectj' gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
 	id 'io.spring.nohttp' version '0.0.3.RELEASE'
 	id 'de.undercouch.download' version '4.0.0'
 	id "com.jfrog.artifactory" version '4.9.8' apply false
+	id "io.freefair.aspectj" version "4.0.0" apply false
 }
 
 ext {

--- a/spring-aspects/spring-aspects.gradle
+++ b/spring-aspects/spring-aspects.gradle
@@ -1,88 +1,18 @@
 description = "Spring Aspects"
 
-// Redefine the compileJava and compileTestJava tasks in order to compile sources with ajc instead of javac
+apply plugin: "io.freefair.aspectj"
 
-configurations {
-	rt
-	ajc
-	aspects
-	ajInpath
-}
+sourceSets.main.aspectj.srcDir "src/main/java"
+sourceSets.main.java.srcDirs = files()
 
-compileJava {
-	actions = []
-	dependsOn configurations.ajc.getTaskDependencyFromProjectDependency(true, "compileJava")
+sourceSets.test.aspectj.srcDir "src/test/java"
+sourceSets.test.java.srcDirs = files()
 
-	def outputDir = project.sourceSets.main.java.outputDir
-	inputs.files(project.sourceSets.main.allSource + project.sourceSets.main.compileClasspath)
-	outputs.dir outputDir
-
-	sourceCompatibility = 1.8  // fixed even when general compatibility level set to e.g. 10
-	targetCompatibility = 1.8
-
-	doLast{
-		// Assemble runtime classpath from folders and JARs that actually exist
-		def runtimeClasspath = project.files(sourceSets.main.runtimeClasspath.files.findAll({ it.exists() }))
-
-		ant.taskdef(resource: "org/aspectj/tools/ant/taskdefs/aspectjTaskdefs.properties",
-				classpath: configurations.ajc.asPath)
-
-		ant.iajc(source: sourceCompatibility, target: targetCompatibility,
-				maxmem: "1024m", fork: "true", Xlint: "ignore",
-				destDir: outputDir.absolutePath,
-				aspectPath: configurations.aspects.asPath,
-				inpath: configurations.ajInpath.asPath,
-				sourceRootCopyFilter: "**/*.java,**/*.aj",
-				classpath: (runtimeClasspath + configurations.rt).asPath) {
-			sourceroots {
-				sourceSets.main.java.srcDirs.each {
-					pathelement(location:it.absolutePath)
-				}
-			}
-		}
-	}
-}
-
-compileTestJava {
-	actions = []
-	dependsOn configurations.ajc.getTaskDependencyFromProjectDependency(true, "compileTestJava")
-	dependsOn jar
-
-	def outputDir = project.sourceSets.test.java.outputDir
-	inputs.files(project.sourceSets.test.allSource + project.sourceSets.test.compileClasspath)
-	outputs.dir outputDir
-
-	sourceCompatibility = 1.8  // fixed even when general compatibility level set to e.g. 10
-	targetCompatibility = 1.8
-
-	doLast{
-		// Assemble runtime classpath from folders and JARs that actually exist
-		def runtimeClasspath = project.files(sourceSets.test.runtimeClasspath.files.findAll({ it.exists() }))
-
-		ant.taskdef(resource: "org/aspectj/tools/ant/taskdefs/aspectjTaskdefs.properties",
-				classpath: configurations.ajc.asPath)
-
-		ant.iajc(source: sourceCompatibility, target: targetCompatibility,
-				maxmem: "1024m", fork: "true", Xlint: "ignore",
-				destDir: outputDir.absolutePath,
-				aspectPath: jar.archivePath,
-				inpath: configurations.ajInpath.asPath,
-				classpath: (runtimeClasspath + project.files(jar.archivePath) + configurations.rt).asPath) {
-			sourceroots {
-				sourceSets.test.java.srcDirs.each {
-					pathelement(location:it.absolutePath)
-				}
-			}
-		}
-	}
-}
-
+aspectj.version = aspectjVersion
 
 dependencies {
-	aspects(project(":spring-orm"))
-	ajc("org.aspectj:aspectjtools:${aspectjVersion}")
-	rt("org.aspectj:aspectjrt:${aspectjVersion}")
-	compile("org.aspectj:aspectjweaver:${aspectjVersion}")
+	aspect(project(":spring-orm"))
+	compile("org.aspectj:aspectjrt:${aspectjVersion}")
 	optional(project(":spring-aop"))  // for @Async support
 	optional(project(":spring-beans"))  // for @Configurable support
 	optional(project(":spring-context"))  // for @Enable* support


### PR DESCRIPTION
This simplifies the ajc configuration by using the external `io.freefair.aspectj` gradle plugin.

This should be in line with the optimizations in https://github.com/spring-projects/spring-framework/issues/23282

The same plugin is already used by spring-security: https://github.com/spring-projects/spring-security/pull/7183
