### PR TITLE
Correct formatting of MessageSource example in documentation

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -10421,7 +10421,7 @@ resolved is specified manually:
 [literal,subs="verbatim,quotes"]
 ----
 # in exceptions_en_GB.properties
-argument.required=Ebagum lad, the {0} argument is required, I say, required.
+argument.required=Ebagum lad, the ''{0}'' argument is required, I say, required.
 ----
 
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]


### PR DESCRIPTION
The formatting of MessageSource example is not correct. To have as an output the sentence "Ebagum lad, the 'userDao' argument is required, I say, required." we should add two pairs of single quotes.