### PR TITLE
Omit cancellation of transactional Monos in TransactionOperator

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperator.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperator.java
@@ -38,6 +38,10 @@ import org.springframework.transaction.TransactionException;
  * application services utilizing this class, making calls to the low-level
  * services via an inner-class callback object.
  *
+ * <p>Transactional Publishers should avoid Subscription cancellation.
+ * Cancelling initiates asynchronous transaction cleanup that does not allow for
+ * synchronization on completion.
+ *
  * @author Mark Paluch
  * @author Juergen Hoeller
  * @since 5.2
@@ -64,9 +68,7 @@ public interface TransactionalOperator {
 	 * @throws TransactionException in case of initialization, rollback, or system errors
 	 * @throws RuntimeException if thrown by the TransactionCallback
 	 */
-	default <T> Mono<T> transactional(Mono<T> mono) {
-		return execute(it -> mono).next();
-	}
+	<T> Mono<T> transactional(Mono<T> mono);
 
 	/**
 	 * Execute the action specified by the given callback object within a transaction.


### PR DESCRIPTION
`TransactionOperator.as(Mono)` now no longer short-cuts via a `Flux.next()` but provides an implementation via `Mono.usingWhen(…)`.
The short-cut previously issued a cancellation signal to the transactional `Mono` causing the transaction cleanup to happen without a handle for synchronization.

Using `Mono.usingWhen(…)` initiates transaction cleanup when the `Mono` completes eliminating the need for cancellation of the transactional `Publisher`.

This change does not fully fix #23304 but it softens its impact because `TransactionalOperator.transactional(Mono)` avoids cancellation.

/cc @michael-simons @simonbasle @smaldini 

---

- [x] We should get feedback from Michael or someone from the reactor team prior to merging this PR.