### PR TITLE
Log HTTP method in logging filters and revise log message format

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/AbstractRequestLoggingFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/AbstractRequestLoggingFilter.java
@@ -322,7 +322,8 @@ public abstract class AbstractRequestLoggingFilter extends OncePerRequestFilter 
 	protected String createMessage(HttpServletRequest request, String prefix, String suffix) {
 		StringBuilder msg = new StringBuilder();
 		msg.append(prefix);
-		msg.append("uri=").append(request.getRequestURI());
+		msg.append(request.getMethod()).append(" ");
+		msg.append(request.getRequestURI());
 
 		if (isIncludeQueryString()) {
 			String queryString = request.getQueryString();
@@ -334,15 +335,15 @@ public abstract class AbstractRequestLoggingFilter extends OncePerRequestFilter 
 		if (isIncludeClientInfo()) {
 			String client = request.getRemoteAddr();
 			if (StringUtils.hasLength(client)) {
-				msg.append(";client=").append(client);
+				msg.append(", client=").append(client);
 			}
 			HttpSession session = request.getSession(false);
 			if (session != null) {
-				msg.append(";session=").append(session.getId());
+				msg.append(", session=").append(session.getId());
 			}
 			String user = request.getRemoteUser();
 			if (user != null) {
-				msg.append(";user=").append(user);
+				msg.append(", user=").append(user);
 			}
 		}
 
@@ -357,13 +358,13 @@ public abstract class AbstractRequestLoggingFilter extends OncePerRequestFilter 
 					}
 				}
 			}
-			msg.append(";headers=").append(headers);
+			msg.append(", headers=").append(headers);
 		}
 
 		if (isIncludePayload()) {
 			String payload = getMessagePayload(request);
 			if (payload != null) {
-				msg.append(";payload=").append(payload);
+				msg.append(", payload=").append(payload);
 			}
 		}
 

--- a/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
@@ -24,7 +24,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.test.MockHttpServletRequest;
@@ -44,31 +43,23 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class RequestLoggingFilterTests {
 
-	private MyRequestLoggingFilter filter = new MyRequestLoggingFilter();
-
-	@BeforeEach
-	public void reset() {
-		filter = new MyRequestLoggingFilter();
-	}
+	private final MyRequestLoggingFilter filter = new MyRequestLoggingFilter();
 
 	@Test
 	public void defaultPrefix() throws Exception {
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.startsWith(AbstractRequestLoggingFilter.DEFAULT_BEFORE_MESSAGE_PREFIX)).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.startsWith(AbstractRequestLoggingFilter.DEFAULT_AFTER_MESSAGE_PREFIX)).isTrue();
+		assertThat(filter.beforeRequestMessage).startsWith(AbstractRequestLoggingFilter.DEFAULT_BEFORE_MESSAGE_PREFIX);
+		assertThat(filter.afterRequestMessage).startsWith(AbstractRequestLoggingFilter.DEFAULT_AFTER_MESSAGE_PREFIX);
 	}
 
 	@Test
 	public void customPrefix() throws Exception {
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		filter.setBeforeMessagePrefix("Before prefix: ");
@@ -77,31 +68,25 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.startsWith("Before prefix: ")).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.startsWith("After prefix: ")).isTrue();
+		assertThat(filter.beforeRequestMessage).startsWith("Before prefix: ");
+		assertThat(filter.afterRequestMessage).startsWith("After prefix: ");
 	}
 
 	@Test
 	public void defaultSuffix() throws Exception {
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.endsWith(AbstractRequestLoggingFilter.DEFAULT_BEFORE_MESSAGE_SUFFIX)).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.endsWith(AbstractRequestLoggingFilter.DEFAULT_AFTER_MESSAGE_SUFFIX)).isTrue();
+		assertThat(filter.beforeRequestMessage).endsWith(AbstractRequestLoggingFilter.DEFAULT_BEFORE_MESSAGE_SUFFIX);
+		assertThat(filter.afterRequestMessage).endsWith(AbstractRequestLoggingFilter.DEFAULT_AFTER_MESSAGE_SUFFIX);
 	}
 
 	@Test
 	public void customSuffix() throws Exception {
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		filter.setBeforeMessageSuffix("}");
@@ -110,16 +95,13 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.endsWith("}")).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.endsWith(")")).isTrue();
+		assertThat(filter.beforeRequestMessage).endsWith("}");
+		assertThat(filter.afterRequestMessage).endsWith(")");
 	}
 
 	@Test
 	public void method() throws Exception {
-		final MockHttpServletRequest request = new MockHttpServletRequest("PATCH", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("PATCH", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		filter.setBeforeMessagePrefix("");
@@ -128,16 +110,13 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.startsWith("PATCH")).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.startsWith("PATCH")).isTrue();
+		assertThat(filter.beforeRequestMessage).startsWith("PATCH");
+		assertThat(filter.afterRequestMessage).startsWith("PATCH");
 	}
 
 	@Test
 	public void uri() throws Exception {
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		request.setQueryString("booking=42");
@@ -145,13 +124,11 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("/hotel")).isTrue();
-		assertThat(filter.beforeRequestMessage.contains("booking=42")).isFalse();
+		assertThat(filter.beforeRequestMessage).contains("/hotel");
+		assertThat(filter.beforeRequestMessage).doesNotContain("booking=42");
 
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("/hotel")).isTrue();
-		assertThat(filter.afterRequestMessage.contains("booking=42")).isFalse();
+		assertThat(filter.afterRequestMessage).contains("/hotel");
+		assertThat(filter.afterRequestMessage).doesNotContain("booking=42");
 	}
 
 	@Test
