### PR TITLE
Fix consecutive-word duplications in documentation

### DIFF
--- a/src/docs/asciidoc/core/core-aop-api.adoc
+++ b/src/docs/asciidoc/core/core-aop-api.adoc
@@ -576,7 +576,7 @@ methods can be combined in a single class. The following listing shows the final
 
 NOTE: If a throws-advice method throws an exception itself, it overrides the
 original exception (that is, it changes the exception thrown to the user). The overriding
-exception is typically a RuntimeException, which is is compatible with any method
+exception is typically a RuntimeException, which is compatible with any method
 signature. However, if a throws-advice method throws a checked exception, it must
 match the declared exceptions of the target method and is, hence, to some degree
 coupled to specific target method signatures. _Do not throw an undeclared checked

--- a/src/docs/asciidoc/rsocket.adoc
+++ b/src/docs/asciidoc/rsocket.adoc
@@ -79,7 +79,7 @@ The responder may then return `PAYLOAD` frames with response messages, and in th
 of `REQUEST_CHANNEL` the requester may also send `PAYLOAD` frames with more request
 messages.
 
-When a request involves a stream of messages such as as `Request-Stream` and `Channel`,
+When a request involves a stream of messages such as `Request-Stream` and `Channel`,
 the responder must respect demand signals from the requester. Demand is expressed as a
 number of messages. Initial demand is specified in `REQUEST_STREAM` and
 `REQUEST_CHANNEL` frames. Subsequent demand is signaled via `REQUEST_N` frames.

--- a/src/docs/asciidoc/web/webflux-webclient.adoc
+++ b/src/docs/asciidoc/web/webflux-webclient.adoc
@@ -662,7 +662,7 @@ or, in the case of a `Resource`, based on the file extension. If necessary, you 
 explicitly provide the `MediaType` to use for each part through one of the overloaded
 builder `part` methods.
 
-Once a `MultiValueMap` is prepared, the easiest way to pass it to the the `WebClient` is
+Once a `MultiValueMap` is prepared, the easiest way to pass it to the `WebClient` is
 through the `body` method, as the following example shows:
 
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]

--- a/src/docs/asciidoc/web/webflux.adoc
+++ b/src/docs/asciidoc/web/webflux.adoc
@@ -868,7 +868,7 @@ when consumed to avoid memory leaks.
 WebFlux applications generally do not need to be concerned with such issues, unless they
 consume or produce data buffers directly, as opposed to relying on codecs to convert to
 and from higher level objects, or unless they choose to create custom codecs. For such
-cases please review the the information in <<core#databuffers, Data Buffers and Codecs>>,
+cases please review the information in <<core#databuffers, Data Buffers and Codecs>>,
 especially the section on <<core#databuffers-using, Using DataBuffer>>.
 
 

--- a/src/docs/asciidoc/web/webmvc-view.adoc
+++ b/src/docs/asciidoc/web/webmvc-view.adoc
@@ -1716,7 +1716,7 @@ the `WEB-INF/defs` directory. At initialization of the `WebApplicationContext`, 
 files are loaded, and the definitions factory are initialized. After that has
 been done, the Tiles included in the definition files can be used as views within your
 Spring web application. To be able to use the views, you have to have a `ViewResolver`
-as with any other view technology used with Spring. You can can use either of two
+as with any other view technology used with Spring. You can use either of two
 implementations, the `UrlBasedViewResolver` and the `ResourceBundleViewResolver`.
 
 You can specify locale-specific Tiles definitions by adding an underscore and then

--- a/src/docs/asciidoc/web/webmvc.adoc
+++ b/src/docs/asciidoc/web/webmvc.adoc
@@ -3739,7 +3739,7 @@ level, <<mvc-exceptionhandlers, HandlerExceptionResolver>> mechanism.
 
 | `javax.servlet.ServletRequest`, `javax.servlet.ServletResponse`
 | Choose any specific request or response type (for example, `ServletRequest` or
-  `HttpServletRequest` or or Spring's `MultipartRequest` or `MultipartHttpServletRequest`).
+  `HttpServletRequest` or Spring's `MultipartRequest` or `MultipartHttpServletRequest`).
 
 | `javax.servlet.http.HttpSession`
 | Enforces the presence of a session. As a consequence, such an argument is never `null`. +
@@ -4284,7 +4284,7 @@ as the following example shows:
 	}
 ----
 
-The return value can then be obtained by running the the given task through the
+The return value can then be obtained by running the given task through the
 <<mvc-ann-async-configuration-spring-mvc, configured>> `TaskExecutor`.
 
 


### PR DESCRIPTION
This is a follow-up of the other PR https://github.com/spring-projects/spring-security/pull/7673, which checks for consecutive words for possible duplication(s). such as `the the`, `can can` etc.
