### PR TITLE
Fixing NPE in AbstractNamedValueMethodArgumentResolver

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/AbstractNamedValueMethodArgumentResolver.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.ValueConstants;
@@ -72,10 +73,10 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements Handle
 	 * @param beanFactory a bean factory for resolving {@code ${...}}
 	 * placeholders and {@code #{...}} SpEL expressions in default values
 	 */
-	protected AbstractNamedValueMethodArgumentResolver(ConversionService conversionService,
+	protected AbstractNamedValueMethodArgumentResolver(@Nullable ConversionService conversionService,
 			@Nullable ConfigurableBeanFactory beanFactory) {
 
-		this.conversionService = conversionService;
+		this.conversionService = conversionService != null ? conversionService : DefaultConversionService.getSharedInstance();
 		this.configurableBeanFactory = beanFactory;
 		this.expressionContext = (beanFactory != null ? new BeanExpressionContext(beanFactory, null) : null);
 	}

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/DestinationVariableMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/DestinationVariableMethodArgumentResolver.java
@@ -41,7 +41,7 @@ public class DestinationVariableMethodArgumentResolver extends AbstractNamedValu
 			DestinationVariableMethodArgumentResolver.class.getSimpleName() + ".templateVariables";
 
 
-	public DestinationVariableMethodArgumentResolver(ConversionService conversionService) {
+	public DestinationVariableMethodArgumentResolver(@Nullable ConversionService conversionService) {
 		super(conversionService, null);
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/HeaderMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/HeaderMethodArgumentResolver.java
@@ -49,7 +49,7 @@ public class HeaderMethodArgumentResolver extends AbstractNamedValueMethodArgume
 
 
 	public HeaderMethodArgumentResolver(
-			ConversionService conversionService, @Nullable ConfigurableBeanFactory beanFactory) {
+			@Nullable ConversionService conversionService, @Nullable ConfigurableBeanFactory beanFactory) {
 
 		super(conversionService, beanFactory);
 	}

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/HeaderMethodArgumentResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/HeaderMethodArgumentResolverTests.java
@@ -146,6 +146,14 @@ public class HeaderMethodArgumentResolverTests {
 	}
 
 	@Test
+	public void resolveOptionalHeaderWithValueFromNullConversionServiceInput() throws Exception {
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.refresh();
+		resolver = new HeaderMethodArgumentResolver(null, context.getBeanFactory());
+		resolveOptionalHeaderWithValue();
+	}
+
+	@Test
 	public void resolveOptionalHeaderAsEmpty() throws Exception {
 		Message<String> message = MessageBuilder.withPayload("foo").build();
 		MethodParameter param = this.resolvable.annot(header("foo")).arg(Optional.class, String.class);


### PR DESCRIPTION
Upgrading one of our apps to Spring Boot 2.2.0.RELEASE (with Spring 5.2.0.RELEASE) is blocked by a null pointer exception in AbstractNamedValueMethodArgumentResolver that occurs whenever we are trying to receive a message via an `SqsListener`.

My approach is to undo https://github.com/spring-projects/spring-framework/commit/5b3b0b1a7b01b0ee752ee5e100d1238e9c6fdddf#diff-ba4bc09499d8cbf059d24ea9c6062b9cL82 