### PR TITLE
Avoid indefinite wait to connect in JettyWebSocketClient

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
@@ -155,7 +156,13 @@ public class JettyWebSocketClient extends AbstractWebSocketClient implements Lif
 
 		Callable<WebSocketSession> connectTask = () -> {
 			Future<Session> future = this.client.connect(listener, uri, request);
-			future.get();
+			try {
+				// TODO Configurable timeout
+				future.get(2000, TimeUnit.MILLISECONDS);
+			} catch (Exception ex){
+				logger.error("Failed to connect to remote websocket endpoint", ex);
+				future.cancel(true); // This method will stop the running underlying task
+			}
 			return wsSession;
 		};
 


### PR DESCRIPTION
In some cases, `org.eclipse.jetty.websocket.client.WebSocketClient.connect(listener, uri, request)` call will return a future that is never completed. It is reasonable that our `future.get()` must have a timeout to avoid thread blocking.
I suggest something like:
```java
Callable<WebSocketSession> connectTask = () -> {
	Future<Session> future = this.client.connect(listener, uri, request);
	try {
		// TODO Configurable timeout
		future.get(2000, TimeUnit.MILLISECONDS);
	} catch (Exception ex){
		logger.error("Failed to connect to remote websocket endpoint", ex);
		future.cancel(true); // This method will stop the running underlying task
	}
	return wsSession;
};
```