### PR TITLE
Introduce getContentAsString and getContentAsByteArray to Resource

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/AbstractFileResolvingResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/AbstractFileResolvingResource.java
@@ -323,7 +323,7 @@ public abstract class AbstractFileResolvingResource extends AbstractResource {
 	}
 
 	@Override
-	public String getContentAsString(Charset encoding) throws IOException {
+	public String getContentAsString(Charset charset) throws IOException {
 
 		if( !exists() ) {
 			throw new FileNotFoundException(getDescription() + " cannot be found.");
@@ -331,7 +331,7 @@ public abstract class AbstractFileResolvingResource extends AbstractResource {
 		if ( !isReadable() ) {
 			throw new IOException(getDescription() + " cannot be opened for reading.");
 		}
-		return new String(Files.readAllBytes(Paths.get(getFile().getAbsolutePath())), encoding);
+		return new String(Files.readAllBytes(Paths.get(getFile().getAbsolutePath())), charset);
 
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/io/AbstractFileResolvingResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/AbstractFileResolvingResource.java
@@ -25,7 +25,10 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 
 import org.springframework.util.ResourceUtils;
@@ -298,6 +301,39 @@ public abstract class AbstractFileResolvingResource extends AbstractResource {
 		con.setRequestMethod("HEAD");
 	}
 
+	/**
+	 * This implementation returns the contents of a file as a string using the
+	 * system default Charset. Provided the resource exists and the context has
+	 * access to it, the contents will be returned as a single string with line
+	 * feed characters retained.
+	 * @return the contents of the requested file as a {@code String}.
+	 * @throws FileNotFoundException in the event the file path is invalid.
+	 * @throws IOException if the file can not be read or cannot be serialzied.
+	 */
+	@Override
+	public String getContentAsString() throws IOException {
+
+		if( !exists() ) {
+			throw new FileNotFoundException(getDescription() + " cannot be found.");
+		}
+		if ( !isReadable() ) {
+			throw new IOException(getDescription() + " cannot be opened for reading.");
+		}
+		return new String(Files.readAllBytes(Paths.get(getFile().getAbsolutePath())), Charset.defaultCharset());
+	}
+
+	@Override
+	public String getContentAsString(Charset encoding) throws IOException {
+
+		if( !exists() ) {
+			throw new FileNotFoundException(getDescription() + " cannot be found.");
+		}
+		if ( !isReadable() ) {
+			throw new IOException(getDescription() + " cannot be opened for reading.");
+		}
+		return new String(Files.readAllBytes(Paths.get(getFile().getAbsolutePath())), encoding);
+
+	}
 
 	/**
 	 * Inner delegate class, avoiding a hard JBoss VFS API dependency at runtime.

--- a/spring-core/src/main/java/org/springframework/core/io/Resource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/Resource.java
@@ -204,13 +204,13 @@ public interface Resource extends InputStreamSource {
 	/**
 	 * Returns the contents of a file as a string using the specified Charset.
 	 * <p>The default implementation returns a {@link Object#toString()} representation of the resource.
-	 * @param encoding the {@code Charset} to use to deserialize the content. Defaults to system default.
+	 * @param charset the {@code Charset} to use to deserialize the content. Defaults to system default.
 	 * @return the contents of the requested file as a {@code String}.
 	 * @throws FileNotFoundException in the event the file path is invalid.
 	 * @throws IOException if the file can not be read or cannot be accessed.
 	 * @since 5.2.5
 	 */
-	default String getContentAsString(Charset encoding) throws IOException{
+	default String getContentAsString(Charset charset) throws IOException{
 		return toString();
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/io/Resource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/Resource.java
@@ -17,12 +17,14 @@
 package org.springframework.core.io;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.Charset;
 
 import org.springframework.lang.Nullable;
 
@@ -174,5 +176,42 @@ public interface Resource extends InputStreamSource {
 	 * @see Object#toString()
 	 */
 	String getDescription();
+
+	/**
+	 * Return a {@link ReadableByteChannel}.
+	 * <p>It is expected that each call creates a <i>fresh</i> channel.
+	 * <p>The default implementation returns {@link Channels#newChannel(InputStream)}
+	 * with the result of {@link #getInputStream()}.
+	 * @return the byte channel for the underlying resource (must not be {@code null})
+	 * @throws java.io.FileNotFoundException if the underlying resource doesn't exist
+	 * @throws IOException if the content channel could not be opened
+	 * @since 5.0
+	 * @see #getInputStream()
+	 */
+
+	/**
+	 * Returns the contents of a file as a string using the system default Charset.
+	 * <p>The default implementation returns a {@link Object#toString()} representation of the resource.
+	 * @return the contents of the requested file as a {@code String}.
+	 * @throws FileNotFoundException in the event the file path is invalid.
+	 * @throws IOException if the file can not be read or cannot be accessed.
+	 * @since 5.2.5
+	 */
+	default String getContentAsString() throws IOException{
+		return toString();
+	}
+
+	/**
+	 * Returns the contents of a file as a string using the specified Charset.
+	 * <p>The default implementation returns a {@link Object#toString()} representation of the resource.
+	 * @param encoding the {@code Charset} to use to deserialize the content. Defaults to system default.
+	 * @return the contents of the requested file as a {@code String}.
+	 * @throws FileNotFoundException in the event the file path is invalid.
+	 * @throws IOException if the file can not be read or cannot be accessed.
+	 * @since 5.2.5
+	 */
+	default String getContentAsString(Charset encoding) throws IOException{
+		return toString();
+	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/io/ResourceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/ResourceTests.java
@@ -337,4 +337,25 @@ class ResourceTests {
 				new ClassPathResource("Resource.class", getClass()).createRelative("X").readableChannel());
 	}
 
+	@Test
+	void getContentAsString_givenValidFile_ShouldReturnFileContent() throws IOException {
+		String expectedString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+				+ "<!DOCTYPE properties SYSTEM \"http://java.sun.com/dtd/properties.dtd\">\n"
+				+ "<properties version=\"1.0\">\n"
+				+ "\t<entry key=\"foo\">bar</entry>\n"
+				+ "</properties>";
+
+		String fileDirString =
+				new ClassPathResource("org/springframework/core/io/example.xml").getContentAsString();
+		assertThat(fileDirString).isNotBlank();
+		assertThat(fileDirString).isEqualTo(expectedString);
+	}
+
+	@Test
+	void getContentAsString_givenAnInvalidFile_ShouldThrowFileNotFoundException(){
+		assertThatExceptionOfType(FileNotFoundException.class)
+				.isThrownBy(new ClassPathResource("nonExistantFile")::getContentAsString);
+
+	}
+
 }

--- a/spring-core/src/test/resources/org/springframework/core/io/example.xml
+++ b/spring-core/src/test/resources/org/springframework/core/io/example.xml
@@ -3,4 +3,3 @@
 <properties version="1.0">
 	<entry key="foo">bar</entry>
 </properties>
-


### PR DESCRIPTION
Projects that use java heavily rely on a clunky, verbose, and error prone method to access Resources for tests. 

Adding the ability to request a file's contents as a string for testing REST or WEBMVC allows for cleaner test classes and more readable code.