### PR TITLE
Repeatable Read HttpServletRequest InputStream

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/RepeatableReadInputStreamAndContentCacheFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/RepeatableReadInputStreamAndContentCacheFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.filter;
+
+import org.springframework.web.util.RepeatableReadInputStreamAndContentCacheRequestWrapper;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+public abstract class RepeatableReadInputStreamAndContentCacheFilter extends OncePerRequestFilter {
+
+
+	/**
+	 * Forwards the request to the next filter in the chain and delegates down to the subclasses
+	 * to perform the actual request logging both before and after the request is processed.
+	 */
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+
+		if (!(request instanceof RepeatableReadInputStreamAndContentCacheRequestWrapper)) {
+			filterChain.doFilter(new RepeatableReadInputStreamAndContentCacheRequestWrapper(request), response);
+		}
+		else {
+			filterChain.doFilter(request, response);
+		}
+
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/web/filter/RepeatableReadInputStreamAndContentCacheFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/RepeatableReadInputStreamAndContentCacheFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,7 @@ import java.io.IOException;
 public abstract class RepeatableReadInputStreamAndContentCacheFilter extends OncePerRequestFilter {
 
 
-	/**
-	 * Forwards the request to the next filter in the chain and delegates down to the subclasses
-	 * to perform the actual request logging both before and after the request is processed.
-	 */
+
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 			throws ServletException, IOException {

--- a/spring-web/src/main/java/org/springframework/web/util/RepeatableReadInputStreamAndContentCacheRequestWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/RepeatableReadInputStreamAndContentCacheRequestWrapper.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.util;
+
+import java.io.*;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.lang.Nullable;
+
+/**
+ * {@link javax.servlet.http.HttpServletRequest} wrapper that caches all content read from
+ * the {@linkplain #getInputStream() input stream} and {@linkplain #getReader() reader},
+ * and allows this content to be retrieved via a {@link #getContentAsByteArray() byte array}.
+ *
+ * <p>Used e.g. by {@link org.springframework.web.filter.AbstractRequestLoggingFilter}.
+ * Note: As of Spring Framework 5.0, this wrapper is built on the Servlet 3.1 API.
+ *
+ * @author Juergen Hoeller
+ * @author Brian Clozel
+ * @since 4.1.3
+ * @see ContentCachingResponseWrapper
+ */
+public class RepeatableReadInputStreamAndContentCacheRequestWrapper extends HttpServletRequestWrapper {
+
+	private static final String FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
+
+
+	@Nullable
+	private byte[] contentBytes;
+
+	private HttpServletRequest request;
+
+
+	/**
+	 * Create a new ContentCachingRequestWrapper for the given servlet request.
+	 * @param request the original servlet request
+	 */
+	public RepeatableReadInputStreamAndContentCacheRequestWrapper(HttpServletRequest request) {
+		super(request);
+		this.request = request;
+	}
+
+	@Override
+	public ServletInputStream getInputStream() throws IOException {
+		cacheContentAndInitParams();
+		return new ByteServletInputStream(contentBytes);
+	}
+
+	@Override
+	public String getCharacterEncoding() {
+		String enc = super.getCharacterEncoding();
+		return (enc != null ? enc : WebUtils.DEFAULT_CHARACTER_ENCODING);
+	}
+
+	@Override
+	public BufferedReader getReader() throws IOException {
+		cacheContentAndInitParams();
+		return new BufferedReader(new InputStreamReader(getInputStream(), getCharacterEncoding()));
+	}
+
+	private void cacheContentAndInitParams() {
+		// 初始化过了
+		if (contentBytes != null)
+			return;
+
+		// 1.先初始化内容
+		try {
+			contentBytes = IOUtils.toByteArray(request.getInputStream());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		// 2.初始化参数
+//		if (contentBytes.length != 0 && isFormPost())
+//			writeRequestParametersToCachedContent();
+	}
+
+	@Override
+	public String getParameter(String name) {
+		cacheContentAndInitParams();
+		return super.getParameter(name);
+	}
+
+	@Override
+	public Map<String, String[]> getParameterMap() {
+		cacheContentAndInitParams();
+		return super.getParameterMap();
+	}
+
+	@Override
+	public Enumeration<String> getParameterNames() {
+		cacheContentAndInitParams();
+		return super.getParameterNames();
+	}
+
+	@Override
+	public String[] getParameterValues(String name) {
+		cacheContentAndInitParams();
+		return super.getParameterValues(name);
+	}
+
+
+	private boolean isFormPost() {
+		String contentType = getContentType();
+		return (contentType != null && contentType.contains(FORM_CONTENT_TYPE) &&
+				HttpMethod.POST.matches(getMethod()));
+	}
+
+//	private void writeRequestParametersToCachedContent() {
+//		try {
+//			if (this.cachedContent.size() == 0) {
+//				String requestEncoding = getCharacterEncoding();
+//				Map<String, String[]> form = super.getParameterMap();
+//				for (Iterator<String> nameIterator = form.keySet().iterator(); nameIterator.hasNext(); ) {
+//					String name = nameIterator.next();
+//					List<String> values = Arrays.asList(form.get(name));
+//					for (Iterator<String> valueIterator = values.iterator(); valueIterator.hasNext(); ) {
+//						String value = valueIterator.next();
+//						this.cachedContent.write(URLEncoder.encode(name, requestEncoding).getBytes());
+//						if (value != null) {
+//							this.cachedContent.write('=');
+//							this.cachedContent.write(URLEncoder.encode(value, requestEncoding).getBytes());
+//							if (valueIterator.hasNext()) {
+//								this.cachedContent.write('&');
+//							}
+//						}
+//					}
+//					if (nameIterator.hasNext()) {
+//						this.cachedContent.write('&');
+//					}
+//				}
+//			}
+//		}
+//		catch (IOException ex) {
+//			throw new IllegalStateException("Failed to write request parameters to cached content", ex);
+//		}
+//	}
+
+	/**
+	 * Return the cached request content as a byte array.
+	 */
+	public byte[] getContentAsByteArray() {
+		return this.contentBytes;
+	}
+
+
+
+	private class ByteServletInputStream extends ServletInputStream {
+
+		private final InputStream byteInputStream;
+
+		private ByteServletInputStream(byte[] content) {
+			this.byteInputStream = new ByteArrayInputStream(content);
+		}
+
+		@Override
+		public boolean isFinished() {
+			return true;
+		}
+
+		@Override
+		public boolean isReady() {
+			return true;
+		}
+
+		@Override
+		public void setReadListener(ReadListener readListener) {
+
+		}
+
+		@Override
+		public int read() throws IOException {
+			return this.byteInputStream.read();
+		}
+
+		@Override
+		public void close() throws IOException {
+			super.close();
+			byteInputStream.close();
+		}
+	}
+}


### PR DESCRIPTION
### Cannot Read HttpServletRequest,getInputStream() Multi Times.
- When I readed HttpServletRequest.getInputStream() in the Filter, then the `@RequestBody` parsing parmeter face an exception like "java.io.IOException: Stream closed".
- The exception above is that HttpServletRequest,getInputStream() can only be read once, I read HttpServletRequest.getInputStream() in the filter before RequestParamMethodArgumentResolver read.
### The Same Problem In StackOverFlow
- https://stackoverflow.com/questions/4449096/how-to-read-request-getinputstream-multiple-times
- https://stackoverflow.com/questions/5345173/unable-to-read-request-getinputstream