### PR TITLE
Regression: default values for implicit aliases no longer honored in MergedAnnotations

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMapping.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMapping.java
@@ -646,6 +646,9 @@ final class AnnotationTypeMapping {
 					boolean isDefaultValue = (value == null ||
 							isEquivalentToDefaultValue(attribute, value, valueExtractor));
 					if (isDefaultValue || ObjectUtils.nullSafeEquals(lastValue, value)) {
+						if (result == -1) {
+							result = this.indexes[i];
+						}
 						continue;
 					}
 					if (lastValue != null &&

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
@@ -368,13 +368,13 @@ class AnnotationTypeMappingsTests {
 	}
 
 	@Test
-	void resolveMirrorsWhenOnlyHasDefaultValuesResolvesNone() {
+	void resolveMirrorsWhenOnlyHasDefaultValuesUsesFirst() {
 		AnnotationTypeMapping mapping = AnnotationTypeMappings.forAnnotationType(
 				AliasPair.class).get(0);
 		Method[] resolved = resolveMirrorSets(mapping, WithDefaultValueAliasPair.class,
 				AliasPair.class);
-		assertThat(resolved[0]).isNull();
-		assertThat(resolved[1]).isNull();
+		assertThat(resolved[0].getName()).isEqualTo("a");
+		assertThat(resolved[1].getName()).isEqualTo("a");
 	}
 
 	@Test


### PR DESCRIPTION
A single low-level annotation attribute can change a high-level attribute via `@AliasFor`, but when some low-level attribute is mirrored and is the default value, the high-level attribute will not be changed.

I think this is unreasonable.