### PR TITLE
Run webflux's tests in parallel to shorten long tail of builds

### DIFF
--- a/spring-webflux/spring-webflux.gradle
+++ b/spring-webflux/spring-webflux.gradle
@@ -55,3 +55,7 @@ dependencies {
 	testRuntime("com.sun.xml.bind:jaxb-impl")
 	testRuntime("com.sun.activation:javax.activation")
 }
+
+test {
+	maxParallelForks = 4
+}


### PR DESCRIPTION
When built in an environment where many Gradle build workers are available, `:spring-webflux:test` is regularly the only task running at the end of the build. Therefore, the build's overall execution time can be reduced by running its tests in parallel, spreading the tests' execution across the available workers. The configured number of forks is a maximum with Gradle reducing this as necessary for environments with low numbers of cores where multiple workers will not improve build performance.