### PR TITLE
Support variable resolution of wildcard types

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -873,6 +873,12 @@ public class ResolvableType implements Serializable {
 				return forType(ownerType, this.variableResolver).resolveVariable(variable);
 			}
 		}
+		if (this.type instanceof WildcardType) {
+			ResolvableType resolved = resolveType().resolveVariable(variable);
+			if (resolved != null) {
+				return resolved;
+			}
+		}
 		if (this.variableResolver != null) {
 			return this.variableResolver.resolveVariable(variable);
 		}

--- a/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
@@ -688,6 +688,13 @@ class ResolvableTypeTests {
 		assertThat(type.resolve()).isEqualTo(CharSequence.class);
 	}
 
+
+	@Test
+	void resolveBoundedTypeVariableWildcardResult() throws Exception {
+		ResolvableType type = ResolvableType.forMethodReturnType(Methods.class.getMethod("boundedTypeVaraibleWildcardResult"));
+		assertThat(type.getGeneric(1).asCollection().resolveGeneric()).isEqualTo(CharSequence.class);
+	}
+
 	@Test
 	void resolveVariableNotFound() throws Exception {
 		ResolvableType type = ResolvableType.forMethodReturnType(Methods.class.getMethod("typedReturn"));
@@ -1416,6 +1423,8 @@ class ResolvableTypeTests {
 		void charSequenceParameter(List<CharSequence> cs);
 
 		<R extends CharSequence & Serializable> R boundedTypeVaraibleResult();
+
+		Map<String, ? extends List<? extends CharSequence>> boundedTypeVaraibleWildcardResult();
 
 		void nested(Map<Map<String, Integer>, Map<Byte, Long>> p);
 


### PR DESCRIPTION
Update `ResolvableType` so that variable referenced can be resolved
against wildcard types. Prior to this commit, given a type:

	Map<String, ? extends List<? extends CharSequence>>

Calling `type.getGeneric(1).asCollection().resolveGeneric()` would
return `null`. This was because the `List` variable `E` referenced a
wildcard type which `resolveVariable` did not support.
