### PR TITLE
containsAny in CollectionUtils delegates to findFirstMatch

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
@@ -181,15 +181,7 @@ public abstract class CollectionUtils {
 	 * @return whether any of the candidates has been found
 	 */
 	public static boolean containsAny(Collection<?> source, Collection<?> candidates) {
-		if (isEmpty(source) || isEmpty(candidates)) {
-			return false;
-		}
-		for (Object candidate : candidates) {
-			if (source.contains(candidate)) {
-				return true;
-			}
-		}
-		return false;
+		return findFirstMatch(source, candidates) != null;
 	}
 
 	/**


### PR DESCRIPTION
This method implementation named `containsAny` is redundant with that method implementation named `findFirstMatch`.
Consider reuse `findFirstMatch` to optimize `containsAny` implementation.