### PR TITLE
Add default methods to `MailSender` and `JavaMailSender` as appropriate

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/mail/MailSender.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/MailSender.java
@@ -38,7 +38,9 @@ public interface MailSender {
 	 * @throws MailAuthenticationException in case of authentication failure
 	 * @throws MailSendException in case of failure when sending the message
 	 */
-	void send(SimpleMailMessage simpleMessage) throws MailException;
+	default void send(SimpleMailMessage simpleMessage) throws MailException {
+		send(new SimpleMailMessage[] {simpleMessage});
+	}
 
 	/**
 	 * Send the given array of simple mail messages in batch.

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSender.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSender.java
@@ -17,10 +17,15 @@
 package org.springframework.mail.javamail;
 
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.springframework.mail.MailException;
+import org.springframework.mail.MailParseException;
+import org.springframework.mail.MailPreparationException;
 import org.springframework.mail.MailSender;
 
 /**
@@ -92,7 +97,9 @@ public interface JavaMailSender extends MailSender {
 	 * in case of failure when sending the message
 	 * @see #createMimeMessage
 	 */
-	void send(MimeMessage mimeMessage) throws MailException;
+	default void send(MimeMessage mimeMessage) throws MailException {
+		send(new MimeMessage[] {mimeMessage});
+	}
 
 	/**
 	 * Send the given array of JavaMail MIME messages in batch.
@@ -121,7 +128,9 @@ public interface JavaMailSender extends MailSender {
 	 * @throws org.springframework.mail.MailSendException
 	 * in case of failure when sending the message
 	 */
-	void send(MimeMessagePreparator mimeMessagePreparator) throws MailException;
+	default void send(MimeMessagePreparator mimeMessagePreparator) throws MailException {
+		send(new MimeMessagePreparator[] {mimeMessagePreparator});
+	}
 
 	/**
 	 * Send the JavaMail MIME messages prepared by the given MimeMessagePreparators.
@@ -138,6 +147,25 @@ public interface JavaMailSender extends MailSender {
 	 * @throws org.springframework.mail.MailSendException
 	 * in case of failure when sending a message
 	 */
-	void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException;
+	default void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException {
+		try {
+			List<MimeMessage> mimeMessages = new ArrayList<>(mimeMessagePreparators.length);
+			for (MimeMessagePreparator preparator : mimeMessagePreparators) {
+				MimeMessage mimeMessage = createMimeMessage();
+				preparator.prepare(mimeMessage);
+				mimeMessages.add(mimeMessage);
+			}
+			send(mimeMessages.toArray(new MimeMessage[0]));
+		}
+		catch (MailException ex) {
+			throw ex;
+		}
+		catch (MessagingException ex) {
+			throw new MailParseException(ex);
+		}
+		catch (Exception ex) {
+			throw new MailPreparationException(ex);
+		}
+	}
 
 }

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderDecorator.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderDecorator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.mail.javamail;
+
+import java.io.InputStream;
+
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+
+
+/**
+ * A decorator pattern facility for a {@link JavaMailSender}, where the sending
+ * operation can be customized (e.g. implement a whitelist, feature-toggle, etc)
+ * by overriding {@link JavaMailSenderDecorator#send(MimeMessage...)}.
+ * Any deriving class <em>may</em> also override the methods to
+ * {@link #createMimeMessage() create messages}, if applicable, but this is not
+ * a requirement.
+ *
+ * <h2>Implementation note</h2>
+ * When overriding {@link #send(MimeMessage...)}, the decorated
+ * {@code JavaMailSender} can be accessed as {@code super.}{@link #decoratedMailSender}.
+ *
+ * @author Rune Flobakk
+ */
+public abstract class JavaMailSenderDecorator implements JavaMailSender {
+
+	/**
+	 * The decorated {@link JavaMailSender} which may (or not) be delegated to
+	 * by {@link #send(MimeMessage...)}.
+	 */
+	protected final JavaMailSender decoratedMailSender;
+
+	public JavaMailSenderDecorator(JavaMailSender decoratedMailSender) {
+		this.decoratedMailSender = decoratedMailSender;
+	}
+
+	@Override
+	public MimeMessage createMimeMessage() {
+		return this.decoratedMailSender.createMimeMessage();
+	}
+
+	@Override
+	public MimeMessage createMimeMessage(InputStream contentStream) throws MailException {
+		return this.decoratedMailSender.createMimeMessage(contentStream);
+	}
+
+	@Override
+	public final void send(SimpleMailMessage simpleMessage) throws MailException {
+		JavaMailSender.super.send(simpleMessage);
+	}
+
+	@Override
+	public final void send(SimpleMailMessage... simpleMessages) throws MailException {
+		JavaMailSender.super.send(simpleMessages);
+	}
+
+	@Override
+	public final void send(MimeMessage mimeMessage) throws MailException {
+		JavaMailSender.super.send(mimeMessage);
+	}
+
+	@Override
+	public final void send(MimeMessagePreparator mimeMessagePreparator) throws MailException {
+		JavaMailSender.super.send(mimeMessagePreparator);
+	}
+
+	@Override
+	public final void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException {
+		JavaMailSender.super.send(mimeMessagePreparators);
+	}
+
+}

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderImpl.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderImpl.java
@@ -37,7 +37,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailParseException;
-import org.springframework.mail.MailPreparationException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.util.Assert;
@@ -308,11 +307,6 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	//---------------------------------------------------------------------
 
 	@Override
