### PR TITLE
Enhanced form data request support in MockRestServiceServer

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/match/FormDataRequestMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/match/FormDataRequestMatchers.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.web.client.match;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.test.web.client.RequestMatcher;
+import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.springframework.test.util.AssertionErrors.fail;
+
+/**
+ * Factory for assertions on the form data parameters.
+ *
+ * <p>An instance of this class is typically accessed via {@link MockRestRequestMatchers#formData()}
+ *
+ * @author Valentin Spac
+ * @since 5.2
+ */
+public class FormDataRequestMatchers {
+
+
+	public RequestMatcher value(String parameter, String... expectedValues) {
+		List<Matcher<? super String>> matcherList = Arrays.stream(expectedValues)
+				.map(Matchers::equalTo)
+				.collect(Collectors.toList());
+
+		return this.value(parameter, matcherList);
+	}
+
+	@SafeVarargs
+	@SuppressWarnings("varargs")
+	public final RequestMatcher value(String parameter, Matcher<? super String>... matchers) {
+		return this.value(parameter, Arrays.stream(matchers).collect(Collectors.toList()));
+	}
+
+	public RequestMatcher value(String parameter, Matcher<Iterable<? extends String>> matchers) {
+		return new AbstractFormDataRequestMatcher() {
+			@Override
+			protected void matchInternal(MultiValueMap<String, String> requestParams) {
+				assertValueCount(parameter, requestParams, 1);
+
+				List<String> values = requestParams.get(parameter);
+				assertThat("Request parameter [" + parameter + "]", values, matchers);
+			}
+		};
+	}
+
+
+	private RequestMatcher value(String parameter, List<Matcher<? super String>> matchers) {
+		return new AbstractFormDataRequestMatcher() {
+			@Override
+			protected void matchInternal(MultiValueMap<String, String> requestParams) {
+				assertValueCount(parameter, requestParams, matchers.size());
+
+				List<String> values = requestParams.get(parameter);
+
+				Assert.state(values != null, "No request parameter values");
+				for (int i = 0; i < matchers.size(); i++) {
+					assertThat("Request parameter [" + parameter + "]", values.get(i), matchers.get(i));
+				}
+			}
+		};
+	}
+
+	private static void assertValueCount(String value, MultiValueMap<String, String> map, int count) {
+		List<String> values = map.get(value);
+		String message = "Expected request parameter <" + value + ">";
+		if (values == null) {
+			fail(message + " to exist but was null");
+		}
+		if (count > values.size()) {
+			fail(message + " to have at least <" + count + "> values but found " + values);
+		}
+	}
+
+	private abstract static class AbstractFormDataRequestMatcher implements RequestMatcher {
+		private FormHttpMessageConverter formHttpMessageConverter;
+
+		AbstractFormDataRequestMatcher() {
+			this.formHttpMessageConverter = new FormHttpMessageConverter();
+		}
+
+		@Override
+		public final void match(ClientHttpRequest request) throws IOException, AssertionError {
+			MockClientHttpRequest mockRequest = (MockClientHttpRequest) request;
+			MockHttpInputMessage mockHttpInputMessage = new MockHttpInputMessage(mockRequest.getBodyAsBytes());
+
+			MultiValueMap<String, String> requestParams = this.formHttpMessageConverter.read(null, mockHttpInputMessage);
+
+			matchInternal(requestParams);
+		}
+
+		abstract void matchInternal(MultiValueMap<String, String> requestParams) throws IOException;
+	}
+
+}

--- a/spring-test/src/main/java/org/springframework/test/web/client/match/MockRestRequestMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/match/MockRestRequestMatchers.java
@@ -258,4 +258,11 @@ public abstract class MockRestRequestMatchers {
 		return new XpathRequestMatchers(expression, namespaces, args);
 	}
 
+	/**
+	 * Access to response body matchers for form data parameters.
+	 */
+	public static FormDataRequestMatchers formData() {
+		return new FormDataRequestMatchers();
+	}
+
 }

