### PR TITLE
Preserve expires attribute in MockCookie

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockCookie.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockCookie.java
@@ -16,6 +16,9 @@
 
 package org.springframework.mock.web;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 import javax.servlet.http.Cookie;
 
 import org.springframework.lang.Nullable;
@@ -36,6 +39,9 @@ public class MockCookie extends Cookie {
 
 
 	@Nullable
+	private ZonedDateTime expires;
+
+	@Nullable
 	private String sameSite;
 
 
@@ -49,6 +55,20 @@ public class MockCookie extends Cookie {
 		super(name, value);
 	}
 
+	/**
+	 * Add the "Expires" attribute to the cookie.
+	 */
+	public void setExpires(@Nullable ZonedDateTime expires) {
+		this.expires = expires;
+	}
+
+	/**
+	 * Return the "Expires" attribute, or {@code null} if not set.
+	 */
+	@Nullable
+	public ZonedDateTime getExpires() {
+		return this.expires;
+	}
 
 	/**
 	 * Add the "SameSite" attribute to the cookie.
@@ -93,6 +113,10 @@ public class MockCookie extends Cookie {
 			}
 			else if (StringUtils.startsWithIgnoreCase(attribute, "Max-Age")) {
 				cookie.setMaxAge(Integer.parseInt(extractAttributeValue(attribute, setCookieHeader)));
+			}
+			else if (StringUtils.startsWithIgnoreCase(attribute, "Expires")) {
+				cookie.setExpires(ZonedDateTime.parse(extractAttributeValue(attribute, setCookieHeader),
+						DateTimeFormatter.RFC_1123_DATE_TIME));
 			}
 			else if (StringUtils.startsWithIgnoreCase(attribute, "Path")) {
 				cookie.setPath(extractAttributeValue(attribute, setCookieHeader));

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -27,6 +27,7 @@ import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -374,9 +375,14 @@ public class MockHttpServletResponse implements HttpServletResponse {
 		if (maxAge >= 0) {
 			buf.append("; Max-Age=").append(maxAge);
 			buf.append("; Expires=");
-			HttpHeaders headers = new HttpHeaders();
-			headers.setExpires(maxAge > 0 ? System.currentTimeMillis() + 1000L * maxAge : 0);
-			buf.append(headers.getFirst(HttpHeaders.EXPIRES));
+			if (cookie instanceof MockCookie && ((MockCookie) cookie).getExpires() != null) {
+				buf.append(((MockCookie) cookie).getExpires().format(DateTimeFormatter.RFC_1123_DATE_TIME));
+			}
+			else {
+				HttpHeaders headers = new HttpHeaders();
+				headers.setExpires(maxAge > 0 ? System.currentTimeMillis() + 1000L * maxAge : 0);
+				buf.append(headers.getFirst(HttpHeaders.EXPIRES));
+			}
 		}
 
 		if (cookie.getSecure()) {

--- a/spring-test/src/test/java/org/springframework/mock/web/MockCookieTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockCookieTests.java
@@ -18,6 +18,9 @@ package org.springframework.mock.web;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -62,8 +65,8 @@ class MockCookieTests {
 
 	@Test
 	void parseHeaderWithAttributes() {
-		MockCookie cookie = MockCookie.parse(
-				"SESSION=123; Domain=example.com; Max-Age=60; Path=/; Secure; HttpOnly; SameSite=Lax");
+		MockCookie cookie = MockCookie.parse("SESSION=123; Domain=example.com; Max-Age=60; " +
+				"Expires=Tue, 8 Oct 2019 19:50:00 GMT; Path=/; Secure; HttpOnly; SameSite=Lax");
 
 		assertCookie(cookie, "SESSION", "123");
 		assertThat(cookie.getDomain()).isEqualTo("example.com");
@@ -71,6 +74,8 @@ class MockCookieTests {
 		assertThat(cookie.getPath()).isEqualTo("/");
 		assertThat(cookie.getSecure()).isTrue();
 		assertThat(cookie.isHttpOnly()).isTrue();
+		assertThat(cookie.getExpires()).isEqualTo(ZonedDateTime.parse("Tue, 8 Oct 2019 19:50:00 GMT",
+				DateTimeFormatter.RFC_1123_DATE_TIME));
 		assertThat(cookie.getSameSite()).isEqualTo("Lax");
 	}
 
@@ -104,8 +109,8 @@ class MockCookieTests {
 
 	@Test
 	void parseHeaderWithAttributesCaseSensitivity() {
-		MockCookie cookie = MockCookie.parse(
-				"SESSION=123; domain=example.com; max-age=60; path=/; secure; httponly; samesite=Lax");
+		MockCookie cookie = MockCookie.parse("SESSION=123; domain=example.com; max-age=60; " +
+				"expires=Tue, 8 Oct 2019 19:50:00 GMT; path=/; secure; httponly; samesite=Lax");
 
 		assertCookie(cookie, "SESSION", "123");
 		assertThat(cookie.getDomain()).isEqualTo("example.com");
@@ -113,6 +118,8 @@ class MockCookieTests {
 		assertThat(cookie.getPath()).isEqualTo("/");
 		assertThat(cookie.getSecure()).isTrue();
 		assertThat(cookie.isHttpOnly()).isTrue();
+		assertThat(cookie.getExpires()).isEqualTo(ZonedDateTime.parse("Tue, 8 Oct 2019 19:50:00 GMT",
+				DateTimeFormatter.RFC_1123_DATE_TIME));
 		assertThat(cookie.getSameSite()).isEqualTo("Lax");
 	}
 

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * @author Sam Brannen
  * @author Brian Clozel
  * @author Sebastien Deleuze
+ * @author Vedran Pavic
  * @since 19.02.2006
  */
 class MockHttpServletResponseTests {
@@ -360,6 +361,14 @@ class MockHttpServletResponseTests {
 		assertNumCookies(2);
 		assertPrimarySessionCookie("123");
 		assertCookieValues("123", "999");
+	}
+
+	@Test
+	void addCookieHeaderWithExpires() {
+		String cookieValue = "SESSION=123; Path=/; Max-Age=100; Expires=Tue, 8 Oct 2019 19:50:00 GMT; Secure; " +
+				"HttpOnly; SameSite=Lax";
+		response.addHeader(HttpHeaders.SET_COOKIE, cookieValue);
+		assertThat(response.getHeader(HttpHeaders.SET_COOKIE)).isEqualTo(cookieValue);
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/mock/web/test/MockCookie.java
+++ b/spring-web/src/test/java/org/springframework/mock/web/test/MockCookie.java
@@ -16,6 +16,9 @@
 
 package org.springframework.mock.web.test;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 import javax.servlet.http.Cookie;
 
 import org.springframework.lang.Nullable;
@@ -36,6 +39,9 @@ public class MockCookie extends Cookie {
 
 
 	@Nullable
+	private ZonedDateTime expires;
+
+	@Nullable
 	private String sameSite;
 
 
@@ -49,6 +55,20 @@ public class MockCookie extends Cookie {
 		super(name, value);
 	}
 
+	/**
+	 * Add the "Expires" attribute to the cookie.
+	 */
+	public void setExpires(@Nullable ZonedDateTime expires) {
+		this.expires = expires;
+	}
+
+	/**
+	 * Return the "Expires" attribute, or {@code null} if not set.
+	 */
+	@Nullable
+	public ZonedDateTime getExpires() {
+		return this.expires;
+	}
 
 	/**
 	 * Add the "SameSite" attribute to the cookie.
@@ -93,6 +113,10 @@ public class MockCookie extends Cookie {
 			}
 			else if (StringUtils.startsWithIgnoreCase(attribute, "Max-Age")) {
 				cookie.setMaxAge(Integer.parseInt(extractAttributeValue(attribute, setCookieHeader)));
+			}
+			else if (StringUtils.startsWithIgnoreCase(attribute, "Expires")) {
+				cookie.setExpires(ZonedDateTime.parse(extractAttributeValue(attribute, setCookieHeader),
+						DateTimeFormatter.RFC_1123_DATE_TIME));
 			}
 			else if (StringUtils.startsWithIgnoreCase(attribute, "Path")) {
 				cookie.setPath(extractAttributeValue(attribute, setCookieHeader));

--- a/spring-web/src/test/java/org/springframework/mock/web/test/MockHttpServletResponse.java
+++ b/spring-web/src/test/java/org/springframework/mock/web/test/MockHttpServletResponse.java
@@ -27,6 +27,7 @@ import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -374,9 +375,14 @@ public class MockHttpServletResponse implements HttpServletResponse {
 		if (maxAge >= 0) {
 			buf.append("; Max-Age=").append(maxAge);
 			buf.append("; Expires=");
-			HttpHeaders headers = new HttpHeaders();
-			headers.setExpires(maxAge > 0 ? System.currentTimeMillis() + 1000L * maxAge : 0);
-			buf.append(headers.getFirst(HttpHeaders.EXPIRES));
+			if (cookie instanceof MockCookie && ((MockCookie) cookie).getExpires() != null) {
+				buf.append(((MockCookie) cookie).getExpires().format(DateTimeFormatter.RFC_1123_DATE_TIME));
+			}
+			else {
+				HttpHeaders headers = new HttpHeaders();
+				headers.setExpires(maxAge > 0 ? System.currentTimeMillis() + 1000L * maxAge : 0);
+				buf.append(headers.getFirst(HttpHeaders.EXPIRES));
+			}
 		}
 
 		if (cookie.getSecure()) {


### PR DESCRIPTION
At present, `MockCookie` doesn't preserve expires attribute. This has a consequence that cookie value set using `MockHttpServletResponse#addHeader` containing expires attribute will not match the cookie value obtained from `MockHttpServletResponse#getHeader` since the expires will get calculated based on current time.

This is very simple to demonstrate using a test that's added to `MockHttpServletResponseTests` as a part of this PR:

```java
@Test
void addCookieHeaderWithExpires() {
    String cookieValue = "SESSION=123; Path=/; Max-Age=100; Expires=Tue, 8 Oct 2019 19:50:00 GMT; Secure; " +
            "HttpOnly; SameSite=Lax";
    response.addHeader(HttpHeaders.SET_COOKIE, cookieValue);
    assertThat(response.getHeader(HttpHeaders.SET_COOKIE)).isEqualTo(cookieValue);
}
```

This PR enhances `MockCookie` to preserve expires attribute.