-	public void send(SimpleMailMessage simpleMessage) throws MailException {
-		send(new SimpleMailMessage[] {simpleMessage});
-	}
-
-	@Override
 	public void send(SimpleMailMessage... simpleMessages) throws MailException {
 		List<MimeMessage> mimeMessages = new ArrayList<>(simpleMessages.length);
 		for (SimpleMailMessage simpleMessage : simpleMessages) {
@@ -352,40 +346,8 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	}
 
 	@Override
-	public void send(MimeMessage mimeMessage) throws MailException {
-		send(new MimeMessage[] {mimeMessage});
-	}
-
-	@Override
 	public void send(MimeMessage... mimeMessages) throws MailException {
 		doSend(mimeMessages, null);
-	}
-
-	@Override
-	public void send(MimeMessagePreparator mimeMessagePreparator) throws MailException {
-		send(new MimeMessagePreparator[] {mimeMessagePreparator});
-	}
-
-	@Override
-	public void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException {
-		try {
-			List<MimeMessage> mimeMessages = new ArrayList<>(mimeMessagePreparators.length);
-			for (MimeMessagePreparator preparator : mimeMessagePreparators) {
-				MimeMessage mimeMessage = createMimeMessage();
-				preparator.prepare(mimeMessage);
-				mimeMessages.add(mimeMessage);
-			}
-			send(mimeMessages.toArray(new MimeMessage[0]));
-		}
-		catch (MailException ex) {
-			throw ex;
-		}
-		catch (MessagingException ex) {
-			throw new MailParseException(ex);
-		}
-		catch (Exception ex) {
-			throw new MailPreparationException(ex);
-		}
 	}
 
 	/**

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/SmartMimeMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/SmartMimeMessage.java
@@ -21,6 +21,7 @@ import javax.mail.Session;
 import javax.mail.internet.MimeMessage;
 
 import org.springframework.lang.Nullable;
+import org.springframework.mail.SimpleMailMessage;
 
 /**
  * Special subclass of the standard JavaMail {@link MimeMessage}, carrying a
@@ -45,6 +46,9 @@ class SmartMimeMessage extends MimeMessage {
 	@Nullable
 	private final FileTypeMap defaultFileTypeMap;
 
+	@Nullable
+	private SimpleMailMessage originalMessage;
+
 
 	/**
 	 * Create a new SmartMimeMessage.
@@ -60,6 +64,13 @@ class SmartMimeMessage extends MimeMessage {
 		this.defaultFileTypeMap = defaultFileTypeMap;
 	}
 
+	void setOriginalSimpleMailMessage(@Nullable SimpleMailMessage originalMessage) {
+		this.originalMessage = originalMessage;
+	}
+
+	Object getOriginalOrElseThis() {
+		return this.originalMessage != null ? this.originalMessage : this;
+	}
 
 	/**
 	 * Return the default encoding of this message, or {@code null} if none.


### PR DESCRIPTION
The mail sending API is structured around the two interfaces `MailSender` and `JavaMailSender`, together with the class `JavaMailSenderImpl` which implements the two aforementioned interfaces. The numerous overloads of `send(..)`-methods in the interfaces makes it a bit cumbersome and errorprone to extend these interfaces directly.

Default methods introduced with Java 8 can to a large degree resolve this issue by moving from JavaMailSenderImpl to default methods in the interfaces. For methods which is "piping" to another method of the public API, this is a trivial refactoring (a820753). But `JavaMailSenderImpl.send(SimpleMailMessage...)` can not be refactored in such a trivial manner, as this method delegates to the internal `doSend`-method of `JavaMailSenderImpl`. To rectify, this pull-request also contains a suggested change to allow passing SimpleMailMessages contained in SmartMimeMessages further down the method stack, and allow the `doSend` to resolve the original message instances in case of errors, so existing behaviour is preserved. (f95659b168d479db3711d64ff02f533f437d0418)

The interfaces are now simpler to extend directly, and this also allows for more clean composable decorators, as demonstrated with the new `JavaMailSenderDecorator` class in 39724cdb0150b3894b23276bb1f287bdccc35af8. It "seals" the default methods as `final`, allowing decorating an arbitrary JavaMailSender with only overriding _one_ method, which is part of the public API. It is simple to wrap several layers of JavaMailSenderDecorators, if one should need to, and eventually end in a JavaMailSenderImpl.

I have used this structure for a client to separately implement a whitelisting `JavaMailSenderDecorator`, and a performance monitoring "aspect" `JavaMailSenderDecorator`, which are composed together, and ultimately wrapping an instance of `JavaMailSenderImpl`.

This also may yield some advantages when testing, as one would only have to intercept the _one_ `send(..)`-method which is not provided by the interfaces, and tests does not need to know which overload is used by the main code. `JavaMailSenderImpl` instances can be separated strictly away from testing. For instance, if using mock libraries as Mockito, mocking a `JavaMailSenderDecorator`, it will ensure that all real `final` methods are invoked, and one may verify invocations of only one method regardless of which overloaded method is invoked by the main code.

I hope this can be a relevant contribution, and I am very open for any feedback and discussion on this design! 

Thank you :)