### PR TITLE
Improve documentation for @Autowired/@Value in @Configuration classes

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -8876,8 +8876,9 @@ parameter-based injection, as in the preceding example.
 
 Also, be particularly careful with `BeanPostProcessor` and `BeanFactoryPostProcessor` definitions
 through `@Bean`. Those should usually be declared as `static @Bean` methods, not triggering the
-instantiation of their containing configuration class. Otherwise, `@Autowired` and `@Value` do not
-work on the configuration class itself, since it is being created as a bean instance too early.
+instantiation of their containing configuration class. Otherwise, `@Autowired` and `@Value` may not
+work on the configuration class itself, since it is possible to create it as a bean instance earlier than
+{api-spring-framework}/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.html[`AutowiredAnnotationBeanPostProcessor`].
 ====
 
 The following example shows how one bean can be autowired to another bean:


### PR DESCRIPTION
Original：
`Otherwise, @Autowired and @Value do not work on the configuration class itself, since it is being created as a bean instance too early.`

I think this statement is not accurate enough. `@Autowired` actually works, if the priority of the definition of `BeanPostProcessor ` through `@Bean` lower than `AutowiredAnnotationBeanPostProcessor`.
So, I think we can adjust this description.
