### PR TITLE
PartsHttpMessageWriter introduced

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageWriter.java
@@ -330,7 +330,7 @@ public class MultipartHttpMessageWriter extends LoggingCodecSupport
 	}
 
 
-	private Mono<DataBuffer> generateBoundaryLine(byte[] boundary, DataBufferFactory bufferFactory) {
+	static Mono<DataBuffer> generateBoundaryLine(byte[] boundary, DataBufferFactory bufferFactory) {
 		return Mono.fromCallable(() -> {
 			DataBuffer buffer = bufferFactory.allocateBuffer(boundary.length + 4);
 			buffer.write((byte)'-');
@@ -342,7 +342,7 @@ public class MultipartHttpMessageWriter extends LoggingCodecSupport
 		});
 	}
 
-	private Mono<DataBuffer> generateNewLine(DataBufferFactory bufferFactory) {
+	static Mono<DataBuffer> generateNewLine(DataBufferFactory bufferFactory) {
 		return Mono.fromCallable(() -> {
 			DataBuffer buffer = bufferFactory.allocateBuffer(2);
 			buffer.write((byte)'\r');
@@ -351,7 +351,7 @@ public class MultipartHttpMessageWriter extends LoggingCodecSupport
 		});
 	}
 
-	private Mono<DataBuffer> generateLastLine(byte[] boundary, DataBufferFactory bufferFactory) {
+	static Mono<DataBuffer> generateLastLine(byte[] boundary, DataBufferFactory bufferFactory) {
 		return Mono.fromCallable(() -> {
 			DataBuffer buffer = bufferFactory.allocateBuffer(boundary.length + 6);
 			buffer.write((byte)'-');
@@ -365,8 +365,7 @@ public class MultipartHttpMessageWriter extends LoggingCodecSupport
 		});
 	}
 
-
-	private static class MultipartHttpOutputMessage implements ReactiveHttpOutputMessage {
+	static class MultipartHttpOutputMessage implements ReactiveHttpOutputMessage {
 
 		private final DataBufferFactory bufferFactory;
 

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/PartsHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/PartsHttpMessageWriter.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import org.reactivestreams.Publisher;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.DataBufferEncoder;
+import org.springframework.core.codec.Hints;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.PooledDataBuffer;
+import org.springframework.core.log.LogFormatUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpOutputMessage;
+import org.springframework.http.codec.EncoderHttpMessageWriter;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.LoggingCodecSupport;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeTypeUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
+import static org.springframework.http.codec.multipart.MultipartHttpMessageWriter.*;
+
+/**
+ * {@link HttpMessageWriter} for writing a {@code Flux<Part>}
+ * as multipart form data, i.e. {@code "multipart/form-data"}, to the body
+ * of a request.
+ *
+ * @author Sergii Karpenko
+ * @since 5.2
+ */
+public class PartsHttpMessageWriter extends LoggingCodecSupport
+		implements HttpMessageWriter<Part> {
+
+	/**
+	 * THe default charset used by the writer.
+	 */
+	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+	/** Suppress logging from individual part writers (full map logged at this level). */
+	private static final Map<String, Object> DEFAULT_HINTS = Hints.from(Hints.SUPPRESS_LOGGING_HINT, true);
+
+	private final HttpMessageWriter<DataBuffer> writer;
+
+	private Charset charset = DEFAULT_CHARSET;
+
+	/**
+	 * Constructor with a default list of part writers (String and Resource).
+	 */
+	public PartsHttpMessageWriter() {
+		this(new EncoderHttpMessageWriter<>(new DataBufferEncoder()));
+	}
+
+	/**
+	 * Constructor with explicit list of writers for serializing parts and a
+	 * writer for plain form data to fall back when no media type is specified
+	 * and the actual map consists of String values only.
+	 * @param writer the writer for serializing parts
+	 */
+	public PartsHttpMessageWriter(HttpMessageWriter<DataBuffer> writer) {
+		this.writer = writer;
+	}
+
+	@Override
+	public List<MediaType> getWritableMediaTypes() {
+		return singletonList(MULTIPART_FORM_DATA);
+	}
+
+	@Override
+	public boolean canWrite(ResolvableType elementType, @Nullable MediaType mediaType) {
+		return Part.class.isAssignableFrom(elementType.toClass())
+				&& MULTIPART_FORM_DATA.equals(mediaType);
+	}
+
+	@Override
+	public Mono<Void> write(Publisher<? extends Part> inputStream,
+							ResolvableType elementType, @Nullable MediaType mediaType, ReactiveHttpOutputMessage outputMessage,
+							Map<String, Object> hints) {
+
+		return writeMultipart(Flux.from(inputStream), outputMessage, hints);
+	}
+
+	private Mono<Void> writeMultipart(
+			Flux<Part> parts, ReactiveHttpOutputMessage outputMessage, Map<String, Object> hints) {
+
+		byte[] boundary = generateMultipartBoundary();
+
+		Map<String, String> params = new HashMap<>(2);
+		params.put("boundary", new String(boundary, StandardCharsets.US_ASCII));
+		params.put("charset", getCharset().name());
+
+		outputMessage.getHeaders().setContentType(new MediaType(MULTIPART_FORM_DATA, params));
+
+		LogFormatUtils.traceDebug(logger, traceOn -> Hints.getLogPrefix(hints) + "Encoding " +
+				(isEnableLoggingRequestDetails() ?
+						LogFormatUtils.formatValue(parts, !traceOn) :
+						"parts (content masked)"));
+
+		DataBufferFactory bufferFactory = outputMessage.bufferFactory();
+
+		Flux<DataBuffer> body = parts
+				.concatMap(part -> encodePart(boundary, part, bufferFactory))
+				.concatWith(generateLastLine(boundary, bufferFactory))
+				.doOnDiscard(PooledDataBuffer.class, PooledDataBuffer::release);
+
+		return outputMessage.writeWith(body);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> Flux<DataBuffer> encodePart(byte[] boundary, Part part, DataBufferFactory bufferFactory) {
+		MultipartHttpMessageWriter.MultipartHttpOutputMessage outputMessage = new MultipartHttpOutputMessage(bufferFactory, getCharset());
+		HttpHeaders outputHeaders = outputMessage.getHeaders();
+		outputHeaders.putAll(part.headers());
+
+		String name = part.name();
+		Flux<DataBuffer> body = part.content();
+
+		if (!outputHeaders.containsKey(HttpHeaders.CONTENT_DISPOSITION)) {
+			if (part instanceof FilePart) {
+				outputHeaders.setContentDispositionFormData(name, ((FilePart) part).filename());
+			}
+			else {
+				outputHeaders.setContentDispositionFormData(name, null);
+			}
+		}
+
+		MediaType contentType = outputHeaders.getContentType();
+
+		final ResolvableType finalBodyType = ResolvableType.forClass(DataBuffer.class);
+
+		// The writer will call MultipartHttpOutputMessage#write which doesn't actually write
+		// but only stores the body Flux and returns Mono.empty().
+
+		Mono<Void> partContentReady = writer.write(body, finalBodyType, contentType, outputMessage, DEFAULT_HINTS);
+
+		// After partContentReady, we can access the part content from MultipartHttpOutputMessage
+		// and use it for writing to the actual request body
+
+		Flux<DataBuffer> partContent = partContentReady.thenMany(Flux.defer(outputMessage::getBody));
+
+		return Flux.concat(
+				generateBoundaryLine(boundary, bufferFactory),
+				partContent,
+				generateNewLine(bufferFactory));
+	}
+
+	/**
+	 * Set the character set to use for part headers such as
+	 * "Content-Disposition" (and its filename parameter).
+	 * <p>By default this is set to "UTF-8".
+	 */
+	public void setCharset(Charset charset) {
+		Assert.notNull(charset, "Charset must not be null");
+		this.charset = charset;
+	}
+
+	/**
+	 * Return the configured charset for part headers.
+	 */
+	public Charset getCharset() {
+		return this.charset;
+	}
+
+	/**
+	 * Generate a multipart boundary.
+	 * <p>By default delegates to {@link MimeTypeUtils#generateMultipartBoundary()}.
+	 */
+	protected byte[] generateMultipartBoundary() {
+		return MimeTypeUtils.generateMultipartBoundary();
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/codec/support/BaseDefaultCodecs.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/support/BaseDefaultCodecs.java
@@ -50,6 +50,7 @@ import org.springframework.http.codec.json.Jackson2SmileDecoder;
 import org.springframework.http.codec.json.Jackson2SmileEncoder;
 import org.springframework.http.codec.multipart.MultipartHttpMessageReader;
 import org.springframework.http.codec.multipart.MultipartHttpMessageWriter;
+import org.springframework.http.codec.multipart.PartsHttpMessageWriter;
 import org.springframework.http.codec.multipart.SynchronossPartHttpMessageReader;
 import org.springframework.http.codec.protobuf.ProtobufDecoder;
 import org.springframework.http.codec.protobuf.ProtobufEncoder;
@@ -400,6 +401,7 @@ class BaseDefaultCodecs implements CodecConfigurer.DefaultCodecs, CodecConfigure
 		writers.add(new EncoderHttpMessageWriter<>(new ByteBufferEncoder()));
 		writers.add(new EncoderHttpMessageWriter<>(new DataBufferEncoder()));
 		writers.add(new ResourceHttpMessageWriter());
+		writers.add(new PartsHttpMessageWriter());
 		writers.add(new EncoderHttpMessageWriter<>(CharSequenceEncoder.textPlainOnly()));
 		if (protobufPresent) {
 			writers.add(new ProtobufHttpMessageWriter(this.protobufEncoder != null ?

--- a/spring-web/src/test/java/org/springframework/http/codec/multipart/PartsHttpMessageWriterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/multipart/PartsHttpMessageWriterTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.StringDecoder;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.core.testfixture.io.buffer.AbstractLeakCheckingTests;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.http.codec.ClientCodecConfigurer;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.testfixture.http.server.reactive.MockServerHttpRequest;
+import org.springframework.web.testfixture.http.server.reactive.MockServerHttpResponse;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.UnicastProcessor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Sebastien Deleuze
+ * @author Rossen Stoyanchev
+ */
+public class PartsHttpMessageWriterTests extends AbstractLeakCheckingTests {
+
+	private final PartsHttpMessageWriter writer = new PartsHttpMessageWriter();
+
+	private final MockServerHttpResponse response = new MockServerHttpResponse(this.bufferFactory);
+
+	@Test
+	public void canWrite() {
+		assertThat(this.writer.canWrite(
+				ResolvableType.forClass(Part.class),
+				MediaType.MULTIPART_FORM_DATA)).isTrue();
+
+		assertThat(this.writer.canWrite(
+				ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Object.class),
+				MediaType.MULTIPART_FORM_DATA)).isFalse();
+		assertThat(this.writer.canWrite(
+				ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, String.class),
+				MediaType.MULTIPART_FORM_DATA)).isFalse();
+
+		assertThat(this.writer.canWrite(
+				ResolvableType.forClassWithGenerics(Map.class, String.class, Object.class),
+				MediaType.MULTIPART_FORM_DATA)).isFalse();
+		assertThat(this.writer.canWrite(
+				ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Object.class),
+				MediaType.APPLICATION_FORM_URLENCODED)).isFalse();
+	}
+
+	@Test
+	public void writeMultipart() {
+		FilePart mockFilePart = mockFilePart();
+		HttpHeaders fileHeaders = new HttpHeaders();
+		fileHeaders.setContentType(MediaType.IMAGE_JPEG);
+		given(mockFilePart.headers()).willReturn(fileHeaders);
+
+		Part mockPart = mockPart();
+		given(mockPart.headers()).willReturn(new HttpHeaders());
+
+		Map<String, Object> hints = Collections.emptyMap();
+		this.writer.write(Flux.just(mockFilePart, mockPart), null, MediaType.MULTIPART_FORM_DATA, this.response, hints).block(Duration.ofSeconds(5));
+
+		MultiValueMap<String, Part> requestParts = parse(hints);
+		assertThat(requestParts.size()).isEqualTo(2);
+
+		Part part = requestParts.getFirst("filePart");
+		assertThat(part).isInstanceOf(FilePart.class);
+		assertThat(part.name()).isEqualTo("filePart");
+		assertThat(((FilePart) part).filename()).isEqualTo("file.txt");
+		assertThat(part.headers().getContentType()).isEqualTo(MediaType.IMAGE_JPEG);
+
+		part = requestParts.getFirst("part");
+		assertThat(part).isInstanceOf(Part.class);
+		assertThat(part.name()).isEqualTo("part");
+	}
+
+	@Test  // SPR-16376
+	public void customContentDisposition() throws IOException {
+		FilePart mockFilePart = mockFilePart();
+		HttpHeaders fileHeaders = new HttpHeaders();
+		fileHeaders.setContentType(MediaType.IMAGE_JPEG);
+		fileHeaders.setContentDispositionFormData("fileCustomPart", "file_custom.jpg");
+		given(mockFilePart.headers()).willReturn(fileHeaders);
+
+		Part mockPart = mockPart();
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.IMAGE_JPEG);
+		headers.setContentDispositionFormData("customPart", null);
+		given(mockPart.headers()).willReturn(headers);
+
+		Map<String, Object> hints = Collections.emptyMap();
+		this.writer.write(Flux.just(mockFilePart, mockPart), null, MediaType.MULTIPART_FORM_DATA, this.response, hints).block(Duration.ofSeconds(5));
+
+		MultiValueMap<String, Part> requestParts = parse(hints);
+		assertThat(requestParts.size()).isEqualTo(2);
+
+		Part part = requestParts.getFirst("fileCustomPart");
+		assertThat(part).isInstanceOf(FilePart.class);
+		assertThat(part.name()).isEqualTo("fileCustomPart");
+		assertThat(((FilePart) part).filename()).isEqualTo("file_custom.jpg");
+		assertThat(part.headers().getContentType()).isEqualTo(MediaType.IMAGE_JPEG);
+
+		part = requestParts.getFirst("customPart");
+		assertThat(part).isInstanceOf(Part.class);
+		assertThat(part.name()).isEqualTo("customPart");
+	}
+
+	private MultiValueMap<String, Part> parse(Map<String, Object> hints) {
+		MediaType contentType = this.response.getHeaders().getContentType();
+		assertThat(contentType.getParameter("boundary")).as("No boundary found").isNotNull();
+
+		// see if Synchronoss NIO Multipart can read what we wrote
+		SynchronossPartHttpMessageReader synchronossReader = new SynchronossPartHttpMessageReader();
+		MultipartHttpMessageReader reader = new MultipartHttpMessageReader(synchronossReader);
+
+		MockServerHttpRequest request = MockServerHttpRequest.post("/")
+				.contentType(MediaType.parseMediaType(contentType.toString()))
+				.body(this.response.getBody());
+
+		ResolvableType elementType = ResolvableType.forClassWithGenerics(
+				MultiValueMap.class, String.class, Part.class);
+
+		MultiValueMap<String, Part> result = reader.readMono(elementType, request, hints)
+				.block(Duration.ofSeconds(5));
+
+		assertThat(result).isNotNull();
+		return result;
+	}
+
+	@NotNull
+	private Part mockPart() {
+		Flux<DataBuffer> bufferPublisher2 = Flux.just(
+				this.bufferFactory.wrap("Db".getBytes(StandardCharsets.UTF_8)),
+				this.bufferFactory.wrap("Ee".getBytes(StandardCharsets.UTF_8))
+		);
+
+		Part mockPart = mock(Part.class);
+		given(mockPart.content()).willReturn(bufferPublisher2);
+		given(mockPart.name()).willReturn("part");
+		return mockPart;
+	}
+
+	@NotNull
+	private FilePart mockFilePart() {
+		Flux<DataBuffer> bufferPublisher1 = Flux.just(
+				this.bufferFactory.wrap("Aa".getBytes(StandardCharsets.UTF_8)),
+				this.bufferFactory.wrap("Bb".getBytes(StandardCharsets.UTF_8)),
+				this.bufferFactory.wrap("Cc".getBytes(StandardCharsets.UTF_8))
+		);
+		FilePart mockFilePart = mock(FilePart.class);
+		given(mockFilePart.content()).willReturn(bufferPublisher1);
+		given(mockFilePart.filename()).willReturn("file.txt");
+		given(mockFilePart.name()).willReturn("filePart");
+		return mockFilePart;
+	}
+
+
+
+}


### PR DESCRIPTION
Currently there is no option to pass `Flux<Part>` as body via `WebClient`. This pr extends `WebClient` functionality and allows accept  `Flux<Part>` as body.