### PR TITLE
use StringBuilder instead of StringBuffer in ReflectUtils#getClass

### DIFF
--- a/spring-core/src/main/java/org/springframework/cglib/core/ReflectUtils.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/ReflectUtils.java
@@ -260,7 +260,7 @@ public class ReflectUtils {
 		while ((index = className.indexOf("[]", index) + 1) > 0) {
 			dimensions++;
 		}
-		StringBuffer brackets = new StringBuffer(className.length() - dimensions);
+		StringBuilder brackets = new StringBuilder(className.length() - dimensions);
 		for (int i = 0; i < dimensions; i++) {
 			brackets.append('[');
 		}


### PR DESCRIPTION
It could use StringBuilder instead of StringBuffer in ```ReflectUtils#getClass```