### PR TITLE
Remove unnecessary semicolon in some enum classes

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ScopedProxyMode.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ScopedProxyMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,6 @@ public enum ScopedProxyMode {
 	/**
 	 * Create a class-based proxy (uses CGLIB).
 	 */
-	TARGET_CLASS;
+	TARGET_CLASS
 
 }

--- a/spring-context/src/main/java/org/springframework/jmx/support/RegistrationPolicy.java
+++ b/spring-context/src/main/java/org/springframework/jmx/support/RegistrationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,6 @@ public enum RegistrationPolicy {
 	 * Registration should replace the affected MBean when attempting to register an MBean
 	 * under a name that already exists.
 	 */
-	REPLACE_EXISTING;
+	REPLACE_EXISTING
 
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessageType.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,6 @@ public enum SimpMessageType {
 
 	DISCONNECT_ACK,
 
-	OTHER;
+	OTHER
 
 }

--- a/spring-orm/src/test/java/org/springframework/orm/jpa/hibernate/beans/BeanSource.java
+++ b/spring-orm/src/test/java/org/springframework/orm/jpa/hibernate/beans/BeanSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,5 +18,5 @@ package org.springframework.orm.jpa.hibernate.beans;
 
 public enum BeanSource {
 	SPRING,
-	FALLBACK;
+	FALLBACK
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/WebSocketMessage.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/WebSocketMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,7 +159,7 @@ public class WebSocketMessage {
 		/**
 		 * WebSocket pong.
 		 */
-		PONG;
+		PONG
 	}
 
 }


### PR DESCRIPTION
These are unnecessary semicolons.
So I removed.