### PR TITLE
Optimize WebClient BodyExtractors default contentType strategy

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyExtractors.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyExtractors.java
@@ -59,6 +59,8 @@ public abstract class BodyExtractors {
 
 	private static final ResolvableType VOID_TYPE = ResolvableType.forClass(Void.class);
 
+	private static MediaType defaultContentType = MediaType.APPLICATION_OCTET_STREAM;
+
 
 	/**
 	 * Extractor to decode the input content into {@code Mono<T>}.
@@ -187,7 +189,7 @@ public abstract class BodyExtractors {
 			return emptySupplier.get();
 		}
 		MediaType contentType = Optional.ofNullable(message.getHeaders().getContentType())
-				.orElse(MediaType.APPLICATION_OCTET_STREAM);
+				.orElse(defaultContentType);
 
 		return context.messageReaders().stream()
 				.filter(reader -> reader.canRead(elementType, contentType))
@@ -278,4 +280,11 @@ public abstract class BodyExtractors {
 	private static class ReadCancellationException extends RuntimeException {
 	}
 
+	public static MediaType getDefaultContentType() {
+		return defaultContentType;
+	}
+
+	public static void setDefaultContentType(MediaType defaultContentType) {
+		BodyExtractors.defaultContentType = defaultContentType;
+	}
 }


### PR DESCRIPTION
The ContentType of APPLICATION_OCTET_STREAM is used by default, and an exception will be thrown when using the BodyToMono to transform the Entity. I think in addition to the default strategy here, users should be free to choose which default ContentType to use