### PR TITLE
Introduce MockMvc content() method to convert object to JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,7 @@ configure(allprojects.findAll { (it.name != "framework-bom") } ) { project ->
 	}
 
 	dependencies {
+        compile("com.fasterxml.jackson.core:jackson-databind:${jackson2Version}")
 		testCompile("org.junit.jupiter:junit-jupiter-api")
 		testCompile("org.junit.jupiter:junit-jupiter-params")
 		testCompile("org.mockito:mockito-core:3.0.0") {

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
@@ -269,10 +269,9 @@ public class MockHttpServletRequestBuilder
 	}
 
 	/**
-	 * Set the request body as a UTF-8 string and
-	 * Tries to convert the object to a JSON object.
+	 * Set the request body as a UTF-8 formatted JSON object.
 	 * Automatically sets the content type to application/json.
-	 * @param content the body content that will be converted to json
+	 * @param content the object that will be converted to json
 	 */
 	public MockHttpServletRequestBuilder content(Object content) {
 		ObjectMapper mapper = new ObjectMapper();

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
@@ -27,12 +27,16 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
 import java.util.Map;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpSession;
 
+import net.sourceforge.htmlunit.corejs.javascript.json.JsonParser;
 import org.springframework.beans.Mergeable;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.http.HttpHeaders;
@@ -40,6 +44,7 @@ import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.lang.Nullable;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -260,6 +265,25 @@ public class MockHttpServletRequestBuilder
 	 */
 	public MockHttpServletRequestBuilder content(String content) {
 		this.content = content.getBytes(StandardCharsets.UTF_8);
+		return this;
+	}
+
+	/**
+	 * Set the request body as a UTF-8 string and
+	 * Tries to convert the object to a JSON object.
+	 * Automatically sets the content type to application/json.
+	 * @param content the body content that will be converted to json
+	 */
+	public MockHttpServletRequestBuilder content(Object content) {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+		ObjectWriter objectWriter = mapper.writer().withDefaultPrettyPrinter();
+		try {
+			this.content = objectWriter.writeValueAsString(content).getBytes(StandardCharsets.UTF_8);
+			this.contentType = MediaType.APPLICATION_JSON_VALUE;
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
 		return this;
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
@@ -39,6 +39,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.web.Person;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -346,6 +347,26 @@ public class MockHttpServletRequestBuilderTests {
 		byte[] result = FileCopyUtils.copyToByteArray(request.getInputStream());
 
 		assertThat(result).isEqualTo(body);
+	}
+
+	@Test
+	public void jsonBody() throws IOException {
+		Person person = new Person();
+		person.setName("Spring Boot");
+		person.setSomeBoolean(true);
+		this.builder.content(person);
+
+		MockHttpServletRequest request = this.builder.buildRequest(this.servletContext);
+		byte[] result = FileCopyUtils.copyToByteArray(request.getInputStream());
+
+		String json = "{\n" +
+				"  \"name\" : \"Spring Boot\",\n" +
+				"  \"someDouble\" : 0.0,\n" +
+				"  \"someBoolean\" : true\n" +
+				"}";
+
+		assertThat(result).isEqualTo(json.getBytes());
+		assertThat(request.getContentType()).isEqualTo("application/json");
 	}
 
 	@Test


### PR DESCRIPTION
While using springs mock mcv class to handle tests in a spring boot API it is **necessary** to send JSON content with the request body.

Eg.
```java
mockMvc.perform(post("/api/v1/user_registration/phone_code/resend").content(jsonBody).contentType(MediaType.APPLICATION_JSON_UTF8))
                .andDo(print())
                .andExpect(MockMvcResultMatchers.status().isOk()); 
```
Unfortunately, the only way I can do this is by first converting the object that I wish to send in the request body to JSON and then pass it as an argument to the ```MockHttpServletRequestBuilder.content()``` method. 

This usually adds extra noise to tests to handle the object to JSON serialization.

It would be very handy for those of us writing tests for APIs to have a ```content(Object content)``` method that 
accepts a plain old java object and does the conversion to JSON for us as well as define the content-type to "application/js" since it is obvious by the context that we will be sending JSON in the request body.