### PR TITLE
Ensure MvcUriComponentsBuilder generates correct URL from type-level mapping without leading slash

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilder.java
@@ -102,6 +102,8 @@ public class MvcUriComponentsBuilder {
 	 */
 	public static final String MVC_URI_COMPONENTS_CONTRIBUTOR_BEAN_NAME = "mvcUriComponentsContributor";
 
+	/** Path separator: "/". */
+	public static final String PATH_SEPARATOR = "/";
 
 	private static final Log logger = LogFactory.getLog(MvcUriComponentsBuilder.class);
 
@@ -545,7 +547,7 @@ public class MvcUriComponentsBuilder {
 		String typePath = getClassMapping(controllerType);
 		String methodPath = getMethodMapping(method);
 		String path = pathMatcher.combine(typePath, methodPath);
-		builder.path(path);
+		builder.path(path.startsWith(PATH_SEPARATOR) ? path : PATH_SEPARATOR + path);
 
 		return applyContributors(builder, method, args);
 	}
@@ -576,11 +578,11 @@ public class MvcUriComponentsBuilder {
 		Assert.notNull(controllerType, "'controllerType' must not be null");
 		RequestMapping mapping = AnnotatedElementUtils.findMergedAnnotation(controllerType, RequestMapping.class);
 		if (mapping == null) {
-			return "/";
+			return PATH_SEPARATOR;
 		}
 		String[] paths = mapping.path();
 		if (ObjectUtils.isEmpty(paths) || !StringUtils.hasLength(paths[0])) {
-			return "/";
+			return PATH_SEPARATOR;
 		}
 		if (paths.length > 1 && logger.isTraceEnabled()) {
 			logger.trace("Using first of multiple paths on " + controllerType.getName());
@@ -596,7 +598,7 @@ public class MvcUriComponentsBuilder {
 		}
 		String[] paths = requestMapping.path();
 		if (ObjectUtils.isEmpty(paths) || !StringUtils.hasLength(paths[0])) {
-			return "/";
+			return PATH_SEPARATOR;
 		}
 		if (paths.length > 1 && logger.isTraceEnabled()) {
 			logger.trace("Using first of multiple paths on " + method.toGenericString());

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilderTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/MvcUriComponentsBuilderTests.java
@@ -435,6 +435,20 @@ public class MvcUriComponentsBuilderTests {
 	}
 
 	@Test
+	public void fromMappingNameWithNonSlashPath() {
+
+		initWebApplicationContext(NonSlashPathWebConfig.class);
+
+		this.request.setServerName("example.org");
+		this.request.setServerPort(9999);
+		this.request.setContextPath("/base");
+
+		String mappingName = "NSPC#getAddressesForCountry";
+		String url = fromMappingName(mappingName).arg(0, "DE;FR").encode().buildAndExpand("_+_");
+		assertThat(url).isEqualTo("/base/people/DE%3BFR");
+	}
+
+	@Test
 	public void fromControllerWithPrefix() {
 
 		initWebApplicationContext(PathPrefixWebConfig.class);
@@ -498,6 +512,15 @@ public class MvcUriComponentsBuilderTests {
 		}
 	}
 
+
+	@RequestMapping({"people"})
+	static class NonSlashPathController {
+
+		@RequestMapping("/{country}")
+		HttpEntity<Void> getAddressesForCountry(@PathVariable String country) {
+			return null;
+		}
+	}
 
 	@RequestMapping({"/persons", "/people"})
 	private class InvalidController {
@@ -618,6 +641,16 @@ public class MvcUriComponentsBuilderTests {
 		@Bean
 		public PersonsAddressesController controller() {
 			return new PersonsAddressesController();
+		}
+	}
+
+
+	@EnableWebMvc
+	static class NonSlashPathWebConfig implements WebMvcConfigurer {
+
+		@Bean
+		public NonSlashPathController controller() {
+			return new NonSlashPathController();
 		}
 	}
 


### PR DESCRIPTION
There seems to be a bug in `MvcUriComponentsBuilder`, so I fixed it.

### affects

* Spring 5.2.1 and older.
* Using Spring WebMVC and JSP/Thymeleaf.

### problem

`MvcUriComponentsBuilder` generates incorrect URLs from paths without slashes.

* Context Path

`/demo`

* Controller

```java
@Controller
@RequestMapping("test") // non slash path
public class TestController {

    @GetMapping
    public String test() {
        return "test";
    }
}
```

* JSP (The same problem will happen with Thymeleaf)

```jsp
<a href="${spring:mvcUrl('TC#test').build()}">test</a>
```

* Created HTML

```html
<a href="/demotest">test</a>
<!-- expected '/demo/test' -->
```

### Cause

At `MvcUriComponentsBuilder#fromMethodInternal`, 
`PathMatcher` adds a slash between the path of class `@RequestMapping` and the path of method  `@RequestMapping`. However, no slash is added at the beginning of the merged path.
