### PR TITLE
Fix OkHttp3ClientHttpRequestFactory shutdown flow

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/OkHttp3ClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/OkHttp3ClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,7 @@ public class OkHttp3ClientHttpRequestFactory
 				cache.close();
 			}
 			this.client.dispatcher().executorService().shutdown();
+			this.client.connectionPool().evictAll();
 		}
 	}
 


### PR DESCRIPTION
This fix now triggers closing and removing all idle connections inside the connection pool used by OkHttpClient.

The problem was discovered after switching from Java 8 to Java 11 and consequently to HTTP/2.

The recommendation from OkHttp developer was a proper shutdown:
https://github.com/square/okhttp/issues/5446

Problem can be reproduced with this snippet of code:
https://github.com/alexey-anufriev/okhttpclient-shutdown-problem/commit/29abbda198dc2ad9aa2714141c0b17a573490d34#diff-70a5fa50b52c03a98de3a02c98de30a1