### PR TITLE
Add opt-in build scan integration with Gradle Enterprise

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,19 @@ plugins {
 	id 'org.asciidoctor.convert' version '1.5.8'
 	id 'io.spring.nohttp' version '0.0.3.RELEASE'
 	id 'de.undercouch.download' version '4.0.0'
+	id 'com.gradle.build-scan' version '2.4.1'
 	id "com.jfrog.artifactory" version '4.9.8' apply false
 	id "io.freefair.aspectj" version "4.0.0" apply false
 	id "com.github.ben-manes.versions" version "0.24.0"
+}
+
+if (System.getenv('GRADLE_ENTERPRISE_URL')) {
+	apply from: "$rootDir/gradle/build-scan-user-data.gradle"
+	buildScan {
+		captureTaskInputFiles = true
+		publishAlways()
+		server = System.getenv('GRADLE_ENTERPRISE_URL')
+	}
 }
 
 ext {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=5.2.0.BUILD-SNAPSHOT
+org.gradle.caching=false

--- a/gradle/build-scan-user-data.gradle
+++ b/gradle/build-scan-user-data.gradle
@@ -1,0 +1,75 @@
+tagOs()
+tagIde()
+tagCiOrLocal()
+addCiMetadata()
+addGitMetadata()
+
+void tagOs() {
+	buildScan.tag System.getProperty('os.name')
+}
+
+void tagIde() {
+	if (System.getProperty('idea.version')) {
+		buildScan.tag 'IntelliJ IDEA'
+	} else if (System.getProperty('eclipse.buildId')) {
+		buildScan.tag 'Eclipse'
+	}
+}
+
+void tagCiOrLocal() {
+	buildScan.tag(isCi() ? 'CI' : 'LOCAL')
+}
+
+void addGitMetadata() {
+	buildScan.background {
+		def gitCommitId = execAndGetStdout('git', 'rev-parse', '--short=8', '--verify', 'HEAD')
+		def gitBranchName = execAndGetStdout('git', 'rev-parse', '--abbrev-ref', 'HEAD')
+		def gitStatus = execAndGetStdout('git', 'status', '--porcelain')
+
+		if(gitCommitId) {
+			def commitIdLabel = 'Git Commit ID'
+			value commitIdLabel, gitCommitId
+			link 'Git commit build scans', customValueSearchUrl([(commitIdLabel): gitCommitId])
+		}
+		if (gitBranchName) {
+			tag gitBranchName
+			value 'Git branch', gitBranchName
+		}
+		if (gitStatus) {
+			tag 'dirty'
+			value 'Git status', gitStatus
+		}
+	}
+}
+
+void addCiMetadata() {
+	def ciBuild = 'CI BUILD'
+	if (System.getenv('bamboo.resultsUrl')) {
+		buildScan.link ciBuild, System.getenv('bamboo.resultsUrl')
+	}
+}
+
+boolean isCi() {
+	System.getenv('bamboo.resultsUrl')
+}
+
+String execAndGetStdout(String... args) {
+	def stdout = new ByteArrayOutputStream()
+	exec {
+		commandLine(args)
+		standardOutput = stdout
+	}
+	return stdout.toString().trim()
+}
+
+String customValueSearchUrl(Map<String, String> search) {
+    def query = search.collect { name, value ->
+        "search.names=${encodeURL(name)}&search.values=${encodeURL(value)}"
+    }.join('&')
+
+    "$buildScan.server/scans?$query"
+}
+
+String encodeURL(String url){
+    URLEncoder.encode(url, 'UTF-8')
+}


### PR DESCRIPTION
With thanks to @etiennestuder for his guidance, this pull request adds opt-in build scan integration with Gradle Enterprise. When the GRADLE_ENTERPRISE_URL environment variable is set on a developer's machine or on CI, a build scan will be automatically uploaded to Gradle Enterprise at the end of the build.

This initial integration will establish a baseline for Spring Framework builds. Once that has happened we can use the build scans to identify ways in which the build can be optimized and updated to make use of Gradle's build caching which should reduce build times, significantly so for changes that only affect tasks near the leaf nodes of the task graph.