### PR TITLE
Hoist concatenation of two constant Strings out of loops

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReader.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReader.java
@@ -422,10 +422,13 @@ public class PropertiesBeanDefinitionReader extends AbstractBeanDefinitionReader
 		ConstructorArgumentValues cas = new ConstructorArgumentValues();
 		MutablePropertyValues pvs = new MutablePropertyValues();
 
+		String prefixWithSep = prefix + SEPARATOR;
+		int beginIndex = prefix.length() + SEPARATOR.length();
+
 		for (Map.Entry<?, ?> entry : map.entrySet()) {
 			String key = StringUtils.trimWhitespace((String) entry.getKey());
-			if (key.startsWith(prefix + SEPARATOR)) {
-				String property = key.substring(prefix.length() + SEPARATOR.length());
+			if (key.startsWith(prefixWithSep)) {
+				String property = key.substring(beginIndex);
 				if (CLASS_KEY.equals(property)) {
 					className = StringUtils.trimWhitespace((String) entry.getValue());
 				}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/AnnotationMetadataReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/AnnotationMetadataReadingVisitor.java
@@ -166,9 +166,10 @@ public class AnnotationMetadataReadingVisitor extends ClassMetadataReadingVisito
 		if (attributes == null) {
 			return null;
 		}
+		String annotatedElement = "class '" + getClassName() + "'";
 		for (AnnotationAttributes raw : attributes) {
 			for (Map.Entry<String, Object> entry : AnnotationReadingVisitorUtils.convertClassValues(
-					"class '" + getClassName() + "'", this.classLoader, raw, classValuesAsString).entrySet()) {
+					annotatedElement, this.classLoader, raw, classValuesAsString).entrySet()) {
 				allAttributes.add(entry.getKey(), entry.getValue());
 			}
 		}


### PR DESCRIPTION
In cases when concatenation arguments are the same they produce equal String at each iteration. This is why we can hoist them to reduce output of String garbage.