### PR TITLE
Reduce Class[] garbage when creating proxies

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -56,6 +56,8 @@ import org.springframework.lang.Nullable;
  */
 public abstract class ClassUtils {
 
+	public static final Class<?>[] EMPTY_CLASS_ARRAY = {};
+
 	/** Suffix for array class names: {@code "[]"}. */
 	public static final String ARRAY_SUFFIX = "[]";
 
@@ -682,7 +684,7 @@ public abstract class ClassUtils {
 	 * @see StringUtils#toStringArray
 	 */
 	public static Class<?>[] toClassArray(Collection<Class<?>> collection) {
-		return collection.toArray(new Class<?>[0]);
+		return collection.isEmpty() ? EMPTY_CLASS_ARRAY : collection.toArray(EMPTY_CLASS_ARRAY);
 	}
 
 	/**
@@ -1066,6 +1068,17 @@ public abstract class ClassUtils {
 	 */
 	public static boolean hasConstructor(Class<?> clazz, Class<?>... paramTypes) {
 		return (getConstructorIfAvailable(clazz, paramTypes) != null);
+	}
+
+	/**
+	 * Determine whether the given class has a public no-args constructor.
+	 * <p>Essentially translates {@code NoSuchMethodException} to "false".
+	 * @param clazz the clazz to analyze
+	 * @return whether the class has public no-args constructor
+	 * @see Class#getMethod
+	 */
+	public static boolean hasConstructor(Class<?> clazz) {
+		return hasConstructor(clazz, EMPTY_CLASS_ARRAY);
 	}
 
 	/**

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/ExtendedEntityManagerCreator.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/ExtendedEntityManagerCreator.java
@@ -232,10 +232,10 @@ public abstract class ExtendedEntityManagerCreator {
 
 		if (emIfc != null) {
 			interfaces = cachedEntityManagerInterfaces.computeIfAbsent(emIfc, key -> {
-				Set<Class<?>> ifcs = new LinkedHashSet<>();
-				ifcs.add(key);
-				ifcs.add(EntityManagerProxy.class);
-				return ClassUtils.toClassArray(ifcs);
+				if (EntityManagerProxy.class.equals(key)) {
+					return new Class[]{EntityManagerProxy.class};
+				}
+				return new Class<?>[]{key, EntityManagerProxy.class};
 			});
 		}
 		else {


### PR DESCRIPTION
Simple clean-up of reflection-related code: use ReflectionUtils.isEqualsMethod() / ReflectionUtils.isHashCodeMethod() / ReflectionUtils.isToStringMethod() in order to have unified approach in all pieces of code.