### PR TITLE
Fix URL to Spring Tools for Eclipse

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -74,7 +74,7 @@ In most application scenarios, explicit user code is not required to instantiate
 more instances of a Spring IoC container. For example, in a web application scenario, a
 simple eight (or so) lines of boilerplate web descriptor XML in the `web.xml` file
 of the application typically suffices (see <<context-create>>). If you use the
-https://spring.io/tools/sts[Spring Tool Suite] (an Eclipse-powered development
+https://spring.io/tools[Spring Tool Suite] (an Eclipse-powered development
 environment), you can easily create this boilerplate configuration with a few mouse clicks or
 keystrokes.
 
@@ -1481,7 +1481,7 @@ XML configuration:
 
 The preceding XML is more succinct. However, typos are discovered at runtime rather than
 design time, unless you use an IDE (such as https://www.jetbrains.com/idea/[IntelliJ
-IDEA] or the https://spring.io/tools/sts[Spring Tool Suite])
+IDEA] or the https://spring.io/tools[Spring Tool Suite])
 that supports automatic property completion when you create bean definitions. Such IDE
 assistance is highly recommended.
 
@@ -4649,7 +4649,7 @@ No matter the choice, Spring can accommodate both styles and even mix them toget
 It is worth pointing out that through its <<beans-java, JavaConfig>> option, Spring lets
 annotations be used in a non-invasive way, without touching the target components
 source code and that, in terms of tooling, all configuration styles are supported by the
-https://spring.io/tools/sts[Spring Tool Suite].
+https://spring.io/tools[Spring Tool Suite].
 ****
 
 An alternative to XML setup is provided by annotation-based configuration, which relies on
@@ -8985,7 +8985,7 @@ modularity, but determining exactly where the autowired bean definitions are dec
 still somewhat ambiguous. For example, as a developer looking at `ServiceConfig`, how do
 you know exactly where the `@Autowired AccountRepository` bean is declared? It is not
 explicit in the code, and this may be just fine. Remember that the
-https://spring.io/tools/sts[Spring Tool Suite] provides tooling that
+https://spring.io/tools[Spring Tool Suite] provides tooling that
 can render graphs showing how everything is wired, which may be all you need. Also,
 your Java IDE can easily find all declarations and uses of the `AccountRepository` type
 and quickly show you the location of `@Bean` methods that return that type.

--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -74,9 +74,8 @@ In most application scenarios, explicit user code is not required to instantiate
 more instances of a Spring IoC container. For example, in a web application scenario, a
 simple eight (or so) lines of boilerplate web descriptor XML in the `web.xml` file
 of the application typically suffices (see <<context-create>>). If you use the
-https://spring.io/tools[Spring Tool Suite] (an Eclipse-powered development
-environment), you can easily create this boilerplate configuration with a few mouse clicks or
-keystrokes.
+https://spring.io/tools[Spring Tool], you can easily create
+this boilerplate configuration with a few mouse clicks or keystrokes.
 
 The following diagram shows a high-level view of how Spring works. Your application classes
 are combined with configuration metadata so that, after the `ApplicationContext` is
@@ -1481,7 +1480,7 @@ XML configuration:
 
 The preceding XML is more succinct. However, typos are discovered at runtime rather than
 design time, unless you use an IDE (such as https://www.jetbrains.com/idea/[IntelliJ
-IDEA] or the https://spring.io/tools[Spring Tool Suite])
+IDEA] or the https://spring.io/tools[Spring Tool])
 that supports automatic property completion when you create bean definitions. Such IDE
 assistance is highly recommended.
 
@@ -4649,7 +4648,7 @@ No matter the choice, Spring can accommodate both styles and even mix them toget
 It is worth pointing out that through its <<beans-java, JavaConfig>> option, Spring lets
 annotations be used in a non-invasive way, without touching the target components
 source code and that, in terms of tooling, all configuration styles are supported by the
-https://spring.io/tools[Spring Tool Suite].
+https://spring.io/tools[Spring Tool].
 ****
 
 An alternative to XML setup is provided by annotation-based configuration, which relies on
@@ -8985,7 +8984,7 @@ modularity, but determining exactly where the autowired bean definitions are dec
 still somewhat ambiguous. For example, as a developer looking at `ServiceConfig`, how do
 you know exactly where the `@Autowired AccountRepository` bean is declared? It is not
 explicit in the code, and this may be just fine. Remember that the
-https://spring.io/tools[Spring Tool Suite] provides tooling that
+https://spring.io/tools[Spring Tool] provides tooling that
 can render graphs showing how everything is wired, which may be all you need. Also,
 your Java IDE can easily find all declarations and uses of the `AccountRepository` type
 and quickly show you the location of `@Bean` methods that return that type.

--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -74,7 +74,7 @@ In most application scenarios, explicit user code is not required to instantiate
 more instances of a Spring IoC container. For example, in a web application scenario, a
 simple eight (or so) lines of boilerplate web descriptor XML in the `web.xml` file
 of the application typically suffices (see <<context-create>>). If you use the
-https://spring.io/tools[Spring Tool], you can easily create
+https://spring.io/tools[Spring Tools 4], you can easily create
 this boilerplate configuration with a few mouse clicks or keystrokes.
 
 The following diagram shows a high-level view of how Spring works. Your application classes
@@ -1480,7 +1480,7 @@ XML configuration:
 
 The preceding XML is more succinct. However, typos are discovered at runtime rather than
 design time, unless you use an IDE (such as https://www.jetbrains.com/idea/[IntelliJ
-IDEA] or the https://spring.io/tools[Spring Tool])
+IDEA] or the https://spring.io/tools[Spring Tools 4])
 that supports automatic property completion when you create bean definitions. Such IDE
 assistance is highly recommended.
 
@@ -4648,7 +4648,7 @@ No matter the choice, Spring can accommodate both styles and even mix them toget
 It is worth pointing out that through its <<beans-java, JavaConfig>> option, Spring lets
 annotations be used in a non-invasive way, without touching the target components
 source code and that, in terms of tooling, all configuration styles are supported by the
-https://spring.io/tools[Spring Tool].
+https://spring.io/tools[Spring Tools 4].
 ****
 
 An alternative to XML setup is provided by annotation-based configuration, which relies on
@@ -8984,7 +8984,7 @@ modularity, but determining exactly where the autowired bean definitions are dec
 still somewhat ambiguous. For example, as a developer looking at `ServiceConfig`, how do
 you know exactly where the `@Autowired AccountRepository` bean is declared? It is not
 explicit in the code, and this may be just fine. Remember that the
-https://spring.io/tools[Spring Tool] provides tooling that
+https://spring.io/tools[Spring Tools 4] provides tooling that
 can render graphs showing how everything is wired, which may be all you need. Also,
 your Java IDE can easily find all declarations and uses of the `AccountRepository` type
 and quickly show you the location of `@Bean` methods that return that type.


### PR DESCRIPTION
The page of the url of Spring Tool Suite is 404.
I found that deleting the last string of "/sts", page can reach the Spring Tool Suite page