@@ -166,11 +143,8 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("/hotels?booking=42")).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("/hotels?booking=42")).isTrue();
+		assertThat(filter.beforeRequestMessage).contains("/hotels?booking=42");
+		assertThat(filter.afterRequestMessage).contains("/hotels?booking=42");
 	}
 
 	@Test
@@ -183,11 +157,8 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("/hotels]")).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("/hotels]")).isTrue();
+		assertThat(filter.beforeRequestMessage).contains("/hotels]");
+		assertThat(filter.afterRequestMessage).contains("/hotels]");
 	}
 
 	@Test
@@ -201,11 +172,8 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("client=4.2.2.2")).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("client=4.2.2.2")).isTrue();
+		assertThat(filter.beforeRequestMessage).contains("client=4.2.2.2");
+		assertThat(filter.afterRequestMessage).contains("client=4.2.2.2");
 	}
 
 	@Test
@@ -220,11 +188,8 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("session=42")).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("session=42")).isTrue();
+		assertThat(filter.beforeRequestMessage).contains("session=42");
+		assertThat(filter.afterRequestMessage).contains("session=42");
 	}
 
 	@Test
@@ -238,16 +203,13 @@ public class RequestLoggingFilterTests {
 		FilterChain filterChain = new NoOpFilterChain();
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("user=Arthur")).isTrue();
-
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("user=Arthur")).isTrue();
+		assertThat(filter.beforeRequestMessage).contains("user=Arthur");
+		assertThat(filter.afterRequestMessage).contains("user=Arthur");
 	}
 
 	@Test
 	public void headers() throws Exception {
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		request.setContentType("application/json");
 		request.addHeader("token", "123");
 		MockHttpServletResponse response = new MockHttpServletResponse();
@@ -257,10 +219,7 @@ public class RequestLoggingFilterTests {
 		filter.setHeaderPredicate(name -> !name.equalsIgnoreCase("token"));
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.beforeRequestMessage).isNotNull();
 		assertThat(filter.beforeRequestMessage).isEqualTo("Before request [POST /hotels, headers=[Content-Type:\"application/json\", token:\"masked\"]]");
-
-		assertThat(filter.afterRequestMessage).isNotNull();
 		assertThat(filter.afterRequestMessage).isEqualTo("After request [POST /hotels, headers=[Content-Type:\"application/json\", token:\"masked\"]]");
 	}
 
