### PR TITLE
Use array.clone() instead of manual array creation

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/ReflectiveMethodInvocation.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/ReflectiveMethodInvocation.java
@@ -212,8 +212,7 @@ public class ReflectiveMethodInvocation implements ProxyMethodInvocation, Clonea
 		Object[] cloneArguments = this.arguments;
 		if (this.arguments.length > 0) {
 			// Build an independent copy of the arguments array.
-			cloneArguments = new Object[this.arguments.length];
-			System.arraycopy(this.arguments, 0, cloneArguments, 0, this.arguments.length);
+			cloneArguments = this.arguments.clone();
 		}
 		return invocableClone(cloneArguments);
 	}

--- a/spring-context-support/src/main/java/org/springframework/mail/SimpleMailMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/SimpleMailMessage.java
@@ -276,9 +276,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 	}
 
 	private static String[] copy(String[] state) {
-		String[] copy = new String[state.length];
-		System.arraycopy(state, 0, copy, 0, state.length);
-		return copy;
+		return state.clone();
 	}
 
 }

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
@@ -48,8 +48,7 @@ public class SimpleKey implements Serializable {
 	 */
 	public SimpleKey(Object... elements) {
 		Assert.notNull(elements, "Elements must not be null");
-		this.params = new Object[elements.length];
-		System.arraycopy(elements, 0, this.params, 0, elements.length);
+		this.params = elements.clone();
 		this.hashCode = Arrays.deepHashCode(this.params);
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/FastByteArrayOutputStream.java
+++ b/spring-core/src/main/java/org/springframework/util/FastByteArrayOutputStream.java
@@ -206,9 +206,7 @@ public class FastByteArrayOutputStream extends OutputStream {
 	 */
 	public byte[] toByteArray() {
 		byte[] bytesUnsafe = toByteArrayUnsafe();
-		byte[] ret = new byte[bytesUnsafe.length];
-		System.arraycopy(bytesUnsafe, 0, ret, 0, bytesUnsafe.length);
-		return ret;
+		return bytesUnsafe.clone();
 	}
 
 	/**


### PR DESCRIPTION
Tiny simplification making code more brief and readable: in case we create a copy of the same length as original array and copy all the data into it we can use `array.clone()` instead of hand-made code snippet.