### PR TITLE
Update Stream.map() instead of Stream.peek()

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/adapter/WebHttpHandlerBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/WebHttpHandlerBuilder.java
@@ -240,10 +240,12 @@ public final class WebHttpHandlerBuilder {
 		}
 
 		List<WebFilter> filtersToUse = this.filters.stream()
-				.peek(filter -> {
+				.map(filter -> {
 					if (filter instanceof ForwardedHeaderTransformer && this.forwardedHeaderTransformer == null) {
 						this.forwardedHeaderTransformer = (ForwardedHeaderTransformer) filter;
 					}
+
+					return filter;
 				})
 				.filter(filter -> !(filter instanceof ForwardedHeaderTransformer))
 				.collect(Collectors.toList());


### PR DESCRIPTION
#### Motivation
When I read `Stream.peek()` in java 8 document, It was for debugging.
and `Stream.peek()` has side effect in Java 9.
so I updated it with `Stream.map`

#### Modification
Update `Stream.peek()` -> `Stream.map()`

#### Reference
> Java8 API Note:
This method exists mainly to support debugging, where you want to see the elements as they flow past a certain point in a pipeline:

- [Java 8 Document](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#peek-java.util.function.Consumer-)


Java 9 Issue
- [Java9 Stream Count - Peek Issue](https://docs.oracle.com/javase/9/docs/api/java/util/stream/Stream.html#count--)


