### PR TITLE
Fix typo in rsocket doc

### DIFF
--- a/src/docs/asciidoc/rsocket.adoc
+++ b/src/docs/asciidoc/rsocket.adoc
@@ -689,7 +689,7 @@ you need to share configuration between a client and a server in the same proces
 
 		@Bean
 		public RSocketStrategies rsocketStrategies() {
-			retrun RSocketStrategies.builder()
+			return RSocketStrategies.builder()
 				.encoders(encoders -> encoders.add(new Jackson2CborEncoder))
 				.decoders(decoders -> decoders.add(new Jackson2CborDecoder))
 				.routeMatcher(new PathPatternRouteMatcher())


### PR DESCRIPTION
In rsocket.adoc, there is a typo in a Java code snippet 

This typo is only affecting master (5.2).