### PR TITLE
Update CciLocalTransactionManager.java

### DIFF
--- a/spring-tx/src/main/java/org/springframework/jca/cci/connection/CciLocalTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/jca/cci/connection/CciLocalTransactionManager.java
@@ -164,10 +164,7 @@ public class CciLocalTransactionManager extends AbstractPlatformTransactionManag
 			connectionHolder.setSynchronizedWithTransaction(true);
 
 			con.getLocalTransaction().begin();
-			int timeout = determineTimeout(definition);
-			if (timeout != TransactionDefinition.TIMEOUT_DEFAULT) {
-				connectionHolder.setTimeoutInSeconds(timeout);
-			}
+			connectionHolder.setTimeoutInSeconds(determineTimeout(definition));
 
 			txObject.setConnectionHolder(connectionHolder);
 			TransactionSynchronizationManager.bindResource(connectionFactory, connectionHolder);


### PR DESCRIPTION
The `determineTimeout(TransactionDefinition definition)` method  will fall back to this manager's default timeout if the transaction definition doesn't specify a non-default value , so can remove the code here and use  `determineTimeout(TransactionDefinition definition)`  directly