### PR TITLE
Add ability for StopWatch to aggregate results

### DIFF
--- a/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
@@ -139,6 +139,27 @@ class StopWatchTests {
 			.withMessage("Task info is not being kept!");
 	}
 
+	@Test
+	void validUsageAggregatesTasks() throws Exception {
+		stopWatch.setAggregateTasks(true);
+
+		stopWatch.start(name1);
+		Thread.sleep(duration1);
+		assertThat(stopWatch.currentTaskName()).isEqualTo(name1);
+		stopWatch.stop();
+		long firstDuration = stopWatch.getTaskInfo()[0].getTimeMillis();
+
+		stopWatch.start(name1);
+		Thread.sleep(duration2);
+		assertThat(stopWatch.currentTaskName()).isEqualTo(name1);
+		stopWatch.stop();
+
+		assertThat(stopWatch.getTaskCount()).isEqualTo(1);
+		assertThat(stopWatch.prettyPrint()).contains("100%");
+		assertThat(stopWatch.toString()).contains(name1);
+		assertThat(stopWatch.getTaskInfo()[0].getTimeMillis()).isGreaterThan(firstDuration);
+	}
+
 	private static long millisToNanos(long duration) {
 		return MILLISECONDS.toNanos(duration);
 	}


### PR DESCRIPTION
Add configuration option for the StopWatch to aggregate results of
timers with the same name, as opposed to replacing them. To preserve
existing behaviour, this functionality is disabled (set to false) by
default.

Changed the internals of the taskList to use a LinkedHashMap instead
of a LinkedList so as to enable fast lookups of previous timers whilst
also preserving the previous behaviour of ordering the list by
insertion order.

Closes gh-6655