### PR TITLE
Publish a build scan only if authenticated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,8 @@ buildScan {
 	obfuscation {
 		ipAddresses { addresses -> addresses.collect { address -> '0.0.0.0'} }
 	}
-	publishAlwaysIf(System.getenv('GRADLE_ENTERPRISE_URL') != null)
+	publishAlways()
+	publishIfAuthenticated()
 	server = 'https://ge.spring.io'
 }
 


### PR DESCRIPTION
Previously, anyone could publish a scan and publishing was performed if the `GRADLE_ENTERPRISE_URL` environment variable was set. ge.spring.io has now been locked down to prohibit anonymous build scan publishing. This commit aligns with this change by only attempting to publish a build scan when authenticated with the server. Authentication is achieved via an access token that is made available via an environment variable on CI and locally via a file in `~/.gradle`.