### PR TITLE
Improve BeanPropertyRowMapper.underscoreName()

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
@@ -248,15 +248,14 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
 			return "";
 		}
 		StringBuilder result = new StringBuilder();
-		result.append(lowerCaseName(name.substring(0, 1)));
+		result.append(Character.toLowerCase(name.charAt(0)));
 		for (int i = 1; i < name.length(); i++) {
-			String s = name.substring(i, i + 1);
-			String slc = lowerCaseName(s);
-			if (!s.equals(slc)) {
-				result.append("_").append(slc);
+			char c = name.charAt(i);
+			if (Character.isUpperCase(c)) {
+				result.append("_").append(Character.toLowerCase(c));
 			}
 			else {
-				result.append(s);
+				result.append(c);
 			}
 		}
 		return result.toString();


### PR DESCRIPTION
Currently the method allocates a substring of length = 1 for each character in field name. This can be improved by using `char` instead of `String`.

Also I doubt that we need name's length check: in fact there can be no property with empty name or one consisting of  exclusively whitespaces/tabs. I think this check can be removed, and even if the code throws after transformation this indicates a problem on the upper level.