### PR TITLE
Add parameter name module to object mapper

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
@@ -82,6 +82,8 @@ import org.springframework.util.xml.StaxUtils;
  * <ul>
  * <li><a href="https://github.com/FasterXML/jackson-datatype-jdk8">jackson-datatype-jdk8</a>:
  * support for other Java 8 types like {@link java.util.Optional}</li>
+ * <li><a href="https://github.com/FasterXML/jackson-module-parameter-names">jackson-module-parameter-names</a>:
+ * support for constructor parameter names during deserialization</li>
  * <li><a href="https://github.com/FasterXML/jackson-datatype-jsr310">jackson-datatype-jsr310</a>:
  * support for Java 8 Date & Time API types</li>
  * <li><a href="https://github.com/FasterXML/jackson-datatype-joda">jackson-datatype-joda</a>:
@@ -778,6 +780,16 @@ public class Jackson2ObjectMapperBuilder {
 		}
 		catch (ClassNotFoundException ex) {
 			// jackson-datatype-jdk8 not available
+		}
+
+		try {
+			Class<? extends Module> parameterNamesModuleClass = (Class<? extends Module>)
+					ClassUtils.forName("com.fasterxml.jackson.module.paramnames.ParameterNamesModule", this.moduleClassLoader);
+			Module parameterNamesModule = BeanUtils.instantiateClass(parameterNamesModuleClass);
+			modulesToRegister.set(parameterNamesModule.getTypeId(), parameterNamesModule);
+		}
+		catch (ClassNotFoundException ex) {
+			// jackson-parameter-names not available
 		}
 
 		try {

--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
@@ -80,11 +80,11 @@ import org.springframework.util.xml.StaxUtils;
  * <p>It also automatically registers the following well-known modules if they are
  * detected on the classpath:
  * <ul>
- * <li><a href="https://github.com/FasterXML/jackson-datatype-jdk8">jackson-datatype-jdk8</a>:
+ * <li><a href="https://github.com/FasterXML/jackson-modules-java8">jackson-datatype-jdk8</a>:
  * support for other Java 8 types like {@link java.util.Optional}</li>
- * <li><a href="https://github.com/FasterXML/jackson-module-parameter-names">jackson-module-parameter-names</a>:
+ * <li><a href="https://github.com/FasterXML/jackson-modules-java8">jackson-module-parameter-names</a>:
  * support for constructor parameter names during deserialization</li>
- * <li><a href="https://github.com/FasterXML/jackson-datatype-jsr310">jackson-datatype-jsr310</a>:
+ * <li><a href="https://github.com/FasterXML/jackson-modules-java8">jackson-datatype-jsr310</a>:
  * support for Java 8 Date & Time API types</li>
  * <li><a href="https://github.com/FasterXML/jackson-datatype-joda">jackson-datatype-joda</a>:
  * support for Joda-Time types</li>


### PR DESCRIPTION
The three modules for Java 8 feature support in Jackson have been merged into one (https://github.com/FasterXML/jackson-modules-java8). It makes sense to treat all three now as well known modules that are registered by default.

As the documentation from the new project says about Jackson 3:

> Because of this parameter-names and datatypes modules are merged into jackson-databind and need not be registered; datetime module (JavaTimeModule) remains separate module due to its size and configurability options.

Spring could provide this behavior already today.