### PR TITLE
Remove UTF-8 charset parameter from Content-Type in SseEmitter

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
@@ -41,9 +41,6 @@ public class SseEmitter extends ResponseBodyEmitter {
 
 	static final MediaType TEXT_PLAIN = new MediaType("text", "plain", StandardCharsets.UTF_8);
 
-	static final MediaType TEXT_EVENTSTREAM = new MediaType("text", "event-stream", StandardCharsets.UTF_8);
-
-
 	/**
 	 * Create a new SseEmitter instance.
 	 */
@@ -70,7 +67,7 @@ public class SseEmitter extends ResponseBodyEmitter {
 
 		HttpHeaders headers = outputMessage.getHeaders();
 		if (headers.getContentType() == null) {
-			headers.setContentType(TEXT_EVENTSTREAM);
+			headers.setContentType(MediaType.TEXT_EVENT_STREAM);
 		}
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterReturnValueHandlerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitterReturnValueHandlerTests.java
@@ -211,7 +211,7 @@ public class ResponseBodyEmitterReturnValueHandlerTests {
 		emitter.send(SseEmitter.event().
 				comment("a test").name("update").id("1").reconnectTime(5000L).data(bean1).data(bean2));
 
-		assertThat(this.response.getContentType()).isEqualTo("text/event-stream;charset=UTF-8");
+		assertThat(this.response.getContentType()).isEqualTo("text/event-stream");
 		assertThat(this.response.getContentAsString()).isEqualTo((":a test\n" +
 						"event:update\n" +
 						"id:1\n" +
@@ -238,7 +238,7 @@ public class ResponseBodyEmitterReturnValueHandlerTests {
 		processor.onNext("baz");
 		processor.onComplete();
 
-		assertThat(this.response.getContentType()).isEqualTo("text/event-stream;charset=UTF-8");
+		assertThat(this.response.getContentType()).isEqualTo("text/event-stream");
 		assertThat(this.response.getContentAsString()).isEqualTo("data:foo\n\ndata:bar\n\ndata:baz\n\n");
 	}
 
@@ -272,7 +272,7 @@ public class ResponseBodyEmitterReturnValueHandlerTests {
 
 		assertThat(this.request.isAsyncStarted()).isTrue();
 		assertThat(this.response.getStatus()).isEqualTo(200);
-		assertThat(this.response.getContentType()).isEqualTo("text/event-stream;charset=UTF-8");
+		assertThat(this.response.getContentType()).isEqualTo("text/event-stream");
 		assertThat(this.response.getHeader("foo")).isEqualTo("bar");
 	}
 


### PR DESCRIPTION
SseEmitter is adding header "Content-type:text/event-stream;charset=UTF-8".
Golang revproxy is expecting header "Content-Type: text/event-stream" for
immediately flushing the event stream.

HTML standard says [ https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model ]
ignore the MIME type param and the data is always expected in utf-8.

https://github.com/golang/go/blob/master/src/net/http/httputil/reverseproxy.go#L374