### PR TITLE
Avoid ArrayIndexOutOfBoundsException in SpEL's Indexer

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
@@ -439,7 +439,7 @@ public class Indexer extends SpelNodeImpl {
 	}
 
 	private void checkAccess(int arrayLength, int index) throws SpelEvaluationException {
-		if (index > arrayLength) {
+		if (index >= arrayLength) {
 			throw new SpelEvaluationException(getStartPosition(), SpelMessage.ARRAY_INDEX_OUT_OF_BOUNDS,
 					arrayLength, index);
 		}

--- a/spring-expression/src/test/java/org/springframework/expression/spel/ast/IndexerTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/ast/IndexerTests.java
@@ -1,0 +1,23 @@
+package org.springframework.expression.spel.ast;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
+import org.springframework.expression.spel.testresources.Inventor;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Joyce Zhan
+ */
+public class IndexerTests {
+	@Test
+	public void testAccess() {
+		SimpleEvaluationContext context = SimpleEvaluationContext.forReadOnlyDataBinding().build();
+		SpelExpression expression = (SpelExpression) new SpelExpressionParser().parseExpression("stringArrayOfThreeItems[3]");
+		assertThatExceptionOfType(EvaluationException.class).isThrownBy(() ->
+				expression.getValue(context, new Inventor()));
+	}
+}


### PR DESCRIPTION
When `index == arrayLength`, the array index is also out of bounds.

For this use case, a `SpelEvaluationException` should be thrown instead of
`ArrayIndexOutOfBoundsException`.