### PR TITLE
Add Informix to supported database products for procedure calls

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProviderFactory.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProviderFactory.java
@@ -46,7 +46,8 @@ public final class CallMetaDataProviderFactory {
 			"Microsoft SQL Server",
 			"Oracle",
 			"PostgreSQL",
-			"Sybase"
+			"Sybase",
+			"Informix Dynamic Server"
 		);
 
 	/** List of supported database products for function calls. */


### PR DESCRIPTION
Hi everyone,

We're facing an issue in our application when we try to call a procedure in Informix database, 
our app uses standard JDBC (spring-jdbc and com.ibm.informix.jdbc.4.50.3) without Hibernate 
to connect to the database  

Issue:
When we trying to execute any procedure call in our Informix database there is no data returned.

Diagnostic:
It points to the Java class called CallMetaDataProviderFactory in spring-jdbc project.

Taking a look of this class there is no explicit support for Informix procedure calls, so I added "Informix Dynamic Server" to the 
list of supported databases and now I can execute procedures call without issues.

Basically I added the line "Informix Dynamic Server" to the list called "supportedDatabaseProductsForProcedures" 
of CallMetaDataProviderFactory class in my local environment and it worked as expected.


I really appreciate any feedback/suggestion for this approach due we would like to continue using the framework 
normally in our development without losing updates using a workaround in our end.

Many thanks in advance.