### PR TITLE
Only enable caching in main build when building a snapshot

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,9 @@ pluginManagement {
 	}
 }
 
-apply from: "$rootDir/gradle/build-cache-settings.gradle"
+if (version.endsWith("-SNAPSHOT")) {
+	apply from: "$rootDir/gradle/build-cache-settings.gradle"
+}
 
 include "spring-aop"
 include "spring-aspects"


### PR DESCRIPTION
Previously, caching was enabled for the main build irrespective of what type of version was being built. This meant that caching was used for snapshots, milestones, release candidates, and releases.

To ensure that tagged and released versions are built in isolation from previous builds, this PR only enables caching when building a snapshot.