### PR TITLE
Honor generic type information in BeanUtils.copyProperties()

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -19,7 +19,6 @@ package org.springframework.beans;
 import java.beans.PropertyDescriptor;
 import java.beans.PropertyEditor;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -45,7 +44,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.core.KotlinDetector;
 import org.springframework.core.MethodParameter;
-import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.ResolvableType;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -679,8 +678,7 @@ public abstract class BeanUtils {
 	}
 
 	/**
-	 * Copy the property values of the given source bean into the given target bean
-	 * and ignored if 
+	 * Copy the property values of the given source bean into the given target bean.
 	 * <p>Note: The source and target classes do not have to match or even be derived
 	 * from each other, as long as the properties match. Any bean properties that the
 	 * source bean exposes but the target bean does not will silently be ignored.
@@ -713,30 +711,25 @@ public abstract class BeanUtils {
 			if (writeMethod != null && (ignoreList == null || !ignoreList.contains(targetPd.getName()))) {
 				PropertyDescriptor sourcePd = getPropertyDescriptor(source.getClass(), targetPd.getName());
 				if (sourcePd != null) {
-					Field sourcefield = ReflectionUtils.findField(source.getClass(), sourcePd.getName());
-					Field targetfield = ReflectionUtils.findField(target.getClass(), targetPd.getName());
-										
-					TypeDescriptor sourceTypeDescriptor = new TypeDescriptor(sourcefield);
-					TypeDescriptor targetTypeDescriptor = new TypeDescriptor(targetfield);
-					
 					Method readMethod = sourcePd.getReadMethod();
-					
-					if (readMethod != null &&
-							ClassUtils.isAssignable(writeMethod.getParameterTypes()[0], readMethod.getReturnType()) &&
-							sourceTypeDescriptor.getResolvableType().equals(targetTypeDescriptor.getResolvableType())) {
-						try {
-							if (!Modifier.isPublic(readMethod.getDeclaringClass().getModifiers())) {
-								readMethod.setAccessible(true);
+					if (readMethod != null) {
+						ResolvableType sourceResolvableType = ResolvableType.forMethodReturnType(readMethod);
+						ResolvableType targetResolvableType = ResolvableType.forMethodParameter(writeMethod, 0);
+						if (targetResolvableType.isAssignableFrom(sourceResolvableType)) {
+							try {
+								if (!Modifier.isPublic(readMethod.getDeclaringClass().getModifiers())) {
+									readMethod.setAccessible(true);
+								}
+								Object value = readMethod.invoke(source);
+								if (!Modifier.isPublic(writeMethod.getDeclaringClass().getModifiers())) {
+									writeMethod.setAccessible(true);
+								}
+								writeMethod.invoke(target, value);
 							}
-							Object value = readMethod.invoke(source);
-							if (!Modifier.isPublic(writeMethod.getDeclaringClass().getModifiers())) {
-								writeMethod.setAccessible(true);
-							}							
-							writeMethod.invoke(target, value);
-						}
-						catch (Throwable ex) {
-							throw new FatalBeanException(
-									"Could not copy property '" + targetPd.getName() + "' from source to target", ex);
+							catch (Throwable ex) {
+								throw new FatalBeanException(
+										"Could not copy property '" + targetPd.getName() + "' from source to target", ex);
+							}
 						}
 					}
 				}

--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -45,6 +45,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.core.KotlinDetector;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -73,8 +74,6 @@ public abstract class BeanUtils {
 			Collections.newSetFromMap(new ConcurrentReferenceHashMap<>(64));
 
 	private static final Map<Class<?>, Object> DEFAULT_TYPE_VALUES;
-	
-	private static SimpleTypeConverter SIMPLE_TYPE_CONVERTER;
 
 	static {
 		Map<Class<?>, Object> values = new HashMap<>();
@@ -84,7 +83,6 @@ public abstract class BeanUtils {
 		values.put(int.class, 0);
 		values.put(long.class, (long) 0);
 		DEFAULT_TYPE_VALUES = Collections.unmodifiableMap(values);
-		SIMPLE_TYPE_CONVERTER = new SimpleTypeConverter();
 	}
 
 
@@ -682,7 +680,7 @@ public abstract class BeanUtils {
 
 	/**
 	 * Copy the property values of the given source bean into the given target bean
-	 * with possible type casting.
+	 * and ignored if 
 	 * <p>Note: The source and target classes do not have to match or even be derived
 	 * from each other, as long as the properties match. Any bean properties that the
 	 * source bean exposes but the target bean does not will silently be ignored.
@@ -715,9 +713,17 @@ public abstract class BeanUtils {
 			if (writeMethod != null && (ignoreList == null || !ignoreList.contains(targetPd.getName()))) {
 				PropertyDescriptor sourcePd = getPropertyDescriptor(source.getClass(), targetPd.getName());
 				if (sourcePd != null) {
+					Field sourcefield = ReflectionUtils.findField(source.getClass(), sourcePd.getName());
+					Field targetfield = ReflectionUtils.findField(target.getClass(), targetPd.getName());
+										
+					TypeDescriptor sourceTypeDescriptor = new TypeDescriptor(sourcefield);
+					TypeDescriptor targetTypeDescriptor = new TypeDescriptor(targetfield);
+					
 					Method readMethod = sourcePd.getReadMethod();
+					
 					if (readMethod != null &&
-							ClassUtils.isAssignable(writeMethod.getParameterTypes()[0], readMethod.getReturnType())) {
+							ClassUtils.isAssignable(writeMethod.getParameterTypes()[0], readMethod.getReturnType()) &&
+							sourceTypeDescriptor.getResolvableType().equals(targetTypeDescriptor.getResolvableType())) {
 						try {
 							if (!Modifier.isPublic(readMethod.getDeclaringClass().getModifiers())) {
 								readMethod.setAccessible(true);
@@ -725,10 +731,8 @@ public abstract class BeanUtils {
 							Object value = readMethod.invoke(source);
 							if (!Modifier.isPublic(writeMethod.getDeclaringClass().getModifiers())) {
 								writeMethod.setAccessible(true);
-							}
-							Field field = ReflectionUtils.findField(target.getClass(), targetPd.getName());
-							Object convertedValue = SIMPLE_TYPE_CONVERTER.convertIfNecessary(value, field.getType(), field);
-							writeMethod.invoke(target, convertedValue);
+							}							
+							writeMethod.invoke(target, value);
 						}
 						catch (Throwable ex) {
 							throw new FatalBeanException(

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -331,24 +331,23 @@ class BeanUtilsTests {
 	private void assertSignatureEquals(Method desiredMethod, String signature) {
 		assertThat(BeanUtils.resolveSignature(signature, MethodSignatureBean.class)).isEqualTo(desiredMethod);
 	}
-	
+
 	@Test
-	void testCopiedParametersType() {
-		
-		A a = new A();
+	void copyPropertiesWithGenericTypes() {
+		ListComponentA a = new ListComponentA();
 		a.getList().add(42);
-		B b = new B();
+		ListComponentB b = new ListComponentB();
+		ListComponentC c = new ListComponentC();
 
 		BeanUtils.copyProperties(a, b);
-
 		assertThat(a.getList()).containsOnly(42);
+		assertThat(b.getList()).containsOnly(42);
 
-		b.getList().forEach(n -> assertThat(n).isInstanceOf(Long.class));
-		assertThat(b.getList()).isEmpty();	
-		
+		BeanUtils.copyProperties(a, c);
+		assertThat(c.getList()).isEmpty();
 	}
-	
-	class A {
+
+	static class ListComponentA {
 
 		private List<Integer> list = new ArrayList<>();
 
@@ -359,9 +358,22 @@ class BeanUtilsTests {
 		public void setList(List<Integer> list) {
 			this.list = list;
 		}
-		
 	}
-	class B {
+
+	static class ListComponentB {
+
+		private List<Integer> list = new ArrayList<>();
+
+		public List<Integer> getList() {
+			return list;
+		}
+
+		public void setList(List<Integer> list) {
+			this.list = list;
+		}
+	}
+
+	static class ListComponentC {
 
 		private List<Long> list = new ArrayList<>();
 
@@ -372,7 +384,6 @@ class BeanUtilsTests {
 		public void setList(List<Long> list) {
 			this.list = list;
 		}
-		
 	}
 
 

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -334,27 +334,23 @@ class BeanUtilsTests {
 	
 	@Test
 	void testCopiedParametersType() {
+		
 		A a = new A();
-		B b = new B();
 		a.getList().add(42);
-		a.getList2().add(34.2F);		
+		B b = new B();
 
 		BeanUtils.copyProperties(a, b);
 
-		assertThat(b.getList()).containsOnly(42L);
+		assertThat(a.getList()).containsOnly(42);
 
 		b.getList().forEach(n -> assertThat(n).isInstanceOf(Long.class));
-		assertThat(b.getList()).isNotEmpty();
-		
-		b.getList2().forEach(n -> assertThat(n).isInstanceOf(Integer.class));
-		assertThat(b.getList2()).isNotEmpty();		
+		assertThat(b.getList()).isEmpty();	
 		
 	}
 	
 	class A {
 
 		private List<Integer> list = new ArrayList<>();
-		private List<Float> list2 = new ArrayList<>();
 
 		public List<Integer> getList() {
 			return list;
@@ -363,20 +359,11 @@ class BeanUtilsTests {
 		public void setList(List<Integer> list) {
 			this.list = list;
 		}
-
-		public List<Float> getList2() {
-			return list2;
-		}
-
-		public void setList2(List<Float> list2) {
-			this.list2 = list2;
-		}		
 		
 	}
 	class B {
 
 		private List<Long> list = new ArrayList<>();
-		private List<Integer> list2 = new ArrayList<>();
 
 		public List<Long> getList() {
 			return list;
@@ -385,14 +372,6 @@ class BeanUtilsTests {
 		public void setList(List<Long> list) {
 			this.list = list;
 		}
-
-		public List<Integer> getList2() {
-			return list2;
-		}
-
-		public void setList2(List<Integer> list2) {
-			this.list2 = list2;
-		}	
 		
 	}
 

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URL;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -329,6 +330,70 @@ class BeanUtilsTests {
 
 	private void assertSignatureEquals(Method desiredMethod, String signature) {
 		assertThat(BeanUtils.resolveSignature(signature, MethodSignatureBean.class)).isEqualTo(desiredMethod);
+	}
+	
+	@Test
+	void testCopiedParametersType() {
+		A a = new A();
+		B b = new B();
+		a.getList().add(42);
+		a.getList2().add(34.2F);		
+
+		BeanUtils.copyProperties(a, b);
+
+		assertThat(b.getList()).containsOnly(42L);
+
+		b.getList().forEach(n -> assertThat(n).isInstanceOf(Long.class));
+		assertThat(b.getList()).isNotEmpty();
+		
+		b.getList2().forEach(n -> assertThat(n).isInstanceOf(Integer.class));
+		assertThat(b.getList2()).isNotEmpty();		
+		
+	}
+	
+	class A {
+
+		private List<Integer> list = new ArrayList<>();
+		private List<Float> list2 = new ArrayList<>();
+
+		public List<Integer> getList() {
+			return list;
+		}
+
+		public void setList(List<Integer> list) {
+			this.list = list;
+		}
+
+		public List<Float> getList2() {
+			return list2;
+		}
+
+		public void setList2(List<Float> list2) {
+			this.list2 = list2;
+		}		
+		
+	}
+	class B {
+
+		private List<Long> list = new ArrayList<>();
+		private List<Integer> list2 = new ArrayList<>();
+
+		public List<Long> getList() {
+			return list;
+		}
+
+		public void setList(List<Long> list) {
+			this.list = list;
+		}
+
+		public List<Integer> getList2() {
+			return list2;
+		}
+
+		public void setList2(List<Integer> list2) {
+			this.list2 = list2;
+		}	
+		
 	}
 
 


### PR DESCRIPTION
Fixes #24187 Honor generic type information when copying properties with BeanUtils

Handled standard supported Type Casting of properties. Any custom Object level property casting is restricted.

