### PR TITLE
Fix meta-annotations: @Timed and @Repeat

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/annotation/Repeat.java
+++ b/spring-test/src/main/java/org/springframework/test/annotation/Repeat.java
@@ -21,6 +21,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 /**
  * Test annotation for use with JUnit 4 to indicate that a test method should be
@@ -44,6 +45,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 public @interface Repeat {
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/annotation/Timed.java
+++ b/spring-test/src/main/java/org/springframework/test/annotation/Timed.java
@@ -21,6 +21,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 /**
  * Test annotation for use with JUnit 4 to indicate that a test method has to finish
@@ -47,6 +48,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 public @interface Timed {
 
 	/**


### PR DESCRIPTION
The javadoc of the annotations `@Timed` & `@Repeat` says: "This annotation may be used as a meta-annotation to create custom composed annotations."

The `@Inherited` annotation is missing in the definitions of both annotation. We should add the `@Inherited` annotation to make them meta-annotations or update the javadoc.

// Steps to reproduce the problem:

```
@Timed(millis = 5000L)
@Retention(RUNTIME)
@Target(TYPE)
@interface MetaAnnotation {}

@MetaAnnotation
class TargetClass {
}

Timed timed = TargetClass.class.getAnnotation(Timed.class);
// timed is null
```