### PR TITLE
Fix ampersands in AOP examples in documentation

### DIFF
--- a/src/docs/asciidoc/core/core-aop.adoc
+++ b/src/docs/asciidoc/core/core-aop.adoc
@@ -2069,7 +2069,7 @@ collects the `this` object as the join point context and passes it to the advice
 		<aop:aspect id="myAspect" ref="aBean">
 
 			<aop:pointcut id="businessService"
-				expression="execution(* com.xyz.myapp.service.*.*(..)) &amp;&amp; this(service)"/>
+				expression="execution(* com.xyz.myapp.service.*.*(..)) && this(service)"/>
 
 			<aop:before pointcut-ref="businessService" method="monitor"/>
 


### PR DESCRIPTION
The documentation contains incorrect code sample with ampersands `&amp;&amp;` instead of `&&`

```java
<aop:config>
    <aop:aspect id="myAspect" ref="aBean">
        <aop:pointcut id="businessService"
            expression="execution(* com.xyz.myapp.service.*.*(..)) &amp;&amp;
        this(service)"/>
        <aop:before pointcut-ref="businessService" method="monitor"/>
        ...
    </aop:aspect>
</aop:config>
```

But correct form should be as follows:

```java
<aop:config>
    <aop:aspect id="myAspect" ref="aBean">
        <aop:pointcut id="businessService"
            expression="execution(* com.xyz.myapp.service.*.*(..)) &&
        this(service)"/>
        <aop:before pointcut-ref="businessService" method="monitor"/>
        ...
    </aop:aspect>
</aop:config>
```