### PR TITLE
Simplify getCache() method in CaffeineCacheManager

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
@@ -178,17 +178,11 @@ public class CaffeineCacheManager implements CacheManager {
 	@Override
 	@Nullable
 	public Cache getCache(String name) {
-		Cache cache = this.cacheMap.get(name);
-		if (cache == null && this.dynamic) {
-			synchronized (this.cacheMap) {
-				cache = this.cacheMap.get(name);
-				if (cache == null) {
-					cache = createCaffeineCache(name);
-					this.cacheMap.put(name, cache);
-				}
-			}
+		if (this.dynamic) {
+			return this.cacheMap.computeIfAbsent(name, this::createCaffeineCache);
 		}
-		return cache;
+
+		return this.cacheMap.get(name);
 	}
 
 	/**


### PR DESCRIPTION
I would like to make some contributions.

Current spring framework is based on JDK8. So, CaffeineCacheManager.getCache() method can be simplified with Map.computeIfAbsent

Thank you.