### PR TITLE
Fix typo in EventSourceTransportHandler

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/EventSourceTransportHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/EventSourceTransportHandler.java
@@ -30,7 +30,7 @@ import org.springframework.web.socket.sockjs.transport.TransportType;
 import org.springframework.web.socket.sockjs.transport.session.StreamingSockJsSession;
 
 /**
- * A TransportHandler for sending messages via Server-Sent events:
+ * A TransportHandler for sending messages via Server-Sent Events:
  * <a href="https://dev.w3.org/html5/eventsource/">https://dev.w3.org/html5/eventsource/</a>.
  *
  * @author Rossen Stoyanchev


### PR DESCRIPTION
The other files are written as Server-Sent **E**vents.

* https://github.com/spring-projects/spring-framework/blob/3a0f309e2c9fdbbf7fb2d348be861528177f8555/spring-web/src/main/java/org/springframework/http/codec/ServerSentEvent.java#L24
* https://github.com/spring-projects/spring-framework/blob/3a0f309e2c9fdbbf7fb2d348be861528177f8555/spring-web/src/main/java/org/springframework/http/codec/ClientCodecConfigurer.java#L88
* https://github.com/spring-projects/spring-framework/blob/ef14d76d3637abeb31edd8a22031c21f9445efef/spring-web/src/main/java/org/springframework/http/codec/ServerCodecConfigurer.java#L94
* https://github.com/spring-projects/spring-framework/blob/3a0f309e2c9fdbbf7fb2d348be861528177f8555/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/EventSourceTransportHandler.java#L33