### PR TITLE
Add fast path for ClassUtils.hasMethod

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
@@ -365,7 +365,7 @@ class CglibAopProxy implements AopProxy, Serializable {
 	 */
 	private static boolean implementsInterface(Method method, Set<Class<?>> ifcs) {
 		for (Class<?> ifc : ifcs) {
-			if (ClassUtils.hasMethod(ifc, method.getName(), method.getParameterTypes())) {
+			if (ClassUtils.hasMethod(ifc, method)) {
 				return true;
 			}
 		}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
@@ -97,7 +97,7 @@ abstract class AutowireUtils {
 		// It was declared by CGLIB, but we might still want to autowire it
 		// if it was actually declared by the superclass.
 		Class<?> superclass = wm.getDeclaringClass().getSuperclass();
-		return !ClassUtils.hasMethod(superclass, wm.getName(), wm.getParameterTypes());
+		return !ClassUtils.hasMethod(superclass, wm);
 	}
 
 	/**
@@ -112,8 +112,7 @@ abstract class AutowireUtils {
 		if (setter != null) {
 			Class<?> targetClass = setter.getDeclaringClass();
 			for (Class<?> ifc : interfaces) {
-				if (ifc.isAssignableFrom(targetClass) &&
-						ClassUtils.hasMethod(ifc, setter.getName(), setter.getParameterTypes())) {
+				if (ifc.isAssignableFrom(targetClass) && ClassUtils.hasMethod(ifc, setter)) {
 					return true;
 				}
 			}

--- a/spring-context/src/main/java/org/springframework/jmx/export/assembler/InterfaceBasedMBeanInfoAssembler.java
+++ b/spring-context/src/main/java/org/springframework/jmx/export/assembler/InterfaceBasedMBeanInfoAssembler.java
@@ -207,7 +207,7 @@ public class InterfaceBasedMBeanInfoAssembler extends AbstractConfigurableMBeanI
 	 * configured interfaces and is public, otherwise {@code false}.
 	 */
 	private boolean isPublicInInterface(Method method, String beanKey) {
-		return ((method.getModifiers() & Modifier.PUBLIC) > 0) && isDeclaredInInterface(method, beanKey);
+		return Modifier.isPublic(method.getModifiers()) && isDeclaredInInterface(method, beanKey);
 	}
 
 	/**

--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationInterceptor.java
@@ -145,7 +145,7 @@ public class MethodValidationInterceptor implements MethodInterceptor {
 			factoryBeanType = FactoryBean.class;
 		}
 		return (factoryBeanType != null && !method.getName().equals("getObject") &&
-				ClassUtils.hasMethod(factoryBeanType, method.getName(), method.getParameterTypes()));
+				ClassUtils.hasMethod(factoryBeanType, method));
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -1102,6 +1102,24 @@ public abstract class ClassUtils {
 	}
 
 	/**
+	 * Determine whether the given class has a public method with the given signature.
+	 * @param clazz the clazz to analyze
+	 * @param method checked method
+	 * @return whether the class has a corresponding method
+	 * @see Method#getDeclaringClass
+	 */
+	public static boolean hasMethod(Class<?> clazz, Method method) {
+		Assert.notNull(clazz, "Class must not be null");
+		Assert.notNull(method, "Method must not be null");
+		if (clazz == method.getDeclaringClass()) {
+			return true;
+		}
+		String methodName = method.getName();
+		Class<?>[] paramTypes = method.getParameterTypes();
+		return getMethodOrNull(clazz, methodName, paramTypes) != null;
+	}
+
+	/**
 	 * Determine whether the given class has a public method with the given signature,
 	 * and return it if available (else throws an {@code IllegalStateException}).
 	 * <p>In case of any signature specified, only returns the method if there is a
@@ -1158,12 +1176,7 @@ public abstract class ClassUtils {
 		Assert.notNull(clazz, "Class must not be null");
 		Assert.notNull(methodName, "Method name must not be null");
 		if (paramTypes != null) {
-			try {
-				return clazz.getMethod(methodName, paramTypes);
-			}
-			catch (NoSuchMethodException ex) {
-				return null;
-			}
+			return getMethodOrNull(clazz, methodName, paramTypes);
 		}
 		else {
 			Set<Method> candidates = findMethodCandidatesByName(clazz, methodName);
@@ -1369,5 +1382,14 @@ public abstract class ClassUtils {
 			}
 		}
 		return candidates;
+	}
+
+	@Nullable
+	private static Method getMethodOrNull(Class<?> clazz, String methodName, Class<?>[] paramTypes) {
+		try {
+			return clazz.getMethod(methodName, paramTypes);
+		} catch (NoSuchMethodException ex) {
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
Detecting of whether a Class has particular method could have a fastpath for the case when the method is declared directly in that class. When we have an instance of `Method` then we could first check its declaring class and only then go through conventional path involving heavy usage of reflection.