### PR TITLE
Stop Created-By manifest header from causing a test task cache miss

### DIFF
--- a/gradle/spring-module.gradle
+++ b/gradle/spring-module.gradle
@@ -18,6 +18,12 @@ jar {
 	}
 }
 
+normalization {
+	runtimeClasspath {
+		ignore "META-INF/MANIFEST.MF"
+	}
+}
+
 javadoc {
 	description = "Generates project-level javadoc for use in -javadoc jar"
 

--- a/integration-tests/integration-tests.gradle
+++ b/integration-tests/integration-tests.gradle
@@ -20,3 +20,9 @@ dependencies {
 	testCompile("org.hsqldb:hsqldb")
 	testCompile("org.hibernate:hibernate-core")
 }
+
+normalization {
+	runtimeClasspath {
+		ignore "META-INF/MANIFEST.MF"
+	}
+}


### PR DESCRIPTION
Previously, when a project's jar was an input into a test task, a cache hit required the current build to be using the same JDK as the one that created the cache entry. This was due to the `Created-By` entry in the jar's manifest which will vary if JDKs with different values for the java.version and java.specification.vendor version are used.

This commit configures normalization of the runtime classpath to ignore `META-INF/MANIFEST.MF`, thereby allowing a cache hit when the tests were previously run on a different JDK than the one being used now. Typically this is a different update release being used on a CI agent and a developer's machine. This change will therefore improve the likelihood of a cache hit once remote caching has been enabled.