### PR TITLE
Cache result of String.getBytes() in ExtendedBeanInfo.PropertyDescriptorComparator

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/ExtendedBeanInfo.java
+++ b/spring-beans/src/main/java/org/springframework/beans/ExtendedBeanInfo.java
@@ -208,7 +208,7 @@ class ExtendedBeanInfo implements BeanInfo {
 	}
 
 	private String propertyNameFor(Method method) {
-		return Introspector.decapitalize(method.getName().substring(3, method.getName().length()));
+		return Introspector.decapitalize(method.getName().substring(3));
 	}
 
 
@@ -534,11 +534,13 @@ class ExtendedBeanInfo implements BeanInfo {
 		public int compare(PropertyDescriptor desc1, PropertyDescriptor desc2) {
 			String left = desc1.getName();
 			String right = desc2.getName();
+			byte[] leftBytes = left.getBytes();
+			byte[] rightBytes = right.getBytes();
 			for (int i = 0; i < left.length(); i++) {
 				if (right.length() == i) {
 					return 1;
 				}
-				int result = left.getBytes()[i] - right.getBytes()[i];
+				int result = leftBytes[i] - rightBytes[i];
 				if (result != 0) {
 					return result;
 				}


### PR DESCRIPTION
Hoist constant byte[] out of loop. This is likely to improve start-up time for the cases when `ExtendedBeanInfo` is widely used as their property descriptors are stored in `TreeSet`