### PR TITLE
Simplify AdvisedSupport.removeAdvisor()

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -283,16 +283,16 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 					"This configuration only has " + this.advisors.size() + " advisors.");
 		}
 
-		Advisor advisor = this.advisors.get(index);
+		Advisor advisor = this.advisors.remove(index);
 		if (advisor instanceof IntroductionAdvisor) {
 			IntroductionAdvisor ia = (IntroductionAdvisor) advisor;
 			// We need to remove introduction interfaces.
-			for (int j = 0; j < ia.getInterfaces().length; j++) {
-				removeInterface(ia.getInterfaces()[j]);
+			Class<?>[] interfaces = ia.getInterfaces();
+			for (Class<?> iface : interfaces) {
+				removeInterface(iface);
 			}
 		}
 
-		this.advisors.remove(index);
 		updateAdvisorArray();
 		adviceChanged();
 	}


### PR DESCRIPTION
1) it's not necessary to call `IntroductionAdvisor.getInterfaces()` twice for each iteration
2) instead of calling `ArrayList.get()` and then `ArrayList.remove()` we can once call `ArrayList.remove()` to get and remove item by its index