### PR TITLE
Allow schemaZip Gradle task to execute on MS Windows

### DIFF
--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -148,14 +148,14 @@ task schemaZip(type: Zip) {
 		def Properties schemas = new Properties();
 
 		subproject.sourceSets.main.resources.find {
-			it.path.endsWith("META-INF/spring.schemas")
+			(it.path.endsWith("META-INF/spring.schemas")||it.path.endsWith("META-INF\\spring.schemas"))
 		}?.withInputStream { schemas.load(it) }
 
 		for (def key : schemas.keySet()) {
 			def shortName = key.replaceAll(/http.*schema.(.*).spring-.*/, '$1')
 			assert shortName != key
 			File xsdFile = subproject.sourceSets.main.resources.find {
-				it.path.endsWith(schemas.get(key))
+				(it.path.endsWith(schemas.get(key))||it.path.endsWith(schemas.get(key).replaceAll('\\/','\\\\')))
 			}
 			assert xsdFile != null
 			into (shortName) {


### PR DESCRIPTION
Because of the different file separators in different operating
systems, the schemazip task in Windows system cannot be executed.
Now it has been repaired