### PR TITLE
Capture maxParallelForks of Test tasks in build scans

### DIFF
--- a/gradle/build-scan-user-data.gradle
+++ b/gradle/build-scan-user-data.gradle
@@ -3,6 +3,7 @@ tagIde()
 tagCiOrLocal()
 addCiMetadata()
 addGitMetadata()
+addTestTaskMetadata()
 
 void tagOs() {
 	buildScan.tag System.getProperty('os.name')
@@ -46,6 +47,16 @@ void addCiMetadata() {
 	def ciBuild = 'CI BUILD'
 	if (isBamboo()) {
 		buildScan.link ciBuild, System.getenv('bamboo_resultsUrl')
+	}
+}
+
+void addTestTaskMetadata() {
+	allprojects {
+		tasks.withType(Test) { test ->
+			doFirst {
+				buildScan.value "Test#maxParallelForks[${test.path}]", test.maxParallelForks.toString()
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
The parallel forks configuration of `Test` tasks can have a big impact on their execution time. This pull request updates the build scan configuration to capture each `Test` task's `maxParallelForks` configuration as custom values in the build scan. This will make this data available when comparing scans which will be useful as we experiment with different parallel fork settings to reduce the build's overall execution time.