### PR TITLE
Upgrade to Shadow Plugin 5.2.0

### DIFF
--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-	id "com.github.johnrengelman.shadow" version "5.1.0"
+	id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
 description = "Spring Core"


### PR DESCRIPTION
There are a few improvements, the most notable of which for Framework's build is that the [shadow jar task is now cacheable](https://github.com/johnrengelman/shadow/pull/524).