### PR TITLE
Changed the default character encoding to UTF-8 in both the exceptions

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestClientResponseException.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClientResponseException.java
@@ -16,7 +16,6 @@
 
 package org.springframework.web.client;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -33,8 +32,7 @@ public class RestClientResponseException extends RestClientException {
 
 	private static final long serialVersionUID = -8803556342728481792L;
 
-	private static final Charset DEFAULT_CHARSET = StandardCharsets.ISO_8859_1;
-
+	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
 	private final int rawStatusCode;
 
@@ -48,13 +46,13 @@ public class RestClientResponseException extends RestClientException {
 	@Nullable
 	private final String responseCharset;
 
-
 	/**
 	 * Construct a new instance of with the given response data.
-	 * @param statusCode the raw status code value
-	 * @param statusText the status text
+	 * 
+	 * @param statusCode      the raw status code value
+	 * @param statusText      the status text
 	 * @param responseHeaders the response headers (may be {@code null})
-	 * @param responseBody the response body content (may be {@code null})
+	 * @param responseBody    the response body content (may be {@code null})
 	 * @param responseCharset the response body charset (may be {@code null})
 	 */
 	public RestClientResponseException(String message, int statusCode, String statusText,
@@ -67,7 +65,6 @@ public class RestClientResponseException extends RestClientException {
 		this.responseBody = (responseBody != null ? responseBody : new byte[0]);
 		this.responseCharset = (responseCharset != null ? responseCharset.name() : null);
 	}
-
 
 	/**
 	 * Return the raw HTTP status code value.
@@ -102,16 +99,15 @@ public class RestClientResponseException extends RestClientException {
 	 * Return the response body as a string.
 	 */
 	public String getResponseBodyAsString() {
-		if (this.responseCharset == null) {
-			return new String(this.responseBody, DEFAULT_CHARSET);
-		}
-		try {
-			return new String(this.responseBody, this.responseCharset);
-		}
-		catch (UnsupportedEncodingException ex) {
-			// should not occur
-			throw new IllegalStateException(ex);
-		}
+		return this.responseCharset == null ? getResponseBodyAsString(DEFAULT_CHARSET)
+				: getResponseBodyAsString(Charset.forName(responseCharset));
+	}
+
+	/**
+	 * Return the response body as a string with the given charset
+	 */
+	public String getResponseBodyAsString(Charset requiredCharset) {
+		return new String(this.responseBody, requiredCharset);
 	}
 
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
@@ -97,7 +97,7 @@ public class WebClientResponseException extends WebClientException {
 		this.statusText = statusText;
 		this.headers = (headers != null ? headers : HttpHeaders.EMPTY);
 		this.responseBody = (responseBody != null ? responseBody : new byte[0]);
-		this.responseCharset = (charset != null ? charset : StandardCharsets.ISO_8859_1);
+		this.responseCharset = (charset != null ? charset : StandardCharsets.UTF_8);
 		this.request = request;
 	}
 
@@ -139,10 +139,17 @@ public class WebClientResponseException extends WebClientException {
 	}
 
 	/**
-	 * Return the response body as a string.
+	 * Return the response body as a string with initial or default charset
 	 */
 	public String getResponseBodyAsString() {
-		return new String(this.responseBody, this.responseCharset);
+		return getResponseBodyAsString(this.responseCharset);
+	}
+	
+	/**
+	 * Return the response body as a string with given Charset
+	 */
+	public String getResponseBodyAsString(Charset requiredCharset) {
+		return new String(this.responseBody, requiredCharset);
 	}
 
 	/**


### PR DESCRIPTION
Also added an overload method for clients to get the response body in a different character encoding. Closes [Issue 23803](https://github.com/spring-projects/spring-framework/issues/23803)