### PR TITLE
Add opt-in support for remote build cache and pushing to it from CI

### DIFF
--- a/gradle/build-cache-settings.gradle
+++ b/gradle/build-cache-settings.gradle
@@ -2,7 +2,19 @@ buildCache {
 	local {
 		enabled = true
 	}
-	remote(HttpBuildCache) {
-		enabled = false
+	if (System.getenv('GRADLE_ENTERPRISE_URL')) {
+		remote(HttpBuildCache) {
+			enabled = true
+			url = "${System.getenv('GRADLE_ENTERPRISE_URL')}/cache/"
+			def cacheUsername = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
+			def cachePassword = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
+			if (cacheUsername && cachePassword) {
+				push = true
+				credentials {
+					username = cacheUsername
+					password = cachePassword
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR provides opt-in enablement of Gradle's remote build cache. When the `GRADLE_ENTERPRISE_URL` environment variable is set, its build cache node will be used as a source of cached output. If both `GRADLE_ENTERPRISE_CACHE_USERNAME` and `GRADLE_ENTERPRISE_CACHE_PASSWORD` are also set, task output produced by the build will be pushed to the build cache node for use by subsequent builds.