### PR TITLE
Make Kotlin functions accessible in CoroutinesUtils

### DIFF
--- a/spring-core/kotlin-coroutines/src/main/kotlin/org/springframework/core/CoroutinesUtils.kt
+++ b/spring-core/kotlin-coroutines/src/main/kotlin/org/springframework/core/CoroutinesUtils.kt
@@ -28,9 +28,8 @@ import kotlinx.coroutines.reactor.asFlux
 import kotlinx.coroutines.reactor.mono
 import reactor.core.publisher.Mono
 import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.Method
+import kotlin.reflect.KFunction
 import kotlin.reflect.full.callSuspend
-import kotlin.reflect.jvm.kotlinFunction
 
 /**
  * Convert a [Deferred] instance to a [Mono] one.
@@ -58,8 +57,7 @@ internal fun <T: Any> monoToDeferred(source: Mono<T>) =
  * @since 5.2
  */
 @Suppress("UNCHECKED_CAST")
-internal fun invokeSuspendingFunction(method: Method, bean: Any, vararg args: Any?): Any? {
-	val function = method.kotlinFunction!!
+internal fun invokeSuspendingFunction(function: KFunction<*>, bean: Any, vararg args: Any?): Any? {
 	return if (function.isSuspend) {
 		val mono = mono(Dispatchers.Unconfined) {
 			function.callSuspend(bean, *args.sliceArray(0..(args.size-2)))

--- a/spring-core/src/main/kotlin/org/springframework/util/KotlinReflectionUtils.kt
+++ b/spring-core/src/main/kotlin/org/springframework/util/KotlinReflectionUtils.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("KotlinReflectionUtils")
+package org.springframework.util
+
+import java.lang.reflect.Method
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.kotlinFunction
+
+/**
+ * Convert a [Method] to a [KFunction].
+ *
+ * @author Michael Gmeiner
+ * @since 5.2
+ */
+internal fun methodToFunction(method: Method) = method.kotlinFunction
+		?: throw IllegalStateException("Could not convert Java method to Kotlin function")
+
+/**
+ * Make the given [KFunction] accessible if necessary.
+ * The [isAccessible] setter is only called when actually necessary, to avoid unnecessary conflicts with a JVM
+ * SecurityManager (if active).
+ *
+ * @author Michael Gmeiner
+ * @since 5.2
+ */
+internal fun makeFunctionAccessible(function: KFunction<*>) {
+	if (!function.isAccessible) {
+		function.isAccessible = true
+	}
+}

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/result/KotlinInvocableHandlerMethodTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/result/KotlinInvocableHandlerMethodTests.kt
@@ -120,7 +120,7 @@ class KotlinInvocableHandlerMethodTests {
 				.verifyComplete()
 	}
 
-	class CoroutinesController {
+	private class CoroutinesController {
 
 		suspend fun singleArg(q: String?): String {
 			delay(10)
@@ -146,7 +146,5 @@ class KotlinInvocableHandlerMethodTests {
 			delay(10)
 			response.headers.add("foo", "bar")
 		}
-
-
 	}
 }


### PR DESCRIPTION
After updating to spring-webflux 5.2 i noticed that `@ExceptionHandler`'s in private Kotlin-Classes stopped working. 
After debbuging I found that this regression was introduced with kotlin-coroutines support for reactive Webflux and reactive Messaging handlers. 

The Problem is that when converting Java methods to Kotlin functions the information if a method is accessible or not will not be copied and the Kotlin function has to be made accessible again via its `isAccessible` setter.

For this I introduced a new very simple `KotlinReflectionUtils` class which both `InvocableHandlerMethod's` use when Kotlin is available. I'm not 100% sure if this is the best solution and if its worth to introduce a new utils class for this. 
