### PR TITLE
Ensure CORS processing does not add Vary header twice on async requests

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/cors/DefaultCorsProcessor.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/DefaultCorsProcessor.java
@@ -36,6 +36,7 @@ import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.lang.Nullable;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.context.request.async.WebAsyncUtils;
 
 /**
  * The default implementation of {@link CorsProcessor}, as defined by the
@@ -59,6 +60,10 @@ public class DefaultCorsProcessor implements CorsProcessor {
 	@SuppressWarnings("resource")
 	public boolean processRequest(@Nullable CorsConfiguration config, HttpServletRequest request,
 			HttpServletResponse response) throws IOException {
+
+		if (WebAsyncUtils.getAsyncManager(request).hasConcurrentResult()) {
+			return true;
+		}
 
 		response.addHeader(HttpHeaders.VARY, HttpHeaders.ORIGIN);
 		response.addHeader(HttpHeaders.VARY, HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);


### PR DESCRIPTION
## spring boot version `2.2.2`
## example 

`WebMvcConfigurer`
```
CorsRegistration corsRegistration = registry.addMapping("/**")
                .allowCredentials(true);
corsRegistration.allowedHeaders("*")
                .maxAge(1800L)
                .allowedMethods(HttpMethod.GET.name(),
                        HttpMethod.POST.name(),
                        HttpMethod.PUT.name(),
                        HttpMethod.OPTIONS.name(),
                        HttpMethod.DELETE.name())
                .exposedHeaders("Content-Length");
```
`controller`
```
@RequestMapping("/test)
@RestController
public class ExampleController {
    @GetMapping
    public CompletableFuture<T> test() {
        // do something
    }
}
```

`reponse headers`
```
Vary | Origin
Vary | Access-Control-Request-Method
Vary | Access-Control-Request-Headers
Vary | Origin
Vary | Access-Control-Request-Method
Vary | Access-Control-Request-Headers
```

Ref #24222 