### PR TITLE
Ensure spring-core jar task is UP-TO-DATE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,7 +307,6 @@ configure(allprojects) { project ->
 
 	tasks.withType(AbstractArchiveTask) {
 		preserveFileTimestamps = false
-		reproducibleFileOrder = true
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -304,10 +304,6 @@ configure(allprojects) { project ->
 			cacheDynamicVersionsFor 0, "seconds"
 		}
 	}
-
-	tasks.withType(AbstractArchiveTask) {
-		preserveFileTimestamps = false
-	}
 }
 
 configure([rootProject] + javaProjects) { project ->

--- a/build.gradle
+++ b/build.gradle
@@ -304,6 +304,11 @@ configure(allprojects) { project ->
 			cacheDynamicVersionsFor 0, "seconds"
 		}
 	}
+
+	tasks.withType(AbstractArchiveTask) {
+		preserveFileTimestamps = false
+		reproducibleFileOrder = true
+	}
 }
 
 configure([rootProject] + javaProjects) { project ->

--- a/spring-core/kotlin-coroutines/kotlin-coroutines.gradle
+++ b/spring-core/kotlin-coroutines/kotlin-coroutines.gradle
@@ -3,10 +3,10 @@ description = "Spring Core Coroutines support"
 apply plugin: "kotlin"
 
 configurations {
-    classesOnlyElements {
-        canBeConsumed = true
-        canBeResolved = false
-    }
+	classesOnlyElements {
+		canBeConsumed = true
+		canBeResolved = false
+	}
 }
 
 artifacts {

--- a/spring-core/kotlin-coroutines/kotlin-coroutines.gradle
+++ b/spring-core/kotlin-coroutines/kotlin-coroutines.gradle
@@ -2,6 +2,17 @@ description = "Spring Core Coroutines support"
 
 apply plugin: "kotlin"
 
+configurations {
+    classesOnlyElements {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+artifacts {
+	classesOnlyElements(compileKotlin.destinationDir)
+}
+
 dependencies {
 	compile("org.jetbrains.kotlin:kotlin-reflect")
 	compile("org.jetbrains.kotlin:kotlin-stdlib")

--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -21,6 +21,7 @@ configurations {
 }
 
 task cglibRepackJar(type: ShadowJar) {
+	outputs.cacheIf { true }
 	baseName = 'spring-cglib-repack'
 	version = cglibVersion
 	configurations = [project.configurations.cglib]
@@ -29,6 +30,7 @@ task cglibRepackJar(type: ShadowJar) {
 }
 
 task objenesisRepackJar(type: ShadowJar) {
+	outputs.cacheIf { true }
 	baseName = 'spring-objenesis-repack'
 	version = objenesisVersion
 	configurations = [project.configurations.objenesis]

--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -21,7 +21,6 @@ configurations {
 }
 
 task cglibRepackJar(type: ShadowJar) {
-	outputs.cacheIf { true }
 	baseName = 'spring-cglib-repack'
 	version = cglibVersion
 	configurations = [project.configurations.cglib]
@@ -30,7 +29,6 @@ task cglibRepackJar(type: ShadowJar) {
 }
 
 task objenesisRepackJar(type: ShadowJar) {
-	outputs.cacheIf { true }
 	baseName = 'spring-objenesis-repack'
 	version = objenesisVersion
 	configurations = [project.configurations.objenesis]

--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -1,3 +1,9 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+plugins {
+	id "com.github.johnrengelman.shadow" version "5.1.0"
+}
+
 description = "Spring Core"
 
 apply plugin: "kotlin"
@@ -9,62 +15,30 @@ def cglibVersion = "3.3.0"
 def objenesisVersion = "3.0.1"
 
 configurations {
-	jarjar
 	cglib
 	objenesis
-	coroutines {
-		transitive = false
-	}
+	coroutines
 }
 
-task cglibRepackJar(type: Jar) { repackJar ->
-	repackJar.baseName = "spring-cglib-repack"
-	repackJar.version = cglibVersion
-
-	doLast() {
-		project.ant {
-			taskdef name: "jarjar", classname: "org.pantsbuild.jarjar.JarJarTask",
-					classpath: configurations.jarjar.asPath
-			jarjar(destfile: repackJar.archivePath) {
-				configurations.cglib.each { originalJar ->
-					zipfileset(src: originalJar)
-				}
-				// Repackage net.sf.cglib => org.springframework.cglib
-				rule(pattern: "net.sf.cglib.**", result: "org.springframework.cglib.@1")
-				// As mentioned above, transform cglib's internal asm dependencies from
-				// org.objectweb.asm => org.springframework.asm. Doing this counts on the
-				// the fact that Spring and cglib depend on the same version of asm!
-				rule(pattern: "org.objectweb.asm.**", result: "org.springframework.asm.@1")
-			}
-		}
-	}
+task cglibRepackJar(type: ShadowJar) {
+	baseName = 'spring-cglib-repack'
+	version = cglibVersion
+	configurations = [project.configurations.cglib]
+	relocate 'net.sf.cglib', 'org.springframework.cglib'
+	relocate 'org.objectweb.asm', 'org.springframework.asm'
 }
 
-task objenesisRepackJar(type: Jar) { repackJar ->
-	repackJar.baseName = "spring-objenesis-repack"
-	repackJar.version = objenesisVersion
-
-	doLast() {
-		project.ant {
-			taskdef name: "jarjar", classname: "org.pantsbuild.jarjar.JarJarTask",
-					classpath: configurations.jarjar.asPath
-			jarjar(destfile: repackJar.archivePath) {
-				configurations.objenesis.each { originalJar ->
-					zipfileset(src: originalJar)
-				}
-				// Repackage org.objenesis => org.springframework.objenesis
-				rule(pattern: "org.objenesis.**", result: "org.springframework.objenesis.@1")
-			}
-		}
-	}
+task objenesisRepackJar(type: ShadowJar) {
+	baseName = 'spring-objenesis-repack'
+	version = objenesisVersion
+	configurations = [project.configurations.objenesis]
+	relocate 'org.objenesis', 'org.springframework.objenesis'
 }
 
 dependencies {
 	cglib("cglib:cglib:${cglibVersion}@jar")
 	objenesis("org.objenesis:objenesis:${objenesisVersion}@jar")
-	jarjar("org.pantsbuild:jarjar:1.7.2")
-	coroutines(project(":kotlin-coroutines"))
-
+	coroutines(project(path: ":kotlin-coroutines", configuration: 'classesOnlyElements'))
 	compile(files(cglibRepackJar))
 	compile(files(objenesisRepackJar))
 	compile(project(":spring-jcl"))
@@ -107,5 +81,5 @@ jar {
 		include "org/springframework/objenesis/**"
 	}
 
-	from { configurations.coroutines.collect { it.isDirectory() ? it : zipTree(it) } }
+	from configurations.coroutines
 }


### PR DESCRIPTION
- Use the [shadow plugin](https://github.com/johnrengelman/shadow) for repackaging.
  - Using this plugin allows to get rid of Ant JarJar task
  - ~Using `preserveFileTimestamps = false` and `reproducibleFileOrder = true` on all jars ensure consistent checksums whenever the jar are rebuilt.~
- Use a more dogmatic approach to embed the `kotlin-coroutines` classes into `spring-core` jar.
  - Instead of using a `zipTree` of the project default configuration, let the `kotlin-coroutines` project export an artifact containing the output of the kotlin compilation task.

~See [this Gradle Enterprise task inputs comparison](https://ge.spring.io/c/e6m3krl5jfwjk/viakdt3a6d5eu/task-inputs) between the same project checkout, in two different directories. The `spring-core:jar` is not present anymore, because its inputs were the same in both builds.~

~Regarding the new generated `spring-core.jar`.
I checked using `pkgdiff` that its content is byte-to-byte identical to the former one. The MD5 is different though, as the timestamps are not changed anymore when rebuilt (and that's the reason why I changed to the Shadow plugin)~

EDIT: After discussion with @lptr, we agreed that using `preserveFileTimestamps = false` and `reproducibleFileOrder = true` just to get the non-cacheable `:spring-core:jar` task up-to-date is not worth it.
A filter on the task input comparison to focus on _cacheable_ task will probably be added, as a way to filter out the noise produced by non-cacheable tasks