### PR TITLE
PatternsRequestCondition combine bug fix

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java
@@ -192,7 +192,7 @@ public final class PatternsRequestCondition extends AbstractRequestCondition<Pat
 		else {
 			result.add("");
 		}
-		return new PatternsRequestCondition(result, this);
+		return new PatternsRequestCondition(result, other);
 	}
 
 	/**

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/condition/PatternsRequestConditionTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/condition/PatternsRequestConditionTests.java
@@ -74,6 +74,14 @@ public class PatternsRequestConditionTests {
 	}
 
 	@Test
+	public void combineOtherInstance() {
+		PatternsRequestCondition c1 = new PatternsRequestCondition("/t1", "/t2");
+		PatternsRequestCondition c2 = new PatternsRequestCondition(new String[]{"/m1", "/m2"}, null, null, false, false);
+		PatternsRequestCondition expected = new PatternsRequestCondition(new String[]{"/t1/m1", "/t1/m2", "/t2/m1", "/t2/m2"}, null, null, false, false);
+		assertThat(c1.combine(c2)).isEqualToComparingOnlyGivenFields(expected, "patterns", "useSuffixPatternMatch", "useTrailingSlashMatch");
+	}
+
+	@Test
 	public void matchDirectPath() {
 		PatternsRequestCondition condition = new PatternsRequestCondition("/foo");
 		PatternsRequestCondition match = condition.getMatchingCondition(new MockHttpServletRequest("GET", "/foo"));


### PR DESCRIPTION
When combining the current `PatternsRequestCondition` instance and another, a new instance with combined URL patterns from both is created and returned.
If the other instance sets other fields such as `useSuffixPatternMatch` and `useTrailingSlashMatch`, they are ignored as [the current instance (`this`) is supplied](https://github.com/spring-projects/spring-framework/blob/v5.2.0.RELEASE/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java#L195) to the [constructor instead of the `other` instance](https://github.com/spring-projects/spring-framework/blob/v5.2.0.RELEASE/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java#L128) presenting buggy behaviour while customizing path matching and URL treatment options.

see gh-23907