### PR TITLE
Hoist Class.getName() from String concatenation to dodge an issue related to profile pollution

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/interceptor/SimpleTraceInterceptor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/interceptor/SimpleTraceInterceptor.java
@@ -73,8 +73,8 @@ public class SimpleTraceInterceptor extends AbstractTraceInterceptor {
 	 * @return the description
 	 */
 	protected String getInvocationDescription(MethodInvocation invocation) {
-		return "method '" + invocation.getMethod().getName() + "' of class [" +
-				invocation.getThis().getClass().getName() + "]";
+		String className = invocation.getThis().getClass().getName();
+		return "method '" + invocation.getMethod().getName() + "' of class [" + className + "]";
 	}
 
 }

--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -523,7 +523,8 @@ public abstract class BeanUtils {
 				return null;
 			}
 		}
-		String editorName = targetType.getName() + "Editor";
+		String targetTypeName = targetType.getName();
+		String editorName = targetTypeName + "Editor";
 		try {
 			Class<?> editorClass = cl.loadClass(editorName);
 			if (!PropertyEditor.class.isAssignableFrom(editorClass)) {
@@ -539,7 +540,7 @@ public abstract class BeanUtils {
 		catch (ClassNotFoundException ex) {
 			if (logger.isTraceEnabled()) {
 				logger.trace("No property editor [" + editorName + "] found for type " +
-						targetType.getName() + " according to 'Editor' suffix convention");
+						targetTypeName + " according to 'Editor' suffix convention");
 			}
 			unknownEditorTypes.add(targetType);
 			return null;

--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -611,7 +611,9 @@ public abstract class ObjectUtils {
 		if (obj == null) {
 			return EMPTY_STRING;
 		}
-		return obj.getClass().getName() + "@" + getIdentityHexString(obj);
+		String className = obj.getClass().getName();
+		String identityHexString = getIdentityHexString(obj);
+		return className + '@' + identityHexString;
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/server/handler/DefaultWebFilterChain.java
+++ b/spring-web/src/main/java/org/springframework/web/server/handler/DefaultWebFilterChain.java
@@ -123,8 +123,8 @@ public class DefaultWebFilterChain implements WebFilterChain {
 	}
 
 	private Mono<Void> invokeFilter(WebFilter current, DefaultWebFilterChain chain, ServerWebExchange exchange) {
-		return current.filter(exchange, chain)
-				.checkpoint(current.getClass().getName() + " [DefaultWebFilterChain]");
+		String currentName = current.getClass().getName();
+		return current.filter(exchange, chain).checkpoint(currentName + " [DefaultWebFilterChain]");
 	}
 
 }


### PR DESCRIPTION
On one of my projects I've run into performance issue related to profile polution when `Class.getName()` is used inside of String concatenation chain. The issue is described here: https://stackoverflow.com/questions/59157085/java-8-class-getname-slows-down-string-concatenation-chain

As far as Spring is likely to remain on Java 8 code base I suggest to hoist Class.getName() from frequently executed concatenation chains at least from `ObjectUtils.identityToString()` which is called from loop in `DefaultListableBeanFactory.findAutowireCandidates()` and `SimpleTraceInterceptor.getInvocationDescription()`.