### PR TITLE
Add missing field to MethodParameter copy constructor

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/MethodParameter.java
+++ b/spring-core/src/main/java/org/springframework/core/MethodParameter.java
@@ -185,6 +185,7 @@ public class MethodParameter {
 		this.parameterAnnotations = original.parameterAnnotations;
 		this.parameterNameDiscoverer = original.parameterNameDiscoverer;
 		this.parameterName = original.parameterName;
+		this.nestedMethodParameter = original.nestedMethodParameter;
 	}
 
 

--- a/spring-core/src/test/java/org/springframework/core/MethodParameterTests.java
+++ b/spring-core/src/test/java/org/springframework/core/MethodParameterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,6 +235,16 @@ class MethodParameterTests {
 		assertThat(m1.getTypeIndexForCurrentLevel()).isNull();
 		assertThat(m2.getTypeIndexForCurrentLevel()).isEqualTo(2);
 		assertThat(m3.getTypeIndexForCurrentLevel()).isEqualTo(3);
+	}
+
+	@Test
+	void cloneShouldKeepNestedMethodParameter() throws Exception {
+		Method method = ArrayList.class.getMethod("get", int.class);
+		MethodParameter m1 = MethodParameter.forExecutable(method, -1);
+		MethodParameter m2 = m1.nested();
+		MethodParameter m3 = m1.clone();
+		MethodParameter m4 = m3.nested();
+		assertThat(m2).isSameAs(m4);
 	}
 
 	public int method(String p1, long p2) {


### PR DESCRIPTION
Hi,

I just noticed that the `MethodParameter` copy constructor misses to copy its `nestedMethodParameter` field.

Cheers,
Christoph