### PR TITLE
Fix an assertion in a test

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/AnnotationConfigApplicationContextTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/AnnotationConfigApplicationContextTests.java
@@ -382,7 +382,7 @@ public class AnnotationConfigApplicationContextTests {
 
 		assertThat(context.getType("&fb")).isNull();
 		assertThat(context.getType("fb")).isEqualTo(String.class);
-		assertThat(context.getBean("&fb") instanceof FactoryBean);
+		assertThat(context.getBean("&fb")).isInstanceOf(FactoryBean.class);
 		assertThat(context.getType("&fb")).isEqualTo(TypedFactoryBean.class);
 		assertThat(context.getType("fb")).isEqualTo(String.class);
 		assertThat(context.getBeanNamesForType(FactoryBean.class).length).isEqualTo(1);


### PR DESCRIPTION
This PR fixes an assertion in the `AnnotationConfigApplicationContextTests.individualBeanWithFactoryBeanObjectTypeAsTargetTypeAndLazy()`.