### PR TITLE
Fix bug : sorting problem with beanPostProcessor annotated by @Order

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java
+++ b/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java
@@ -243,7 +243,7 @@ final class PostProcessorRegistrationDelegate {
 				internalPostProcessors.add(pp);
 			}
 		}
-		// nonOrderedPostProcessors may contain beanPostProcessor which annotated with @order
+		// nonOrderedPostProcessors may contain beanPostProcessor which annotated with @Order
 		sortPostProcessors(nonOrderedPostProcessors, beanFactory);
 		registerBeanPostProcessors(beanFactory, nonOrderedPostProcessors);
 

--- a/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java
+++ b/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java
@@ -243,6 +243,8 @@ final class PostProcessorRegistrationDelegate {
 				internalPostProcessors.add(pp);
 			}
 		}
+		// nonOrderedPostProcessors may contain beanPostProcessor which annotated with @order
+		sortPostProcessors(nonOrderedPostProcessors, beanFactory);
 		registerBeanPostProcessors(beanFactory, nonOrderedPostProcessors);
 
 		// Finally, re-register all internal BeanPostProcessors.


### PR DESCRIPTION
The `beanPostProcessor` annotated with @Order will not be sorted, but the implementation of `PriorityOrdered` or `Ordered` will be sorted.
