### PR TITLE
AbstractRequestLoggingFilter.isIncludeHeaders() declared as protected

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/AbstractRequestLoggingFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/AbstractRequestLoggingFilter.java
@@ -136,7 +136,7 @@ public abstract class AbstractRequestLoggingFilter extends OncePerRequestFilter 
 	 * Return whether the request headers should be included in the log message.
 	 * @since 4.3
 	 */
-	public boolean isIncludeHeaders() {
+	protected boolean isIncludeHeaders() {
 		return this.includeHeaders;
 	}
 


### PR DESCRIPTION
Fix SPR-16881 in 4.3.x. (It was supposed to be backported in 4.3.18, but it was not actually fixed.)