### PR TITLE
Fix common HashMap initial capacity issue in HttpMethod

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -16,9 +16,8 @@
 
 package org.springframework.http;
 
-import java.util.HashMap;
 import java.util.Map;
-
+import com.google.common.collect.Maps;
 import org.springframework.lang.Nullable;
 
 /**
@@ -35,7 +34,7 @@ public enum HttpMethod {
 	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE;
 
 
-	private static final Map<String, HttpMethod> mappings = new HashMap<>(16);
+	private static final Map<String, HttpMethod> mappings = Maps.newHashMapWithExpectedSize(16);
 
 	static {
 		for (HttpMethod httpMethod : values()) {


### PR DESCRIPTION
It is a common error to specify HashMap's initial capacity as expected size. It doesn't take `load factor` into consideration, which is never 1.0.
Fixed the issue in HttpMethod via the util method from guava library.