### PR TITLE
Correct Ant-style Patterns example in documentation

### DIFF
--- a/src/docs/asciidoc/core/core-resources.adoc
+++ b/src/docs/asciidoc/core/core-resources.adoc
@@ -596,9 +596,9 @@ Path locations can contain Ant-style patterns, as the following example shows:
 
 [literal,subs="verbatim,quotes"]
 ----
-/WEB-INF/*-context.xml
-com/mycompany/**/applicationContext.xml
-file:C:/some/path/*-context.xml
+/WEB-INF/\*-context.xml
+com/mycompany/\**/applicationContext.xml
+file:C:/some/path/\*-context.xml
 classpath:com/mycompany/**/applicationContext.xml
 ----
 


### PR DESCRIPTION
The documentation contains incorrect Ant-style pattern code snippet. 
```
/WEB-INF/-context.xml
com/mycompany//applicationContext.xml
file:C:/some/path/-context.xml
classpath:com/mycompany//applicationContext.xml
```
But correct form should be as follows:

```
/WEB-INF/*-context.xml
com/mycompany/**/applicationContext.xml
file:C:/some/path/*-context.xml
classpath:com/mycompany/**/applicationContext.xml
```