### PR TITLE
Use hasSize() where possible

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/AnnotationConfigApplicationContextTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/AnnotationConfigApplicationContextTests.java
@@ -56,7 +56,7 @@ class AnnotationConfigApplicationContextTests {
 		context.getBean(uncapitalize(ComponentForScanning.class.getSimpleName()));
 		context.getBean(uncapitalize(Jsr330NamedForScanning.class.getSimpleName()));
 		Map<String, Object> beans = context.getBeansWithAnnotation(Configuration.class);
-		assertThat(beans).size().isEqualTo(1);
+		assertThat(beans).hasSize(1);
 	}
 
 	@Test
@@ -68,7 +68,7 @@ class AnnotationConfigApplicationContextTests {
 		context.getBean("testBean");
 		context.getBean("name");
 		Map<String, Object> beans = context.getBeansWithAnnotation(Configuration.class);
-		assertThat(beans).size().isEqualTo(2);
+		assertThat(beans).hasSize(2);
 	}
 
 	@Test
@@ -80,7 +80,7 @@ class AnnotationConfigApplicationContextTests {
 		context.getBean("testBean");
 		context.getBean("name");
 		Map<String, Object> beans = context.getBeansWithAnnotation(Configuration.class);
-		assertThat(beans).size().isEqualTo(2);
+		assertThat(beans).hasSize(2);
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/scheduling/config/ScheduledTaskRegistrarTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/config/ScheduledTaskRegistrarTests.java
@@ -79,7 +79,7 @@ class ScheduledTaskRegistrarTests {
 	@Test
 	void addCronTaskWithValidExpression() {
 		this.taskRegistrar.addCronTask(no_op, "* * * * * ?");
-		assertThat(this.taskRegistrar.getCronTaskList()).size().isEqualTo(1);
+		assertThat(this.taskRegistrar.getCronTaskList()).hasSize(1);
 	}
 
 	@Test

--- a/spring-test/src/test/java/org/springframework/test/context/event/CustomTestEventTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/event/CustomTestEventTests.java
@@ -57,7 +57,7 @@ public class CustomTestEventTests {
 
 	@Test
 	public void customTestEventPublished() {
-		assertThat(events).size().isEqualTo(1);
+		assertThat(events).hasSize(1);
 		CustomEvent customEvent = events.get(0);
 		assertThat(customEvent.getSource()).isEqualTo(getClass());
 		assertThat(customEvent.getTestName()).isEqualTo("customTestEventPublished");

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/SpringExtensionParameterizedTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/SpringExtensionParameterizedTests.java
@@ -50,7 +50,7 @@ class SpringExtensionParameterizedTests {
 	@ParameterizedTest
 	@ValueSource(strings = { "Dilbert", "Wally" })
 	void people(String name, @Autowired List<Person> people) {
-		assertThat(people.stream().map(Person::getName).filter(name::equals)).size().isEqualTo(1);
+		assertThat(people.stream().map(Person::getName).filter(name::equals)).hasSize(1);
 	}
 
 	@ParameterizedTest

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/defaultmethods/GenericComicCharactersInterfaceDefaultMethodsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/defaultmethods/GenericComicCharactersInterfaceDefaultMethodsTests.java
@@ -45,7 +45,7 @@ interface GenericComicCharactersInterfaceDefaultMethodsTests<C extends Character
 
 	@Test
 	default void autowiredParameterWithParameterizedList(@Autowired List<C> characters) {
-		assertThat(characters).as("Number of characters in context").size().isEqualTo(getExpectedNumCharacters());
+		assertThat(characters).as("Number of characters in context").hasSize(getExpectedNumCharacters());
 	}
 
 	@Test

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/generics/GenericComicCharactersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/generics/GenericComicCharactersTests.java
@@ -53,7 +53,7 @@ abstract class GenericComicCharactersTests<T extends Character> {
 	void autowiredFields() {
 		assertThat(this.character).as("Character should have been @Autowired by Spring").isNotNull();
 		assertThat(this.character).as("character's name").extracting(Character::getName).isEqualTo(getExpectedName());
-		assertThat(this.characters).as("Number of characters in context").size().isEqualTo(getExpectedNumCharacters());
+		assertThat(this.characters).as("Number of characters in context").hasSize(getExpectedNumCharacters());
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/web/accept/MappingMediaTypeFileExtensionResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/accept/MappingMediaTypeFileExtensionResolverTests.java
@@ -41,7 +41,7 @@ public class MappingMediaTypeFileExtensionResolverTests {
 	public void resolveExtensions() {
 		List<String> extensions = this.resolver.resolveFileExtensions(MediaType.APPLICATION_JSON);
 
-		assertThat(extensions).size().isEqualTo(1);
+		assertThat(extensions).hasSize(1);
 		assertThat(extensions.get(0)).isEqualTo("json");
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestScopedControllerAdviceIntegrationTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestScopedControllerAdviceIntegrationTests.java
@@ -51,7 +51,7 @@ class RequestScopedControllerAdviceIntegrationTests {
 		assertThatCode(context::refresh).doesNotThrowAnyException();
 
 		List<ControllerAdviceBean> adviceBeans = ControllerAdviceBean.findAnnotatedBeans(context);
-		assertThat(adviceBeans).size().isEqualTo(1);
+		assertThat(adviceBeans).hasSize(1);
 		assertThat(adviceBeans.get(0))//
 				.returns(RequestScopedControllerAdvice.class, ControllerAdviceBean::getBeanType)//
 				.returns(42, ControllerAdviceBean::getOrder);


### PR DESCRIPTION
This PR changes to use `hasSize()` where possible.