### PR TITLE
Upgrade to io.freefair.aspectj 4.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 	id 'de.undercouch.download' version '4.0.0'
 	id 'com.gradle.build-scan' version '2.4.2'
 	id "com.jfrog.artifactory" version '4.9.8' apply false
-	id "io.freefair.aspectj" version "4.0.0" apply false
+	id "io.freefair.aspectj" version "4.1.1" apply false
 	id "com.github.ben-manes.versions" version "0.24.0"
 }
 


### PR DESCRIPTION
This new version of the plugin addresses one of the caching problems described in https://github.com/spring-projects/spring-framework/pull/23700#issue-321189415.