### PR TITLE
Updates Tomcat to 9.0.27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,14 +137,14 @@ configure(allprojects) { project ->
 			dependency "org.webjars:webjars-locator-core:0.37"
 			dependency "org.webjars:underscorejs:1.8.3"
 
-			dependencySet(group: 'org.apache.tomcat', version: '9.0.26') {
+			dependencySet(group: 'org.apache.tomcat', version: '9.0.27') {
 				entry 'tomcat-util'
 				entry('tomcat-websocket') {
 					exclude group: "org.apache.tomcat", name: "tomcat-websocket-api"
 					exclude group: "org.apache.tomcat", name: "tomcat-servlet-api"
 				}
 			}
-			dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.26') {
+			dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.27') {
 				entry 'tomcat-embed-core'
 				entry 'tomcat-embed-websocket'
 			}


### PR DESCRIPTION
Tomcat should be updated to version 9.0.27 as it cannot load a ssl key-store without exception. 

See: [Stackoverflow Question](https://stackoverflow.com/questions/58189855/spring-boot-2-embed-tomcat-9-0-26-can-not-load-jks-file-stream-closed)

Affects all spring-framework 5.x versions.