### PR TITLE
Add checksum-dependency-plugin for verification of plugin/dependency checksums

### DIFF
--- a/buildSrc/checksum.xml
+++ b/buildSrc/checksum.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<dependency-verification version='1'>
+  <trust-requirement pgp='GROUP' checksum='NONE' />
+  <ignored-keys />
+  <trusted-keys>
+    <trusted-key id='beabcfbee059e4e5' group='com.github.siom79.japicmp' />
+    <trusted-key id='10066a9707090cf9' group='org.javassist' />
+  </trusted-keys>
+  <dependencies>
+    <dependency group='javax.activation' module='activation' version='1.1'>
+      <sha512>C0FF5BF3ACE7ACC1B31FCC109CEE48D9EB8F025AE15A31DC91ECA760933BDB97C93F05D61E95AF1E317859D72E5F179F897F5BF3DF0E3810F4212D43BACEE4BD</sha512>
+    </dependency>
+    <dependency group='me.champeau.gradle' module='japicmp-gradle-plugin' version='0.2.8'>
+      <sha512>7539000D0A0A996154A8A61C2F9B82D6EB57666134118E53CC85EFA1A3864812965A83C1A7E922369137FB32DE09DA7BF280B1252C82549C3E74357C1B928664</sha512>
+    </dependency>
+  </dependencies>
+</dependency-verification>

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,50 +1,10 @@
-pluginManagement {
-	repositories {
-		gradlePluginPortal()
-		maven { url 'https://repo.spring.io/plugins-release' }
-	}
-}
-
-enableFeaturePreview("GRADLE_METADATA")
-
-include "spring-aop"
-include "spring-aspects"
-include "spring-beans"
-include "spring-context"
-include "spring-context-support"
-include "spring-context-indexer"
-include "spring-core"
-include "kotlin-coroutines"
-project(':kotlin-coroutines').projectDir = file('spring-core/kotlin-coroutines')
-include "spring-expression"
-include "spring-instrument"
-include "spring-jcl"
-include "spring-jdbc"
-include "spring-jms"
-include "spring-messaging"
-include "spring-orm"
-include "spring-oxm"
-include "spring-test"
-include "spring-tx"
-include "spring-web"
-include "spring-webmvc"
-include "spring-webflux"
-include "spring-websocket"
-include "framework-bom"
-include "integration-tests"
-
-rootProject.name = "spring"
-rootProject.children.each {project ->
-	project.buildFileName = "${project.name}.gradle"
-}
-
 // See https://github.com/vlsi/vlsi-release-plugins
 // It is a  plugin that verifies checksums of all the resolved files (plugins, dependencies, ...)
 // By default the plugin generates an updated checksums to $rootDir/build/checksum/checksum.xml,
 // and you can make it update rootDir/checksum.xml by adding -PchecksumUpdate
 buildscript {
   dependencies {
-    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.28.0') {
+    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.26.0') {
       // Gradle ships kotlin-stdlib which is good enough
       exclude(group: "org.jetbrains.kotlin", module:"kotlin-stdlib")
     }
@@ -64,8 +24,8 @@ def expectedSha512 = [
     "okhttp-4.1.0.jar",
   "93E7A41BE44CC17FB500EA5CD84D515204C180AEC934491D11FC6A71DAEA761FB0EECEF865D6FD5C3D88AAF55DCE3C2C424BE5BA5D43BEBF48D05F1FA63FA8A7":
     "okio-2.2.2.jar",
-  "2ABC83FF0675D69697D4530D4853411761FE947E57EB8D68F6590DC2BFF0436906ADE619822EEE5F80B0DA28285FBE75FDCB50B67421DB7BF78B34CF6A613714":
-    "checksum-dependency-plugin-1.28.0.jar"
+  "2AB28DC6026A9CFC869C6287501D1002B8F2B61C7C3896B61A5616CE686DD41FD22EE9FD2D122111E4DABAA8359A4947C3F43B9DF29B1AFC8AA5D809A8188CAD":
+    "checksum-dependency-plugin-1.26.0.jar"
 ]
 
 def sha512(File file) {

--- a/checksum.xml
+++ b/checksum.xml
@@ -1,0 +1,3491 @@
+<?xml version='1.0' encoding='utf-8'?>
+<dependency-verification version='1'>
+  <trust-requirement pgp='GROUP' checksum='NONE' />
+  <ignored-keys />
+  <trusted-keys>
+    <trusted-key id='1c8d5ef0df2b70d4' group='cglib' />
+    <trusted-key id='2c7b12f2a511e325' group='ch.qos.logback' />
+    <trusted-key id='5ad66315fc018797' group='com.beust' />
+    <trusted-key id='cc54b93c018511a4' group='com.beust' />
+    <trusted-key id='9e158ba4340c5f43' group='com.caucho' />
+    <trusted-key id='9cd8549acf9bd0ce' group='com.fasterxml' />
+    <trusted-key id='c9fbaa83a8753994' group='com.fasterxml' />
+    <trusted-key id='c9fbaa83a8753994' group='com.fasterxml.jackson' />
+    <trusted-key id='c9fbaa83a8753994' group='com.fasterxml.jackson.core' />
+    <trusted-key id='c9fbaa83a8753994' group='com.fasterxml.jackson.dataformat' />
+    <trusted-key id='c9fbaa83a8753994' group='com.fasterxml.jackson.datatype' />
+    <trusted-key id='c9fbaa83a8753994' group='com.fasterxml.jackson.module' />
+    <trusted-key id='c9fbaa83a8753994' group='com.fasterxml.woodstox' />
+    <trusted-key id='1ae999ff489b55cb' group='com.github.albfernandez' />
+    <trusted-key id='3c0a8f4744f37328' group='com.github.ben-manes.caffeine' />
+    <trusted-key id='62ebfc78fe4156d1' group='com.github.jnr' />
+    <trusted-key id='8e26ff248bc7aead' group='com.github.jnr' />
+    <trusted-key id='6a24b91e0472cc1c' group='com.github.librepdf' />
+    <trusted-key id='ccc16740c5666d5a' group='com.github.spullara.mustache.java' />
+    <trusted-key id='d5c6377ede50786b' group='com.github.virtuald' />
+    <trusted-key id='59a252fb1199d873' group='com.google.code.findbugs' />
+    <trusted-key id='7a01b0f236e5430f' group='com.google.code.gson' />
+    <trusted-key id='912d2c0eccda55c0' group='com.google.errorprone' />
+    <trusted-key id='9a259c7ee636c5ed' group='com.google.errorprone' />
+    <trusted-key id='bf935c771a8474f8' group='com.google.errorprone' />
+    <trusted-key id='021e5b388199bce2' group='com.google.guava' />
+    <trusted-key id='abe9f3126bb741c1' group='com.google.guava' />
+    <trusted-key id='f6d4a1d411e9d1ae' group='com.google.guava' />
+    <trusted-key id='29579f18fa8fd93b' group='com.google.j2objc' />
+    <trusted-key id='0e621275cdadb760' group='com.google.protobuf' />
+    <trusted-key id='6239edb70f8b00c7' group='com.googlecode.protobuf-java-format' />
+    <trusted-key id='0a4b343f2a55fdae' group='com.h2database' />
+    <trusted-key id='860675eebac22464' group='com.hazelcast' />
+    <trusted-key id='8e26ff248bc7aead' group='com.headius' />
+    <trusted-key id='bda590c5b58b6056' group='com.jamonapi' />
+    <trusted-key id='3684155e9365c30e' group='com.jayway.jsonpath' />
+    <trusted-key id='a50569c7ca7fa1f0' group='com.jcraft' />
+    <trusted-key id='32baf781c2d456c2' group='com.martiansoftware' />
+    <trusted-key id='982f38d39bb64ba8' group='com.mchange' />
+    <trusted-key id='1063fe98bcecb758' group='com.puppycrawl.tools' />
+    <trusted-key id='45e8359dfc6dcd0e' group='com.rometools' />
+    <trusted-key id='8671a8df71296252' group='com.squareup.okhttp3' />
+    <trusted-key id='8671a8df71296252' group='com.squareup.okio' />
+    <trusted-key id='6425559c47cc79c4' group='com.sun.activation' />
+    <trusted-key id='0315bfb7970a144f' group='com.sun.istack' />
+    <trusted-key id='6425559c47cc79c4' group='com.sun.mail' />
+    <trusted-key id='0315bfb7970a144f' group='com.sun.xml.bind' />
+    <trusted-key id='0315bfb7970a144f' group='com.sun.xml.fastinfoset' />
+    <trusted-key id='1b2718089ce964b8' group='com.thoughtworks.qdox' />
+    <trusted-key id='602ec18d20c4661c' group='com.thoughtworks.xstream' />
+    <trusted-key id='ca62973fbf0451c0' group='com.vaadin.external.google' />
+    <trusted-key id='4cc08e7f47c3ec76' group='com.zaxxer' />
+    <trusted-key id='1861c322c56014b2' group='commons-beanutils' />
+    <trusted-key id='411063a3a0ffd119' group='commons-beanutils' />
+    <trusted-key id='3faad2cd5ecbb314' group='commons-codec' />
+    <trusted-key id='86fdc7e2a11262cb' group='commons-codec' />
+    <trusted-key id='1861c322c56014b2' group='commons-collections' />
+    <trusted-key id='a41f13c999945293' group='commons-collections' />
+    <trusted-key id='50bdce2258812457' group='commons-digester' />
+    <trusted-key id='3faad2cd5ecbb314' group='commons-fileupload' />
+    <trusted-key id='86fdc7e2a11262cb' group='commons-io' />
+    <trusted-key id='9c4f7e9d98b1cc53' group='commons-io' />
+    <trusted-key id='1241bc872c5e4ec0' group='commons-lang' />
+    <trusted-key id='a41f13c999945293' group='commons-logging' />
+    <trusted-key id='7a8860944fad5f62' group='commons-net' />
+    <trusted-key id='89c5ce2fb52bcb56' group='de.bechte.junit' />
+    <trusted-key id='379ce192d401ab61' group='info.picocli' />
+    <trusted-key id='8edf2667d0ecffaf' group='io.mockk' />
+    <trusted-key id='056aca74d46000bf' group='io.netty' />
+    <trusted-key id='9a2c7a98e457c53d' group='io.projectreactor' />
+    <trusted-key id='94b291aef984a085' group='io.reactivex' />
+    <trusted-key id='94b291aef984a085' group='io.reactivex.rxjava2' />
+    <trusted-key id='6809ab7eb7be7b2d' group='io.rsocket' />
+    <trusted-key id='9a2c7a98e457c53d' group='io.spring.gradle' />
+    <trusted-key id='9a2c7a98e457c53d' group='io.spring.javaformat' />
+    <trusted-key id='9a2c7a98e457c53d' group='io.spring.nohttp' />
+    <trusted-key id='276962ca56e73c81' group='io.vavr' />
+    <trusted-key id='6425559c47cc79c4' group='javax.activation' />
+    <trusted-key id='6425559c47cc79c4' group='javax.annotation' />
+    <trusted-key id='8db9fa0b0718bbf9' group='javax.cache' />
+    <trusted-key id='6425559c47cc79c4' group='javax.ejb' />
+    <trusted-key id='6425559c47cc79c4' group='javax.el' />
+    <trusted-key id='5bcee695141e6086' group='javax.enterprise' />
+    <trusted-key id='6425559c47cc79c4' group='javax.enterprise.concurrent' />
+    <trusted-key id='d3b7479720ee1af8' group='javax.faces' />
+    <trusted-key id='a0e8a2e551ee7606' group='javax.inject' />
+    <trusted-key id='6425559c47cc79c4' group='javax.interceptor' />
+    <trusted-key id='6425559c47cc79c4' group='javax.jms' />
+    <trusted-key id='0315bfb7970a144f' group='javax.json' />
+    <trusted-key id='5f46eb39af9138fe' group='javax.json.bind' />
+    <trusted-key id='6425559c47cc79c4' group='javax.mail' />
+    <trusted-key id='8524979b11a1e4d6' group='javax.money' />
+    <trusted-key id='0a71e49a4906bf73' group='javax.persistence' />
+    <trusted-key id='6425559c47cc79c4' group='javax.resource' />
+    <trusted-key id='6425559c47cc79c4' group='javax.servlet' />
+    <trusted-key id='6425559c47cc79c4' group='javax.servlet.jsp' />
+    <trusted-key id='6425559c47cc79c4' group='javax.servlet.jsp.jstl' />
+    <trusted-key id='a077240bc1422fb9' group='javax.transaction' />
+    <trusted-key id='2d910134368593f3' group='javax.websocket' />
+    <trusted-key id='0315bfb7970a144f' group='javax.xml.bind' />
+    <trusted-key id='0a71e49a4906bf73' group='javax.xml.soap' />
+    <trusted-key id='0315bfb7970a144f' group='javax.xml.ws' />
+    <trusted-key id='72385ff0af338d52' group='joda-time' />
+    <trusted-key id='efe8086f9e93774e' group='junit' />
+    <trusted-key id='86e02c5a42196ca8' group='log4j' />
+    <trusted-key id='bb2914c1fa0811c3' group='net.bytebuddy' />
+    <trusted-key id='571a5291e827e1c7' group='net.java' />
+    <trusted-key id='586654072ead6677' group='net.java' />
+    <trusted-key id='f6bc09712c8df6ec' group='net.minidev' />
+    <trusted-key id='b83a12a027fc6962' group='net.sf.ehcache' />
+    <trusted-key id='0da8a5ec02d11ead' group='net.sf.jopt-simple' />
+    <trusted-key id='1d185615d0a84648' group='net.sf.saxon' />
+    <trusted-key id='25a73bfc746e1035' group='net.sourceforge.htmlunit' />
+    <trusted-key id='6b1b008864323b92' group='org.antlr' />
+    <trusted-key id='012579464d01c06a' group='org.apache' />
+    <trusted-key id='21a24b3f8b0f594a' group='org.apache' />
+    <trusted-key id='873a8e86b4372146' group='org.apache' />
+    <trusted-key id='c92c5fec70161c62' group='org.apache' />
+    <trusted-key id='411063a3a0ffd119' group='org.apache-extras.beanshell' />
+    <trusted-key id='f135dbe269cc103e' group='org.apache.activemq' />
+    <trusted-key id='62ed4df0bacb8793' group='org.apache.activemq.protobuf' />
+    <trusted-key id='a2115ae15f6b8b72' group='org.apache.ant' />
+    <trusted-key id='9daadc1c9fcc82d0' group='org.apache.bcel' />
+    <trusted-key id='32ac66c4fbf15ecb' group='org.apache.commons' />
+    <trusted-key id='3faad2cd5ecbb314' group='org.apache.commons' />
+    <trusted-key id='64a16faaec16a4be' group='org.apache.commons' />
+    <trusted-key id='7a8860944fad5f62' group='org.apache.commons' />
+    <trusted-key id='86fdc7e2a11262cb' group='org.apache.commons' />
+    <trusted-key id='9daadc1c9fcc82d0' group='org.apache.commons' />
+    <trusted-key id='9e6917b5c467526e' group='org.apache.commons' />
+    <trusted-key id='a2115ae15f6b8b72' group='org.apache.commons' />
+    <trusted-key id='bffc9b54721244ad' group='org.apache.commons' />
+    <trusted-key id='66c02fe18b5c5237' group='org.apache.derby' />
+    <trusted-key id='ecdfea3cb4493b94' group='org.apache.geronimo.specs' />
+    <trusted-key id='7c25280eae63ebe5' group='org.apache.httpcomponents' />
+    <trusted-key id='5be0ba8cb80602ae' group='org.apache.ivy' />
+    <trusted-key id='73129f58de61ecbd' group='org.apache.johnzon' />
+    <trusted-key id='b4c70893b62babe8' group='org.apache.logging' />
+    <trusted-key id='3595395eb3d8e1ba' group='org.apache.logging.log4j' />
+    <trusted-key id='c7bf26d0bb617866' group='org.apache.maven' />
+    <trusted-key id='2d15e54a1556f3a4' group='org.apache.poi' />
+    <trusted-key id='a54ad08ea7a0233c' group='org.apache.taglibs' />
+    <trusted-key id='fdd3b769b21c125c' group='org.apache.tiles' />
+    <trusted-key id='10c01c5a2f6059e7' group='org.apache.tomcat' />
+    <trusted-key id='10c01c5a2f6059e7' group='org.apache.tomcat.embed' />
+    <trusted-key id='ca9843a0ae4c69ec' group='org.apache.velocity' />
+    <trusted-key id='d0eb627d4885ced1' group='org.apache.velocity' />
+    <trusted-key id='d9876bb8d5718ba4' group='org.apache.xmlbeans' />
+    <trusted-key id='85911f425ec61b51' group='org.apiguardian' />
+    <trusted-key id='c1d3063467f1ebd1' group='org.asciidoctor' />
+    <trusted-key id='521a9c06820d5c1d' group='org.aspectj' />
+    <trusted-key id='e2b3d84202b812d9' group='org.assertj' />
+    <trusted-key id='368557390486f2c5' group='org.awaitility' />
+    <trusted-key id='528dc75aa68f0923' group='org.beanshell' />
+    <trusted-key id='b16698a4adf4d638' group='org.checkerframework' />
+    <trusted-key id='f6a1a3215196472a' group='org.codehaus.fabric3.api' />
+    <trusted-key id='41321490758aad6f' group='org.codehaus.groovy' />
+    <trusted-key id='858fc4c4f43856a3' group='org.codehaus.jettison' />
+    <trusted-key id='6525fd70cc303655' group='org.codehaus.mojo' />
+    <trusted-key id='873a8e86b4372146' group='org.codehaus.mojo' />
+    <trusted-key id='b7c3b43d18eaa8b7' group='org.codehaus.mojo' />
+    <trusted-key id='2e2010f8a7ff4a41' group='org.codehaus.plexus' />
+    <trusted-key id='466caed6e0747d50' group='org.codehaus.plexus' />
+    <trusted-key id='c7bf26d0bb617866' group='org.codehaus.plexus' />
+    <trusted-key id='c9fbaa83a8753994' group='org.codehaus.woodstox' />
+    <trusted-key id='79e193516be7998f' group='org.dom4j' />
+    <trusted-key id='1677d141bcf3584d' group='org.eclipse.jetty' />
+    <trusted-key id='2d0e1fb8fe4b68b4' group='org.eclipse.jetty' />
+    <trusted-key id='2d0e1fb8fe4b68b4' group='org.eclipse.jetty.websocket' />
+    <trusted-key id='d3af8233bb247d51' group='org.eclipse.persistence' />
+    <trusted-key id='01d734ee5ee9c3f8' group='org.eclipse.sisu' />
+    <trusted-key id='b83a12a027fc6962' group='org.ehcache' />
+    <trusted-key id='1939a2520bab1d90' group='org.freemarker' />
+    <trusted-key id='9ff25980f5ba7e4f' group='org.fusesource.hawtbuf' />
+    <trusted-key id='6425559c47cc79c4' group='org.glassfish' />
+    <trusted-key id='2d6641c6af88103e' group='org.glassfish.external' />
+    <trusted-key id='728ffdddb25b0af3' group='org.glassfish.grizzly' />
+    <trusted-key id='0315bfb7970a144f' group='org.glassfish.jaxb' />
+    <trusted-key id='6425559c47cc79c4' group='org.glassfish.jersey' />
+    <trusted-key id='6425559c47cc79c4' group='org.glassfish.main' />
+    <trusted-key id='6425559c47cc79c4' group='org.glassfish.tyrus' />
+    <trusted-key id='a6adfc93ef34893e' group='org.hamcrest' />
+    <trusted-key id='bede11eaf1164480' group='org.hamcrest' />
+    <trusted-key id='379ce192d401ab61' group='org.hibernate' />
+    <trusted-key id='313cba932516c4d3' group='org.hsqldb' />
+    <trusted-key id='c7c7bcb30f973835' group='org.javamoney.moneta' />
+    <trusted-key id='10066a9707090cf9' group='org.javassist' />
+    <trusted-key id='e93671c7272b7b3f' group='org.jdom' />
+    <trusted-key id='bcf4173966770193' group='org.jetbrains' />
+    <trusted-key id='379ce192d401ab61' group='org.jetbrains.intellij.deps' />
+    <trusted-key id='6a0975f8b1127b83' group='org.jetbrains.kotlin' />
+    <trusted-key id='379ce192d401ab61' group='org.jetbrains.kotlinx' />
+    <trusted-key id='5aa04e99057d01bf' group='org.jibx' />
+    <trusted-key id='62ebfc78fe4156d1' group='org.jruby' />
+    <trusted-key id='82d8373a8e0f8d06' group='org.jruby.jcodings' />
+    <trusted-key id='82d8373a8e0f8d06' group='org.jruby.joni' />
+    <trusted-key id='85911f425ec61b51' group='org.junit' />
+    <trusted-key id='85911f425ec61b51' group='org.junit.jupiter' />
+    <trusted-key id='85911f425ec61b51' group='org.junit.platform' />
+    <trusted-key id='85911f425ec61b51' group='org.junit.vintage' />
+    <trusted-key id='0315bfb7970a144f' group='org.jvnet.staxex' />
+    <trusted-key id='a1b4460d8ba7b9af' group='org.mockito' />
+    <trusted-key id='3f36885c24df4b75' group='org.mozilla' />
+    <trusted-key id='7c7d8456294423ba' group='org.objenesis' />
+    <trusted-key id='79b3f4fd617ddbad' group='org.ogce' />
+    <trusted-key id='85911f425ec61b51' group='org.opentest4j' />
+    <trusted-key id='5f69ad087600b22c' group='org.ow2.asm' />
+    <trusted-key id='93e55cb567b5c626' group='org.pantsbuild' />
+    <trusted-key id='3979a71621665974' group='org.python' />
+    <trusted-key id='b83a12a027fc6962' group='org.quartz-scheduler' />
+    <trusted-key id='1364c5e2df3e99c5' group='org.reactivestreams' />
+    <trusted-key id='25a73bfc746e1035' group='org.seleniumhq.selenium' />
+    <trusted-key id='c484292642e79bb9' group='org.seleniumhq.selenium' />
+    <trusted-key id='4c5eed3c53b75933' group='org.skyscreamer' />
+    <trusted-key id='2c7b12f2a511e325' group='org.slf4j' />
+    <trusted-key id='0374cf2e8dd1bdfd' group='org.sonatype.oss' />
+    <trusted-key id='586654072ead6677' group='org.sonatype.oss' />
+    <trusted-key id='9a2c7a98e457c53d' group='org.springframework' />
+    <trusted-key id='9a2c7a98e457c53d' group='org.springframework.boot' />
+    <trusted-key id='51a00fa751b91849' group='org.springframework.data' />
+    <trusted-key id='51a00fa751b91849' group='org.springframework.data.build' />
+    <trusted-key id='9a2c7a98e457c53d' group='org.springframework.integration' />
+    <trusted-key id='9a2c7a98e457c53d' group='org.springframework.security' />
+    <trusted-key id='9a2c7a98e457c53d' group='org.springframework.session' />
+    <trusted-key id='3d5008619690c602' group='org.synchronoss.cloud' />
+    <trusted-key id='9440c8d6decafa12' group='org.testng' />
+    <trusted-key id='e0130a3ed5a2079e' group='org.webjars' />
+    <trusted-key id='e57a697a70cfe5f9' group='org.webjars' />
+    <trusted-key id='a2115ae15f6b8b72' group='org.xmlunit' />
+    <trusted-key id='55c7e5e701832382' group='org.yaml' />
+    <trusted-key id='9ff25980f5ba7e4f' group='xalan' />
+    <trusted-key id='858fc4c4f43856a3' group='xerces' />
+    <trusted-key id='86fdc7e2a11262cb' group='xml-apis' />
+  </trusted-keys>
+  <dependencies>
+    <dependency group='antlr' module='antlr' version='2.7.7'>
+      <sha512>311C3115F9F6651D1711C52D1739E25A70F25456CACB9A2CDDE7627498C30B13D721133CC75B39462AD18812A82472EF1B3B9D64FAB5ABB0377C12BF82043A74</sha512>
+    </dependency>
+    <dependency group='antlr' module='antlr' version='2.7.7' extension='pom'>
+      <sha512>4A34DE18BEE216852F43EFDDCD3BCED1708548EBFF7372B4EC4ECB6C289B36190B4D0D5588B86F9B65B3BC64756290B66BF1D6D9ED49D0CB8B972921829CBA9E</sha512>
+    </dependency>
+    <dependency group='aopalliance' module='aopalliance' version='1.0'>
+      <sha512>3F44A932D8C00CFEEE2EB057BCD7C301A2D029063E0A916E1E20B3AEC4877D19D67A2FD8AAF58FA2D5A00133D1602128A7F50912FFB6CABC7B0FDC7FBDA3F8A1</sha512>
+    </dependency>
+    <dependency group='aopalliance' module='aopalliance' version='1.0' extension='pom'>
+      <sha512>E15970E4DFE9A5DF2D105A5F220F9950B0932E3E3D50534098E21BA2A602DA375ECC17E5C0E54AF8CF120DA50C9148E749ED87E5153353B53BF92F8FCED47425</sha512>
+    </dependency>
+    <dependency group='cglib' module='cglib-parent' version='3.3.0' extension='pom'>
+      <sha512>610891AB065E1828C6B4C0B090A5BB81FEA4B8F8E05312D21F07BEBBF9B7674B61053171B7FF982104CCD3E913136BCA326D7162D580C75615BD46A1367A8FCB</sha512>
+    </dependency>
+    <dependency group='cglib' module='cglib' version='3.3.0'>
+      <sha512>9EAEE4A52BD9261364BFF9F7DEE145F3D7F7E1A842BBB179C6C9FEC065BEB162BEA312B566C875DB20DEA317BD76267774C73E102E9EE46AB27C4C2B488BF96B</sha512>
+    </dependency>
+    <dependency group='cglib' module='cglib' version='3.3.0' extension='pom'>
+      <sha512>118FAF55B80A4E649932031901C4635B1D38BEE5481715F0E2CCB3906607C58311154FED03F09122AFA54284579B0ABD155BDB2DCF7CE4C88FE41D781916C0AA</sha512>
+    </dependency>
+    <dependency group='com.beust' module='jcommander' version='1.72'>
+      <sha512>2DA86589FF7ECBB53CFCE845887155BCA7400ECF2FDFDEF7113EA03926A195A1CBCF0C071271DF6BEDC5CDFA185C6576F67810F6957CD9B60AB3600A4545420E</sha512>
+    </dependency>
+    <dependency group='com.beust' module='jcommander' version='1.72' extension='pom'>
+      <sha512>EE143A860323E0231AFB5A9CDF8A0E977F65B5A0F11B94E1BD4CD929A70037B60D9EF58705D8A249F00CC290DD1F2CFD06F5AD81DD9D46426EE2EFC91620D786</sha512>
+    </dependency>
+    <dependency group='com.caucho' module='hessian' version='4.0.62'>
+      <sha512>6B9548C6195648B68D7925C9C8C51233DF529CC17F7D4F6A75A46FB1166F578A9A39D687CA6D08154165CE429AE72536E00F149F4F81B727243DAE2E679D5495</sha512>
+    </dependency>
+    <dependency group='com.caucho' module='hessian' version='4.0.62' extension='pom'>
+      <sha512>263D8BA957F7055AE2F3DB9390513356ACF999888B1C7620BB528050BED2A6759C2B6DC067B21D026D9591B63EAFFBCAC225F79934594328625DED3A8A78ECDB</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.core' module='jackson-annotations' version='2.9.0'>
+      <sha512>266589C36EA544EBCA94AECD76BA9DFE88637563B94CF24E46846466B103074C9F95508BFA237C20D0AB9C60BFB6BEFA2628236DCF7222A69CF1EF9462BCF0B3</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.core' module='jackson-annotations' version='2.9.0' extension='pom'>
+      <sha512>908387A04516F5B841ED387507969652079A4E543A428B3047206E56A39B4895CBDCB5A4FF5DDCF9BFEA0C62F85B5E2150462104F2E6D558CC14EBA4AEDAA45C</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.core' module='jackson-core' version='2.9.9'>
+      <sha512>D8BEAC9E71444BC795C9D99308EAD3284A39AA161F825708DA7DBDFCE410D099C0BBC76C31C27ADAD540CF3BCCF6826D539FCB157923EFAE84B10B3778B920A9</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.core' module='jackson-core' version='2.9.9' extension='pom'>
+      <sha512>CFDC1E35EA30B5F24FD7CD35A037933845DD23A3B61EFBA66B6397C5254859150B49CC9D0871F14400206D1F0B88A2DC2B06D52F52DC4A58F7E5864159D650C9</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.core' module='jackson-databind' version='2.9.9'>
+      <sha512>47204158C4ADBBC8D6659055786641EF6EC95EF6648662AD797AFACE0A3E1074C7BD4D2F565BBE5837BFD0BC06AEC2D8888415FF94A94583F5BDA644CA5004A5</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.core' module='jackson-databind' version='2.9.9' extension='pom'>
+      <sha512>C829A3F01261729F5FA5EC09D179C134B251A57E99318BBC8510C07175BDA748F1166D59744D64A3A81729FFF3D960F2626B106CA99E80A2CD7AD347505E051</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.dataformat' module='jackson-dataformat-cbor' version='2.9.9'>
+      <sha512>82695D50CD7DF578388DB52433F56C8533E5565D01D2C17CC18B26536367EEDD7A249AFE070249FDAF8FA02C3D1C06A542D0A4303696B4D1DDC4CDCB3145A7BC</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.dataformat' module='jackson-dataformat-cbor' version='2.9.9' extension='pom'>
+      <sha512>19EACA21C2C4A0A0FCB184FE8AB52356A5EB22723113EDFA4B70967F1DCFC4CAF3362E2293C477E6039468256B23456EC80F573C0B7445ABC4700BBEE72BB5C9</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.dataformat' module='jackson-dataformat-smile' version='2.9.9'>
+      <sha512>409C39B581FA758A65E1E5344F08AC5607F5E3AF41C5A307E61F2D0E54BA85487CFE6A6BBBEAA89A99C9FCA0240C9DC5676CB50635378AE796570EB3BB427FE0</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.dataformat' module='jackson-dataformat-smile' version='2.9.9' extension='pom'>
+      <sha512>B71968FDB6764E6DBE9BE924D424E7EFC3648FF03F9EF582F3C7CFBC3F3EDEC71C2D89049E1BE39F61E02C7011481F7DE2E2A822092FC2680F251DC56F6BD73F</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.dataformat' module='jackson-dataformat-xml' version='2.9.9'>
+      <sha512>3C9E2E3872737BC3C067D3E68D5D390BA40C20C84BBD0566DC73F1BF12315F8A8AF35F308D8ACE63A4F8B127D0C31A6B075037BD6036F828BFE128510181CDE0</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.dataformat' module='jackson-dataformat-xml' version='2.9.9' extension='pom'>
+      <sha512>45BF4121FAE86EECC39838BC73A22C804E85EA9A5B7C6B3C012E2640A206A0E264BF0DA3D55D1C20BEBF348D6C59CF93DEA3EF9FC4DD14344B85356357BDE463</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.dataformat' module='jackson-dataformats-binary' version='2.9.9' extension='pom'>
+      <sha512>C9B5A1FCAA091D579E1A5B8D33E31D667C587F2734C94F65C65490A71D216990AF1CCE5C57ABC4AB1FBB6830745A2112554435FC233D681E45374A23146840EF</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.datatype' module='jackson-datatype-jdk8' version='2.9.9'>
+      <sha512>3BB8D1493485D196D63DE90440AF529EBF758FD143C07B3BA4B0ECD673436864E5256227181C73B37A8AE37B87F2BF3228C92549AD1DBDE6F00F625F9BB7C4B5</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.datatype' module='jackson-datatype-jdk8' version='2.9.9' extension='pom'>
+      <sha512>FFDEFFAD209A2199B5C5A6CEF02DC2BC862361E5B625F267621B968ED311A5EDF50270BFC3485C41537EA7BFBCA6972AC7FE260A92AC1ABC3546D5DAF9EAE039</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.datatype' module='jackson-datatype-joda' version='2.9.9'>
+      <sha512>16DCCF5DF27768A8CB9EB4E0BBCA145E5D0E9EA72D60973C3158FAF99B5C00EFE0291250ABBA91BF883B8995E6E9B96CEA6C73E894AB75E02E17AA197BBF4D75</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.datatype' module='jackson-datatype-joda' version='2.9.9' extension='pom'>
+      <sha512>DE5F26151B08174A3A03A68BFFD619DFB8429F0502A996ABE555C07EAC33302EE008148111427799F6F555840CBA6C19D03DBA8C0F2D06F88C2D1594D0F02918</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.datatype' module='jackson-datatype-jsr310' version='2.9.9'>
+      <sha512>CBB5AE6A26263FEEC6B3D97A3E5A3B9009DE8C5463BDB03B6D32F8EA919B412390C6DD1E33AFA6143101012E1F613A971FC63FC78D62809FFCE7E0B71ADC74D6</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.datatype' module='jackson-datatype-jsr310' version='2.9.9' extension='pom'>
+      <sha512>62AB83537C15832B20DCFF4E6BF66F1746368395C23B338C87B9994B99D1948FA29D808C014D9CE16CF89322C1E78FFCBE667D926B1F5937B4B4ECB02E7781A0</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.module' module='jackson-module-jaxb-annotations' version='2.9.9'>
+      <sha512>9D5D7BEDEFF5E60B1951E3D7EF78D1B4ACEA4BE5BD6341EB541E87A36B2286934A1B78FB3AE5C583289D94A2A70BFE487AAFFC648C5AFEC9F09C3D4ACFE0BDC4</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.module' module='jackson-module-jaxb-annotations' version='2.9.9' extension='pom'>
+      <sha512>967A1154E6D36B44BA830D842FA9A1B1D025B107ECD8279F16D54FD8B83B8D0F9301C4AB2477D0FA6463739BBE109FD01B2E58F6C5808B57D86DF86189696BC2</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.module' module='jackson-module-kotlin' version='2.9.9'>
+      <sha512>617C9C89FAAD5006480F7FD6E8A2EABB226F14106B693799C7DDBEBC5E5BE902BB3757CAC4C4AA1DBCA082419F72D8ECC213926AA692B3ECA5F7E27EECD33060</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.module' module='jackson-module-kotlin' version='2.9.9' extension='pom'>
+      <sha512>1D41F27811C1E97C377CB7ACD9C6B99BEC5BC99E7ABF3DEC4CD8C221EB01D6119668FD5E4537712EB4DB4379D49465EB6DCF4DA4190C1554C0BEA31B5363E7A6</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.module' module='jackson-modules-base' version='2.9.9' extension='pom'>
+      <sha512>E8BEE5B0107BAD6F1BD58CAA07261E2A6A7B6078B58303D2EBF4FACA498C535EC4F419254C0522156EF8B78B1CF5218F276A033B88BB8C23449D5C2D19EBC6A</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson.module' module='jackson-modules-java8' version='2.9.9' extension='pom'>
+      <sha512>171C51A706AFE785C2B7E73361C80C65FDF1C914A2213D2B29539830567C9F7D052F05094AC04609729262F9EB942042C8937843B152695D4D6465ADA2A5B271</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson' module='jackson-base' version='2.9.9' extension='pom'>
+      <sha512>E4A952A5F96620FF81AC4C385096E248B9D51D96B7FB1B28E941CE5028FE7613D1438340E99345D6937FCAAA4E2C019C0EC185E1BAA2BAF5088467BEDE9C5D4E</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson' module='jackson-bom' version='2.9.9' extension='pom'>
+      <sha512>461A0456C45936BABF0013E2CE70B2B40DB9E78AADBAD36F72A827C5D6311F5941C76EB7916D2FB06F5C2ADEF4FDD53AB322D0493BEC44D92EB7C7FBAA5333C</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson' module='jackson-parent' version='2.9.0' extension='pom'>
+      <sha512>72513CF8FE95BE878923DDA844B95F02AA7F97E053D20CD5C63443530E43F3A01C146EFB07E0CC53EDC7629876357E4A9722681AD69B6360B32AC98466F53A24</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.jackson' module='jackson-parent' version='2.9.1.2' extension='pom'>
+      <sha512>40A1AC61BA98C427A50CF2419E7AB75DED835582E984F33D201F197742B3CF299D365D1F99EED3E06F71B4D27CFC9C4CB66D61C517DF698B41BCAFD7310D6781</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.woodstox' module='woodstox-core' version='5.2.0'>
+      <sha512>59E3A352C1D4982FB886E1487C71C0DB2528B9A100201E08D318F9BB9FE6930212346D4DE2CDCD2153DAD0D7090DAB62094A156B7A64AF94311256FC8244FBC9</sha512>
+    </dependency>
+    <dependency group='com.fasterxml.woodstox' module='woodstox-core' version='5.2.0' extension='pom'>
+      <sha512>8E0EC91F1B35532478A47028726FF6BD6F69C32C4D2B7FE1DF98349C2636AB6C423859B49990767D7BB27069B6FA29E3BDE73A4586CE3448192766FA4E19A80F</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='aalto-xml' version='1.2.1'>
+      <sha512>2667649F07BDB7D28E1E7EF14CCCCF321640E0A955A88BA82FBC3962350DD881CE59594CF8E0B6DDC15526C55767F9E97F756F538BE30B689230F02461363196</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='aalto-xml' version='1.2.1' extension='pom'>
+      <sha512>9B776E4B30A050B026852D868A70091AFAC0191AA14B046B2DA11B3E9201C73A08E208826036A1C0AB4C7AE9385478654A3ACC6B7F8B03A377C094C9FF50ABED</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='classmate' version='1.3.1'>
+      <sha512>82B53871F346C6AA3B177F1E195BD15B88EA8D371CEE15CE972F60DA0E8CEAF63FAEB09947660CF5BE88B3AF74F7A972E2377A7CB9EC98235C56FF82AC59D825</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='classmate' version='1.3.1' extension='pom'>
+      <sha512>2B26E9433116EF0F5D6AF0FE9D5B8EAEB698E97EDC96170049A5E2D25642B4A17698900F85909460CBC73DFCDA1FC5F710F0601083D8CDF991CE45C353DB3350</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='classmate' version='1.3.4'>
+      <sha512>15E32620C434FFADAB0B198E1F3346F4B3F0DD8F47BBDD3EDDB7384FFFC14B593E1679A7F4200A9B9F7CC25A8DEF67DED0A27F0DCD564703284DCE6231891EF</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='classmate' version='1.3.4' extension='pom'>
+      <sha512>E9CBC9C12FA6DA6DBDDC945B996A001F304F63F8B9BA945F3E212B3CA9E1F973C96612DCE5BABE7504FC1826C7B501FE3094846A6FD4233980E851857386BA0F</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='oss-parent' version='24' extension='pom'>
+      <sha512>391DDB6442E232A22F25C63E2B6A36937F367CAE7046625679009950632BC2D85508DE93C1B95E0639FA9CACDB04BC97B69195F090B6DD9F21EE6EC1B7DE126E</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='oss-parent' version='28' extension='pom'>
+      <sha512>1A87D632621CC26473D7D5B4CAE8875C7B59A9BAEB0538A43A4E7EACAA132BE19B19BD2860B3B6166154E22A69445ABCBD62CE6952051D3596726179FBD3975E</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='oss-parent' version='32' extension='pom'>
+      <sha512>14B56137FAB269244DC38DE47F57663F1DB5DFDEB24906B37213F2242E707FF56AC079B6CDA3CBC401838F12DC666B3BF87096250D38A6C4BDD5DB8CF42B3975</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='oss-parent' version='33' extension='pom'>
+      <sha512>3985DE5D18533455EBC3511D3236671B553EB40287243B1FFA9397E21DA1E6B98E7E3AC02F7359A139357EB4D6165D8F46C3E70810A6243E1AA0FDE30E5F9ACD</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='oss-parent' version='34' extension='pom'>
+      <sha512>5FD7A9EC5E204DAF673E5A878AB431FEF75F7B9C53CD3EEFBF653EA3257EE5DE75BC30008E4DFFE5591FDE27A58CEA57B652FA7C0DC4EAF3F6C67D0EE4D40F49</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='oss-parent' version='35' extension='pom'>
+      <sha512>D1AD5637299B5EF5BF425BE8F7E79EE3145785477BA6CA9629EC9411FB559F53ECEBB49E62D745A49D8E7EE4D9025B1D4DA1FE78E56EF757064E29089FDCA146</sha512>
+    </dependency>
+    <dependency group='com.fasterxml' module='oss-parent' version='37' extension='pom'>
+      <sha512>E66EA3440D324A2DE88FFCABE3DC25ECF25C5EBC57C96542264DC12AB493E3FB5F18CF514AD0A9EA09DE0CCAF673BC49F4EB3DFED305E33F752CD2B231F6183F</sha512>
+    </dependency>
+    <dependency group='com.github.albfernandez' module='juniversalchardet' version='2.3.0'>
+      <sha512>536B2530ACEC9949A4163109597AD2A1A6F00185E3993E6945C8880F87D7123BF77C8B6D72D2BE870D849E5201D091D42727DC133E24BCB7AFC38BAC74BFC3D0</sha512>
+    </dependency>
+    <dependency group='com.github.albfernandez' module='juniversalchardet' version='2.3.0' extension='pom'>
+      <sha512>DCEACCD5B1DFDD003BC25C78FD2614650C105742FD83E53DF95905BD89858BF1713924E3A9838F719FD220F4326A36F028E3BE3E0407D2CA78D3AB02C6E02FE7</sha512>
+    </dependency>
+    <dependency group='com.github.ben-manes.caffeine' module='caffeine' version='2.8.0'>
+      <sha512>F8FEFDB21CB04D9C229D3C27DC03BDF141A943AED99D29B1349CAFB10758901AE8A564C0C00FF55F574D1CBCE4BEF9E33B6F6CF92B8ABD31A8D98009870DB800</sha512>
+    </dependency>
+    <dependency group='com.github.ben-manes.caffeine' module='caffeine' version='2.8.0' extension='pom'>
+      <sha512>5693EC2BDE8862E7E2E3F9FD8340589933EBA6BE62E5225D645BC60E2EE7E2CA33915152F4835CB67E4B98AC97D77921C7D70F5BAA5EDD72C9094D63147A7F71</sha512>
+    </dependency>
+    <dependency group='com.github.ben-manes' module='gradle-versions-plugin' version='0.24.0'>
+      <sha512>6F5D54B61291563CE720F78ED8EB29D0D5675449C7F91A822F56312C7EFA56C2F318ED60D632234C59F87BC7CEBF10549C204AEB05C236FC8C58437EF1514929</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jffi' version='1.2.18'>
+      <sha512>82D42F94B90A9F8AEF1DF696219478FDBFE0198970E578C8C6AC7F983F26F3D5488076222CA5F6C9F262EFFDF2192D6C8F32F1BFB54930ED488F2830C34BB074</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jffi' version='1.2.18' classifier='native'>
+      <sha512>7DCF0386441EDB80E6B5E65849A10C669BCF564E1B6C8A3715D188176EF5EFA17839F627E051798142A91786F114D4DED7B3947C9687D3122091CEC711F504AC</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jffi' version='1.2.18' extension='pom'>
+      <sha512>15C743E5D633AE6A507D68B1C753C49268A5CDBF70C5FD4CE538F1F25ED7307A5633FD6C426AFEFD4C4960E01231BFE1A1CCE02BD1BCDF4B43FF8E2222D445CB</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-constants' version='0.9.12'>
+      <sha512>2788A85E23C7C14248515690B4E594B55A912A85F3D9B052E2A137191B1B178A2059BC67602A14BF6B21E3CE625576AC48BFABE5500D2CEEF2F9CE33C0790677</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-constants' version='0.9.12' extension='pom'>
+      <sha512>86481A4652ECE0BF8AB4BB797BCE70A8B0642FF8026F7178ABD9AF81ED6489B7076D22B12F360E3045B31A22D56C1D2BBBEE41387C37D9B5EBD18A8EAB230C41</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-enxio' version='0.19'>
+      <sha512>C1310F27EB6DD731E89225101DA5A7581116AF61B7618BE652BC1166037E13EBF51F7BFCB0B052FDD896759A76F4C59B2D63DB7BDD1513DA672E183D4D2A29AE</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-enxio' version='0.19' extension='pom'>
+      <sha512>217E49830589D20E72068F5FC48733D269548E22EE815009F887A4FB7E257DB24869FB219C01F4188BBE3A359611C29412A5751877EB622F0967AA8F1935468B</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-netdb' version='1.1.6'>
+      <sha512>266FB8D9204B2C312B12F2C2231F27157D76FA3E7242F3BF2E3FDE94B65B2FE28492A2C67A9F87C404051AE4E95D2BA567A873943F349AAED4A6E262E7C6E4A1</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-netdb' version='1.1.6' extension='pom'>
+      <sha512>3879488481365BBD6704234FF62CFF7173325A67B69E9003BA8D80546C642F25D0D77B222DD9CFAB6A501D1BE7087450CA69D73A1638B27205823B42357B347D</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-posix' version='3.0.49'>
+      <sha512>E7FCF87DC230CE95DC389753D8D646737FD71478043A16E0C186490AC0BBBF3A006D00875F57C58D8E0DAA332B7A3F0E035C9F239E431071D22D8C3FDA6C28C2</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-posix' version='3.0.49' extension='pom'>
+      <sha512>3981C96CE917ABC237CC082E13F86F2F80E99FFE82F69D6F4C9C2605E4C1F0CECACCEE4BA7493A141DF7BB1169734725D038B6CC0EE7D67C4580E6D8325856DB</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-unixsocket' version='0.20'>
+      <sha512>48424E910121C303154481A1DE89169D3673D57EE72795A4FED0CA7E15BAE107BF1161A453EE706BBBE0A934D4D000AB3BA599C9DEBA952995A32363E6226429</sha512>
+    </dependency>
+    <dependency group='com.github.jnr' module='jnr-unixsocket' version='0.20' extension='pom'>
+      <sha512>8D7BA625C394A22201F25E1D651D0B7B73C075831130D8F36C93D8E542CD0882374EDFCB03577CE03861D4F6F66609062076C727EAE62F55AA64DF3424ADB35E</sha512>
+    </dependency>
+    <dependency group='com.github.librepdf' module='openpdf-parent' version='1.2.21' extension='pom'>
+      <sha512>965704725CBD15E11DE2D6C7BABE766C1A8ABD690BED914D009AB49468617523D2A5C9CCF72CB5E607272EC08CCA7041977589C7AC1F4A8FEEE9405882B8A10B</sha512>
+    </dependency>
+    <dependency group='com.github.librepdf' module='openpdf' version='1.2.21'>
+      <sha512>83A63B63716D3C23C958CC475116A0AC1DE67A1D9BF6148EB07F02FCA314CCE2C7BA93F85F3056BC2B0DE09125D915A7F903688294745FBCDCEFB1F6579D097</sha512>
+    </dependency>
+    <dependency group='com.github.librepdf' module='openpdf' version='1.2.21' extension='pom'>
+      <sha512>5D5EF693112E401AF69AF273C8439F398CA9049F81E1B701964D4E0EF4EC70EA230728BFFCE0C6A669EE9E42864A8495D54D790D6A8C28F0190EBF57A81F865D</sha512>
+    </dependency>
+    <dependency group='com.github.spullara.mustache.java' module='compiler' version='0.8.4'>
+      <sha512>8F69B362D136C0C6FCF4E920AA8D7AE76AE023CF08EEB6E2B16608112ACE671A4A45A1E001F1E3900FD01F0A32833C12FC608C724256555B41CFFD6D0391FD58</sha512>
+    </dependency>
+    <dependency group='com.github.spullara.mustache.java' module='compiler' version='0.8.4' extension='pom'>
+      <sha512>94192BFB833A28CFE381D9F367530DBE708CD0389698E14051DF57F1CC10EF56D1640FD45346D85008BA74C822971910B81C46F867E68AA4DCF228F08BB02854</sha512>
+    </dependency>
+    <dependency group='com.github.spullara.mustache.java' module='mustache.java' version='0.8.4' extension='pom'>
+      <sha512>4EB58A73C7094890ED72A292553CACB16037D1D2DBCDF014D90D81BA0E16AC5D9F63D674384B62CBF51542D54265D28E9AE44653B141D552384F484585DB5C23</sha512>
+    </dependency>
+    <dependency group='com.github.virtuald' module='curvesapi' version='1.06'>
+      <sha512>B659B6D923A1EF51C11FB266BEBB49F1C868352C5C3966E59B47B785D87A93B7E8CE1A5CA0C9440BC02738F342DDBAFB937551593DDA59A9FE3A1653303A4B1D</sha512>
+    </dependency>
+    <dependency group='com.github.virtuald' module='curvesapi' version='1.06' extension='pom'>
+      <sha512>10DE88A47ACE38D72978907BA1AE819D7AF3838A26096ECA61B59DE6D4B43803754E6C99FB5724A079A55A41421A7FF45506A6863950323F228E8881F093E274</sha512>
+    </dependency>
+    <dependency group='com.google.code.findbugs' module='jsr305' version='3.0.2'>
+      <sha512>BB09DB62919A50FA5B55906013BE6CA4FC7ACB2E87455FAC5EAF9EDE2E41CE8BBAFC0E5A385A561264EA4CD71BBBD3EF5A45E02D63277A201D06A0AE1636F804</sha512>
+    </dependency>
+    <dependency group='com.google.code.findbugs' module='jsr305' version='3.0.2' extension='pom'>
+      <sha512>8E1CC341A153F64B670D87831EEDFE79A150B8FB7E3A4AFBAEF54DEAA28D2767AE86D12B4F0C5404184360AB8E48A3655E610F3BF2FE6C97A06E9FC3DF49B37</sha512>
+    </dependency>
+    <dependency group='com.google.code.gson' module='gson-parent' version='2.8.5' extension='pom'>
+      <sha512>F06D974836E270B164D4754C3A34F8D63269930BE829F6098C83111757B7CDB2AC2D01B7D5CD7E99AA0A427A096A7770709093FD3AB4D4EADE22D9568B5F4673</sha512>
+    </dependency>
+    <dependency group='com.google.code.gson' module='gson' version='2.8.5'>
+      <sha512>5DD7214C542A7B93AAB3EAB0BA13E4AC3D6DDB05C795FB6D3992E21925A98DCE87CB186AC67B4D3AD146F96E14D38B3892837ECA57A27B4E845ACA6D4E4F708A</sha512>
+    </dependency>
+    <dependency group='com.google.code.gson' module='gson' version='2.8.5' extension='pom'>
+      <sha512>54D60D8EB07BD432C113A30FAFE13A0B36C72A9B8CA42B74FD903159F8CA434AFDEEA073B5447E96B3E98F0625C0C33F2C49BAB0E0FBB2CB66298C7A4481F126</sha512>
+    </dependency>
+    <dependency group='com.google.errorprone' module='error_prone_annotations' version='2.1.3'>
+      <sha512>BD2135CC9EB2C652658A2814EC9C565FA3E071D4CFF590CBE17B853885C78C9F84C1B7B24BA736F4F30ED8CEC60A6AF983827FCBED61FF142F27AC808E97FC6B</sha512>
+    </dependency>
+    <dependency group='com.google.errorprone' module='error_prone_annotations' version='2.2.0'>
+      <sha512>8F5F13FAC4C40D680A1F062C609AA598E7585684AF37D695357738935FC0683DDCB94C880DDDD03E78B1DB071C2E5CEBD054A061F8F24322C5FFA43ACA34A859</sha512>
+    </dependency>
+    <dependency group='com.google.errorprone' module='error_prone_annotations' version='2.2.0' extension='pom'>
+      <sha512>14BA97BF3C7B5CAF9A3663F1DE7D88EB012A04B4888B83EC60F591C4480DF80F28409D00CB3BD183D86086163DB935109E5EF0C072C1E892EB8D24D01136281B</sha512>
+    </dependency>
+    <dependency group='com.google.errorprone' module='error_prone_annotations' version='2.3.2'>
+      <sha512>D85B0296D88EBBF117BE06EDA27503652AE8D3CFD9DB91F492D9FCB2FF205F8A30C0451708A4C4AFFB69096AB245940E2FDBC88A93D660EA256BEE8E967FAB93</sha512>
+    </dependency>
+    <dependency group='com.google.errorprone' module='error_prone_annotations' version='2.3.3'>
+      <sha512>48BFBDF0CF1C08DC54A3748F315D40C548EAABC08DFC4347E625A2AFB7AE206970C0B74BD7E6CF9356314B5C26D2AB51522FB192CF8D6C6B5A6A610021544501</sha512>
+    </dependency>
+    <dependency group='com.google.errorprone' module='error_prone_parent' version='2.2.0' extension='pom'>
+      <sha512>D87BA486B8FC253E5AD3B1589600E06B58FD265E97D7ED11B3B7087EDBBA4FED7A06C454747EF0D8E7A23E346A126260108AAE93855A27A21DAA5436229664E0</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='failureaccess' version='1.0.1'>
+      <sha512>F8D59B808D6BA617252305B66D5590937DA9B2B843D492D06B8D0B1B1F397E39F360D5817707797B979A5BF20BF21987B35333E7A15C44ED7401FEA2D2119CAE</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='failureaccess' version='1.0.1' extension='pom'>
+      <sha512>D8384A1A93045EEFE330570DC9D0DE4D0704CA396580D41D20D683EEAB452CF78973EF166D5582F0D7E1D4DD5856DA5BEB88D4FD9FF5D28CD8E862306A471839</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='guava-parent' version='26.0-android' extension='pom'>
+      <sha512>1D786F14FBFA5C90EEDCC160D1E0A71ACB2141F372049B22CE62B0BD1E883C17CC24A59DC8B00E5037E959CCCDB54D4D8DC8F252302D4BB7CE82DFDAFF764476</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='guava-parent' version='27.1-jre' extension='pom'>
+      <sha512>9418563763A4F94E9788B9A592CF295F7E35701117973C21F3CE1325B08FC78465EF426F33B20F6A9E9B5E6D20A4353BCC3266B923BBA0C61D03A8BDEFB6F4A7</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='guava' version='12.0.1'>
+      <sha512>8C95781321A94EDEB184037A6DC4DC01DAA0FE4ADD2CACE9F9F86986F3E92748A3DC467E1186887193371D4828AC835046169ADDD20088A3025D486A5035B20A</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='guava' version='25.0-jre'>
+      <sha512>8533D76F54B8992BDE67AF1565CBC49CD689CFD2C8C6F2B67FDC53C660FF548D06E55C0C57F853D55A2AA132D42BB13FDB674E1CE16EC37A1DB34F7E25016924</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='guava' version='26.0-android'>
+      <sha512>6246C28875AC84BCA8C9DC4EE026AAEDEA4463367AF161DBEFD6B02FD62DCA727D2419213845DD0353B59F311990144B7B981B9529845E554C669622C950B6BA</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='guava' version='27.1-jre'>
+      <sha512>5C32A58148C3B91577CD6D335D61A1994041A2A5C77A240303BA6E786C895336400F6FD449EAB0802594BF47C17985C5587AB87C3C4B628BFC1D7090DDC0B006</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='guava' version='27.1-jre' extension='pom'>
+      <sha512>8D1B91C0FC987663D0204787C41F37EDD24785C9020F447EE51EDEB352098670B50945C67B0BBC195CE8047B845CB266114F40FABE9FF723736BE2704D61939C</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='listenablefuture' version='9999.0-empty-to-avoid-conflict-with-guava'>
+      <sha512>C5987A979174CBACAE2E78B319F080420CC71BCDBCF7893745731EEB93C23ED13BFF8D4599441F373F3A246023D33DF03E882DE3015EE932A74A774AFDD0782F</sha512>
+    </dependency>
+    <dependency group='com.google.guava' module='listenablefuture' version='9999.0-empty-to-avoid-conflict-with-guava' extension='pom'>
+      <sha512>140544970539199C860D5E7E2D8096BBCCD55980602773F29E8D74AB4F3E24C43AA369B0C7D06B026BA7A9DB3353BE285D7FFB9CD94B2BEDF62820C3FDFD1D5F</sha512>
+    </dependency>
+    <dependency group='com.google.j2objc' module='j2objc-annotations' version='1.1'>
+      <sha512>A4A0B58FFC2D9F9B516F571BCD0AC14E4D3EEC15AACD6320A4A1A12045ACCE8C6081E8CE922C4E882221CEDB2CC266399AB468487AE9A08124D65EDC07AE30F0</sha512>
+    </dependency>
+    <dependency group='com.google.j2objc' module='j2objc-annotations' version='1.1' extension='pom'>
+      <sha512>989870FFF43BE31B11250C6CD86261857B0037A04DD2AB2F3EC26D23B92DD8C0D8B61460E1C03B1991411A28DAD1498DABEF568A5EC4F565945A4C983E69F165</sha512>
+    </dependency>
+    <dependency group='com.google.protobuf' module='protobuf-bom' version='3.9.0' extension='pom'>
+      <sha512>294CCA64D57283F396CDB8D40B5C8B8D30783C602BDA17DD97BF524EB94F7BCC15D732C9217711394888EA6513D6B13666604F533E817C736276BB2FB1C8F281</sha512>
+    </dependency>
+    <dependency group='com.google.protobuf' module='protobuf-java-util' version='3.9.0'>
+      <sha512>413849A6CA5A3B47136B476D1538B736DD06A1D18C63ECDA7D22873247B8DFAD8282235F6F41EAC2ECBA31D862CC79ADA079D7303425E0CB4DEAB7F43CC49CF3</sha512>
+    </dependency>
+    <dependency group='com.google.protobuf' module='protobuf-java-util' version='3.9.0' extension='pom'>
+      <sha512>CACBC3A3AC9D81D0285EF27D0BAB28850ABAA6682DFA2AD911BCCD7D753DB00B422F07BF996B4613CC7FA3E8FF0C7EA24D428325D5F73391ABB200DE54628D6</sha512>
+    </dependency>
+    <dependency group='com.google.protobuf' module='protobuf-java' version='3.9.0'>
+      <sha512>4B65C814BC02F6373C208B2D1F579B6199E71CAC630494B826F818B2128789F8F69286E6CB59153A4697057603ACCD7A7382F59941E9F58AAE82B9A74F26426F</sha512>
+    </dependency>
+    <dependency group='com.google.protobuf' module='protobuf-java' version='3.9.0' extension='pom'>
+      <sha512>925147C5DDD0D3E8170B18A44E5CF7265D36112B87802A481B4C83EF705C27103E9E6B85C3C2159FCF36EC1AC0BDCEBE0F1B9C2CB338FD3B5C37FCD97AAD554</sha512>
+    </dependency>
+    <dependency group='com.google.protobuf' module='protobuf-parent' version='3.9.0' extension='pom'>
+      <sha512>32DF3B26B42219FE24461380AE07AF2197823BF0AA45DDC4B3190AEF173DD1FA30D8DEFCB4FB1640C03AFA473E4043986D7E1FA9D32E6632C64EDEB55328509D</sha512>
+    </dependency>
+    <dependency group='com.googlecode.protobuf-java-format' module='protobuf-java-format' version='1.4'>
+      <sha512>BE99309ECDEFD8FCB1092B92DF04CC8562C460C9C86F43C8391003810CD374CDD1AC033D03A9295BC21F0C56E8083C865CBBB7901A9BB271CF9726BE58630679</sha512>
+    </dependency>
+    <dependency group='com.googlecode.protobuf-java-format' module='protobuf-java-format' version='1.4' extension='pom'>
+      <sha512>A9B5DB98C485FA01481F79FF88D09D9813FCAB7E3A3B553FC3DCB1C62AAB01757FF2E2EA0BA6874FEC71DCAD4D1B3379DF7C78BEEB883D75EB35B6FCEBF86365</sha512>
+    </dependency>
+    <dependency group='com.gradle' module='build-scan-plugin' version='2.4.1'>
+      <sha512>347F865BD5B9310D6972BDA95AB089D2BA911C4EA897A1E4E316465077A0153609E31DFFD3C2D61DEEA7E54C07D7D36D5807F9B24F3111A97553DFD260A205F1</sha512>
+    </dependency>
+    <dependency group='com.h2database' module='h2' version='1.4.199'>
+      <sha512>79A256B47DDB1EC3370606A9C08022B2199715ECBBEF5CB6C91E6CEBFC7837AA745EB35D90BE5D2991D10B006C7E475F915595ECD652C9553F39C1BAFE2F1477</sha512>
+    </dependency>
+    <dependency group='com.h2database' module='h2' version='1.4.199' extension='pom'>
+      <sha512>EC156F9B648AB641C120954AC3E88004703947CED277D09F99246AF16B84851EBC87B13CA067419C889C609BAC923CFC3D6C7942688BD61E94A78AA7EC7E54B9</sha512>
+    </dependency>
+    <dependency group='com.hazelcast' module='hazelcast-all' version='3.2.5'>
+      <sha512>2BDBE2535E164A7D3D07393D4B6648929613C9CA662BD6817DB3D31A8854E18047F2B04B178A36689385154A724DED3A7B675D80C245C2B51CB5635E4CF89B97</sha512>
+    </dependency>
+    <dependency group='com.hazelcast' module='hazelcast-all' version='3.2.5' extension='pom'>
+      <sha512>32E934CFAC6B2D27452FF430EACF5EDB9F6F610994593C8CBD9694A093AA3B750189D8AC9C7EA5D9A5C441D2B0AE5F2C4D47FB683734066F64ADF04A0A1E1A32</sha512>
+    </dependency>
+    <dependency group='com.hazelcast' module='hazelcast-root' version='3.2.5' extension='pom'>
+      <sha512>8CDB84C37408067EB9F8A9FDE330F364CC0B7D009B67E7AEEF16855E9E1AD90FEF33AB81FEB0A04F58736982A0133B998A55BF313ADBB74B6C8027B740864548</sha512>
+    </dependency>
+    <dependency group='com.headius' module='backport9' version='1.2'>
+      <sha512>A7EEFCB55EAF5960689C55B1CB0357CDAF44B0EA8D6B50D51B5487D2FA68224110B80CA2F8F2137FD0A7ED4F213862C93E50D2141D8AD4163E640111A031FE2C</sha512>
+    </dependency>
+    <dependency group='com.headius' module='backport9' version='1.2' extension='pom'>
+      <sha512>F1C3FB62D8A530C73EF30529810BE94F2A870D42C6490B595F9AA6E8ECE2B9E07E16CF01FD6E1AA7D94460050EAB679D94B6980EEB5DCB9984A493BCC07234CF</sha512>
+    </dependency>
+    <dependency group='com.headius' module='invokebinder' version='1.11'>
+      <sha512>7D2B18412E82A5251C761753531AB8FDD9B80BA944ED83A540F78EBE36B5305585598BCB5760C5422BCCFDCAC9A0902B5DB08E41E3B29D7529ED5CFC55E3C31C</sha512>
+    </dependency>
+    <dependency group='com.headius' module='invokebinder' version='1.11' extension='pom'>
+      <sha512>2530755256C2E330D26929065888E1D19EF66C7922FFEB5E53BEDC0E3FA5D3055F10E6A966FADF9117ED5146CCDC800ABCC71D8725DB1B785AEC28967BCC1FA4</sha512>
+    </dependency>
+    <dependency group='com.headius' module='options' version='1.4'>
+      <sha512>F9DE3DEAD7104EE2020B3BE21C4B3DF3EC4C05632D5E7353DE7BFEB20B5CBA140FFE47B017CF9EC96CE861A808C6A77234EA25B1258C18A5B0DB463C0C1ED7F8</sha512>
+    </dependency>
+    <dependency group='com.headius' module='options' version='1.4' extension='pom'>
+      <sha512>18F71F705621A51528D4F73069C9762CD3F18CF4D52D4A3BCC3D60ED31CE5BD5367B976E296BF759578EA5141ACAC7968946AD0BB0A6BBE918C961C602584372</sha512>
+    </dependency>
+    <dependency group='com.ibm.icu' module='icu4j' version='2.6.1'>
+      <sha512>74315F283CCB0CF93E6353E2C52D7CAB7CB2B2495F3C447275FA329CCF9398CEB73D74D1FB8E81FAAA5A8CA76B0A3A32E19C47CED39C55635EDC5754A257D580</sha512>
+    </dependency>
+    <dependency group='com.ibm.icu' module='icu4j' version='2.6.1' extension='pom'>
+      <sha512>D103851CAC1CE6504D3DF9186757419B0175DC5D510DFD35B45BEEFD99E96A127632B19FED12BE85451D0EC55574B8AEE6306F39469508BA39833E3056362D83</sha512>
+    </dependency>
+    <dependency group='com.ibm.websphere' module='uow' version='6.0.2.17'>
+      <sha512>EB760B0A9BCCC726610EE5E3270211A89A06EDB32D3FC49B45C6FDDBB1AE8C6F90D121C5CE652A47FB8820135C50AAC468B1BF7383FAEA4ADCE0B9831862F97D</sha512>
+    </dependency>
+    <dependency group='com.ibm.websphere' module='uow' version='6.0.2.17' extension='pom'>
+      <sha512>DC6C459196C9563F1279AD3130FC00346BA51E20576AFDD875C769336379E5C4279013C16FB29B50EF579F8FDF551A9DA5C6310D50AA0D3974976A573C964F3B</sha512>
+    </dependency>
+    <dependency group='com.jamonapi' module='jamon-parent' version='2.81' extension='pom'>
+      <sha512>52C1B1D49D97431AE8DEB65DDD5165D431B59AB456EF103E468A34DDE5D1D27F1152332F307C3BAC27085C60707F932B7AE1314AAAC67876B579CEB2DBBDBC5C</sha512>
+    </dependency>
+    <dependency group='com.jamonapi' module='jamon' version='2.81'>
+      <sha512>3D71F037A5C0F1F4CDF15E293BA7070ED4F16CD2E1A572A47855F5AC10029DE0FC7097448BC851811119225B4080F8CC8FCE4E7B74845FED91D505E7EEF189D</sha512>
+    </dependency>
+    <dependency group='com.jamonapi' module='jamon' version='2.81' extension='pom'>
+      <sha512>F97379F1A65AC8599EE4539C1CA042538F4C7AAAA9C4BC5DB3A290922EB765C0AEA6F008FAA52F8BE407B6A9E7F92377125FD92F5842E44D224D9DE1CA2B1EC2</sha512>
+    </dependency>
+    <dependency group='com.jayway.jsonpath' module='json-path' version='2.4.0'>
+      <sha512>B55B30CF85CA12E6A492FD48D4B6BB0B1F3BA610C195AA1A36EDA2A80E24BF7688A6A802362D398108E822F6DCB7B713CF421BB4208897FC4F5CC7B8B9B4C97C</sha512>
+    </dependency>
+    <dependency group='com.jayway.jsonpath' module='json-path' version='2.4.0' extension='pom'>
+      <sha512>573261A8BE8DD3344D78666CF8FE61B5CEF271977D83CA9B9771E9A650603A5054B34130A3705269EFA75A422F31A1EAE18D8B0C5264B9DED1682DE1FD120ED3</sha512>
+    </dependency>
+    <dependency group='com.jcraft' module='jzlib' version='1.1.3'>
+      <sha512>339793DF0001214AAADAC2A5456C3CD54A0C09BA2C9E73CF13155ADBFDF1C2A953F7336903E45E76A52CE6B48C5B7C78436667D7836E7354E02E85BA0908AFD3</sha512>
+    </dependency>
+    <dependency group='com.jcraft' module='jzlib' version='1.1.3' extension='pom'>
+      <sha512>4B0CACBE286930B3561F88522A0A5E1F756ABE2A05DEE9422FB12F58E9E504438CF94A0EBBBBC794792AC39BA2F5D92B738CBC52BD38E561134ACB7A141929C6</sha512>
+    </dependency>
+    <dependency group='com.martiansoftware' module='nailgun-all' version='0.9.1' extension='pom'>
+      <sha512>48CD0BC04A40AA50258A24DFD3BEB9339BAFBE2A70B88CF59355B14B2BB3C005D39A5908BF56D2470516453D7C2D6B9542FE0EF119E174B895DEDDE7119A9544</sha512>
+    </dependency>
+    <dependency group='com.martiansoftware' module='nailgun-server' version='0.9.1'>
+      <sha512>A3CB0804B9FA1F2FAF8A31F5E2C3BEF4F4D3DAF7D4F99B054982411B3247F2D3B806A3E0671EDF20289E65D2A6E15E9BE1BFEE8867D16C45198DFDB16E2333CF</sha512>
+    </dependency>
+    <dependency group='com.martiansoftware' module='nailgun-server' version='0.9.1' extension='pom'>
+      <sha512>CA91B8C6F3234A183DD1D0BC520FCDD86DE877A44DC49F61DAF5ED8230E24C1C17C4E885A26EEFBCF6725C934C17DD59ACC84578C7E2548004F851E2E0C91DFB</sha512>
+    </dependency>
+    <dependency group='com.mchange' module='c3p0' version='0.9.5.3'>
+      <sha512>D196CA7BBD50227661B5A4924F4C21F827AFDFF7250E872727B07E216C5CB6BB45F47A2ABC64E33C70EDDE3EF793CE0E7D988A920A73AB232170846F272F56B3</sha512>
+    </dependency>
+    <dependency group='com.mchange' module='c3p0' version='0.9.5.3' extension='pom'>
+      <sha512>52019980CE073DDAB69580BDE3B93AFE005127E3E15718D73226CFCBE9338EB89434692F1F805E5E57FBD917F4389D03B565244C524B3719D40298376759D39A</sha512>
+    </dependency>
+    <dependency group='com.mchange' module='mchange-commons-java' version='0.2.15'>
+      <sha512>288BCC948B0438B4C9D67189EFF87D1C7B7CBBAC386A295AF86C0606021A904E0501B42EEC3B788AEFFD686EDEC5BEA4A30D3698B6DECE99D8F16B692CFD41AC</sha512>
+    </dependency>
+    <dependency group='com.mchange' module='mchange-commons-java' version='0.2.15' extension='pom'>
+      <sha512>DCF3E14E1908DFCC544EB432DDB8AC300CACCE9767709BEF2B20876CC4B9DC76F884CF77CCC49A54F1E98F9D23976F337ED776E21089559084A360293F58FB6A</sha512>
+    </dependency>
+    <dependency group='com.puppycrawl.tools' module='checkstyle' version='8.22'>
+      <sha512>880C32F20AA476BD2209FF77AE04BC65427BA2D47401EC9372F1385EA43BDE9055539249DB2D8429325D2EDA0BB62152C9E3F21C25184A04047649A5C4B61098</sha512>
+    </dependency>
+    <dependency group='com.puppycrawl.tools' module='checkstyle' version='8.22' extension='pom'>
+      <sha512>B233072FEEC16F602BEF145F91DF9F86B7666B1C9795DD9C8344B621D489BF6F2F875BEF591C2AD56151E3B67C21F406171393956BED13679B3CBCF0B3F8BC6B</sha512>
+    </dependency>
+    <dependency group='com.rometools' module='rome-parent' version='1.12.1' extension='pom'>
+      <sha512>C4C796985E05A4560A785D990F9150514DB1BF7D33E422634EB0C01A65059CE1F4F836D315BF6E3BA838ED4F149380536206C1013922FB5C6B857EBEEF9B903</sha512>
+    </dependency>
+    <dependency group='com.rometools' module='rome-utils' version='1.12.1'>
+      <sha512>74B1EA71C973A975CFCD6C9429795DDDB67C84C107130BCE1DD141134DC664CEE003511F96CDF0B183243F945929FDF837DD1956D363E01B6BCEB3AACEEF1759</sha512>
+    </dependency>
+    <dependency group='com.rometools' module='rome-utils' version='1.12.1' extension='pom'>
+      <sha512>EBAB66734A5A6A119E6EAFE01046CE82B7607DB01F9945E39894C692A517955C8CC6FFB6FE36D22BB9EABFEC5C531948CB50238696F0EAB41151A9B8B05566C1</sha512>
+    </dependency>
+    <dependency group='com.rometools' module='rome' version='1.12.1'>
+      <sha512>279032BBAB9BA4303D552FB21CA99805A5BFE255901D951CD1FB689D9EA0261BC9D3287C49A7F0F245F2713FF238F455ACF33ABD5D754C9174FF6997126CA907</sha512>
+    </dependency>
+    <dependency group='com.rometools' module='rome' version='1.12.1' extension='pom'>
+      <sha512>7995F0AA20CB1B1D4C252A2F6D2DA4D698AFFB5A878856C2B8C78A0A319948BA74B530C51A347457267DC9EB3864CCEF75CFA34DF05B0D7A317022DF8F96696D</sha512>
+    </dependency>
+    <dependency group='com.squareup.okhttp3' module='mockwebserver' version='3.14.2'>
+      <sha512>D1BBF02DE51312D4AE488B2DE4BD88E6CFF8B46E38AAC401D583619079A6C7410D49D25BF163B1B92BA4F583303B5D7F007FA19D2DB299A5C563A4A8D77C458C</sha512>
+    </dependency>
+    <dependency group='com.squareup.okhttp3' module='mockwebserver' version='3.14.2' extension='pom'>
+      <sha512>7E58404B7E19D1FB4E81124E6E7E374C3A37C633087B9188EF7B496669C7231DCF7674C7A5A4BE8845C2E5A047E33C7F38F91D60143822126A0BEC28BBEBA255</sha512>
+    </dependency>
+    <dependency group='com.squareup.okhttp3' module='okhttp' version='3.14.2'>
+      <sha512>4D9AB31C6815552D2514E5134FD9B0C8EC3F1CD4FA1B3AB01E253737DC2D66E9AB8CE580488FD375238932E4F20AA3F6B08DE7D937E81924CFA33A3B3E44054</sha512>
+    </dependency>
+    <dependency group='com.squareup.okhttp3' module='okhttp' version='3.14.2' extension='pom'>
+      <sha512>FC97A5493D720A5C010FC6A3CF152BDA95F25E57C29ADF7D50DA52D39E611410048912B54DFEE97CFB2CBFAC45EA93A9F53D89FDDEA8CAF06C8BA5D5F40FC3DD</sha512>
+    </dependency>
+    <dependency group='com.squareup.okhttp3' module='parent' version='3.14.2' extension='pom'>
+      <sha512>BFF8484072049B6DA8F92AD2C77E3116620D5DB3C88B72AD2C950916BFB332017FB11D06FCB663F3820DF6510108CE55985D6E2A62D4D5FCC2C50DA5E0E78864</sha512>
+    </dependency>
+    <dependency group='com.squareup.okio' module='okio-parent' version='1.17.2' extension='pom'>
+      <sha512>13876EC90B7DDBAAB6C21CE96AF818D490B3C3F4F1E65668C3D91940F60CF2C88FF62E35056BAF2EEB0E3F06D4583BA1875B2AE0E9604E7C434B55F5B4A665D2</sha512>
+    </dependency>
+    <dependency group='com.squareup.okio' module='okio' version='1.17.2'>
+      <sha512>3AD9127705AD00962B96A10D134A06378A3EF5558B0C5955ACE54E15A771027A11503981A8DCF0959FB806D35BA8DA9B12282A5A2F3D6DD7C71266120A4E0B4D</sha512>
+    </dependency>
+    <dependency group='com.squareup.okio' module='okio' version='1.17.2' extension='pom'>
+      <sha512>A2B102D85A607331D4F6A4AF46B93D8F21420124C4831A157CFFFD3172310634A098059C9F20DE187B79606F4484BFCF279906593F181EB042C0BB790AFA43AC</sha512>
+    </dependency>
+    <dependency group='com.sun.activation' module='all' version='1.2.0' extension='pom'>
+      <sha512>9EFE921F24FF6F0E5713F3E327B0029DDABA7BF7DA93738CA04F80CCAD2F0A26870195BA7EB990D8A026DAEDD83DAF8042137CCE9CD71FFEEF12DDC329E3163D</sha512>
+    </dependency>
+    <dependency group='com.sun.activation' module='javax.activation' version='1.2.0'>
+      <sha512>B4CBDD8FD1703E4B2E1E691DB78FBCF2232D836F740D1821C4C191A14F9472508E27A40D06E4B6B153964AF68032959C22945BA169A0CA4018B7748162F420A6</sha512>
+    </dependency>
+    <dependency group='com.sun.activation' module='javax.activation' version='1.2.0' extension='pom'>
+      <sha512>A90BA81C3572F2169933F535B10A5B9CF6405E8B812464887AE2B5A2B25532BE2A905468796512BD034119883869825B3AC858D51DA23D01AFAB6BB990577ADE</sha512>
+    </dependency>
+    <dependency group='com.sun.istack' module='istack-commons-runtime' version='3.0.7'>
+      <sha512>1FBB4D883725319028FD3B558086A29FFD0FD0006B56ECA627DDDA23B1155E287AF29860038D92D4C475975F4D1F4AC8249AC55B88852869623485171934B31A</sha512>
+    </dependency>
+    <dependency group='com.sun.istack' module='istack-commons-runtime' version='3.0.7' extension='pom'>
+      <sha512>2DAA95DCB7BA1667A95533C438E7BC1C14DE139FA245B06232FFFAA7519CA10906B5B99D310F2DCF983B9EA275BC30D6B1289ADE77C0E23734325C6214A80FA7</sha512>
+    </dependency>
+    <dependency group='com.sun.istack' module='istack-commons' version='3.0.7' extension='pom'>
+      <sha512>15BD8B871E4F3C060C029B00B28EBA6F77617F71BD287C82C8A684A74AB875AF103F2CC520E3812795F234B79F7AF0FA34FF3ABEE834C1CB94263078537C6DA9</sha512>
+    </dependency>
+    <dependency group='com.sun.mail' module='all' version='1.6.2' extension='pom'>
+      <sha512>501487D8CC87F375504DE8D2151941178F38CC521E3270CC8A1DEAADEDB1B7BFAD662C6B603203593DFE2E7045307EE26E88FAA41E20A30AE44819590DECFCFD</sha512>
+    </dependency>
+    <dependency group='com.sun.mail' module='javax.mail' version='1.6.2'>
+      <sha512>D76243093D93C556AE399CE9B65EA35BC5A7E12703110108CF8EAA314D8F9B094034DD530438189775F61F0994727CAC6F68EFB8EAB2F13349922B08EB00D4EC</sha512>
+    </dependency>
+    <dependency group='com.sun.mail' module='javax.mail' version='1.6.2' extension='pom'>
+      <sha512>6E96A4AFB109AC7EDCAFC7CE0E7B13C59189E5EAAD1B7410D434CBA3B5B168A8FB10067D8F529E4838E4599EE1BF694C209CA0F3DB0E774B009DF2149F979818</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind.mvn' module='jaxb-bundles' version='2.3.0.1' extension='pom'>
+      <sha512>644BB8A04E8BA7EDD63688B344F9DCDCB245AFA18688D8F9EF8A57D66D1215318DF2BB7F0420FC8ABD2938C8ED4B9819293F512C416BBA98BA6E0FD072599C4F</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind.mvn' module='jaxb-bundles' version='2.3.1' extension='pom'>
+      <sha512>E8940F97B0197505E1B605CF319EC72FC681E3D027F9205833D76A5A22085BB2E26FC9F005D14C6D3858ACA278AB40A5A905A4C309F59C4E5FCC91BB0F356D4E</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind.mvn' module='jaxb-parent' version='2.3.0.1' extension='pom'>
+      <sha512>EA66DD748A110E37FC7023EB78F37C660EB8409B0DA99EDC29AA03210EE7B32E63B5AC6E993222282754882D17411549F64751A5EB589C338C31E3550655554C</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind.mvn' module='jaxb-parent' version='2.3.1' extension='pom'>
+      <sha512>87DE27769B0C66797239A44EBA8DB3A9DD6D9CA70B37A9FAA46F91DAB8B4F2467BAA3CA178CC66A7A0D81CFBF78A6D7F2E6460E4A847837664C121DE4CDA5547</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind.mvn' module='jaxb-runtime-parent' version='2.3.1' extension='pom'>
+      <sha512>8F73ADE4C6F7465FB71A7025EDB68F280B0C5C35F4708ECF909D76EFA435CCDE153BF33B3E290A2D2E6CD5930ECE0C7D0A8B02F05EEA59E582FFA70709897964</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind.mvn' module='jaxb-txw-parent' version='2.3.1' extension='pom'>
+      <sha512>2EE1F321B874D0A17F38F7F5B67ED2BD0204EFADB20893B0E11B976942AC2D85C3F0BE67754E78A35D3AAB72A95F4DAF8B0589970ABF26282CD22EC7A8DFE124</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind' module='jaxb-bom-ext' version='2.3.0.1' extension='pom'>
+      <sha512>53DDF144C631BFA549CA40D75B5923151E4B322A15F4A8582B979AFDFFCF3C4687CBB425955B94111CB95FB3A2740D274BF4202987439E271C0987147C9C3F42</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind' module='jaxb-bom-ext' version='2.3.1' extension='pom'>
+      <sha512>EEDD7129AC5EB49734567CAAC8F3E47009747F1FC7686143D7CCFCCC95E8BFECB1C6C5B0A3344CDCDAC6FCD4308FF371EF910CB09943CC48B2F988BC75CC4EA1</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind' module='jaxb-core' version='2.3.0.1'>
+      <sha512>FDA51767B175AB5B12C7438B9A11873FE570FA4B5FFA2C3D10EEBCA9D1DCADA6A8FF2D287AC76017C6A546E1F5CB02988FB7E2FAC32A4A95AD443E1A1B4ADE35</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind' module='jaxb-core' version='2.3.0.1' extension='pom'>
+      <sha512>348C00845706BFE7A2C0E2C8B3B7819A113741C3A01A779E3E95AD7DCFBF054A5885BDBB13F7F5A470ECA025114B7C5E8FE6E8BE9D1EF1927CE1E1D5F8716A1</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind' module='jaxb-impl' version='2.3.0.1'>
+      <sha512>F6152FD8CEB1197C0296BDDE443B67FD4E0F0EBD47BEDA1D8EEE9FBA396468B3C4A515EBDE53EE3262164E6BB75BFD59F470EF3A7EA71B30CB7F9BFD9DF8743B</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind' module='jaxb-impl' version='2.3.0.1' extension='pom'>
+      <sha512>60A1A059F4076B6224E05CD660657A05055A0A7327A926F846C86EB007032EDF142F810EA8295F5130C8E2504774AC6568E341B620B9CBE980605494DFEF66DB</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind' module='jaxb-xjc' version='2.3.1'>
+      <sha512>B48A2DFB5D30281D3990D6216739064B74E10CD2B031EB9B08CE92C547ED1DEE9E84919C5AC481EB5ED3BA8F7EBBF795ACAA6CBEAE36B30B786481C293431111</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.bind' module='jaxb-xjc' version='2.3.1' extension='pom'>
+      <sha512>88969B1A43C85F5166241E03DE1D73D6B49A1B0B0844CDBD94A604C8510D4FCF37AFA58DC5F4F2092BF1A2229C55C5FD503A6B8DB4A1428BB69197EDE7EF8CB7</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.fastinfoset' module='FastInfoset' version='1.2.15'>
+      <sha512>95950422534FE074F993D9E9DAC2EEF3BAC16D5843E12F63B05CF6779DC30752F87E065DF918FC41FD8B8EF89D86B44A4861CADCB808A1C62D93A25FC2CF4CE2</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.fastinfoset' module='FastInfoset' version='1.2.15' extension='pom'>
+      <sha512>1A5E927DC4CB94954A1D96841C57FB911430D36DF7D11AD2EBBE4E89562EE9CA7D4341D88698332C4E2E07A945002CC0835E96978D8620AC63CB1B55781F2CFF</sha512>
+    </dependency>
+    <dependency group='com.sun.xml.fastinfoset' module='fastinfoset-project' version='1.2.15' extension='pom'>
+      <sha512>CC7F265A9C5CCD86F9BBEF6FAAB06783353FCE1AF28521C51D0BD2D9F8B4333C4FF14942D9D1DFCD7BFFBDDCAAAB90E7832CF49066D9CCBC3A36B56D895CEACE</sha512>
+    </dependency>
+    <dependency group='com.thoughtworks.qdox' module='qdox' version='1.12.1'>
+      <sha512>50557E884BD963F405E25319036A278CFE10ED2BF886D05CCF61F98DB90ED78D7A587B07379E120323A4BA7A707CBAB612B40DA78598A3CE3E86ADC53A6A189B</sha512>
+    </dependency>
+    <dependency group='com.thoughtworks.qdox' module='qdox' version='1.12.1' extension='pom'>
+      <sha512>A0E21E75118323396FB3664133D329E71669A932D436DBC2025540AFDD04D3DDEA11883EC070629E04B9D533B92458344ADAE5E19174B9DA03B1022DEFC15057</sha512>
+    </dependency>
+    <dependency group='com.thoughtworks.xstream' module='xstream-parent' version='1.4.11.1' extension='pom'>
+      <sha512>9D3AE4C7D6C488F692B6FEE21FAAFAEDE614F9953147C7D30742600B3315727AE64AAD2CB806011F8F3BD8ECC163B298ABBC880428986C7AB989D8E0E50BB773</sha512>
+    </dependency>
+    <dependency group='com.thoughtworks.xstream' module='xstream' version='1.4.11.1'>
+      <sha512>866C00611179DB0A1D2B6ECD1D712557906BCFC95DAE88D84083E89F81B0D2F86CAC298227C9FC8BC0B64C4DCEEA9D0E1E4AD52176454ABCAD159244B38E4A5D</sha512>
+    </dependency>
+    <dependency group='com.thoughtworks.xstream' module='xstream' version='1.4.11.1' extension='pom'>
+      <sha512>B7E193C5584AB91D4A813304562A82A85882D345E9EC7A4E1A0CEB40DF9C7667A21B4193A35FEE94195B33FC49D79FA8FE8FEB3EFFBAE62A8059E4819CDC221E</sha512>
+    </dependency>
+    <dependency group='com.vaadin.external.google' module='android-json' version='0.0.20131108.vaadin1'>
+      <sha512>C4A06A0A3CE7BDBEE702C06944265C050A4C8D2FBD21C248936E2EDFDAB63ACEA30F2CF3568D3C21A559940D939985A8B10D30AFF972A3E8CBEB392C0B02DA3A</sha512>
+    </dependency>
+    <dependency group='com.vaadin.external.google' module='android-json' version='0.0.20131108.vaadin1' extension='pom'>
+      <sha512>570C5E0EF46401C818F9A730D474D57C8D5ECF993BC84093A9F231166AAE95FE5829064B4E1E68238ED5F1BDE00480A9A59501A52CE7CE769FDE55F8BC1C233E</sha512>
+    </dependency>
+    <dependency group='com.zaxxer' module='HikariCP-java7' version='2.4.13'>
+      <sha512>7A72A1C50946904EC4B46A0F66059C5287A1138AEAE66EACA523A7D40CD5327D164AEB49C9B60A40FDC4109889D847870B34A4D11F9845B8AC2E474C9E066B6F</sha512>
+    </dependency>
+    <dependency group='com.zaxxer' module='HikariCP-java7' version='2.4.13' extension='pom'>
+      <sha512>741BCA381AE26690B0FFC05D3410DFAF81D47DE6E857B479B078AE6668FDF30B07258D0750904E0DCD8E539A548B1735A321C16E1485FCC7F5F8F03DAD7804B3</sha512>
+    </dependency>
+    <dependency group='commons-beanutils' module='commons-beanutils' version='1.8.0'>
+      <sha512>AA6C0E0A8F0422964025B36FC2AC8FCA04C39EA697C7DFCD265CA06FC3070F1F639083C7EDC00B2A42D8823AB4375023C6BCB198BB606D56DB0AA67FB1A671D1</sha512>
+    </dependency>
+    <dependency group='commons-beanutils' module='commons-beanutils' version='1.9.3'>
+      <sha512>F19B50135FCF20D9B4FB193CC651C97081D389EF320A691B51637809E7E99ACBCA2B28BEEB60F0997525FDE923125FEDEACF7FBE17D203F97F1C3A66DC84D3CA</sha512>
+    </dependency>
+    <dependency group='commons-beanutils' module='commons-beanutils' version='1.9.3' extension='pom'>
+      <sha512>51488BCD4A49187D20E47BF49FDA3E0F40DC018A4ECE5D7116393E43535133596802DAF842EEA39342EBA0F578A4D1DEE014D00FAF212EA994E5E2A974C3A760</sha512>
+    </dependency>
+    <dependency group='commons-codec' module='commons-codec' version='1.11'>
+      <sha512>D9586162B257386B5871E7E9AE255A38014A9EFAEEF5148DE5E40A3B0200364DAD8516BDDD554352AA2E5337BEC2CC11DF88C76C4FDDE96A40F3421AA60650D7</sha512>
+    </dependency>
+    <dependency group='commons-codec' module='commons-codec' version='1.11' extension='pom'>
+      <sha512>1B7A0A986A1BD222C0795972DAABEE4F16E308498F67D62B99749506B5A71E9811DEAA323C080517A8184D6481E8281C91BD012D5614B7D5D2BA14AA96F2596C</sha512>
+    </dependency>
+    <dependency group='commons-codec' module='commons-codec' version='1.12'>
+      <sha512>B2EF7A042957EA8AF2C09EC4EB5ACB3173B714D09DD8AE46F2EB03F6A880E7EECE26CB77265E6A83578D824252EBE1F1D7B86A176B34CCA1572D57FD4F6D31E8</sha512>
+    </dependency>
+    <dependency group='commons-codec' module='commons-codec' version='1.12' extension='pom'>
+      <sha512>E0A196B985A0DED34B5712227B18372CAC607B6BFE9FA39B540223AD1E47F772660DCE05E66AF9F6E6CB19C31CAA436F06CA1CC350ECC9F0BFF7A9FAFAB05DBE</sha512>
+    </dependency>
+    <dependency group='commons-collections' module='commons-collections' version='3.2.1'>
+      <sha512>8D0AA0E4E328C2E391D4D972F361A19FF085F508CB0478F5967280953ABD3520EE92CC1D19B21CB4E29E4A7BC557487DDBAEE9807B751824241269367B9E92CB</sha512>
+    </dependency>
+    <dependency group='commons-collections' module='commons-collections' version='3.2.2'>
+      <sha512>51C72F9ACA7726F3C387095E66BE85A6DF97C74B00A25434B89188C1B8EAB6E2B55ACCF7B9BD412430D22BD09324DEC076E300B3D1FA39FCCAD471F0F2A3DA16</sha512>
+    </dependency>
+    <dependency group='commons-collections' module='commons-collections' version='3.2.2' extension='pom'>
+      <sha512>E7A3F8A4B295BC040D15FC5AD5D14A2EB0A4139A2BC734853F6FC5DB55170FA9E822532F9EF8E63AE00D7C7AE768E1EA55CE44A66392B25FECA4859AC4A35A49</sha512>
+    </dependency>
+    <dependency group='commons-digester' module='commons-digester' version='2.0'>
+      <sha512>85BA596C95A29E3D2D73176E6389187E9D712600088FA971DC69AF10A86E630B9013E71FCC66DA54EC59E41C3A7DE8106E9C26F4EE79BFA124BA2F4C6F099AA8</sha512>
+    </dependency>
+    <dependency group='commons-digester' module='commons-digester' version='2.0' extension='pom'>
+      <sha512>B8FC9D13A467F6E749669EEC29E97A117C72D93512FB82D0212F1D996D53141A9977A95A34F2E608F516FEE45180E2147DFDFFCF8045008FF5DC8B8A77C5BAEE</sha512>
+    </dependency>
+    <dependency group='commons-fileupload' module='commons-fileupload' version='1.4'>
+      <sha512>A8780B7DD7AB68F9E1DF38E77A5207C45FF50EC53D8B1476570D069EDC8F59E52FB1D0FC534D7E513AC5A01B385BA73C320794C82369A72BD6D817A3B3B21F39</sha512>
+    </dependency>
+    <dependency group='commons-fileupload' module='commons-fileupload' version='1.4' extension='pom'>
+      <sha512>B15ACB34CFC8EF5EA5D1C3CB6B36BF316C46E4FAA04834577E730DB559F71CD23001D37C91A7FC61416CC25354C47CB4EE23826A8A82E708426C315BA58C1BD8</sha512>
+    </dependency>
+    <dependency group='commons-io' module='commons-io' version='2.5'>
+      <sha512>1F6BFC215DA9AE661DBABBA80A0F29101A2D5E49C7D0C6ED760D1CAFEA005B7F0FF177B3B741E75B8E59804B0280FA453A76940B97E52B800EC03042F1692B07</sha512>
+    </dependency>
+    <dependency group='commons-io' module='commons-io' version='2.5' extension='pom'>
+      <sha512>723217D16BE4FD30608D72E8DB8D05331AF704FE31E404EBE91FB5AA735956A252CD3899B1C26103A68824C65F48EF99DAEDD680E7F32334005C100ECE784D68</sha512>
+    </dependency>
+    <dependency group='commons-lang' module='commons-lang' version='2.4'>
+      <sha512>AE35B761D16F4327CDB6FDA16789166FC67020EFD71FD2CC3395B97444F439DFCC7EEE948A3EFD3B02440416CAEB873417D95DB6A2B16F4EF198DE9D1AFBC045</sha512>
+    </dependency>
+    <dependency group='commons-lang' module='commons-lang' version='2.4' extension='pom'>
+      <sha512>2D7868EC371802F1CFAC7876D5FDE947DAFDF4802D415BB3CCAF8749B1B470D68D6FB09CD36A4A8BC800B86CE48319361C87FE57C4BE55558BFF0BE556F64980</sha512>
+    </dependency>
+    <dependency group='commons-logging' module='commons-logging' version='1.2'>
+      <sha512>ED00DBFABD9AE00EFA26DD400983601D076FE36408B7D6520084B447E5D1FA527CE65BD6AFDCB58506C3A808323D28E88F26CB99C6F5DB9FF64F6525ECDFA557</sha512>
+    </dependency>
+    <dependency group='commons-logging' module='commons-logging' version='1.2' extension='pom'>
+      <sha512>75BEF548EEA62AB04569791F2FDEED3D0A61EDAE0534AA035A905DC1D011988FC0F06F52BDE377F44E94E6AFD4380197148120B152B7A4D20628FB6236CC7261</sha512>
+    </dependency>
+    <dependency group='commons-net' module='commons-net' version='3.2'>
+      <sha512>FC3031B0CACC123BA3D4062F772061D9B533951E7E3AA91EE078045AD51FE071EAC0CC49B4BA24AECB784B7942E6F5D01B253866944D056B9B875B589C9CC8A1</sha512>
+    </dependency>
+    <dependency group='commons-net' module='commons-net' version='3.2' extension='pom'>
+      <sha512>79038C231465297F542A6DA8BB25D09D2A758241D039FB73CB797717F218DF787336136F4B44A23AC65F0665C400F8FEB1CA36DB77E08EF7DEB12C4C00A1ED6</sha512>
+    </dependency>
+    <dependency group='commons-net' module='commons-net' version='3.6'>
+      <sha512>DBA414CEA9FB4B47DFE6D20C347BD91052185DD958996BFDD1E709F66B5FA7812EBB0DAD80C47E72BCC0075B3B5526C705216EFE771CAC1CC53B2F7923124FAF</sha512>
+    </dependency>
+    <dependency group='commons-net' module='commons-net' version='3.6' extension='pom'>
+      <sha512>ED90061CCEC8347F06E0D3494C0824CCDC5CE6D90FD137B7DE329D4AC5D17CCECFE9310DBF708670FE4A5F73D5CD46A32870DDB5194B500C452FFFAF8A12047</sha512>
+    </dependency>
+    <dependency group='de.bechte.junit' module='junit-hierarchicalcontextrunner' version='4.12.1'>
+      <sha512>30E3C4276A6E81C4FF684D04215FA16F5333F0BD69A4D13B4E646E8CB0EB3589E58C6C837CBB580C7EFC06B7F9AC8677E5D131A831CD36B132713957CF3FE72A</sha512>
+    </dependency>
+    <dependency group='de.bechte.junit' module='junit-hierarchicalcontextrunner' version='4.12.1' extension='pom'>
+      <sha512>B116CC7B37DCDFC4AD21E5585D856DF2FB033065F5339552622438E0FA9426208A2AC2FC7B4CD7D3D930B87AD8CB982B5F976086D5542DA62282E9F2FD23718D</sha512>
+    </dependency>
+    <dependency group='de.undercouch' module='gradle-download-task' version='4.0.0'>
+      <sha512>26D24B1B774E2F5536E9BCBD5F2FADE4B00FF0236BA68F349E1A1AE36310CE7C9E472DAFD7F97C0ADD43948EECB143C989C4ECA973C91BD484605D815361D4BD</sha512>
+    </dependency>
+    <dependency group='dom4j' module='dom4j' version='1.6.1'>
+      <sha512>E3737EF4A1551E46410916FCDA298A629B2681D7469CEAAFFFD668E6055D9C0E795BC9D12EA3300D218981D5AA5B2F38BB2E641211997C962E6086068F62AD67</sha512>
+    </dependency>
+    <dependency group='dom4j' module='dom4j' version='1.6.1' extension='pom'>
+      <sha512>7CA57A12C8BD9D3EC9AFA2F26A1771152D97E79D25474723AC6BAA4FE915DDCB782A88ADBB645E5E73C11B5DB2C00CB048916B5C7A45A91FC0A2825E759E2608</sha512>
+    </dependency>
+    <dependency group='info.picocli' module='picocli' version='3.9.6'>
+      <sha512>3DDB7ABE7AFD0AFF754BE5616481C589E1354692BE583179503DDFD5F542A7F520960A6FB0D5320E171AE02E3A01B9E6B51E298B74518F8BF690EA9E9C7C8162</sha512>
+    </dependency>
+    <dependency group='info.picocli' module='picocli' version='3.9.6' extension='pom'>
+      <sha512>CCA0059EAC0976AD978D3BC3390DFB72099C6B703EC5572F8401198E9D5A7B91B13C149CDBCA4AA7E8A814D8F8E48259EF632BC5F87FF81161FDA333C79F7E7B</sha512>
+    </dependency>
+    <dependency group='io.freefair.gradle' module='aspectj-plugin' version='4.0.0'>
+      <sha512>2834FEAB455401C2C4F56A77E3B622040180A03269F0C2073972B719114166599561C15AE4C4252AE84DD1E54E4CD747F2431BD39D75B43A2F27454DDE9D84D2</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-agent-api' version='1.9.3'>
+      <sha512>6F665AB7CB1FB5C10D4ABD9A5793A96D2C3EDBDD024E825E4A713D823CFA359C6EE76AC9D3BFFE9F411E6C4D4236B23D013EEC1D41EA8C72AB28DE7D6DD1BC7</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-agent-api' version='1.9.3' extension='pom'>
+      <sha512>1649D98A4FBA8B5A38FDE18A4309C11FD8E1C3BA8B7929C28629D312025C3BEA91C936FFB415FD2657341A2F50B86C83C9EE4BE5AC464ED985DB6F909275AA7D</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-agent-common' version='1.9.3'>
+      <sha512>8AA7B27D4FE77A8AA58FC8AA602738E5311EF802B256C087470AF267D324FA1A3A746870ECCB2C410303D1F5B5B7125821EE8C2920F54A342F3F92BF5A4D1DC8</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-agent-common' version='1.9.3' extension='pom'>
+      <sha512>73C10A1F61EEC4FBBC7702103333BFE099F15962D78DB99BB38BCED23CF2FCD4F69ADCBD1A609BF8EAEB68C2B6D2F18695DA2213E1AF444A0DED06F8F2D001A6</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-agent-jvm' version='1.9.3'>
+      <sha512>B803F1522A32178431D2560977ABFCC3C93FD8D47381D31822464204999E0EA4AD9D4606E45BCF013FF138554FA8D65F2B3727039DBCD275FF2AC8B84B113B80</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-agent-jvm' version='1.9.3' extension='pom'>
+      <sha512>E413C1494048EB3F364A9E6DBCA114089147FD96A512139EAE0B2B7C945F393CCA9B9699C79622D012E61C645EE5DD2290A922FC24F95905F07F1E33ED8864EB</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-common' version='1.9.3'>
+      <sha512>CEF4C468668EC33916886389302D431FD226099408146A339E1EFDF31DB0EFF3F66DB52BEE8E05DF49EB0E5C77976ABECCD38855AED9078C4790E18BF7EFC40A</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-common' version='1.9.3' extension='pom'>
+      <sha512>CF08AFA6620DB4B3A7462B4A043DD7E0E7611A11620492D30EC5D9409EB43C0609D33236AE387DCDA386C49AFA45D443031C4D2849311CFBABB28F13EF029AEF</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-dsl-jvm' version='1.9.3'>
+      <sha512>12259764B7ED20D28C8F695B591AA69D25BA0239715E75110FEE88D3BD41EA24C8927BED448C74193E7CBCFC577338C4593BF4B9367B0B261211A0BBB2D48A31</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-dsl-jvm' version='1.9.3' extension='pom'>
+      <sha512>F1D58C0B24CD05077C747B9C602AA9AE95990C60F2C92B803255B27318CDAF33717C46854A5072200BEBE60122D70894DA5F7F84390B2194C2714AC810D20DAF</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-dsl' version='1.9.3'>
+      <sha512>8D9C70F141DA0FAFC81D2E30A4EC13F13A4ED948FD0A526BDEC3262A81445C17B385EED3AB5EC066397C21BEED2DE0FD2A287D8B08120A0A2120498CCF429ABF</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk-dsl' version='1.9.3' extension='pom'>
+      <sha512>A615E6AD8D46E072DD8954EEE90313A32E6258B7DF5E0D74A4444A43E7090F1D15BE096E1EF3CA63B21D071C6F9F4C6B380FE979E23F7B33C54EC098CF027734</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk' version='1.9.3'>
+      <sha512>3717C469818E1FB49017CD2C449EC28E10C12287C035983C4895A24A895A3C61B9C903C817CD080B2DB9C7DF00656BAC104C36323946A432007DEDC8D989EA7F</sha512>
+    </dependency>
+    <dependency group='io.mockk' module='mockk' version='1.9.3' extension='pom'>
+      <sha512>6B5D6986CD45A92FAB307F8A2C603C265930B8F344CA24AB69FEB1425281C7751F06D5E22D4D162AC1C4ECA7CE05EDF8E0460CC963A21F50968F92D9E6614B32</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-all' version='4.1.39.Final'>
+      <sha512>8C29FAF98FBDC39DC4F674AE4BF60696B69538609CB34AE3E722775D3E4EE2324B67F2EECE7794F99589439E30F9A6934D78F4A7DA7F0D6BF74968AA4E36769F</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-all' version='4.1.39.Final' extension='pom'>
+      <sha512>FF8EFAC737C1C18769FB2CFBF821D4DA21CB9922933EA7C7671D8B3A6828FB661C310943DC482A893818252DC54F1FA9FCD9B6C1E182F9D7DE85DCC16BA0BA75</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-bom' version='4.1.39.Final' extension='pom'>
+      <sha512>55C30F1341011C01BC51CBD6573F7EBD75C1F21E949D7AF70DFC4404C7BAB1166B643960F7EF1AB6F1729BC352C240022D133C357E32BBE101878521812C3906</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-buffer' version='4.1.39.Final'>
+      <sha512>C1BDDBDE2B39ED343C17411BF79EBAB2BE26784AE56DAF0A4AFC11D6CA4C623BD86D36EFF4FE9D56F1101DF769CD46806314316E399DC1A4C4ECC82F3AEBC9D2</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-buffer' version='4.1.39.Final' extension='pom'>
+      <sha512>9DEAEE59DC6B7579A89841738C7E10FE02685FD8CAE335BBF20CC71A38DA2D637070042A95F7F363F6793A27783B23D3D16B44EBE92052016A64323DB66D6486</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-codec-http2' version='4.1.39.Final'>
+      <sha512>8FE70C97B3684D23DA7C4A2D75614A35EF127ADDF0437C72E6743C640BE93E36BD5F2699349E9022F6C457133D123ECF98F15B37CCBB9360062DC733E6DE5CA7</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-codec-http2' version='4.1.39.Final' extension='pom'>
+      <sha512>5F9C609D127FAB4BC6A75DA6202B865AACD5369E44F474F4A4D2D1F916EFF4802FD485884E18BE5FD5EFBB531EC44AF18D35AB446BE04E13F21FCCF5E4EDC5D9</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-codec-http' version='4.1.39.Final'>
+      <sha512>2E02004448EC922A98465C5FDB798F788FE50AAAE5B2332C135647B764E66D8454E047ACC6E12397F52226D9640C6F2002D4FFD8393C8DEDC1B94120C2B345A9</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-codec-http' version='4.1.39.Final' extension='pom'>
+      <sha512>4272AC2D51DA06894883B4FA963E3D4385BCE3A39AACF4D94AE5164FC61CEEE335CC61828DAF27EA277544981036CF8950B87D138692382ECB3819B67B64E624</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-codec-socks' version='4.1.39.Final'>
+      <sha512>752E8C4F6B8646852E284F8FD27252603650B79CCA9E3D4FA6AAE8CCB14C48924133DD200A180A73C2E48FA0744F86EC10FC793A2899E9E763FE7D19174900FF</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-codec-socks' version='4.1.39.Final' extension='pom'>
+      <sha512>50D0EF5702C64DFAE92A8AD7934445C68B82EFEDAAB19B52B1622C86616D035B995CB946ECB57A69D5701A559C9F729052EFE37EE21CAE96A3A71FDBA9DE48C1</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-codec' version='4.1.39.Final'>
+      <sha512>11695D2D3E0197148CB9D18F78DFFEF51ADF73ACDBFED896A913FFD7F7EF13E1074FAD247CFF567B0925CECE9F9CBA8FDECB5ACDFBBE37EBBB544AFCA045FEAD</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-codec' version='4.1.39.Final' extension='pom'>
+      <sha512>E1A5C2A4A3DB507D30152B335491B5C4673B027655E39824B2B30BBF54295357D3B60DB13DC92CAD0990B6BD3C0D64C99B3928D296DF7D62BD02545A7A06E7E8</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-common' version='4.1.39.Final'>
+      <sha512>8EDF506D03A2A8CE18024ACDCA8DA9AE71CEEF86023DCF41D18DDACD0341963789BF3078714524C0E424B1077C80C12610749C13FB312F3857FA3B0D7E2A65EF</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-common' version='4.1.39.Final' extension='pom'>
+      <sha512>B20816AF52836198E3046CD8E619EC6A8D3D90E0740A11E8DB1089A6984FE9AE54BEC23D1DF8B2F92ACE61EE26D13DA842BEBFFE7DC493F5C6374AF3288AB86A</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-handler-proxy' version='4.1.39.Final'>
+      <sha512>C5274EED27024B25B2F59F608EE4B646801828284BEC3CF11960EAEE9521308AD8CE00F81FB6BC0AFF1C79A174AAE98E77F1CA234E86E3E6CEB1DF579A43D637</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-handler-proxy' version='4.1.39.Final' extension='pom'>
+      <sha512>23B062D27BCC3FFB41249D738D0E66092BC0484DEBE091103CE0943FD5F836F37C49320457246F98CFFA2A9A86BD0C85B99AE295C23C9F203A5166D1EC70CF7A</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-handler' version='4.1.39.Final'>
+      <sha512>B7D5B17A870A70C3FEE581F87CAE5D9D841BE184CEE377AB12A2029058A6D6BF793F722B8BE9DEDD2E8C9090FCEE79A03D553854E798A36CF1C54F52C9CE4A80</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-handler' version='4.1.39.Final' extension='pom'>
+      <sha512>53C04CAEEBDBAE448B6DF627BFA8F26EF950F0047C54CA1F4BDDA5816C77288E63CFAF5BF7EAB6ED900D09E9214A5198C9692BBF90C6AECC9B38499F258F072E</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-parent' version='4.1.39.Final' extension='pom'>
+      <sha512>195FDBED203FC97B5EDEE02C31971E9003D31549A20696C027A291C0704F8864C1469F8966C400717BBCCF1856CD28B6309BCE3303A8AE7A8FB414FEB8F9603C</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-resolver' version='4.1.39.Final'>
+      <sha512>F608A9F2D14E9D450C628329B89FA832FAAD069D4920E7C37B3ED758C5CE142588294D74C0105CB3CF89EC1F1E6039913769A3522FF04D0F702E37DF87A294B0</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-resolver' version='4.1.39.Final' extension='pom'>
+      <sha512>CAEE5685BAAD84540C69B327D68ED38EE0225F9BD381AF43A5905F2E955995DE3BEE093FCBBC46609A6FE57233CEF136FC8BE971DA99A502104AEE9E2443627C</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-transport-native-epoll' version='4.1.39.Final' classifier='linux-x86_64'>
+      <sha512>7235EB1670ADA1E38BC680EEAAAE22827FAF068DBA05E3277307EC5796686F7FD25497F29586F0440E808753DDA82EE1FDE00F3D368B001F2276AA70BBD3EE9</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-transport-native-epoll' version='4.1.39.Final' extension='pom'>
+      <sha512>D2C3415D075C0064144EECF4ADD6F87FA3B9D38E6100BFD5CB729CA58F612316BEC6CF586790BFF8252A6D31A02264C8B163A2E94DD95CB2477751B787795C85</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-transport-native-unix-common' version='4.1.39.Final'>
+      <sha512>B81DFB14266AA17E22FF7A8881AC4ACFD01FA2431AD0D1FFE0CD7F503A934E4966FF6AA4CDC6884DB247BABD623F019C669F1A19DE15D660F9B8C3F56AB327B8</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-transport-native-unix-common' version='4.1.39.Final' extension='pom'>
+      <sha512>ED7CF6BF47B56171543CD51F10F6278D339472724FAE3B462C56A7F317DD3E3748961930D9A49BED210E3C55C6D36D92F4052BDA5A902672D58FB88304E65AA</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-transport' version='4.1.39.Final'>
+      <sha512>CC524FD60A858123370B95E27394705FDC6285EED3A0787E076FD0B5700A2DD8DB4FB959EC5FC844CDB51E0A37FB7443C5D42BBE35528075FF1D91037D5B2301</sha512>
+    </dependency>
+    <dependency group='io.netty' module='netty-transport' version='4.1.39.Final' extension='pom'>
+      <sha512>FA04FB37D1535F9BF42AF936CAF3DB0DE47B478B808BC02A7321C3C9FF81750BB23D94A02F5A1DDBE417DC22578868C3CC5627CF2202F564E29A5D9912D15BE6</sha512>
+    </dependency>
+    <dependency group='io.projectreactor.addons' module='reactor-pool' version='0.1.0.RC1'>
+      <sha512>26F3903323210FB50CC93BDC3368A0D06C59B4A7A7AFDF4FD84482848D598874C71E5A7EB0B07EA744634643643CCB4E43C8EEDBC67D84FE3DB5EFA1956F1790</sha512>
+    </dependency>
+    <dependency group='io.projectreactor.addons' module='reactor-pool' version='0.1.0.RC1' extension='pom'>
+      <sha512>6D29EBB6E569FB02F56991E03FE2D920906BB8B71A6187D01D10559564D9177F36D33B641EF91DC83EE8B3C3EF5EEE5E91AEA685C0D525C9AFCDAAD07B59292C</sha512>
+    </dependency>
+    <dependency group='io.projectreactor.netty' module='reactor-netty' version='0.9.0.RC1'>
+      <sha512>A1122453EA51951F32733C8C79E5BD082FBC4B1566A221BE2C4E1D53453630204DE6371BCF05718E54D7809377DB57E9D6BB9C75AD7A054F4CD8358C6673064D</sha512>
+    </dependency>
+    <dependency group='io.projectreactor.netty' module='reactor-netty' version='0.9.0.RC1' extension='pom'>
+      <sha512>AD3C5342403CAC440B872D7422494AC2265FB175FBBC20EADF3AC1F5D2F4206A40237C0930BDA7A25A5F093CE53275EC78D41B351AFAC56447C11B9C58C26E85</sha512>
+    </dependency>
+    <dependency group='io.projectreactor' module='reactor-bom' version='Dysprosium-M3' extension='pom'>
+      <sha512>8BD41A07A6BDE416C80C32C19126F62162F74C607BF9EFB69A22592C83F40103AE86F5C7F81032D964C4427E244173598577E37FE5A25B484712CE209BE9CD8D</sha512>
+    </dependency>
+    <dependency group='io.projectreactor' module='reactor-bom' version='Dysprosium-RC1' extension='pom'>
+      <sha512>729A28BEFC2D1E0A2D0C72F8AE44AA17C87558F25510561BCC6B5D5C612AF9CF12C13A92BEEDCDF5899AEC0E7A595E0C8D1B03C36BE4AD78F9E6367A142DD4FF</sha512>
+    </dependency>
+    <dependency group='io.projectreactor' module='reactor-core' version='3.3.0.RC1'>
+      <sha512>D5EDCEFADBFD073C250B75F000852DD5EE011A02559089257FA4D9411B6A2743DBC6B71EA25D3DAD16D4C9F5436ED1971C0B7007931E09591BE53924F9AB4632</sha512>
+    </dependency>
+    <dependency group='io.projectreactor' module='reactor-core' version='3.3.0.RC1' extension='pom'>
+      <sha512>5D8B8E547947792D26FA7E310E86FCCED046853C6454468348CB5A795390C0BBA7E4EF1082E6C2618B0BCF6D8DCD697B80675C3A24380FB2E4209A77539D9310</sha512>
+    </dependency>
+    <dependency group='io.projectreactor' module='reactor-test' version='3.3.0.RC1'>
+      <sha512>D539F8D4F04DB8A16176D4E1290F09097FCA06ED4D7164B5B4668C7081FCF8E8209C4396B77E26BF8D25F74A0A7C14B1E7DAAE01BDDB82AB243A73D8EFADA453</sha512>
+    </dependency>
+    <dependency group='io.projectreactor' module='reactor-test' version='3.3.0.RC1' extension='pom'>
+      <sha512>65A63F51CDB38214170B78957BAC18E3058048B9647E02D994FD27E0AB7597609D120E9941B3BA742DC38345B0B78576C8247E35B0D91B862E571745FAFBBEAC</sha512>
+    </dependency>
+    <dependency group='io.reactivex.rxjava2' module='rxjava' version='2.2.12'>
+      <sha512>C18F78A7658AE951C601935B6AE42A04D2B8D0344F9973F034CBCABF91718A3B3F34DB167A4A0B052D6536BA202DF6163AE0EED5B6FA1AF02A2D8A29E2293573</sha512>
+    </dependency>
+    <dependency group='io.reactivex.rxjava2' module='rxjava' version='2.2.12' extension='pom'>
+      <sha512>5C3FBFED39B97E2B571213E5720E7F4C3F18FC32BC88719EFDB9CCACD206FC525B773549DDE11B553B1A7186E683C1837C21DCFACA95EBD8A0541EB8531081B5</sha512>
+    </dependency>
+    <dependency group='io.reactivex' module='rxjava-reactive-streams' version='1.2.1'>
+      <sha512>58D459ADB032E732832982BAC0F5062F0D2BB7BD05EF1B4EE931D6860186FCB8CF133780E3119768E3D5E114B62C0676510F68910B6B577A74A0DBBC8B4CA88C</sha512>
+    </dependency>
+    <dependency group='io.reactivex' module='rxjava-reactive-streams' version='1.2.1' extension='pom'>
+      <sha512>428E54581B2C3B1806DFF021A7A4C4F6F8A053EAE7DDE1FF04DBE4D76886C1F7FC8ECC80E6E11306D1158E76860D0901FA5D67AA33D5C623F7509F023A2B6BA4</sha512>
+    </dependency>
+    <dependency group='io.reactivex' module='rxjava' version='1.3.8'>
+      <sha512>25A37A853A943724B96068CF05232C927754F1102F1265590C1B9E0088CC815E26FD2BC249AEB3B317AD0F2FA8499EBFF81CBE2CEA00790016DC6F7B7EFF4E78</sha512>
+    </dependency>
+    <dependency group='io.reactivex' module='rxjava' version='1.3.8' extension='pom'>
+      <sha512>83A6061824EAACB2AE449F5306B2B39F29516025F839DDF3705BADD249B8F847F9151E6ECC34F0C4A87736E794FA632BD6DA441E9A4FDBFA940BDAB491DB6AA1</sha512>
+    </dependency>
+    <dependency group='io.rsocket' module='rsocket-core' version='1.0.0-RC3'>
+      <sha512>1B82FCAD542BE4500CA41F8745BCD90F36D6CBEDB9651B9C7A5B5DDED90FFCF9D72412D764D8B340093E03E9E799886FCDD420641425650133949A47BC837C1D</sha512>
+    </dependency>
+    <dependency group='io.rsocket' module='rsocket-core' version='1.0.0-RC3' extension='pom'>
+      <sha512>C23DBA5774A6AD199948EF5C12D0E273FF56EE09D21AFDE5DCE00774470B5BC8CB2C21B5A87D52FFE2EAD5EE03754A45C0ED6DFF02C2FCA1FB3BFAB2DECF5306</sha512>
+    </dependency>
+    <dependency group='io.rsocket' module='rsocket-transport-netty' version='1.0.0-RC3'>
+      <sha512>C5729D4D3DC590A8B9120C5FFB1F15FA424BD87A5EFCB7E9A2B3779C9E23A6C2731DC731F8B7B4105D70F812CB1DC8FBB2A43E7BB3207FB49E6C6F0442545977</sha512>
+    </dependency>
+    <dependency group='io.rsocket' module='rsocket-transport-netty' version='1.0.0-RC3' extension='pom'>
+      <sha512>CC24FAFCBB4933AB3A6097EB9BB2BBD8998889636570A6D2AD27BAFBE47E90A0170688EEDE3776765591ECC3BCAE003B6B38A6107A350E0A4E492A85DC7186CC</sha512>
+    </dependency>
+    <dependency group='io.spring.asciidoctor' module='spring-asciidoctor-extensions' version='0.1.3.RELEASE'>
+      <sha512>94B0A366451C962D96629087FF6E026653A2C294083467ED31D3B32CAC9EF6A388E104CC5C83B402CE8976C96A3D9966841794C2FA631FDD5DED03DEE40357D7</sha512>
+    </dependency>
+    <dependency group='io.spring.asciidoctor' module='spring-asciidoctor-extensions' version='0.1.3.RELEASE' extension='pom'>
+      <sha512>2B91C45F4968B8BA38175F9DAE2C424484A0CADBE5175A184E0536EFCE804E62873DCC1B65BB4729788AF89B9FE2B0A4064D1EC8F7DCE1CEE975511F8F5F1ED9</sha512>
+    </dependency>
+    <dependency group='io.spring.javaformat' module='spring-javaformat-build' version='0.0.15' extension='pom'>
+      <sha512>1A3ED30F20F7002DAC981A1B85E74368206E52E62981E400B94B1B6308DC007B4521ED255FD51842E79744716E35D87F79045B3EB860B2C7F3620ECB2CE5D71D</sha512>
+    </dependency>
+    <dependency group='io.spring.javaformat' module='spring-javaformat-checkstyle' version='0.0.15'>
+      <sha512>41DA61D5338236F72430472859C309CA74B36FC99709B072D41AB302DAB2486174DDA22D3D2F7010931B1359BCDE73CF055E0364B725A7314CFF6696EAE23888</sha512>
+    </dependency>
+    <dependency group='io.spring.javaformat' module='spring-javaformat-checkstyle' version='0.0.15' extension='pom'>
+      <sha512>D13FF16788A4E1F0A718C6AC3BF75B58E81D7BF50212ECE5C16FBD7F3BC104F2D830BDF675C458B4BF883E67B3C8E19CCFAF13ED01B3624EDEB06C8C5864A99A</sha512>
+    </dependency>
+    <dependency group='io.spring.javaformat' module='spring-javaformat' version='0.0.15' extension='pom'>
+      <sha512>4064D32DFF3CC4C7B1DA02938B661D6139AE0307F8B92A0E709B32C889430104CEFABB87B286AABA8F38E476293DF2B6C2C7439974B0ABAA922927A268DBE3A0</sha512>
+    </dependency>
+    <dependency group='io.undertow' module='undertow-core' version='2.0.26.Final'>
+      <sha512>EA152C098E1E9C37840ED1EC126FD81BDE290F10894095855881F53F10238B8E8753DDCC4281B6CBE5146C8731EC94A39AC23EBA095578316BF3F970D1AAFA37</sha512>
+    </dependency>
+    <dependency group='io.undertow' module='undertow-core' version='2.0.26.Final' extension='pom'>
+      <sha512>1C373CDDB5F942A0BF72CB9D8A598DA6D7C05F6F63CB7A4B8C9FE36DC8E559AE21E8AFCA1466DE123C661CA27393518DD8E5619CC2D8C6BDD8D2A596DA97676D</sha512>
+    </dependency>
+    <dependency group='io.undertow' module='undertow-parent' version='2.0.26.Final' extension='pom'>
+      <sha512>A93AFC31F1A913AAA43B987198D48E84533C46A00C748F55C44D2C917A0B6796E0CE9438E192E2BC38C95EAC63A795BF59F1BFB0CFD7BB946D90A2D187506993</sha512>
+    </dependency>
+    <dependency group='io.undertow' module='undertow-servlet' version='2.0.26.Final'>
+      <sha512>57CFE8A6F7D753523FE6DDECD0D19F744B56736DDB109517193CE4D4DA0BADC21B7BB929FB526E14F7DB8652B0DEF7238F8D034FFAA549935D2E6D697525F268</sha512>
+    </dependency>
+    <dependency group='io.undertow' module='undertow-servlet' version='2.0.26.Final' extension='pom'>
+      <sha512>2FC7A3B5D7446AF15BBA7E81F6142D28E9DE6613FC42C0BE69736F5AA30757C7BA50C422379ECB1221D1175D084A002ADFD42649B8A297EBD1B7DAF96B675A6A</sha512>
+    </dependency>
+    <dependency group='io.undertow' module='undertow-websockets-jsr' version='2.0.26.Final'>
+      <sha512>81A3E01E85C14662D70803D89B364B6A3BBB174A05AB6CA6B347C3E15965FB885A1E96537B5D1D33B6A61F315D94584271E72613C4361B77BE7A13CB1D4E35A9</sha512>
+    </dependency>
+    <dependency group='io.undertow' module='undertow-websockets-jsr' version='2.0.26.Final' extension='pom'>
+      <sha512>B864DEC5ADE308AD306ABF0DA4FF3D11D5AB68A6BE116CDC8BBD0C6E7CBD0DF210D12E11931F50BB7A4D38FEF3B7C3C27EE6DFFFF6FE30F46F180FD04A20B251</sha512>
+    </dependency>
+    <dependency group='io.vavr' module='vavr-match' version='0.10.0'>
+      <sha512>3683EB971A38DE00A3C480C4838DDCDB2635E74904C3D60174C3D18FE6E8EE38A0B16A4CAE95984695595640ED953B95ED6829D17FB620614EC58437ADAD8961</sha512>
+    </dependency>
+    <dependency group='io.vavr' module='vavr-match' version='0.10.0' extension='pom'>
+      <sha512>3A02FE8B1B8A8EB5ACF49BFEC9118986DFC2BF129A69482C59B8CFC284326519E865A8DCA01A3A9B2B6BB1A9BF9CB3C937898D52A86C6CCC00BD1A25A3D7EFA7</sha512>
+    </dependency>
+    <dependency group='io.vavr' module='vavr-parent' version='0.10.0' extension='pom'>
+      <sha512>2B859E9B698D30633F1E5C352107FE194AA39EE1D793D2D3FC110FEA5BC07FA0877111172C378A2041C1FF27DF30F05DB8819F905EB6E34D40F3F229A8379E3C</sha512>
+    </dependency>
+    <dependency group='io.vavr' module='vavr' version='0.10.0'>
+      <sha512>DDD50F5D71FA750BDB222F3A53402B51823CFC239CC42C850CD8AA00280020298CFE03318203780FC15663ECDCEBF599DFCA305F1F644A477A50BDB2814B0298</sha512>
+    </dependency>
+    <dependency group='io.vavr' module='vavr' version='0.10.0' extension='pom'>
+      <sha512>363C501ED68E2D6A40B084F6ADBCE8E3B0F674BA7CD49339EB190D5E733CA7E90DB3503048D942DA5CB56428629A58B19D534116466912160C711248958ABDD0</sha512>
+    </dependency>
+    <dependency group='jakarta-regexp' module='jakarta-regexp' version='1.4'>
+      <sha512>FF21513DAE9717C3B3EB15FEADD606EA74D94D253CC7F375EF06B6AC91C7FBB52AABCF470CB3F5A10FF9AC73AFD6A002C046EC9763B97A7C22E5DDFA48E6DC89</sha512>
+    </dependency>
+    <dependency group='jakarta-regexp' module='jakarta-regexp' version='1.4' extension='pom'>
+      <sha512>E5FFE4A13EB4D20F54E339C16E29A22A3CD6B1FDBE6F4C826ADF1DB9C19B804C491AC103E8927C4A193C7AC788E939739334127306A680D6C5E242FFD4E59980</sha512>
+    </dependency>
+    <dependency group='javax.activation' module='activation' version='1.1'>
+      <sha512>C0FF5BF3ACE7ACC1B31FCC109CEE48D9EB8F025AE15A31DC91ECA760933BDB97C93F05D61E95AF1E317859D72E5F179F897F5BF3DF0E3810F4212D43BACEE4BD</sha512>
+    </dependency>
+    <dependency group='javax.activation' module='activation' version='1.1' extension='pom'>
+      <sha512>3191F2DF56303BD0E711D932B79680225A718AF6DCB2B8C7B8B1AE09219E2B2F2A856E089B405DDB9D9FD5EE3DF7C4FAB7648E50A0D61FB3671C48D288E85CB7</sha512>
+    </dependency>
+    <dependency group='javax.activation' module='javax.activation-api' version='1.2.0'>
+      <sha512>8EE0DB43AE402F0079A836EF2BFF5D15160E3FF9D585C3283F4CF474BE4EDD2FCC8714D8F032EFD72CAE77EC5F6D304FC24FA094D9CDBA5CF72966CC964AF6C9</sha512>
+    </dependency>
+    <dependency group='javax.activation' module='javax.activation-api' version='1.2.0' extension='pom'>
+      <sha512>6C7D47EB29E1D6AED90A9A587CE690A2E75292F0CB8B9F81CEB88DD27D1766014B2D39B06AFEA68FDF79F47B98F772B7674CE03DA387CF40C9F555093A179122</sha512>
+    </dependency>
+    <dependency group='javax.annotation' module='javax.annotation-api' version='1.3.2'>
+      <sha512>679CF44C3B9D635B43ED122A555D570292C3F0937C33871C40438A1A53E2058C80578694EC9466EAC9E280E19BFB7A95B261594CC4C1161C85DC97DF6235E553</sha512>
+    </dependency>
+    <dependency group='javax.annotation' module='javax.annotation-api' version='1.3.2' extension='pom'>
+      <sha512>B97C6FB3B5C6F9BA5C6EC2AA35713816FCA94927C1393D2EAA04CAC6A6C44C464BAEB34D62D9AF33268A7EAA817318DF1B2116641FF7E8ADE84C70B358E60BAC</sha512>
+    </dependency>
+    <dependency group='javax.annotation' module='jsr250-api' version='1.0'>
+      <sha512>8B5DD24460E42763F3645205BE4B4F80691E217D36BEE5FC5B5DF6EBC8782ED0F641FB9E2FE918A2D0EEDE32556656F6B61FE65D2CBEC5086E61EF3D91E4D871</sha512>
+    </dependency>
+    <dependency group='javax.annotation' module='jsr250-api' version='1.0' extension='pom'>
+      <sha512>4CDEFF750C958DA97E0D590E54D95345F2C5D4CEABB5C8E30AA6C88FE5CCB48A2642403EB0DC8414C1AFF38F964EB4FE391F2162E1542BE7FF8851414F52582</sha512>
+    </dependency>
+    <dependency group='javax.cache' module='cache-api' version='1.1.0'>
+      <sha512>35824A03CE90B198AAFB18E7943594ED833B257BF02E5EF9690D782224E6838232298430627455BB5EB7A91BCD42144B34273CF8473719D7D7F64638164C89F9</sha512>
+    </dependency>
+    <dependency group='javax.cache' module='cache-api' version='1.1.0' extension='pom'>
+      <sha512>A3A7F7A15E841616B7DD8F0E78AD87BE9AF95DBBB4EE9AD4EAF9184C6DFD2232D52AD4185A9099DFCA1A66FC5040D979FA18BFBEAD610739D36EA3D0CC18200C</sha512>
+    </dependency>
+    <dependency group='javax.ejb' module='javax.ejb-api' version='3.2'>
+      <sha512>2E7B931525B8261EB9FEFFE4B11CDC6B44B6C4F61F0873871734A74FE348B61539E7830025295BBEE942F8195ECF095811A6B3A59CEBEFC8B97AC88658439D7B</sha512>
+    </dependency>
+    <dependency group='javax.ejb' module='javax.ejb-api' version='3.2' extension='pom'>
+      <sha512>C50D4EF2AC8CC19FD33230E665EA98F213437AB6B3DA373E0BD41390B774E72F946642D768D16A2A82E7F9BB4F5F19F0F17C9502A0CBEAF5AE059F9332160419</sha512>
+    </dependency>
+    <dependency group='javax.el' module='javax.el-api' version='3.0.1-b04'>
+      <sha512>E963B4C1299D104B42ABD6813B9E1EFD1F740C22C5A28F9436194E1F6165CA2DB07FEFA90473D4D4E172683BF0A77129CD9ADE6EB361680140A843D9E1042A68</sha512>
+    </dependency>
+    <dependency group='javax.el' module='javax.el-api' version='3.0.1-b04' extension='pom'>
+      <sha512>555F5EA399D0514C543AC94B1CB21C76348EDD9EAF553B932214AE9A6BE9ED1457C8F87E0BCAAC38349AAE1C47E98A43E34A426B33D43368E644DA0DEA50DFA2</sha512>
+    </dependency>
+    <dependency group='javax.enterprise.concurrent' module='javax.enterprise.concurrent-api' version='1.0'>
+      <sha512>30DCA1BA9C93F38DFF2B5C8B77C5D9ACA754FCD678966F5F752089BA2FBFE4C6F9866140D52A6331B99C794EE7F38E75D5D3542625E5B42CC3A74C60DCC015E</sha512>
+    </dependency>
+    <dependency group='javax.enterprise.concurrent' module='javax.enterprise.concurrent-api' version='1.0' extension='pom'>
+      <sha512>640BA3473F061AF90C990FA4251FBE5032B118DF2A6CC452979BDFB640EC1BBDB898AFE7A4639794ECBF283430031CB22EB903D66950D65DE41F2092E4D23A54</sha512>
+    </dependency>
+    <dependency group='javax.enterprise' module='cdi-api' version='1.0'>
+      <sha512>3E326196A2CBF19375803CE37D743A9818C4FA2292914439E748060D6889C997FE33077F52E52D4DD61B60E7342AA31B446D7571A92EC864F44CEAD45EBD612B</sha512>
+    </dependency>
+    <dependency group='javax.enterprise' module='cdi-api' version='1.0' extension='pom'>
+      <sha512>7226D6BF6F18D9C036790A671DC788797E99EC2ECD704309B203CAD82A20B2907E48FB53F008EE8D144FFA2A7560CBB4A0D46549C4B82501E1F103226B708DD6</sha512>
+    </dependency>
+    <dependency group='javax.faces' module='javax.faces-api' version='2.2'>
+      <sha512>83D1364A381F7D30A213FF3C40D6E124E513664ED938E5FB763A43C963D7D95C800972149ED6AC19161799706E1033F47D751EFA722723A5E9345706E3B3A5B5</sha512>
+    </dependency>
+    <dependency group='javax.faces' module='javax.faces-api' version='2.2' extension='pom'>
+      <sha512>453D2001E93FDB00F27094D3FF8A16D6C14C4CD52E90EDA1F9CF773B3F2222D593D6F433B0A873A1EA4E46C5EC67217621E0EE03C8CDBCD557E88A32F643FEF5</sha512>
+    </dependency>
+    <dependency group='javax.inject' module='javax.inject-tck' version='1'>
+      <sha512>5414209B077A86C18BA994F900316D2601B776E83072139686D0C8B7B9F1BF1595B8360AD0D61873277682515796BD5B7F21D5D0BF6E2F9AE9AB0CC07FFA26C9</sha512>
+    </dependency>
+    <dependency group='javax.inject' module='javax.inject-tck' version='1' extension='pom'>
+      <sha512>6F3BD3BBA6D1DA6C3C2D47EC7027214C8CC082F5915C715E36763852CCDE24706F21259B44C7A3543B9580FA6376149772528AB69C9F35E1FAEF8E4F64B1F8DD</sha512>
+    </dependency>
+    <dependency group='javax.inject' module='javax.inject' version='1'>
+      <sha512>E126B7CCF3E42FD1984A0BEEF1004A7269A337C202E59E04E8E2AF714280D2F2D8D2BA5E6F59481B8DCD34AAF35C966A688D0B48EC7E96F102C274DC0D3B381E</sha512>
+    </dependency>
+    <dependency group='javax.inject' module='javax.inject' version='1' extension='pom'>
+      <sha512>2F0C773BA24B74F45F6519C653CB118395F81389C7E73A034F82074A3E277F793D77783D794143236B05FC5247AF5F69D9B2605D0929B742A5673A55E51F880</sha512>
+    </dependency>
+    <dependency group='javax.interceptor' module='javax.interceptor-api' version='1.2.2'>
+      <sha512>C949C10A81D3AC7310E18F14E5D1736D558BA0CBC06B82235EFE60616A59225FABD523794EB542E95423F9E2DD86C56CE37740F482F8097509C94A568E2BBEC</sha512>
+    </dependency>
+    <dependency group='javax.interceptor' module='javax.interceptor-api' version='1.2.2' extension='pom'>
+      <sha512>2E1FEF6B7AAEE0283B587C983FD61012A361F8CF70F69D8E0BE57F88701F70CC2E218FA08A884699B14A8C1AED51180E9911218BD2E582A64020B0B55625DD82</sha512>
+    </dependency>
+    <dependency group='javax.jms' module='javax.jms-api' version='2.0.1'>
+      <sha512>9BB8C8E65FAD5D321DD2E2BDB12251664CBB4DF2B73EEA0BAA5E3C20207FCC238E6D459B735E0CB5FAB8A17D34417B4AB12C351E26CB6BB46646A471AE87341A</sha512>
+    </dependency>
+    <dependency group='javax.jms' module='javax.jms-api' version='2.0.1' extension='pom'>
+      <sha512>34A88B112753A227D53AAB6A95273445647207DA20700FFA52F5B4AB7B716946DCA31875206AF52DB331E5834A50DA1846AEABFABC83957BE77A18E537C9DB9B</sha512>
+    </dependency>
+    <dependency group='javax.json.bind' module='javax.json.bind-api' version='1.0'>
+      <sha512>886A60A3EC9889EE4A0E09071DE24D1388F34DD283509258563FCF6C096E4955DBB54836ADE509CF24A18FF1FCA270E39B6E49A98D3E48D72157ADA2895726CF</sha512>
+    </dependency>
+    <dependency group='javax.json.bind' module='javax.json.bind-api' version='1.0' extension='pom'>
+      <sha512>7A8A16A9FDDBADBF417D9F81A74E58AA4E6427341A874C083D8A1D6E1DD484420EFE1D63AB94617050E6B098D09884B00E7F216C2432F0FCD7795A19583951C5</sha512>
+    </dependency>
+    <dependency group='javax.json' module='javax.json-api' version='1.1.4'>
+      <sha512>5DAA6155F1A9CF34657ED3B0163109DD550A3A8F1AB6B92CDBBE6473DCD6BA77A353272C17546D4F788B87ABD5FD3A332A725A6F1B5F99C311DC05F851DE2E3E</sha512>
+    </dependency>
+    <dependency group='javax.json' module='javax.json-api' version='1.1.4' extension='pom'>
+      <sha512>C8D0916230C8988101DB7EE3B19E13600033557C8D9B93E904282F67E8BE230962CAFF2E0B9076E233CB44104BBDA5BCD64DB65823248BB93147383AFD268074</sha512>
+    </dependency>
+    <dependency group='javax.mail' module='javax.mail-api' version='1.6.2'>
+      <sha512>CAFFE967707DA5931160C21F01B4168FB469B75845B1E569CB315715C83B39A86DA382E8E8D9D93EEA203F25174F48C15A5F50B99F9F8284A304B1140AD59F4C</sha512>
+    </dependency>
+    <dependency group='javax.mail' module='javax.mail-api' version='1.6.2' extension='pom'>
+      <sha512>7000007A6012E29BCA8E065B9F7E86E0F5A13C4F11D6619D03C52210756CEE11F0732B7ECE8E03911DB9BCF7619CB9FAE1D319FD94EDEFB5D179B36EA1CA7CEC</sha512>
+    </dependency>
+    <dependency group='javax.money' module='money-api' version='1.0.3'>
+      <sha512>F17F8020EF30CF9FF85DD7475802F703E5C3DED0531CCA705B138E61AD95C9E0014B835A4AB5A1CACDB9C4C9CCC5A8CD1AE395031C51FC269E5DD1DCE942AE58</sha512>
+    </dependency>
+    <dependency group='javax.money' module='money-api' version='1.0.3' extension='pom'>
+      <sha512>9731F4BD357135A8C4D104701BE200037AAE5D7E90503CC3D16E6F17B610AB99F3D7F46B18CE99E0B15B310A3A3414CFDDB0B3A5259CAA3D5D508F66018A5FA9</sha512>
+    </dependency>
+    <dependency group='javax.persistence' module='javax.persistence-api' version='2.2'>
+      <sha512>13E4E0EFE64B1CF6744DCE44ED716B4D8513B2AD5B6A0131AF663B7918EB65705BD09D4DF763FF4A810829F4F6B6C198CA7670CE439940BE57AED0914B513F8</sha512>
+    </dependency>
+    <dependency group='javax.persistence' module='javax.persistence-api' version='2.2' extension='pom'>
+      <sha512>83B11037B61B736EDDA4DA7135C97BBECCAAE07464C8168731359F369D776D0E8324E05AE2EE4D1A28021ED25E88BDD0655D5547C38998B2519220FF8C3D1B4A</sha512>
+    </dependency>
+    <dependency group='javax.resource' module='javax.resource-api' version='1.7.1'>
+      <sha512>854A28F9088CEBCA0D09C56BBD9A51E4A82364AE3D61F1556ADE34A220BB4E3F629944BCA342B607E88BE4809B9B82C619938633E93CB2C30359F363C5A52C42</sha512>
+    </dependency>
+    <dependency group='javax.resource' module='javax.resource-api' version='1.7.1' extension='pom'>
+      <sha512>5A0BF94882C71A9CF46D411D4A95C6543FAFDC07F0BDE852C67F9140B7A29E20512A05B8CCF06FCB111AF6FE913B8E7DE978DA878DEABE051310A48292274079</sha512>
+    </dependency>
+    <dependency group='javax.servlet.jsp.jstl' module='javax.servlet.jsp.jstl-api' version='1.2.1'>
+      <sha512>C78DB8068FC7E6AA67F747BD474372F4C2133099F732FF0C1D7A7F17661968F2F4F3EAD43301E74A1C9E892861CF485DF35246B40AA6810AFBE908ED5A7639A6</sha512>
+    </dependency>
+    <dependency group='javax.servlet.jsp.jstl' module='javax.servlet.jsp.jstl-api' version='1.2.1' extension='pom'>
+      <sha512>3D9A12A1F98E25F3AF663A9089053AA3C6C3BFFB3C344B73F001A064DDC062FA48E402F4567F89267C0986CE1429F3A4ABA98D928308DAB07100B9DC586A4C0A</sha512>
+    </dependency>
+    <dependency group='javax.servlet.jsp' module='javax.servlet.jsp-api' version='2.3.2-b02'>
+      <sha512>300F55F32DB7B414BCC767600506857C01D070B568DA399DEDE713785C82BFD5B0AAA769565B1729F975AF5237D61A6064B3879DDA3E1A78C569D0D4E351D165</sha512>
+    </dependency>
+    <dependency group='javax.servlet.jsp' module='javax.servlet.jsp-api' version='2.3.2-b02' extension='pom'>
+      <sha512>D6528A50A980112CAC5BB40448AEDBED79C2930D16F146F3E265A991B775D6A9020891569572E3D1021BECD49091CBA75A7FF1B02D0FAACA89D22AB5D7653A98</sha512>
+    </dependency>
+    <dependency group='javax.servlet' module='javax.servlet-api' version='3.1.0'>
+      <sha512>32F7E3565C6CDF3D9A562F8FD597FE5059AF0CF6B05B772A144A74BBC95927AC275EB38374538EC1C72ADCCE4C8E1E2C9F774A7B545DB56B8085AF0065E4A1E5</sha512>
+    </dependency>
+    <dependency group='javax.servlet' module='javax.servlet-api' version='3.1.0' extension='pom'>
+      <sha512>15F79408C44AA4EE0374B8FD74B51AD413698F7314D458E3EFD1239FCFD7965D8ED2E66B82144362BE7B11C02D27B9A50CE74E583353865E03EE40991CDC4F2C</sha512>
+    </dependency>
+    <dependency group='javax.servlet' module='javax.servlet-api' version='4.0.1'>
+      <sha512>763DEC9801F647B1A45E492EB2A67F6A60FC608BEF4738EB7B1A92D93F1F6DB02B32F4C6553D4557C320DFC25C0EA0B9854C59E793262B6CA453C71CAF05EF38</sha512>
+    </dependency>
+    <dependency group='javax.servlet' module='javax.servlet-api' version='4.0.1' extension='pom'>
+      <sha512>C10A207B28BD02BBBAA7FB4C77594662C3B3857212385B295EF531F2A672CF36630B470C4A4544CE289606B3D91105CD668CFEABFCDF123C7846F5BB5036A9CF</sha512>
+    </dependency>
+    <dependency group='javax.transaction' module='javax.transaction-api' version='1.3'>
+      <sha512>3497CF77352AA1317C70AD1D28E8E7DA51337D844C8227A35707209C750BA6F5D644A4FFDBDB10E5FBDE204003AA43FF80E9E2FF3164584A7A34D8292266B2BC</sha512>
+    </dependency>
+    <dependency group='javax.transaction' module='javax.transaction-api' version='1.3' extension='pom'>
+      <sha512>A496C01D26CF3551D0D75EE6DF157E78787A8C45D307943E3F466086E9F548E973150E76B747F71541DB97B116B1FC639B95DCA1C4B535066359521AF833784C</sha512>
+    </dependency>
+    <dependency group='javax.validation' module='validation-api' version='1.1.0.Final'>
+      <sha512>BC137C5F7FA6B7092F9FC233D8BE7D21D6767F8AA51C2E934B73692C82D28DBB410F55674D7B5A0E1523B514654339277B535B7F5BB01D457A11ABA2ECA3BBED</sha512>
+    </dependency>
+    <dependency group='javax.validation' module='validation-api' version='1.1.0.Final' extension='pom'>
+      <sha512>3B1E69F5B7AB0161509BEF87DC441BB263B9A97A835ADAFABC3B1FEB33EF732BD2AEB3FA37314FD0EF67BD111144CC6CFC2F41091AC206AA98F0E6F3D220E05D</sha512>
+    </dependency>
+    <dependency group='javax.validation' module='validation-api' version='2.0.1.Final'>
+      <sha512>2F136D337C49A83DC0EFF1CAAE74BA11413269B779257AE0B76864E207ABD729B2392AB2AE3A3DC7A6D065D60BAEF844AD797A11F69589119A827CCEE5C20840</sha512>
+    </dependency>
+    <dependency group='javax.validation' module='validation-api' version='2.0.1.Final' extension='pom'>
+      <sha512>920A611FB9BF129C7B6A702C46B0E550A2B1B8B39A3C9E4F7AA98C99AC8F45E10A1EA9B5A49194CCA970678CB49960668FF8C8216F05E8A3B262394768B3C63F</sha512>
+    </dependency>
+    <dependency group='javax.websocket' module='javax.websocket-all' version='1.1' extension='pom'>
+      <sha512>50068387702713DC15AECDD463B916CABC4CE21052540142F038BEE289F1A0ADAE05A248ABFE3663FAE8E73497D8D8C27D7A1DCEB1586F21708EB92B7A84BCE8</sha512>
+    </dependency>
+    <dependency group='javax.websocket' module='javax.websocket-api' version='1.1'>
+      <sha512>F11E66B42EC76D022D91DCC9E5922BF751CF3B116FA8DE882EFE5A7E2926B2A45D86A5DE925DF8BD01E389B1CC65BAFAAA5C7AAAD310BC9D755E747962570053</sha512>
+    </dependency>
+    <dependency group='javax.websocket' module='javax.websocket-api' version='1.1' extension='pom'>
+      <sha512>B40ACCA166199D2490746BE67EB3C21BC950F11F922586AAD1C6D158A9FD5B3351065C339DFBA4015F8A6DE55021978075D1546C5FEE70B10FE18677970F1684</sha512>
+    </dependency>
+    <dependency group='javax.xml.bind' module='jaxb-api-parent' version='2.3.1' extension='pom'>
+      <sha512>A981346203530F22BBADF3DA8BEC2E1D11EEC5E447732620389462113FB3DF5C683EF7AC3F1E3B49C623F49CDC9E4AC7608F8C3E7CB0B2CD176E82C0132A5B4</sha512>
+    </dependency>
+    <dependency group='javax.xml.bind' module='jaxb-api' version='2.3.1'>
+      <sha512>93A47B245AB830D664A48C9D14E86198A38809CE94F72CA66B3D68746AE1D7B902F6FEF2D1AC1A92C01701549AE80A07DB69BD822FFD831A95D8DBFFAD435790</sha512>
+    </dependency>
+    <dependency group='javax.xml.bind' module='jaxb-api' version='2.3.1' extension='pom'>
+      <sha512>7E301CF3F5B69C6CB1FDC63BF76537F5A9B87C0B23B36014EB5C98720D94BDD2FD4A43B0BE6318841B324D70C6BFFF6A271BC479F18E7375EC864A7878CAA307</sha512>
+    </dependency>
+    <dependency group='javax.xml.soap' module='javax.xml.soap-api' version='1.4.0'>
+      <sha512>359293D81529080015F79663ED8ADB4A0245DE99AA8AB427F57CCEAA222622ADA80763728FD9473EACD0E70BD24D1A5E8737DED0ADE7C510B73ECD30DA284109</sha512>
+    </dependency>
+    <dependency group='javax.xml.soap' module='javax.xml.soap-api' version='1.4.0' extension='pom'>
+      <sha512>8A7091958E3A95227CADA78EB1F91A62824364307EE68FA6CC5BD8AFDAE9AAF173130FF45AD63FB3AFAAF021F913BD2E2C017F878B14C21D102E7645346C8B4D</sha512>
+    </dependency>
+    <dependency group='javax.xml.ws' module='jaxws-api' version='2.3.1'>
+      <sha512>F6795F2E1E72902C29EB976313DBB423D46D22F665846D20AD2AC8F486D32367566E0D81D2BA4614F65C80298B8BDC3FA37DE81D7B6C4341A1E228DC8C2B09A1</sha512>
+    </dependency>
+    <dependency group='javax.xml.ws' module='jaxws-api' version='2.3.1' extension='pom'>
+      <sha512>A65D0532E43C88A4D9AE9A0EB6A4AD67551534DDBC6F81D94E771C4B21839B8C588F94016595079BAACFE113926B0963C5E9BE4FAF63DF43E7C285AACFE59E7E</sha512>
+    </dependency>
+    <dependency group='jaxen' module='jaxen' version='1.1.1'>
+      <sha512>CE710D709B29A24D57BF6325521963975B97D1608AAF3098C2AE7900F3C1326FB8310D3AC0A8BF7A003FDF375FA4C37BA0E7DC50BB90269F25776EE806249B06</sha512>
+    </dependency>
+    <dependency group='jaxen' module='jaxen' version='1.1.1' extension='pom'>
+      <sha512>7D7E601CB3A9FB107B3456CEBBFDD7336893AFDD5E1A1270D62998032D0E44312C6496088140E8611B72F706BF2E99ACACB5DA7726F28F3E7A641215C92529B5</sha512>
+    </dependency>
+    <dependency group='jboss' module='javassist' version='3.7.ga'>
+      <sha512>204F307096C7206C669933153AE1126DA07EE66CC09EA319721E164AD90461038389A7DD55E45382F9383B13F38FC813B903BAE910AE879186D01D9F50F76130</sha512>
+    </dependency>
+    <dependency group='jboss' module='javassist' version='3.7.ga' extension='pom'>
+      <sha512>8840013C4BE28B9D5990DF7F4024C896B8D0EAF0D77D3CE0FA8EA6A56FD9F2A9B2B61B54255C1BB44CB0070B33B87B1D8BCEE99E6715CE2D0D9B42F34064A3ED</sha512>
+    </dependency>
+    <dependency group='jdom' module='jdom' version='1.0'>
+      <sha512>267BCFF47FD428447EEB2A4B08886133B41D00D1BBDAAD928234E88917499F7D06A8D7783702EFA67149D12577D7B59265C1FF42DCC2CF75BA71FF9026E0E2AC</sha512>
+    </dependency>
+    <dependency group='jdom' module='jdom' version='1.0' extension='pom'>
+      <sha512>6611CD3F96B4C71BE102FCE0E9F8A469006F9060501FF95E29F853E4A91274F8460DA3E87CB61BCD1B773D2479F05029C48B1732989D0762D07D65AF246F5912</sha512>
+    </dependency>
+    <dependency group='joda-time' module='joda-time' version='2.10.3'>
+      <sha512>16103FAC4BDE0D59B80BBCCDFFD86A8367D4B93B8AEAB694EF632AA06077626C44DFB7D043AA6AE6BAC45439090B22016302F276D6DE90CC129F360FC7276D7B</sha512>
+    </dependency>
+    <dependency group='joda-time' module='joda-time' version='2.10.3' extension='pom'>
+      <sha512>DD381380F30621FEF27A5F12681CF6BE48ADA746A593CFC86D51626B093D08C313AB76A3ECF1C2FF67BAE23889CE98E18D2E6D66CDE0E07BF76F5820C22F1EA8</sha512>
+    </dependency>
+    <dependency group='junit' module='junit' version='4.12'>
+      <sha512>5974670C3D178A12DA5929BA5DD9B4F5FF461BDC1B92618C2C36D53E88650DF7ADBF3C1684017BB082B477CB8F40F15DCF7526F06F06183F93118BA9EBEACCCE</sha512>
+    </dependency>
+    <dependency group='junit' module='junit' version='4.12' extension='pom'>
+      <sha512>BAD5814D39ED0ECCBAB35272B004DE4109BFBA2BF96F8CEC262F02D58A810602378C6EB9F4D4587AFCC5573141FAAD5936C914E2217F1FC798B4396E375AEB1B</sha512>
+    </dependency>
+    <dependency group='log4j' module='log4j' version='1.2.17'>
+      <sha512>3F12937A69BA60D0F5E86265168D6A0D069CE20D95B99A3ACE463987655E7C63053F4D7E36E32F2B53F86992B888CA477BF81253AD04C721896B397F94EE57FC</sha512>
+    </dependency>
+    <dependency group='log4j' module='log4j' version='1.2.17' extension='pom'>
+      <sha512>2A18E3ACC45437C2D6C4628F14DDA9B185A95A7B4759680A23E770B09088A510892230C4D5F7B6EB940D90A94339C7A92D5A1C5E46EE4465337069841A889F1</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy-agent' version='1.9.10'>
+      <sha512>1F66CF4FC5BAD55C2AD103C79DD19529288C8DF5AF2ACEA121229677B445B2B06D029B207C5D2D348565998B458014D405CEE4534EB0A12EC2F0D634F8925634</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy-agent' version='1.9.10' extension='pom'>
+      <sha512>EF1624B4CDD067C6524ADB344F54C3FFA6091FE507188813819D09EA2730A314CEA3DBBBD60F47D8A29005052E82660302DDA0A1151BF588F11DA162E10FA204</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy-parent' version='1.8.15' extension='pom'>
+      <sha512>D5855027BE0440FDB8B18BE84E9BA3753916B8457013B0AD1EFE76C1EAF6E6893701EC6E6BE09968296CB13CE2287AC26CCD38C365C4ECE8F9F3E783B3B8149E</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy-parent' version='1.9.10' extension='pom'>
+      <sha512>67F2D8879CDB0966DF2654A3727042710CA323819E9810F3C541631EAB231CADB35E55EDBC7ACA265068C66EC76A49FD3E24D7314DAB9CFB34F453FD8DFC2FDE</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy-parent' version='1.9.11' extension='pom'>
+      <sha512>26CE0229D99EAF24D5FF783A9E980CC589E42AC3100A597BB1372883388DAB66D5BF8C2443C131237E474BA77B3F999CE0E23C12A5C249BD44178302B843456A</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy' version='1.8.15'>
+      <sha512>56207B87DF47859F740DC73DE4BF6F152B766B9CC8FC72FE2EF01E5D01309DFC4BBCD6104F7DE56CB43E59F267AD1717EBFDF9960223F2FC6673FB08E68FB104</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy' version='1.8.15' extension='pom'>
+      <sha512>D3BD8DDCBB287DF7A17EC8C66E679F1012CC2B392A82282D48C4D3C586D1A28C8818B3EE7FA28CA205A048BE6303509B3BF2F9E2E61F5A4660A2574BD91ECB71</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy' version='1.9.10'>
+      <sha512>518CF557D6E913A3F5AD83F86475E96EA9009D52928EE8FFEEACF32A84B70A439BDA6957D1B9E9018D3467B4A7D6E80F1CEF4E51D187A7F91A123701E51FD912</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy' version='1.9.10' extension='pom'>
+      <sha512>3D35005EFD61F43BF23ECC41839089052C72568DA481BED8FE10EA794C04D6C94B25FD6507F8A3306B0ECB62F18BA153EE6DE36F27176ADFEB713A3F92E7CA13</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy' version='1.9.11'>
+      <sha512>36AC6B5D8330B1723D4FDDCC2BA34C572F17F2E99580D84BF2F7A083241BF322A63D5EE6AFA4096D246CADEACA759F40AD7E7F801FB7831A17DBA1F2A51F3500</sha512>
+    </dependency>
+    <dependency group='net.bytebuddy' module='byte-buddy' version='1.9.11' extension='pom'>
+      <sha512>658D5DFCB890EE8E0B6C873476AE81C49F0562DC7121B7657F2C99919467DFAF48D3C56B60C72158A605D2ADF877802ED73A7646C6E81B89034A940B3C6C8AB5</sha512>
+    </dependency>
+    <dependency group='net.java' module='jvnet-parent' version='1' extension='pom'>
+      <sha512>22FB9B68F57380088955B5526BFC382DA87332202BB4741DEF44AF2EC340240D8D2AD1283FFCAB0433175FE35AB5540A503AAF9A2E44AAD1DE005C8915BFABE8</sha512>
+    </dependency>
+    <dependency group='net.java' module='jvnet-parent' version='3' extension='pom'>
+      <sha512>93B78FAC40CA4DE12D5A2FB4E339BA9E3C40A25DDCFE58272DC2A8E4B36D2C7CC51075AA2A25F0B3C1D4BD3142551E77847D1BD5599C60F5D50D548B72B74BFA</sha512>
+    </dependency>
+    <dependency group='net.java' module='jvnet-parent' version='4' extension='pom'>
+      <sha512>97864EAA272261C1A39AD549327A0974D647AA2F473C897226F4E495DE886703F6AD257B4ED73316221886438651DB18AE7E26A8319DB2B629B86F1FDBF2F522</sha512>
+    </dependency>
+    <dependency group='net.java' module='jvnet-parent' version='5' extension='pom'>
+      <sha512>E8CE64D5697C3A282CF84E250F9586FFAAB10EBE9F2E17817EC7C0931CD7C0CF0B03425D914A59F87AB145D49027EEB845345F9F4DA037844BD9D90D1E735D7</sha512>
+    </dependency>
+    <dependency group='net.minidev' module='accessors-smart' version='1.2'>
+      <sha512>39FE6A5EBD2AE2D33D8737C8407A8CAA4F6A62CE2057D726BB82496D35104B76F230BBB9721E1DB5F535FEFA3D70EE88C0A5A5E4A3F1266D7317CAE897AD0882</sha512>
+    </dependency>
+    <dependency group='net.minidev' module='accessors-smart' version='1.2' extension='pom'>
+      <sha512>532015C8BA9F62046DB32A677D75446C9B43688F95F86804152B6CB7EA2544E3947F39A3FC89203A0AFA68D0867E5401B30ADF2BF5DCBB26E2FE6B0BBD546B2</sha512>
+    </dependency>
+    <dependency group='net.minidev' module='json-smart' version='2.3'>
+      <sha512>977FFE05C17965B403A60471EB6C160103263BBE454E942D67D4D725E1826B504DE6C15038FF01EA90632BF9AD8A31B47C6662613BB905F020EFFA68C44D6F9A</sha512>
+    </dependency>
+    <dependency group='net.minidev' module='json-smart' version='2.3' extension='pom'>
+      <sha512>2131CD4C12C56B6BB1B383544CFE2DA89E7513E0A630879C6E96CE4033D977023DCA7994F6BE45B1498ECAD1692C12DE49C94F36B6868ADC00EE146D88D16E2B</sha512>
+    </dependency>
+    <dependency group='net.minidev' module='minidev-parent' version='2.3' extension='pom'>
+      <sha512>6A14121FE72025A1ED285F5DD7B361CF59A7BB6AF120CB65FA94BEDBF06F48D6BE4F0E5DD358F67611BA7F2B739DB614D4F7D1DFE8708808C07389AC11AE8166</sha512>
+    </dependency>
+    <dependency group='net.sf.ehcache' module='ehcache-parent' version='2.22' extension='pom'>
+      <sha512>6B402FBBBBFC4EDF1EE76C34B3A71FD5993E3E78B9204AF051298764E4F6515732E9BF19EF77D178FDCE351568383130A3C9D1BD6F5C4AF58CC0382DE36A1EE5</sha512>
+    </dependency>
+    <dependency group='net.sf.ehcache' module='ehcache-root' version='2.10.6' extension='pom'>
+      <sha512>DF572FF4913035665A914CDA9BB9662150CAC46D0D182D247B73DC95DDAA00B31DE28DD9706D5F9E11571CE7FC0E6A6133B197314E0C18A780A4721313C0F8B7</sha512>
+    </dependency>
+    <dependency group='net.sf.ehcache' module='ehcache' version='2.10.6'>
+      <sha512>157E19452F8349966260B5201BCAF4C862C1B8AB2F2B883DAFB9454B9F093DE1482F67A9F7D75E5E7D9BB16DE701AF0B1D001A6D57D055E87B28DBE6E0EFCB8B</sha512>
+    </dependency>
+    <dependency group='net.sf.ehcache' module='ehcache' version='2.10.6' extension='pom'>
+      <sha512>7D3AD7350E68E44EA56E1B68706FD967AC8FF3F7818E56BF60EB4C38E3300AA5C2691187400B3FB3453E56B289EBE11D4A5FDA70AC6EA70AE73F820B8AEC44AC</sha512>
+    </dependency>
+    <dependency group='net.sf.jopt-simple' module='jopt-simple' version='5.0.4'>
+      <sha512>CBC27E0B6DA6AE4B6245353D6626D2E3C171C3026A555FA21E8EF61B30714E286DB85086D1A57C167016E8A7F07BE2A243E34B3AB504B1877806F3BCEC5DF986</sha512>
+    </dependency>
+    <dependency group='net.sf.jopt-simple' module='jopt-simple' version='5.0.4' extension='pom'>
+      <sha512>D40F8B34B139B2BEFADB1892F0B90319C125777555DB5D382974D26187E720CCBD0F59EC6FA28885D723B7ED58AE68A24DB763302026C327FA1050D6DDEF1356</sha512>
+    </dependency>
+    <dependency group='net.sf.saxon' module='Saxon-HE' version='9.9.1-3'>
+      <sha512>6580E24632116449CB420F8D854FA0AE9CD61E3029586922F658D611EF3E735EC8D62A80A0A102C31C020C8EF6038E8817AB4D045E6B9A7B2FF67885CB361FED</sha512>
+    </dependency>
+    <dependency group='net.sf.saxon' module='Saxon-HE' version='9.9.1-3' extension='pom'>
+      <sha512>61C240ED45527400E2F193F19794E2EA11C886708F24BDAB41F13526050850AF29CEAF18CA16EA3481D36CFF55AF73BB8C0CD87F3E3216B201776D11BB165643</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.findbugs' module='annotations' version='1.3.2'>
+      <sha512>C9D00C49F91677F7E7B5E6A615992F31C18E39E59FDADC82735299FF5D42065FD443E3D85422C688226FE49CD11F26F4EB527AB531BF2B59A121F516902E4F52</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.findbugs' module='annotations' version='1.3.2' extension='pom'>
+      <sha512>FB0A72DBC4EE00B24E566526259309F25E13F91CB8B123B69656DF53FAA84D4069083D087CE158613A639E269AC0BEC046D455FF8D6BEB3C151136A9E872573</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.htmlunit' module='htmlunit-core-js' version='2.35.0'>
+      <sha512>696644F911E30B9283E3373442479D7DE988E558B99FF4F636D257B4F6D3C24C05699203AABC3AC5DFB7FE530C602D17819D4680A8A80739C82A3133C1DF0920</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.htmlunit' module='htmlunit-core-js' version='2.35.0' extension='pom'>
+      <sha512>752903CC6432C5642998F573A6CDFEB4FF98112A60C6081C6B83BC3D0E8C1FA168A7022580ED54BA8C2E269390100EF94393347B1E92840DB37B2DD274953345</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.htmlunit' module='htmlunit-cssparser' version='1.4.0'>
+      <sha512>A4D08DF3D61FA5CB6BD5CA08F95DD7340948CD42E68E30200C49E6D7B3C2345C565EE30575F3E2B616A736C5D641DCC06007EC7885A16E4F4256FBEA93303998</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.htmlunit' module='htmlunit-cssparser' version='1.4.0' extension='pom'>
+      <sha512>87AA5EC4D1567BD061AB653DBB3EA9A8F226D11198602D524853CBBB3280A4A4962A8764A1A5AE3A44C8D2BABBE2737C53BC295E6E998F30E12D44484C068AE4</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.htmlunit' module='htmlunit' version='2.35.0'>
+      <sha512>DE44C36735E79E04E6C737015012E950DA8AC0A9B86E80A839129A0C905BCF75EC5C2CD31E96E779BCEE292D0CDF4DA45D2B397FC96C58EB204023C284C41327</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.htmlunit' module='htmlunit' version='2.35.0' extension='pom'>
+      <sha512>24685DF7941BD99E1349587FBD9E5E1EC1235034A5A5A371181DAD08ABE8E0CEE02AC99AE4A1149ACD24CCFA0353A9224E1256D760DF4868C99FAE2AC9032AA0</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.htmlunit' module='neko-htmlunit' version='2.35.0'>
+      <sha512>8B2F993CC7DE0621FD81993D1EA6BB8A2C987F98F609AAA187ECC41E8B4C56A6E1C71FF9BE9336716E3843F6B0A3D63A538B0837A4125052F0FB7B0E496D93B9</sha512>
+    </dependency>
+    <dependency group='net.sourceforge.htmlunit' module='neko-htmlunit' version='2.35.0' extension='pom'>
+      <sha512>CD60D258A8B77467B3E2CFDEBBF3DA9D748B95F2C974E5D81F9661D5BEFF7A0B0CE577848D36AD3B0AE5E2C37B84D8DF8AEDE82904FDD6E761E0252A7D3F2E16</sha512>
+    </dependency>
+    <dependency group='ognl' module='ognl' version='2.7.3'>
+      <sha512>6029F706FA027A79361E78DA350037EAB78FFEABF713C4DBFB841B1522D063633491E2677367115667E509FCB9E05410FB9ADA5F67E19C57EE13F57B8451AA0F</sha512>
+    </dependency>
+    <dependency group='ognl' module='ognl' version='2.7.3' extension='pom'>
+      <sha512>B96BC6A0A43A544366CC5CB9E7C9A40F4225B8677E1620FC74B8B384EC953969207AB9119294A5F40E9098DE2989FC4AA7C19144FEEA502E9527BDAB084AE2EC</sha512>
+    </dependency>
+    <dependency group='org.antlr' module='antlr4-master' version='4.7.2' extension='pom'>
+      <sha512>2C1BBF8DB9B73A54853A359EB547FF64D8BF9BFCE25460648AE75229226CC9382202D14EB003BC41FCE4FED015A3E4315BD7A4BAE379A310D130FEA65277DC37</sha512>
+    </dependency>
+    <dependency group='org.antlr' module='antlr4-runtime' version='4.7.2'>
+      <sha512>F057286FA0F7E3D0CCA414A348893577288882B887C0278DD0C012447D3C48AC150B30E023F886F038C6B0A144329FF927A3869AF5534D23B279CF88F302E0BB</sha512>
+    </dependency>
+    <dependency group='org.antlr' module='antlr4-runtime' version='4.7.2' extension='pom'>
+      <sha512>2E00788F067CAE508E50B59FC4CDC284567996D9B2B624E35F89BFB1A5269CA4B3E16091DDAC2D8C7D4CA2A83E42F3BE8A5383EC4D05464ABD936E8D7623D5F5</sha512>
+    </dependency>
+    <dependency group='org.apache-extras.beanshell' module='bsh' version='2.0b6'>
+      <sha512>A39321A99A8A619A48B65752F6EE6B8F11D3B28EBB051082EC70A70A0D5041E83D144378DF191929E3D6562BD5EE4C4F1CCADB0BA42055529D18800A41D8AE18</sha512>
+    </dependency>
+    <dependency group='org.apache-extras.beanshell' module='bsh' version='2.0b6' extension='pom'>
+      <sha512>52F4D03510691259EE13799726EE18B31255DBFDEF1B46FF3B82E7FC065021D0B391772804B201380366C2CBD23392F6EC1BA50D9D5CF15C9BECAAE331FBA1C6</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq.protobuf' module='activemq-protobuf-pom' version='1.1' extension='pom'>
+      <sha512>7BF2A1F3ACD100021A0085BB5ED0A0AC76EDE7C2BC1069C791E7A60FEE97BBBFC274659501CDCDCA6E3BD56553B86281C9383F544113EAB3DA4B6B5EF0767154</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq.protobuf' module='activemq-protobuf' version='1.1'>
+      <sha512>F1C3646DBF18C2C160A8FD6720ACE268494C9180FF9FA4D5E5A21105ABEDD14FDF6454F6B716F222C223F9693C328F776C750E3E365493FD629BDE803F91AAF2</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq.protobuf' module='activemq-protobuf' version='1.1' extension='pom'>
+      <sha512>B736D199E7E92440440BD64AC7F84EFCD828E22D8604DF1600DEE8E03E2C1E612A911B41E300446A8297B3F998A2C9AC8554695A2AC9075067E1777CA544C161</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-broker' version='5.8.0'>
+      <sha512>475131F80AEC850B77DC40F00B67D4DE78B49198F884EF72EA882163CDFB65D70F82FA6F4EC2F5199B969D30C07A975365D408847D4658560A6E6108435C0089</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-broker' version='5.8.0' extension='pom'>
+      <sha512>8FC3E9CBE555E85994A9939999AD055C543E3D36B0538DBDAB11F6D987AF05F9E075E6D19D1414ABF170747F08C80EF2CF3FEA42DBB15F22F3B308DEAC952703</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-client' version='5.8.0'>
+      <sha512>C098893F3FF5533F988E7CD2EF268F0FB3FA74A253EF04CD6BE975E8D90395BC1AACEE54A0D8BA5E2DFB07C7A05E67771BA6A8B3BD617FB788092A0CC27F9BD5</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-client' version='5.8.0' extension='pom'>
+      <sha512>E5CD402E52887D6BC0DFF3745B8BF5B47757656692C3214CD88849D060979CD227A09FD0909534878D9E69129B0FDACCA5CF5FD686A4A8BAFBEDBA75F5D30A92</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-kahadb-store' version='5.8.0'>
+      <sha512>D6DD39C589225BD0F6067A33E2A9B1C9568AFC7A54F505AC80C4B02ABA1A59E490A713B00E45A9EFD1C0BD72F773ED0BD4285767B1F44C6AB8BB0A341004A49A</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-kahadb-store' version='5.8.0' extension='pom'>
+      <sha512>C4694ED73037A43570021A87FE51E222CCBCE5C7B08AF7048704F8804F328D10F422DFE6046B978E8F9C459188A9EC2E8629D649751ED9AC1898B623EFBA58BC</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-openwire-legacy' version='5.8.0'>
+      <sha512>DBD9F96552B5EED1B29DCD5E91B199532626A91443F8EA8170290EDBB5596AA6CC3C75AD79CC4E365FDA37AAAFDD447E9A0ED54E0A4C745247632899CC46EB49</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-openwire-legacy' version='5.8.0' extension='pom'>
+      <sha512>F5332857354649F3BA3BB848F4A3C2B20C6A2A30468DCB58F18F924FAC070E7F98C3BD2EC0381D8711B83D1E2E59051C78EE83F3CA1D9589129C05C833D9569F</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-parent' version='5.8.0' extension='pom'>
+      <sha512>378CF99D0DE34CBAF51AAEC5516730124CEE9222D361D4BB3F79CE2A3932EC3B53AD47DC91613793F8750C33E91898AFA0506A75392972181659F59913A621F0</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-stomp' version='5.8.0'>
+      <sha512>710B1016724854E68F5172D4EFC093B765080D915B8B80EA08F153F09D500217D2FD84017F545809A578ACE652B10743CE0C21FD551D39C82AE87D7A840A8EE2</sha512>
+    </dependency>
+    <dependency group='org.apache.activemq' module='activemq-stomp' version='5.8.0' extension='pom'>
+      <sha512>A71E4DBEF98CFA7A414B656B434CBDE5D49E195CB744A4EE04858F27FC4FA13D60C9D067F9B0B3F7C129CBE361AEDC3D350BCA41E9F45A826DC2DE3B8A9C62CC</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant-launcher' version='1.8.4'>
+      <sha512>5148C9D0577350959454717B985DAAAF834C28CCD8BB00BCCB362370D12E10ACF04174797A177497D8C9E5259220D94CA54C060D32BCD3B74204B9B80EAAF07B</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant-launcher' version='1.8.4' extension='pom'>
+      <sha512>7CE887325DD7BF31FA0ADEE97966F8E27ACB04ECCE34BD612B8564169656A2210237790FD49ADF26DA86A7B083B24176E8B092027DCBAF353CF10EC2EEE65E57</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant-launcher' version='1.9.9'>
+      <sha512>6031F0A113DEB8AC6CFBA352CDB43C7523C57DA901BA4EAE498E048863373EF4DBD97273E5D5EEE68BE627E3B2DA0DBEDCC7A1E3045721FC58F559B292DF338D</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant-launcher' version='1.9.9' extension='pom'>
+      <sha512>6EE5492C465C120D0481B61DCEC2F74E2864A2F756A1779C443DA23B83B44B48DB56CE525CE39DCE523282C70F8D65F558C7CF1118E95A22360CD5B2E45643E8</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant-parent' version='1.8.4' extension='pom'>
+      <sha512>B60879AA667B957A9EF56F82939ED7F4BC0A496FBDC3332DD1ACD7FC980E2397C182DB728D7EC00595A46DEB71331BD0C7810C3CA07D5CD5F009605298A78D36</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant-parent' version='1.9.9' extension='pom'>
+      <sha512>12AFAD28068AB5688DFDB5327C97BB7E327539F1FC545427A13A29AD8E49F20985569DFAEEFFE042EC612C0D3E91E81F836FCB55D6A131BED432D6D368C021F8</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant' version='1.8.4'>
+      <sha512>F56919C08C6E02B8F417CCAA58A5AD4A6AAD783D80DAA68442A2CEDBD2C0414F817664AC6B7B2B31492DFDECB15716FCD44EF1B98A56579566E4101817410F09</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant' version='1.8.4' extension='pom'>
+      <sha512>C7094233A8AB6F2968FA7CDD82FC5ED7722B96BDF296B8BE739B6A052F94DD79299C5A7D81B85D526104BEA95857EF23D32708020A417F218DABD9FAB4B016C</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant' version='1.9.9'>
+      <sha512>197BF6A34E222C362929ECAE365B8EB0933DB80FCA2DCBDBF574143C8536BF02BF0C57EE9A2AF4C35721AF82A4DCDAE1EDAA3E3469DC7332573853193FA434F</sha512>
+    </dependency>
+    <dependency group='org.apache.ant' module='ant' version='1.9.9' extension='pom'>
+      <sha512>EDA583F188F32DDF81EA39C86C4B5E6BCEBBB54B2767C2C5524A82EA189AA7FA774BEE731AA96C44BCBC108893E900D62567943717AED81BC791DDAAABCDAFE7</sha512>
+    </dependency>
+    <dependency group='org.apache.bcel' module='bcel' version='6.0'>
+      <sha512>D30D069D4154C5A2538BF918F436B583797285F07C7281F69D1A10F1D195A93806673829C99D9C8B645F33FF997A15BDA08153CEFC3B8C4886F86F293C6DEACA</sha512>
+    </dependency>
+    <dependency group='org.apache.bcel' module='bcel' version='6.0' extension='pom'>
+      <sha512>689D867B45CDA5817D939C9ACF0086BF597480A51062E687AD5BF20327BBA5E3E7A3CEEA60EABF1A1AFB01E2C85B0F10F5E405481533D2DDEE98827629CB14E6</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-collections4' version='4.3'>
+      <sha512>CC4D3698AD958155FF141B17F11B5B80FE6279BCF00A07BF0F07172837B54CBD06019A89C12F68C49267306B6E95F7C60AE47C64685BD47B422CE06977FB235D</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-collections4' version='4.3' extension='pom'>
+      <sha512>B30A441EED203B0AEFF4CAC9E0B067B5123FCC259D0D00F785F97301140BCB0BE11C7D227C7DF81812A141953BE0B5FF17ED87E8C2F2F81BAEC17C1889C9DBC5</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-compress' version='1.18'>
+      <sha512>CB581DF3820FDFA810826F00BE2AEE1B7E551DE8363ED6D8D712098E545D61CD9C903F057F7BBDF5AF6BACFD314754A13FF9694B44F848DF0DE51239F01805FB</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-compress' version='1.18' extension='pom'>
+      <sha512>445AD9285DD3D6CC097D9BF1426285A1734B5DD6722175804E798BBDAE8016C7961D8855FACEB70DB1B80F8CE109B3797D8F9392BEB4393F794BC3EEB6434C6C</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-exec' version='1.3'>
+      <sha512>1543FB3D06491A25DABFDB889808942ED31A403EE349D59FD1C7A850B74FC826E8847CCFC9EEFDA111F126FE38298083CAE5968C1F447D6D81005EA06449C3BE</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-exec' version='1.3' extension='pom'>
+      <sha512>6E6434F7A11B7851B2F77750C55D87AFD03149E56E4FC584151E1E6392F18A0FB965730F0C9E7094B2AAE61CB46B131B18B808390B98FB9B97A3F2319F145834</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-lang3' version='3.4'>
+      <sha512>B1B556692341A240F8B81F8F71B8B5C0225CCF857CE1B185E7FE6D7A9BB2A4D77823496CD6E2697A20386E7F3BA02D476A0E4FF38071367BEB3090104544922D</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-lang3' version='3.4' extension='pom'>
+      <sha512>A62B2134FE4F9758E04ED7B9EB3D72A806F7EFE3D36954E05681C4471F78B580FD684671911F88556791302F1187E2BA577E0184E8B3E4020FB93181AFF63AB8</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-lang3' version='3.8.1'>
+      <sha512>FB0FE98385496A565678A000C26A3245082ABFBF879CC29A35112B4BF18C966697A7A63BB1FD2FAE4A42512CD3DE5A2E6DC9D1DF4A4058332A6DDEAE06CDF667</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-lang3' version='3.8.1' extension='pom'>
+      <sha512>8F3D314294F1AD4F83205C2E9866F0D47B95399BF6EEB5475D3F719CDAC1B409AB461A4DD3A2BFF1D63A42189BE20DD04A1F7A93847F7DD55A8600E5CFEC1458</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-lang3' version='3.9'>
+      <sha512>C6516EBAA0D83D3DFC421061A57D0F7EB30D0CF9EA05A0D5FA1C94B4D42BCA211444EA9023DE1A812533B88112BE95CD5D9638E160AFCB31C31D6570F95A9610</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-lang3' version='3.9' extension='pom'>
+      <sha512>FE261755CE369FF943BFA3AED3A6C3678A12FD87C3A34327BA9209EC16E29D2B066CF01E9AC66E167DA512A8802C990DAC0B7BC16D40319DC5671E0F48679023</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-math3' version='3.6.1'>
+      <sha512>8BC2438B3B4D9A6BE4A47A58410B2D4D0E56E05787AB24BADAB8CBC9075D61857E8D2F0BFFEDAD33F18F8A356541D00F80A8597B5DEDB995BE8480D693D03226</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-math3' version='3.6.1' extension='pom'>
+      <sha512>F1E99878A99261E9D5818C9FBFD77C015131F959E2FBF836BA45679EA642D97102BF3770267169A58F17B6C0871601F065446179EDEF0546EFC516495B937CF6</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='11' extension='pom'>
+      <sha512>5B8ED9B97B49EAE2318DCCF8ED011824B581604A8D0FB89DFD7C3CF4F1913CE4B39A83FBE551CBE7AB3AAAB715A058BF79B261B94F8EC3EE8868B9B2154483D2</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='27' extension='pom'>
+      <sha512>451F8D5DF746D3E55C402BDBC83E57BD13974E80AE8FBB8F1D7B74C2F99602D1E6C70296392756AA189FBD75B8A5247CD113404079E61E17A46B250539C496E4</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='34' extension='pom'>
+      <sha512>364EDE203A23157EC601D28FF141C0C69759FC5C483E44E346FA1592403F343F0722F7763243B2EE7A190C7A744B1CCE1F40247F5A6C7B3DBFBF487C505A40BF</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='35' extension='pom'>
+      <sha512>865329EFEFEBF61A54B273BD0AB8BEAA09CCECEA0D12D5CC02479EA62B154CD6973D65FBEE5A7773CF87F6B793AC0B0F1681B4B08E6E57049A166AC3F61ED95E</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='37' extension='pom'>
+      <sha512>9183A0085F8F05FDA802DF3F6984470E62C1F9219AEA8FD476636D0324406A5C393CF67F958A2EDFC5827EA0CE5E169FC404D9BBAF27372B1392D2473FC21255</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='39' extension='pom'>
+      <sha512>EF77FA2D64E33773DD36CE047C467AC698945A2E2DB54027A939A583FB4093FC5E2C1DE2587E8F94A9985F7C3D37C6385C11C9B9F21303A52BC585307F44376C</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='40' extension='pom'>
+      <sha512>EC9DB3E47E59B175B39D137360EF1A7E76C79C48B50382A85AFEE67FF858675ECDAA8B7FEF26AD4A8DCB9C921108513928F3B87E4FF43C8FA78DED7168FE317B</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='41' extension='pom'>
+      <sha512>45F64076EDC7633861BFAD73112AF31328B4AA194312D023BE753CC941D9FB288AC62647931322774070F28A57DA7A77F2A26A3A27D14EB5B03D5B56F2BEBFF9</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='42' extension='pom'>
+      <sha512>A35D1F7919551ADBEADA88D9F47A4D6DE200380AA43266F91D4B65255120CBF4B11F73BB3F9B98EEB960FD9F1B0793DD48095B46270ED2376CE3B122861A94D6</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='47' extension='pom'>
+      <sha512>317A5572388FF9E6DD17F4ED7913568763BF3D27D9815BE8C8315AFDAF387929F21FC38637BB00712F7715B8EB7B8BDB6D68B8461CF6A29A8799DAFCBDA25CE4</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='48' extension='pom'>
+      <sha512>6873A43261B38DCB241A30F4E947F425F10C3DE2CFBDF6B684E813FF0D7FEDDD56FCC6F96A357E430FB98CBF05CBA64FD9B516F79D5BC47311F2E60A6E334ED6</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-parent' version='9' extension='pom'>
+      <sha512>F723BA4D2561CC42B44FE638ECEBC3D33CB418F2644ACC85D7BEF04CD8D2AD8269852D628000799BF741B7AC3036A88170CFBB0FC389816AFE17A202ECCB2E2D</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-pool2' version='2.6.0'>
+      <sha512>C31D44FF2D527DEC5189BAF8AE1D888C37A53A60283C58CBEACD723C773DB8219DD54E0FCA15F29F781E0AF66E60E894254D6AAC80178207B51DD2F9DCC972C3</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-pool2' version='2.6.0' extension='pom'>
+      <sha512>86C998E8BA690C63BA1BA7B614752F216537CA284E7AEA2F59D228DD9F0CF68BC9B2C5AD92B5BD0FFB44A2B95BFC369F7B615E05D5D03DDB197BCEDC7C4EA738</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-text' version='1.6'>
+      <sha512>A0C077E33C075FFD2A9BF6776C1C27F6D19B451DD6F9A26CC06AED586BD746E5DADEFEE72E130F0D43768F8E3F24CDDABE79B1E94ABF227FBC8E8C58DB0C6504</sha512>
+    </dependency>
+    <dependency group='org.apache.commons' module='commons-text' version='1.6' extension='pom'>
+      <sha512>8CB53C649D2243E9F69D79CDEA37F783102E855963AB40F06D7D6592A39E0D8E696B9EE10DAF5FD4C8F32AF6D0B92D32440450A61D07983CA38253E593972AFF</sha512>
+    </dependency>
+    <dependency group='org.apache.derby' module='derby-project' version='10.14.2.0' extension='pom'>
+      <sha512>C3908DF05E861069CBEB8C5E7BEC632CBB0FF873E4C02367210E3832E9CD0F63A98ECA66AB5D54BABF572F8F9FF11130FD6E175B126CB835F1DF5B3044110980</sha512>
+    </dependency>
+    <dependency group='org.apache.derby' module='derby' version='10.14.2.0'>
+      <sha512>B2A8B60DF47BEE2526783030CCA53CAB6E6C051D25CC3D2EE0A70B20DD21E1AA264BE46585E0D38DED310F8431A6CF699910395274216F7D8F5FB597E92B176F</sha512>
+    </dependency>
+    <dependency group='org.apache.derby' module='derby' version='10.14.2.0' extension='pom'>
+      <sha512>CE59A04EE3E2786439EFD23E837FE3CE43D1F2E9BFAB4CA9813CCAA1C409817D696BBCBFCC53E6A0709C9D4A499F207734FFFA6072FEA90C49E4BD788F926350</sha512>
+    </dependency>
+    <dependency group='org.apache.derby' module='derbyclient' version='10.14.2.0'>
+      <sha512>62C70DAED354D1B742406303EEE9A97CECDC270EC1F79240E601CBA2639BF89D86BC2DE1186FFCBF6C2AB01C513E5D7A2DF2F076F49142429BE5997D7A735699</sha512>
+    </dependency>
+    <dependency group='org.apache.derby' module='derbyclient' version='10.14.2.0' extension='pom'>
+      <sha512>7C32145F7192D454DAA9B68AFE8DDD367162BF1CABAC88A2EA8F00ED9B08F30535B9DB465A25751D66C95EA50F84C112705B98619F06C7EDB8A86C47AEF953E5</sha512>
+    </dependency>
+    <dependency group='org.apache.geronimo.genesis.config' module='config' version='1.2' extension='pom'>
+      <sha512>F17E2B0EBA26B6C7B9C38FEB4469BE16BFAB890A6E11AFFC5C2808A35735D0E09BEFEF024E2E770AB36DA423A81EE1499E2C922B3DFBBE294B7B49E59D2A667B</sha512>
+    </dependency>
+    <dependency group='org.apache.geronimo.genesis.config' module='project-config' version='1.2' extension='pom'>
+      <sha512>B77B491597CBE6DB69B978F6120C708DC8445CDCBC2D7BF77FD62CD79ADAD990C274F495F8888F7F956C8270E1905D248AEC7DEF95764AE484B634798E7DDD30</sha512>
+    </dependency>
+    <dependency group='org.apache.geronimo.genesis' module='genesis' version='1.2' extension='pom'>
+      <sha512>561B15E9C6F261926C2EFF273E8FD578664A08C632C24617114AC18A7641070033F85D237A6CB228E11EA8316344206EFA18FBD5477A07D8D63AD68F5C02FD89</sha512>
+    </dependency>
+    <dependency group='org.apache.geronimo.specs' module='geronimo-j2ee-management_1.1_spec' version='1.0.1'>
+      <sha512>32E38035E7A9BC63F31CAA612421BDC33DDB9503E37C97B587490926D35831A8E3C2FEF324ACADC9A301AA977A761B36C94188A64E53E0AEC8641B04A21B3597</sha512>
+    </dependency>
+    <dependency group='org.apache.geronimo.specs' module='geronimo-j2ee-management_1.1_spec' version='1.0.1' extension='pom'>
+      <sha512>B2D1AEF5D61BDF1E92F99C34B0255CBCC6DD3A32C14EC2CE3506EF74D725FAA21F08683D1819276771505D340CA1AD12E5BB6E68FB62CDC1E955C982AD640C73</sha512>
+    </dependency>
+    <dependency group='org.apache.geronimo.specs' module='geronimo-jms_1.1_spec' version='1.1.1'>
+      <sha512>94CB8660775596B298DB93E11FDBB28D2A582B161F7A6D667D41946F59E8B114AA80E15C28C4186F05B43F432B1AC555D845AD870309609202382C3F6061E319</sha512>
+    </dependency>
+    <dependency group='org.apache.geronimo.specs' module='geronimo-jms_1.1_spec' version='1.1.1' extension='pom'>
+      <sha512>6B72EC11C4436A93D5C12701FC73F40EC99D97A26AA532EC12C9D3DDDD5263A2DAB3E90C39E4E97E39A312CB0F599D81A7D8E9E119350517FFE756317478A213</sha512>
+    </dependency>
+    <dependency group='org.apache.geronimo.specs' module='specs' version='1.4' extension='pom'>
+      <sha512>94AFA6A437D9664893E2F8EC4DBF68777E4BF2F3AE1CFA4716F8FFAAC6BA2EDF2A4E48070E35F5255483EE7AA3A857B73E8F163F05F1A001D68247C161A16A4C</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpasyncclient' version='4.1.4'>
+      <sha512>A80DB5DBF772F02D02BA6C7C163E8DA9517DD7195714B495ACB845C429580C1FC926D3E71C115E75BE8C145651DCE2FDFA0DC380132F7809C14B3AD95492AEE</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpasyncclient' version='4.1.4' extension='pom'>
+      <sha512>38B6DE7AD56741E73329C1744C047288B660C5B55FD7CC6DAEDC71571FC75D1498F4E936F91BBD5BF9E77D8781C993280242B07DD640B3FA3D7F1B17365DAA59</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpclient' version='4.5.9'>
+      <sha512>F6CA7FE0DD9BFADA4B08F67AF536CCB1111538F1319C3C046F7030544C1A7FCE72CF693EF8901D946621217FF1A4D45DC7458F4554D2E37F5B0D691A8CE1124</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpclient' version='4.5.9' extension='pom'>
+      <sha512>B8CECD16B220804D16D607A641AE5767E03985947A619F4F315ED486FDE73EAFACB5FF2D037AF5321E5E326F5366E7A80846116D2316C0C09DACA17723BB90BA</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcomponents-asyncclient' version='4.1.4' extension='pom'>
+      <sha512>12D909B08F124AEBB97787B288E8DF68D46589E43095ABDAAAD8D7742465053B30C33410EB93A592EF2EBA47FE70538E8BBE19293DEA2BEE231F5F63CC3D8E32</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcomponents-client' version='4.5.8' extension='pom'>
+      <sha512>D5060196F60132854FA688B80C2BE20E279C79948A758F4B465976C25B85CBB416C2FC14CF2FBEE547843D3D6E70B96606A3556FE62AF79C0E0AA305BFED85D9</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcomponents-client' version='4.5.9' extension='pom'>
+      <sha512>EAA6572D4140A5270D48009DC7B8DE68C5DE0F5109AC796BEEA0F10DF1610F2A7B956EE49387F994653EDFDD8866F96089E456369F57BA72D3188EF29152CE1</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcomponents-core' version='4.4.10' extension='pom'>
+      <sha512>D90F48A8382BEAF472246ECB51AC8BAB5919E8720BC4F8052C75262CC301723DE23A46FB0342D3756C3FC5A6A8FFF2E8002BE62F9F2ED964C1D032DF6683DB75</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcomponents-core' version='4.4.11' extension='pom'>
+      <sha512>3481B7EC66CBC17A838D8CF4B72A21A2FA8674C1E70F5D7AD3498D2791F28C043E64FB045AFA4EB4C3250A55EA391842F8E8E959F328B5DC1AB965D2F45ADF80</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcomponents-parent' version='10' extension='pom'>
+      <sha512>2A13D94B4AF958E39D49408842080F097C662CF2276BEFB89B13B94B95EABA64EEB389B5BC6638170658A00DE42104001DAA3EB0650FAE32BA4CB44503022C71</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcomponents-parent' version='11' extension='pom'>
+      <sha512>BC676698CAEC72D525B9BF408432E9CD9C7B5D2227E0778FD79C303041CB5B07B88F98433D59C0149D6C11C27C3834722CEB283048919E467785EFD7F4C399A2</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcore-nio' version='4.4.10'>
+      <sha512>2AF5F72B68A4FF1B1FF46B788013283D195E1D62EE1D7B102AA930B30F77F7E215A6D18EDBEA0FCCD18FB1FA3A66CC4AEF6070D72D6D1886F0044DFE0E16C7</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcore-nio' version='4.4.10' extension='pom'>
+      <sha512>846246775084E7136A1DABCCA16AD65FA73873D7AE7BCC5D15E553E7391D7171C181EF9DA0A978DF0C5385A5069D727CD646745E5756D5ACF5C85462014C7F6</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcore' version='4.4.11'>
+      <sha512>1F45A26F97E5488BF1985F5F5C88C5E2744F46D422040708F7641DEB14BB04561BCEC35C9284C1DCE606FCDCB768EDC3EF970EF965BD6BB591EC362DFD417C74</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpcore' version='4.4.11' extension='pom'>
+      <sha512>4874F966A873DB0DB0FEE6B21469674C7BBB29F00858CAE05394236CE4E8AD3EACF9F4EFEE9F7183F70F55EBFD102771FC5C6F292462B212685E3DC30A85D691</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpmime' version='4.5.8'>
+      <sha512>E44EEBDC57A0E2F99FFDD7907A8D5ADCC18FF05FF5CE353AA7D05A2C7914272E6D4746F09399DF024C2663E1838C6477581D2787B8D07B8EDD3B18D526381993</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='httpmime' version='4.5.8' extension='pom'>
+      <sha512>56835C93B7AF958D7ED65D051909CE55DCBBD28643D13392077DF72333C4780BED5854BEE776C4CE48618468F994921878626B2F79D8BDC17EED9B7F1AFAFF12</sha512>
+    </dependency>
+    <dependency group='org.apache.httpcomponents' module='project' version='7' extension='pom'>
+      <sha512>BBF658AD8F5FC0B54851147ADD99A134B944801E9579B17FEC45486B36694A6BD007AE43BD9D4B5EA1D3A2778A8137A16D2226B7BDF65F0CCFDA65D397858B6E</sha512>
+    </dependency>
+    <dependency group='org.apache.johnzon' module='johnzon-core' version='1.1.12'>
+      <sha512>6CBCD4AEBC5209C92BC05DD111B87620EC795E91A6012BA76491C8ED6E5BA9DFCBEE25C3B357FAB6C41B406965D13AC1A8506DC55BC21C6BD0A0D096D07CD9F4</sha512>
+    </dependency>
+    <dependency group='org.apache.johnzon' module='johnzon-core' version='1.1.12' extension='pom'>
+      <sha512>12B66C035C35F37926B35D1F68399DC02E9F1AB9DF617C9F189E4E078DBAF767DA38018CD078B8FAFE989D17CAABD9FBC37EE81D625002FE2FE4D903B44469D</sha512>
+    </dependency>
+    <dependency group='org.apache.johnzon' module='johnzon-jsonb' version='1.1.12'>
+      <sha512>D54EC16E564D2213ECA40EF74810605C3A0666CA29E816BDFA2393A1C03F23CE155A9DC4CA6DF5C65D447BF632F6879F8E694C80C5B09A98399CEFAF2BCAD43B</sha512>
+    </dependency>
+    <dependency group='org.apache.johnzon' module='johnzon-jsonb' version='1.1.12' extension='pom'>
+      <sha512>C54EAD51F61A1CA50DAF0F661AAF5AF150499328C2ABB940E259D50FED7B539FDDED9BE68D816FEAEE6FC08A572A3D359FCEDE3DFB8DBAC808F02BCA1FD03E13</sha512>
+    </dependency>
+    <dependency group='org.apache.johnzon' module='johnzon-mapper' version='1.1.12'>
+      <sha512>34A0587BBE6CAE02CE048527EADC7A6676063641AF71134E3313ECADAD845C50B395DCDFBFB6B495538F92E1C2EECF624989B6585E96034CFC4BC94A2C3D259B</sha512>
+    </dependency>
+    <dependency group='org.apache.johnzon' module='johnzon-mapper' version='1.1.12' extension='pom'>
+      <sha512>FE4A14ED92600D4EE097139DDAFC36D8C28467E0EE92338601B3B15BA2D156E0CA6AA9B6B12E2EAF3A56CB88E96710D45B199D1630C9B0453A298A71F8641A71</sha512>
+    </dependency>
+    <dependency group='org.apache.johnzon' module='johnzon' version='1.1.12' extension='pom'>
+      <sha512>AE80858D516CC130A1E91D01C8D3311E68E6FF123D361618A74486BADA45EFD04312125AA366CFC391479B2FBFA20B0E7204B4FD7CD56560A467A834A239FFA2</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j-api' version='2.12.1'>
+      <sha512>182FD4B7B2642BE8AA3C9C3A78A7401670FED6C404596FC916AD21ECC7EA5752D3CD9572F135F0510DB958B867F8EB7718EC66EE3D317DA6E06201942D12DB2B</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j-api' version='2.12.1' extension='pom'>
+      <sha512>FDF1050A9DA429D1538A991B6931D48BFF72B63E3029F4DB48C818B3E4FD10D31C0DEED0A9A07F759582D2601AD1D7855DA943FB2DF737F78F70FEF43D5D7647</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j-core' version='2.12.1'>
+      <sha512>7735610C7FE1C6DE6FF11195F76AD3721CBB6DA8D8D55F333F93831BAF782E2B181816C12AB092503F8099F419E72B33C8C3C226D61449D5427DD8E5AAC1E2A1</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j-core' version='2.12.1' extension='pom'>
+      <sha512>1EF2711B2AF283290508E7D368B1BA5E3492CC2C1597416429E9EBD70D6226675BE004D5A8D9D787DB10AE42F0F4926DFD9E21049105AFFE4B9007DEE7335341</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j-jul' version='2.12.1'>
+      <sha512>3753A50D9C6661BE157366D0CCEF64738C724D8A66DE5B59CA247AA4C4E7EA9F5DEB4EE4A39EA81543CEF9474800901062379367F5E05482C602CF015A37E861</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j-jul' version='2.12.1' extension='pom'>
+      <sha512>E802D1B625D7C35C6BDF24C3677F44E8B897564C4DFE8E9B3769386805281481E5E09B2A7AFFC450BB8E80061DF2C6B8B2B3D9E766EF69457C00F01FFEC28CD</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j-slf4j-impl' version='2.12.1'>
+      <sha512>97359607234101E935091BF2A3E2CB063AA6A784C663E58530C00FC37ECC8B08EF37BDDAE8222FBC96EE2E2BA2D29798708992A299634C47354DFAB12060EB85</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j-slf4j-impl' version='2.12.1' extension='pom'>
+      <sha512>822E119A4DF600DA6E79C0A028CAB7B2FE32AF526F74E2D772A4733D2A71E1BE19043B74A8E84D245FD282DEBCF174762E163B23094EA820234DE01D19704D98</sha512>
+    </dependency>
+    <dependency group='org.apache.logging.log4j' module='log4j' version='2.12.1' extension='pom'>
+      <sha512>2AA5D96E313E5527073BE1C15283EFB28D4D18D0263B2F7329E97924010EE6F4D0920399F9705B22382EBD881B4A968EB6227FB25DA5524413CA017F5DC2A336</sha512>
+    </dependency>
+    <dependency group='org.apache.maven' module='maven-artifact' version='3.3.9'>
+      <sha512>22F5203E5B6639EF6134E811052A4E94CAAFA4FFB25C9F821C19672A7A7097AD3562CEF0E7B9802AE66E005B151D410D4822A8E48A4E92819255758EF6C073EA</sha512>
+    </dependency>
+    <dependency group='org.apache.maven' module='maven-artifact' version='3.3.9' extension='pom'>
+      <sha512>E16479B3B9E78F3E0FAB35D49AE7BAAE60E57F3B5B4DFA9C478A06FA49945112CD1A686EB71609E8E100AE2CC9748053E0B7A1C1F79924D6D50A70013B6C8686</sha512>
+    </dependency>
+    <dependency group='org.apache.maven' module='maven-model' version='3.3.9'>
+      <sha512>974B613509AE56BDD6B1592DBFE43432A804030183935ED5D4F045C411DA8174887A16394ABD6E543DA2198DEA2DD5898241694C890AE158EF79E7F897915124</sha512>
+    </dependency>
+    <dependency group='org.apache.maven' module='maven-model' version='3.3.9' extension='pom'>
+      <sha512>4D255F156BAB867C65A4A4AE88EAB3B3F5EDDDCF2B20A0B5B27BEB60372F2656C32FF2EB0B8393DB98C440E03080E00E2BEDDA9F2C1FE69C60E89E947780B93C</sha512>
+    </dependency>
+    <dependency group='org.apache.maven' module='maven-parent' version='27' extension='pom'>
+      <sha512>B9B25530846F650855A8A6121E18C7E7E04596C03A471599227F13B47A8036B5B4865238A346FB385E44F1ED800FCF8F1B67A5BAA7CF8125FAC6ABA512B211E</sha512>
+    </dependency>
+    <dependency group='org.apache.maven' module='maven-plugin-api' version='3.3.9'>
+      <sha512>A6E993E404932F23B7FAC1BDD0079FC33492C8A0406FF11431A27188F8F56345684D7D2FF73B07C1432D911830089474BF83A0B76A6ADD22AA3F565AEDE54BE0</sha512>
+    </dependency>
+    <dependency group='org.apache.maven' module='maven-plugin-api' version='3.3.9' extension='pom'>
+      <sha512>654D28EF7D4C75B0D15E9FAB480D49D746D35F2AA6ECC2F3535AE1B55903C52DAC6A74790774FB19B50C83CA2A79F7AD7E14B5232A2B72D8D9BCF28181A9324C</sha512>
+    </dependency>
+    <dependency group='org.apache.maven' module='maven' version='3.3.9' extension='pom'>
+      <sha512>5A66A333C4C0AD9CC0B650EB8B6D9E21817D030F719895D3BBF7315E422EDE884F9711744B97580250736B8238F76EA335218DF1A8BF7A679FAF646AFEFBE56F</sha512>
+    </dependency>
+    <dependency group='org.apache.poi' module='poi-ooxml-schemas' version='4.1.0'>
+      <sha512>2A7DDB1E3F4811AFDA5A8903A76C6576D1431FA10A2D01C396575C946C0B3530BFAD574980A24EEF6B49FCCE687848B627CCC0F13EB8431880034A2352D5F1CD</sha512>
+    </dependency>
+    <dependency group='org.apache.poi' module='poi-ooxml-schemas' version='4.1.0' extension='pom'>
+      <sha512>773A1E0F5EB9E7A0CF573FE1772F22D4CAD953C1F4B93B398D14ED9F49F9AB83B4075140488615AB0D874D13A563A4D902D2B78BE9D85B54A00728EE8970216D</sha512>
+    </dependency>
+    <dependency group='org.apache.poi' module='poi-ooxml' version='4.1.0'>
+      <sha512>2BA7AFC83E0DE3AFB5C05B4A9DD0D075A16FB7B20500CD6E18BEFD7D88A560641E2AA0A227551E4B78FE1ED56786463BCF0C2BFECA28EDAECD781B879593F39B</sha512>
+    </dependency>
+    <dependency group='org.apache.poi' module='poi-ooxml' version='4.1.0' extension='pom'>
+      <sha512>5E14CD2B5FD464C73611A2B02A0869A62DFD821893D7D80E7AEC0968748C11A58E76B9115DDC610F04D928768F75CB546017C68DF64C88875D7398D37BD618E0</sha512>
+    </dependency>
+    <dependency group='org.apache.poi' module='poi' version='4.1.0'>
+      <sha512>B7ED6FF524702C5270CAA215D03A24859B3A277432B91C25E742437B1609F23D3C361BBF4BDCBC373B7CF8ADAE47F0D77AFE0FCFCE19612116C3BC34F1A40CE4</sha512>
+    </dependency>
+    <dependency group='org.apache.poi' module='poi' version='4.1.0' extension='pom'>
+      <sha512>CEC934CEF5FB1842C20CEB80B2C966EB933EC3447AF553B2CFADFD19EAAD5F250CF355CA33D9ED019BB04F4F53636E1F23C663FB0DF256448E4ABB53C0D6AAF2</sha512>
+    </dependency>
+    <dependency group='org.apache.taglibs' module='taglibs-parent' version='3' extension='pom'>
+      <sha512>F394F7309C3874675226CFBB1374A2754CC97FD419F718888E5F204F4496F201EBD2A869634A0B6CD4D2841D5EA68EED4BFFFC3BDCFDE99A633254A9AAAB65BD</sha512>
+    </dependency>
+    <dependency group='org.apache.taglibs' module='taglibs-standard-impl' version='1.2.5'>
+      <sha512>4F52748DCC333164A8ABBD3A5964072AFE6A91D771700BEF15385FA33B618CD73CC34D3E2DFC6929CDE52C45624B7C7735BF839DDD69C3E23C086672B96039D9</sha512>
+    </dependency>
+    <dependency group='org.apache.taglibs' module='taglibs-standard-impl' version='1.2.5' extension='pom'>
+      <sha512>19F1F6C76579BD44F2F6647EFCE1273A4F63A3040692C78F97879E46422E164F6B30113AD52CE6573AF48FF184ACDDE1CBB4244E32020436B9BCF98BDADEB59B</sha512>
+    </dependency>
+    <dependency group='org.apache.taglibs' module='taglibs-standard-jstlel' version='1.2.5'>
+      <sha512>14C45FF9A4BEF71177CB838CA58096C152A3F1426B3381BFF8BF3F97957DF55B9204C8CF6614B55BA751ACFED334D87644E4DD0CA2FE1E429ECE0E47CE2C2A26</sha512>
+    </dependency>
+    <dependency group='org.apache.taglibs' module='taglibs-standard-jstlel' version='1.2.5' extension='pom'>
+      <sha512>6E5665D27151F9BAFB7B9EA5023B01D780375379C9C3DD58DAB387353BCAE8C76860BC9207270CB258F44527E5B7914024FB62AB9B33C9BAEF3FC93A51234316</sha512>
+    </dependency>
+    <dependency group='org.apache.taglibs' module='taglibs-standard-spec' version='1.2.5'>
+      <sha512>3D377ED4DF8372AB4816F99E53BF874C73338AD13666F1FD5C59D500A26240DB3A6C3C06E81E610D2302A96B5D2372175C31008268AF97B2FC19FE4B0F8AC174</sha512>
+    </dependency>
+    <dependency group='org.apache.taglibs' module='taglibs-standard-spec' version='1.2.5' extension='pom'>
+      <sha512>F8E147201BB01279C60CA6219450DF2483F890CB4D54510EC3C30A9C963F87361157C2D73C345D6BDD36B4BC6A34393196045B501DA320F27FCACBBD31C01D61</sha512>
+    </dependency>
+    <dependency group='org.apache.taglibs' module='taglibs-standard' version='1.2.5' extension='pom'>
+      <sha512>55BA9FE1CF0DFCBD5927CA81EE1A2F48BB68F923EEAA54175B724FBBA6BADB3828207CF803BA631CF5D920918ED5F66B0C05B5198CCF32CDAECB011A21109071</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-api' version='3.0.8'>
+      <sha512>40B3DA8E217DE82BD92BA5B2CC36CBDC8553AE27C4D2CCABF88A412966F09E52A7D2B352201AA1851123BC32B59477449B596C910C68E5D7CDC8DB20B9CABAC1</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-api' version='3.0.8' extension='pom'>
+      <sha512>5A534FCA7E5EEC4173FAA09AB7CDFBD33E4CAA896191D7BF5FE76E1648314FEC8C40FBCEAA31264FA43F7CDAEF4D385F565F3E6423CD787CC8FAC3A54FD6C158</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-autotag-core-runtime' version='1.2'>
+      <sha512>552BD6CC77C80E0F00B3039F22B8922F17B20F2F0BF991DFD833977AC509A4A18B995B50E9EA9DA6A556A61A8A02EE3A9C22864B0214E10E841FF09889773ED2</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-autotag-core-runtime' version='1.2' extension='pom'>
+      <sha512>AEDC2735F0A7A47386FB6A0A264028CD543DF47566376493DA485F77D5B414A90137DE19F8914812FB1607653600FDBBF1FD62555BC472F1A3B8AC2B86C849F4</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-autotag' version='1.2' extension='pom'>
+      <sha512>FE9167A128BFB9B2067E50AFD19C09EF2318ED519C39FFD542B467B53D26A185CCEEA9B975E841E5F029D8DBFC4CBB72C2A9D66481974E8D0F5760DB98494D6A</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-compat' version='3.0.8'>
+      <sha512>1750FA159D8D221F58345B71C0D79D8DF242706AAD6B252B319BEE526EB5364A1A71D4870B865A1B4A1E780ABB77D96094E330BDB447644005F0039ED4262B47</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-compat' version='3.0.8' extension='pom'>
+      <sha512>EBEE8A3E30D58883D813D8F4AA485C82D52B3C92A414D6C8BB3D2989283432E5D66DAE024646F17A80F952AB2BA04B208F4B9F3ADEF9FD964216DAB834C0DB32</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-core' version='3.0.8'>
+      <sha512>6CB1405FDE83643374C59CBAF476114B342F418EBC8B74B6478043C85A163D95B7CE746F9815ADA99569A80BAFBFC9B4EB799E4BF2F077DA00493C417B9BA445</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-core' version='3.0.8' extension='pom'>
+      <sha512>30208F5317B47B1531ADEE05687BB364EFDDE689B828B36B50CDC30DB481BF673FC4B1FA11034966A14607729085387B1AA5FAA3BECC902C9B37E9F4C91C8789</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-el' version='3.0.8'>
+      <sha512>AD2FE116D5C5CE7E67A64BF8A27CF449327DEA6B7F45C866A047B81C6016CAFA00CC94496531594E3B97FE4BDB4907534BF574BBAC0FD4D3D91F1E5E76E4F77C</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-el' version='3.0.8' extension='pom'>
+      <sha512>15A7944E6283DA6D3410D02C0D7E0B697BCB9291301E354C3F1451AE3D84C9673E24F4FD5E357103E8D88683E97F13F2E9414FBC5B32326B4D78789C80C1B7EC</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-extras' version='3.0.8'>
+      <sha512>1D089D626DB4C0695A2709A44BDDD8F1F2AE7B7247FDBAA3BD24B749C75AE66979C6FF6392301D8998F17707AA189C839E3374DFBC0855EE4812DFAA373E9EEA</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-extras' version='3.0.8' extension='pom'>
+      <sha512>91A9A6A049487A8B6997BA61D574B8A31D1630B788F51B4F52CCCF7140B53244FD58BD6E3886CB44F7C6197F99F8C109FBC0442EE017E40773E446024EDF6A4C</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-freemarker' version='3.0.8'>
+      <sha512>1AD08EDD23D5E1E691B8516D8508A3F4F65D45ED7D204867477C010BEC59D59CA1EA9B4BCCDB67539BE85F6DB356DFACA0A2426B0DA29A8603D0DEEFBBB3A77F</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-freemarker' version='3.0.8' extension='pom'>
+      <sha512>EC6DFBB4A57027AF64CCE4D74C6C0B70E2CDC13FA990254C68ACD0753EBF4FB6C339739CEE396A0908539FAE005D64785302C5A713A1B0FC528EB50410ED3E9A</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-jsp' version='3.0.8'>
+      <sha512>74B3C82753733D2AE30C681D3C3144BB86D8CA0AF9C0F7A5BA606F206E4A7667E0FAE0265153E90F2AA8D52AC5B35EA9A412F08D74956876BD7FC1ECD1EF088E</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-jsp' version='3.0.8' extension='pom'>
+      <sha512>743739D66D41BDFD889A492BFA7E53CD7FB325E5370DF8D3B12B91021CE3C4FC3C089DB2C990DA752EC81A0BBE8E36BAAFE8D99DBF6594ED3E875FCD4CAC9093</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-master' version='6' extension='pom'>
+      <sha512>E166B95DA24F4698E8FF1141DE117F1A22E2D4B2FF4FE34563E5AAA5CB0709F2FEA06B283A547BD18A836F1DC1A00B6A5B5C3F23B99F1B8A0D34EB9FCC852041</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-mvel' version='3.0.8'>
+      <sha512>FB9767C5525C979230F2438E544CEAC2BB4E81A37D0CFF2BD19CD5FF25F73BB24EA29E9A323C2D9F9E0E3CED451AEBAD8EFA531D02AF1F6738CFCC43949E1A57</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-mvel' version='3.0.8' extension='pom'>
+      <sha512>6B3482B979EC63D08F98CD9BE69656A044FAA8E8A8EEAAD5858A726954C3B09C57C1416EDF9079928B6DF074C230B3E45C5E47BE09849101EBF620A3068ABEDB</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-ognl' version='3.0.8'>
+      <sha512>57BF9DE3D3C6DCDDD25D76364B63C267AFE66D04CB2658DAECF2F2A9E87FEABACAE049DADAD47F9F37C2CF5A51932CEBDC54411476C1268F18801E9D6FAA55C0</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-ognl' version='3.0.8' extension='pom'>
+      <sha512>6120682DD4F85400219CA283F1F30B56B453BFF261B53452DA89850C342A55CCABFE19137859B41EFE2A195EE3F1E9C8C7CB5108A7F52CCF94B37464ABEBFDDD</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-parent' version='3.0.8' extension='pom'>
+      <sha512>F5EE46F1FAA2E90A0130ACB5F6EEC95BB0057E5ED08BEE232CD4ACE9800521830E05AD6FC81146E0278082D5DF316DE0CCB9509721678B8A8689C7D73466AA0C</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-api' version='1.0.7'>
+      <sha512>BE071418C376296E11FC40E4CEEC4CC4ED479EDBBC4C22E0DD885A2A832D74612A9D4A251BEAB222AD4D6BEAB2218318CEC64C7AC0B973DD0A030B7A478209D0</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-api' version='1.0.7' extension='pom'>
+      <sha512>91C13A3EC81F27D726A4581B3D60CD5D411637B1EFCF6157CC61F1B982C1B021D89BFC825E8DAFF8C65A8A4B23287D639E262AF8FF7D0145EC0EA6B364DB4023</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-freemarker' version='1.0.7'>
+      <sha512>82ADC72094C8BB06C443637F384EA393DA9FDB50C4AD13EF1C3A817E2452E54313B39CAC4C69D219653BA3908BDFA671E7BF069C556F3AAAAD28D2F7C032E625</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-freemarker' version='1.0.7' extension='pom'>
+      <sha512>ACF6E0536ED4E36530103AA3E7171C8161C0CCE00AC52086443BD325AA4FC249A1A170C462CA92E7982613516EF9760E0C35D816AFCA5766629FEFD03E9A5287</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-jsp' version='1.0.7'>
+      <sha512>1F5C57A454DA6B2641F7F56D6CC5ECCACA2296182180B0D8B150C5C7DDEED90A7412AE5059E6BE074FB6B44BF65C175ED16336CA69F771FC36AB912595A6BB54</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-jsp' version='1.0.7' extension='pom'>
+      <sha512>9E8FEE43D9DAC3A0D76E76A0A9DB11CC09E645735CFC3BE51C3012CF58E55A4C5262D468F8B5B845D44B123E5E4E6CD5E36FCB3CC036355EBF5F730E72F2877B</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-mustache' version='1.0.7'>
+      <sha512>DF9B978CBE0754FD142747CD94BB01755C5AB52B4E6A458F3492CCFCF0ABAB02D9400F4B0EC5D921CE036244003C44FDFB8FE7D146D37502878CA3E26FBE18E3</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-mustache' version='1.0.7' extension='pom'>
+      <sha512>5AAE2CCE2CFC4A2468FB973485E2ED643AF77695F00AE5B95FAA076C291822BD2E557AB535711044BE80BD69FD8EDB51B53089437A69CD2BCB499390D817C6B6</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-servlet-wildcard' version='1.0.7'>
+      <sha512>4571869B6358ED8F508077C8D13DB963039627065DA1EBD00D0D81C8AEDD98590AFEC5EEE12B1036685F44E3A58E4BAF8CF6EC047B32B5EF546134C8DCE65C85</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-servlet-wildcard' version='1.0.7' extension='pom'>
+      <sha512>EA7AA138AAAF3D6526F9FCB4F7C54A86C4775ECD6C07F6C8680CB016EAFFFE7AADC5A8386DB81928FC98A572CBCA9C8BE32C16402D9C12E420ECD9A5B94B274E</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-servlet' version='1.0.7'>
+      <sha512>70FF152FAE60EE2EAA0CB0C29320E15C9432059813C6232FD1C9E89F8ECFA3CAE977E61D3AE2AAC5850BECCF339D6F2D611F99FBCBD1BBD6F407F3062E09E226</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-servlet' version='1.0.7' extension='pom'>
+      <sha512>BF5E084896511E42AEFE301FDE48F635BC88BF18E163A57124C2269CD10CD3FB6A6BE42935A8C9579F5EB2DEDE75792CC3F260D844A6D0E3D2A2C83DBA29AA09</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-velocity' version='1.0.7'>
+      <sha512>778456C5B7121A842D2CD0435822D86BC3E5DA54C8D396C4B3EED4F33D74F31E1EDEDBEA23229596A433A9C6EADAA1AB2F0A06C00474833CB3C7930893AD3CB5</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request-velocity' version='1.0.7' extension='pom'>
+      <sha512>AE95848036342E3C0F7CFAD5DD53B29537B5D3940FE8F06E7DD548C0538BB4621D3BE761A4DE14CE294B11E8B1BF06AFDA30A8208F11F44573A190ADB2C2BFBA</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-request' version='1.0.7' extension='pom'>
+      <sha512>AFC9CFCD8F4C0A78D89290F619396F0CBC996E1682EC6A2B110775C273D4E163CB5EB3F516857D42C216A57240703C475C069EBF7DF9ADB56D295BB94F6525B8</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-servlet' version='3.0.8'>
+      <sha512>C18413345F8A55A8CC48BFB1E326CBB4AA7C698016AF2DE151AE312F299762BCC3C89C2DE5AFEE7D25CA35B1D21B4EE1E6CC2116EB10D0FA0F21B370650ABC8F</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-servlet' version='3.0.8' extension='pom'>
+      <sha512>3DCB73BB316FE90627BD0E4B180D411E007A342E3096D357EE8DE0B85407B43E9526556C468B42FB65C2EC92D69A6DD9F189CAE05AC0FB26C84840CB487D3D4A</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-template' version='3.0.8'>
+      <sha512>89899DAD73BB17D2E1540B0E9FC4332091BC973A22E4A88315465F6BF4A096FA788336A88F517E9989F7DE25E87260C8C3B2BC8BDE5F772EA937264246B409FC</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-template' version='3.0.8' extension='pom'>
+      <sha512>6198D6BF064D885C307951BE969755193C38B5BC14431F7A90D2018F4E1A10AF0EF7D46D878F394967E627DAF60C3EE393712CD40D9D42A1B9F892907017D7A7</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-velocity' version='3.0.8'>
+      <sha512>8ADD5D2BE868172AB2071737F56F6E1C2C973B59903B6E68061B216E70A44F344B69750A2153FF91F1E6D47BFBBE7044B7CACFF2E4DAEED030E92B06AF1463DC</sha512>
+    </dependency>
+    <dependency group='org.apache.tiles' module='tiles-velocity' version='3.0.8' extension='pom'>
+      <sha512>EC59B5575A2F16BA0885D4E54BCFF0FE29D53FC8CF4263325DF402283F39EBBCF2F7B416758B8D3BF290169A9A428B64D7A5F7531253C1D89EB89A130540261B</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat.embed' module='tomcat-embed-core' version='9.0.22'>
+      <sha512>EDA391943A3AA2F0AC289C554FB8B6DE4037CB0EF96997CAFBC205979F827EAA74CC6DF2FB3361BB24746F2CE1AFCA4AF03CD0C9D192352E1D9CE91610AB840D</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat.embed' module='tomcat-embed-core' version='9.0.22' extension='pom'>
+      <sha512>D421C0A32D2FD4C10BACAB7598BF4DD7844473846FFA9FC8B01C9F063794AC0F576746EB323A743279728CB05BE3866CEB04303CB2BE5759BECF2470E4F728E4</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat.embed' module='tomcat-embed-websocket' version='9.0.22'>
+      <sha512>652F0FD95C58729C2B6D336E9117700CAEC4E5E9598F9D72CBE2E5FB67F1A76296803EB66F438C160629B0FCD9D4DB4FBB3BE08E66AFBE035144EB2FF85BA46D</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat.embed' module='tomcat-embed-websocket' version='9.0.22' extension='pom'>
+      <sha512>CDCCE117061BF07F5A70D95964D6EF0074C96205FD8BA578406C4D196277ADCBFF000D08AD792D1DE2A90A306DA3DECEF39162409AA88B4895FFE41482A1E5E6</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-annotations-api' version='9.0.22'>
+      <sha512>108F674E6BF76415EC1400B26580BD1FB0A688B2584886501FCFDD6D316E1FCFF0FC752169C4D424243D7766DC506B71627FBF656974B549BA77985D7609D47</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-annotations-api' version='9.0.22' extension='pom'>
+      <sha512>4EB1858103088F426D9B3CD5C9AAD54FA4440886E35CDE924E7BD74CB589D71A597EF2D5A3D230CD5FD73198EC2A23367438A3037E8E581485D6E0513929D701</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-juli' version='9.0.24'>
+      <sha512>C45909BA6ECE64620DD225A64BA90183644740B2D620B63E51A3BEA2F97A9AFC3923A3A38F097FF73753F718CBF031AB28F508E075DEAF5066BB7798AB164972</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-juli' version='9.0.24' extension='pom'>
+      <sha512>DFB9249DDA480055B3F45F8B97AAF6DBBD14912C94EF912A4926D1E45766902A1DA89A346A9336D72992E23998B3B475D6A38090FECB185798EE58B2D1B74E34</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-servlet-api' version='9.0.24'>
+      <sha512>7150C8894AC7069B9F30E0CBF177745A037430C6484B62F611F810F3F133E3A10D90DC03D1B8B8C7FCEB6FC1C56A0B1D9ACEE682E83CA7D861D8D24033C27300</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-servlet-api' version='9.0.24' extension='pom'>
+      <sha512>54E67021E2D151E4C204DC5AEE4BAA3374A09208A8C63D653E5AB0295A5FCB37B9A3B3B44A119D64658430BF52CF7D8F50FF7616573BB62C2931E754647D91B9</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-util' version='9.0.24'>
+      <sha512>48149BBAE258DF97B7680BAB30841AED53793D7E80A5E3826D319C2A28B533E4D7E9B5F5FBF6D6A030C27BF22E281D2C80CAB40BCA56B441FDBCEE2FE10B479D</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-util' version='9.0.24' extension='pom'>
+      <sha512>563B27FDBFB7FA9BD734E96BCD8448B91E3F479322A26BDE37BA1833C34A5FA2712AD3094883FA7CC15B50933D10CC022774B62955096333923DED94EBDA798F</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-websocket-api' version='9.0.24'>
+      <sha512>CEE2EDCAE6046D65FBF01DFCADAADF376FE1B3BEA584A5B4D889D77431112BE2B23327C9D5822F25FEF53E3E4759EBA7B88C23D36BA83D2E9C9E8304701A9E63</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-websocket-api' version='9.0.24' extension='pom'>
+      <sha512>2CF6E45942270E80D383036300CB65D38CC1FB00D053F963A54242249832FE85A1B5D69F45D4B8EE07767061ECB8001B7DBED773CBBFA54F77E8482806BBDB30</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-websocket' version='9.0.24'>
+      <sha512>F7B7DACB0DBA7A61F793D1963B16837147FA2699ACD79AD9F508FB3642C5641EBF952FEA04AE3DC31BB441CCEE7437B87A45166242A0529C94C113C3760592E0</sha512>
+    </dependency>
+    <dependency group='org.apache.tomcat' module='tomcat-websocket' version='9.0.24' extension='pom'>
+      <sha512>B5E3407A15729377C4872D4854CE000F528054E7FF5D8071E96AFB0C3A2A84BAB60123761241DCDD4689C4D1FDA78432AB254B4689959DC82C4E1A3BDA5750D6</sha512>
+    </dependency>
+    <dependency group='org.apache.velocity' module='velocity-tools' version='2.0'>
+      <sha512>C10486F112BB7119A557FE9A138878EAE980EB57027A5BDDFA249E171EB2589FA8D3D36CB77E825CC336245D7F8455E106DAA04C54C6EAE9741875A332AF15BA</sha512>
+    </dependency>
+    <dependency group='org.apache.velocity' module='velocity-tools' version='2.0' extension='pom'>
+      <sha512>EF3751F1C98910A96AD86D8DC700EBF7B2B1AA6B35F434FE124CD62C955516816D695C7AA49B504FD61325726D91B7F13FF2D45FF63486285FEF3431675E11FF</sha512>
+    </dependency>
+    <dependency group='org.apache.velocity' module='velocity' version='1.6.2'>
+      <sha512>7336DF9EE80E0C11E847E4B9259EE045300224CE37D966210050F7AC3F41221E14732B1A040CC111677469197B3F27058A246B3D5E46DE85B595EAEAF7E81F5F</sha512>
+    </dependency>
+    <dependency group='org.apache.velocity' module='velocity' version='1.6.2' extension='pom'>
+      <sha512>448C533E26553C2F4C191F4B0AD2C755909D557DE65741714EE5A42C179C64607037AE56EFA84D438089B82EC3D976EE0735869937BC934118C6C0F684D1F7C1</sha512>
+    </dependency>
+    <dependency group='org.apache.xmlbeans' module='xmlbeans' version='3.1.0'>
+      <sha512>21B85E532411EDBBF4929E20C4491D3FE0D7B4BB15733B58C6455C901D4A05F918E73B6521E71C62A89A6576D416CDDCB79B0C52082CD8132FC30C40E506B4D7</sha512>
+    </dependency>
+    <dependency group='org.apache.xmlbeans' module='xmlbeans' version='3.1.0' extension='pom'>
+      <sha512>B45684AA06CED1C1D3EAC1C6F0695E75E778722CE8580D854CFFBAEB4ECF8D4A184D9485550B3F94EF3FD70977C49D869B33A9DB8FF26EB6A7F73526EC457D8</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='10' extension='pom'>
+      <sha512>D5EC11A0D102169ABC3C86BAA7C7C8B4E4D9052FB04D86272204F5DEC194496E826D7B8A05232FFEABAA5D759F521F2938513D0FCB254D331F9C0B16CEA85D27</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='11' extension='pom'>
+      <sha512>4059F0F01DEC786DFCE4667B7680F8787679B28533E596A16113B18F8398BD941C3BA089588301AB03E1227631163F613E11DD0C66AFBD63661BBB6AF069B313</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='13' extension='pom'>
+      <sha512>3B25F9F51A7EE9647FE2E1287E75A67CCDF3F08055BEC20C6A60B290876AFC691F16B23AB3DF7B733695B828411B716A0B3509C22EC6FB0C5DCE4F21811AE434</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='15' extension='pom'>
+      <sha512>FB2E3C20F895461A76F8A40D69BB61D8AD17EFAA7959877772C290BF982950204F3069F8E60191F1CE8251281A77594BDF010FB3E178DD8E7AB9930CE1D13F23</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='16' extension='pom'>
+      <sha512>82393CF3A0282C45DF8CB945CEDFF90E314CC30E96C0F1D112C9B1A222084250D465377973FD8AACCA8BFED5D4B9032544A5369929164811A289E0899FF6F08D</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='17' extension='pom'>
+      <sha512>1F46CDFD0B29F7FAABE6B0C3EC096408D52CF321DB81100E69B737443F2B9E71B68A3BFA8F64E318C16859E2DE8DAAFBF40BB0C375C10354A892217CFEEE5BEC</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='18' extension='pom'>
+      <sha512>9EF6F99B30FE2603AD8F2C88116072DE36BD2DC99590FD9E7EECF153DBF50CBD766694D861E666138D2A26137BE69FE98CC38A491F6A2A68E8D421D656731ED1</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='19' extension='pom'>
+      <sha512>DF32B2A73711680FCAEF0B986BE9092E241869A105013001BF33D93FA828A82103280259B78D3F6E1F0ADF166288C8D063EE8EB9ED9139F558DAC90E3EC588D4</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='21' extension='pom'>
+      <sha512>C82BD27C06D76B3F467118B1A8E0976C60FD0E7D7A01DAC685C9A91E1822C0E6F5829BF48AD532A9FC000089CDB894A97C5686365FD3C8C8BFA787136A4FA9D2</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='3' extension='pom'>
+      <sha512>2E07DC80988C9CC3DDEF4D31DBA266AA71F01F25E1E8BF541D3C538C8D7C9C19C7D3C8BCD2A7E19693DA311D32911DD677FB4A44E48CEAAE25D5FF91CC77BCF7</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='4' extension='pom'>
+      <sha512>866F80B02DCFA294FBC77DEE0C14E019F5B9FD0D7CDF893C2269E93B17B9B6AC49AF76AD30952E87B55C8EA5896D812842FF2F05C69A1553B6EEBE0A11A5B4FC</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='6' extension='pom'>
+      <sha512>40C2E903702015BB14AF416BC1E33E04B18EF8D714B3424F82B1CD7154A9195E8797C9362D83BF4B88F999D42382D25DC4E7E48D0628CF9BE4C57084EE4CBEAD</sha512>
+    </dependency>
+    <dependency group='org.apache' module='apache' version='9' extension='pom'>
+      <sha512>E909813E0E718BCD76B53EEFE9DA1325DD1254CFFB7F11AE5016B53DF500DA562B1C100A49C171CAE87DAC3A75B03610F4FFC39C14656C34E61FE93FB4A4A938</sha512>
+    </dependency>
+    <dependency group='org.apiguardian' module='apiguardian-api' version='1.1.0'>
+      <sha512>EB05878CF282E971A7FFF0FF4A1B7B90D61E6405EA368B19832177269B21F66AD4DE211F6ABDD762165A72E1C19781A6DF1187E6C1CCE1AE2CBF0E913FC5F504</sha512>
+    </dependency>
+    <dependency group='org.apiguardian' module='apiguardian-api' version='1.1.0' extension='pom'>
+      <sha512>F3E80C4B33B5E75F1584CF48E3FA2AA9D9BF3CBAFBCC7EC4A74E7B2EF661D32E7785D2D286C15FC47718A54B33BA899718ABD8210B5997AB5AC26807B3DF5389</sha512>
+    </dependency>
+    <dependency group='org.asciidoctor' module='asciidoctor-gradle-plugin' version='1.5.8'>
+      <sha512>DC21707A30C84A426C898CA8C7C6619C8F903D55AAD72B279E263D099D6E72E16995BBF1879537E24319B043A2DC95911CA42D220E4CBAF3ADDD285CE61FE65B</sha512>
+    </dependency>
+    <dependency group='org.asciidoctor' module='asciidoctorj-groovy-dsl' version='1.0.0.Alpha2'>
+      <sha512>2FC7BC739EB3ED204C851864848007711EDD1B59A8A838B446CE7F770C7E27AD03F0BBF02F2AA18D77A08D721FE107471FEFC0F37C513E4BBC8501D82D13D501</sha512>
+    </dependency>
+    <dependency group='org.asciidoctor' module='asciidoctorj-groovy-dsl' version='1.0.0.Alpha2' extension='pom'>
+      <sha512>36895B751E32F1167E1DB2D1F372290F9565B64D780E3863E2CE8A1D72B6296B6EAFC0C564FBAE36AB5F7A4257CD352EC1B5AFB8759EA546AED62DDFC028E912</sha512>
+    </dependency>
+    <dependency group='org.aspectj' module='aspectjrt' version='1.9.4'>
+      <sha512>F0A619BF94B92A5C8DC2ABBD0D0E03DDE573B5CCA205E0CBF36BBCCA646B312B92F473B7318D2064A0D8D2645675ED3953AD5BA87BE78D21041CB006C2613F13</sha512>
+    </dependency>
+    <dependency group='org.aspectj' module='aspectjrt' version='1.9.4' extension='pom'>
+      <sha512>5409767A9F7D2C915286783F6B9D611FC064FDB498820396500D78A5821A0F56236FE3F9F8ED21821AEC45F93AB17610F92F822873386F8ABDB328C8F2DBE8C7</sha512>
+    </dependency>
+    <dependency group='org.aspectj' module='aspectjtools' version='1.9.4'>
+      <sha512>4D1BC5A05F23D1108CFC77EBB7B67F24F2C8C6C747446818C0A66918131D965190AA92B01BFB4741EEE34BAF3773AF9324D17F9D527F42EAAED62A16D8CA7CDF</sha512>
+    </dependency>
+    <dependency group='org.aspectj' module='aspectjtools' version='1.9.4' extension='pom'>
+      <sha512>9F968E49218C780F6911E953A2317F08E365B5FC9BFC4374856AA43C03E22BCF5529163F36B822DDE165EEDFF8474DC2273CF4D29714BD8B59CE1064B030518A</sha512>
+    </dependency>
+    <dependency group='org.aspectj' module='aspectjweaver' version='1.9.4'>
+      <sha512>57F85FBE052A662063DF3353E5294C51DD8696462EC930526D1DA632B4100E62BA62CB6A044DC93EA6F38B4AE40B1FF9C9CD9F1728CD9C474ADA3E07562B3BCC</sha512>
+    </dependency>
+    <dependency group='org.aspectj' module='aspectjweaver' version='1.9.4' extension='pom'>
+      <sha512>6F7D92447BE826656A023AA38D6304A567E7C502FD6819316252A870F92CF1F332B81342B70FA84DBCE9FC3A0DE9A58F1C9961C98EE6ABB745CE30B356711E89</sha512>
+    </dependency>
+    <dependency group='org.assertj' module='assertj-core' version='3.13.2'>
+      <sha512>2C1D7238FBA893F3C693BDC49815605C6B5F5EAD60DED678FD66A68FFA318FEDC66DDC9298A423F7532293536C653DD7BA701A2AED97884C3099556415AAE0</sha512>
+    </dependency>
+    <dependency group='org.assertj' module='assertj-core' version='3.13.2' extension='pom'>
+      <sha512>1ECFA19F5491427A9D548AB65F9BF38CFF49EC3933C4512FF29D995B78739429C5C96046663901CADFBE01A33F7A671D0C66AF058B988B1988B298327EE5914E</sha512>
+    </dependency>
+    <dependency group='org.assertj' module='assertj-parent-pom' version='2.2.5' extension='pom'>
+      <sha512>A8DAFFD6869757DAB6FC28E8747F756B76A12D8342280296605249487A4B6B21591EC61072A52D71B0A37423C1D19A85F733318BC35B1C5D5510A9C1A72DF436</sha512>
+    </dependency>
+    <dependency group='org.awaitility' module='awaitility-parent' version='3.1.3' extension='pom'>
+      <sha512>60CD9D6509505794DED75992EE34B8DCC662B9B2288AAB61B380FF5D5EDD7E034943A16BFDA30BF2BA72BCBD831B32A74B922598DA331B99CF9A01163427EA4A</sha512>
+    </dependency>
+    <dependency group='org.awaitility' module='awaitility' version='3.1.3'>
+      <sha512>397B9EBF93F8BA648D5D9F759C5E75019F62EC18FDB9F4936D6165776C4A9957FA6502C0A915407C3B771107F5E662E451A0E198FF8EB807AC745BACC08F74B0</sha512>
+    </dependency>
+    <dependency group='org.awaitility' module='awaitility' version='3.1.3' extension='pom'>
+      <sha512>5BAA9E77497D10307302AC688D5EA98383B34DFD44DC3B9FA5D7D9FE2BF80A8AFF0E567BCCC3A577708D6210B221CBF4EF303E749980B25BF1FFA938129DCA8D</sha512>
+    </dependency>
+    <dependency group='org.beanshell' module='bsh' version='2.0b5'>
+      <sha512>D3AC6E7E72BF2653F81734B4632D8F53107099FAF959E2AA732591E16303DFBC94BEB8DD7CA6C718EB2B6493EA2E2F3090CD477798A90F96F8721E969058DFB5</sha512>
+    </dependency>
+    <dependency group='org.beanshell' module='bsh' version='2.0b5' extension='pom'>
+      <sha512>C6E7C98FD86FF2727C34FAA316E84E351DC23ED419F9D9854053EB4143697D04C70D56AB5E4DFCDACA44D6B45364B57FEA835792A003BC298DA78CF56D30CA39</sha512>
+    </dependency>
+    <dependency group='org.checkerframework' module='checker-compat-qual' version='2.0.0'>
+      <sha512>FDECC20EFD6943426E7F8BDFB8BEF9D28258F9F934CF29090E2F5B297C501454606CC28593CD7D089A5C14F6D2DCAFC59F4606053405D7F91D623A0E3202F4A8</sha512>
+    </dependency>
+    <dependency group='org.checkerframework' module='checker-compat-qual' version='2.0.0' extension='pom'>
+      <sha512>859C0A3F0942A9AE83746C126438E4B713ACD4B3BC18B6441A37A0689E2F8C0807219CF5DCEB1A888A899C2B93298B8E578BB62E0C394899609A01A70C96CFF4</sha512>
+    </dependency>
+    <dependency group='org.checkerframework' module='checker-compat-qual' version='2.5.2'>
+      <sha512>D3191EA47827D2B6366E5D9DDCA246D191CB6067E64DC5569FBB9DAD5896C17F6F009EC63FE68808626859684CDB08604C17FA6E9F1B72DEDBB529D6F900365D</sha512>
+    </dependency>
+    <dependency group='org.checkerframework' module='checker-compat-qual' version='2.5.2' extension='pom'>
+      <sha512>1A32A0A11A86265CA33336F343FF365497FF14FBCD78C00CC64AB2472DD0064CBEEC3BDE54098837F34ADA46809F07F79C6CDAB67FB9F815D8DD921BB9C8D4DA</sha512>
+    </dependency>
+    <dependency group='org.checkerframework' module='checker-qual' version='2.10.0'>
+      <sha512>28E6BD26434803086432751E50F22D1F412FE69A52EC8159720B24A83510F9DD75EA8AFC1AD470522F56BA5DAA4BE21A43FC81735155697D96B72DBC02AAC4F8</sha512>
+    </dependency>
+    <dependency group='org.checkerframework' module='checker-qual' version='2.5.2'>
+      <sha512>FB32E3893F9EBC956EF99066B219A8FC8049B47B80A7253CD89B7FAADF0A2FA14D60B52DD5C2F4AAEB1DB0359F49FEC9E29D3616BD314EC8C82DB1C657BE8CD2</sha512>
+    </dependency>
+    <dependency group='org.checkerframework' module='checker-qual' version='2.5.2' extension='pom'>
+      <sha512>1ADED4CA8C790036A3DD733CD539B81D14F29C1100F45E60324ACCD02099ED9CABF4EDDE2DBA6B690F4D205CD389455B6552572FC2C62AB7784295AC245DAF25</sha512>
+    </dependency>
+    <dependency group='org.codehaus.fabric3.api' module='commonj' version='1.1.0'>
+      <sha512>39FA764393F981FEF84F7163193C28810E15B17B61E7EF36EB9BEDD2F35B2B201B434ACC7F875869B886269930B787A99A7A56BC70E6B7C5C2DA0D8A16DD1FFB</sha512>
+    </dependency>
+    <dependency group='org.codehaus.fabric3.api' module='commonj' version='1.1.0' extension='pom'>
+      <sha512>11D5C63A23E3D4979B2350EEECDE6B8A9AE7157D5A77D7CD2DFB02766586E9A200821B6A63066B62A97A836317D202FA762020218DEC57D7A27F4C22B5994E84</sha512>
+    </dependency>
+    <dependency group='org.codehaus.fabric3.api' module='parent-pom' version='1.0' extension='pom'>
+      <sha512>BA3B6D7CD6B4CCFBD5E45DD77EA7CCCA670B32BDF42BDD824D00396F2276D3A94471947C8B1B1601395E27F633DFF30FCED20674A934F3AD3EA0EA04330E2B6</sha512>
+    </dependency>
+    <dependency group='org.codehaus.fabric3' module='parent' version='5' extension='pom'>
+      <sha512>58C9354EE7E7789674A6CFBA3CAB0C20DF157A3C756554709D80F48BAA4B09176043F994ED8F270EB2C298661F2F5589EB8A06DCAEB866A77174878B3B0CF920</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy-jsr223' version='2.5.7'>
+      <sha512>31FBA23A00684DE2F154BBE583CE25BEB997D1F2AC4092EE2783F0CB1262ADA527E3A68BE4A0F2B60FA3DD5B83878699FD7C2B4B52E86E0E37EF6B8E78BD1B30</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy-jsr223' version='2.5.7' extension='pom'>
+      <sha512>1EA65A3ADFE56ADE80AE93A929DACB6F050CB875378E1D6F72C8C9E8F026C29C73F2B2282BCEF0209D338E578E545C4CACEB96F8E50E508C0BF78CD2A0B35519</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy-templates' version='2.5.7'>
+      <sha512>E9E6E60D8283944DD50C680CDDEC016517751ECD92D163429546CE20DC1C32F66AA8D085E7A7983DD1B83E7A7F30A963766FD61205A42911802533EEFD5323CD</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy-templates' version='2.5.7' extension='pom'>
+      <sha512>21FF0240B4EEBACC31052444D57907430FB89A647D1405CF804094848E065338EE674E5B9CCA05FAC7BB8B24F450B76E4DD5FAD3333FEC6C2682C4A643657E15</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy-test' version='2.5.7'>
+      <sha512>4E07343B625205CEAE672B4CCA0D4C56D377EB91D936D679BF78A79A0323294CA60690CEEB8B06D3BEF0035D7ED11DD9FB0D381C6D4B94D3CF32D3D8E79376D9</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy-test' version='2.5.7' extension='pom'>
+      <sha512>3C59B404BE405930E6D44935060FC76DB8E7626866DEE99D06388E27F19A280E205990CB5B37BAE69F449CAFCB605B168A2C26361EC3DEB37B174B30716F65E</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy-xml' version='2.5.7'>
+      <sha512>13C5AA3494514C4DF3F3D6E703C5B9C2E25566F047003B2975198D098EBA6E2AD9FF6B91F99EAD87C60FAEEAA4783C1F2428E92F7D98C24588881A78085CBDF4</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy-xml' version='2.5.7' extension='pom'>
+      <sha512>E8BABB4008C4AA35CE339918F03AD73824AA7D1705072BD62AE8159E1EF91160877EEB6C2516C4C41A2BDE793700EFAD224393F7C3DA15C652C32FCD724FFCD5</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy' version='2.5.7'>
+      <sha512>5C5B808CCE8AB631606CDBBD5980A5843D1B3DE09934F32C8AEDB011467722507728C47A7F4BFC2D4907F0B1ED4507D49D545FE965379981DEB9269C5A8CA3AC</sha512>
+    </dependency>
+    <dependency group='org.codehaus.groovy' module='groovy' version='2.5.7' extension='pom'>
+      <sha512>D484C953B1AEDE18F69DD1D80D987230F8A533511C23667BDFB4DD1375456B559D44BBF188AD1A71407970AB96E5BDCEFD214D2E5B7012059E0170A3697788F9</sha512>
+    </dependency>
+    <dependency group='org.codehaus.jettison' module='jettison' version='1.3.8'>
+      <sha512>A000B0BD481AE4ABFBD18AB3DF141266E979BE87D1B2116835AE93269BE2ACC816D8C6A4E3C9580331F572A997EEBFEA1054C71FFEB1499FD39C8B074194AA9E</sha512>
+    </dependency>
+    <dependency group='org.codehaus.jettison' module='jettison' version='1.3.8' extension='pom'>
+      <sha512>D0BCA67A16686DE7670F13582E10CEAECBC76BA44819953423AF61369069C129B379CDE9336579F241B658D7ECEF9A12BF79F892D0346ED6E17637216ECF249</sha512>
+    </dependency>
+    <dependency group='org.codehaus.mojo' module='animal-sniffer-annotations' version='1.14'>
+      <sha512>9E5E3EA9E06E0AC9463869FD0E08ED38F7042784995A7B50C9BFD7F692A53F0E1430B9E1367DC772D0D4EAFE5FD2BEABBCC60DA5008BD792F9E7EC8436C0F136</sha512>
+    </dependency>
+    <dependency group='org.codehaus.mojo' module='animal-sniffer-annotations' version='1.17'>
+      <sha512>94D0335CDF94AA547AD6C0C7E44B8E3BDA736CE19D941DD0FAA3A45390E5AB2D122022FF4E07BB9AAEDD41FFBD9500F324E0A9E42F4C5441BCE0774F44872F45</sha512>
+    </dependency>
+    <dependency group='org.codehaus.mojo' module='animal-sniffer-annotations' version='1.17' extension='pom'>
+      <sha512>7BBEDFECBBAE0DBF9FC422BCFA5C3FAA8FA7F339C24DF73EA8D5BEF71ED3E7B0EBC6656F574E2AFB9D58B65FCCFC2D8A65B934B559D2AB29642DEC8292F29748</sha512>
+    </dependency>
+    <dependency group='org.codehaus.mojo' module='animal-sniffer-parent' version='1.17' extension='pom'>
+      <sha512>4422F2615DD9FE2611B1DB3D7D3BD02CA178544D63B62D8EAAD0340A6DB6326F508F9DEAF4C8038F6C480BE435C20C063398BDC0C835484DE895137BCD47CB0A</sha512>
+    </dependency>
+    <dependency group='org.codehaus.mojo' module='mojo-parent' version='40' extension='pom'>
+      <sha512>B203B18E4F0C410D7BDCD2ACB73DFB84DF48ACB6E3A5BC344CC6862C7E0FEBD0D7E67DC343D4E36E6C0692110EC2230DCDD504439AB0C2EFFC187E60EE966DD7</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus-classworlds' version='2.5.2'>
+      <sha512>5BBBCE8880A8513BA1314C202005DE96FE263B48F45D5CD6A3A3577FDFE7CCD88C2B908093EEC237E6624F5DBBA664DFB8AA82939CC540BB6652C0F4EEA7B333</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus-classworlds' version='2.5.2' extension='pom'>
+      <sha512>F4A2A895694519F1E53BFF3488E6DDBA51C6BE4C6785B3261339DCC5DF0A13A208FFC45F286707627297A7B47279B9834FD328B4C3074F5288A6DE98907D52D6</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus-component-annotations' version='1.5.5'>
+      <sha512>2EA4AFB8888F157483C6A8E99852FA8A80E90A3CF0756B3B22C73A8BC59A4AA3D7B50B975A1D810F28A090023B268DAB49AF14E8F8E33C7553FA61315AFE06B2</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus-component-annotations' version='1.5.5' extension='pom'>
+      <sha512>DEFCF51A9D23C6B6E6E143B1FF20051A9980B2306B8400888A9C2FEE7C4C4822146797D024483B97CB6A3D5E7B2AD0E0F324A8870FB09E848FCE11AE83B6D47D</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus-containers' version='1.5.5' extension='pom'>
+      <sha512>1CF02E85512A39504EC9128F3D90B955EB2D365F054358D44F194AEA15B592CB5A910F812BB6A1F175EFC5CC4ECEDFB63301369BC4C21500EBC8F4383E8FF75B</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus-utils' version='3.0.22'>
+      <sha512>B0BE4608A6246630463989CBC7A554E4D6A886895FE9B9D1D38FF525E5EF9BCDBC96219731EB16940C6936808824E533BD6AEDB77D8376657680A137E51E1FFF</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus-utils' version='3.0.22' extension='pom'>
+      <sha512>4184DA9701A6DE161D20C6520BCB96AFB70A38C0A7FC37C1BB1906BDE3307F189BCBCD8D1CBA7149FD281E2284D8122F61BD994E19668085563289605D60506B</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus' version='2.0.7' extension='pom'>
+      <sha512>597B26C100D02736E4FCC5B87FB7F8C3BFC4BF7787F6FA1DB95A8CF7283A3DE6F6389986AD3B941D9BC5161A904D23055072A9285C9487A6D8F39007E6CAD59A</sha512>
+    </dependency>
+    <dependency group='org.codehaus.plexus' module='plexus' version='3.3.1' extension='pom'>
+      <sha512>58306C21CFE930E2A0E4F200BD57C63E5A479951590E260C515035B155AFD0C09912A4E7EAF6127455712BCC3708A71B31687F1FAC3D70CACEDBE0FC4E831B70</sha512>
+    </dependency>
+    <dependency group='org.codehaus.woodstox' module='stax2-api' version='4.1'>
+      <sha512>A3C760FC50D584BA9CDD7795F380F6BA5B173B655FBB7246AC6BF3A590BE6362F06E7F04F41B8274FF6A93883877826CCB0E0090B16CD8E9336FC8BD378E139E</sha512>
+    </dependency>
+    <dependency group='org.codehaus.woodstox' module='stax2-api' version='4.1' extension='pom'>
+      <sha512>CC84B16974D6834AB200FB5BD5898B767CA94FE259E05A3B9E833F2D7A849840B3DD5E58965191735314BB9A70D91455821BDBBFB295B80ADD35730DCD1A5B51</sha512>
+    </dependency>
+    <dependency group='org.codehaus.woodstox' module='stax2-api' version='4.2'>
+      <sha512>4C7642993E96B6941CF80FEB8AE7A285A0C6C8102D629CD265EC493BD05A6F2BAB5B37979749430E0AA0625C269088692C36ED063B52E3B95E346F54E5DFA358</sha512>
+    </dependency>
+    <dependency group='org.codehaus.woodstox' module='stax2-api' version='4.2' extension='pom'>
+      <sha512>C2E665EC252F4CF393AA67D529097CB7ADE3032F43A1F17DD458C6CE09CA0D4127385F7FA7D794646DED1D259E179D035B3B265A5C7E5B8BBD638AA356A32217</sha512>
+    </dependency>
+    <dependency group='org.codehaus' module='codehaus-parent' version='4' extension='pom'>
+      <sha512>F7D1EED462EC0F6E5EEE903672EF1593203041CCA328F9969F94DE5495297AF719A6B73901708038916333170D882F55C2F5E179D5321B360FD64B094433D542</sha512>
+    </dependency>
+    <dependency group='org.dom4j' module='dom4j' version='2.1.1'>
+      <sha512>547DA0752FFB12CE40800449376F2F7E20F053F816DE4AE8ADF1A4FAD5A3B87CE4E98E95650671A6C9CDCBBF7C20A4B61E711E5AE8D324C923D508BCB07E02E1</sha512>
+    </dependency>
+    <dependency group='org.dom4j' module='dom4j' version='2.1.1' extension='pom'>
+      <sha512>861DE2340BB3E2EF6D31A0A11F7CD42EF0111035988AA52674D66D6B42E3E3E564436F287E7769B9F21B52A703E9BE394A5E32ED50261962F2BC3712A5E5FEA8</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-api' version='9.4.20.v20190813'>
+      <sha512>4FFA92CD7B3018831BB03E0BAF225D5438E6784B7016496CAED2E1815DE31329A76CD6C2E425445301E84B59F0B89E279FEB007A338B3950A5365D30B7248230</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-api' version='9.4.20.v20190813' extension='pom'>
+      <sha512>A903242F0CDD7274589651C07DD343A94B4E46F274D305AFC9D895CCF07F9FB744C3BB805B1E4DC5CBAA615B9DFCCE21E32B15EDAF943B67345A472B9F5FBCA2</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-client' version='9.4.20.v20190813'>
+      <sha512>ACFFD78781E67772D366B6ED4BC6804BCC9A96395F67E2A02AFC30761BBC4E22751843E0A82D33BF23047CDDF6BC3C63E293C4F65A78F40774CA0D9038547B02</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-client' version='9.4.20.v20190813' extension='pom'>
+      <sha512>BB3D9787307885E2C9D8B41B7937483816E28F66F41736530065B2098C7C2741BFF1CDC0669378FADD6397DE58BFD1C533AAD4D867FD79AE89E8D20B14397041</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-common' version='9.4.20.v20190813'>
+      <sha512>9AF7068618287266B109F463A6B16F69A4D25027425ACCA204DC14CC13EE47717FC39D03D314B1905B2AC5C6DBE0B36C1EC45DF1D13D90042034A4C8FFF1D87A</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-common' version='9.4.20.v20190813' extension='pom'>
+      <sha512>3CB0639FCFDD4716828041EB2917E5A2AF2C1E93CA47A18620B70E7B1EBF93263B1A222E60961A54CB22937EAF37A8ED3B29E60CC81EDC4649FBEFCAD4180A4D</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-parent' version='9.4.20.v20190813' extension='pom'>
+      <sha512>A8743869A4B230F259C05A78A391C35EF96FE99F36D4455530D53A06673F90C0DE9E20C3FF06D9CCA84A7ADD2762F08F5B8245AF617FB03F8C739AD3B528B05C</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-server' version='9.4.20.v20190813'>
+      <sha512>ABCCA0396F98C92107BFEEDDEDB6F5AB7A31B3233FFB9483B0D47779680CEF377E93C6EA71AD9E3A7AD0DAB0FC152CC1885349CD9D5E03E7A7A46450C8B5AFB8</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-server' version='9.4.20.v20190813' extension='pom'>
+      <sha512>CB779AD99F827BE7FFA0F35D5DE0DBA78229827AC2DE900FCF0913F0678FD978927B95ACD6B83F2218439185FD5C86CF0F01C570B89C70E43AE9D3941B3ED6E4</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-servlet' version='9.4.20.v20190813'>
+      <sha512>5A1817F9FDB458AC0CAF117966C8587BC190FEC981C1D56702D7AB7E0790148214BF89CEEEFECF8F2E0913454FAF8AF898545AE387DD570BCF17619683E70BBF</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty.websocket' module='websocket-servlet' version='9.4.20.v20190813' extension='pom'>
+      <sha512>CC9893878E9B409D33E94B324580CDB4E9E2640ACD04CB591AEF2EB031F0CB160B0F8601B4C6ABBF8A03F4A26431CBD534D5816FA1B1783E443BC72E336C9430</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-bom' version='9.4.20.v20190813' extension='pom'>
+      <sha512>15BE5A4EFF0EF9777347654E37F4F6B45FF0FDF8097A82844F882151E74716865AF455DAAFD45DA2F561B3166491F5D716232CB19EE7A1AB6AA66DF45682284E</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-client' version='9.4.20.v20190813'>
+      <sha512>EA4C1C5B09D3200E4D412ACD6A8806EDC80B353CC620D9A37B6C35843F27A8847D23D2F6C42FA1AC849734B3FEE54D7C490CFC0023629029F2CE98066BA1297F</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-client' version='9.4.20.v20190813' extension='pom'>
+      <sha512>6923328B65F6EB80FED997E8C79FC0A3BA95F1FA56ABE514EC19EC1C487365FF522361CD01FF5CC64DA89A6198B9B2EBE45DC9282D09C7D6075F5FADCC31BB09</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-http' version='9.4.20.v20190813'>
+      <sha512>34F2C99B0EAAC6112A426EBE48D9AF75E73241D300E773690ACC262766904D36B7B49EEF4E1C23CCE20E68D79D021E4D7520EF8267922DFC65624A300CDEDA54</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-http' version='9.4.20.v20190813' extension='pom'>
+      <sha512>2675A9787C8296E47F12140EA87EE0E4EFA592CE103BD1C385199201FC9F36AB884F7AA666A51121C67A1A2697BEFD3F708A59F0F81259D09848673BB0B3CF82</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-io' version='9.4.20.v20190813'>
+      <sha512>3C3E6759658F952B0F777E4BB75924C61A0F024AD9CD87C06F54AC2C6790FCC9D97AEBF3430B4F3BA7E8869A4CEAF4B6B703C8B8EBC460C8AB427A553C0D6768</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-io' version='9.4.20.v20190813' extension='pom'>
+      <sha512>8705667E99C092D3E896007F45CFF18D1711662B32202FA110876AC9ADDCE2930A6B6F23F5540F589146E4DC40DEA980B4668225CF2314D68EAE7D34D6C5D279</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-project' version='9.4.20.v20190813' extension='pom'>
+      <sha512>E39ED89C8EA0A578F3F79EB199039911321BD0CE7E41F26F3CD92748458741744182720BCCFC4A138B6D5773E3F4204A46396F3AAC00EF60AF9B67CC16306956</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-reactive-httpclient' version='1.0.3'>
+      <sha512>5A4C997E0EC0754A3D7983521641C511960AD1E5EF8175A2E8026860212651A45765BD06DF74FBCE4188B96915D15288D427C216FB40776AFB32E62337F0C082</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-reactive-httpclient' version='1.0.3' extension='pom'>
+      <sha512>86944FBE838D76FAB73092AAADA5427AB6A0CB255E29B822541AB95517AD8CADA9EA176BAD03A35E9BFA5B8EC9C03AB2D4EC19B09E3750E2350C0716C01C561E</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-security' version='9.4.20.v20190813'>
+      <sha512>2EB2EB9B4BB925A860EBBB8B9788824E7584F026EF729CF277CF85EEF0916149B71112D0DFE12E869B379E4DC15FDBA36AA5D610BE233C0F440E3A6E099C4F44</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-security' version='9.4.20.v20190813' extension='pom'>
+      <sha512>74CA4B0CDA1AC20B2764A4FA0F40D97D82E68F3BF7ECE559828CB97BA79094B6DA170EC65CDAFEF287DC1B5D1C303FE568BF2A729A9AEEE6C26B4CD1E21A53F4</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-server' version='9.4.20.v20190813'>
+      <sha512>4CA2920BEEADDEB7395AFF5BE56C84B675C32E6A417460283030AD3544577423720D75C8AB2A6FC0303D7528FA4D78F3D27F6A5138D78516E54D07B2C5AF4B9D</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-server' version='9.4.20.v20190813' extension='pom'>
+      <sha512>22ABD3CC6D37375BF196AE0F8A430834A66B3FB5664A6F1E1F115E20E7AB7CB3D1B3E4AC94E25DF0BA6E13C10D3170AA965206F00DD0D1848908D69203F16C2B</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-servlet' version='9.4.20.v20190813'>
+      <sha512>165688985EA7ECD0480ABF9B197E0A7498923FC5E0FAE60F0D6607881B52F17CD72A0A8175736F0FC5E46DC5223006CFB68B74F5A7DEE4E6F1FA6BE08A4025BA</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-servlet' version='9.4.20.v20190813' extension='pom'>
+      <sha512>9DBE71D4640FF46F3B00F01F3B24B226CA98E89598940EF4A6F43FAE1E8DB004A85449ACC741B48D54F4F83864FA396036E11AA6065F61790942F01F282E6EE</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-util' version='9.4.20.v20190813'>
+      <sha512>A49B005E7C6A13299361A97152A1D30769EF4EF4076350167707CBC2280584BE0C8130134652132A3D286C401EA1714E251B21516F9B2805D7C373EC6F709316</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-util' version='9.4.20.v20190813' extension='pom'>
+      <sha512>80535F7874CE6EE547E1E6D43F1FA86EF11C500A54A30EF0023E370EABE9970EF99504E07BC4D0D5AAFE8A9367ACFFD9C55E5CB44A3C0D1D7FD83137DBEA5F0D</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-webapp' version='9.4.20.v20190813'>
+      <sha512>9D7C45FA411F4930573BB5ED9089E498BE00E2D358E09085A5D26B2B3765BC3D09F2C7C40C85939787EF845C988BDC5777EE2D2328E7A6EC6B91C9B0F636ABF1</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-webapp' version='9.4.20.v20190813' extension='pom'>
+      <sha512>16312F720EE706283E8F75B464A31B23527BC2BB6462A56C2D461FF4B651D9368D3E2AD64582A2EDB9DB31B34E5F9283435B756EF9B83A6F4E22710AA37B11E3</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-xml' version='9.4.20.v20190813'>
+      <sha512>909D51FA90CDD3A9BCD5A7A0C0935F8469F26426D549F6EFCBDA014FF2833FE62A48CCE2D1E9BC37D3EB154129DB5AE440EB5930329C32F9094169A6FDCFEAE3</sha512>
+    </dependency>
+    <dependency group='org.eclipse.jetty' module='jetty-xml' version='9.4.20.v20190813' extension='pom'>
+      <sha512>ADF046DD7258A9BA8C88DA83A3BE9C45176FA0F6112BCB455A84BD7548AB67D57ABB363B290A275D6B9692EDA478FBC214CF70438E9A9404991EF01B9E2916AF</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='jakarta.persistence' version='2.2.2'>
+      <sha512>68FF94EDB570B5C4B40CC1D12611F0B2CCCEFF7AB66839D286322C4AA88B491284C1AE7424F5FA6A25CD7F4FC59DC8FBE0564DA5D1FDCB481CAD9AAEEA1A4A6D</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='jakarta.persistence' version='2.2.2' extension='pom'>
+      <sha512>E5DC7FB57649A3F6E68F62BC8C1078E2EA7D705562A336B92B5B9DF5A590424753FDCFBA603A40FC1C4EC9C2D144113BB8D9FCBDCCE63B5DF0FCAA21104C6F5A</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='javax.persistence' version='2.2.0'>
+      <sha512>E121DED520EC275E33B25E25F76C806B3108B2DCA35243771DD089DEF295A3325886DE71ED687AF1D35653ADA942630768A813E5B22EE89C8B0354F01D93FE38</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='javax.persistence' version='2.2.0' extension='pom'>
+      <sha512>E48482ECAABF038831BD62B62FBDF292EC19587FD34804EAA8D0160FC56D244F1BB1B0997BE5114102AFB1B3AAAB4B2C6C3964036C879A3A7A64DA7B0FF0DEF</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.antlr' version='2.7.4'>
+      <sha512>A0EA81B4BF57A885EE7971E28E43FA8F41AB37B2FE4D3EA4FB970A068C2F40E9E9A8E66D92868FA1BD8F140C28B23FACF0BA938BE8273ADFBC64BA882D0F277B</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.antlr' version='2.7.4' extension='pom'>
+      <sha512>DE523B70AF9E59825FA5AACE1298089DA6D1F33ECBEB7B312818D5F353874DC61C3EC88BD4B8F368C2FBA1F211952492F288CEE37DEC4AF085D481CEAF876450</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.asm' version='2.7.4'>
+      <sha512>FE8B21B6F7958875AF1A0FB4A06EEFFEA20D9C4FFB87170B46DDB3A99C4F2774E37EA057DD89CC07BAFBE5D49CBB8E42E75C3CFCD7DCD0F47A1EC4E04F374908</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.asm' version='2.7.4' extension='pom'>
+      <sha512>31C50C08DCD7E6854A847734D9B00FD3D28995C3460390E4517DD583C6A923702298B90D9BFDEAF7DAC1048AAEB8F433B129F141F7BAC5738440A0B74C337647</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.core' version='2.7.4'>
+      <sha512>697F744FE903F418E30C6EA44B9D54C22CC0BF66AD6FB130B65298FFE1FD66517297F0D05342B2176A8FE978FC8E156A65D77427C3164061644B6ABA34039F57</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.core' version='2.7.4' extension='pom'>
+      <sha512>C61D2BBE7A619B4A6FE6BCE4835801B58D6B0D464AED3D0C0C955F95016F82898D11D1DFB50E00C43E0C64F3177BD3AA50FEA394CF21E8C39EBAEA4E8A838FFA</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.jpa.jpql' version='2.7.4'>
+      <sha512>7225B155AF1C9CE97D2C979BC914DE4D4E273456FE9E3642A19942D8B04602E86843FDE65D29443A5B64AB9E31FACBF91F5F2BCDF8CD14A02B4A52EF1783F208</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.jpa.jpql' version='2.7.4' extension='pom'>
+      <sha512>E680C82768D245D481CD6AF759EE5423B153855D1F5EEFD66EFFF08897DF4C4BDFCA8E9C8B1E8BBAB5E3B5F9318B492B58A0744ACEEF9B5EBA12989CC0E69AF6</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.jpa' version='2.7.4'>
+      <sha512>35EC324AD0EF0E625FD39671C244C7AB54700F3436A88CAD6025A689C8ADD7C34EFDE1BAE883900114032F5C4DEC8C556E51AE466031AB78396D7334ED5E8B4A</sha512>
+    </dependency>
+    <dependency group='org.eclipse.persistence' module='org.eclipse.persistence.jpa' version='2.7.4' extension='pom'>
+      <sha512>2C11D017D464406120C79AB3D374BAB922A97056112B568B6462DDE16A17CEED4B9D090E82D4FCB5B65B5024E4051A5A9F8BE36696E944D21581D89824C7D311</sha512>
+    </dependency>
+    <dependency group='org.eclipse.sisu' module='org.eclipse.sisu.inject' version='0.3.2'>
+      <sha512>AF65B27E56628C3AC018476916AA6ED420FE5C07FB36483F6B4ABD10966E35D3814D404F5B34974B54AA146C717042D8E31B74BED4A57B9C51B3B2B85DD87633</sha512>
+    </dependency>
+    <dependency group='org.eclipse.sisu' module='org.eclipse.sisu.inject' version='0.3.2' extension='pom'>
+      <sha512>4E481FFDDB15FEB416DC9931BE8F20A6943FFDC4D3A87227B7A9DD19078EA872B10B4F9E5AADEAC1EF7B0CDA993EEC689B4F9CFEAC03E921DF30DF8C248D0ADD</sha512>
+    </dependency>
+    <dependency group='org.eclipse.sisu' module='org.eclipse.sisu.plexus' version='0.3.2'>
+      <sha512>2CC1AF5470D06D1CC6A2F47C1A0781CB618F0B32995C02B1C84EDC3BF92E7D0E01BDEFAD063F9332510D8B32EA87E369E4A2936CD2CF569B1E09C13A77646E64</sha512>
+    </dependency>
+    <dependency group='org.eclipse.sisu' module='org.eclipse.sisu.plexus' version='0.3.2' extension='pom'>
+      <sha512>4DD88FDA2CCF4F47145174AE36092C45B57082C90C0C4F5B8AAC5A303C26C797CBCC083D2E4495122ECFE3AFE6764D9B21251B4BFE85EDDFECD6D348F75BD1B9</sha512>
+    </dependency>
+    <dependency group='org.eclipse.sisu' module='sisu-inject' version='0.3.2' extension='pom'>
+      <sha512>672A64D7A0D8C1E10302C34C854BB637BD82E127D17AD38A571FEBB25EEB71F22C14FF9E06DDDC888FDBCD0A1E2253B21FC37EBCA727C46AE52953F42C1E3BFC</sha512>
+    </dependency>
+    <dependency group='org.eclipse.sisu' module='sisu-plexus' version='0.3.2' extension='pom'>
+      <sha512>CC271AA3678A5C53D8268F3A509F9523ED99D7F6D545340628715DECA6174E8689879DE89DF0CE238F2A497607CE913EA23990D2F63CD88F0F751C030D29A8BD</sha512>
+    </dependency>
+    <dependency group='org.ehcache' module='ehcache-jcache-parent' version='1.0.1' extension='pom'>
+      <sha512>390DD55E61F6A8CCE598F9B33B88D950ECB4F7DA4DCFC50B13DFB632EF4965AF3D696DA97531A11EF3C29C5DDD04810B9AA842832522DC6CD516F909147E112A</sha512>
+    </dependency>
+    <dependency group='org.ehcache' module='ehcache' version='3.4.0'>
+      <sha512>6BD42464C883508FA852647CB2B98652C8199B20EF4A846985EA13FD940ADB5E2468E561974E5DF1DB1D4689568292F8311527B991872D9BF99303C038906054</sha512>
+    </dependency>
+    <dependency group='org.ehcache' module='ehcache' version='3.4.0' extension='pom'>
+      <sha512>1AB6102FB13DA8462169B80EEA076DBE36CF399F2A42046BF07E69929D8C4DC6E42F870670FA26DC3604BA1A89008196CCC4818DD10F6183409160272A2EBBA7</sha512>
+    </dependency>
+    <dependency group='org.ehcache' module='jcache' version='1.0.1'>
+      <sha512>9D5645C8553E367DD7FE38166B4135DDF96DA41159F95E525B0614CEEF5ABE19EC62AA17DD7AB21B94CFA0E6BC17BA0CF81CE1B51EB10D798B50CC94D296ADB3</sha512>
+    </dependency>
+    <dependency group='org.ehcache' module='jcache' version='1.0.1' extension='pom'>
+      <sha512>91F5009B87F72FD384A3D9BA061B0B499868256EB32823BC18E1B620E89900421F75AAAB162E76751F5DFE65D787862D4B57AB892495444902F1508B02026A12</sha512>
+    </dependency>
+    <dependency group='org.freemarker' module='freemarker' version='2.3.28'>
+      <sha512>44435CB2B6BA02ABACDC4A21BEA44A2DC50FAA1B486FC5B2F79097A68F1F98CA24AA835448AC5DEC33A1869EED1B8A32AC285E95FDABBDAFAA810D575951894E</sha512>
+    </dependency>
+    <dependency group='org.freemarker' module='freemarker' version='2.3.28' extension='pom'>
+      <sha512>5C4C832747419D347F79363ADA59B68F6040776398A178B4E79659143C11AF5F72AC4F04996865FAA6D40B65C9BF7D01E7681BCDFCBC19A3CF0CEC4D5624E83D</sha512>
+    </dependency>
+    <dependency group='org.fusesource.hawtbuf' module='hawtbuf-project' version='1.9' extension='pom'>
+      <sha512>CF45353EFB955A4BBA746E453528D0F6539183A0ADBA94521F51C08CEC890DC25C2B37309D01337D2E9602EAE83D937A26EC3A9B5520C3403B25BE6FAACA950B</sha512>
+    </dependency>
+    <dependency group='org.fusesource.hawtbuf' module='hawtbuf' version='1.9'>
+      <sha512>A9FDA5738A7737AFAACE29AAECA52031E7EA87387D33C673DA3F598DC964670F309B2CAA95A0948F98F8B17970D5C6161EC71DA35C74926F30C1D11797104372</sha512>
+    </dependency>
+    <dependency group='org.fusesource.hawtbuf' module='hawtbuf' version='1.9' extension='pom'>
+      <sha512>666B58BCF7D4AE8A16716A7E338CA23CB449FD6270A391E85C7B200DACA0605CCF688C5C6906B46E3896B48675B4FAB9EE92D90CA8CCD6DAD37CC5606AA58FA5</sha512>
+    </dependency>
+    <dependency group='org.fusesource' module='fusesource-pom' version='1.9' extension='pom'>
+      <sha512>48EB0B8B9B8037FDE1321B07D6E35F3D63ABC2DF08289EB7D3F979A9D9C52241578D7AA15B0D2422A2B941639FA0107431974B97F0661B7B34D2258BE2FD1744</sha512>
+    </dependency>
+    <dependency group='org.glassfish.external' module='opendmk_jmxremote_optional_jar' version='1.0-b01-ea'>
+      <sha512>A985C9076BEA5A28D727A53F1A8A46F15BB62884D1B242808562009BBF1349595A162617921154868F543FADBBACC1FB1BBB6E84942C9DD705C34B420C4DEC9F</sha512>
+    </dependency>
+    <dependency group='org.glassfish.external' module='opendmk_jmxremote_optional_jar' version='1.0-b01-ea' extension='pom'>
+      <sha512>5D504AEAC7756FE4B067654226611AFB39174CCAE37059206A81BC02801E8E8C172636FE3BA799C1892BCD1C6756BD927C61E8FE2AE33E291AC9BBC0E7C34FC6</sha512>
+    </dependency>
+    <dependency group='org.glassfish.grizzly' module='grizzly-bom' version='2.3.25' extension='pom'>
+      <sha512>B368266148715345955DDC57260BEC563C70A866F56F8ED604AD9E7738FEBAB6F127B5884C252A5CAED8846FBA7971D3AA8DC83FB5B2C571E3103A9F0E4C5674</sha512>
+    </dependency>
+    <dependency group='org.glassfish.grizzly' module='grizzly-framework' version='2.3.25'>
+      <sha512>849BD5FDFB2E6D4095BA326776499190FD3351F6D8F148B91FF13751BA7980159993B7FC52D7D60992027FE81B2EDF91ED174F54632370CA2C2109EEBF2CCB40</sha512>
+    </dependency>
+    <dependency group='org.glassfish.grizzly' module='grizzly-framework' version='2.3.25' extension='pom'>
+      <sha512>5EB94BC26A73B9B6F3B153A023B63F8BE968761588B54F551E52C63AA0301CE04262455D3C98478CEFB25DD4CA3DEAE72DE155993C1AB5B8AFA1E0C8EE399465</sha512>
+    </dependency>
+    <dependency group='org.glassfish.grizzly' module='grizzly-http-server' version='2.3.25'>
+      <sha512>A27C8813FF3245E3A5F6774337FF716F6BE1D2961F518E685E190992CBE1F7860045B313E1C169C3BED9418263C8E75FF4D7C283B568FF23ECD92003CF0036EA</sha512>
+    </dependency>
+    <dependency group='org.glassfish.grizzly' module='grizzly-http-server' version='2.3.25' extension='pom'>
+      <sha512>20C9E09C11753F363CB810EA3762723CEB56A294D04414B2795609E6F6A32573AE4A2E844637B1369D173E084E27475FEFFD078A839A9A865D9B222597699A94</sha512>
+    </dependency>
+    <dependency group='org.glassfish.grizzly' module='grizzly-http' version='2.3.25'>
+      <sha512>D1A280C63D1EE21FCC47362421EB87D72F201C548BC0A2F653ADD760CF1CB6C1CB226E22E0C21811748406264379A22DD27E047D8FD438005220758778B1002</sha512>
+    </dependency>
+    <dependency group='org.glassfish.grizzly' module='grizzly-http' version='2.3.25' extension='pom'>
+      <sha512>51992640219EB5D3AEF703ED9B8445489CF1A677878B8FE2295A7CAF0B57C460377A6FD104D77EEFF4C3FF25E71FBC97EE412B5D77841C2A0D9C99518A647DB9</sha512>
+    </dependency>
+    <dependency group='org.glassfish.grizzly' module='grizzly-project' version='2.3.25' extension='pom'>
+      <sha512>DF4A3EB15FC8825FA50AB2BE8816F348BE38E571D4AC4B6BB13C2687CC4C3E2D258636BC5319CB1805BA8E23BEB471540E549189EB28A17EFDF4478207849DC</sha512>
+    </dependency>
+    <dependency group='org.glassfish.jaxb' module='jaxb-bom' version='2.3.0.1' extension='pom'>
+      <sha512>EEA68A56BED214F4715F08FDD9351F8680E9F934AD31B6337A7427E425CD0F61F156721307B95AC5BD27026F4AF0E7A8AFD739E98353A26F55657F0F3306490D</sha512>
+    </dependency>
+    <dependency group='org.glassfish.jaxb' module='jaxb-bom' version='2.3.1' extension='pom'>
+      <sha512>342B8501A0F27FFE57C2D3388B856707E286D6185728EE726BB0C6C20BFCF04809042D3F17D085D21ECC479670E77BB2255CC999B8F70477799BE33811C79F2F</sha512>
+    </dependency>
+    <dependency group='org.glassfish.jaxb' module='jaxb-runtime' version='2.3.1'>
+      <sha512>42E778DF68DEBCB6CF1B42985E7C60067E7C0B5BF576EEB630E97288D8FBCCDC2CF1FFA23ABE651B44AF1EF4CD36C522B06A19AB586AB6777EF03979DE1AC951</sha512>
+    </dependency>
+    <dependency group='org.glassfish.jaxb' module='jaxb-runtime' version='2.3.1' extension='pom'>
+      <sha512>5746811138570C3596474EC6937BB57ED31EF3E5DFB23D353E393B92C9CCE5FDA8A9F8A848EF2EDE78E1FB5BF9249608C15A6DC66F8B6CBA5D9F02838A14A4AE</sha512>
+    </dependency>
+    <dependency group='org.glassfish.jaxb' module='txw2' version='2.3.1'>
+      <sha512>ED556215443E9B190D9A18208735B576F94B5965DE631F3B291AF7AD60945414BAE1BA0EA4130D6B0A0453052162F79D1BBCF822370F58D61AACEFEB6B718523</sha512>
+    </dependency>
+    <dependency group='org.glassfish.jaxb' module='txw2' version='2.3.1' extension='pom'>
+      <sha512>5306A6ED207E170E07DA4EB1E44080921703EA3F92E1143294B3DF64D5F163C0C59892B7161499C01DDCFA19A570D67F1DD491E9D787B3C303238BBEE4F6FF92</sha512>
+    </dependency>
+    <dependency group='org.glassfish.main' module='glassfish-main-parent' version='4.0-b33' extension='pom'>
+      <sha512>E6D0E0A80166F36989A1F3FFC509C28E44EFEDD70B9057065053C211DEB8C0FF470091A904F053329C829737228381E0167B44CFEA8EC6464F0B327DE97A972B</sha512>
+    </dependency>
+    <dependency group='org.glassfish.main' module='glassfish-parent' version='4.0-b33' extension='pom'>
+      <sha512>2DBF152B4CC57801DB12A1BACFCCE6EBF160B09F636B6105E35E7F297600CAC43EF3BA5D167D2EFD0FD1313FF5091869A8DD142725DEB672CBB417209DAAED61</sha512>
+    </dependency>
+    <dependency group='org.glassfish.main' module='javaee-api' version='4.0-b33' extension='pom'>
+      <sha512>A36A036D632C865FDE5988EBF810BBC3CB555533F4E973F11655057D469BC9D8F7FB30492FCF7F5E32123257B9A436D22626C0E37BCA2B927CB2170A175297C2</sha512>
+    </dependency>
+    <dependency group='org.glassfish.main' module='javax.jws' version='4.0-b33'>
+      <sha512>32AAB98F9179EA72D6311DA5BE878EB3803BCAF442693FBA2C5C63985A527313FB38CD49DABE92A1F2DD028A201CE47349378C9C34576413844010B4304D5BC0</sha512>
+    </dependency>
+    <dependency group='org.glassfish.main' module='javax.jws' version='4.0-b33' extension='pom'>
+      <sha512>56D003F7FB2DFAE6D77F657AD7339CBA5903809F79B2FAC66369CA89287BF302989E95AA41BA100D4B7B827EA2676B9C2C0306503B7860995E9EBACED13DEE99</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-client' version='1.13.1'>
+      <sha512>80FF586408009B4A91328D77C4DA74D14846B484A7ACF74799EBE0C2E24B228138A309A6752016ADA102970405FB528D6ABD009AF7EA887CCCA733EA1905BAD2</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-client' version='1.13.1' extension='pom'>
+      <sha512>C5C8525F74A01CBD614B608E130FF8118274BFA115E9FE7C324013839623D4A7D75F2983BD2DD674AF76538A8E77E358B7A3AE644D762A3E9FD2544E7218EBA</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-container-grizzly-client' version='1.13.1'>
+      <sha512>865B488C3B438AFBC1380FD3BF4A4BBDCD01F6C0ED2B6DADAC595E7A4FD9AA53862094BB7FB27FF0536BCFD13A2EB94848269EE3F09B84AD7FF3C574286DA889</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-container-grizzly-client' version='1.13.1' extension='pom'>
+      <sha512>8D703927BF0B9C304D2B523C241A94C2BF0608E1555345F9332CF0ECC1F9B183595BAA6E080229C8BA9A3285AEB1C14A74CD2C23356FCB11F4F83BD6E18D6946</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-container-servlet' version='1.13.1'>
+      <sha512>4AB380E3FAC4B3EAF4F1228CD0098924589543D75CBA5823F100A80BBA7740957F01D209B6409FC13716840ECD750B196C4A89A165B7F5471B37DB8A3E42D39F</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-container-servlet' version='1.13.1' extension='pom'>
+      <sha512>FA6106065DF16C901741DF63A809B5F9FF38C2EA2FDA00F77EA093FE60F119E0606419E1B97F03E228E4E0A60BE67655EA3F44FA6C33B13D843BFE18F383C4D2</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-containers-project' version='1.13.1' extension='pom'>
+      <sha512>37B601C55C524F80FBEF9B5ECA692D329D8D909A92674D4D0FDAF9FBB674D4CDCF126BECB639200216C6A5CDC022F8A04927EA971AA1D681B892FA758AEAEF31</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-core' version='1.13.1'>
+      <sha512>4057DAD4B0145916451F77FC378DD74B8C293D8039AD5A92F796BBE705963D66162B9938535F47F1F0A1365A23F949A36EBEF0F732FCC2A3244BD590BB53635B</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-core' version='1.13.1' extension='pom'>
+      <sha512>86174AC877D6277D392E27FA4A3F1D555EE3373422AEF4C307F4BF301BC721462C6D0F34F59C97E62901366EAAE8A5218D49A7324FD430312770BE0C4F68D70F</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-project' version='1.13.1' extension='pom'>
+      <sha512>2E9658349D3A789E3EE7D8405CB361C47822527B25649DCF89833125D1C91310EB0833942E2B8FB5BCC03813475CA5E9ADAA7D27F7E14558D75486D7CE8792E8</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-server' version='1.13.1'>
+      <sha512>EFAE612BF5FA5A7E6B55FBE073CE33CF8340C7CEEB53F282205711CDE4B9DF29EFEB9A5176BFC6AF904B582B6A46884E5CF48A6DB63F462A4EBB3C4F2BECC600</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-server' version='1.13.1' extension='pom'>
+      <sha512>5D1D40731F516A9F397D2D6B220E920596BD80CA30B7514DE7524FB2FFB8CAA591B7D6791437D8203B0C11E644ECFE9A3EBABFC7A96AB026AC250592C5AB7792</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-spi' version='1.13.1'>
+      <sha512>84FB674A94BC8C6BAC1FFA85EFE58902E377D02D48913ABCB292CAA3ED6DFC06CA4AB76AF5705EF9E86B8D1F770D84CD8E5C8FEF9EF2D604FEEFFEDC6D3F8AC4</sha512>
+    </dependency>
+    <dependency group='org.glassfish.tyrus' module='tyrus-spi' version='1.13.1' extension='pom'>
+      <sha512>8F7663FE75492142764C9B98D08208264DA8895ACA98077E476A4D64CBFF580BD9E9148419F1DEC25019AB042B15AD63CE64711386FBDAC9761F2C897F2B8558</sha512>
+    </dependency>
+    <dependency group='org.glassfish' module='javax.el' version='3.0.1-b08'>
+      <sha512>C9941DA35303DCF1190C4A631B4DBFC84075F6E69829C15D136EA644FFA17CE0D2044F9D4F41FB6B263213ED8474D91A73AA95692DC647B4449B0B216918F6EB</sha512>
+    </dependency>
+    <dependency group='org.glassfish' module='javax.el' version='3.0.1-b08' extension='pom'>
+      <sha512>3B857AE2D36A888D75DF52412B1411DBEFE3C6CA45087076DC976F6F696C5C08A7DC3DE91DE0B8D39CD5D48F5636E0D65C4E482D1D3B46A8E2436F92EDFEA223</sha512>
+    </dependency>
+    <dependency group='org.glassfish' module='json' version='1.1.4' extension='pom'>
+      <sha512>9E9AB54ED151C6257C3C5E0D4AB6BE4B7A048B3498DB797A0121DBEE9AE81947C9386E1AABD59A3103B5E3FD12A58FC52F59FD1BB637E3A1298A404F59C27209</sha512>
+    </dependency>
+    <dependency group='org.hamcrest' module='hamcrest-core' version='1.3'>
+      <sha512>E237AE735AAC4FA5A7253EC693191F42EF7DDCE384C11D29FBF605981C0BE077D086757409ACAD53CB5B9E53D86A07CC428D459FF0F5B00D32A8CBBCA390BE49</sha512>
+    </dependency>
+    <dependency group='org.hamcrest' module='hamcrest-core' version='1.3' extension='pom'>
+      <sha512>2F9B748225F8F6E47AE2DA383F8D74568F0F4E469F387095392F516A7308EABAB058877A514EC040C1A9CE8CFCA77A404FA8694B391B36213D6E5B8F492F62F3</sha512>
+    </dependency>
+    <dependency group='org.hamcrest' module='hamcrest-library' version='1.3'>
+      <sha512>6D70F03C36C682812A4B499F911F4FA12BAC2461C4E391E7DD956E11F76CA0AC960C39E473AD45341E1F1E7113AAC231A9FAA1E921D50FF4D770E0F0BCA75A4C</sha512>
+    </dependency>
+    <dependency group='org.hamcrest' module='hamcrest-library' version='1.3' extension='pom'>
+      <sha512>8555E1918208969BBA219FAC3345FE9C87AC6C28E5E8A61575AC54B5B3FAC4F59978F64DC7ABC63B45816A27F699C9FEA0754DE3ADABA82597E57A1640B12F46</sha512>
+    </dependency>
+    <dependency group='org.hamcrest' module='hamcrest-parent' version='1.3' extension='pom'>
+      <sha512>3F22BCF14820F04DB8193E3AF50EBD3DEB7B62C9587128092F35C1E7963DE5C24B6123A80BFDE4833F723B100085C043B895B9DF6E02E83C201834D77C7A15A</sha512>
+    </dependency>
+    <dependency group='org.hamcrest' module='hamcrest' version='2.1'>
+      <sha512>13F22E9EC1598BF9105342B8DB314FF0B687BD1CA939895F4F8039621D7882D9BC90CE763A79A0663230E806278C819966A8751F665F18B5FFD8DEC8D1718709</sha512>
+    </dependency>
+    <dependency group='org.hamcrest' module='hamcrest' version='2.1' extension='pom'>
+      <sha512>B5B82C4333BF8B882286A6F8470F6A8C9EABE1A3E89353E9B744010EA2F64345815B6999D3C6EAEB44F3308280A9062AB2A770985BA45B445506659D331BC145</sha512>
+    </dependency>
+    <dependency group='org.hibernate.common' module='hibernate-commons-annotations' version='5.1.0.Final'>
+      <sha512>12A3C896D8CB0FC9FAA3499A3ADB964B525737284476661DD1449F940E0232049606D825AD0CB73F895926DB198184916F0756B70373922AF07734DE7F1671AE</sha512>
+    </dependency>
+    <dependency group='org.hibernate.common' module='hibernate-commons-annotations' version='5.1.0.Final' extension='pom'>
+      <sha512>A8C5815E4ADA7F5065023FD9739B1C98DD7086AAB8AE4335577CE0E095802E2533AF51E82406A06E1399EA16F9B6759792652BBFD33F046F61DC42D79B9982DA</sha512>
+    </dependency>
+    <dependency group='org.hibernate.validator' module='hibernate-validator-parent' version='6.0.17.Final' extension='pom'>
+      <sha512>50A30B2253324F8AD3BA196F3322E811D4C690ABCB574FB0ED9827CF42A37F3E7F00C89137B3D7AD21986DCA739864CA0003B2B782474AF9423C83FB79F8A110</sha512>
+    </dependency>
+    <dependency group='org.hibernate.validator' module='hibernate-validator-relocation' version='6.0.17.Final' extension='pom'>
+      <sha512>D5AA628209D9F6548B8CC84AF3F7426718ABBD9E23F1C78DB6C497F0571E68DFCFBEEA6A8CCC31E7F0BD759D334F551C9E247112966F04CE1E9B82C6EE190321</sha512>
+    </dependency>
+    <dependency group='org.hibernate.validator' module='hibernate-validator' version='6.0.17.Final'>
+      <sha512>C851437C5E35DF205AE13F1C1344894E85B5AE453317355C85566AFA995E6AABE723AA4AD12BA776A656CF45EC57824A87CF262C6EE3FD4F404B264C5C9D5436</sha512>
+    </dependency>
+    <dependency group='org.hibernate.validator' module='hibernate-validator' version='6.0.17.Final' extension='pom'>
+      <sha512>A879683FB107F94AABD13F9BC47FB281F62B194733966A69B640E7FA5CDE27806FC8EF1C6866432C952F4D328CA001AFBBFC03DF48E417DD46152E026E7DB9E7</sha512>
+    </dependency>
+    <dependency group='org.hibernate' module='hibernate-core' version='5.4.4.Final'>
+      <sha512>88164CD2ABE0E0C46B43A3DAC7CE5D62FD085EC910F374AC9372A4D05654203E1DE8029338279A05CBF4E96AD3240C4516871DD847992D6BBEDC696A9C705D2</sha512>
+    </dependency>
+    <dependency group='org.hibernate' module='hibernate-core' version='5.4.4.Final' extension='pom'>
+      <sha512>1D2FBBF2CC95B0CA4CD743FA9F68C1A89DCA35FA0614FDA7B4D17F49D53379084102DE806CAF8A0D26B11236B3A41F64117FC4C9E44D5ECE1499CC0F424CB795</sha512>
+    </dependency>
+    <dependency group='org.hibernate' module='hibernate-validator-parent' version='5.4.3.Final' extension='pom'>
+      <sha512>CCDFFBD248B8944E16529C398BD594B5E4BFA493785931D880D6FBD203F7B0BF9322A1BF18809B911201993F44034B3ED69C90752CC7A733D94A44938DC00DCE</sha512>
+    </dependency>
+    <dependency group='org.hibernate' module='hibernate-validator' version='5.4.3.Final'>
+      <sha512>38C1BC5692588FABC86904F75DD3481CA13BE43BFDA2F33278CB91A0AE229C7ABD0F095989FA23E25B78AFF51B2B7232F271579E13BD062595E498F9C92EA830</sha512>
+    </dependency>
+    <dependency group='org.hibernate' module='hibernate-validator' version='5.4.3.Final' extension='pom'>
+      <sha512>56A83B8C3EF17F49D04CB32D98C06EBAEB2657FC1C9F647A0B5AA891C30B55D3D6DDB5396CCA32F45B9295A27493EC708864DA2F55FD27EB73A66F40597A7D01</sha512>
+    </dependency>
+    <dependency group='org.hibernate' module='hibernate-validator' version='6.0.17.Final' extension='pom'>
+      <sha512>2CD6F7F2A6385EC434E4CFD75F428B20641BCDE4B8C8F5D22D63CFE24DF2C99B029BE84FD212A44DBF0B9A3D79310D6259F195B17CF6BF9B33F6A818C9D86DCD</sha512>
+    </dependency>
+    <dependency group='org.hsqldb' module='hsqldb' version='2.5.0'>
+      <sha512>4209B37BC6DCD24CA9B599F9AA491E5B36758E13EF557611F257A480CC50DF993EB31A9573DDA6CC637874927A2DB8D6F584B00D16310361FD055B8C70C5F7A0</sha512>
+    </dependency>
+    <dependency group='org.hsqldb' module='hsqldb' version='2.5.0' extension='pom'>
+      <sha512>C87E57BB477A2E5E923FB1645DB2A907D6A121960BAD19E61D94D50B4DED4E8650F09E180FF50E5BC58BB20C2AC5EC3DF2FBBF2008844B1F30D45491B9CAFAAE</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-convert-ecb' version='1.3'>
+      <sha512>5FFC0DF6DDE0BF0A8084A7994DEEA05399ED69B49FB56D77C7A149D12FA4EEB2ED5D44A44AA6853D414644B7FF5562D4AD46966FAC2C97801AC54B4238465CF7</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-convert-ecb' version='1.3' extension='pom'>
+      <sha512>B63466B3936B6235B6EDA7D0C99EC41B2A1ED560739948F329784498B9A450CB4B6C3C3A7F22BD6D2264AEEA9EEEBA8102D67B74BF411CDF74A53F9D8C75CBA0</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-convert-imf' version='1.3'>
+      <sha512>891FD9BBAAC85F8E05055565DED777F3AAFF7533632F973DF339298B07A49FE9FDD4EB386F948C8D86FACFCA036C314BD35305D212597C8C353F3C18B895FF31</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-convert-imf' version='1.3' extension='pom'>
+      <sha512>DF63878C4C43B8A64EC2ECBD709326A22D7EDC2AEB6FE7BF6389C65344047CC49F07D1F77ED93B201589E87E9677CB7A2DE716D981D9EB7E6F7DFE4EADFF19C0</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-convert-parent' version='1.3' extension='pom'>
+      <sha512>5628BB25BBBAB3C4B519BB5BA0F69DB9330DEECC129BE6EF330E304EAF8A25DCF8546E0EEC6E1881C666F909903BAEABA0F929AD52E7EEE04815CADE16AD6BF3</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-convert' version='1.3'>
+      <sha512>75DF27F84B9C6A3ADEF29C7EFAC0D3D11A72CA97841429D724A51F8F96461E01E5716D30856A27DCA18F24C9C5B4CEBF6BEBAA02D3DE95FDFCB32A1C34DA55FC</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-convert' version='1.3' extension='pom'>
+      <sha512>C7539B4321D7F23DE2C13E63C199765F5CC0B0F41EDF5C0774F4AA49A58877704ADF9E4AE67FD4962FD4892D15A17B6BCB36F58E846F6426590AD2AA899DF18A</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-core' version='1.3'>
+      <sha512>594122A0EA9724A211D3CE81AC23C3E6816A85188AD3C65422C9988AC2E35D68616460ACBB8C6A49BFB5F0A76F6D9B0AD2E61E3911C9E90EFC8F09BC55E4B397</sha512>
+    </dependency>
+    <dependency group='org.javamoney.moneta' module='moneta-core' version='1.3' extension='pom'>
+      <sha512>B11AB7FC17EC6E85ED62BF93266B9C08E7686015547F46841C5CF505574DEA0E19510F6390592637DC8EFA7B2B46AFBAA650D24FC1A401571817227BB766F5EE</sha512>
+    </dependency>
+    <dependency group='org.javamoney' module='javamoney-parent' version='1.0' extension='pom'>
+      <sha512>5E19AEF1976EF55EC6A4015A643BAAACF6C66C038CE1CEE5D39E242D57B847CC1D8B26518C8270F5C0AF3D102A176A785F583BD859C78DE2D47D7AA109A9ECF6</sha512>
+    </dependency>
+    <dependency group='org.javamoney' module='moneta-parent' version='1.3' extension='pom'>
+      <sha512>E491FE73F114CF3614ED32038F6F315B43D133FAB81DB10990C8EA6F68E2A6F4DF6B7A0F58E6A2F98300C12BE045C35D8BD657A6611209F8792B9E125061F2B0</sha512>
+    </dependency>
+    <dependency group='org.javamoney' module='moneta' version='1.3' extension='pom'>
+      <sha512>81EEF75E35012915213A31025662A0BF9D3986F8E0F862E88237B1EF6B3655D41A95F86862063323DA1A79048BDD2BB585F4D6A335177495C246BB74671553FA</sha512>
+    </dependency>
+    <dependency group='org.javassist' module='javassist' version='3.24.0-GA'>
+      <sha512>E57DAD74A3EDEF837ECE841D06E4A7C96FFECAB8FBCBA56FE5F7ECCD662F0C0D757880A6073793A8C75AD7A0A1D146346B75CDBFE4FD8A271048A54446E5D1A2</sha512>
+    </dependency>
+    <dependency group='org.javassist' module='javassist' version='3.24.0-GA' extension='pom'>
+      <sha512>2D741B72E2D0636E6E397A94BFA1DA47CEC57FDE0A53E2568A9732FAC56388D07B673182A831FEC6FC3A1E66F0AD238B247F47400DE6606FC989C898BCFEE2E1</sha512>
+    </dependency>
+    <dependency group='org.jboss.arquillian' module='arquillian-bom' version='1.1.11.Final' extension='pom'>
+      <sha512>CAA8797B5AC78B1DB17BA92EE7BC3D81DE45F9F84DBB89AEDD8BF0E82575155D38D2806BF64AEBE7AAB1DB1FC581766934A51D0D2A18ECFF1B4C3312D25A5C87</sha512>
+    </dependency>
+    <dependency group='org.jboss.logging' module='jboss-logging' version='3.3.0.Final'>
+      <sha512>6CD839A07C55A75BEFA9A95C7CB2E4A87445432D475BC747410FCE625AD4496EE5CC6631A445420940EF1CB408D74873980504E4D785D8EC851223301A76807B</sha512>
+    </dependency>
+    <dependency group='org.jboss.logging' module='jboss-logging' version='3.3.0.Final' extension='pom'>
+      <sha512>F8A503D49BCFA06F4090F08271FE450297E2667A06743F4CC875C57BF3342408AFEFE7EDB520812C2C38DA8EC5F98DB5B8B33EAAE53EC7721ACDB1FCF1E3EB6A</sha512>
+    </dependency>
+    <dependency group='org.jboss.logging' module='jboss-logging' version='3.3.2.Final'>
+      <sha512>29FFCC84716C6E8C8AEE56534F2D09C7235FD5DDC7F9E6E0D093CFCD278C2FAE6F4FC8526B4BE22832C348E2D1D81D1347963A53F8840F2D048470E85EC36BB5</sha512>
+    </dependency>
+    <dependency group='org.jboss.logging' module='jboss-logging' version='3.3.2.Final' extension='pom'>
+      <sha512>CBA4F65065D172CF76228830D0E4B03A597849D305AEA826A5E4FAE4CBF6AEB6C6783A58BCB70E2201E1E2D5445614CC7ED7FB781FE2DAECCD6485F32D5AE0AE</sha512>
+    </dependency>
+    <dependency group='org.jboss.logging' module='jboss-logging' version='3.4.0.Final'>
+      <sha512>2316AE680A937B5A0EFE8CEDC5437AFC1B326682E103F7D2C3CB9A689F61402326446F08F24CEBBC72DCEF44AD9F81D307FCF6D6FB186E3AA3818D15CEB517F9</sha512>
+    </dependency>
+    <dependency group='org.jboss.logging' module='jboss-logging' version='3.4.0.Final' extension='pom'>
+      <sha512>780FC2514CC8A79AA428DABAAEB011BFF7F353507518AA774EB8251AAF2CF784985280A717BE193A0C531A65DFC8674726891EFE84A5698CBC8A0DB97E3042E2</sha512>
+    </dependency>
+    <dependency group='org.jboss.shrinkwrap.descriptors' module='shrinkwrap-descriptors-bom' version='2.0.0-alpha-8' extension='pom'>
+      <sha512>D6C8F2A4701571E9FD761F38AF820BF7CDC8B47D8E9379213E0846B5FBB55717F3CE072EA7CC193E2572534D834F068EE4ACC94A185C706858823D2146A1BA69</sha512>
+    </dependency>
+    <dependency group='org.jboss.shrinkwrap.resolver' module='shrinkwrap-resolver-bom' version='2.2.0' extension='pom'>
+      <sha512>29276DAD72649A662850070B3EED475AA6D3696ECF24E25D77816AD722983B1A2F09708F5ED17585697315A5820A5302D175EDACF4AC9303011E5D1E10C6DD6D</sha512>
+    </dependency>
+    <dependency group='org.jboss.shrinkwrap' module='shrinkwrap-bom' version='1.2.3' extension='pom'>
+      <sha512>667E4B3810A4F46909548CB8157B86A375550CFF0C1E161186585FFCF569C979C80A44D6D0C28B67F80D2E02506DD12BC8CAE14F5B329869B37D921DFE718F84</sha512>
+    </dependency>
+    <dependency group='org.jboss.spec.javax.annotation' module='jboss-annotations-api_1.2_spec' version='1.0.2.Final'>
+      <sha512>4989263A1A7DC1A22A3F206A28D3E20A81D6CDB47045BBFE9C68D5A8F6AD1D19DD4395315820A57546CCBA01F2BE7262C56F8C057E641E85A9F52A57AF152F38</sha512>
+    </dependency>
+    <dependency group='org.jboss.spec.javax.annotation' module='jboss-annotations-api_1.2_spec' version='1.0.2.Final' extension='pom'>
+      <sha512>E49E9930145B03423B37E69725E7C9295827DEA244AEBEF7580879795E7D9953A7F59A5C6F3999FD10CADA49B95A286CE7A0507F782434AE9762DDA5357F2855</sha512>
+    </dependency>
+    <dependency group='org.jboss.spec.javax.servlet' module='jboss-servlet-api_4.0_spec' version='1.0.0.Final'>
+      <sha512>DFE82F912D2F8D13BEE740D7BDF13B883B87551685FBF2827006EA06B7380140A3021F1CC3EF5B3C6DF18EAFB553560691A8D45D0BCCDC9346B72E5FFEDFF968</sha512>
+    </dependency>
+    <dependency group='org.jboss.spec.javax.servlet' module='jboss-servlet-api_4.0_spec' version='1.0.0.Final' extension='pom'>
+      <sha512>E77E1B9F2F9F784EF4F0A1B8289E802C77C36AFA666077D9A971DDA18376381B7B9A347FEEA0917DA953AD142167346A7F0A344D063E00C079BACF3D386B2C0E</sha512>
+    </dependency>
+    <dependency group='org.jboss.spec.javax.transaction' module='jboss-transaction-api_1.2_spec' version='1.1.1.Final'>
+      <sha512>A38870771313EBD16CCD83739566F77B7D2D9C56210166C634A23F152305952287CA09FB17A2DC19F148FE49AE8A70AE9043622A428F62F9F588FBD56A065FAA</sha512>
+    </dependency>
+    <dependency group='org.jboss.spec.javax.transaction' module='jboss-transaction-api_1.2_spec' version='1.1.1.Final' extension='pom'>
+      <sha512>4A0BA706FFF62E40E1863BBA89179F4740227BD60C4CC4291B91BC618DE683C156F344999181720B4D6A79CFF6B1042C6E8B66E1CA2FBF19C4985E92C8E96DD</sha512>
+    </dependency>
+    <dependency group='org.jboss.spec.javax.websocket' module='jboss-websocket-api_1.1_spec' version='1.1.4.Final'>
+      <sha512>62E3A62EDA18C72302290B202D8B86EFD632F1466C63B968209B3BF9FCA0E85F6E19B2EB917151B76F92176310D6FF2C9F43BDAA37B6BFC5986F92C6E211E80B</sha512>
+    </dependency>
+    <dependency group='org.jboss.spec.javax.websocket' module='jboss-websocket-api_1.1_spec' version='1.1.4.Final' extension='pom'>
+      <sha512>E1154B05D6B663AA80DCA6056A75F93CA3CF8550174E727E4F2D473EE87DE83DD890F6B42AF8CEF37C7A220F021031F40EED8FB47C993F28DAFF6BEF0F7DCF0C</sha512>
+    </dependency>
+    <dependency group='org.jboss.weld' module='weld-api-bom' version='1.0' extension='pom'>
+      <sha512>2C52F27405DF423896A4AEE7F5B9119C8FAB02AD7B2F83A72A6B64A7AFDAF17F7732039CC851DA9E6594DC7F370CD8970E0DB1DF04A4C0C0A94A04F2B9615B37</sha512>
+    </dependency>
+    <dependency group='org.jboss.weld' module='weld-api-parent' version='1.0' extension='pom'>
+      <sha512>9B10422DA8A83E680468BDA5BD7E57076A675EB4F20860365D7A7EA8B82694251DDE67F42711D24DDD7951AB96D48EA3EC7C08406DDA2AADF79A549E8AD693AA</sha512>
+    </dependency>
+    <dependency group='org.jboss.weld' module='weld-parent' version='6' extension='pom'>
+      <sha512>17CBC63CEDF45598228ADA686F5B8635A4030419FB8A5CD782306DF7C1E50D671EC7DAFCAEFC65A2A4E0921A49D20AEF5F0188BEBBE19D0D0085657938A6AB38</sha512>
+    </dependency>
+    <dependency group='org.jboss.xnio' module='xnio-all' version='3.3.8.Final' extension='pom'>
+      <sha512>92FDA96E4F75F422880E4B4C14761CE592A44CC71645DED2E9A192B45423D98D208BC48543A3282E1D50D4BB734D058FFA7D364106F0551D53DD2D91D1E69B57</sha512>
+    </dependency>
+    <dependency group='org.jboss.xnio' module='xnio-api' version='3.3.8.Final'>
+      <sha512>B12EDED4EAC28F9CBD873D6C987341959A67DEF602AB44071AABEDB2E5D444B964E5ACD39785E0ABA362080A4E157284FE89E3E514740265F5C5352C0255E4FA</sha512>
+    </dependency>
+    <dependency group='org.jboss.xnio' module='xnio-api' version='3.3.8.Final' extension='pom'>
+      <sha512>9A62E2245ED878057B754063CFC2286E20FFE1F1368A172F8F71FAC6C5C36A1F8C91A1DA86BB2CD9413E2724F22156894925A223A5234BEBBF992FCCAA025A35</sha512>
+    </dependency>
+    <dependency group='org.jboss.xnio' module='xnio-nio' version='3.3.8.Final'>
+      <sha512>1ABBBF1316D766EA6A5326AEC1DB9EBF947FE621FC8456A66B1F39846875936C118C20FD4CAFBBDBFF6B404E7BE896C7C1CD4574E6BBFF979C39E8F45BE6E238</sha512>
+    </dependency>
+    <dependency group='org.jboss.xnio' module='xnio-nio' version='3.3.8.Final' extension='pom'>
+      <sha512>D12423FCBDF46C0E2EF7EC1A5267A8CC227456613C99DD11FE0956A525FE2D74F22B9A4F05364319A803C7DDAFCFFF248B0E47059E1DF9C91AE3F7A771962308</sha512>
+    </dependency>
+    <dependency group='org.jboss' module='jandex' version='2.0.5.Final'>
+      <sha512>A028020685542E387113B40A5B79CC634D8312336D13702F893FCE187CD653B5E7A67C80067BC719C6C214D4A32E19EA0D854BE322334AC1F9B6DB8FDC78F13C</sha512>
+    </dependency>
+    <dependency group='org.jboss' module='jandex' version='2.0.5.Final' extension='pom'>
+      <sha512>C968D9E195E225401087CCBC2ED964982F406EE8DFAFB578D85FCE820033B89882B187AA8726ED0A81969F5CF7F963C4FA8BD088E5B031009C5D9D275D04483F</sha512>
+    </dependency>
+    <dependency group='org.jboss' module='jboss-parent' version='12' extension='pom'>
+      <sha512>542692A58B0EE255F39AFAF95F11FAF9712DAF98159E773D05B15F3AF42410D979C5710074B5B9CEE16284F991E5FDD3A979D2EA62D4EC0E28F70F9ED2173DB3</sha512>
+    </dependency>
+    <dependency group='org.jboss' module='jboss-parent' version='15' extension='pom'>
+      <sha512>D4653E7E948BFDBB0EBA42305247F51878AD2BC5B6CFB0E8A5E6BB873D5B69A2C3AB8A0505B41E1F9701CF6EA301B4E2AC9E9B729963C23ABC56B4AFDC59DEA0</sha512>
+    </dependency>
+    <dependency group='org.jboss' module='jboss-parent' version='20' extension='pom'>
+      <sha512>D8194102C8F32E01A8400CC10F7926B0A73D7023B6B3A645479972BED892DFC546973650A07FABE12DDCA4904A2A218A6657822CCE1F311CD7A88DA7448E7575</sha512>
+    </dependency>
+    <dependency group='org.jboss' module='jboss-parent' version='25' extension='pom'>
+      <sha512>65B76CCC11E31BB0F833AF758A286B32DCA39C17023B14440A03F1E681E02D8E6EB0FE87E4C779C2115C607AA4BAFF1801041D3213AFBEB4BE4CE204F36E8814</sha512>
+    </dependency>
+    <dependency group='org.jboss' module='jboss-parent' version='34' extension='pom'>
+      <sha512>63B0B10837F4BC9A334AF0F76D588138F22DEDAF8C7DFB7EF171301C8571747A4F9F5AD55658241CBF89D127C44626048A3C59CBEF29AD3CFBEBF4937D2B6151</sha512>
+    </dependency>
+    <dependency group='org.jboss' module='jboss-parent' version='35' extension='pom'>
+      <sha512>D4AADF9A7D81AD04D5B6FAF8ACDDB9B2C461C0F008AA0ABEFCEFF9E08E53376DBB511015665DD88A89A5F47133A8EAA8AB44F667FAB908C7EF58330EF50C10C7</sha512>
+    </dependency>
+    <dependency group='org.jdom' module='jdom2' version='2.0.6'>
+      <sha512>315791DC16BC6240D81DA7FEE9AE325102FF7DB19A57805335D189BC747ABC4D1C80144589EBF956613B93B2263C7565FDF171ACA0C6C598616EB3F0BDF4CC58</sha512>
+    </dependency>
+    <dependency group='org.jdom' module='jdom2' version='2.0.6' extension='pom'>
+      <sha512>1C111E5C52440B00B5573E05A9F08C048D5630B1D77D4DBCC8B9EFE8B68584D7926D8B4C867EF6B212ECC5CF549360EB8ECD654F96F04C2A354AA52E493BCE93</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.dokka' module='dokka-gradle-plugin' version='0.9.18'>
+      <sha512>637CFA881FC656F441A2568B4EEC2596DC12EC3B2AE6DD69B913D8A65D8ED47D454256DB713E57A622432ACFD7C1CAFAB60B8F2CD64DC9991D843F372CC2C41A</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.intellij.deps' module='trove4j' version='1.0.20181211'>
+      <sha512>1C805EFE0DD5700941D20F02D6BA8DD79C54BFFE3B0147D82AF9B7525DBDCC97EEE5B3258CBCE161A39A699C28574BA43BA401DBF3AD3D73600293146949D512</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.intellij.deps' module='trove4j' version='1.0.20181211' extension='pom'>
+      <sha512>7F2B870D35B5A4DDDDB6707FC8EBE4A58560A98C3A43E3BC051A7FA7458963C3AF0CBC233B4D12B9B2307E9DD43935889D31DD2B494A1E0D8CE5F74534441E16</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-bom' version='1.3.50' extension='pom'>
+      <sha512>43EE5CE0396CB4D92952275C01B4ED1F82A08C249A3E43CD0E145A61251C0F4EB7703C281123A6AED86B5E196D4B8E0F4C5315351300E59BCA5E89400E2B6BD3</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-compiler-embeddable' version='1.3.50'>
+      <sha512>BFCD143B8A0714100E71F9668746456E5605CA18C92EBABA1F362A0E667F5B8E461D862D71E67D85ADA1516BD7937C4A954E7E2A55F8C43CE5C866E586179BA0</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-compiler-embeddable' version='1.3.50' extension='pom'>
+      <sha512>363DF022C0C69AF60D8131BB604623DD491EE58245638098DC9A061999C274D1D5D5DD2588E5AFE3B900272FCCEDBC2E95520E1A8C7BD03D70461B5BFB65B7F7</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-daemon-embeddable' version='1.3.50'>
+      <sha512>8897F200CB3CEC5E99A50DF2ADE20EA39C5E13A1E02E354FB73438243D1ADB7E6CD4C12E1A04E84AED6DA63F9A7A51E293F1F6810F17D24A1DBA5700DB72BB8C</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-daemon-embeddable' version='1.3.50' extension='pom'>
+      <sha512>18038950F789CA5F3CAF0B67720B62654C8EAFC9AF35F50E676B311FB3F705E76D6F3FD5AE6071F0EEED15A8F7AE92DED2EC990C5AB444CA66E5F540A77B11ED</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-reflect' version='1.3.50'>
+      <sha512>7B67728C6103ED8963DA2A1F947F02251B327C67BBCC7527AA5BD4EC2A89A279CA7FA4F77EA1C59C2605E7C8573DD36DA65B05748E74392C2B1F35B0824967DF</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-reflect' version='1.3.50' extension='pom'>
+      <sha512>C8CAF1D84296929A0D048A1B1FA8DC39BFD9AAD158AF1E348FFA641F8A9BD6C95433C25657DEAEF08C039A93769A39D900979676B3E30408FF8CF924E84D9465</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-script-runtime' version='1.3.50'>
+      <sha512>28260CD59F5064127D4D7B6CC3BCB8125EAF1E070E206B1D4E1268DAF2B52FB913FC8AE31F7BB83315F312E73CD8F5BA512351CFDF5A79B71FC3232E80CBD971</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-script-runtime' version='1.3.50' extension='pom'>
+      <sha512>B625A22B2DC28B0C433F4A848AA889C929DC06D853E59FC2D614BCCB3A8FA321EEB3249F86BADC2F687ACD45E5F071B15ED4BB543948A8E92394389F5FF4B2D1</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-common' version='1.3.50'>
+      <sha512>7BF16CDE52C2D709EEBAB2AE05D2164A4E231D9B17D6DFC8DC6BDDB90ED2E8FB0624223D55FB6EF214548A2CF1F269F2FE1245DE210F822D216C0641B6E4A861</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-common' version='1.3.50' extension='pom'>
+      <sha512>2CF51F84689C7E32E6DF849C2AEFF463A7A46AE31DB5906F2E4508D198F584DAE7DB900E7B3674FF442E171AC10705FF5B6A3F4ACBF5CDC381A99EC6F923B1BE</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-compiler-embeddable' version='1.3.50'>
+      <sha512>CFA569BA68D4D254B106FC53F1FFE997AA4C8A7E6426FAFCD7B89E879491F0BBBF99BF2B8092BBE6CAED6B299A55FC375B9D5466F06A2FFB2EEF001AAFE11059</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-compiler-embeddable' version='1.3.50' extension='pom'>
+      <sha512>B9C76560F2282812DFBABD3FB13DA96F82AFA433FBFDB04C58169D4ACCFD1B3C087111941F77651EF61DF9645EEFE29396A1FF3A0D60A10E10D4FE1569C6E80A</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-compiler-impl-embeddable' version='1.3.50'>
+      <sha512>218C1A7841D2450BB032CEEE61F413902532B6CAA9F2FD3565CEF7B7B0DCAA2526CE52FBF4766213067897319CC3296A49AF85F4FA5185BBE92A1AEBBF782C44</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-compiler-impl-embeddable' version='1.3.50' extension='pom'>
+      <sha512>39CF09071449D3ED9BCC3384C774DAA43C0CA62422A07073717DADD07FE287E5620EEB38FEDADE6A8244880142B7D302D112E6BE2EFB88407C15D76C29B185EB</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-jsr223-embeddable' version='1.3.50'>
+      <sha512>56C99087BEF1E357FF3031410AFD3C1721F2A6D1CFF0CF0CFD109E886D6C8741F2C65B26D50473F2F273CBB92086C4BD43DA7D3BBE21CEDD31396414882185FF</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-jsr223-embeddable' version='1.3.50' extension='pom'>
+      <sha512>E48F6FD91EF449F2C1A6DCC060045185E34EF289AC906F0423D07500AC31AD6DE3E789C2AB562C03292B07721B1CEFEC95C329ECC0C34F1A40C1417021E2F204</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-jvm-host-embeddable' version='1.3.50'>
+      <sha512>FA4198A33D5C960B2323F6BE0A1E6BA125390FC8458B55F7ABBD38AFB0C78C317D890112BA3488C51C6ECC62CBB2C6AD0DF6E81983EA8762DEF7154CD2EC6600</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-jvm-host-embeddable' version='1.3.50' extension='pom'>
+      <sha512>E646B3BCBC5E72A36E9A701E875D16ED095ABCC50AE86EFC9565404F436474A86FEA1617FC06FDE30D8BF5BDC9A9BF1159C9B5412FDADDBDE4F4ABE501B79D58</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-jvm' version='1.3.50'>
+      <sha512>36FF2D6497329A827C4A12C439273EE1C30E3BFEE884BB251DF023EB49B62ED437AC689895FF778FE2AD27840EC9647E943B83B419BA4FDB23EA9019E230ED0</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-scripting-jvm' version='1.3.50' extension='pom'>
+      <sha512>E357B19A2C4DE7B1F79A976FEA9D35E44B03FD5FD5B056C40333EFFF0615BE0BE553A6527AC3217C552C80B3CB0656C137D6A303EFA0C72094F2BE17690C0875</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-stdlib-common' version='1.3.50'>
+      <sha512>F436ECDC416AF75217EA33431A6406DEB58E08B92C9FB14356AE276E5E6DDB1F4AF40F5C627C4DCB1099DDF9B1605B4464AD90C8047D22468B8B7C398EE251F8</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-stdlib-common' version='1.3.50' extension='pom'>
+      <sha512>2C5A4F441D0D655DA1C38A13065A227A1F7F7AB5F1B6569D9AC86A79046E4B1248390CF5AF63AEB6BB84F81A733F7DCEB178DF4A603873C91D9C49685C00310A</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-stdlib' version='1.3.50'>
+      <sha512>D99670CA927D0E1B4D3FDCBD1FE549405A9E7B90485B7AA8469493F5A0C5A46FF23B7D4CDDFA505DEAF62720AA2CA91485C9180D2A5346BA4E7C046E25A9FA4B</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlin' module='kotlin-stdlib' version='1.3.50' extension='pom'>
+      <sha512>FD2F20EA047977A24BA4AFE8BC3E907A4AD80F6E8D944BF2CFAA1E1C933B35A4ED33812EEBC7EF7AF7FBB702E281F090BE77881F3F43989180C34B4C57A2795B</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlinx' module='kotlinx-coroutines-bom' version='1.3.1' extension='pom'>
+      <sha512>81CDF3D60839B2FD32D0FBDA2449233B5E6DE448C339DCB2821252D56B543F29BB6ACD1367DB60A9D2B4A7D558CB3E8CA569C71A2E9022989D3B18ABC023C854</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlinx' module='kotlinx-coroutines-core' version='1.3.1'>
+      <sha512>EBCB869283F0EE986893CEEA04809586CE01D4D26DA7806D6038A64D8BC740BC5A609BAC8F9A0E2004E2000D21625D05897B8C3313699A7878B684A53D9745B3</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlinx' module='kotlinx-coroutines-core' version='1.3.1' extension='pom'>
+      <sha512>D3521CAEC62C771B81B5DA8942691F4AF269CA10F0059BEE6FD09C9C9EE2B38DBFF065170AF2F3653342CBA6E16D70A293290B00D577A8CCDB05BB5F57E56233</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlinx' module='kotlinx-coroutines-reactive' version='1.3.1'>
+      <sha512>B817A3CF86BEBD07C46F8D9636D59CF96C1833AD6A825E6A5A3C9BE21AB26B9E18C7D53E483E8ACADED91B58E0F8919B3021CFCA2AF9EE4D603F9179859DC022</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlinx' module='kotlinx-coroutines-reactive' version='1.3.1' extension='pom'>
+      <sha512>FDBF21C9ED6E79416900C78F0104F543C47B9F9E08E76864C216922DC70548CA47362D841E3D0EFCEEB731DD4384807A2AF28B6C833156683DAF8E232657F5A5</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlinx' module='kotlinx-coroutines-reactor' version='1.3.1'>
+      <sha512>D376985565DA2D35E6615058F65AC14E3516C6869CAC76996FE520162B5AFC048C55082B8214B232E939774AF330D202B2C2281580CFED3CCCA3F57F3ADF3FE6</sha512>
+    </dependency>
+    <dependency group='org.jetbrains.kotlinx' module='kotlinx-coroutines-reactor' version='1.3.1' extension='pom'>
+      <sha512>39CF5D2E0F6C65B8333CC4FDA659005C4F7B101F310F3EF72991FE10534A9969CAF0D1A9A2A5D9E57C8DB2D559D0F1C9298C426F2CEF44400B833B565A4A4826</sha512>
+    </dependency>
+    <dependency group='org.jetbrains' module='annotations' version='13.0'>
+      <sha512>5622D0FFE410E7272E2BB9FAE1006CAEDEB86D0C62D2D9F3929A3B3CDCDEF1963218FCF0CEDE82E95EF9F4DA3ED4A173FA055EE6E4038886376181E0423E02FF</sha512>
+    </dependency>
+    <dependency group='org.jetbrains' module='annotations' version='13.0' extension='pom'>
+      <sha512>63EF480F698215D4CD4501B06E86DF1A741AC2B86216FD3FF6EEE146DA746CAA390DF27351E25598971EDB368AEAE41055FF1ED77E4BF5D7EDB6ABC832D150CE</sha512>
+    </dependency>
+    <dependency group='org.jfrog.buildinfo' module='build-info-api' version='2.13.10'>
+      <sha512>F05CE75FB352B1D1A2106A94FF4C24D5FA6E8D9E1B011D502CB8D1A56ABD73E6E888716B505D7336BED203C0CE51169F02041D2B4B707F315F8F9745472FDC69</sha512>
+    </dependency>
+    <dependency group='org.jfrog.buildinfo' module='build-info-client' version='2.13.10'>
+      <sha512>C9C73CFE98439E5A1AF8C8C65E74B975B3009B7BAC798A24EEEED5C9A5B1AD226545E0374045ABDAC00DA3231832031D44C4DB63703B0C3F581A6CDEC25BCD93</sha512>
+    </dependency>
+    <dependency group='org.jfrog.buildinfo' module='build-info-extractor-gradle' version='4.9.8'>
+      <sha512>E7EDA49B33C6601238BE9A7B1B7710486EE5C5DF7920BB1FA58DFA84D2DF73A91F0591ED7983118F804C7673BA1F658EEA3E3A5DE4D85A27F52DBF74C8ED8C57</sha512>
+    </dependency>
+    <dependency group='org.jfrog.buildinfo' module='build-info-extractor' version='2.13.10'>
+      <sha512>2B1F3EF5C93AAF3ED170C1581EBCED318409555706534AD5E069ADDA7E732BCC009D462224EFAD2C61F44638C317480344DCC0DFE9DDC68189B81A0888B605F4</sha512>
+    </dependency>
+    <dependency group='org.jibx.config' module='core-reactor' version='1.3.1' extension='pom'>
+      <sha512>F26B6A1BB7561237450BF7904CC5C76E2E13B4A0A402129CE989146243EEFA9CB1A32A3AF52E6D4E5A20DDE9CA5D33A35BDF232251ECF3C8A2012546C9114349</sha512>
+    </dependency>
+    <dependency group='org.jibx.config' module='jibx-parent' version='7.1.4' extension='pom'>
+      <sha512>DC1B5788C6E25F5A6CD8AAD532CB61FAE8F86D34B3BFAB6119FE4F255144B671456FEBEE0E1C7E908823F03672EBA7580AF963955361D074FB0E2693DE12895E</sha512>
+    </dependency>
+    <dependency group='org.jibx.config' module='main-reactor' version='1.3.1' extension='pom'>
+      <sha512>8FA0A0F8DBC3370365F1168D2CDBCDF5243F691C96FF420966013BE9BD9947EBFEC42903A47B1C0767C6DF444919FF28A99CF12208C29FBFD2313DBA78D77E07</sha512>
+    </dependency>
+    <dependency group='org.jibx' module='jibx-bind' version='1.3.1'>
+      <sha512>ECDAA5EF4E1F46A0A010528E9A76DE7F7FB877C2F439B103E36B1CBA03C213424C9CD6404ACBE9A16D6E982283CA2E5E05BE02373B53AED74272CA140822CEF0</sha512>
+    </dependency>
+    <dependency group='org.jibx' module='jibx-bind' version='1.3.1' extension='pom'>
+      <sha512>64534D9A29D61C21BFD61C879A530213912AF3C50A374C7FF85B48785462A5CC99B0793DC7AA7791034192E9BEC49877DE13F8DF8B44CC299A512827A5C7A930</sha512>
+    </dependency>
+    <dependency group='org.jibx' module='jibx-run' version='1.3.1'>
+      <sha512>6149B9CED0262857B13DC5758201DCBCF55EB54D5C78D3523543570BD74248839B147178794DCF1426D37E7BCD1D34B4F4E38CDB1FCE33E884975A23C4964587</sha512>
+    </dependency>
+    <dependency group='org.jibx' module='jibx-run' version='1.3.1' extension='pom'>
+      <sha512>85FAC8A8B2F127B8809A013E2F118DF1773AB7D43D64E1324EE3C418B4B6144D0E85C5F2AC05FF4728E0D85DBC07BCEEEBCA84746747EA46475F2822AEBF7C8E</sha512>
+    </dependency>
+    <dependency group='org.jruby.jcodings' module='jcodings' version='1.0.43'>
+      <sha512>16AB9BC369CE0EC600C73F2C41EFA59185375DECAC1151C0FB059580660EBE3B5DAAC62236ACC55BE8590E5E7502752C2ACF3CB73F532B7E570CA8A569FA29B4</sha512>
+    </dependency>
+    <dependency group='org.jruby.jcodings' module='jcodings' version='1.0.43' extension='pom'>
+      <sha512>DEC23E0D837196DB7C42EDF0FAE673C83B42FC504F6C03F8F1E13067567D941BD1018D121AC6276C6062F14E6B4AB4F1482C1CA514B3FDB615154F2A5825A269</sha512>
+    </dependency>
+    <dependency group='org.jruby.joni' module='joni' version='2.1.26'>
+      <sha512>237B2FD858F63D24523669134E216CB4E9FE691A8DD48CDFB5F927CBD024FE01A1E11DA0511B271A92DD5A578EF390A49EC91F157B5C4EEDC75DBF8BEB502F8</sha512>
+    </dependency>
+    <dependency group='org.jruby.joni' module='joni' version='2.1.26' extension='pom'>
+      <sha512>B91B3504F1A0AA6C40714ABA88B0DA2071C5BC40B89A825D4C1BAE7B9C194C25796460E7C2460FD1D8CA7EBB38D2BC9C9A2F0A08C867462829F54A49EBB3131A</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='dirgra' version='0.3'>
+      <sha512>A3CA12E57A48C3D8401329ADA8EA80F8E3587A282095778C35E44F875324C7B75B9C9C0534D864FDFCC61FCD2B46742246C733E09B135050D24FA5EE08A4319A</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='dirgra' version='0.3' extension='pom'>
+      <sha512>CB4072377714D2BF3034CE1540E0877B8C039C95D07344983905CC71DFC103A7F1C20F18E53070B04726D8330CFAADF121720A4B3F5B25A6D6422119DFF0E86D</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='jruby-artifacts' version='9.2.7.0' extension='pom'>
+      <sha512>711A305F7C4E4213037AAEDE705ED2F4AFA6E3F881660993A291F4E4625275516A9B5BEDA32833572A262EE45A54834673D3B1EA2422D2DF1954FF77011ED67E</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='jruby-core' version='9.2.7.0'>
+      <sha512>C20008016BD7ECBB537AC89034C6082ADC495D4E9B2BD20A510BA4C6ED72F19C245686946BF99B3DFAE34621F2CE49AF209F8B9E2AFD3E50FFBEFD0B628EFB98</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='jruby-core' version='9.2.7.0' extension='pom'>
+      <sha512>35CA6723C91B41544DE9744CA7987FBAF3E5877E986FCB8C95466B45DEEC0218A8F90BDF446D590C9BD17565BE265452D7F755F36D0ADFE25B55588141F27B3</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='jruby-parent' version='9.2.7.0' extension='pom'>
+      <sha512>CA6A584FF6D0FB09F292AAD7DE906691746FD0FDE5D80A41395BF2B960CEC7033686BA71184E4AEFAD77C73A3230F59963BEE514F4F4ADCE2BA7F29004BEBFD3</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='jruby-stdlib' version='9.2.7.0'>
+      <sha512>BCCBDF3B05923D56666D100B4F8ECADFCF4E12847C999920E933BF9133FDB9C2C60DC8A9ADCC8E92DD54C89AF66892DB028237970CDAC4B060B790B7C6759119</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='jruby-stdlib' version='9.2.7.0' extension='pom'>
+      <sha512>7E275FBDC61DB884CD827125B283E4FDFF90B798C848F408F33C7BB1D55C8F48BCE03CD325E31C7619EBC29F5ACA3A58AF8FF8391981F44A003B2F19E675CA2F</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='jruby' version='9.2.7.0'>
+      <sha512>18632A515C2A4BFB346B8832369AFD9E4353AF034A463BF2351F2C82B9B492B2D2D01BECBFFFFB89EF8966D80D574BFCB203B773289C49D7CDECAE8B5ABE236C</sha512>
+    </dependency>
+    <dependency group='org.jruby' module='jruby' version='9.2.7.0' extension='pom'>
+      <sha512>6B7F2F14A320ABBF6D34DDBEB81BF3AAD2EA0D41AC6A77B0DD35859EBD263CA0DCCC03944816F8EA93BB5D775FE405D949424013C84175F5FE90485DD51D9CE0</sha512>
+    </dependency>
+    <dependency group='org.junit.jupiter' module='junit-jupiter-api' version='5.5.2'>
+      <sha512>48FF2733F0C4C9A47C532FF5EAD91AA4C49E2A35FF368414D4BC920541E3889DD81B68AB7E2A76A836CE2D30FAA55E11496B188E30F13911D9B667DDF670AD7A</sha512>
+    </dependency>
+    <dependency group='org.junit.jupiter' module='junit-jupiter-api' version='5.5.2' extension='pom'>
+      <sha512>A03629BF37BA194F738B672440476C573400DB5F1DE5CA163EE8AACA2903F9AAE5802F7C2A6F6DCD9F77B0F5BC632549A57716128E04244751BBCC4EC7B5124C</sha512>
+    </dependency>
+    <dependency group='org.junit.jupiter' module='junit-jupiter-engine' version='5.5.2'>
+      <sha512>9E1FABD9CBC0C96B3E8C4A75F59AE247DA830C6ACEE19A8636188E51C8472BF11DA4FB701559D6CBBD07579D6A2E96A503B362F997174E7AE09370172DCC16C6</sha512>
+    </dependency>
+    <dependency group='org.junit.jupiter' module='junit-jupiter-engine' version='5.5.2' extension='pom'>
+      <sha512>C7A5C24D5DE7294573E995242D0BFB557AC1C4390B094229F8083617C4FF909AA03B0F91CFA1A8AAD836F0BADFFD285759636EE301AC82977EB605EC7E47BAA8</sha512>
+    </dependency>
+    <dependency group='org.junit.jupiter' module='junit-jupiter-params' version='5.5.2'>
+      <sha512>E3CEB11AFB9E9C340A184AEDA405888CDE14F1626868939E6C2E93082A7C62143C153530A0758070CD83BC07555B5492E07D8168F4B797C7142F81BA618C370A</sha512>
+    </dependency>
+    <dependency group='org.junit.jupiter' module='junit-jupiter-params' version='5.5.2' extension='pom'>
+      <sha512>991C1D7D1AC49337970B0660E62CE6293CA3F7F576AACC6C4FBB3D996ECD751E0009F381A9EBF4955A937DB180DE5E33F58C2144425BA533B54A46F0684D00B</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-commons' version='1.5.2'>
+      <sha512>EDF559F50AA67D85DEAECF8D45463BDBF6669B3A1AB7CCFB4BBAF2AA9A88CFE0FAE79585592C793D7B0CD0975A8A140D3573AD39782F3FB2789E8105CDCD5EAF</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-commons' version='1.5.2' extension='pom'>
+      <sha512>8BA867F0FE0DD31E758E03C1293DE7ACE865896DB6F1DDD344138E8E1C5E5D28A5C26AE6BD189D3C9EBB27254EC8F6B0BF89FE9B69ED4698B13F63401145216E</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-engine' version='1.5.2'>
+      <sha512>EB0EFD2908B21E32E44A0412F35ECA35D712664D5276277A25AC287A21B121C4BE9F609E6517C3ADC8C9652A5FFA5FA6293BEFC0273A2649E51DA5335CC82B5A</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-engine' version='1.5.2' extension='pom'>
+      <sha512>37F9DF42F90C9F20D03264D6B686BFA5C73F5F35B691A717B7A8C4D8DC9CD6D8B2F88F710F63469C68BA71ECBF3261ABF91E7E34EF40CE209C8F8C17ED261002</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-launcher' version='1.5.2'>
+      <sha512>395B19608C80BDE5074DBD9C1D93DF6C74D80138C49392E9241F2C769F7D473B2699FB4BEF1D64E88D0DC480656CC36E07087BA49B499E1465BB648555C67D59</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-launcher' version='1.5.2' extension='pom'>
+      <sha512>4BD03EE23D23E632F7D7601F69234E6E93AA9FEE22D69D209221D2242D734EB26A4932A4CA36DFAC6D6AFCA3B85C17AAF361064E8D8E29AAA8759DFB9C1D327D</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-runner' version='1.5.2'>
+      <sha512>F9AF93325052BEE45FEAB7D80504DF3F18CF1043C18E76F7397574F0910215D5825CCC1F09EE3B4651AEAA01F4AA3D15BB65E9E167DF10E871771A5B37336234</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-runner' version='1.5.2' extension='pom'>
+      <sha512>729222BB7C4EFBDE90754E49A0AE5DA57863536BD5C8A836DAC419812F916A4ED20E0EDEFAFF93D95686C6BC832EB8A194EBCC0BA8E67B2A739682EC62D50E43</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-suite-api' version='1.5.2'>
+      <sha512>72E755F1998C22F50B658C5082DFEF4F79896F6154CF3154FE8FCA7D2B9C8E843411A0CD969AE6E17F50CB858D1358AF1ACE20CF9CFC3E98D925E5961CAED71</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-suite-api' version='1.5.2' extension='pom'>
+      <sha512>75A9A000ADB4FBC096AFF5404C104EB24F547495ACB1EC1EFE8F4BF2DEA3F49CC1DFD04432B1052A33FD35BF4962AD962B5E1DC93F8EA690903EFFF6DD0C4B4F</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-testkit' version='1.5.2'>
+      <sha512>885D6414867C9D9A9FC531B2BDDD3DEE667F228167448E14E78DD9613843E2845F134739069F5D66B51B3FC1B2F95B5E41B0A317F481261E8773C96529DA02D4</sha512>
+    </dependency>
+    <dependency group='org.junit.platform' module='junit-platform-testkit' version='1.5.2' extension='pom'>
+      <sha512>3A36D1DF95A9EF3BFC246A3140ED3724072F3BB320ECF2FF7F22D5DCA09625B9D2C2DDC47984CB75911CB36500F12AF79EAB6BED17A3383358C65BC012E6B1FA</sha512>
+    </dependency>
+    <dependency group='org.junit.vintage' module='junit-vintage-engine' version='5.5.2'>
+      <sha512>291B4D93BFFA2ABCE8EA73AB2984380160DF69D42E08FC77FD4D282C7B3B63D48EBF0EE07ECE7A554D17E0A636422E5E387C979BE9EC5C515CD66FEB14BCBDDF</sha512>
+    </dependency>
+    <dependency group='org.junit.vintage' module='junit-vintage-engine' version='5.5.2' extension='pom'>
+      <sha512>BF1B77DA9898A25B29C2443B7E193D5F7A61D056E6892ACB324AE7771FB8175D5897D4F858622E7A71969F5405F0138A0CC0F8FBBB40860982D200ED121AADF1</sha512>
+    </dependency>
+    <dependency group='org.junit' module='junit-bom' version='5.3.1' extension='pom'>
+      <sha512>CD6A5ED57ED5B87B200EA61D9E3B193F17DB1D5E85723E2C017433E60214A2621E261C7E913735C1E64632061189B79ACAEAFA1EA05E675D1B91B2B78FFCF92E</sha512>
+    </dependency>
+    <dependency group='org.junit' module='junit-bom' version='5.5.1' extension='pom'>
+      <sha512>4AFD1472BC83A7F669967BA05642D7BB16995F6BA904F1C3F644E28F6D493C7D744899E570ECB378CD28EB515EF9F94EA33321BABFA1A7F268FECFD0073FA447</sha512>
+    </dependency>
+    <dependency group='org.junit' module='junit-bom' version='5.5.2' extension='pom'>
+      <sha512>56236162C167146D4FDBBA8CE27189CA95B46D67635C5F8439CC352F1595A67DA8AC530605E322FF10BD355FCFF048CE92CAFAFDB01CF9380700CCFC10161F5F</sha512>
+    </dependency>
+    <dependency group='org.jvnet.staxex' module='stax-ex' version='1.8'>
+      <sha512>EBABD330A2D7C109105FA55C4236FC2F2D52668E70B17B8FC36B8AC9F524AA2C67040E75371267D8E9523D94DEE0CE064E76584C9F206687E89B9F3B2A387F03</sha512>
+    </dependency>
+    <dependency group='org.jvnet.staxex' module='stax-ex' version='1.8' extension='pom'>
+      <sha512>9A03CC888243551D2CA46C8968982A4106FFCD39A84281EE9EB5E54A938E03BEB32A2FE2B26A2BAB43435100618EF7C1BFD7741E46D9CDD5BB84A40AE02B27C2</sha512>
+    </dependency>
+    <dependency group='org.mockito' module='mockito-core' version='3.0.0'>
+      <sha512>90E7EB5E0D1ED8F35014DB76623E90D3914329E218EE8570C2614370F87BF525C198EE508277C11241C643355EEE958B9606A029793E7F4ED980E7CD2DA8E67A</sha512>
+    </dependency>
+    <dependency group='org.mockito' module='mockito-core' version='3.0.0' extension='pom'>
+      <sha512>A4E7EFDCF27F897D08F8AAB6F4E3F7479B4C97E246933E29AF526DACA95F5421D65ECEB7D86F6A2449A39B0EAF385D1AB3729A0BCA2E1387C58E92E8FD2075F8</sha512>
+    </dependency>
+    <dependency group='org.mockito' module='mockito-junit-jupiter' version='3.0.0'>
+      <sha512>F77B3ADB98CBF246F01EEE3F0735C2CCD0135AC3F54CFCFCF7A85DE24EDA27B8B8AE3D66CBC9203A3958E7B3D6DCC78D5AD8E6C8FB9D98E040543BCC98FAB2E3</sha512>
+    </dependency>
+    <dependency group='org.mockito' module='mockito-junit-jupiter' version='3.0.0' extension='pom'>
+      <sha512>C6FAD6790A575E9B34CE8CBB85C4C3CAD48287798A7EB1544E7D271E3ACDF9CEEF38204E045BADB201541BC9D0801ED154D1D1296B05D43BA8CD2867D54CA176</sha512>
+    </dependency>
+    <dependency group='org.mozilla' module='rhino' version='1.7.10'>
+      <sha512>FF4F8BFA5F1AFDD4F2E4C34DE8AA3CE18E4955F3804A3B864CB54583B7CB20621302786D625A2E4ED9EE879452F2E5BA70E855E65C34E58CF7F716D8A4515BC2</sha512>
+    </dependency>
+    <dependency group='org.mozilla' module='rhino' version='1.7.10' extension='pom'>
+      <sha512>F5383122410754CBACCA69153E8FF2DCB7A50B6CCAC0DA5EF6FECA528C4FEF4F3C37830475F7DDDD213FB56EE981675374D3FA1160E4991A7AA03B34A07CF877</sha512>
+    </dependency>
+    <dependency group='org.mvel' module='mvel2' version='2.0.11'>
+      <sha512>CD1A24F847953861D002D0B8F9485D101676A8AD90492A46303566759008D86B7E9963F69F042921CBA493261AAAE297781922B21D66CE6921749E26B885499A</sha512>
+    </dependency>
+    <dependency group='org.mvel' module='mvel2' version='2.0.11' extension='pom'>
+      <sha512>1836334421AC918FB293A7AC7F7AD94D033C205F153AD207BC3A28EA3E03AFC2AC66295DECC5CC09E1211312650BADED82FF7855001FA46C35BED0E01A597C3B</sha512>
+    </dependency>
+    <dependency group='org.objenesis' module='objenesis-parent' version='3.0.1' extension='pom'>
+      <sha512>164A81AECE2AF9B8DD05F568445EF33F4AD9127CFE5F0BAA52E76C582FC65A6C9AF4F0C95EA9408AB2A2693620D263068DDD943765F162BFBCEF0E2DFB450330</sha512>
+    </dependency>
+    <dependency group='org.objenesis' module='objenesis' version='3.0.1'>
+      <sha512>A241931A86DAAAA16C6717B55109F20DFE34BA8904DF2A027FCD3E8BB1D65B4C13AF0A6E0AA8C66C80351360452F6E629ED77C3E74077E602E0ED671BBA28103</sha512>
+    </dependency>
+    <dependency group='org.objenesis' module='objenesis' version='3.0.1' extension='pom'>
+      <sha512>3A0A1026B2AA431CE5F9D136979328EC47601841F6EC00C99B4CAB322DA480F130D1DBD2346C83ED4A3EBFFD2108123750CF96979C5A0F36224EE6DC280C7DA5</sha512>
+    </dependency>
+    <dependency group='org.ogce' module='xpp3' version='1.1.6'>
+      <sha512>49F7106774944AB02F6CC2B4EA3171F555AA43C0F32CF92FEA8CECC34DF106A90C2C6060F1768221BE1A83292B09A3A91B030E181FC69DDBB9775E0ACDE42B44</sha512>
+    </dependency>
+    <dependency group='org.ogce' module='xpp3' version='1.1.6' extension='pom'>
+      <sha512>25AFDAAB005E43E0711C92F0E6B6B595D2055CA50B8CBCB25E7C06BF5678153C75E3788F557550A600A57275DB97608F09766940BA898C3E8D088B389B27A709</sha512>
+    </dependency>
+    <dependency group='org.opentest4j' module='opentest4j' version='1.2.0'>
+      <sha512>17F77797A260EB2BD1666A90E25EFC79A5413AFA9DF1C1CB6C4CD1949D61C38B241E3BB20956396B5F54D144720303D72A2AC00BC5BF245A260A3C3099E01C74</sha512>
+    </dependency>
+    <dependency group='org.opentest4j' module='opentest4j' version='1.2.0' extension='pom'>
+      <sha512>28CE0D0B5CCEEAC5ADFCDD16EE6F5FBEFD43EEF8057B924993FB7A9F4B7A7085B980F3E808DB5FB7750A53D0072B7FE7B118F5C0011E3EF0EFE6C9A90A87B868</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-analysis' version='7.0'>
+      <sha512>1A6CA169E9E2D29256F9C45570D89E5B039EAF7D405CCB3F7F79926552F2A0818975CE2C6ADCE3F1F59E28172E4303A1C790C52AB06263C61C9C8181FF279CEE</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-analysis' version='7.0' extension='pom'>
+      <sha512>B2AD03AEDCD027E02D493BFB39AD454AD1F969F420AF9A27531CA2650B9720375E3F65657820BD5E4B3095625CD9E5C30543A2BE14ABB9F04B9928514CFDCB99</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-commons' version='7.0'>
+      <sha512>CA97B49EECE30DA774055B58A63C6E4F65A6BC4C0F40A829DCAF7164FBFFDEC10C6B2D9A22DF0A0918FDC83A47EA9906294AA99D3F170B35FD9E0632578C80B2</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-commons' version='7.0' extension='pom'>
+      <sha512>A092E8DBB0AE7417C3A245BA022485B84432FBB7C072EA1100F60266346CC94E9D4176C25F981C3E05A86E0E0C8348AE6EA0856CF29EAD310946FA982BD70EC4</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-parent' version='5.0.4' extension='pom'>
+      <sha512>8F997A690395BF41874257C8446A5C99EAE3CDDDE13E74DB4E30E433FB76287D82230A8A951B34855E1FB156DBA2C2DA554C96589C292B1169B9609C0AF8FA71</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-tree' version='7.0'>
+      <sha512>81A223620DD16340D18ECBA20AB15CFE078F61AB0EC1AEF091AFCD282E3F6047B9800200412116289EC14917B5ECE9414C8009E92CC9A3333C677B5BFEC13BCF</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm-tree' version='7.0' extension='pom'>
+      <sha512>E88F0D20160061E9B6EBA203A80D50471DEB53ECE26C256388D06A8026A455C0463C2CC9463C427E88797BD075DDAA8E9F1594FE2F0939997677C629E86F6CCA</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm' version='5.0.4'>
+      <sha512>AFEE8F98EE21771F104318D95B839D9EA6EA083157BD62D8BC3462D9302DC20EA939D1B4AE2222F92F09B92BC9AB1317AFF02734007F716CC805FE49B92A8A5A</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm' version='5.0.4' extension='pom'>
+      <sha512>837AEB03DF629D187CF83BA9CB6A1E7637F044EC86A3217C04C0DAC44FAC3E100E9CBE3EAD1F3BB27285B6478CC961D7CF7009E84892662B299876A0BBFDF3B3</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm' version='7.0'>
+      <sha512>B31699F50485DDC4E84466064CF5789A3E61BAFBEC53C4B9CB19FFEF07B36722D3EFDCA8722884FD6D6DEDACA65DB4DD6F71CD886BBA599E8A77971955167A60</sha512>
+    </dependency>
+    <dependency group='org.ow2.asm' module='asm' version='7.0' extension='pom'>
+      <sha512>A7A2060B33710202034E1F025A687A40EC97232213BF21A8AEB70E23D8B2200A0F7C33697D0ADAF942C1AC2852D7B5A4032A43132A89B5692FA68A26CE32C77E</sha512>
+    </dependency>
+    <dependency group='org.ow2' module='ow2' version='1.3' extension='pom'>
+      <sha512>DABD83686169BF4771C719D055FF296A05D108552EAD8A531954AC081EB128EDB9CB0FB9631F20E4BBE16035E2F1A1D5972C09DDFF7F2153E64D538015638765</sha512>
+    </dependency>
+    <dependency group='org.ow2' module='ow2' version='1.5' extension='pom'>
+      <sha512>5445748E294CF9F23FE8F1E18E2EBB7108800D40F81A4566A73F9434FE21D2058D05ACF3BC4D15F629151DF47C42BCF948DE3BBA0B6A37982DFC3A8F1BAF244D</sha512>
+    </dependency>
+    <dependency group='org.pantsbuild' module='jarjar' version='1.7.2'>
+      <sha512>D5AC3AE63A4C5DF853F84CB0A1ABAF6D32A8CCCA39C6FE328C995588EE22A2F9D034D885749547EB93D16D49A22596AF4405B3E7B25B35517602A726AF58EAE8</sha512>
+    </dependency>
+    <dependency group='org.pantsbuild' module='jarjar' version='1.7.2' extension='pom'>
+      <sha512>59E7CAA595CD9B1B4DB92F69068DAECC2F1CB74B4913C8D61A4254ABD4A46B44D46BED5AF1C109DD3ED1BEE19851230ABCC19D7B3291141DC35849183C3FF0A3</sha512>
+    </dependency>
+    <dependency group='org.python' module='jython-standalone' version='2.7.1'>
+      <sha512>4824D43A3991C68C837D3F9AB7BAB4144CC129DA75A3D15E1FD6A54E6B941C469E76EE7827C619A10546361B44C5F146595019B7341689CB9631FDFA159C9931</sha512>
+    </dependency>
+    <dependency group='org.python' module='jython-standalone' version='2.7.1' extension='pom'>
+      <sha512>6610EB44429B87A5CB0CE380BC8F77B0296FDE6C13569AFE38021FFE06E4606FF83E8ACBA080CAE54F57801B4D1BC54E67488023757E529EF495C86BA394DC16</sha512>
+    </dependency>
+    <dependency group='org.quartz-scheduler' module='quartz-parent' version='2.3.1' extension='pom'>
+      <sha512>1A537B27B10A26693DDF0B96C9794558D1DE034C79AD2AFF00C189EB7F68F1C053BDA00A94F38D1C4E408069414E955138867E5CD04B1D5118B962561FF29D24</sha512>
+    </dependency>
+    <dependency group='org.quartz-scheduler' module='quartz' version='2.3.1'>
+      <sha512>116601257CE176117A085582C021D231CDFA4F5FA7A87F81C4A56B03366142A339B26E01CA50C679800E59BD01CD1A9C2A0E7AF015DADADCAFA6F76EE26DB026</sha512>
+    </dependency>
+    <dependency group='org.quartz-scheduler' module='quartz' version='2.3.1' extension='pom'>
+      <sha512>D6089CDDF562F1EFA95AA882F10D8B76EF6B6DC50DEF341561E3375434E0270FA3718E202EED424EEA1515800E743ED0C586DD9DBAC4389F20FAFEAD18F0C80</sha512>
+    </dependency>
+    <dependency group='org.reactivestreams' module='reactive-streams' version='1.0.3'>
+      <sha512>AAFC86186D82B4F3BD44EF7F955978481172EAB267D208AA80B24F8CA218BD902D69B587FCAE2FE44A888B7A9F81FC5A209E837958307FDC0EE815248F7065F9</sha512>
+    </dependency>
+    <dependency group='org.reactivestreams' module='reactive-streams' version='1.0.3' extension='pom'>
+      <sha512>7E1E70ECEA77701E994E2D3A9294CFC7206B81D77ADB9B7B404589ABEAF98FF86A17C3C07E3089E84E94C20922AB57E7686742C06FEC763C3EB3FFB1AEE40990</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='htmlunit-driver' version='2.35.1'>
+      <sha512>52CACA92D4A81E84298E304949FBBAE3C40F5410439D180D1D41DBA59C72C146A154DF9C2A195D81919E48FAD273101E1693A46D92AA232636BBD7644AE7B0F</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='htmlunit-driver' version='2.35.1' extension='pom'>
+      <sha512>563188849D781DC61F477FA9DEE05F384FB8E0CB015BADCE6B622FE4D60F69652D72CDF232C712825EB0B9B2861359E399754BADEC6F26D91D6E86920D79EFF9</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-api' version='3.141.59'>
+      <sha512>96F1FA8D4FEE6A45225B18E4DFC1143BB704F2DBFF5BA4983A5E890DD6C34B74EEBE62181B7C576F2A2507591AE02976E4DC479317D7028E03CCD45949492E53</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-api' version='3.141.59' extension='pom'>
+      <sha512>A0507A7440CE53936C1D710EF34FD87E4A01458C304AFB9220D31DF95D0BE90E12EFCC1B3E3C9F0050627172FB62497A0A6C2F64053105D61E5ADA1967EE4A4A</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-chrome-driver' version='3.141.59'>
+      <sha512>A86A32BD23975A5AF30FAD41F3C9D4D939670D08670CAE94FB7FB42205A4181B93C81F5F58F057C43D68160FD0184E70CB6183F5B6C8C47A88202C024633E886</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-chrome-driver' version='3.141.59' extension='pom'>
+      <sha512>2B25178F01647C15A71F966FDB0719D1EFC24BF7F118A1D435E607C1B729738D8E0FDDDAC8493AB22759162DE662A52BA05E0472D193E914AB7062F56730C6D6</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-edge-driver' version='3.141.59'>
+      <sha512>106780D63D2276F8BFBAEF5493858BD7D23CD5E0098DBD64F0BD17922B3EE5FF5F2120F2902CB46BAA64086E5DE9A15E86149D9985F785B9A4BD454EA78C79EC</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-edge-driver' version='3.141.59' extension='pom'>
+      <sha512>E17A0E464C8D18B7E6AD2CD24F74F8E4E951B29036A2B29CAFE4942BF991221841DA3FD7A5D76E0E3A19368EB27CAB9045C9FCAB144967506527B4A839FD115D</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-firefox-driver' version='3.141.59'>
+      <sha512>9FA55C7C7879F9FB6BE78A5611F9227FE35F644A1D3AE393865D5CB19546F3C078A6E4D3A9D7DF65C3F48199584C894935C40A683943DA9DB5205CE64F193C8E</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-firefox-driver' version='3.141.59' extension='pom'>
+      <sha512>9D01403B48F4413B5C86A07C8A2ECF87074182FB2117E5EBEC712B7F0DF7E07B4329E7B6D1B183614E8854BFDF4D94E8F4688E1E808F2114CB0CEE3B7FE70946</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-ie-driver' version='3.141.59'>
+      <sha512>58DB50C7DF70488371390A6AD0EC484C204C707F9619567CED96D319B06B511CDB3C42BEAB15C8F28C836A20A92C38243DD5C4F55A36FC19176FC513CB05C969</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-ie-driver' version='3.141.59' extension='pom'>
+      <sha512>FF3881A0D0CF22F711C77B09B2DF520DD23384A50676148C106113E7A563B8BF7ED95E34840EC54CADAA4D886AC593045C91032218404C0ADD3B506A615660F</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-java' version='3.141.59'>
+      <sha512>26A7A5C63A663AC4085CED70C7AE5A0CDC7C2D642801B96C2D32B97BFDFA4A6B36A9A9FEAFD4045E3DFB766F90159B0948D421E3609D870363358B5E346BA870</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-java' version='3.141.59' extension='pom'>
+      <sha512>1E1403455280E7651BC950CE58FACA7BD07794D58E7F5B38848BAA5F50987BC43BC59C851BBDA7CB351D8A0C4B3EE9CFFE8CF25C60AC88233017738E653F5F41</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-opera-driver' version='3.141.59'>
+      <sha512>642385B80A370B481E86D788CBA06F66E63077897754E2BB94F896C3284A41746282238DFB70BA69D84B918E3F384A6E16D29CB728B0646EE983214DF67D9B6</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-opera-driver' version='3.141.59' extension='pom'>
+      <sha512>9BEE61B25B51C770E2D8012C856D0BC0D9FB5A9783152A7A8ABC0B48E4E58BE9BCD99F60DA905671F0D479FB13373BD509E14CD4CD45A90FC5E8C98961957EE0</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-remote-driver' version='3.141.59'>
+      <sha512>44739DFC05D939FC23E237344E8EE62EBB2F42812F933B5ADDB5C9B0358457444AAA82869AAD6BF4ED25770F7FCA63D521E49ECA170292360F230D0E15605ABB</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-remote-driver' version='3.141.59' extension='pom'>
+      <sha512>73D14CE1E561080CAF24D3F2B29191EEA0CF91D117057B3AAFF26252F5FC4F6055E1DC3B41C4E2659FF5BE3F6F97C43B6ED36F71A3DC1B9404A48328EDDCC7DA</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-safari-driver' version='3.141.59'>
+      <sha512>ACEB09774567EC726B0D12F69A80C2813D86A23C529E4F01A1C45C4C438873666EFF67C34ADFBCF67799897FD195B111C232AD5B8B09D0D552931D7BA2CEF957</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-safari-driver' version='3.141.59' extension='pom'>
+      <sha512>EFEBF81F877D5E3EF8B5027F4E537C736A20BB886D80625DB1086BB1A93F063A3AF86E531612BFCE5E456E55D432F8B052055C2AD85735BF9821C985C1BFD336</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-support' version='3.141.59'>
+      <sha512>BB81EFC5662313B31F50DD66D93F8CDE6FC7B92936CAD185F0E91A0C9DE55C16E5A3F943E094A0E46FBC03AF06D98B4101B7073F1F1D2831BFA37C1A93C19417</sha512>
+    </dependency>
+    <dependency group='org.seleniumhq.selenium' module='selenium-support' version='3.141.59' extension='pom'>
+      <sha512>695E58E80BBFCE9032C5068370D2D4960452FC6929137309F7835DB4D5A2CAC1A2EA70B1BC9AF02A86BAFA4F8D0D64273E0D398BA60413F9F4075BABA7565CEA</sha512>
+    </dependency>
+    <dependency group='org.skyscreamer' module='jsonassert' version='1.5.0'>
+      <sha512>CE2100374F56027C950DF4BCFE10987FE46905690DB83393504A2198761429594A9E7D51743EEED102A9F6584C7032E87C4BBE262E1A4D5591B8692B76E594DE</sha512>
+    </dependency>
+    <dependency group='org.skyscreamer' module='jsonassert' version='1.5.0' extension='pom'>
+      <sha512>D76EE20D753B06DD01A24D591F3DCF913DAB2634C0D17EAA67455F458287F01F5D610242708BD8D67DFA5BE6A36B684947FC8E615D91CB55DE7F677184FDB133</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='jcl-over-slf4j' version='1.7.6'>
+      <sha512>FE4D11CF1954157DBD205235B46FD1E9F4BD09FCE2A9982283D8ADA4028BEDA0F21C837620FD0E16CFF8733EA1891AF61A55CC2E906EFD762ED9C2822809EDD3</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='jcl-over-slf4j' version='1.7.6' extension='pom'>
+      <sha512>9CD5C2D66F49AEA7E4B0CEF8059B2813802F0C7C883D9DD6E239F319DE42F80ADB44FDDC1359C0F8EA2D88A92815127FAC65B0A2F70663C3A3133C9B982540B8</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='slf4j-api' version='1.7.26'>
+      <sha512>A944468440A883BB3BDE1F78D39ABE43A90B6091FD9F1A70430AC10EA91B308B2EF035E4836D68BA97AFDBA2B04F62EDECE204278AAA416276A5F8596F8688AF</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='slf4j-api' version='1.7.26' extension='pom'>
+      <sha512>8F49743FE7C6F69391FF34DF4406433488D9A409AC790D4A1062491E99317AD659E048F430FC01955BC031E498802158720EB9C1797E039A4BD5F9DCEFBF8948</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='slf4j-parent' version='1.7.26' extension='pom'>
+      <sha512>8A1C1D9DD09C764CD0AA52B801319767D0EE809EF5B9250E05F8162369559105C9DA8728FBF1AE606688ECBAE1EDE79378F0BD0AF9B5ADFC7B6735EF4459DAFC</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='slf4j-parent' version='1.7.6' extension='pom'>
+      <sha512>7D08D837F15885CD92F6AE4009B6DCED9B6DD20C3C48B0263BCB12DAA8A7CEDBEBEDDE3A598911E0ADBC4318620277F4F97ADCC3CCEB5639ECB95ABE1883F298</sha512>
+    </dependency>
+    <dependency group='org.sonatype.forge' module='forge-parent' version='10' extension='pom'>
+      <sha512>8A9CC1F099B074E3CC729A0CFD4A6E8EF9C4E61AABC26F42D9EA40C275A1ED403F20C17BE546B36104C27CE5C2317DB009C5FE077E9EB1BAE17EFB743D6F7BDD</sha512>
+    </dependency>
+    <dependency group='org.sonatype.oss' module='oss-parent' version='6' extension='pom'>
+      <sha512>33E5110A816ECF0A9AC73F41243B6481AA85ACE660F00D6D3C22738D72D9C1A426AAB9BC6BAB156DEC04491D4805471F00E960D033DFF266B4354FCB33F3F57E</sha512>
+    </dependency>
+    <dependency group='org.sonatype.oss' module='oss-parent' version='7' extension='pom'>
+      <sha512>63B0951F793EE9D25239EE44760E4D51DE3B8503E438E567862306F2D175019D8617EB854BC4EE2374C39F385E0A1094C3C7097F899B2074E4ACDA14FE6030FB</sha512>
+    </dependency>
+    <dependency group='org.sonatype.oss' module='oss-parent' version='9' extension='pom'>
+      <sha512>1C4F18CACD3A9F99A168BD20845D12D94824E66B5CAEBE57C164B6AC3DC89803508F60E35C4D1DA81D3F3866C89ED407826F0D108F1E624C2D8A258E01E1064A</sha512>
+    </dependency>
+    <dependency group='org.sonatype.spice' module='spice-parent' version='17' extension='pom'>
+      <sha512>DCB3C40AD537F5B0A2D1125B4CFD51E98A1B52B67801A938C110E4A267B1555EAB663034D6FEF5B32C6BAFC8BD70EECF704F44D6B3141FE3CB952AF5BD5C8C65</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-aop' version='3.1.3.RELEASE'>
+      <sha512>BB1C3A49EE25BFF40D6EE14A91BA8F457ED6A6AA8BF9ADCCBBBF8B7AAC19BBB81690D5AD46E592D57C3C453ACF4EFB4F759B58E48317B746D8D1F8060E2B6558</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-aop' version='3.1.3.RELEASE' extension='pom'>
+      <sha512>5E93CCBB4AE498936376E1E1E99C677808804FCD8E362F89DE80CB0DFF50235C566F7B8F46A4B9A4A42B0ACB71DED8761BEEE4F234ABDC949F10160EF8C431CA</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-asm' version='3.1.3.RELEASE'>
+      <sha512>A0EBAEEAF14B46A5891630AECCF0BE4672AC222BA96DA40EB9A5F3F383CB1C0C535E77FA7DB830588558283122ED5C7188C2A35FDB1A1B12608F35B58C097E87</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-asm' version='3.1.3.RELEASE' extension='pom'>
+      <sha512>A998B9BBEF14142AAB78D4A67B4D4AF8133A379A6CF564515EF8C3AA6F8C0E6532791545256B7A025859B7AAE5287BC4EAA5B4B590C75CB23590691E887C358E</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-context' version='3.1.3.RELEASE'>
+      <sha512>76EAF8B8659E8E2F563B3D3AF9F5A8D7DEB8441BC6CC71F0EEA86F1380F6FB9CAB7BA56A068EC3446176A82D67735B14161F6DF027FC86D8AD7FEA09B6B81C24</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-context' version='3.1.3.RELEASE' extension='pom'>
+      <sha512>71C5BBD8ACD46880075E5966CD4711547768ECB8E0EF0A58DEC39B1EA9251B4EC9DE369B5577E9306B6226B96DA0104CD0B5A2AAA505D4298D725C056AB967D</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-expression' version='3.1.3.RELEASE'>
+      <sha512>6D856B969B355032FB09B8FBFCC784AB34AC50A0719563F6E68708EF55709A5BDD3F219F545F484BC27EE82225D5D49FD3B9F405877814B6364819CE82856A84</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-expression' version='3.1.3.RELEASE' extension='pom'>
+      <sha512>44E433DF3C1D2B99A8FFA4128A35886F2DCD951FF4AF33D6B11ADFC7E6092E6D43BD4AAEFDBADB88CE82E71D6F41E69E13684A5F80458587B4B91D7024383341</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-parent' version='3.1.3.RELEASE' extension='pom'>
+      <sha512>AB6DFB55345C3CD1F939912C7512C6EE9D6BF9846BE5B3200A76EC772F499B72B317635E84D988ED739C75908EC0F81BDC9D89B8AACCB41D303EAAA6FC623510</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-web' version='3.2.0.RELEASE'>
+      <sha512>5181812BE64307F2D78AEC80710A079EB5CC4293D0C28CA930A55519AAE19D8993240557FF392BAB225851FBFE938B2D9669B8692F1CFC9548FE52DF6467A846</sha512>
+    </dependency>
+    <dependency group='org.springframework' module='spring-web' version='3.2.0.RELEASE' extension='pom'>
+      <sha512>8EC25F13F1C3D6D92A059CA35461AA66664CA061CC28049B9CFC20BBBC9406B2FA36558C65D1DC103038A10476D42607F0F14FF652C0922B93E95E9E1666DA66</sha512>
+    </dependency>
+    <dependency group='org.synchronoss.cloud' module='nio-multipart-parser' version='1.1.0'>
+      <sha512>9687E3B1EB292FB1180413721EF42BBAD97C26552AB78B2461CAFC73161EC5E91A38BEF20AEC729A2AB1A9BA08B99A8B5B2B6DBFA889E9445DFD2B635036BA4</sha512>
+    </dependency>
+    <dependency group='org.synchronoss.cloud' module='nio-multipart-parser' version='1.1.0' extension='pom'>
+      <sha512>F3B8F00488F6096C9DA3FD5D65945C5512279BF95B915BB38F63F2ED85C2AABB114E7BA4723CC2720DBD529CAB223A1B39679364FD98A8F19EA423AE6C8CD84D</sha512>
+    </dependency>
+    <dependency group='org.synchronoss.cloud' module='nio-multipart' version='1.1.0' extension='pom'>
+      <sha512>6D89F5DB86526591AB1D8643159AE5D46959D043B678F1FA6885EB81D9EE8665831651F58CAF17FA1F1BF964350D69C14BB42013718F221949AF63D77EB5121B</sha512>
+    </dependency>
+    <dependency group='org.synchronoss.cloud' module='nio-stream-storage' version='1.1.3'>
+      <sha512>2A1F65C437C3B2BCC475C546E9B5CA7AE3F1B448BCD65DC29F442F3AF1A7A70B8D815603430A1C43F8C761AC17D36109A33B012BF3CA87CE1F71E12188026670</sha512>
+    </dependency>
+    <dependency group='org.synchronoss.cloud' module='nio-stream-storage' version='1.1.3' extension='pom'>
+      <sha512>270BC784F1E6FBE38272F98BAF49464A5033C2ED74D8F81D7F3596BA846F4678CF0B9A12C7089C77C5EE569E44AC6F690E228657EDD2DBE78BF072E8FBD9B86F</sha512>
+    </dependency>
+    <dependency group='org.testng' module='testng' version='6.14.3'>
+      <sha512>9AC5B7D487339E949DF9F57C0A58366F3501B831500D7273C01B1C57862AAD1ADA4281B65D19814E44557ACC91CED474D5AC0F921CCD60216528ACE09838B68C</sha512>
+    </dependency>
+    <dependency group='org.testng' module='testng' version='6.14.3' extension='pom'>
+      <sha512>D6BCE83989E645A49927EB7E250C7A27B5580DE1366E69A0F9C0EDEB247A7E229854D228C166FDB3944F6377DE027A32AAAFF0D21BC45701A601547C75FDD01D</sha512>
+    </dependency>
+    <dependency group='org.webjars' module='underscorejs' version='1.8.3'>
+      <sha512>FC7B3B7997E1722DD28F081501ACA08835BFB69E63A0EF0B7927A0201FE14F4455130E1B451C85F2724A4EEDC4E4C76D1B96ABBC4C980C6EF27D10D32DA409D9</sha512>
+    </dependency>
+    <dependency group='org.webjars' module='underscorejs' version='1.8.3' extension='pom'>
+      <sha512>7C46C1BCB0003ACF49712A59FD9FFF7219B802B058B144C136A64E11AC9DAF1217DA17B73F56B7204AE18E1F812B220E4248E2FAB2B9C1B2CFC1CA1D4C114C2A</sha512>
+    </dependency>
+    <dependency group='org.webjars' module='webjars-locator-core' version='0.37'>
+      <sha512>2E80D3CA52D22A7C6E867028475DCA21CDE850F4C3692DD3C732C6350D533B8AB481C955169D7523E1203650B69ED49EB4933D5149F8B79E04E04C4D3249BB7C</sha512>
+    </dependency>
+    <dependency group='org.webjars' module='webjars-locator-core' version='0.37' extension='pom'>
+      <sha512>1BECE42E881C8B23620F6981E58D7044966D8DEA9C6732B6287D39112F40CBF18804F1261F01CC5FD516DD361E0B5EE4E130356AD2CB6EA1D262B016F6448C8C</sha512>
+    </dependency>
+    <dependency group='org.xmlunit' module='xmlunit-assertj' version='2.6.2'>
+      <sha512>F645A320BA18B216A59C59C438460B67202D25FD73E72A5A31B888830AF821B11C4EE487456F7A17ED43F0A86E154F0FA37E5AFE88CFBC7DAFAE954856ADE265</sha512>
+    </dependency>
+    <dependency group='org.xmlunit' module='xmlunit-assertj' version='2.6.2' extension='pom'>
+      <sha512>305F7FAF3601D1833AA4D3F53B129B4DDD859D42C3F85A767A35B75837402850DDED8A75B9EB8931832A26DE214F20EED9D6767B226B00FD32A2CA1EBADB9B0B</sha512>
+    </dependency>
+    <dependency group='org.xmlunit' module='xmlunit-core' version='2.6.2'>
+      <sha512>866AF862B5CCB9609EC4410F90E95765BBA0FCA156E2E4396CCDCD2312AC6531D99AF012E93E35DD12594998D5A26867C1B9D6B219488C7D14B1B3F52B7C57E0</sha512>
+    </dependency>
+    <dependency group='org.xmlunit' module='xmlunit-core' version='2.6.2' extension='pom'>
+      <sha512>7D5F1881ED601EFAA3A85F225282CB0B5A8A253AE05E5584740112D0D440865AA4BEF89BE28E7C5031523EC95ADD5149D84FD3D6DED71F89EEEA04B81D0FD582</sha512>
+    </dependency>
+    <dependency group='org.xmlunit' module='xmlunit-matchers' version='2.6.2'>
+      <sha512>AF9D7A42ED79A0C5CA7CD931191851824B334E23E602FEDD4E110F15E3D7AADE50F14BF8D352BBA7C0BC91D7576015959E6A48E15546BB0AC5A9C153E201A6D7</sha512>
+    </dependency>
+    <dependency group='org.xmlunit' module='xmlunit-matchers' version='2.6.2' extension='pom'>
+      <sha512>7D952311120B270B77B83BCDF7DBC733B5A7044E09463C18CCA1C68DC25DDAB3F55C979FDC010EEB4F3B6D29A207E9F9B6DADB363D05CE0171D83D08255A1520</sha512>
+    </dependency>
+    <dependency group='org.xmlunit' module='xmlunit-parent' version='2.6.2' extension='pom'>
+      <sha512>B63CE837244A525F02D9583A51446F1BFA332E81D8C77E49CC7BD45F0C0A4437E2D22DE444F1E2B833AEFD60914209E419698890E2BD79E606218BA8E58FBD4C</sha512>
+    </dependency>
+    <dependency group='org.yaml' module='snakeyaml' version='1.24'>
+      <sha512>9446975C997819BB6E11AFF45F94BA38B77628F72C39C4F0BCEA70BF00BD8EF5C8CB73622C07300A38771B6CDABC6FB4E3E7728BFDA69D7387075A7F9C376E2</sha512>
+    </dependency>
+    <dependency group='org.yaml' module='snakeyaml' version='1.24' extension='pom'>
+      <sha512>E2E63962D452149E9EACA6475CA0A8CE9AF7FCB031FC2E2CA9619FD973C19FC92FC0A98F86A26D81CD8590A4AB74033B30B2B600C12FD344F408D70FF172220E</sha512>
+    </dependency>
+    <dependency group='oro' module='oro' version='2.0.8'>
+      <sha512>9A98E493C4D771322B1331EC05AB0E363A83D8AC2AF8018D96A44DF2BF5BFC97D33EBE6F6F93E46AB10BF1536F0C29E9D9569318ED49BC18B4E96B1A8B476D37</sha512>
+    </dependency>
+    <dependency group='oro' module='oro' version='2.0.8' extension='pom'>
+      <sha512>3DE8B29359B5B84A6EBB525BA7525BDA1332AC00D880BB5C85F650B2A0B7F245F7288434F6E9506302B7FFEDFC44F941090E0BC8F6D66C440EB7A9544E6857C9</sha512>
+    </dependency>
+    <dependency group='xalan' module='serializer' version='2.7.2'>
+      <sha512>884D865865858A46306A3680DF69F3F0EFA0DF1313706B54E6900D36AF21E17CB6828F5A6BAC551C59F7F80BDD1CB64C3FDBDE44E213519C4AF87969E9E70774</sha512>
+    </dependency>
+    <dependency group='xalan' module='serializer' version='2.7.2' extension='pom'>
+      <sha512>1A20CD7008AB876F9605A67515D558B26B9BE009C4F49CB27DDF5AA715B5D164C476C236B6D6EDF39E81538DFB1516271C3859AF8E73F8CDBEEE24EFB45E9A44</sha512>
+    </dependency>
+    <dependency group='xalan' module='xalan' version='2.6.0'>
+      <sha512>676D3ED755821496F9ACD14EEA0F89755E67E4F6B3A7B9309E8758C74829F74741BE58C846C7EFD42B6BB1891329AB2F1C6A9A5A2D4B825DCABBB3DE201532C</sha512>
+    </dependency>
+    <dependency group='xalan' module='xalan' version='2.6.0' extension='pom'>
+      <sha512>DC7BE0488A850B51EB7685D6EE2233591EB47F867780578D9718B43728D09195C170A65B2643255571CAA471BE2B069CFC5A1AEF1245546251EA9532A7C4B988</sha512>
+    </dependency>
+    <dependency group='xalan' module='xalan' version='2.7.2'>
+      <sha512>F859C5BD65F6DC91E396CE91FE2F6D30B2354D6B419CD9EA96984C5403E5CD1342BB9362B0AE1F2792612F0DF731C4F7AC92F16A825BB7E22089C27A129C6C</sha512>
+    </dependency>
+    <dependency group='xalan' module='xalan' version='2.7.2' extension='pom'>
+      <sha512>4B95E3EB3A2AB262C9A27040A5214CFB8C49C36ECE8E71A933074EB063205EF96DEFF351F017B034C9C97D43D77B020482AADE7BC01E1245D8EE10A51269C5CE</sha512>
+    </dependency>
+    <dependency group='xerces' module='xercesImpl' version='2.12.0'>
+      <sha512>E9D62DC311DF808F88AC63B427BB40567C19CEC618A33D0A9C7C830B1BB7C64DAE263A5EE6C824D8E51A63CD24F49FE2EF4E2563D6E6AA0400F63E9BB35DCE97</sha512>
+    </dependency>
+    <dependency group='xerces' module='xercesImpl' version='2.12.0' extension='pom'>
+      <sha512>DA659CAE1AD06F86EB071A5C0D3CCFE4FA7EF2848AC74F0C6FFBF65F2872D0892575DFF9A98A7E9029C0B5E14B95B4364444F43DC2F18F43C946E6D50E568253</sha512>
+    </dependency>
+    <dependency group='xerces' module='xercesImpl' version='2.6.2'>
+      <sha512>9219427FC6693B59A1E6D6BE1EB93B9DF7A717B0B450396E3E74B0092076B3F04AEC7763C36DD688A94B99D9DD2685DCFABA4B770C28C0FCDD19FB4654029B91</sha512>
+    </dependency>
+    <dependency group='xerces' module='xercesImpl' version='2.6.2' extension='pom'>
+      <sha512>72BAF1FB855B0A953DB90D389FC408A579200DEB364B999E880C4AB93DF755C544D1644D6B72897C2F68EF131859321FFDD6D37B264A370BD2546E69E374737B</sha512>
+    </dependency>
+    <dependency group='xerces' module='xmlParserAPIs' version='2.6.2'>
+      <sha512>EC33F820102BB329F1F058596CCA2F5DA8A3CCFE2EBBFB7C5E34696C305DC4D1ED66CDCAA674EA14758F0DC28EEEE81283F95B5208D8F29C4E764BC092B7A9C1</sha512>
+    </dependency>
+    <dependency group='xerces' module='xmlParserAPIs' version='2.6.2' extension='pom'>
+      <sha512>2A606B6CDD58C81BFE175C08F413F5F2ACC97A100FF141EC416D2AF2C8B897B11B0A877975C1D6276AF2B3FD73788DA41B62EF4AE9741E82898525D5472EBCFF</sha512>
+    </dependency>
+    <dependency group='xml-apis' module='xml-apis' version='1.4.01'>
+      <sha512>8DB0283B6840CD6407957D296B802E3EDF90653E2722F8E29F86C1C0B60996C4B43E9E065E6864DAB89B2138DDB0174D9B4FDDA4A93F94EEB884783DB82F3268</sha512>
+    </dependency>
+    <dependency group='xml-apis' module='xml-apis' version='1.4.01' extension='pom'>
+      <sha512>814138BA9398F277244281968FF82A3F772425B48A720D401DDFCEFDAB9BECCE0E87D3475838E07B5BA23383D2106E36C515F35868643079EBE8A37A4381F990</sha512>
+    </dependency>
+    <dependency group='xml-apis' module='xml-apis' version='2.0.2' extension='pom'>
+      <sha512>4671BFCC044B8FA86D82B32A4504563AFD687DF7CF955140A5A76B0A8CF668317D43513C3E591783EF97BF4F6F63DF95E17DB90ECE8E736C979271EF85F957D3</sha512>
+    </dependency>
+    <dependency group='xmlpull' module='xmlpull' version='1.1.3.1'>
+      <sha512>54D1090623497E81270B2AF633268656E8855E1EDCE2217886431039516A391BA9F8D8DB3C21A0B5E51C7F7CB672D63EBE77BE75708B760B06F399486960F261</sha512>
+    </dependency>
+    <dependency group='xmlpull' module='xmlpull' version='1.1.3.1' extension='pom'>
+      <sha512>88BC2E6DA97259215867F3593A99C6DF31A6FC7DE6DEC2A4931F98CD7BECDCA0E96979EB26A9958005682555B86CC0415357E17AE962A98F59A1C6EAC7AB387B</sha512>
+    </dependency>
+    <dependency group='xom' module='xom' version='1.0'>
+      <sha512>981BDBDE307D309EA98F0AB0D6BDBC3EDC6DB5BB5B2A0BE1ABD695F80B738C101F41BE360D7DE191CDF2DDA7A24268E97A48057FD4AEE60904D5ED2F28210305</sha512>
+    </dependency>
+    <dependency group='xom' module='xom' version='1.0' extension='pom'>
+      <sha512>A616A1B933D42A46831AB80F4500F74B9B7BDBE0F52D3132CC656F9F6BBCF7504650B006CE502C7ABFDB6744B7975C74C9643FBF334609BD7B52507A9DFE9DEC</sha512>
+    </dependency>
+    <dependency group='xpp3' module='xpp3' version='1.1.3.4.O'>
+      <sha512>B9C527961D62B015936F67A6ADC701B319617C358043972D3C19377C671B6ADAABD664F682FB5AB2D863A8984AD976C7044157290FA33B3B71CC5B4ADFF2D3B6</sha512>
+    </dependency>
+    <dependency group='xpp3' module='xpp3' version='1.1.3.4.O' extension='pom'>
+      <sha512>3FEC991FF1497BD8694FB977643AB3D552177E0A531432729B40E5ABC737FD573FE893B23EF649A18AF2E9DFC55619D00480E25AC46ADBF4A6F53901F3DF947D</sha512>
+    </dependency>
+    <dependency group='xpp3' module='xpp3_min' version='1.1.4c'>
+      <sha512>34989289CE8ED861499F31742EE1E7B9DC3C59973CE915A7B561D33D98968E77DB5BB94C1692802CCDBD86D04CAA7DB67748EFAFB1402428B2D6AE3056497618</sha512>
+    </dependency>
+    <dependency group='xpp3' module='xpp3_min' version='1.1.4c' extension='pom'>
+      <sha512>31F0799BACC8DE2D9D315CB5C8FCD014E445266A4FEA30BCAF303027CF4BDE54A0D2D278D9C6F01406F16E5514E0FEE17C7DD7333B69747D1CB00470E96017AB</sha512>
+    </dependency>
+  </dependencies>
+</dependency-verification>


### PR DESCRIPTION
`checksum-dependency-plugin` is a superset of `gradle-witness`, and it enables to increase the level of security.

See https://github.com/vlsi/vlsi-release-plugins#checksum-dependency-plugin
See https://medium.com/@vladimirsitniko/dependency-verification-checksum-vs-pgp-582e76207019?sk=7485298b76eaf9f935b899b002f4c3b5

See https://github.com/spring-projects/spring-framework/issues/23434