### PR TITLE
Disable caching of changing modules (snapshots) and dynamic versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -279,7 +279,7 @@ configure(allprojects) { project ->
 			dependency "javax.xml.ws:jaxws-api:2.3.1"
 
 			dependency "org.eclipse.persistence:javax.persistence:2.2.0"
-			
+
 			// Substitute for "javax.management:jmxremote_optional:1.0.1_04" which
 			// is not available on Maven Central
 			dependency "org.glassfish.external:opendmk_jmxremote_optional_jar:1.0-b01-ea"
@@ -297,6 +297,12 @@ configure(allprojects) { project ->
 			mavenCentral()
 			maven { url "https://repo.spring.io/libs-release" }
 			maven { url "https://repo.spring.io/milestone" } // Reactor
+		}
+	}
+	configurations.all {
+		resolutionStrategy {
+			cacheChangingModulesFor 0, "seconds"
+			cacheDynamicVersionsFor 0, "seconds"
 		}
 	}
 }


### PR DESCRIPTION
Previously, changing modules (snapshots) and dynamic versions were cached for Gradle's default period of 24 hours and `--refresh-dependencies` was used to pick up the latest artifacts. This approach has a notable downside. `--refresh-dependencies` causes all dependencies to be refreshed, irrespective of whether they are expected to change. At a minimum, this results in a HEAD request for every dependency in the build. Running an up-to-date build without `--refresh-dependencies` takes in the region of 6 seconds:

```
$ ./gradlew build

BUILD SUCCESSFUL in 6s
203 actionable tasks: 203 up-to-date
```

The same build with --refresh-dependencies takes almost ten times as long:

```
$ ./gradlew build --refresh-dependencies

BUILD SUCCESSFUL in 58s
203 actionable tasks: 203 up-to-date
```

This commit replaces the manual usage of `--refresh-dependencies` on the command line with a 0 second caching period for changing modules and dynamic versions. This should remove the need to use `--refresh-dependencies` both locally and on CI, saving almost 1 minute per full build.

/cc @etiennestuder