### PR TITLE
Upgrade to nohttp plugin 0.0.4.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 	id 'org.jetbrains.kotlin.jvm' version '1.3.61' apply false
 	id 'org.jetbrains.dokka' version '0.9.18' apply false
 	id 'org.asciidoctor.convert' version '1.5.8'
-	id 'io.spring.nohttp' version '0.0.3.RELEASE'
+	id 'io.spring.nohttp' version '0.0.4.RELEASE'
 	id 'de.undercouch.download' version '4.0.0'
 	id 'com.gradle.build-scan' version '2.4.2'
 	id "com.jfrog.artifactory" version '4.11.0' apply false


### PR DESCRIPTION
This updates the nohttp plugin to 0.0.4.RELEASE which contains improvements to make the `checkstyleNoHttp` task cacheable.