### PR TITLE
Allow genJaxb's output to be cached when checkout locations differ

### DIFF
--- a/spring-oxm/spring-oxm.gradle
+++ b/spring-oxm/spring-oxm.gradle
@@ -22,7 +22,7 @@ task genJaxb {
 	ext.sourcesDir = "${genSourcesDir}/jaxb"
 	ext.classesDir = "${buildDir}/classes/jaxb"
 
-	inputs.files flightSchema
+	inputs.files(flightSchema).withPathSensitivity(PathSensitivity.RELATIVE)
 	outputs.dir classesDir
 
 	doLast() {


### PR DESCRIPTION
Previously, the `genJaxb` task's input files were compared using absolute paths. This would result in a cache miss for two builds with identical files contents and different root directories.

This PR updates the path sensitivity of the input to be relative to the build's root directory, thereby allowing caching to work irrespective of the source checkout location.