### PR TITLE
Introduce sessionAttributeDoesNotExist in RequestResultMatchers

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/RequestResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/RequestResultMatchers.java
@@ -31,6 +31,7 @@ import org.springframework.web.context.request.async.WebAsyncTask;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.test.util.AssertionErrors.assertEquals;
+import static org.springframework.test.util.AssertionErrors.assertTrue;
 
 /**
  * Factory for assertions on the request.
@@ -147,6 +148,19 @@ public class RequestResultMatchers {
 			HttpSession session = result.getRequest().getSession();
 			Assert.state(session != null, "No HttpSession");
 			assertEquals("Session attribute '" + name + "'", value, session.getAttribute(name));
+		};
+	}
+
+	/**
+	 * Assert the given session attributes do not exist.
+	 */
+	public <T> ResultMatcher sessionAttributeDoesNotExist(String... names) {
+		return result -> {
+			HttpSession session = result.getRequest().getSession();
+			Assert.state(session != null, "No HttpSession");
+			for (String name : names) {
+				assertTrue("Session attribute '" + name + "' exists", session.getAttribute(name) == null);
+			}
 		};
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resultmatchers/SessionAttributeAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/resultmatchers/SessionAttributeAssertionTests.java
@@ -65,6 +65,12 @@ public class SessionAttributeAssertionTests {
 			.andExpect(request().sessionAttribute("locale", notNullValue()));
 	}
 
+	@Test
+	public void testSessionAttributeDoesNotExist() throws Exception {
+		this.mockMvc.perform(get("/"))
+			.andExpect(request().sessionAttributeDoesNotExist("myAttr1", "myAttr2"));
+	}
+
 
 	@Controller
 	@SessionAttributes("locale")


### PR DESCRIPTION
Given the matcher `attributeDoesNotExist` of `ModelResultMatchers`, it makes sense for a session attribute `ResultMatcher` equivalent – `sessionAttributeDoesNotExist` which asserts that the given session attributes are `null` in the `HttpSession`.