### PR TITLE
Fix javadoc in DependencyDescriptor

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/DependencyDescriptor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/DependencyDescriptor.java
@@ -371,7 +371,7 @@ public class DependencyDescriptor extends InjectionPoint implements Serializable
 
 	/**
 	 * Determine the name of the wrapped parameter/field.
-	 * @return the declared name (never {@code null})
+	 * @return the declared name
 	 */
 	@Nullable
 	public String getDependencyName() {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/DependencyDescriptor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/DependencyDescriptor.java
@@ -371,7 +371,7 @@ public class DependencyDescriptor extends InjectionPoint implements Serializable
 
 	/**
 	 * Determine the name of the wrapped parameter/field.
-	 * @return the declared name
+	 * @return the declared name (may be {@code null})
 	 */
 	@Nullable
 	public String getDependencyName() {


### PR DESCRIPTION
The java doc description of `(never {@code null})` does not match the annotation of `@Nullable`.
Suggest to fix this description.
