### PR TITLE
Add Nullable to Joinpoint and MethodInterceptor

### DIFF
--- a/spring-aop/src/main/java/org/aopalliance/intercept/Joinpoint.java
+++ b/spring-aop/src/main/java/org/aopalliance/intercept/Joinpoint.java
@@ -17,6 +17,7 @@
 package org.aopalliance.intercept;
 
 import java.lang.reflect.AccessibleObject;
+import javax.annotation.Nullable;
 
 /**
  * This interface represents a generic runtime joinpoint (in the AOP
@@ -46,6 +47,7 @@ public interface Joinpoint {
 	 * @return see the children interfaces' proceed definition
 	 * @throws Throwable if the joinpoint throws an exception
 	 */
+	@Nullable
 	Object proceed() throws Throwable;
 
 	/**
@@ -53,6 +55,7 @@ public interface Joinpoint {
 	 * <p>For instance, the target object for an invocation.
 	 * @return the object (can be null if the accessible object is static)
 	 */
+	@Nullable
 	Object getThis();
 
 	/**

--- a/spring-aop/src/main/java/org/aopalliance/intercept/MethodInterceptor.java
+++ b/spring-aop/src/main/java/org/aopalliance/intercept/MethodInterceptor.java
@@ -16,6 +16,8 @@
 
 package org.aopalliance.intercept;
 
+import javax.annotation.Nullable;
+
 /**
  * Intercepts calls on an interface on its way to the target. These
  * are nested "on top" of the target.
@@ -52,6 +54,7 @@ public interface MethodInterceptor extends Interceptor {
 	 * @throws Throwable if the interceptors or the target object
 	 * throws an exception
 	 */
+	@Nullable
 	Object invoke(MethodInvocation invocation) throws Throwable;
 
 }


### PR DESCRIPTION
These annotations enable better Kotlin Interop.
With these annotations the Kotlin compiler correctly picks up
nullability when calling .proceed() used on a method returning void.

closes gh-24028