### PR TITLE
Add custom TriggerContext to ReschedulingRunnable

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/scheduling/commonj/TimerManagerTaskScheduler.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/commonj/TimerManagerTaskScheduler.java
@@ -28,6 +28,7 @@ import commonj.timers.TimerListener;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 import org.springframework.scheduling.support.TaskUtils;
 import org.springframework.util.Assert;
@@ -62,6 +63,12 @@ public class TimerManagerTaskScheduler extends TimerManagerAccessor implements T
 	@Nullable
 	public ScheduledFuture<?> schedule(Runnable task, Trigger trigger) {
 		return new ReschedulingTimerListener(errorHandlingTask(task, true), trigger).schedule();
+	}
+
+	@Override
+	@Nullable
+	public ScheduledFuture<?> schedule(Runnable task, Trigger trigger, TriggerContext triggerContext) {
+		return new ReschedulingTimerListener(errorHandlingTask(task, true), trigger, triggerContext).schedule();
 	}
 
 	@Override
@@ -166,13 +173,20 @@ public class TimerManagerTaskScheduler extends TimerManagerAccessor implements T
 
 		private final Trigger trigger;
 
-		private final SimpleTriggerContext triggerContext = new SimpleTriggerContext();
+		private final TriggerContext triggerContext;
 
 		private volatile Date scheduledExecutionTime = new Date();
 
 		public ReschedulingTimerListener(Runnable runnable, Trigger trigger) {
 			super(runnable);
 			this.trigger = trigger;
+			this.triggerContext = new SimpleTriggerContext();
+		}
+
+		public ReschedulingTimerListener(Runnable runnable, Trigger trigger, TriggerContext triggerContext) {
+			super(runnable);
+			this.trigger = trigger;
+			this.triggerContext = triggerContext;
 		}
 
 		@Nullable

