### PR TITLE
Update Artifactory plugin to 4.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 	id 'io.spring.nohttp' version '0.0.4.RELEASE'
 	id 'de.undercouch.download' version '4.0.0'
 	id 'com.gradle.build-scan' version '3.1.1'
-	id "com.jfrog.artifactory" version '4.11.0' apply false
+	id "com.jfrog.artifactory" version '4.12.0' apply false
 	id "io.freefair.aspectj" version "4.1.1" apply false
 	id "com.github.ben-manes.versions" version "0.24.0"
 }


### PR DESCRIPTION
This updates the artifactory plugin to 4.12.0 which includes improvements to parallelism when uploading artifacts during publish.