### PR TITLE
Improve part content type determination in MockMultipartHttpServletRequest

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockMultipartHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockMultipartHttpServletRequest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.mock.web;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -23,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.Part;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -121,9 +124,17 @@ public class MockMultipartHttpServletRequest extends MockHttpServletRequest impl
 		if (file != null) {
 			return file.getContentType();
 		}
-		else {
-			return null;
+
+		try {
+			Part part = getPart(paramOrFileName);
+			if (part != null) {
+				return part.getContentType();
+			}
+		} catch (ServletException | IOException e) {
+			throw new IllegalStateException("Cannot extract content type from multipart request.", e);
 		}
+
+		return null;
 	}
 
 	@Override

--- a/spring-test/src/test/java/org/springframework/mock/web/MockMultipartHttpServletRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockMultipartHttpServletRequestTests.java
@@ -27,6 +27,8 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -59,6 +61,24 @@ class MockMultipartHttpServletRequestTests {
 		request.addFile(new MockMultipartFile("file2", "myOrigFilename", "text/plain", new ByteArrayInputStream(
 			"myContent2".getBytes())));
 		doTestMultipartHttpServletRequest(request);
+	}
+
+	@Test
+	void mockMultiPartHttpServletRequestWithMixedData() {
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		request.addFile(new MockMultipartFile("file", "myOrigFilename", MediaType.TEXT_PLAIN_VALUE, "myContent2".getBytes()));
+
+		MockPart metadataPart = new MockPart("metadata", "{\"foo\": \"bar\"}".getBytes());
+		metadataPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+		request.addPart(metadataPart);
+
+		HttpHeaders fileHttpHeaders = request.getMultipartHeaders("file");
+		assertThat(fileHttpHeaders).isNotNull();
+		assertThat(fileHttpHeaders.getContentType()).isEqualTo(MediaType.TEXT_PLAIN);
+
+		HttpHeaders dataHttpHeaders = request.getMultipartHeaders("metadata");
+		assertThat(dataHttpHeaders).isNotNull();
+		assertThat(dataHttpHeaders.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
 	}
 
 	private void doTestMultipartHttpServletRequest(MultipartHttpServletRequest request) throws IOException {


### PR DESCRIPTION
The MockMultipartHttpServletRequest does not support handling of non-file multiparts.
This aligns the behavior of MockMultipartHttpServletRequest with StandardMultipartHttpServletRequest and DefaultMultipartHttpServletRequest, which support such scenarios by looking up content types in file as well as non-file parts of the request.