### PR TITLE
Upgrade to Gradle build scan plugin 3.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 	id 'org.asciidoctor.convert' version '1.5.8'
 	id 'io.spring.nohttp' version '0.0.3.RELEASE'
 	id 'de.undercouch.download' version '4.0.0'
-	id 'com.gradle.build-scan' version '2.4.2'
+	id 'com.gradle.build-scan' version '3.1.1'
 	id "com.jfrog.artifactory" version '4.11.0' apply false
 	id "io.freefair.aspectj" version "4.1.1" apply false
 	id "com.github.ben-manes.versions" version "0.24.0"


### PR DESCRIPTION
This updates the Gradle build scan plugin to the latest release.