### PR TITLE
Re-ordering Stream APIs

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -853,8 +853,8 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 				List<MediaType> allSupportedMediaTypes = getMessageConverters().stream()
 						.filter(converter -> canReadResponse(this.responseType, converter))
 						.flatMap(this::getSupportedMediaTypes)
-						.distinct()
 						.sorted(MediaType.SPECIFICITY_COMPARATOR)
+						.distinct()
 						.collect(Collectors.toList());
 				if (logger.isDebugEnabled()) {
 					logger.debug("Accept=" + allSupportedMediaTypes);


### PR DESCRIPTION
We are conducting a research project on re-ordering Stream APIs for improving program execution speed.

Before and after re-ordering, we measured running time of tests which execute target Stream.
Command for running tests is : 
`time ./gradlew -Dtest.single=RestTemplateTests test`

and the result is :
```
the order of Stream API      test running time
===============================================
distinct().sorted()                 50.165s
sorted().distinct()                 47.752s
```
