### PR TITLE
Fixing logic error.

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/cors/CorsUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsUtils.java
@@ -44,7 +44,10 @@ public abstract class CorsUtils {
 			return false;
 		}
 		UriComponents originUrl = UriComponentsBuilder.fromOriginHeader(origin).build();
-		String scheme = request.getScheme();
+		String scheme = request.getHeader("x-forwarded-proto");
+		if (scheme == null) {
+			scheme = request.getScheme();
+		}
 		String host = request.getServerName();
 		int port = request.getServerPort();
 		return !(ObjectUtils.nullSafeEquals(scheme, originUrl.getScheme()) &&


### PR DESCRIPTION
My application server provides HTTP(http://172.18.0.120) service on port 80, which runs behind the reverse proxy server providing HTTPS(https://domain.com) service on port 443. Then the websocket handshake to https://domain.com/websocket failed because the method org. Springframework. Web. CORS. Corsutils. Iscorsrequest() returns true(originUrl.getScheme() returns "https", request.getScheme() returns "http") when using HTTPS reverse proxy server to proxy HTTP service.