### PR TITLE
Fixing 22325 issue application listeners logic

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -604,7 +604,7 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 		getEnvironment().validateRequiredProperties();
 
 		// Store pre-refresh ApplicationListeners...
-		if (this.earlyApplicationListeners == null) {
+		if (this.earlyApplicationListeners == null || this.earlyApplicationListeners.isEmpty()) {
 			this.earlyApplicationListeners = new LinkedHashSet<>(this.applicationListeners);
 		}
 		else {
@@ -1035,7 +1035,7 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 			onClose();
 
 			// Reset local application listeners to pre-refresh state.
-			if (this.earlyApplicationListeners != null) {
+			if (this.earlyApplicationListeners != null && !this.earlyApplicationListeners.isEmpty()) {
 				this.applicationListeners.clear();
 				this.applicationListeners.addAll(this.earlyApplicationListeners);
 			}


### PR DESCRIPTION
There was an issue #22325 and @jhoeller has fixed it, but now I have the following problem: on the application startup there is a call of prepareRefresh(), so it works like that
`this.earlyApplicationListeners = new LinkedHashSet<>(this.applicationListeners);`
`this.applicationListeners` is an empty collection.
Then it's needed to refresh the Application Context, app provokes the refresh() at AbstractApplicationContext, then Spring calls prepareRefresh and then checks
`this.earlyApplicationListeners == null,`
but it's an empty LinkedHashSet, not null, it's zero size set, so then it comes to
`this.applicationListeners.clear();`
and all the listeners are removed, but they were created, so I'm loosing all of applicationListeners there.
Application listeners collection was filled by CXF Servlet [code](https://github.com/apache/cxf/blob/ec4423437bd7d6b63e3464761394cfafb50cacfa/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/CXFServlet.java#L90)