### PR TITLE
Fix Mockito deprecations

### DIFF
--- a/spring-context/src/test/java/org/springframework/aop/aspectj/AfterReturningAdviceBindingTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/aspectj/AfterReturningAdviceBindingTests.java
@@ -29,7 +29,7 @@ import org.springframework.tests.sample.beans.TestBean;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Tests for various parameter binding scenarios with before advice.
@@ -129,7 +129,7 @@ public class AfterReturningAdviceBindingTests {
 	public void testNoInvokeWhenReturningParameterTypeDoesNotMatch() {
 		testBeanProxy.setSpouse(this.testBeanProxy);
 		testBeanProxy.getSpouse();
-		verifyZeroInteractions(mockCollaborator);
+		verifyNoInteractions(mockCollaborator);
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/context/annotation/EnableLoadTimeWeavingTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/EnableLoadTimeWeavingTests.java
@@ -27,7 +27,7 @@ import org.springframework.instrument.classloading.LoadTimeWeaver;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Unit tests for @EnableLoadTimeWeaving
@@ -50,7 +50,7 @@ public class EnableLoadTimeWeavingTests {
 		ctx.register(EnableLTWConfig_withAjWeavingDisabled.class);
 		ctx.refresh();
 		LoadTimeWeaver loadTimeWeaver = ctx.getBean("loadTimeWeaver", LoadTimeWeaver.class);
-		verifyZeroInteractions(loadTimeWeaver);
+		verifyNoInteractions(loadTimeWeaver);
 	}
 
 	@Test
@@ -61,7 +61,7 @@ public class EnableLoadTimeWeavingTests {
 		LoadTimeWeaver loadTimeWeaver = ctx.getBean("loadTimeWeaver", LoadTimeWeaver.class);
 		// no expectations -> a class file transformer should NOT be added
 		// because no META-INF/aop.xml is present on the classpath
-		verifyZeroInteractions(loadTimeWeaver);
+		verifyNoInteractions(loadTimeWeaver);
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/ejb/access/LocalStatelessSessionProxyFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/ejb/access/LocalStatelessSessionProxyFactoryBeanTests.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * @author Rod Johnson
@@ -175,7 +175,7 @@ public class LocalStatelessSessionProxyFactoryBeanTests {
 			.withMessageContaining("businessInterface");
 
 		// Expect no methods on home
-		verifyZeroInteractions(home);
+		verifyNoInteractions(home);
 	}
 
 

--- a/spring-context/src/test/java/org/springframework/ejb/access/SimpleRemoteStatelessSessionProxyFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/ejb/access/SimpleRemoteStatelessSessionProxyFactoryBeanTests.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * @author Rod Johnson
@@ -260,7 +260,7 @@ public class SimpleRemoteStatelessSessionProxyFactoryBeanTests extends SimpleRem
 			.withMessageContaining("businessInterface");
 
 		// Expect no methods on home
-		verifyZeroInteractions(home);
+		verifyNoInteractions(home);
 	}
 
 

--- a/spring-core/src/test/java/org/springframework/util/concurrent/ListenableFutureTaskTests.java
+++ b/spring-core/src/test/java/org/springframework/util/concurrent/ListenableFutureTaskTests.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * @author Arjen Poutsma
@@ -98,7 +98,7 @@ class ListenableFutureTaskTests {
 		task.addCallback(successCallback, failureCallback);
 		task.run();
 		verify(successCallback).onSuccess(s);
-		verifyZeroInteractions(failureCallback);
+		verifyNoInteractions(failureCallback);
 
 		assertThat(task.get()).isSameAs(s);
 		assertThat(task.completable().get()).isSameAs(s);
@@ -119,7 +119,7 @@ class ListenableFutureTaskTests {
 		task.addCallback(successCallback, failureCallback);
 		task.run();
 		verify(failureCallback).onFailure(ex);
-		verifyZeroInteractions(successCallback);
+		verifyNoInteractions(successCallback);
 
 		assertThatExceptionOfType(ExecutionException.class).isThrownBy(
 				task::get)

--- a/spring-messaging/src/test/java/org/springframework/messaging/rsocket/DefaultRSocketRequesterBuilderTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/rsocket/DefaultRSocketRequesterBuilderTests.java
@@ -53,7 +53,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Unit tests for {@link DefaultRSocketRequesterBuilder}.
@@ -85,7 +85,7 @@ public class DefaultRSocketRequesterBuilderTests {
 				.rsocketStrategies(strategiesConfigurer)
 				.connect(this.transport);
 
-		verifyZeroInteractions(this.transport);
+		verifyNoInteractions(this.transport);
 		assertThat(this.rsocketFactoryConfigurer.rsocketFactory()).isNull();
 	}
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/user/UserDestinationMessageHandlerTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/user/UserDestinationMessageHandlerTests.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.support.MessageBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.springframework.messaging.simp.SimpMessageHeaderAccessor.ORIGINAL_DESTINATION;
 
@@ -173,19 +174,19 @@ public class UserDestinationMessageHandlerTests {
 
 		// no destination
 		this.handler.handleMessage(createWith(SimpMessageType.MESSAGE, "joe", "123", null));
-		Mockito.verifyZeroInteractions(this.brokerChannel);
+		verifyNoInteractions(this.brokerChannel);
 
 		// not a user destination
 		this.handler.handleMessage(createWith(SimpMessageType.MESSAGE, "joe", "123", "/queue/foo"));
-		Mockito.verifyZeroInteractions(this.brokerChannel);
+		verifyNoInteractions(this.brokerChannel);
 
 		// subscribe + not a user destination
 		this.handler.handleMessage(createWith(SimpMessageType.SUBSCRIBE, "joe", "123", "/queue/foo"));
-		Mockito.verifyZeroInteractions(this.brokerChannel);
+		verifyNoInteractions(this.brokerChannel);
 
 		// no match on message type
 		this.handler.handleMessage(createWith(SimpMessageType.CONNECT, "joe", "123", "user/joe/queue/foo"));
-		Mockito.verifyZeroInteractions(this.brokerChannel);
+		verifyNoInteractions(this.brokerChannel);
 	}
 
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/support/ExecutorSubscribableChannelTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/support/ExecutorSubscribableChannelTests.java
@@ -38,8 +38,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * Unit tests for {@link ExecutorSubscribableChannel}.
@@ -126,7 +126,7 @@ public class ExecutorSubscribableChannelTests {
 		catch (MessageDeliveryException actualException) {
 			assertThat(actualException.getCause()).isEqualTo(ex);
 		}
-		verifyZeroInteractions(secondHandler);
+		verifyNoInteractions(secondHandler);
 	}
 
 	@Test

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractReactiveTransactionAspectTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractReactiveTransactionAspectTests.java
@@ -37,7 +37,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Abstract support class to test {@link TransactionAspectSupport} with reactive methods.
@@ -79,7 +79,7 @@ public abstract class AbstractReactiveTransactionAspectTests {
 		checkReactiveTransaction(false);
 
 		// expect no calls
-		verifyZeroInteractions(rtm);
+		verifyNoInteractions(rtm);
 	}
 
 	/**

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractTransactionAspectTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractTransactionAspectTests.java
@@ -42,7 +42,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Mock object based tests for transaction aspects. A true unit test in that it
@@ -90,7 +90,7 @@ public abstract class AbstractTransactionAspectTests {
 		checkTransactionStatus(false);
 
 		// expect no calls
-		verifyZeroInteractions(ptm);
+		verifyNoInteractions(ptm);
 	}
 
 	/**

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/BeanFactoryTransactionTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/BeanFactoryTransactionTests.java
@@ -45,7 +45,7 @@ import org.springframework.transaction.TransactionStatus;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Test cases for AOP transaction management.
@@ -148,7 +148,7 @@ public class BeanFactoryTransactionTests {
 		assertThat(testBean.getAge() == 666).as("Age should not be " + testBean.getAge()).isTrue();
 
 		// Expect no methods
-		verifyZeroInteractions(ptm);
+		verifyNoInteractions(ptm);
 
 		// Install facade expecting a call
 		final TransactionStatus ts = mock(TransactionStatus.class);

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultWebClientTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultWebClientTests.java
@@ -41,8 +41,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * Unit tests for {@link DefaultWebClient}.
@@ -303,7 +303,7 @@ public class DefaultWebClientTests {
 				)
 				.build();
 		Mono<ClientResponse> exchange = client.get().uri("/path").exchange();
-		verifyZeroInteractions(this.exchangeFunction);
+		verifyNoInteractions(this.exchangeFunction);
 		exchange.block(Duration.ofSeconds(10));
 		ClientRequest request = verifyAndGetRequest();
 		assertThat(request.headers().getFirst("Custom")).isEqualTo("value");

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/HandlerExecutionChainTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/HandlerExecutionChainTests.java
@@ -27,7 +27,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * A test fixture with HandlerExecutionChain and mock handler interceptors.
@@ -120,7 +120,7 @@ public class HandlerExecutionChainTests {
 	@Test
 	public void exceptionBeforePreHandle() throws Exception {
 		this.chain.triggerAfterCompletion(this.request, this.response, null);
-		verifyZeroInteractions(this.interceptor1, this.interceptor2, this.interceptor3);
+		verifyNoInteractions(this.interceptor1, this.interceptor2, this.interceptor3);
 	}
 
 	@Test

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/StompSubProtocolHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/StompSubProtocolHandlerTests.java
@@ -66,8 +66,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * Test fixture for {@link StompSubProtocolHandler} tests.
@@ -402,7 +402,7 @@ public class StompSubProtocolHandlerTests {
 		this.protocolHandler.afterSessionStarted(this.session, this.channel);
 		this.protocolHandler.handleMessageFromClient(this.session, textMessage, this.channel);
 
-		verifyZeroInteractions(this.channel);
+		verifyNoInteractions(this.channel);
 		assertThat(this.session.getSentMessages().size()).isEqualTo(1);
 		TextMessage actual = (TextMessage) this.session.getSentMessages().get(0);
 		assertThat(actual.getPayload().startsWith("ERROR")).isTrue();


### PR DESCRIPTION
Hi,

I just noticed a couple of migration warnings coming from `Mockito.verifyZeroInteractions` that should be replaced by `Mockito.verifyNoInteractions`.

Cheers,
Christoph