--- a/spring-context/src/main/java/org/springframework/scheduling/TaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/TaskScheduler.java
@@ -69,6 +69,28 @@ public interface TaskScheduler {
 	ScheduledFuture<?> schedule(Runnable task, Trigger trigger);
 
 	/**
+	 * Schedule the given {@link Runnable}, invoking it whenever the trigger
+	 * indicates a next execution time.
+	 * <p>Execution will end once the scheduler shuts down or the returned
+	 * {@link ScheduledFuture} gets cancelled.
+	 * @param task the Runnable to execute whenever the trigger fires
+	 * @param trigger an implementation of the {@link Trigger} interface,
+	 * e.g. a {@link org.springframework.scheduling.support.CronTrigger} object
+	 * wrapping a cron expression
+	 * @param triggerContext an implementation of the {@link TriggerContext} interface,
+	 * e.g. a {@link org.springframework.scheduling.support.SimpleTriggerContext} object
+	 * wrapping a scheduled and execution times
+	 * @return a {@link ScheduledFuture} representing pending completion of the task,
+	 * or {@code null} if the given Trigger object never fires (i.e. returns
+	 * {@code null} from {@link Trigger#nextExecutionTime})
+	 * @throws org.springframework.core.task.TaskRejectedException if the given task was not accepted
+	 * for internal reasons (e.g. a pool overload handling policy or a pool shutdown in progress)
+	 * @see org.springframework.scheduling.support.CronTrigger
+	 */
+	@Nullable
+	ScheduledFuture<?> schedule(Runnable task, Trigger trigger, TriggerContext triggerContext);
+
+	/**
 	 * Schedule the given {@link Runnable}, invoking it at the specified execution time.
 	 * <p>Execution will end once the scheduler shuts down or the returned
 	 * {@link ScheduledFuture} gets cancelled.

--- a/spring-context/src/main/java/org/springframework/scheduling/Trigger.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/Trigger.java
@@ -27,6 +27,7 @@ import org.springframework.lang.Nullable;
  * @author Juergen Hoeller
  * @since 3.0
  * @see TaskScheduler#schedule(Runnable, Trigger)
+ * @see TaskScheduler#schedule(Runnable, Trigger, TriggerContext)
  * @see org.springframework.scheduling.support.CronTrigger
  */
 public interface Trigger {

--- a/spring-context/src/main/java/org/springframework/scheduling/TriggerContext.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/TriggerContext.java
@@ -50,4 +50,13 @@ public interface TriggerContext {
 	@Nullable
 	Date lastCompletionTime();
 
+	/**
+	 * Update the values of last <i>scheduled</i>, <i>actual</i> and completion times
+	 * @param lastScheduledExecutionTime last <i>scheduled</i> execution time
+	 * @param lastActualExecutionTime last <i>actual</i> execution time
+	 * @param lastCompletionTime last completion time
+	 */
+	@Nullable
+	void update(Date lastScheduledExecutionTime, Date lastActualExecutionTime, Date lastCompletionTime);
+
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ReschedulingRunnable.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ReschedulingRunnable.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
 import org.springframework.scheduling.support.DelegatingErrorHandlingRunnable;
 import org.springframework.scheduling.support.SimpleTriggerContext;
 import org.springframework.util.Assert;
@@ -47,7 +48,7 @@ class ReschedulingRunnable extends DelegatingErrorHandlingRunnable implements Sc
 
 	private final Trigger trigger;
 
-	private final SimpleTriggerContext triggerContext = new SimpleTriggerContext();
+	private final TriggerContext triggerContext;
 
 	private final ScheduledExecutorService executor;
 
@@ -66,6 +67,16 @@ class ReschedulingRunnable extends DelegatingErrorHandlingRunnable implements Sc
 		super(delegate, errorHandler);
 		this.trigger = trigger;
 		this.executor = executor;
+		this.triggerContext = new SimpleTriggerContext();
+	}
+
+	public ReschedulingRunnable(
+			Runnable delegate, Trigger trigger, TriggerContext triggerContext, ScheduledExecutorService executor, ErrorHandler errorHandler) {
+
+		super(delegate, errorHandler);
+		this.trigger = trigger;
+		this.executor = executor;
+		this.triggerContext = triggerContext;
 	}
 
 

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.java
@@ -36,6 +36,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.scheduling.SchedulingTaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
 import org.springframework.scheduling.support.TaskUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.ConcurrentReferenceHashMap;
@@ -311,6 +312,22 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 				errorHandler = TaskUtils.getDefaultErrorHandler(true);
 			}
 			return new ReschedulingRunnable(task, trigger, executor, errorHandler).schedule();
+		}
+		catch (RejectedExecutionException ex) {
+			throw new TaskRejectedException("Executor [" + executor + "] did not accept task: " + task, ex);
+		}
+	}
+
+	@Override
+	@Nullable
+	public ScheduledFuture<?> schedule(Runnable task, Trigger trigger, TriggerContext triggerContext) {
+		ScheduledExecutorService executor = getScheduledExecutor();
+		try {
+			ErrorHandler errorHandler = this.errorHandler;
+			if (errorHandler == null) {
+				errorHandler = TaskUtils.getDefaultErrorHandler(true);
+			}
+			return new ReschedulingRunnable(task, trigger, triggerContext, executor, errorHandler).schedule();
 		}
 		catch (RejectedExecutionException ex) {
 			throw new TaskRejectedException("Executor [" + executor + "] did not accept task: " + task, ex);

--- a/spring-context/src/test/java/org/springframework/scheduling/support/PeriodicTriggerTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/support/PeriodicTriggerTests.java
@@ -240,11 +240,11 @@ public class PeriodicTriggerTests {
 
 	private static class TestTriggerContext implements TriggerContext {
 
-		private final Date scheduled;
+		private Date scheduled;
 
-		private final Date actual;
+		private Date actual;
 
-		private final Date completion;
+		private Date completion;
 
 		TestTriggerContext(Date scheduled, Date actual, Date completion) {
 			this.scheduled = scheduled;
@@ -265,6 +265,12 @@ public class PeriodicTriggerTests {
 		@Override
 		public Date lastScheduledExecutionTime() {
 			return this.scheduled;
+		}
+
+		public void update(Date scheduled, Date actual, Date completion) {
+			this.scheduled = scheduled;
+			this.actual = actual;
+			this.completion = completion;
 		}
 	}
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/HandlersBeanDefinitionParserTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/HandlersBeanDefinitionParserTests.java
@@ -32,6 +32,7 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.context.support.GenericWebApplicationContext;
 import org.springframework.web.servlet.HandlerMapping;
@@ -316,6 +317,11 @@ class TestTaskScheduler implements TaskScheduler {
 
 	@Override
 	public ScheduledFuture schedule(Runnable task, Trigger trigger) {
+		return null;
+	}
+
+	@Override
+	public ScheduledFuture schedule(Runnable task, Trigger trigger, TriggerContext triggerContext) {
 		return null;
 	}
 


### PR DESCRIPTION
Changes based on:

Allow ReschedulingRunnable to receive a TriggerContext on creation #19475

I needed a way to resume work after a downtime - lets say I need to do daily reports based on what happened during that day. It doesn't matter if the report is delayed as long as it will be there when the system goes back online. With changes, you can easily handle this situation by finding last report date and creating triggerContext based on that time AND passing CronTrigger with argument fixedRate set to true.

It takes away burden of having to manually sync up on startup with custom logic (apart from finding last date), it prevents cases where you have rows with date 10.05, 11.05 and then 14.05, because new Cron fired task for day 14.05 but your catchup logic didn't finish yet the days between 11.05 and 14.05 (unless you write logic to handle "holes" between dates).

Example:

```
final String cron = "0/10 * * ? * *";
final CronTrigger cronTrigger = new CronTrigger(cron, true);

// quickly revert time by 1 minute for demonstration purposes
Calendar calendar = Calendar.getInstance();
calendar.set(Calendar.MINUTE, calendar.get(Calendar.MINUTE) - 1);
SimpleTriggerContext simpleTriggerContext = new SimpleTriggerContext(calendar.getTime(), calendar.getTime(), calendar.getTime());

// quickly prepare task for demonstration purposes
Thread task = new Thread(() -> {
    logger.debug("executed scheduled for {} with scheduled time {}", cron, cronTrigger.nextExecutionTime(simpleTriggerContext));
});
taskScheduler.schedule(task, cronTrigger, simpleTriggerContext));
```

The output for printing execution times will be:

```
2019-09-25 14:06:52.903 DEBUG 15336 --- [           main] project.scheduler.SchedulerService         : Scheduling test cron 0/10 * * ? * *
2019-09-25 14:06:52.905 DEBUG 15336 --- [taskScheduler-1] project.scheduler.SchedulerService         : executed scheduled for 0/10 * * ? * * with scheduled time Wed Sep 25 12:06:00 UTC 2019
2019-09-25 14:06:52.906 DEBUG 15336 --- [taskScheduler-1] project.scheduler.SchedulerService         : executed scheduled for 0/10 * * ? * * with scheduled time Wed Sep 25 12:06:10 UTC 2019
2019-09-25 14:06:52.906 DEBUG 15336 --- [taskScheduler-1] project.scheduler.SchedulerService         : executed scheduled for 0/10 * * ? * * with scheduled time Wed Sep 25 12:06:20 UTC 2019
2019-09-25 14:06:52.906 DEBUG 15336 --- [taskScheduler-1] project.scheduler.SchedulerService         : executed scheduled for 0/10 * * ? * * with scheduled time Wed Sep 25 12:06:30 UTC 2019
2019-09-25 14:06:52.906 DEBUG 15336 --- [taskScheduler-1] project.scheduler.SchedulerService         : executed scheduled for 0/10 * * ? * * with scheduled time Wed Sep 25 12:06:40 UTC 2019
2019-09-25 14:06:52.906 DEBUG 15336 --- [taskScheduler-1] project.scheduler.SchedulerService         : executed scheduled for 0/10 * * ? * * with scheduled time Wed Sep 25 12:06:50 UTC 2019
2019-09-25 14:07:00.001 DEBUG 15336 --- [taskScheduler-1] project.scheduler.SchedulerService         : executed scheduled for 0/10 * * ? * * with scheduled time Wed Sep 25 12:07:00 UTC 2019
2019-09-25 14:07:10.002 DEBUG 15336 --- [taskScheduler-1] project.scheduler.SchedulerService         : executed scheduled for 0/10 * * ? * * with scheduled time Wed Sep 25 12:07:10 UTC 2019
```

Our cron fired 6 times on startup - TriggerContext set to 60 seconds before "now" and CronTrigger set to fire every 10 seconds. After "catching up" scheduler will work and do it's job like a normal scheduled would do, apart from taking scheduled time when calculating next execution time instead of completion time, which is especially important in cases where you hit huge load and can't keep up with generating lets say these reports but once the load goes down, the reports will be processed and generated.

### As for code:

I didn't write any tests. I'm not sure if changes didn't break some tests due to small edits in one or two interfaces (I tried to find all usages but I could miss some). I couldn't properly build project from source without excluding some tasks (-x test -x javadoc -x asciidoctor -x docsZip -x schemaZip -x distZip -x publishMavenJavaPublicationToMavenLocal). I tried to match the original code and style as closely as possible, I also provided some basic documentation for new things based on similar parts in classes. I needed this functionality and thought that making changes directly in Spring was the best way instead of writing custom logic, when most of it is already a part of framework. Adjust the code and add tests based on your preferences or needs.