### PR TITLE
Response body available in both message and exception

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
@@ -102,12 +102,12 @@ public class DefaultResponseErrorHandler implements ResponseErrorHandler {
 	public void handleError(ClientHttpResponse response) throws IOException {
 		HttpStatus statusCode = HttpStatus.resolve(response.getRawStatusCode());
 		if (statusCode == null) {
+			byte[] body = getResponseBody(response);
 			String message = getErrorMessage(
-					response.getRawStatusCode(), response.getStatusText(),
-					getResponseBody(response), getCharset(response));
+					response.getRawStatusCode(), response.getStatusText(), body, getCharset(response));
 			throw new UnknownHttpStatusCodeException(message,
 					response.getRawStatusCode(), response.getStatusText(),
-					response.getHeaders(), getResponseBody(response), getCharset(response));
+					response.getHeaders(), body, getCharset(response));
 		}
 		handleError(response, statusCode);
 	}

--- a/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerTests.java
@@ -96,6 +96,21 @@ public class DefaultResponseErrorHandlerTests {
 	}
 
 	@Test
+	public void unknownErrorCodeBothExceptionShouldContainBodyAndMessageShouldReturnBody() throws Exception {
+		String body = "Spring rocks";
+
+		given(response.getRawStatusCode()).willReturn(432);
+		given(response.getStatusText()).willReturn("Unknown status code");
+		given(response.getHeaders()).willReturn(new HttpHeaders());
+		given(response.getBody()).willReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+
+		assertThatExceptionOfType(UnknownHttpStatusCodeException.class)
+				.isThrownBy(() -> handler.handleError(response))
+				.satisfies(ex -> assertThat(ex.getMessage()).isEqualTo("432 Unknown status code: [" + body + "]"))
+				.satisfies(ex -> assertThat(ex.getResponseBodyAsString()).isEqualTo(body));
+	}
+
+	@Test
 	public void handleErrorIOException() throws Exception {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.TEXT_PLAIN);


### PR DESCRIPTION
**Observation**

When the status code is unknown a message will be constructed but the thrown exception does not contain the body anymore.

**Wanted behavior**

The `UnknownHttpStatusCodeException.getResponseBodyAsString()` returns the body and does not return `""`

**Fix**

Same as the method `protected void handleError(ClientHttpResponse response, HttpStatus statusCode)` assign the body to a local variable and use it in the message and pass that one to the constructor of the `UnknownHttpStatusCodeException`