### PR TITLE
Prevent unnecessary refresh for InjectionMetadata.EMPTY

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
@@ -153,6 +153,9 @@ public class InjectionMetadata {
 	 * @return {@code true} indicating a refresh, {@code false} otherwise
 	 */
 	public static boolean needsRefresh(@Nullable InjectionMetadata metadata, Class<?> clazz) {
+		if (metadata == EMPTY) {
+			return false;
+		}
 		return (metadata == null || metadata.targetClass != clazz);
 	}
 


### PR DESCRIPTION
InjectionMetadata.EMPTY won't cached well in AutowiredAnnotationBeanPostProcessor#injectionMetadataCache

org.springframework.beans.factory.annotation.InjectionMetadata#needsRefresh
with InjectionMetadata.EMPTY always returns true,

And therefore AutowiredAnnotationBeanPostProcessor#find always calls
AutowiredAnnotationBeanPostProcessor#buildAutowiringMetadata

As a result of this, Performance degration of constructing component 
happen from 5.1.

Ref: https://github.com/spring-projects/spring-framework/issues/23905

This is a part of performance degration, And this pull request won't improve performance degration 
completely. performance degration remains a little.