### PR TITLE
Add close() method in FileCopyUtils to reduce duplication

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,6 +38,7 @@ import org.springframework.lang.Nullable;
  * <p>Mainly for use within the framework, but also useful for application code.
  *
  * @author Juergen Hoeller
+ * @author Hyunjin Choi
  * @since 06.10.2003
  * @see StreamUtils
  * @see FileSystemUtils
@@ -110,16 +112,8 @@ public abstract class FileCopyUtils {
 			return StreamUtils.copy(in, out);
 		}
 		finally {
-			try {
-				in.close();
-			}
-			catch (IOException ex) {
-			}
-			try {
-				out.close();
-			}
-			catch (IOException ex) {
-			}
+			close(in);
+			close(out);
 		}
 	}
 
@@ -138,11 +132,7 @@ public abstract class FileCopyUtils {
 			out.write(in);
 		}
 		finally {
-			try {
-				out.close();
-			}
-			catch (IOException ex) {
-			}
+			close(out);
 		}
 	}
 
@@ -192,16 +182,8 @@ public abstract class FileCopyUtils {
 			return byteCount;
 		}
 		finally {
-			try {
-				in.close();
-			}
-			catch (IOException ex) {
-			}
-			try {
-				out.close();
-			}
-			catch (IOException ex) {
-			}
+			close(in);
+			close(out);
 		}
 	}
 
@@ -220,11 +202,7 @@ public abstract class FileCopyUtils {
 			out.write(in);
 		}
 		finally {
-			try {
-				out.close();
-			}
-			catch (IOException ex) {
-			}
+			close(out);
 		}
 	}
 
@@ -243,6 +221,20 @@ public abstract class FileCopyUtils {
 		StringWriter out = new StringWriter();
 		copy(in, out);
 		return out.toString();
+	}
+
+	/**
+	 * Close the {@link Closeable}
+	 *
+	 * @param closeable the closeable to close
+	 */
+	private static void close(@Nullable Closeable closeable) {
+		if (closeable == null) return;
+		try {
+			closeable.close();
+		} catch (IOException e) {
+			// do nothing
+		}
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
@@ -224,9 +224,9 @@ public abstract class FileCopyUtils {
 	}
 
 	/**
-	 * Close the {@link Closeable}
+	 * Close the {@link Closeable} as a null-safety.
 	 *
-	 * @param closeable the closeable to close
+	 * @param closeable to close, may be null.
 	 */
 	private static void close(@Nullable Closeable closeable) {
 		if (closeable == null) return;


### PR DESCRIPTION
That can be reduced by the close method.