### PR TITLE
Upgrade to Asciidoctor Gradle 2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,8 @@
-buildscript {
-	dependencies {
-		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
-		classpath 'io.spring.asciidoctor:spring-asciidoctor-extensions:0.1.3.RELEASE'
-	}
-}
-
 plugins {
 	id 'io.spring.dependency-management' version '1.0.8.RELEASE' apply false
 	id 'org.jetbrains.kotlin.jvm' version '1.3.61' apply false
 	id 'org.jetbrains.dokka' version '0.9.18' apply false
-	id 'org.asciidoctor.convert' version '1.5.8'
+	id 'org.asciidoctor.jvm.convert' version '2.4.0'
 	id 'io.spring.nohttp' version '0.0.3.RELEASE'
 	id 'de.undercouch.download' version '4.0.0'
 	id 'com.gradle.build-scan' version '2.4.2'
@@ -410,10 +403,6 @@ configure(rootProject) {
 				.collect { rootPath.relativize(new File(dir, it).toPath()) }
 				.forEach { source.exclude "$it" }
 		}
-	}
-
-	dependencies {
-		asciidoctor("io.spring.asciidoctor:spring-asciidoctor-extensions:0.1.3.RELEASE")
 	}
 
 	publishing {

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -128,11 +128,7 @@ asciidoctor {
 	}
 	logDocuments = true
 	outputOptions {
-		backends = ["html5"]
-		// only ouput PDF documentation for non-SNAPSHOT builds
-		if (!project.getVersion().toString().contains("BUILD-SNAPSHOT")) {
-			backends += "pdf"
-		}
+		backends = ["html5", "pdf"]
 	}
 	options doctype: 'book', eruby: 'erubis'
 	attributes([

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -1,3 +1,11 @@
+configurations {
+	asciidoctorExt
+}
+
+dependencies {
+	asciidoctorExt("io.spring.asciidoctor:spring-asciidoctor-extensions:0.2.0.RELEASE")
+}
+
 /**
  * Produce Javadoc for all Spring Framework modules in "build/docs/javadoc"
  */
@@ -93,11 +101,21 @@ task extractDocResources(type: Copy, dependsOn: downloadResources) {
 	into "$buildDir/docs/spring-docs-resources/"
 }
 
+asciidoctorj {
+	modules {
+		pdf {
+			version '1.5.0-beta.8'
+		}
+	}
+}
+
 /**
  * Produce the Spring Framework Reference documentation
  * from "src/docs/asciidoc" into  "build/asciidoc/html5"
  */
 asciidoctor {
+	baseDirFollowsSourceDir()
+	configurations 'asciidoctorExt'
 	sources {
 		include '*.adoc'
 	}
@@ -106,13 +124,15 @@ asciidoctor {
 		from(sourceDir) {
 			include 'images/*', 'css/**', 'js/**'
 		}
-		from "$buildDir/docs/spring-docs-resources/"
+		from extractDocResources
 	}
 	logDocuments = true
-	backends = ["html5"]
-	// only ouput PDF documentation for non-SNAPSHOT builds
-	if (!project.getVersion().toString().contains("BUILD-SNAPSHOT")) {
-		backends += "pdf"
+	outputOptions {
+		backends = ["html5"]
+		// only ouput PDF documentation for non-SNAPSHOT builds
+		if (!project.getVersion().toString().contains("BUILD-SNAPSHOT")) {
+			backends += "pdf"
+		}
 	}
 	options doctype: 'book', eruby: 'erubis'
 	attributes([
@@ -131,8 +151,6 @@ asciidoctor {
 			'spring-version': project.version
 	])
 }
-
-asciidoctor.dependsOn extractDocResources
 
 /**
  * Zip all docs (API and reference) into a single archive


### PR DESCRIPTION
This pull request updates the build to use version 2.4 of the Asciidoctor Gradle plugin. These changes are made in the first commit. One of the main benefits of the upgrade is that the `asciidoctor` task is now cacheable. To take full advantage of this, the second commit configures the PDF backend for snapshots builds. This will allow PDF documentation to be generated for snapshots, but for the cost to only be incurred when a change to the documentation has been made.