### PR TITLE
Simplify some redundant code

### DIFF
--- a/spring-expression/src/test/java/org/springframework/expression/spel/ConstructorInvocationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/ConstructorInvocationTests.java
@@ -162,8 +162,7 @@ public class ConstructorInvocationTests extends AbstractExpressionTests {
 		ctx.addConstructorResolver(dummy);
 		assertThat(ctx.getConstructorResolvers().size()).isEqualTo(2);
 
-		List<ConstructorResolver> copy = new ArrayList<>();
-		copy.addAll(ctx.getConstructorResolvers());
+		List<ConstructorResolver> copy = new ArrayList<>(ctx.getConstructorResolvers());
 		assertThat(ctx.removeConstructorResolver(dummy)).isTrue();
 		assertThat(ctx.removeConstructorResolver(dummy)).isFalse();
 		assertThat(ctx.getConstructorResolvers().size()).isEqualTo(1);

--- a/spring-expression/src/test/java/org/springframework/expression/spel/ExpressionLanguageScenarioTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/ExpressionLanguageScenarioTests.java
@@ -96,7 +96,7 @@ public class ExpressionLanguageScenarioTests extends AbstractExpressionTests {
 		// Use the standard evaluation context
 		StandardEvaluationContext ctx = new StandardEvaluationContext();
 		ctx.setVariable("favouriteColour","blue");
-		List<Integer> primes = new ArrayList<>(Arrays.asList(2, 3, 5, 7, 11, 13, 17));
+		List<Integer> primes = Arrays.asList(2, 3, 5, 7, 11, 13, 17);
 		ctx.setVariable("primes",primes);
 
 		Expression expr = parser.parseRaw("#favouriteColour");

--- a/spring-expression/src/test/java/org/springframework/expression/spel/ExpressionLanguageScenarioTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/ExpressionLanguageScenarioTests.java
@@ -96,8 +96,7 @@ public class ExpressionLanguageScenarioTests extends AbstractExpressionTests {
 		// Use the standard evaluation context
 		StandardEvaluationContext ctx = new StandardEvaluationContext();
 		ctx.setVariable("favouriteColour","blue");
-		List<Integer> primes = new ArrayList<>();
-		primes.addAll(Arrays.asList(2,3,5,7,11,13,17));
+		List<Integer> primes = new ArrayList<>(Arrays.asList(2, 3, 5, 7, 11, 13, 17));
 		ctx.setVariable("primes",primes);
 
 		Expression expr = parser.parseRaw("#favouriteColour");

--- a/spring-expression/src/test/java/org/springframework/expression/spel/MethodInvocationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/MethodInvocationTests.java
@@ -221,8 +221,7 @@ public class MethodInvocationTests extends AbstractExpressionTests {
 		ctx.addMethodResolver(dummy);
 		assertThat(ctx.getMethodResolvers().size()).isEqualTo(2);
 
-		List<MethodResolver> copy = new ArrayList<>();
-		copy.addAll(ctx.getMethodResolvers());
+		List<MethodResolver> copy = new ArrayList<>(ctx.getMethodResolvers());
 		assertThat(ctx.removeMethodResolver(dummy)).isTrue();
 		assertThat(ctx.removeMethodResolver(dummy)).isFalse();
 		assertThat(ctx.getMethodResolvers().size()).isEqualTo(1);

--- a/spring-expression/src/test/java/org/springframework/expression/spel/PropertyAccessTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/PropertyAccessTests.java
@@ -135,8 +135,7 @@ public class PropertyAccessTests extends AbstractExpressionTests {
 		ctx.addPropertyAccessor(spa);
 		assertThat(ctx.getPropertyAccessors().size()).isEqualTo(2);
 
-		List<PropertyAccessor> copy = new ArrayList<>();
-		copy.addAll(ctx.getPropertyAccessors());
+		List<PropertyAccessor> copy = new ArrayList<>(ctx.getPropertyAccessors());
 		assertThat(ctx.removePropertyAccessor(spa)).isTrue();
 		assertThat(ctx.removePropertyAccessor(spa)).isFalse();
 		assertThat(ctx.getPropertyAccessors().size()).isEqualTo(1);

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
@@ -420,8 +420,7 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 	@Test
 	public void testSpecialVariables() throws Exception {
 		// create an array of integers
-		List<Integer> primes = new ArrayList<>();
-		primes.addAll(Arrays.asList(2,3,5,7,11,13,17));
+		List<Integer> primes = new ArrayList<>(Arrays.asList(2, 3, 5, 7, 11, 13, 17));
 
 		// create parser and set variable 'primes' as the array of integers
 		ExpressionParser parser = new SpelExpressionParser();

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
@@ -420,7 +420,7 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 	@Test
 	public void testSpecialVariables() throws Exception {
 		// create an array of integers
-		List<Integer> primes = new ArrayList<>(Arrays.asList(2, 3, 5, 7, 11, 13, 17));
+		List<Integer> primes = Arrays.asList(2, 3, 5, 7, 11, 13, 17);
 
 		// create parser and set variable 'primes' as the array of integers
 		ExpressionParser parser = new SpelExpressionParser();
@@ -517,4 +517,3 @@ public class SpelDocumentationTests extends AbstractExpressionTests {
 	}
 
 }
-

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/invocation/MethodMessageHandlerTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/invocation/MethodMessageHandlerTests.java
@@ -205,8 +205,7 @@ public class MethodMessageHandlerTests {
 
 		@Override
 		protected List<? extends HandlerMethodReturnValueHandler> initReturnValueHandlers() {
-			List<HandlerMethodReturnValueHandler> handlers = new ArrayList<>();
-			handlers.addAll(getCustomReturnValueHandlers());
+			List<HandlerMethodReturnValueHandler> handlers = new ArrayList<>(getCustomReturnValueHandlers());
 			return handlers;
 		}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/ExtendedEntityManagerCreator.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/ExtendedEntityManagerCreator.java
@@ -240,8 +240,7 @@ public abstract class ExtendedEntityManagerCreator {
 		}
 		else {
 			interfaces = cachedEntityManagerInterfaces.computeIfAbsent(rawEm.getClass(), key -> {
-				Set<Class<?>> ifcs = new LinkedHashSet<>();
-				ifcs.addAll(ClassUtils
+				Set<Class<?>> ifcs = new LinkedHashSet<>(ClassUtils
 						.getAllInterfacesForClassAsSet(key, cl));
 				ifcs.add(EntityManagerProxy.class);
 				return ClassUtils.toClassArray(ifcs);

--- a/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufDecoder.java
@@ -227,8 +227,7 @@ public class ProtobufDecoder extends ProtobufCodecSupport implements Decoder<Mes
 						this.output = input.factory().allocateBuffer(this.messageBytesToRead);
 					}
 
-					chunkBytesToRead = this.messageBytesToRead >= input.readableByteCount() ?
-							input.readableByteCount() : this.messageBytesToRead;
+					chunkBytesToRead = Math.min(this.messageBytesToRead, input.readableByteCount());
 					remainingBytesToRead = input.readableByteCount() - chunkBytesToRead;
 
 					byte[] bytesToWrite = new byte[chunkBytesToRead];

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletAnnotationControllerHandlerMethodTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletAnnotationControllerHandlerMethodTests.java
@@ -320,8 +320,7 @@ public class ServletAnnotationControllerHandlerMethodTests extends AbstractServl
 		assertThat(response.getStatus()).as("Invalid response status").isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
 		String allowHeader = response.getHeader("Allow");
 		assertThat(allowHeader).as("No Allow header").isNotNull();
-		Set<String> allowedMethods = new HashSet<>();
-		allowedMethods.addAll(Arrays.asList(StringUtils.delimitedListToStringArray(allowHeader, ", ")));
+		Set<String> allowedMethods = new HashSet<>(Arrays.asList(StringUtils.delimitedListToStringArray(allowHeader, ", ")));
 		assertThat(allowedMethods.size()).as("Invalid amount of supported methods").isEqualTo(6);
 		assertThat(allowedMethods.contains("PUT")).as("PUT not allowed").isTrue();
 		assertThat(allowedMethods.contains("DELETE")).as("DELETE not allowed").isTrue();


### PR DESCRIPTION
I find some code to refactor using analysis : 
* Redundant `Collection.addAll()` call. It may cause one time array copy.
* The code like `this.messageBytesToRead >= input.readableByteCount() ? input.readableByteCount() : this.messageBytesToRead;` may cause one more time `input.readableByteCount()` call.