### PR TITLE
hasCorsConfigurationSource() now supports HandlerExecutionChain

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
@@ -485,6 +485,9 @@ public abstract class AbstractHandlerMapping extends WebApplicationObjectSupport
 	 * @since 5.2
 	 */
 	protected boolean hasCorsConfigurationSource(Object handler) {
+		if (handler instanceof HandlerExecutionChain) {
+			return hasCorsConfigurationSource(((HandlerExecutionChain) handler).getHandler());
+		}
 		return (handler instanceof CorsConfigurationSource || this.corsConfigurationSource != null);
 	}
 


### PR DESCRIPTION
Call `AbstractHandlerMapping#hasCorsConfigurationSource` again with the actual handler if the passed object is a wrapper. This solves issue gh-23843 in our situation.