### PR TITLE
Cache the default logger for recovery in FailFastProblemReporter

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/parsing/FailFastProblemReporter.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/parsing/FailFastProblemReporter.java
@@ -38,7 +38,9 @@ import org.springframework.lang.Nullable;
  */
 public class FailFastProblemReporter implements ProblemReporter {
 
-	private Log logger = LogFactory.getLog(getClass());
+	private final Log defaultLogger = LogFactory.getLog(getClass());
+
+	private Log logger = this.defaultLogger;
 
 
 	/**
@@ -48,7 +50,7 @@ public class FailFastProblemReporter implements ProblemReporter {
 	 * @param logger the {@link Log logger} that is to be used to report warnings
 	 */
 	public void setLogger(@Nullable Log logger) {
-		this.logger = (logger != null ? logger : LogFactory.getLog(getClass()));
+		this.logger = (logger != null ? logger : this.defaultLogger);
 	}
 
 


### PR DESCRIPTION
I feel that the default logger can be cached here.
If we do this, we can avoid duplicate logger creation, when calling setLogger with a null parameter.
