### PR TITLE
Add SVG mapping to mime.types file for JavaMail support

### DIFF
--- a/spring-context-support/src/main/resources/org/springframework/mail/javamail/mime.types
+++ b/spring-context-support/src/main/resources/org/springframework/mail/javamail/mime.types
@@ -67,6 +67,8 @@ image/x-xbitmap				xbm
 image/x-xpixmap				xpm
 # Portable Network Graphics
 image/png				png
+# Scalable Vector Graphics
+image/svg+xml   svg
 # Image Exchange Format (RFC 1314)
 image/ief				ief
 # RGB


### PR DESCRIPTION
I was trying to change my picture to SVG in a generated email. Now I understand why it was not working properly.