### PR TITLE
Enable reading from the remote build cache for all

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,16 +18,14 @@ plugins {
 	id "com.github.ben-manes.versions" version "0.24.0"
 }
 
-if (System.getenv('GRADLE_ENTERPRISE_URL')) {
-	apply from: "$rootDir/gradle/build-scan-user-data.gradle"
-	buildScan {
-		captureTaskInputFiles = true
-		obfuscation {
-			ipAddresses { addresses -> addresses.collect { address -> '0.0.0.0'} }
-		}
-		publishAlways()
-		server = System.getenv('GRADLE_ENTERPRISE_URL')
+apply from: "$rootDir/gradle/build-scan-user-data.gradle"
+buildScan {
+	captureTaskInputFiles = true
+	obfuscation {
+		ipAddresses { addresses -> addresses.collect { address -> '0.0.0.0'} }
 	}
+	publishAlwaysIf(System.getenv('GRADLE_ENTERPRISE_URL') != null)
+	server = 'https://ge.spring.io'
 }
 
 ext {

--- a/gradle/build-cache-settings.gradle
+++ b/gradle/build-cache-settings.gradle
@@ -2,18 +2,16 @@ buildCache {
 	local {
 		enabled = true
 	}
-	if (System.getenv('GRADLE_ENTERPRISE_URL')) {
-		remote(HttpBuildCache) {
-			enabled = true
-			url = "${System.getenv('GRADLE_ENTERPRISE_URL')}/cache/"
-			def cacheUsername = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
-			def cachePassword = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
-			if (cacheUsername && cachePassword) {
-				push = true
-				credentials {
-					username = cacheUsername
-					password = cachePassword
-				}
+	remote(HttpBuildCache) {
+		enabled = true
+		url = 'https://ge.spring.io/cache/'
+		def cacheUsername = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
+		def cachePassword = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
+		if (cacheUsername && cachePassword) {
+			push = true
+			credentials {
+				username = cacheUsername
+				password = cachePassword
 			}
 		}
 	}


### PR DESCRIPTION
Previously, the remote build cache was only enabled if the `GRADLE_ENTERPRISE_URL` environment variable was configured. This meant that contributors would not benefit from the build time improvements of the caching without some additional setup.

This pull request updates the `buildCache` configuration so that reading from the remote build cache at https://ge.spring.io is enabled for all. Pushing to the cache continues to be disabled unless the required credentials are provided. Build scan configuration has also been updated in line with this change. While the server URL is now hardcoded, publishing is still opt-in via an environment variable. The exact mechanism by which someone can opt in will change in the future once some server-side changes have been made. At this point, only a change to `publishAlwaysIf` should be necessary.