### PR TITLE
Ignore range requests for resources of unknown content lengths

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/AbstractFileResolvingResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/AbstractFileResolvingResource.java
@@ -222,7 +222,7 @@ public abstract class AbstractFileResolvingResource extends AbstractResource {
 	}
 
 	@Override
-	public long contentLength() throws IOException {
+	public Long contentLength() throws IOException {
 		URL url = getURL();
 		if (ResourceUtils.isFileURL(url)) {
 			// Proceed with file system resolution

--- a/spring-core/src/main/java/org/springframework/core/io/AbstractResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/AbstractResource.java
@@ -156,7 +156,7 @@ public abstract class AbstractResource implements Resource {
 	 * @see #getInputStream()
 	 */
 	@Override
-	public long contentLength() throws IOException {
+	public Long contentLength() throws IOException {
 		InputStream is = getInputStream();
 		try {
 			long size = 0;

--- a/spring-core/src/main/java/org/springframework/core/io/ByteArrayResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/ByteArrayResource.java
@@ -86,7 +86,7 @@ public class ByteArrayResource extends AbstractResource {
 	 * This implementation returns the length of the underlying byte array.
 	 */
 	@Override
-	public long contentLength() {
+	public Long contentLength() {
 		return this.byteArray.length;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/io/FileSystemResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/FileSystemResource.java
@@ -272,7 +272,7 @@ public class FileSystemResource extends AbstractResource implements WritableReso
 	 * This implementation returns the underlying File/Path length.
 	 */
 	@Override
-	public long contentLength() throws IOException {
+	public Long contentLength() throws IOException {
 		if (this.file != null) {
 			long length = this.file.length();
 			if (length == 0L && !this.file.exists()) {

--- a/spring-core/src/main/java/org/springframework/core/io/PathResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/PathResource.java
@@ -233,7 +233,7 @@ public class PathResource extends AbstractResource implements WritableResource {
 	 * This implementation returns the underlying file's length.
 	 */
 	@Override
-	public long contentLength() throws IOException {
+	public Long contentLength() throws IOException {
 		return Files.size(this.path);
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/io/Resource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/Resource.java
@@ -140,7 +140,7 @@ public interface Resource extends InputStreamSource {
 	 * @throws IOException if the resource cannot be resolved
 	 * (in the file system or as some other known physical resource type)
 	 */
-	long contentLength() throws IOException;
+	Long contentLength() throws IOException;
 
 	/**
 	 * Determine the last-modified timestamp for this resource.

--- a/spring-core/src/main/java/org/springframework/core/io/VfsResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/VfsResource.java
@@ -97,7 +97,7 @@ public class VfsResource extends AbstractResource {
 	}
 
 	@Override
-	public long contentLength() throws IOException {
+	public Long contentLength() throws IOException {
 		return VfsUtils.getSize(this.resource);
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/HttpRange.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpRange.java
@@ -198,7 +198,8 @@ public abstract class HttpRange {
 
 	private static long getLengthFor(Resource resource) {
 		try {
-			long contentLength = resource.contentLength();
+			Long contentLength = resource.contentLength();
+			Assert.isTrue(contentLength != null, "Resource content length should be known");
 			Assert.isTrue(contentLength > 0, "Resource content length should be > 0");
 			return contentLength;
 		}

--- a/spring-web/src/main/java/org/springframework/http/codec/ResourceHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ResourceHttpMessageWriter.java
@@ -153,7 +153,8 @@ public class ResourceHttpMessageWriter implements HttpMessageWriter<Resource> {
 		// Don't consume InputStream...
 		if (InputStreamResource.class != resource.getClass()) {
 			try {
-				return resource.contentLength();
+				Long length = resource.contentLength();
+				return length == null ? -1 : length;
 			}
 			catch (IOException ignored) {
 			}
@@ -209,7 +210,7 @@ public class ResourceHttpMessageWriter implements HttpMessageWriter<Resource> {
 			response.setStatusCode(HttpStatus.PARTIAL_CONTENT);
 			List<ResourceRegion> regions = HttpRange.toResourceRegions(ranges, resource);
 			MediaType resourceMediaType = getResourceMediaType(mediaType, resource, hints);
-			if (regions.size() == 1){
+			if (regions.size() == 1) {
 				ResourceRegion region = regions.get(0);
 				headers.setContentType(resourceMediaType);
 				long contentLength = lengthOf(resource);

--- a/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
@@ -113,8 +113,8 @@ public class ResourceHttpMessageConverter extends AbstractHttpMessageConverter<R
 		if (InputStreamResource.class == resource.getClass()) {
 			return null;
 		}
-		long contentLength = resource.contentLength();
-		return (contentLength < 0 ? null : contentLength);
+		Long contentLength = resource.contentLength();
+		return (contentLength == null || contentLength < 0) ? null : contentLength;
 	}
 
 	@Override

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
@@ -332,7 +332,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 	 */
 	protected boolean isResourceType(@Nullable Object value, MethodParameter returnType) {
 		Class<?> clazz = getReturnValueType(value, returnType);
-		return clazz != InputStreamResource.class && Resource.class.isAssignableFrom(clazz);
+		return clazz != InputStreamResource.class && Resource.class.isAssignableFrom(clazz) && ((Resource) value).contentLength() != null;
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -483,7 +483,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 		}
 
 		ServletServerHttpResponse outputMessage = new ServletServerHttpResponse(response);
-		if (request.getHeader(HttpHeaders.RANGE) == null) {
+		if (request.getHeader(HttpHeaders.RANGE) == null || resource.contentLength() == null) {
 			Assert.state(this.resourceHttpMessageConverter != null, "Not initialized");
 			setHeaders(response, resource, mediaType);
 			this.resourceHttpMessageConverter.write(resource, mediaType, outputMessage);
@@ -683,12 +683,14 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	protected void setHeaders(HttpServletResponse response, Resource resource, @Nullable MediaType mediaType)
 			throws IOException {
 
-		long length = resource.contentLength();
-		if (length > Integer.MAX_VALUE) {
-			response.setContentLengthLong(length);
-		}
-		else {
-			response.setContentLength((int) length);
+		Long length = resource.contentLength();
+		if (length != null) {
+			if (length > Integer.MAX_VALUE) {
+				response.setContentLengthLong(length);
+			}
+			else {
+				response.setContentLength((int) length);
+			}
 		}
 
 		if (mediaType != null) {


### PR DESCRIPTION
Add support for unknown content lengths.

One use case is:
Currently there is no way to ignore Range requests for Resources that are not specifically InputStreamResource (not even its subclasses). The crux of the matter is that we are trying to ignore Range requests for streams whose content lengths cannot be determined, instead we do it in a roundabout way by excluding specifically InputStreamResource.

For instance:
- I have a custom InputStream that needs to ignore Range requests. It additionally needs to be lazily initialized (i.e. only when the Resource.getInputStream() is called). Its content length is unknown.
- Cannot use any other Resource class other than InputStreamResource because they all will try accepting Range requests and when the content length is unknown, will throw 416s.
- Cannot put the stream in InputStreamResource because of the lazy instantiation requirement
- Cannot subclass InputStreamResource and override the getInputStream() method because the subclass will now accept Range requests and throw a 416

This PR excludes Resources with unknown content lengths from trying to do Partial Range support (which only results in 416s, instead of just a 200 with a full resource)

A more complete redesign would allow the unknown lengths partial support, perhaps using "*" in the Content-Range header