### PR TITLE
Polish ResolvableType equals implementation

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -909,7 +909,7 @@ public class ResolvableType implements Serializable {
 				!ObjectUtils.nullSafeEquals(this.variableResolver.getSource(), otherType.variableResolver.getSource()))) {
 			return false;
 		}
-		if (!ObjectUtils.nullSafeEquals(this.componentType, otherType.componentType)) {
+		if (!ObjectUtils.nullSafeEquals(this.getComponentType(), otherType.getComponentType())) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Please See the following code snippet of method
`org.springframework.core.ResolvableType#forType(Type, TypeProvider, VariableResolver)`

```java
ResolvableType resultType = new ResolvableType(type, typeProvider, variableResolver);
ResolvableType cachedType = cache.get(resultType);
if (cachedType == null) {
	cachedType = new ResolvableType(type, typeProvider, variableResolver, resultType.hash);
	cache.put(cachedType, cachedType);
}
```

Currently, this variable of `cachedType` is always `null`, because the property `componentType` of `resultType` is always `null`, which causes the `equals()` method to always return `false` and `cache.get()` always returns `null`.

The purpose of PR is to fix this problem.
