### PR TITLE
Asssociate timeout to underlying Jetty HTTP client

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
@@ -158,7 +158,7 @@ public class JettyWebSocketClient extends AbstractWebSocketClient implements Lif
 		Callable<WebSocketSession> connectTask = () -> {
 			Future<Session> future = this.client.connect(listener, uri, request);
 			try {
-				future.get(this.client.getConnectTimeout() + 50, TimeUnit.MILLISECONDS);
+				future.get(this.client.getConnectTimeout() + this.client.getMaxIdleTimeout() + 1000, TimeUnit.MILLISECONDS);
 			} catch (Exception ex){
 				future.cancel(true); // This method will stop the running underlying task
 				throw HandshakeFailureException("Failed to connect to remote websocket endpoint", ex);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
@@ -158,7 +158,7 @@ public class JettyWebSocketClient extends AbstractWebSocketClient implements Lif
 		Callable<WebSocketSession> connectTask = () -> {
 			Future<Session> future = this.client.connect(listener, uri, request);
 			try {
-				future.get(this.client.getConnectTimeout() + this.client.getMaxIdleTimeout() + 1000, TimeUnit.MILLISECONDS);
+				future.get(this.client.getConnectTimeout() + this.client.getHttpClient().getIdleTimeout() + 1000, TimeUnit.MILLISECONDS);
 			} catch (Exception ex){
 				future.cancel(true); // This method will stop the running underlying task
 				throw new HandshakeFailureException("Failed to connect to remote websocket endpoint", ex);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
@@ -43,6 +43,7 @@ import org.springframework.web.socket.adapter.jetty.JettyWebSocketHandlerAdapter
 import org.springframework.web.socket.adapter.jetty.JettyWebSocketSession;
 import org.springframework.web.socket.adapter.jetty.WebSocketToJettyExtensionConfigAdapter;
 import org.springframework.web.socket.client.AbstractWebSocketClient;
+import org.springframework.web.socket.server.HandshakeFailureException;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -157,11 +158,10 @@ public class JettyWebSocketClient extends AbstractWebSocketClient implements Lif
 		Callable<WebSocketSession> connectTask = () -> {
 			Future<Session> future = this.client.connect(listener, uri, request);
 			try {
-				// TODO Configurable timeout
-				future.get(2000, TimeUnit.MILLISECONDS);
+				future.get(this.client.getConnectTimeout() + 50, TimeUnit.MILLISECONDS);
 			} catch (Exception ex){
-				logger.error("Failed to connect to remote websocket endpoint", ex);
 				future.cancel(true); // This method will stop the running underlying task
+				throw HandshakeFailureException("Failed to connect to remote websocket endpoint", ex);
 			}
 			return wsSession;
 		};

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
@@ -155,7 +156,13 @@ public class JettyWebSocketClient extends AbstractWebSocketClient implements Lif
 
 		Callable<WebSocketSession> connectTask = () -> {
 			Future<Session> future = this.client.connect(listener, uri, request);
-			future.get();
+			try {
+				// TODO Configurable timeout
+				future.get(2000, TimeUnit.MILLISECONDS);
+			} catch (Exception ex){
+				logger.error("Failed to connect to remote websocket endpoint", ex);
+				future.cancel(true); // This method will stop the running underlying task
+			}
 			return wsSession;
 		};
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/jetty/JettyWebSocketClient.java
@@ -161,7 +161,7 @@ public class JettyWebSocketClient extends AbstractWebSocketClient implements Lif
 				future.get(this.client.getConnectTimeout() + this.client.getMaxIdleTimeout() + 1000, TimeUnit.MILLISECONDS);
 			} catch (Exception ex){
 				future.cancel(true); // This method will stop the running underlying task
-				throw HandshakeFailureException("Failed to connect to remote websocket endpoint", ex);
+				throw new HandshakeFailureException("Failed to connect to remote websocket endpoint", ex);
 			}
 			return wsSession;
 		};


### PR DESCRIPTION
The websocket handshake timeout is now the sum of connection timeout, idle tiemout and 1 margin second.