### PR TITLE
Polish code by using matches() method in HttpMethod

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/SimpleBufferingClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleBufferingClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ final class SimpleBufferingClientHttpRequest extends AbstractBufferingClientHttp
 	 */
 	static void addHeaders(HttpURLConnection connection, HttpHeaders headers) {
 		String method = connection.getRequestMethod();
-		if (method.equals("PUT") || method.equals("DELETE")) {
+		if (HttpMethod.PUT.matches(method) || HttpMethod.DELETE.matches(method)) {
 			if (!StringUtils.hasText(headers.getFirst(HttpHeaders.ACCEPT))) {
 				// Avoid "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
 				// from HttpUrlConnection which prevents JSON error response details.

--- a/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,15 +208,15 @@ public class SimpleClientHttpRequestFactory implements ClientHttpRequestFactory,
 
 		connection.setDoInput(true);
 
-		if ("GET".equals(httpMethod)) {
+		if (HttpMethod.GET.matches(httpMethod)) {
 			connection.setInstanceFollowRedirects(true);
 		}
 		else {
 			connection.setInstanceFollowRedirects(false);
 		}
 
-		if ("POST".equals(httpMethod) || "PUT".equals(httpMethod) ||
-				"PATCH".equals(httpMethod) || "DELETE".equals(httpMethod)) {
+		if (HttpMethod.POST.matches(httpMethod) || HttpMethod.PUT.matches(httpMethod) ||
+				HttpMethod.PATCH.matches(httpMethod) || HttpMethod.DELETE.matches(httpMethod)) {
 			connection.setDoOutput(true);
 		}
 		else {

--- a/spring-web/src/main/java/org/springframework/remoting/caucho/HessianServiceExporter.java
+++ b/spring-web/src/main/java/org/springframework/remoting/caucho/HessianServiceExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.util.NestedServletException;
@@ -54,7 +55,7 @@ public class HessianServiceExporter extends HessianExporter implements HttpReque
 	public void handleRequest(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException {
 
-		if (!"POST".equals(request.getMethod())) {
+		if (!HttpMethod.POST.matches(request.getMethod())) {
 			throw new HttpRequestMethodNotSupportedException(request.getMethod(),
 					new String[] {"POST"}, "HessianServiceExporter only supports POST requests");
 		}

--- a/spring-web/src/main/java/org/springframework/web/filter/HiddenHttpMethodFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/HiddenHttpMethodFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class HiddenHttpMethodFilter extends OncePerRequestFilter {
 
 		HttpServletRequest requestToUse = request;
 
-		if ("POST".equals(request.getMethod()) && request.getAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE) == null) {
+		if (HttpMethod.POST.matches(request.getMethod()) && request.getAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE) == null) {
 			String paramValue = request.getParameter(this.methodParam);
 			if (StringUtils.hasLength(paramValue)) {
 				String method = paramValue.toUpperCase(Locale.ENGLISH);

--- a/spring-web/src/main/java/org/springframework/web/filter/HttpPutFormContentFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/HttpPutFormContentFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
@@ -95,7 +96,7 @@ public class HttpPutFormContentFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(final HttpServletRequest request, HttpServletResponse response,
 			FilterChain filterChain) throws ServletException, IOException {
 
-		if (("PUT".equals(request.getMethod()) || "PATCH".equals(request.getMethod())) && isFormContentType(request)) {
+		if ((HttpMethod.PUT.matches(request.getMethod()) || HttpMethod.PATCH.matches(request.getMethod())) && isFormContentType(request)) {
 			HttpInputMessage inputMessage = new ServletServerHttpRequest(request) {
 				@Override
 				public InputStream getBody() throws IOException {


### PR DESCRIPTION
I think it's safer to compare with using the matches() method than to compare with using the literal. So I changed it like this.