### PR TITLE
Add exchangeAsync to WebTestClient API

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -33,6 +33,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.ByteArrayResource;
@@ -308,6 +309,16 @@ class DefaultWebTestClient implements WebTestClient {
 			Assert.state(clientResponse != null, "No ClientResponse");
 			WiretapConnector.Info info = wiretapConnector.claimRequest(this.requestId);
 			return new DefaultResponseSpec(info, clientResponse, this.uriTemplate, getTimeout());
+		}
+		
+		@Override
+		public Mono<ResponseSpec> exchangeAsync() {
+			return this.bodySpec
+					.exchange()
+					.map(clientResponse -> {
+						WiretapConnector.Info info = wiretapConnector.claimRequest(this.requestId);
+						return new DefaultResponseSpec(info, clientResponse, this.uriTemplate, getTimeout());
+					});
 		}
 	}
 

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/ExchangeResult.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/ExchangeResult.java
@@ -24,7 +24,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -206,6 +208,10 @@ public class ExchangeResult {
 			assertion.run();
 		}
 		catch (AssertionError ex) {
+			if (Schedulers.isInNonBlockingThread()) {
+				throw Exceptions.propagate(ex);
+			}
+			
 			throw new AssertionError(ex.getMessage() + "\n" + this, ex);
 		}
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 
 import org.hamcrest.Matcher;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.ParameterizedTypeReference;
@@ -606,6 +607,12 @@ public interface WebTestClient {
 		 * @return spec for decoding the response
 		 */
 		ResponseSpec exchange();
+		
+		/**
+		 * Perform the exchange without a request body and without blocking
+		 * @return spec for decoding the response wrapped around a Mono publisher
+		 */
+		Mono<ResponseSpec> exchangeAsync();
 	}
 
 


### PR DESCRIPTION
**Affects:** 5.2.0.RELEASE

---

The motivation for this enhancement is that `WebTestClient` API is mostly blocking (with the exception of `.returnResult(Class<?>).getResponseBody()` which exits the chained API), and when it's used with Spring WebFlux it might be very common to get an exception because `reactor-tcp-nio-x` is a non-blocking thread.

The main idea is to have another exchange method that is wrapped around a Mono publisher. This way the exchange can be executed within the reactive stream and the assertion API used in the `assertNext(..)` method of the `StepVerifier`.

This might also indirectly solve issues #21781 and especially #23390 since allowing the API to exchange within the stream will also allow the exchange to be in the same transaction. For example:

```java
@Test 
public void account_test() {
  accountRepo.save( // Create and store an account using spring-data-r2dbc and r2dbc-postgresql
    Account.builder()
      .username("mock")
      .password("1234")
      .build()
  )
  .publishOn(Schedulers.elastic()) // need to publish on an elastic thread or the blocking exchange will throw an exception
  .as(TestHelpers::withRollback) // a transaction wrapper using TransactionalOperator and configured as rollback only
  .as(StepVerifier::create)
  .assertNext(saved -> {
    assertThat(saved.getId()).isGreaterThan(0); // just to verify the account was persited on db

    WebTestClient.bindToApplicationContext(appContext)
      .build()
      .get()
      .uri("/account/" + saved.getUsername()) // a simple WebFlux end-point that finds the account by username and returns it in the response body
      .exchange()
      .expectStatus()
      .isOk();
  })
  .verifyComplete();
}
```

This test will always fail because is running within a transaction. As the `exchange()` method is blocking, it will be executed in another thread outside the transaction, so the saved account will never be found. To run the end-point test within the transaction we need a non-blocking exchange method. In addition, it'll also remove the need to publish on a blockable thread.

Thanks in advance for taking the time to review this PR 🙂 

cc. @sbrannen @jhoeller @mp911de 