### PR TITLE
Tweak detection of Bamboo

### DIFF
--- a/gradle/build-scan-user-data.gradle
+++ b/gradle/build-scan-user-data.gradle
@@ -44,13 +44,17 @@ void addGitMetadata() {
 
 void addCiMetadata() {
 	def ciBuild = 'CI BUILD'
-	if (System.getenv('bamboo.resultsUrl')) {
-		buildScan.link ciBuild, System.getenv('bamboo.resultsUrl')
+	if (isBamboo()) {
+		buildScan.link ciBuild, System.getenv('bamboo_resultsUrl')
 	}
 }
 
 boolean isCi() {
-	System.getenv('bamboo.resultsUrl')
+	isBamboo()
+}
+
+boolean isBamboo() {
+	System.getenv('bamboo_resultsUrl')
 }
 
 String execAndGetStdout(String... args) {


### PR DESCRIPTION
When exposed as an environment variable Bamboo's `bamboo.resultsUrl` is mapped to `bamboo_resultsUrl`. This PR updates the build scan user data script to look for the latter rather than the former.