### PR TITLE
Use Method::getParameterCount where possible

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AopProxyUtils.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AopProxyUtils.java
@@ -224,8 +224,8 @@ public abstract class AopProxyUtils {
 			return new Object[0];
 		}
 		if (method.isVarArgs()) {
-			Class<?>[] paramTypes = method.getParameterTypes();
-			if (paramTypes.length == arguments.length) {
+			if (method.getParameterCount() == arguments.length) {
+				Class<?>[] paramTypes = method.getParameterTypes();
 				int varargIndex = paramTypes.length - 1;
 				Class<?> varargType = paramTypes[varargIndex];
 				if (varargType.isArray()) {

--- a/spring-beans/src/main/java/org/springframework/beans/ExtendedBeanInfo.java
+++ b/spring-beans/src/main/java/org/springframework/beans/ExtendedBeanInfo.java
@@ -145,11 +145,10 @@ class ExtendedBeanInfo implements BeanInfo {
 
 	public static boolean isCandidateWriteMethod(Method method) {
 		String methodName = method.getName();
-		Class<?>[] parameterTypes = method.getParameterTypes();
-		int nParams = parameterTypes.length;
+		int nParams = method.getParameterCount();
 		return (methodName.length() > 3 && methodName.startsWith("set") && Modifier.isPublic(method.getModifiers()) &&
 				(!void.class.isAssignableFrom(method.getReturnType()) || Modifier.isStatic(method.getModifiers())) &&
-				(nParams == 1 || (nParams == 2 && int.class == parameterTypes[0])));
+				(nParams == 1 || (nParams == 2 && int.class == method.getParameterTypes()[0])));
 	}
 
 	private void handleCandidateWriteMethod(Method method) throws IntrospectionException {

--- a/spring-beans/src/main/java/org/springframework/beans/PropertyDescriptorUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyDescriptorUtils.java
@@ -66,8 +66,8 @@ abstract class PropertyDescriptorUtils {
 		Class<?> propertyType = null;
 
 		if (readMethod != null) {
-			Class<?>[] params = readMethod.getParameterTypes();
-			if (params.length != 0) {
+			int parameterCount = readMethod.getParameterCount();
+			if (parameterCount != 0) {
 				throw new IntrospectionException("Bad read method arg count: " + readMethod);
 			}
 			propertyType = readMethod.getReturnType();

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
@@ -696,10 +696,10 @@ public class AutowiredAnnotationBeanPostProcessor extends InstantiationAwareBean
 				arguments = resolveCachedArguments(beanName);
 			}
 			else {
-				Class<?>[] paramTypes = method.getParameterTypes();
-				arguments = new Object[paramTypes.length];
-				DependencyDescriptor[] descriptors = new DependencyDescriptor[paramTypes.length];
-				Set<String> autowiredBeans = new LinkedHashSet<>(paramTypes.length);
+				int argumentCount = method.getParameterCount();
+				arguments = new Object[argumentCount];
+				DependencyDescriptor[] descriptors = new DependencyDescriptor[argumentCount];
+				Set<String> autowiredBeans = new LinkedHashSet<>(argumentCount);
 				Assert.state(beanFactory != null, "No BeanFactory available");
 				TypeConverter typeConverter = beanFactory.getTypeConverter();
 				for (int i = 0; i < arguments.length; i++) {
@@ -724,8 +724,9 @@ public class AutowiredAnnotationBeanPostProcessor extends InstantiationAwareBean
 						if (arguments != null) {
 							DependencyDescriptor[] cachedMethodArguments = Arrays.copyOf(descriptors, arguments.length);
 							registerDependentBeans(beanName, autowiredBeans);
-							if (autowiredBeans.size() == paramTypes.length) {
+							if (autowiredBeans.size() == argumentCount) {
 								Iterator<String> it = autowiredBeans.iterator();
+								Class<?>[] paramTypes = method.getParameterTypes();
 								for (int i = 0; i < paramTypes.length; i++) {
 									String autowiredBeanName = it.next();
 									if (beanFactory.containsBean(autowiredBeanName) &&

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/ConstructorResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/ConstructorResolver.java
@@ -202,21 +202,23 @@ class ConstructorResolver {
 			LinkedList<UnsatisfiedDependencyException> causes = null;
 
 			for (Constructor<?> candidate : candidates) {
-				Class<?>[] paramTypes = candidate.getParameterTypes();
 
-				if (constructorToUse != null && argsToUse != null && argsToUse.length > paramTypes.length) {
+				int parameterCount = candidate.getParameterCount();
+
+				if (constructorToUse != null && argsToUse != null && argsToUse.length > parameterCount) {
 					// Already found greedy constructor that can be satisfied ->
 					// do not look any further, there are only less greedy constructors left.
 					break;
 				}
-				if (paramTypes.length < minNrOfArgs) {
+				if (parameterCount < minNrOfArgs) {
 					continue;
 				}
 
 				ArgumentsHolder argsHolder;
+				Class<?>[] paramTypes = candidate.getParameterTypes();
 				if (resolvedValues != null) {
 					try {
-						String[] paramNames = ConstructorPropertiesChecker.evaluate(candidate, paramTypes.length);
+						String[] paramNames = ConstructorPropertiesChecker.evaluate(candidate, parameterCount);
 						if (paramNames == null) {
 							ParameterNameDiscoverer pnd = this.beanFactory.getParameterNameDiscoverer();
 							if (pnd != null) {
@@ -240,7 +242,7 @@ class ConstructorResolver {
 				}
 				else {
 					// Explicit arguments given -> arguments length must match exactly.
-					if (paramTypes.length != explicitArgs.length) {
+					if (parameterCount != explicitArgs.length) {
 						continue;
 					}
 					argsHolder = new ArgumentsHolder(explicitArgs);
@@ -340,13 +342,22 @@ class ConstructorResolver {
 				if (uniqueCandidate == null) {
 					uniqueCandidate = candidate;
 				}
-				else if (!Arrays.equals(uniqueCandidate.getParameterTypes(), candidate.getParameterTypes())) {
-					uniqueCandidate = null;
-					break;
+				else {
+					boolean paramsNotMatch = isParamsNotMatch(uniqueCandidate, candidate);
+					if (paramsNotMatch) {
+						uniqueCandidate = null;
+						break;
+					}
 				}
 			}
 		}
 		mbd.factoryMethodToIntrospect = uniqueCandidate;
+	}
+
+	private boolean isParamsNotMatch(Method uniqueCandidate, Method candidate) {
+		int uniqueCandidateParameterCount = uniqueCandidate.getParameterCount();
+		int candidateParameterCount = candidate.getParameterCount();
+		return uniqueCandidateParameterCount != candidateParameterCount || !Arrays.equals(uniqueCandidate.getParameterTypes(), candidate.getParameterTypes());
 	}
 
 	/**
@@ -505,11 +516,12 @@ class ConstructorResolver {
 			LinkedList<UnsatisfiedDependencyException> causes = null;
 
 			for (Method candidate : candidates) {
-				Class<?>[] paramTypes = candidate.getParameterTypes();
 
-				if (paramTypes.length >= minNrOfArgs) {
+				int parameterCount = candidate.getParameterCount();
+				if (parameterCount >= minNrOfArgs) {
 					ArgumentsHolder argsHolder;
 
+					Class<?>[] paramTypes = candidate.getParameterTypes();
 					if (explicitArgs != null) {
 						// Explicit arguments given -> arguments length must match exactly.
 						if (paramTypes.length != explicitArgs.length) {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
@@ -311,9 +311,9 @@ class DisposableBeanAdapter implements DisposableBean, Runnable, Serializable {
 	 * assuming a "force" parameter), else logging an error.
 	 */
 	private void invokeCustomDestroyMethod(final Method destroyMethod) {
-		Class<?>[] paramTypes = destroyMethod.getParameterTypes();
-		final Object[] args = new Object[paramTypes.length];
-		if (paramTypes.length == 1) {
+		int paramCount = destroyMethod.getParameterCount();
+		final Object[] args = new Object[paramCount];
+		if (paramCount == 1) {
 			args[0] = Boolean.TRUE;
 		}
 		if (logger.isTraceEnabled()) {

--- a/spring-context/src/main/java/org/springframework/jmx/export/assembler/InterfaceBasedMBeanInfoAssembler.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/assembler/InterfaceBasedMBeanInfoAssembler.java
@@ -231,6 +231,7 @@ public class InterfaceBasedMBeanInfoAssembler extends AbstractConfigurableMBeanI
 		for (Class<?> ifc : ifaces) {
 			for (Method ifcMethod : ifc.getMethods()) {
 				if (ifcMethod.getName().equals(method.getName()) &&
+						ifcMethod.getParameterCount() == method.getParameterCount() &&
 						Arrays.equals(ifcMethod.getParameterTypes(), method.getParameterTypes())) {
 					return true;
 				}

--- a/spring-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
@@ -149,10 +149,10 @@ public final class BridgeMethodResolver {
 	 */
 	private static boolean isResolvedTypeMatch(Method genericMethod, Method candidateMethod, Class<?> declaringClass) {
 		Type[] genericParameters = genericMethod.getGenericParameterTypes();
-		Class<?>[] candidateParameters = candidateMethod.getParameterTypes();
-		if (genericParameters.length != candidateParameters.length) {
+		if (genericParameters.length != candidateMethod.getParameterCount()) {
 			return false;
 		}
+		Class<?>[] candidateParameters = candidateMethod.getParameterTypes();
 		for (int i = 0; i < candidateParameters.length; i++) {
 			ResolvableType genericParameter = ResolvableType.forMethodParameter(genericMethod, i, declaringClass);
 			Class<?> candidateParameter = candidateParameters[i];
@@ -235,6 +235,7 @@ public final class BridgeMethodResolver {
 			return true;
 		}
 		return (bridgeMethod.getReturnType().equals(bridgedMethod.getReturnType()) &&
+				bridgeMethod.getParameterCount() == bridgedMethod.getParameterCount() &&
 				Arrays.equals(bridgeMethod.getParameterTypes(), bridgedMethod.getParameterTypes()));
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/MethodInvoker.java
+++ b/spring-core/src/main/java/org/springframework/util/MethodInvoker.java
@@ -225,8 +225,8 @@ public class MethodInvoker {
 
 		for (Method candidate : candidates) {
 			if (candidate.getName().equals(targetMethod)) {
-				Class<?>[] paramTypes = candidate.getParameterTypes();
-				if (paramTypes.length == argCount) {
+				if (candidate.getParameterCount() == argCount) {
+					Class<?>[] paramTypes = candidate.getParameterTypes();
 					int typeDiffWeight = getTypeDifferenceWeight(paramTypes, arguments);
 					if (typeDiffWeight < minTypeDiffWeight) {
 						minTypeDiffWeight = typeDiffWeight;

--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -240,13 +240,20 @@ public abstract class ReflectionUtils {
 					getDeclaredMethods(searchType, false);
 			for (Method method : methods) {
 				if (name.equals(method.getName()) &&
-						(paramTypes == null || Arrays.equals(paramTypes, method.getParameterTypes()))) {
+						(paramTypes == null || hasSameParams(method, paramTypes))) {
 					return method;
 				}
 			}
 			searchType = searchType.getSuperclass();
 		}
 		return null;
+	}
+
+	private static boolean hasSameParams(Method method, @Nullable Class<?>[] paramTypes) {
+		if (paramTypes.length != method.getParameterCount()) {
+			return false;
+		}
+		return Arrays.equals(paramTypes, method.getParameterTypes());
 	}
 
 	/**
@@ -413,6 +420,7 @@ public abstract class ReflectionUtils {
 			Method methodBeingOverriddenWithCovariantReturnType = null;
 			for (Method existingMethod : methods) {
 				if (method.getName().equals(existingMethod.getName()) &&
+						method.getParameterCount() == existingMethod.getParameterCount() &&
 						Arrays.equals(method.getParameterTypes(), existingMethod.getParameterTypes())) {
 					// Is this a covariant return type situation?
 					if (existingMethod.getReturnType() != method.getReturnType() &&
@@ -504,8 +512,10 @@ public abstract class ReflectionUtils {
 		if (method == null || !method.getName().equals("equals")) {
 			return false;
 		}
-		Class<?>[] paramTypes = method.getParameterTypes();
-		return (paramTypes.length == 1 && paramTypes[0] == Object.class);
+		if (method.getParameterCount() != 1) {
+			return false;
+		}
+		return method.getParameterTypes()[0] == Object.class;
 	}
 
 	/**

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveConstructorExecutor.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveConstructorExecutor.java
@@ -44,8 +44,7 @@ public class ReflectiveConstructorExecutor implements ConstructorExecutor {
 	public ReflectiveConstructorExecutor(Constructor<?> ctor) {
 		this.ctor = ctor;
 		if (ctor.isVarArgs()) {
-			Class<?>[] paramTypes = ctor.getParameterTypes();
-			this.varargsPosition = paramTypes.length - 1;
+			this.varargsPosition = ctor.getParameterCount() - 1;
 		}
 		else {
 			this.varargsPosition = null;

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveConstructorResolver.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveConstructorResolver.java
@@ -69,13 +69,13 @@ public class ReflectiveConstructorResolver implements ConstructorResolver {
 			Constructor<?> matchRequiringConversion = null;
 
 			for (Constructor<?> ctor : ctors) {
-				Class<?>[] paramTypes = ctor.getParameterTypes();
-				List<TypeDescriptor> paramDescriptors = new ArrayList<>(paramTypes.length);
-				for (int i = 0; i < paramTypes.length; i++) {
+				int paramCount = ctor.getParameterCount();
+				List<TypeDescriptor> paramDescriptors = new ArrayList<>(paramCount);
+				for (int i = 0; i < paramCount; i++) {
 					paramDescriptors.add(new TypeDescriptor(new MethodParameter(ctor, i)));
 				}
 				ReflectionHelper.ArgumentsMatchInfo matchInfo = null;
-				if (ctor.isVarArgs() && argumentTypes.size() >= paramTypes.length - 1) {
+				if (ctor.isVarArgs() && argumentTypes.size() >= paramCount - 1) {
 					// *sigh* complicated
 					// Basically.. we have to have all parameters match up until the varargs one, then the rest of what is
 					// being provided should be
@@ -84,7 +84,7 @@ public class ReflectiveConstructorResolver implements ConstructorResolver {
 					// we are supplied does match exactly (it is an array already).
 					matchInfo = ReflectionHelper.compareArgumentsVarargs(paramDescriptors, argumentTypes, typeConverter);
 				}
-				else if (paramTypes.length == argumentTypes.size()) {
+				else if (paramCount == argumentTypes.size()) {
 					// worth a closer look
 					matchInfo = ReflectionHelper.compareArguments(paramDescriptors, argumentTypes, typeConverter);
 				}

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveMethodExecutor.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveMethodExecutor.java
@@ -61,8 +61,7 @@ public class ReflectiveMethodExecutor implements MethodExecutor {
 		this.originalMethod = method;
 		this.methodToInvoke = ClassUtils.getInterfaceMethodIfPossible(method);
 		if (method.isVarArgs()) {
-			Class<?>[] paramTypes = method.getParameterTypes();
-			this.varargsPosition = paramTypes.length - 1;
+			this.varargsPosition = method.getParameterCount() - 1;
 		}
 		else {
 			this.varargsPosition = null;

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveMethodResolver.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveMethodResolver.java
@@ -160,17 +160,17 @@ public class ReflectiveMethodResolver implements MethodResolver {
 
 			for (Method method : methodsToIterate) {
 				if (method.getName().equals(name)) {
-					Class<?>[] paramTypes = method.getParameterTypes();
-					List<TypeDescriptor> paramDescriptors = new ArrayList<>(paramTypes.length);
-					for (int i = 0; i < paramTypes.length; i++) {
+					int paramCount = method.getParameterCount();
+					List<TypeDescriptor> paramDescriptors = new ArrayList<>(paramCount);
+					for (int i = 0; i < paramCount; i++) {
 						paramDescriptors.add(new TypeDescriptor(new MethodParameter(method, i)));
 					}
 					ReflectionHelper.ArgumentsMatchInfo matchInfo = null;
-					if (method.isVarArgs() && argumentTypes.size() >= (paramTypes.length - 1)) {
+					if (method.isVarArgs() && argumentTypes.size() >= (paramCount - 1)) {
 						// *sigh* complicated
 						matchInfo = ReflectionHelper.compareArgumentsVarargs(paramDescriptors, argumentTypes, typeConverter);
 					}
-					else if (paramTypes.length == argumentTypes.size()) {
+					else if (paramCount == argumentTypes.size()) {
 						// Name and parameter number match, check the arguments
 						matchInfo = ReflectionHelper.compareArguments(paramDescriptors, argumentTypes, typeConverter);
 					}


### PR DESCRIPTION
We often use `Method.getParameterTypes()` which clones underlying array:
```java
@Override
public Class<?>[] getParameterTypes() {
    return parameterTypes.clone();
}
```
The problem is that array is often used only to get its length, so we allocate memory mostly in vain.

Instead in numerous cases we call `Method.getParameterCount` introduced in Java 8:
```java
public int getParameterCount() { return parameterTypes.length; }
```
which doesn't allocate.

In cases where we still need parameter types we can postpone retrieving it until it becomes inevitable.