### PR TITLE
Make resolveAutowiringValue method of AutowireUtils support abstract class parameter

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/ConfigurableListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/ConfigurableListableBeanFactory.java
@@ -71,7 +71,7 @@ public interface ConfigurableListableBeanFactory
 	 * <p>Note: There are no such default types registered in a plain BeanFactory,
 	 * not even for the BeanFactory interface itself.
 	 * @param dependencyType the dependency type to register. This will typically
-	 * be a base interface such as BeanFactory, with extensions of it resolved
+	 * be a base interface such as BeanFactory or an abstract class, with extensions of it resolved
 	 * as well if declared as an autowiring dependency (e.g. ListableBeanFactory),
 	 * as long as the given value actually implements the extended interface.
 	 * @param autowiredValue the corresponding autowired value. This may also be an

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
@@ -142,6 +142,7 @@ abstract class AutowireUtils {
 			else if(Modifier.isAbstract(requiredType.getModifiers())){
 				Enhancer enhancer = new Enhancer();
 				enhancer.setSuperclass(requiredType);
+				enhancer.setClassLoader(requiredType.getClassLoader());
 				enhancer.setCallback(new ObjectFactoryDelegatingMethodInterceptor(factory));
 				return enhancer.create();
 			}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AutowireUtils.java
@@ -41,7 +41,6 @@ import org.springframework.cglib.proxy.MethodProxy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
 /**

--- a/spring-beans/src/test/java/org/springframework/beans/factory/support/AutowireUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/support/AutowireUtilsTests.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Loïc Ledoyen
+ * @author Qimiao Chen
  */
 public class AutowireUtilsTests {
 
@@ -78,6 +81,15 @@ public class AutowireUtilsTests {
 		assertThat(AutowireUtils.resolveReturnTypeForFactoryMethod(extractMagicValue, new Object[]{map}, getClass().getClassLoader())).isEqualTo(Object.class);
 	}
 
+	@Test
+	public void resolveAutowiringValueForAbstractType(){
+		ObjectFactory interfaceTypeFactory = (ObjectFactory<InterfaceType>) SimpleInterfaceType::new;
+
+		Object autowiringValue = AutowireUtils.resolveAutowiringValue(interfaceTypeFactory, AbstractType.class);
+		assertThat(autowiringValue instanceof AbstractType).isTrue();
+		AbstractType abstractType = (AbstractType) autowiringValue;
+		assertThat(abstractType.getName()).isEqualTo("SimpleInterfaceType");
+	}
 
 	public interface MyInterfaceType<T> {
 	}
@@ -177,4 +189,21 @@ public class AutowireUtilsTests {
 		}
 	}
 
+}
+
+
+interface InterfaceType{
+	String getName();
+}
+
+class SimpleInterfaceType implements InterfaceType{
+
+	@Override
+	public String getName() {
+		return "SimpleInterfaceType";
+	}
+}
+
+abstract class AbstractType{
+	abstract String getName();
 }

--- a/spring-beans/src/test/java/org/springframework/beans/factory/support/AutowireUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/support/AutowireUtilsTests.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.util.ReflectionUtils;
 


### PR DESCRIPTION
If the argument `requiredType ` of `resolveAutowiringValue` is an abstract class  and meet some other conditions, I think the argument that method return can be an object of subclass to the argument `requiredType`.

So I took the liberty to add some implementations, hoping to meet expectations.
