### PR TITLE
@Async doesn't work well with AopContext

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AopContext.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AopContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public final class AopContext {
 	 * @see #currentProxy()
 	 */
 	@Nullable
-	static Object setCurrentProxy(@Nullable Object proxy) {
+	public static Object setCurrentProxy(@Nullable Object proxy) {
 		Object old = currentProxy.get();
 		if (proxy != null) {
 			currentProxy.set(proxy);

--- a/spring-aop/src/main/java/org/springframework/aop/interceptor/AsyncExecutionInterceptor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/interceptor/AsyncExecutionInterceptor.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+
 import org.springframework.aop.framework.AopContext;
 import org.springframework.aop.framework.ReflectiveMethodInvocation;
 import org.springframework.aop.support.AopUtils;
@@ -114,13 +115,14 @@ public class AsyncExecutionInterceptor extends AsyncExecutionAspectSupport imple
 					"No executor specified and no default executor set on AsyncExecutionInterceptor either");
 		}
 
-		Object oldProxy = exposeProxy ? AopContext.currentProxy() : null;
+		Object oldProxy = this.exposeProxy ? AopContext.currentProxy() : null;
 
 		Callable<Object> task = () -> {
 			try {
-				if (exposeProxy) {
-					if (invocation instanceof ReflectiveMethodInvocation)
+				if (this.exposeProxy) {
+					if (invocation instanceof ReflectiveMethodInvocation) {
 						AopContext.setCurrentProxy(((ReflectiveMethodInvocation) invocation).getProxy());
+					}
 				}
 				Object result = invocation.proceed();
 				if (result instanceof Future) {
@@ -132,8 +134,9 @@ public class AsyncExecutionInterceptor extends AsyncExecutionAspectSupport imple
 			}
 			catch (Throwable ex) {
 				handleError(ex, userDeclaredMethod, invocation.getArguments());
-			} finally {
-				if (exposeProxy) {
+			}
+			finally {
+				if (this.exposeProxy) {
 					AopContext.setCurrentProxy(oldProxy);
 				}
 			}

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/AnnotationAsyncExecutionInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/AnnotationAsyncExecutionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.springframework.scheduling.annotation;
 
-import java.lang.reflect.Method;
-import java.util.concurrent.Executor;
-
 import org.springframework.aop.interceptor.AsyncExecutionInterceptor;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.lang.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.Executor;
 
 /**
  * Specialization of {@link AsyncExecutionInterceptor} that delegates method execution to
@@ -38,6 +38,9 @@ import org.springframework.lang.Nullable;
  * @see org.springframework.scheduling.annotation.AsyncAnnotationAdvisor
  */
 public class AnnotationAsyncExecutionInterceptor extends AsyncExecutionInterceptor {
+
+	private boolean exposeProxy;
+
 
 	/**
 	 * Create a new {@code AnnotationAsyncExecutionInterceptor} with the given executor
@@ -87,4 +90,8 @@ public class AnnotationAsyncExecutionInterceptor extends AsyncExecutionIntercept
 		return (async != null ? async.value() : null);
 	}
 
+
+	public void setExposeProxy(boolean exposeProxy) {
+		this.exposeProxy = exposeProxy;
+	}
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationAdvisor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationAdvisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,12 +59,14 @@ public class AsyncAnnotationAdvisor extends AbstractPointcutAdvisor implements B
 
 	private Pointcut pointcut;
 
+	private boolean exposeProxy;
+
 
 	/**
 	 * Create a new {@code AsyncAnnotationAdvisor} for bean-style configuration.
 	 */
 	public AsyncAnnotationAdvisor() {
-		this((Supplier<Executor>) null, (Supplier<AsyncUncaughtExceptionHandler>) null);
+		this((Supplier<Executor>) null, (Supplier<AsyncUncaughtExceptionHandler>) null, false);
 	}
 
 	/**
@@ -79,7 +81,7 @@ public class AsyncAnnotationAdvisor extends AbstractPointcutAdvisor implements B
 	public AsyncAnnotationAdvisor(
 			@Nullable Executor executor, @Nullable AsyncUncaughtExceptionHandler exceptionHandler) {
 
-		this(SingletonSupplier.ofNullable(executor), SingletonSupplier.ofNullable(exceptionHandler));
+		this(SingletonSupplier.ofNullable(executor), SingletonSupplier.ofNullable(exceptionHandler), false);
 	}
 
 	/**
@@ -93,7 +95,7 @@ public class AsyncAnnotationAdvisor extends AbstractPointcutAdvisor implements B
 	 */
 	@SuppressWarnings("unchecked")
 	public AsyncAnnotationAdvisor(
-			@Nullable Supplier<Executor> executor, @Nullable Supplier<AsyncUncaughtExceptionHandler> exceptionHandler) {
+			@Nullable Supplier<Executor> executor, @Nullable Supplier<AsyncUncaughtExceptionHandler> exceptionHandler, boolean exposeProxy) {
 
 		Set<Class<? extends Annotation>> asyncAnnotationTypes = new LinkedHashSet<>(2);
 		asyncAnnotationTypes.add(Async.class);
@@ -104,6 +106,7 @@ public class AsyncAnnotationAdvisor extends AbstractPointcutAdvisor implements B
 		catch (ClassNotFoundException ex) {
 			// If EJB 3.1 API not present, simply ignore.
 		}
+		this.exposeProxy = exposeProxy;
 		this.advice = buildAdvice(executor, exceptionHandler);
 		this.pointcut = buildPointcut(asyncAnnotationTypes);
 	}
@@ -152,6 +155,7 @@ public class AsyncAnnotationAdvisor extends AbstractPointcutAdvisor implements B
 
 		AnnotationAsyncExecutionInterceptor interceptor = new AnnotationAsyncExecutionInterceptor(null);
 		interceptor.configure(executor, exceptionHandler);
+		interceptor.setExposeProxy(exposeProxy);
 		return interceptor;
 	}
 

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationAdvisor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationAdvisor.java
@@ -155,7 +155,7 @@ public class AsyncAnnotationAdvisor extends AbstractPointcutAdvisor implements B
 
 		AnnotationAsyncExecutionInterceptor interceptor = new AnnotationAsyncExecutionInterceptor(null);
 		interceptor.configure(executor, exceptionHandler);
-		interceptor.setExposeProxy(exposeProxy);
+		interceptor.setExposeProxy(this.exposeProxy);
 		return interceptor;
 	}
 

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationBeanPostProcessor.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.aop.config.AopConfigUtils;
 import org.springframework.aop.framework.autoproxy.AbstractBeanFactoryAwareAdvisingPostProcessor;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;

--- a/spring-tx/src/test/java/org/springframework/transaction/annotation/EnableAsyncTestAopContext.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/annotation/EnableAsyncTestAopContext.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.transaction.annotation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.AopContext;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Service;
+import org.springframework.tests.transaction.CallCountingTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * * @author Li Zhi Long
+ */
+public class EnableAsyncTestAopContext {
+
+
+	public static String mainThreadName;
+	public static String async1ThreadName;
+	public static String async2ThreadName;
+	public static CountDownLatch countDownLatch;
+
+
+	@Test
+	public void asynExposeProxy() throws InterruptedException {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(
+				AysncAppConfig.class);
+		AsyncTransactionalTestBean bean = ctx.getBean(AsyncTransactionalTestBean.class);
+		assertThat(AopUtils.isAopProxy(bean)).as("testBean is not a proxy").isTrue();
+		mainThreadName = Thread.currentThread().getName();
+
+		countDownLatch = new CountDownLatch(2);
+		bean.findAllFoos();
+		countDownLatch.await();
+
+		assertThat(mainThreadName.equals(async1ThreadName)).isFalse();
+		assertThat(mainThreadName.equals(async2ThreadName)).isFalse();
+		assertThat(async1ThreadName.equals(async2ThreadName)).isFalse();
+
+		ctx.close();
+	}
+
+
+	@Service
+	public static class AsyncTransactionalTestBean {
+
+
+		@Transactional(readOnly = true)
+		public Collection<?> findAllFoos() {
+			System.out.println("saveQualifiedFoo " + Thread.currentThread().getName());
+			((AsyncTransactionalTestBean) AopContext.currentProxy()).testAsync();
+			return null;
+		}
+
+
+		@Async
+		public void testAsync() {
+			System.out.println("testAsync " + Thread.currentThread().getName());
+			async1ThreadName = Thread.currentThread().getName();
+			((AsyncTransactionalTestBean) AopContext.currentProxy()).testAsync1();
+			countDownLatch.countDown();
+		}
+
+
+		@Async
+		public void testAsync1() {
+			System.out.println("testAsync1 " + Thread.currentThread().getName());
+			async2ThreadName = Thread.currentThread().getName();
+			countDownLatch.countDown();
+		}
+
+
+	}
+
+
+	@EnableAsync
+	@EnableAspectJAutoProxy(exposeProxy = true)
+	@Configuration
+	@EnableTransactionManagement
+	static class AysncAppConfig {
+
+
+		@Bean
+		public AsyncTransactionalTestBean asyncTransactionalTestBean() {
+			return new AsyncTransactionalTestBean();
+		}
+
+
+		@Bean
+		public PlatformTransactionManager txManager() {
+			return new CallCountingTransactionManager();
+		}
+
+
+	}
+}


### PR DESCRIPTION
### @Async doesn't work well with AopContext

#### First, let's see a example below:
the demo's link:[https://github.com/lixiaolong11000/async](url)

```
class AsynApplicationTests {

    @Test
    void contextLoads() {
    }


    @Test
    public void asynExposeProxy() throws InterruptedException {
        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(AppConfigure.class);
        AsyncTransactionalTestBean asyncTransactionalTestBean = ctx.getBean(AsyncTransactionalTestBean.class);
        AsyncTestBean asyncTestBean = ctx.getBean(AsyncTestBean.class);

        assertThat(AopUtils.isAopProxy(asyncTransactionalTestBean)).as("asyncTransactionalTestBean is not a proxy").isTrue();
        assertThat(AopUtils.isAopProxy(asyncTestBean)).as("asyncTestBean is not a proxy").isTrue();

        asyncTransactionalTestBean.testTransToAsync();

        asyncTransactionalTestBean.testAsyncToAsync();

        asyncTestBean.testAsyncToAsyncTOAsync();

        ctx.close();
    }


    @Service
    public static class AsyncTransactionalTestBean {

        @Transactional
        public Collection<?> testTransToAsync() {
            System.out.println("testTransToAsync " + Thread.currentThread().getName());
            ((AsyncTransactionalTestBean) AopContext.currentProxy()).testAsyncToAsync();
            return null;
        }


        @Async
        public void testAsyncToAsync() {
            System.out.println("testAsyncToAsync " + Thread.currentThread().getName());
            ((AsyncTransactionalTestBean) AopContext.currentProxy()).testAsync();
        }

        @Async
        public void testAsync() {
            System.out.println("testAsync " + Thread.currentThread().getName());
        }
    }


    @Service
    public static class AsyncTestBean {

        @Async
        public Collection<?> testAsyncToAsyncTOAsync() {
            System.out.println("testAsyncToAsyncTOAsync " + Thread.currentThread().getName());
            ((AsyncTransactionalTestBean) AopContext.currentProxy()).testAsyncToAsync();
            return null;
        }

        @Async
        public void testAsyncToAsync() {
            System.out.println("testAsyncToAsync " + Thread.currentThread().getName());
            ((AsyncTransactionalTestBean) AopContext.currentProxy()).testAsync();
        }

        @Async
        public void testAsync() {
            System.out.println("testAsync " + Thread.currentThread().getName());
        }
    }


    @EnableAsync
    @EnableAspectJAutoProxy(exposeProxy = true)
    @Configuration
    @EnableTransactionManagement
    static class AppConfigure  {

        @Bean
        public AsyncTransactionalTestBean asyncTransactionalTestBean() {
            return new AsyncTransactionalTestBean();
        }

        @Bean
        public AsyncTestBean asyncTestBean() {
            return new AsyncTestBean();
        }

        @Bean
        public PlatformTransactionManager txManager() {
            return new MockTransactionManager();
        }
    }
}
```

run AsynApplicationTests.asynExposeProxy() we can find the exception:

```
java.lang.IllegalStateException: Cannot find current proxy: Set 'exposeProxy' property on Advised to 'true' to make it available.
	at org.springframework.aop.framework.AopContext.currentProxy(AopContext.java:69) ~[spring-aop-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at com.example.asyn.AsynApplicationTests$AsyncTransactionalTestBean.testAsyncToAsync(AsynApplicationTests.java:64) ~[test/:na]
	at com.example.asyn.AsynApplicationTests$AsyncTransactionalTestBean$$FastClassBySpringCGLIB$$adeba3a5.invoke(<generated>) ~[test/:na]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:769) ~[spring-aop-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:747) ~[spring-aop-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:115) ~[spring-aop-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_181]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_181]
```

#### Second, I find the reason is : @Async doesn't work well with AopContext. because:
- @EnableAspectJAutoProxy(exposeProxy = true) can make AopContext **work in current Thread**,not work in another Thread. so the test above **asyncTransactionalTestBean.testTransToAsync()** result in Exception
- the test above **asyncTransactionalTestBean.testAsyncToAsync()** result in Excepton because AsyncAnnotationBeanPostProcessor、AsyncExecutionInterceptor、AsyncAnnotationAdvisor not surport AopContext.

#### Third, summary
- When Aop(cglib,jdkproxy) use AopContext,@Async doesn't work well
- @Aysnc is also a Aop, but it not suport AopContext 

#### Final, I want contribute to spring to enhance it, thanks