### PR TITLE
Update section on HTTP/2 in WebFlux documentation

### DIFF
--- a/src/docs/asciidoc/web/webflux.adoc
+++ b/src/docs/asciidoc/web/webflux.adoc
@@ -4273,6 +4273,3 @@ with Servlet API 4. From a programming model perspective, there is nothing speci
 applications need to do. However, there are considerations related to server configuration.
 For more details, see the
 https://github.com/spring-projects/spring-framework/wiki/HTTP-2-support[HTTP/2 wiki page].
-
-Currently, Spring WebFlux does not support HTTP/2 with Netty. There is also no support for
-pushing resources programmatically to the client.


### PR DESCRIPTION
I check the http/2 [Wiki](https://github.com/spring-projects/spring-framework/wiki/HTTP-2-support#reactor-netty).
I think it is a confusing phrase.
