### PR TITLE
MappingJackson2MessageConverter: fix javadoc typo

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/support/converter/MappingJackson2MessageConverter.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/converter/MappingJackson2MessageConverter.java
@@ -340,7 +340,7 @@ public class MappingJackson2MessageConverter implements SmartMessageConverter, B
 	 * sets the resulting value (either a mapped id or the raw Java class name)
 	 * into the configured type id message property.
 	 * @param object the payload object to set a type id for
-	 * @param message the JMS Message to set the type id on
+	 * @param message the JMS Message on which to set the type id property
 	 * @throws JMSException if thrown by JMS methods
 	 * @see #getJavaTypeForMessage(javax.jms.Message)
 	 * @see #setTypeIdPropertyName(String)
@@ -442,7 +442,7 @@ public class MappingJackson2MessageConverter implements SmartMessageConverter, B
 	 * <p>The default implementation parses the configured type id property name
 	 * and consults the configured type id mapping. This can be overridden with
 	 * a different strategy, e.g. doing some heuristics based on message origin.
-	 * @param message the JMS Message to set the type id on
+	 * @param message the JMS Message from which to get the type id property
 	 * @throws JMSException if thrown by JMS methods
 	 * @see #setTypeIdOnMessage(Object, javax.jms.Message)
 	 * @see #setTypeIdPropertyName(String)


### PR DESCRIPTION
`getJavaTypeForMessage()` - wrong parameter description.