--- a/spring-test/src/test/java/org/springframework/test/web/client/match/FormDataRequestMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/match/FormDataRequestMatchersTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.web.client.match;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Unit tests for {@link FormDataRequestMatchers}.
+ *
+ * @author Valentin Spac
+ */
+public class FormDataRequestMatchersTests {
+
+	private MockClientHttpRequest request;
+
+	@BeforeEach
+	public void setUp() {
+		this.request = new MockClientHttpRequest();
+	}
+
+	@Test
+	public void testContains() throws Exception {
+		MultiValueMap<String, String> payload = new LinkedMultiValueMap<>();
+		payload.add("foo", "bar");
+		payload.add("foo", "baz");
+		payload.add("lorem", "ipsum");
+
+		writeForm(payload);
+
+		MockRestRequestMatchers.formData().value("foo", containsInAnyOrder("bar", "baz")).match(request);
+	}
+
+	@Test
+	public void testNoContains() throws Exception {
+		MultiValueMap<String, String> payload = new LinkedMultiValueMap<>();
+		payload.add("foo", "bar");
+		payload.add("foo", "baz");
+		payload.add("lorem", "ipsum");
+
+		writeForm(payload);
+
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				MockRestRequestMatchers.formData().value("foo", containsInAnyOrder("wrongValue")).match(request));
+	}
+
+	@Test
+	public void testEqualMatcher() throws Exception {
+		MultiValueMap<String, String> payload = new LinkedMultiValueMap<>();
+		payload.add("foo", "bar");
+		payload.add("baz", "foobar");
+
+		writeForm(payload);
+		MockRestRequestMatchers.formData().value("foo", equalTo("bar")).match(request);
+	}
+
+	@Test
+	public void testNoEqualMatcher() throws Exception {
+		MultiValueMap<String, String> payload = new LinkedMultiValueMap<>();
+		payload.add("foo", "bar");
+		payload.add("baz", "foobar");
+
+		writeForm(payload);
+
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				MockRestRequestMatchers.formData().value("foo", equalTo("wrongValue")).match(request));
+	}
+
+	@Test
+	public void testStringMatch() throws Exception {
+		MultiValueMap<String, String> payload = new LinkedMultiValueMap<>();
+		payload.add("foo", "bar");
+		payload.add("baz", "foobar");
+
+		writeForm(payload);
+		MockRestRequestMatchers.formData().value("foo", "bar").match(request);
+	}
+
+	@Test
+	public void testStringNoMatch() throws Exception {
+		MultiValueMap<String, String> payload = new LinkedMultiValueMap<>();
+		payload.add("foo", "bar");
+		payload.add("baz", "foobar");
+
+		writeForm(payload);
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+				MockRestRequestMatchers.formData().value("foo", "wrongValue").match(request));
+	}
+
+
+	private void writeForm(MultiValueMap<String, String> payload) throws IOException {
+		FormHttpMessageConverter formHttpMessageConverter = new FormHttpMessageConverter();
+		formHttpMessageConverter.write(payload, MediaType.APPLICATION_FORM_URLENCODED, new HttpOutputMessage() {
+			@Override
+			public OutputStream getBody() throws IOException {
+				return FormDataRequestMatchersTests.this.request.getBody();
+			}
+
+			@Override
+			public HttpHeaders getHeaders() {
+				return FormDataRequestMatchersTests.this.request.getHeaders();
+			}
+		});
+	}
+}


### PR DESCRIPTION
Added FormDataRequestMatchers to be able to verify expected form parameters when using `MockRestServiceServer`

E.g. 

```java
MockRestServiceServer mockServiceServer = MockRestServiceServer.createServer(restTemplate);

mockServiceServer.expect(ExpectedCount.once(), requestTo("/foobar"))
                .andExpect(method(POST))
                .andExpect(formData().value("foo", "bar"))
                .andExpect(formData().value("baz", Matchers.containsInAnyOrder("fizz", "buzz")))
                .andRespond(withSuccess().location(URI.create("/foobar/123")));
```