### PR TITLE
Set MessageProducer's deliveryMode after create Producer

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/core/JmsTemplate.java
+++ b/spring-jms/src/main/java/org/springframework/jms/core/JmsTemplate.java
@@ -1100,6 +1100,7 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 		if (!isMessageTimestampEnabled()) {
 			producer.setDisableMessageTimestamp(true);
 		}
+		producer.setDeliveryMode(this.deliveryMode);
 		return producer;
 	}
 


### PR DESCRIPTION
I find out that the producer does not have the same deliveryMode that the JmsTemplate has.