### PR TITLE
Modify the default value of ddl-auto to "none"

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaVendorAdapter.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaVendorAdapter.java
@@ -148,7 +148,7 @@ public class HibernateJpaVendorAdapter extends AbstractJpaVendorAdapter {
 		}
 
 		if (isGenerateDdl()) {
-			jpaProperties.put(AvailableSettings.HBM2DDL_AUTO, "update");
+			jpaProperties.put(AvailableSettings.HBM2DDL_AUTO, "none");
 		}
 		if (isShowSql()) {
 			jpaProperties.put(AvailableSettings.SHOW_SQL, "true");


### PR DESCRIPTION
My project uses spring-data-jpa.

The company stipulates that the test environment and the generated environment database account have only read and write permissions.

I found that when ddl-auto is set to none, the database structure is also changed because there is no permission to cause the service to fail to start.

Official documentation says：
You can set spring.jpa.hibernate.ddl-auto explicitly and the standard Hibernate property values are none, validate, update, create, and create-drop. 

If I choose none, the program should not do anything.However, in spring-boot-autoconfigure, the none configuration is automatically removed, which is equivalent to not configuring ddl-auto.

I think there needs to be an option for him not to make any changes or verify the behavior of the database.