### PR TITLE
Move jmx.log beneath build/ to avoid up-to-date pollution

### DIFF
--- a/spring-context/src/test/java/org/springframework/jmx/JmxTestBean.java
+++ b/spring-context/src/test/java/org/springframework/jmx/JmxTestBean.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 /**
  * @@org.springframework.jmx.export.metadata.ManagedResource
  *    (description="My Managed Bean", objectName="spring:bean=test",
- *    log=true, logFile="jmx.log", currencyTimeLimit=15, persistPolicy="OnUpdate",
+ *    log=true, logFile="build/jmx.log", currencyTimeLimit=15, persistPolicy="OnUpdate",
  *    persistPeriod=200, persistLocation="./foo", persistName="bar.jmx")
  * @@org.springframework.jmx.export.metadata.ManagedNotification
  *    (name="My Notification", description="A Notification", notificationType="type.foo,type.bar")

--- a/spring-context/src/test/java/org/springframework/jmx/export/annotation/AnnotationTestBean.java
+++ b/spring-context/src/test/java/org/springframework/jmx/export/annotation/AnnotationTestBean.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Service;
  */
 @Service("testBean")
 @ManagedResource(objectName = "bean:name=testBean4", description = "My Managed Bean", log = true,
-		logFile = "jmx.log", currencyTimeLimit = 15, persistPolicy = "OnUpdate", persistPeriod = 200,
+		logFile = "build/jmx.log", currencyTimeLimit = 15, persistPolicy = "OnUpdate", persistPeriod = 200,
 		persistLocation = "./foo", persistName = "bar.jmx")
 @ManagedNotification(name = "My Notification", notificationTypes = { "type.foo", "type.bar" })
 public class AnnotationTestBean implements IJmxTestBean {

--- a/spring-context/src/test/java/org/springframework/jmx/export/assembler/AbstractMetadataAssemblerTests.java
+++ b/spring-context/src/test/java/org/springframework/jmx/export/assembler/AbstractMetadataAssemblerTests.java
@@ -112,7 +112,7 @@ public abstract class AbstractMetadataAssemblerTests extends AbstractJmxAssemble
 		Descriptor desc = info.getMBeanDescriptor();
 
 		assertThat(desc.getFieldValue("log")).as("Logging should be set to true").isEqualTo("true");
-		assertThat(desc.getFieldValue("logFile")).as("Log file should be jmx.log").isEqualTo("jmx.log");
+		assertThat(desc.getFieldValue("logFile")).as("Log file should be build/jmx.log").isEqualTo("build/jmx.log");
 		assertThat(desc.getFieldValue("currencyTimeLimit")).as("Currency Time Limit should be 15").isEqualTo("15");
 		assertThat(desc.getFieldValue("persistPolicy")).as("Persist Policy should be OnUpdate").isEqualTo("OnUpdate");
 		assertThat(desc.getFieldValue("persistPeriod")).as("Persist Period should be 200").isEqualTo("200");


### PR DESCRIPTION
Previously, some tests in spring-context wrote a file named jmx.log into spring-context/. This led to the file being included in the sources of the Checkstyle NoHTTP tasks, breaking that task's up-to-date checks and causing it to execute unnecessarily.

This PR updates the tests to write the jmx.log file beneath spring-context/build/ so that it is not included in the sources of the Checkstyle NoHTTP task.