### PR TITLE
Add ContentLength support for InputStreamResource created in ResourceHttpMessageConverter and ResourceDecoder

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/codec/ResourceDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ResourceDecoder.java
@@ -83,6 +83,11 @@ public class ResourceDecoder extends AbstractDataBufferDecoder<Resource> {
 				public String getFilename() {
 					return filename;
 				}
+
+				@Override
+				public long contentLength() {
+					return bytes.length;
+				}
 			};
 		}
 		else if (Resource.class.isAssignableFrom(clazz)) {

--- a/spring-core/src/test/java/org/springframework/core/codec/ResourceDecoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/ResourceDecoderTests.java
@@ -104,4 +104,22 @@ class ResourceDecoderTests extends AbstractDecoderTests<ResourceDecoder> {
 				Collections.singletonMap(ResourceDecoder.FILENAME_HINT, "testFile"));
 	}
 
+	@Test
+	public void decodeInputStreamResource() {
+		Flux<DataBuffer> input = Flux.concat(dataBuffer(this.fooBytes), dataBuffer(this.barBytes));
+		testDecodeAll(input, InputStreamResource.class, step -> step
+				.consumeNextWith(resource -> {
+					try {
+						byte[] bytes = StreamUtils.copyToByteArray(resource.getInputStream());
+						assertThat(new String(bytes)).isEqualTo("foobar");
+						assertThat(resource.contentLength()).isEqualTo(fooBytes.length + barBytes.length);
+					}
+					catch (IOException ex) {
+						throw new AssertionError(ex.getMessage(), ex);
+					}
+				})
+				.expectComplete()
+				.verify());
+	}
+
 }

--- a/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
@@ -84,6 +84,11 @@ public class ResourceHttpMessageConverter extends AbstractHttpMessageConverter<R
 				public String getFilename() {
 					return inputMessage.getHeaders().getContentDisposition().getFilename();
 				}
+
+				@Override
+				public long contentLength() {
+					return inputMessage.getHeaders().getContentLength();
+				}
 			};
 		}
 		else if (Resource.class == clazz || ByteArrayResource.class.isAssignableFrom(clazz)) {

--- a/spring-web/src/test/java/org/springframework/http/converter/ResourceHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/ResourceHttpMessageConverterTests.java
@@ -80,10 +80,12 @@ public class ResourceHttpMessageConverterTests {
 			inputMessage.getHeaders().setContentType(MediaType.IMAGE_JPEG);
 			inputMessage.getHeaders().setContentDisposition(
 					ContentDisposition.builder("attachment").filename("yourlogo.jpg").build());
+			inputMessage.getHeaders().setContentLength(123);
 			Resource actualResource = converter.read(InputStreamResource.class, inputMessage);
 			assertThat(actualResource).isInstanceOf(InputStreamResource.class);
 			assertThat(actualResource.getInputStream()).isEqualTo(body);
 			assertThat(actualResource.getFilename()).isEqualTo("yourlogo.jpg");
+			assertThat(actualResource.contentLength()).isEqualTo(123);
 		}
 	}
 


### PR DESCRIPTION
**Issue**
InputStreamResource created in ResourceHttpMessageConverter /ResourceDecoder doesn't properly support contentLength.
contentLength() method consumes input stream to calculate size instead of just providing predefined value.

**Motivation**
Streaming use case, where application acts as a proxy for large amount of data.

**Fix**
ResourceHttpMessageConverter should read HTTP Content-Length header.
ResourceDecoder creates ISR based on byte array, so size is always known.

**Caveats**
contentLength() for InputStreamResource created in ResourceHttpMessageConverter  can be -1 if Content-Length header is missing.