### PR TITLE
Support quoted identifiers in `SimpleJdbcInsert`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericTableMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericTableMetaDataProvider.java
@@ -76,6 +76,8 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 	/** Collection of TableParameterMetaData objects. */
 	private List<TableParameterMetaData> tableParameterMetaData = new ArrayList<>();
 
+	/** the string used to quote SQL identifiers. */
+	private String identifierQuoteString = "";
 
 	/**
 	 * Constructor used to initialize with provided database meta-data.
@@ -212,6 +214,15 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 				logger.warn("Error retrieving 'DatabaseMetaData.storesLowerCaseIdentifiers': " + ex.getMessage());
 			}
 		}
+
+		try {
+			this.identifierQuoteString = databaseMetaData.getIdentifierQuoteString();
+		}
+		catch (SQLException ex) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("Error retrieving 'DatabaseMetaData.getIdentifierQuoteString': " + ex.getMessage());
+			}
+		}
 	}
 
 	@Override
@@ -302,6 +313,14 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 	@Nullable
 	protected String getDatabaseVersion() {
 		return this.databaseVersion;
+	}
+
+	/**
+	 * Provide access to identifier quote string.
+	 */
+	@Override
+	public String getIdentifierQuoteString() {
+		return this.identifierQuoteString;
 	}
 
 	/**

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -78,6 +78,9 @@ public class TableMetaDataContext {
 	// Are we using generated key columns
 	private boolean generatedKeyColumnsUsed = false;
 
+	// Are we using escaping for SQL identifiers
+	private boolean usingEscaping = false;
+
 
 	/**
 	 * Set the name of the table for this context.
@@ -275,13 +278,24 @@ public class TableMetaDataContext {
 		for (String key : generatedKeyNames) {
 			keys.add(key.toUpperCase());
 		}
+		String identifierQuoteString = "";
+		if (this.metaDataProvider != null && this.usingEscaping) {
+			identifierQuoteString = this.metaDataProvider.getIdentifierQuoteString();
+		}
 		StringBuilder insertStatement = new StringBuilder();
 		insertStatement.append("INSERT INTO ");
 		if (getSchemaName() != null) {
+			insertStatement.append(identifierQuoteString);
 			insertStatement.append(getSchemaName());
 			insertStatement.append(".");
+			insertStatement.append(getTableName());
+			insertStatement.append(identifierQuoteString);
 		}
-		insertStatement.append(getTableName());
+		else {
+			insertStatement.append(identifierQuoteString);
+			insertStatement.append(getTableName());
+			insertStatement.append(identifierQuoteString);
+		}
 		insertStatement.append(" (");
 		int columnCount = 0;
 		for (String columnName : getTableColumns()) {
@@ -290,7 +304,9 @@ public class TableMetaDataContext {
 				if (columnCount > 1) {
 					insertStatement.append(", ");
 				}
+				insertStatement.append(identifierQuoteString);
 				insertStatement.append(columnName);
+				insertStatement.append(identifierQuoteString);
 			}
 		}
 		insertStatement.append(") VALUES(");
@@ -390,4 +406,11 @@ public class TableMetaDataContext {
 		return obtainMetaDataProvider().isGeneratedKeysColumnNameArraySupported();
 	}
 
+	public boolean isUsingEscaping() {
+		return this.usingEscaping;
+	}
+
+	public void setUsingEscaping(boolean usingEscaping) {
+		this.usingEscaping = usingEscaping;
+	}
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataProvider.java
@@ -123,4 +123,11 @@ public interface TableMetaDataProvider {
 	 */
 	List<TableParameterMetaData> getTableParameterMetaData();
 
+	/**
+	 * Retrieves the string used to quote SQL identifiers. This method returns a space " " if identifier quoting is not supported.
+	 * {@link DatabaseMetaData#getIdentifierQuoteString()}
+	 * @return database identifier quote string.
+	 */
+	String getIdentifierQuoteString();
+
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcInsert.java
@@ -235,6 +235,20 @@ public abstract class AbstractJdbcInsert {
 		return this.insertTypes;
 	}
 
