### PR TITLE
Partial dependency injection into constructor

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/ConstructorResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/ConstructorResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ import org.springframework.util.StringUtils;
  * @author Costin Leau
  * @author Sebastien Deleuze
  * @author Sam Brannen
+ * @author Andrey Golikov
  * @since 2.0
  * @see #autowireConstructor
  * @see #instantiateUsingFactoryMethod
@@ -189,6 +190,10 @@ class ConstructorResolver {
 			int minNrOfArgs;
 			if (explicitArgs != null) {
 				minNrOfArgs = explicitArgs.length;
+				resolvedValues = new ConstructorArgumentValues();
+				for (Object arg : explicitArgs) {
+					resolvedValues.addGenericArgumentValue(arg);
+				}
 			}
 			else {
 				ConstructorArgumentValues cargs = mbd.getConstructorArgumentValues();
@@ -216,7 +221,7 @@ class ConstructorResolver {
 
 				ArgumentsHolder argsHolder;
 				Class<?>[] paramTypes = candidate.getParameterTypes();
-				if (resolvedValues != null) {
+				if (explicitArgs == null || parameterCount > explicitArgs.length) {
 					try {
 						String[] paramNames = ConstructorPropertiesChecker.evaluate(candidate, parameterCount);
 						if (paramNames == null) {


### PR DESCRIPTION
With this commit it is possible to partially autowire constructors.
It is useful, for example, for lookup methods, creating prototype beans.
Sometimes prototype beans depend on singletons, and before to create
such prototypes it was required to write custom factories. This change
allows to use lookup methods.