### PR TITLE
 Delete obsolete comment in RowMapperTests 

### DIFF
--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/RowMapperTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/RowMapperTests.java
@@ -78,7 +78,6 @@ public class RowMapperTests {
 	@AfterEach
 	public void verifyClosed() throws Exception {
 		verify(resultSet).close();
-		// verify(connection).close();
 	}
 
 	@AfterEach


### PR DESCRIPTION
Hello Spring Team🙌

When I read `RowMapperTests`, found it that unnecessary verify code.
so just removed it.

