### PR TITLE
Fix typo in web-uris doc

### DIFF
--- a/src/docs/asciidoc/web/web-uris.adoc
+++ b/src/docs/asciidoc/web/web-uris.adoc
@@ -265,7 +265,7 @@ You can shorten it further still with a full URI template, as the following exam
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]
 .Java
 ----
-	RI uri = UriComponentsBuilder.fromPath("/hotel list/{city}?q={q}")
+	URI uri = UriComponentsBuilder.fromPath("/hotel list/{city}?q={q}")
 			.build("New York", "foo+bar")
 ----
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]


### PR DESCRIPTION
In `web-uris.adoc`, there is a typo in a Java code snippet that builds a `URI`: `RI` when it should be `URI`.

This typo is only affecting master (5.2).