### PR TITLE
Avoid store all beanName in ApplicationListenerDetector

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/ApplicationListenerDetector.java
+++ b/spring-context/src/main/java/org/springframework/context/support/ApplicationListenerDetector.java
@@ -59,7 +59,9 @@ class ApplicationListenerDetector implements DestructionAwareBeanPostProcessor, 
 
 	@Override
 	public void postProcessMergedBeanDefinition(RootBeanDefinition beanDefinition, Class<?> beanType, String beanName) {
-		this.singletonNames.put(beanName, beanDefinition.isSingleton());
+		if (ApplicationListener.class.isAssignableFrom(beanType)) {
+			this.singletonNames.put(beanName, beanDefinition.isSingleton());
+		}
 	}
 
 	@Override


### PR DESCRIPTION
**ApplicationListenerDetector** only process **ApplicationListener** in method like **postProcessAfterInitialization**,  so it's enough to store beanName that type is **ApplicationListener**