### PR TITLE
Reject "%2F" as an invalid sequence in simp messaging usernames

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
@@ -31,7 +31,7 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.messaging.support.MessageHeaderInitializer;
 import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
+import org.springframework.util.Base64Utils;
 
 /**
  * An implementation of
@@ -224,7 +224,8 @@ public class SimpMessagingTemplate extends AbstractMessageSendingTemplate<String
 			throws MessagingException {
 
 		Assert.notNull(user, "User must not be null");
-		user = StringUtils.replace(user, "/", "%2F");
+		if (user.startsWith("B64:") || user.contains("/"))
+			user = "B64:" + Base64Utils.encodeToUrlSafeString(user.getBytes());
 		destination = destination.startsWith("/") ? destination : "/" + destination;
 		super.convertAndSend(this.destinationPrefix + user + destination, payload, headers, postProcessor);
 	}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java
@@ -31,7 +31,7 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.util.Assert;
 import org.springframework.util.PathMatcher;
-import org.springframework.util.StringUtils;
+import org.springframework.util.Base64Utils;
 
 /**
  * A default implementation of {@code UserDestinationResolver} that relies
@@ -214,7 +214,8 @@ public class DefaultUserDestinationResolver implements UserDestinationResolver {
 		String actualDest = sourceDest.substring(userEnd);
 		String subscribeDest = this.prefix.substring(0, prefixEnd - 1) + actualDest;
 		String userName = sourceDest.substring(prefixEnd, userEnd);
-		userName = StringUtils.replace(userName, "%2F", "/");
+		if (userName.startsWith("B64:"))
+			userName = new String(Base64Utils.decodeFromUrlSafeString(userName.split("B64:")[1]));
 
 		String sessionId = SimpMessageHeaderAccessor.getSessionId(headers);
 		Set<String> sessionIds;

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/SimpMessagingTemplateTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/SimpMessagingTemplateTests.java
@@ -83,7 +83,21 @@ public class SimpMessagingTemplateTests {
 				MessageHeaderAccessor.getAccessor(messages.get(0), SimpMessageHeaderAccessor.class);
 
 		assertThat(headerAccessor).isNotNull();
-		assertThat(headerAccessor.getDestination()).isEqualTo("/user/https:%2F%2Fjoe.openid.example.org%2F/queue/foo");
+		assertThat(headerAccessor.getDestination()).isEqualTo("/user/B64:aHR0cHM6Ly9qb2Uub3BlbmlkLmV4YW1wbGUub3JnLw==/queue/foo");
+	}
+
+	@Test
+	public void convertAndSendToUserWithEncodingOfPercentTwoEff() {
+		this.messagingTemplate.convertAndSendToUser("https%3A%2F%2Fjoe.openid.example.org%2F|911276df-8a4f-4fda-986a-0713aba85b5e", "/queue/foo", "data");
+		List<Message<byte[]>> messages = this.messageChannel.getMessages();
+
+		assertThat(messages.size()).isEqualTo(1);
+
+		SimpMessageHeaderAccessor headerAccessor =
+				MessageHeaderAccessor.getAccessor(messages.get(0), SimpMessageHeaderAccessor.class);
+
+		assertThat(headerAccessor).isNotNull();
+		assertThat(headerAccessor.getDestination()).isEqualTo("/user/https%3A%2F%2Fjoe.openid.example.org%2F|911276df-8a4f-4fda-986a-0713aba85b5e/queue/foo");
 	}
 
 	@Test


### PR DESCRIPTION
### Current State
Since messaging destinations are delimited by "/", the existing code performs a simple string replacement of "/" -> "%2F" in usernames.  This allows usernames which contain "/" to be used and have messaging destinations parsed correctly.  See [SimpMessagingTemplate.java](https://github.com/spring-projects/spring-framework/blob/243f2890ee9e98c97c8dc7278f033def3bf33f86/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java#L227) and [DefaultUserDestinationResolver.java](https://github.com/spring-projects/spring-framework/blob/243f2890ee9e98c97c8dc7278f033def3bf33f86/spring-messaging/src/main/java/org/springframework/messaging/simp/user/DefaultUserDestinationResolver.java#L217)

### Issue with Current State
Usernames that already contain "%2F" end up with that character sequence converted to a "/" by DefaultUserDestinationResolver.  E.g., `abc%2Fabc` > `abc/abc`; however, `abc/abc` is not the username, so destination matching fails.

[Here is an example test that fails](https://github.com/njlaw/spring-framework/commit/6683c795465f6ec2a91443549357a05a50a910db), resulting in

```
org.springframework.messaging.simp.user.DefaultUserDestinationResolverTests > handleMessageEncodedUserNameWithPercentTwoEff() FAILED
--
org.opentest4j.AssertionFailedError at DefaultUserDestinationResolverTests.java:205
 
717 tests completed, 1 failed

:spring-messaging:testorg.springframework.messaging.simp.user.DefaultUserDestinationResolverTests » handleMessageEncodedUserNameWithPercentTwoEff() (0.044s)
org.opentest4j.AssertionFailedError: 

Expecting:
 <0> (instead resolves to 0 destinations)
to be equal to:
 <1> (should resolve to a single destination)
but was not.
```
([Gradle build scan](https://gradle.com/s/rbezilmjwrhhi))

### Possible Solutions
1. Use a custom encoding scheme that accounts both for "/" and whatever "/" encodes to in the scheme.
2. Use a known encoding scheme like application/x-www-form-urlencoded or URL-safe Base64 ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5)) and either:
  (a) Encode all usernames
  (b) Encode only usernames that contain characters that need to be encoded and flag the username as encoded so that only encoded usernames are decoded

### Sample Solution
A sample solution is included in this pull request using 2(b).

### Outstanding Questions
Should an explicit encoding be provided for String > byte[] and byte[] > String?  If so, what?  UTF-8?  Or just let the behavior be undefined if running Java in an environment where the default encoding does not support a particular character?

### Other Alternatives

- Document "%2F" as not supported in a username and add a runtime check for invalid user names instead of the current behavior of just not matching message destinations correctly

Any feedback is appreciated!

As a note, I recreated this pull request since I didn't branch my fork of the code first or squash commits as recommended by the contribution guidelines.