### PR TITLE
Add @since for getCacheFilter and setCacheFilter

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/AbstractCachingViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/AbstractCachingViewResolver.java
@@ -151,6 +151,7 @@ public abstract class AbstractCachingViewResolver extends WebApplicationObjectSu
 	/**
 	 * Sets the filter that determines if view should be cached.
 	 * Default behaviour is to cache all views.
+	 * @since 5.2
 	 */
 	public void setCacheFilter(CacheFilter cacheFilter) {
 		Assert.notNull(cacheFilter, "CacheFilter must not be null");
@@ -159,6 +160,7 @@ public abstract class AbstractCachingViewResolver extends WebApplicationObjectSu
 
 	/**
 	 * Return filter function that determines if view should be cached.
+	 * @since 5.2
 	 */
 	public CacheFilter getCacheFilter() {
 		return this.cacheFilter;


### PR DESCRIPTION
This PR adds Javadoc `@since` tags for `getCacheFilter()` and `setCacheFilter()` in `AbstractCachingViewResolver`.