### PR TITLE
Add missing space in AopConfigException message

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactoryBean.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactoryBean.java
@@ -600,7 +600,7 @@ public class ProxyFactoryBean extends ProxyCreatorSupport
 			// We expected this to be an Advisor or Advice,
 			// but it wasn't. This is a configuration error.
 			throw new AopConfigException("Unknown advisor type " + next.getClass() +
-					"; Can only include Advisor or Advice type beans in interceptorNames chain except for last entry," +
+					"; Can only include Advisor or Advice type beans in interceptorNames chain except for last entry, " +
 					"which may also be target or TargetSource", ex);
 		}
 	}


### PR DESCRIPTION
…yBean#namedBeanToAdvisor

@pivotal-issuemaster This is an Obvious Fix