### PR TITLE
DispatcherServlet does not invoke triggerAfterCompletion with dispatch exception

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -1131,7 +1131,7 @@ public class DispatcherServlet extends FrameworkServlet {
 		}
 
 		if (mappedHandler != null) {
-			mappedHandler.triggerAfterCompletion(request, response, null);
+			mappedHandler.triggerAfterCompletion(request, response, exception);
 		}
 	}
 


### PR DESCRIPTION
The method `processDispatchResult` in `DispatcherServlet` receives an `exception` argument if some exception was thrown when invoking the handler, but the exception is not passed as an argument when invoking the `triggerAfterCompletion` method.

Thus a registered `HandlerInterceptor` cannot properly implement `org.springframework.web.servlet.HandlerInterceptor.afterCompletion(HttpServletRequest, HttpServletResponse, Object, Exception)` without knowing if some exception was thrown.