### PR TITLE
Use computeIfAbsent to simplify getSessionAttributesHandler()

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -825,11 +825,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 		SessionAttributesHandler sessionAttrHandler = this.sessionAttributesHandlerCache.get(handlerType);
 		if (sessionAttrHandler == null) {
 			synchronized (this.sessionAttributesHandlerCache) {
-				sessionAttrHandler = this.sessionAttributesHandlerCache.get(handlerType);
-				if (sessionAttrHandler == null) {
-					sessionAttrHandler = new SessionAttributesHandler(handlerType, this.sessionAttributeStore);
-					this.sessionAttributesHandlerCache.put(handlerType, sessionAttrHandler);
-				}
+				sessionAttrHandler = this.sessionAttributesHandlerCache.computeIfAbsent(handlerType, type -> new SessionAttributesHandler(type, this.sessionAttributeStore));
 			}
 		}
 		return sessionAttrHandler;


### PR DESCRIPTION
It can simplify using computeIfAbesnt.