### PR TITLE
AbstractJackson2HttpMessageConverter handles JsonMappingException

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -241,6 +241,9 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 		catch (InvalidDefinitionException ex) {
 			throw new HttpMessageConversionException("Type definition error: " + ex.getType(), ex);
 		}
+		catch (JsonMappingException ex) {
+			throw new HttpMessageConversionException("Content mapping error: " + ex.getOriginalMessage(), ex);
+		}
 		catch (JsonProcessingException ex) {
 			throw new HttpMessageNotReadableException("JSON parse error: " + ex.getOriginalMessage(), ex, inputMessage);
 		}


### PR DESCRIPTION
JsonMappingException is treated as HttpMessageConversionException to keep the same behavior for new exceptions introduced in jackson-databind 2.10
Fixes issue 24455