### PR TITLE
Add BeanPropertyRowMapper.newInstance(mappedClass, conversionService)

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
@@ -388,4 +388,16 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
 		return new BeanPropertyRowMapper<>(mappedClass);
 	}
 
+	/**
+	 * Static factory method to create a new {@code BeanPropertyRowMapper}
+	 * (with the required type specified only once).
+	 * @param mappedClass the class that each row should be mapped to
+	 * @param conversionService the {@link ConversionService} for binding JDBC values to bean properties, or {@code null} for none
+	 */
+	public static <T> BeanPropertyRowMapper<T> newInstance(Class<T> mappedClass, @Nullable ConversionService conversionService) {
+		BeanPropertyRowMapper<T> rowMapper = newInstance(mappedClass);
+		rowMapper.setConversionService(conversionService);
+		return rowMapper;
+	}
+
 }


### PR DESCRIPTION
Please consider adding `BeanPropertyRowMapper.newInstance(mappedClass, conversionService)`.
I believe it's going to cover most use cases requiring custom conversion service.

This is similar to `SingleColumnRowMapper.newInstance(requiredType,
conversionService)` which was added in #1678.



You may like / need to add `@since` in javadoc. I wasn't sure what version to use.