### PR TITLE
Improve exclusions of checkstyleNoHttp task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -406,11 +406,15 @@ configure(rootProject) {
 	nohttp {
 		source.exclude "**/test-output/**"
 		whitelistFile = project.file("src/nohttp/whitelist.lines")
-		def projectDirURI = project.projectDir.toURI()
-		allprojects.forEach { p ->
-			def outURI = p.file("out").toURI()
-			def pattern = projectDirURI.relativize(outURI).path + "**"
-			source.exclude pattern
+		def rootPath = file(rootDir).toPath()
+		def projectDirs = allprojects.collect { it.projectDir } + "${rootDir}/buildSrc"
+		projectDirs.forEach { dir ->
+			[ 'bin', 'build', 'out', '.settings' ]
+				.collect { rootPath.relativize(new File(dir, it).toPath()) }
+				.forEach { source.exclude "$it/**" }
+			[ '.classpath', '.project' ]
+				.collect { rootPath.relativize(new File(dir, it).toPath()) }
+				.forEach { source.exclude "$it" }
 		}
 	}
 


### PR DESCRIPTION
This pull request adds the following exclusions to the source of the `checkstyleNoHttp` task for each project in the build and for `buildSrc`:

- `bin/` directory (created by Eclipse Buildship)
- `.settings/` directory (created by Eclipse)
- `.classpath` file (created by Eclipse)
- `.project` file (created by Eclipse)

An exclusion for the `build/` directory is also configured as the NoHttp plugin does not exclude it by default for `buildSrc`.