+	/**
+	 * Set using using escaping.
+	 */
+	public void setUsingEscaping(boolean usingEscaping) {
+		this.tableMetaDataContext.setUsingEscaping(usingEscaping);
+	}
+
+	/**
+	 * Get using escaping.
+	 */
+	public boolean isUsingEscaping() {
+		return this.tableMetaDataContext.isUsingEscaping();
+	}
+
 
 	//-------------------------------------------------------------------------
 	// Methods handling compilation issues

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsert.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsert.java
@@ -113,6 +113,12 @@ public class SimpleJdbcInsert extends AbstractJdbcInsert implements SimpleJdbcIn
 	}
 
 	@Override
+	public SimpleJdbcInsert usingEscaping(boolean usingEscaping) {
+		setUsingEscaping(usingEscaping);
+		return this;
+	}
+
+	@Override
 	public int execute(Map<String, ?> args) {
 		return doExecute(args);
 	}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsertOperations.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/SimpleJdbcInsertOperations.java
@@ -80,6 +80,13 @@ public interface SimpleJdbcInsertOperations {
 	 */
 	SimpleJdbcInsertOperations includeSynonymsForTableColumnMetaData();
 
+	/**
+	 * Specify should sql identifiers be quoted.
+	 * @param usingEscaping should sql identifiers be quoted
+	 * @return the instance of this SimpleJdbcInsert
+	 */
+	SimpleJdbcInsertOperations usingEscaping(boolean usingEscaping);
+
 
 	/**
 	 * Execute the insert using the values passed in.

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/SimpleJdbcInsertTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/SimpleJdbcInsertTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -79,6 +80,38 @@ public class SimpleJdbcInsertTests {
 		assertThatExceptionOfType(InvalidDataAccessApiUsageException.class).isThrownBy(() ->
 				insert.execute(new HashMap<>()));
 		verify(resultSet).close();
+	}
+
+	@Test
+	public void testSimpleJdbcInsert() {
+		SimpleJdbcInsert jdbcInsert = new SimpleJdbcInsert(dataSource).withTableName("T").usingColumns("F", "S");
+		jdbcInsert.compile();
+		String expected = "INSERT INTO T (F, S) VALUES(?, ?)";
+		String actual = jdbcInsert.getInsertString();
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void testSimpleJdbcInsertWithEscapingWithSchemaName() throws Exception {
+		SimpleJdbcInsert jdbcInsert = new SimpleJdbcInsert(dataSource).withSchemaName("S").withTableName("T").usingColumns("F", "S").usingEscaping(true);
+
+		given(databaseMetaData.getIdentifierQuoteString()).willReturn("`");
+
+		jdbcInsert.compile();
+		String expected = "INSERT INTO `S.T` (`F`, `S`) VALUES(?, ?)";
+		String actual = jdbcInsert.getInsertString();
+		assertThat(actual).isEqualTo(expected);
+	}
+	@Test
+	public void testSimpleJdbcInsertWithEscapingWithoutSchemaName() throws Exception {
+		SimpleJdbcInsert jdbcInsert = new SimpleJdbcInsert(dataSource).withTableName("T").usingColumns("F", "S").usingEscaping(true);
+
+		given(databaseMetaData.getIdentifierQuoteString()).willReturn("`");
+
+		jdbcInsert.compile();
+		String expected = "INSERT INTO `T` (`F`, `S`) VALUES(?, ?)";
+		String actual = jdbcInsert.getInsertString();
+		assertThat(actual).isEqualTo(expected);
 	}
 
 }


### PR DESCRIPTION
Motivation https://github.com/spring-projects/spring-framework/issues/13874

**Current implementation steps**
1.  Getting identifierQuoteString to use for escaping from dataBaseMetadata in `GenericTableMetadataProvider` http://docs.oracle.com/javase/6/docs/api/java/sql/DatabaseMetaData.html#getIdentifierQuoteString%28%29.
2. Added property usingEscaping in `SimpleJdbcInsert` and logic related to handling it in `TableMetadataContext`.
3. Updated tests.
<!-- end list -->
