### PR TITLE
Add a unit test for getMostSpecificMethod of ClassUtils

### DIFF
--- a/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
@@ -437,10 +437,7 @@ class ClassUtilsTests {
 				.isEqualTo(packageAccessiblePrintMethod);
 		assertThat(ClassUtils.getMostSpecificMethod(packageAccessiblePrintMethod, SubMethodsInterfaceImplementation.class))
 				.isEqualTo(ClassUtils.getMethod(SubMethodsInterfaceImplementation.class, "packageAccessiblePrint"));
-
-
-
-
+		
 	}
 
 	@ParameterizedTest

--- a/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
@@ -413,6 +413,35 @@ class ClassUtilsTests {
 		assertThat(ClassUtils.determineCommonAncestor(String.class, List.class)).isNull();
 	}
 
+	@Test
+	void getMostSpecificMethod() throws NoSuchMethodException {
+		Method defaultPrintMethod = ClassUtils.getMethod(MethodsInterface.class, "defaultPrint");
+		assertThat(ClassUtils.getMostSpecificMethod(defaultPrintMethod, MethodsInterfaceImplementation.class)).isEqualTo(defaultPrintMethod);
+		assertThat(ClassUtils.getMostSpecificMethod(defaultPrintMethod, SubMethodsInterfaceImplementation.class)).isEqualTo(defaultPrintMethod);
+
+		Method printMethod = ClassUtils.getMethod(MethodsInterface.class, "print", String.class);
+		assertThat(ClassUtils.getMostSpecificMethod(printMethod, MethodsInterfaceImplementation.class)).isNotEqualTo(printMethod);
+		assertThat(ClassUtils.getMostSpecificMethod(printMethod, MethodsInterfaceImplementation.class))
+				.isEqualTo(ClassUtils.getMethod(MethodsInterfaceImplementation.class, "print", String.class));
+		assertThat(ClassUtils.getMostSpecificMethod(printMethod, SubMethodsInterfaceImplementation.class))
+				.isEqualTo(ClassUtils.getMethod(MethodsInterfaceImplementation.class, "print", String.class));
+
+		Method protectedPrintMethod = MethodsInterfaceImplementation.class.getDeclaredMethod("protectedPrint");
+		assertThat(ClassUtils.getMostSpecificMethod(protectedPrintMethod, MethodsInterfaceImplementation.class)).isEqualTo(protectedPrintMethod);
+		assertThat(ClassUtils.getMostSpecificMethod(protectedPrintMethod, SubMethodsInterfaceImplementation.class))
+				.isEqualTo(SubMethodsInterfaceImplementation.class.getDeclaredMethod("protectedPrint"));
+
+
+		Method packageAccessiblePrint = MethodsInterfaceImplementation.class.getDeclaredMethod("packageAccessiblePrint");
+		assertThat(ClassUtils.getMostSpecificMethod(packageAccessiblePrint, MethodsInterfaceImplementation.class)).isEqualTo(packageAccessiblePrint);
+		assertThat(ClassUtils.getMostSpecificMethod(packageAccessiblePrint, SubMethodsInterfaceImplementation.class))
+				.isEqualTo(ClassUtils.getMethod(SubMethodsInterfaceImplementation.class, "packageAccessiblePrint"));
+
+
+
+
+	}
+
 	@ParameterizedTest
 	@WrapperTypes
 	void isPrimitiveWrapper(Class<?> type) {
@@ -487,6 +516,46 @@ class ClassUtilsTests {
 		void print(String header, String[] messages, String footer) {
 			/* no-op */
 		}
+	}
+
+	@SuppressWarnings("unused")
+	private interface MethodsInterface{
+
+		default void defaultPrint(){
+
+		}
+		void print(String messages);
+	}
+
+	@SuppressWarnings("unused")
+	private class MethodsInterfaceImplementation implements MethodsInterface{
+
+		@Override
+		public void print(String message) {
+
+		}
+
+		protected void protectedPrint(){
+
+		}
+
+		void packageAccessiblePrint(){
+
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private class SubMethodsInterfaceImplementation extends MethodsInterfaceImplementation{
+
+		@Override
+		protected void protectedPrint(){
+
+		}
+
+		public void packageAccessiblePrint(){
+
+		}
+
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
@@ -432,9 +432,10 @@ class ClassUtilsTests {
 				.isEqualTo(SubMethodsInterfaceImplementation.class.getDeclaredMethod("protectedPrint"));
 
 
-		Method packageAccessiblePrint = MethodsInterfaceImplementation.class.getDeclaredMethod("packageAccessiblePrint");
-		assertThat(ClassUtils.getMostSpecificMethod(packageAccessiblePrint, MethodsInterfaceImplementation.class)).isEqualTo(packageAccessiblePrint);
-		assertThat(ClassUtils.getMostSpecificMethod(packageAccessiblePrint, SubMethodsInterfaceImplementation.class))
+		Method packageAccessiblePrintMethod = MethodsInterfaceImplementation.class.getDeclaredMethod("packageAccessiblePrint");
+		assertThat(ClassUtils.getMostSpecificMethod(packageAccessiblePrintMethod, MethodsInterfaceImplementation.class))
+				.isEqualTo(packageAccessiblePrintMethod);
+		assertThat(ClassUtils.getMostSpecificMethod(packageAccessiblePrintMethod, SubMethodsInterfaceImplementation.class))
 				.isEqualTo(ClassUtils.getMethod(SubMethodsInterfaceImplementation.class, "packageAccessiblePrint"));
 
 

--- a/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
@@ -437,7 +437,6 @@ class ClassUtilsTests {
 				.isEqualTo(packageAccessiblePrintMethod);
 		assertThat(ClassUtils.getMostSpecificMethod(packageAccessiblePrintMethod, SubMethodsInterfaceImplementation.class))
 				.isEqualTo(ClassUtils.getMethod(SubMethodsInterfaceImplementation.class, "packageAccessiblePrint"));
-		
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
The method `getMostSpecificMethod` of `ClassUtils` does not seem to be covered by unit test.
Consider adding a unit test method for this method.
Test this method from multiple latitudes of inheritance, method modifiers, implementation, etc.
Looking forward to your reply.