@@ -268,10 +227,10 @@ public class RequestLoggingFilterTests {
 	public void payloadInputStream() throws Exception {
 		filter.setIncludePayload(true);
 
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
-		final byte[] requestBody = "Hello World".getBytes(StandardCharsets.UTF_8);
+		byte[] requestBody = "Hello World".getBytes(StandardCharsets.UTF_8);
 		request.setContent(requestBody);
 
 		FilterChain filterChain = (filterRequest, filterResponse) -> {
@@ -282,18 +241,17 @@ public class RequestLoggingFilterTests {
 
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("Hello World")).isTrue();
+		assertThat(filter.afterRequestMessage).contains("Hello World");
 	}
 
 	@Test
 	public void payloadReader() throws Exception {
 		filter.setIncludePayload(true);
 
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
-		final String requestBody = "Hello World";
+		String requestBody = "Hello World";
 		request.setContent(requestBody.getBytes(StandardCharsets.UTF_8));
 
 		FilterChain filterChain = (filterRequest, filterResponse) -> {
@@ -304,8 +262,7 @@ public class RequestLoggingFilterTests {
 
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains(requestBody)).isTrue();
+		assertThat(filter.afterRequestMessage).contains(requestBody);
 	}
 
 	@Test
@@ -313,10 +270,10 @@ public class RequestLoggingFilterTests {
 		filter.setIncludePayload(true);
 		filter.setMaxPayloadLength(3);
 
-		final MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/hotels");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
-		final byte[] requestBody = "Hello World".getBytes(StandardCharsets.UTF_8);
+		byte[] requestBody = "Hello World".getBytes(StandardCharsets.UTF_8);
 		request.setContent(requestBody);
 
 		FilterChain filterChain = (filterRequest, filterResponse) -> {
@@ -330,9 +287,8 @@ public class RequestLoggingFilterTests {
 
 		filter.doFilter(request, response, filterChain);
 
-		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("Hel")).isTrue();
-		assertThat(filter.afterRequestMessage.contains("Hello World")).isFalse();
+		assertThat(filter.afterRequestMessage).contains("Hel");
+		assertThat(filter.afterRequestMessage).doesNotContain("Hello World");
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.test.MockHttpServletRequest;
@@ -44,8 +45,30 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class RequestLoggingFilterTests {
 
-	private final MyRequestLoggingFilter filter = new MyRequestLoggingFilter();
+	private MyRequestLoggingFilter filter = new MyRequestLoggingFilter();
 
+	@BeforeEach
+	public void reset() {
+		filter = new MyRequestLoggingFilter();
+	}
+
+	@Test
+	public void method() throws Exception {
+		final MockHttpServletRequest request = new MockHttpServletRequest("PATCH", "/hotels");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.setBeforeMessagePrefix("");
+		filter.setAfterMessagePrefix("");
+
+		FilterChain filterChain = new NoOpFilterChain();
+		filter.doFilter(request, response, filterChain);
+
+		assertThat(filter.beforeRequestMessage).isNotNull();
+		assertThat(filter.beforeRequestMessage.startsWith("PATCH")).isTrue();
+
+		assertThat(filter.afterRequestMessage).isNotNull();
+		assertThat(filter.afterRequestMessage.startsWith("PATCH")).isTrue();
+	}
 
 	@Test
 	public void uri() throws Exception {
@@ -58,11 +81,11 @@ public class RequestLoggingFilterTests {
 		filter.doFilter(request, response, filterChain);
 
 		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("uri=/hotel")).isTrue();
+		assertThat(filter.beforeRequestMessage.contains("/hotel")).isTrue();
 		assertThat(filter.beforeRequestMessage.contains("booking=42")).isFalse();
 
 		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("uri=/hotel")).isTrue();
+		assertThat(filter.afterRequestMessage.contains("/hotel")).isTrue();
 		assertThat(filter.afterRequestMessage.contains("booking=42")).isFalse();
 	}
 
@@ -79,10 +102,10 @@ public class RequestLoggingFilterTests {
 		filter.doFilter(request, response, filterChain);
 
 		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("[uri=/hotels?booking=42]")).isTrue();
+		assertThat(filter.beforeRequestMessage.contains("/hotels?booking=42")).isTrue();
 
 		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("[uri=/hotels?booking=42]")).isTrue();
+		assertThat(filter.afterRequestMessage.contains("/hotels?booking=42")).isTrue();
 	}
 
 	@Test
@@ -96,10 +119,10 @@ public class RequestLoggingFilterTests {
 		filter.doFilter(request, response, filterChain);
 
 		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage.contains("[uri=/hotels]")).isTrue();
+		assertThat(filter.beforeRequestMessage.contains("/hotels]")).isTrue();
 
 		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage.contains("[uri=/hotels]")).isTrue();
+		assertThat(filter.afterRequestMessage.contains("/hotels]")).isTrue();
 	}
 
 	@Test
@@ -115,10 +138,10 @@ public class RequestLoggingFilterTests {
 		filter.doFilter(request, response, filterChain);
 
 		assertThat(filter.beforeRequestMessage).isNotNull();
-		assertThat(filter.beforeRequestMessage).isEqualTo("Before request [uri=/hotels;headers=[Content-Type:\"application/json\", token:\"masked\"]]");
+		assertThat(filter.beforeRequestMessage).isEqualTo("Before request [POST /hotels, headers=[Content-Type:\"application/json\", token:\"masked\"]]");
 
 		assertThat(filter.afterRequestMessage).isNotNull();
-		assertThat(filter.afterRequestMessage).isEqualTo("After request [uri=/hotels;headers=[Content-Type:\"application/json\", token:\"masked\"]]");
+		assertThat(filter.afterRequestMessage).isEqualTo("After request [POST /hotels, headers=[Content-Type:\"application/json\", token:\"masked\"]]");
 	}
 
 	@Test


### PR DESCRIPTION
Ahoy,

I was surprised to neither find the http method in the log messages of the `AbstractRequestLoggingFilter` nor the option to turn them on.

This looks like a fairly uncontroversial, fully optional and backwards compatible change to me so I did not open an issue up front. I'm happy to open one if more discussion is required.

### Two things to note for the reviewer:
~~- [ ] I copy-pasted the method javadocs, and I'm not 100% sure if anything else needs to be done to get~~
```
	 * <p>Should be configured using an {@code <init-param>} for parameter name
	 * "includeHttpMethod" in the filter definition in {@code web.xml}.
```
~~to work. I did some CTRL-Fing for the other values and nothing interesting came up.~~


~~- [ ] I did not add a `@since 5.2` annotation as I'm not sure which version this will hit. Just amend it in :)~~



Cheers,
Napster

Btw, setting up the local build and running tests was a breeze, great docs!