### PR TITLE
ApplicationListenerMethodAdapter: gracefully handle beans which are actually NullBean

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/event/ApplicationListenerMethodAdapter.java
+++ b/spring-context/src/main/java/org/springframework/context/event/ApplicationListenerMethodAdapter.java
@@ -295,6 +295,9 @@ public class ApplicationListenerMethodAdapter implements GenericApplicationListe
 	@Nullable
 	protected Object doInvoke(Object... args) {
 		Object bean = getTargetBean();
+		if (bean.equals(null)) {
+		    return null;
+		}
 		ReflectionUtils.makeAccessible(this.method);
 		try {
 			return this.method.invoke(bean, args);


### PR DESCRIPTION
Currently, if you have an optional event listener (via a @Bean method returning `null`)
this causes the event multicaster to explode violently.  Now, we just safely skip it.