### PR TITLE
Fix behavior in ExceptionHandlerExceptionResolver.setResponseBodyAdvice

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
@@ -235,7 +235,6 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 	 * {@code HttpMessageConverter}.
 	 */
 	public void setResponseBodyAdvice(@Nullable List<ResponseBodyAdvice<?>> responseBodyAdvice) {
-		this.responseBodyAdvice.clear();
 		if (responseBodyAdvice != null) {
 			this.responseBodyAdvice.addAll(responseBodyAdvice);
 		}


### PR DESCRIPTION
Removed the `clear()` call on the `responseBodyAdvice` list
before adding the passed list to it in the `setResponseBodyAdvice`.

This brings the method in line with the existing documentation

Closes gh-24015