### PR TITLE
Simplify getParsedSql() method in NamedParameterJdbcTemplate

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
@@ -430,12 +430,7 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 			return NamedParameterUtils.parseSqlStatement(sql);
 		}
 		synchronized (this.parsedSqlCache) {
-			ParsedSql parsedSql = this.parsedSqlCache.get(sql);
-			if (parsedSql == null) {
-				parsedSql = NamedParameterUtils.parseSqlStatement(sql);
-				this.parsedSqlCache.put(sql, parsedSql);
-			}
-			return parsedSql;
+			return parsedSqlCache.computeIfAbsent(sql, NamedParameterUtils::parseSqlStatement);
 		}
 	}
 


### PR DESCRIPTION
It can simplify this way. 