### PR TITLE
Handle %2F in simp messaging usernames [cancelled to recreate based on CONTRIBUTING.md]

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
@@ -31,7 +31,7 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.messaging.support.MessageHeaderInitializer;
 import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
+import org.springframework.util.Base64Utils;
 
 /**
  * An implementation of
@@ -224,7 +224,7 @@ public class SimpMessagingTemplate extends AbstractMessageSendingTemplate<String
 			throws MessagingException {
 
 		Assert.notNull(user, "User must not be null");
-		user = StringUtils.replace(user, "/", "%2F");
+		user = Base64Utils.encodeToUrlSafeString(user.getBytes());
 		destination = destination.startsWith("/") ? destination : "/" + destination;
 		super.convertAndSend(this.destinationPrefix + user + destination, payload, headers, postProcessor);
 	}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
@@ -224,7 +224,8 @@ public class SimpMessagingTemplate extends AbstractMessageSendingTemplate<String
 			throws MessagingException {
 
 		Assert.notNull(user, "User must not be null");
-		user = Base64Utils.encodeToUrlSafeString(user.getBytes());
+		if (user.startsWith("B64:") || user.contains("/"))
+			user = "B64:" + Base64Utils.encodeToUrlSafeString(user.getBytes());
 		destination = destination.startsWith("/") ? destination : "/" + destination;
 		super.convertAndSend(this.destinationPrefix + user + destination, payload, headers, postProcessor);
 	}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
@@ -31,7 +31,7 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.util.Assert;
 import org.springframework.util.PathMatcher;
-import org.springframework.util.StringUtils;
+import org.springframework.util.Base64Utils;
 
 /**
  * A default implementation of {@code UserDestinationResolver} that relies
@@ -214,7 +214,7 @@ public class DefaultUserDestinationResolver implements UserDestinationResolver {
 		String actualDest = sourceDest.substring(userEnd);
 		String subscribeDest = this.prefix.substring(0, prefixEnd - 1) + actualDest;
 		String userName = sourceDest.substring(prefixEnd, userEnd);
-		userName = StringUtils.replace(userName, "%2F", "/");
+		userName = new String(Base64Utils.decodeFromUrlSafeString(userName));
 
 		String sessionId = SimpMessageHeaderAccessor.getSessionId(headers);
 		Set<String> sessionIds;

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
@@ -214,7 +214,8 @@ public class DefaultUserDestinationResolver implements UserDestinationResolver {
 		String actualDest = sourceDest.substring(userEnd);
 		String subscribeDest = this.prefix.substring(0, prefixEnd - 1) + actualDest;
 		String userName = sourceDest.substring(prefixEnd, userEnd);
-		userName = new String(Base64Utils.decodeFromUrlSafeString(userName));
+		if (userName.startsWith("B64:"))
+			userName = new String(Base64Utils.decodeFromUrlSafeString(userName.split("B64:")[1]));
 
 		String sessionId = SimpMessageHeaderAccessor.getSessionId(headers);
 		Set<String> sessionIds;

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/SimpMessagingTemplateTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/SimpMessagingTemplateTests.java
@@ -87,6 +87,20 @@ public class SimpMessagingTemplateTests {
 	}
 
 	@Test
+	public void convertAndSendToUserWithEncodingOfPercentTwoEff() {
+		this.messagingTemplate.convertAndSendToUser("https%3A%2F%2Fjoe.openid.example.org%2F|911276df-8a4f-4fda-986a-0713aba85b5e", "/queue/foo", "data");
+		List<Message<byte[]>> messages = this.messageChannel.getMessages();
+
+		assertThat(messages.size()).isEqualTo(1);
+
+		SimpMessageHeaderAccessor headerAccessor =
+				MessageHeaderAccessor.getAccessor(messages.get(0), SimpMessageHeaderAccessor.class);
+
+		assertThat(headerAccessor).isNotNull();
+		assertThat(headerAccessor.getDestination()).isEqualTo("/user/aHR0cHMlM0ElMkYlMkZqb2Uub3BlbmlkLmV4YW1wbGUub3JnJTJGfDkxMTI3NmRmLThhNGYtNGZkYS05ODZhLTA3MTNhYmE4NWI1ZQ==/queue/foo");
+	}
+
+	@Test
 	public void convertAndSendWithCustomHeader() {
 		Map<String, Object> headers = Collections.<String, Object>singletonMap("key", "value");
 		this.messagingTemplate.convertAndSend("/foo", "data", headers);

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/SimpMessagingTemplateTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/SimpMessagingTemplateTests.java
@@ -83,7 +83,7 @@ public class SimpMessagingTemplateTests {
 				MessageHeaderAccessor.getAccessor(messages.get(0), SimpMessageHeaderAccessor.class);
 
 		assertThat(headerAccessor).isNotNull();
-		assertThat(headerAccessor.getDestination()).isEqualTo("/user/https:%2F%2Fjoe.openid.example.org%2F/queue/foo");
+		assertThat(headerAccessor.getDestination()).isEqualTo("/user/B64:aHR0cHM6Ly9qb2Uub3BlbmlkLmV4YW1wbGUub3JnLw==/queue/foo");
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class SimpMessagingTemplateTests {
 				MessageHeaderAccessor.getAccessor(messages.get(0), SimpMessageHeaderAccessor.class);
 
 		assertThat(headerAccessor).isNotNull();
-		assertThat(headerAccessor.getDestination()).isEqualTo("/user/aHR0cHMlM0ElMkYlMkZqb2Uub3BlbmlkLmV4YW1wbGUub3JnJTJGfDkxMTI3NmRmLThhNGYtNGZkYS05ODZhLTA3MTNhYmE4NWI1ZQ==/queue/foo");
+		assertThat(headerAccessor.getDestination()).isEqualTo("/user/https%3A%2F%2Fjoe.openid.example.org%2F|911276df-8a4f-4fda-986a-0713aba85b5e/queue/foo");
 	}
 
 	@Test

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolverTests.java
@@ -181,7 +181,7 @@ public class DefaultUserDestinationResolverTests {
 		simpUser.addSessions(new TestSimpSession("openid123"));
 		given(this.registry.getUser(userName)).willReturn(simpUser);
 
-		String destination = "/user/" + StringUtils.replace(userName, "/", "%2F") + "/queue/foo";
+		String destination = "/user/B64:" + Base64Utils.encodeToUrlSafeString(userName.getBytes()) + "/queue/foo";
 
 		Message<?> message = createMessage(SimpMessageType.MESSAGE, new TestPrincipal("joe"), null, destination);
 		UserDestinationResult actual = this.resolver.resolveDestination(message);
@@ -198,7 +198,7 @@ public class DefaultUserDestinationResolverTests {
 		simpUser.addSessions(new TestSimpSession("openid123"));
 		given(this.registry.getUser(userName)).willReturn(simpUser);
 
-		String destination = "/user/" + Base64Utils.encodeToUrlSafeString(userName.getBytes()) + "/queue/foo";
+		String destination = "/user/" + userName + "/queue/foo";
 
 		Message<?> message = createMessage(SimpMessageType.MESSAGE, new TestPrincipal("joe"), null, destination);
 		UserDestinationResult actual = this.resolver.resolveDestination(message);

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolverTests.java
@@ -27,6 +27,7 @@ import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.simp.TestPrincipal;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.StringUtils;
+import org.springframework.util.Base64Utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -181,6 +182,23 @@ public class DefaultUserDestinationResolverTests {
 		given(this.registry.getUser(userName)).willReturn(simpUser);
 
 		String destination = "/user/" + StringUtils.replace(userName, "/", "%2F") + "/queue/foo";
+
+		Message<?> message = createMessage(SimpMessageType.MESSAGE, new TestPrincipal("joe"), null, destination);
+		UserDestinationResult actual = this.resolver.resolveDestination(message);
+
+		assertThat(actual.getTargetDestinations().size()).isEqualTo(1);
+		assertThat(actual.getTargetDestinations().iterator().next()).isEqualTo("/queue/foo-useropenid123");
+	}
+
+	@Test
+	public void handleMessageEncodedUserNameWithPercentTwoEff() {
+		String userName = "https%3A%2F%2Fjoe.openid.example.org%2F|911276df-8a4f-4fda-986a-0713aba85b5e";
+
+		TestSimpUser simpUser = new TestSimpUser(userName);
+		simpUser.addSessions(new TestSimpSession("openid123"));
+		given(this.registry.getUser(userName)).willReturn(simpUser);
+
+		String destination = "/user/" + Base64Utils.encodeToUrlSafeString(userName.getBytes()) + "/queue/foo";
 
 		Message<?> message = createMessage(SimpMessageType.MESSAGE, new TestPrincipal("joe"), null, destination);
 		UserDestinationResult actual = this.resolver.resolveDestination(message);


### PR DESCRIPTION
### Current State
Since messaging destinations are delimited by "/", the existing code performs a simple string replacement of "/" -> "%2F" in usernames.  This allows usernames which contain "/" to be used and have messaging destinations parsed correctly.  See [SimpMessagingTemplate.java](https://github.com/spring-projects/spring-framework/blob/243f2890ee9e98c97c8dc7278f033def3bf33f86/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java#L227) and [DefaultUserDestinationResolver.java](https://github.com/spring-projects/spring-framework/blob/243f2890ee9e98c97c8dc7278f033def3bf33f86/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java#L217)

### Issue with Current State
Usernames that already contain "%2F" end up with that character sequence converted to a "/" by DefaultUserDestinationResolver.  E.g., `abc%2Fabc` > `abc/abc`; however, `abc/abc` is not the username, so destination matching fails.

[Here is an example test that fails](https://github.com/njlaw/spring-framework/commit/6683c795465f6ec2a91443549357a05a50a910db), resulting in

```
org.springframework.messaging.simp.user.DefaultUserDestinationResolverTests > handleMessageEncodedUserNameWithPercentTwoEff() FAILED
--
org.opentest4j.AssertionFailedError at DefaultUserDestinationResolverTests.java:205
 
717 tests completed, 1 failed
```
([Gradle build scan](https://gradle.com/s/rbezilmjwrhhi))

### Possible Solutions
1. Use a custom encoding scheme that accounts both for "/" and whatever "/" encodes to in the scheme.
2. Use a known encoding scheme like application/x-www-form-urlencoded or URL-safe Base64 ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5)) and either:
  (a) Encode all usernames
  (b) Encode only usernames that contain characters that need to be encoded and flag the username as encoded so that only encoded usernames are decoded

### Sample Solution
A sample solution is included in this pull request using 2(b).

### Outstanding Questions
Should an explicit encoding be provided for String > byte[] and byte[] > String?  If so, what?  UTF-8?  Or just let the behavior be undefined if running Java in an environment where the default encoding does not support a particular character?

### Other Alternatives

- Document "%2F" as not supported in a username and add a runtime check for invalid user names instead of the current behavior of just not matching message destinations correctly

Any feedback is appreciated!