### PR TITLE
Fix @Configuration class's setBeanFactory method is called multiple times

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
@@ -448,11 +448,6 @@ public class ConfigurationClassPostProcessor implements BeanDefinitionRegistryPo
 
 		@Override
 		public PropertyValues postProcessProperties(@Nullable PropertyValues pvs, Object bean, String beanName) {
-			// Inject the BeanFactory before AutowiredAnnotationBeanPostProcessor's
-			// postProcessProperties method attempts to autowire other configuration beans.
-			if (bean instanceof EnhancedConfiguration) {
-				((EnhancedConfiguration) bean).setBeanFactory(this.beanFactory);
-			}
 			return pvs;
 		}
 


### PR DESCRIPTION
`@Configuration` class's `setBeanFactory` method is called multiple times.

- First point is `AbstractAutowireCapableBeanFactory#invokeAwareMethods`.
- Second point is `ImportAwareBeanPostProcessor#postProcessProperties`.

So, I think we can clean some code.

I don't know if I am right, I am looking forward to your answer.