### PR TITLE
Enable parallel builds by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 version=5.2.0.BUILD-SNAPSHOT
 org.gradle.caching=false
+org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx1536M


### PR DESCRIPTION
Building in parallel is now recommended by the Gradle team so this pull request enables it by default. On my MacBook Pro it reduces build time by roughly 50%. Machines with greater or fewer cores may see a greater or lesser reduction in build time. There may also be improvements that can be made to the build to improve its parallelisation. We can hopefully identify these in the future once we've got a number of parallel builds to examine.
