### PR TITLE
Enable local build cache for buildSrc and main project

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,8 @@
+buildCache {
+	local {
+		enabled = true
+	}
+	remote(HttpBuildCache) {
+		enabled = false
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version=5.2.0.BUILD-SNAPSHOT
-org.gradle.caching=false
+org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1536M

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,15 @@ pluginManagement {
 	}
 }
 
+buildCache {
+	local {
+		enabled = true
+	}
+	remote(HttpBuildCache) {
+		enabled = false
+	}
+}
+
 enableFeaturePreview("GRADLE_METADATA")
 
 include "spring-aop"


### PR DESCRIPTION
This pull request enables Gradle's local [build cache](https://docs.gradle.org/current/userguide/build_cache.html) for both `buildSrc` and the main project. Cacheable task output will be written to `~/.gradle/caches/build-cache-1/` from where it will be reused by subsequent clean builds when a task's inputs have not changed.

This change is the first step towards enabling remote caching which will allow task output produced on CI to be reused when building locally. Before that happens there are some [unwanted cache misses to be resolved](https://ge.spring.io/s/tpvnvnrjizipq/timeline?cacheableFilter=CACHEABLE&outcomeFilter=SUCCESS). This PR should address those in `:buildSrc` (`buildSrc` caching was not enabled for that build). https://github.com/freefair/gradle-plugins/issues/111 should help with those related to AspectJ and could be worked around locally. `:checkstyleNoHttp` will require some local changes. I'll follow up on these in separate PRs in due course.