### PR TITLE
odata uses MERGE method for updating Entity

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -32,7 +32,7 @@ import org.springframework.lang.Nullable;
  */
 public enum HttpMethod {
 
-	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE;
+	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE, MERGE;
 
 
 	private static final Map<String, HttpMethod> mappings = new HashMap<>(16);


### PR DESCRIPTION
If we dont add MERGE HttpMethod here, then [preflight request with asking MERGE method will be rejected](https://github.com/spring-projects/spring-framework/blob/master/spring-web/src/main/java/org/springframework/web/cors/DefaultCorsProcessor.java#L117).

https://www.odata.org/documentation/odata-version-2-0/operations/
2. Operations
The OData service interface has a fixed number of operations that have uniform meaning across all the resources it can act on. These operations are retrieve, create, update and delete and they map to the GET, POST, PUT/MERGE and DELETE HTTP methods.