### PR TITLE
Hoist constant result of SerializableTypeWrapper.unwrap() out of loop

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -1496,9 +1496,9 @@ public class ResolvableType implements Serializable {
 		@Override
 		@Nullable
 		public ResolvableType resolveVariable(TypeVariable<?> variable) {
+			TypeVariable<?> v2 = SerializableTypeWrapper.unwrap(variable);
 			for (int i = 0; i < this.variables.length; i++) {
 				TypeVariable<?> v1 = SerializableTypeWrapper.unwrap(this.variables[i]);
-				TypeVariable<?> v2 = SerializableTypeWrapper.unwrap(variable);
 				if (ObjectUtils.nullSafeEquals(v1, v2)) {
 					return this.generics[i];
 				}


### PR DESCRIPTION
There is no point in calculatation of expression
```java
TypeVariable<?> v2 = SerializableTypeWrapper.unwrap(variable);
```
at each iteration of the loop as far as its result depends only on method's argument.