### PR TITLE
Optimize global advisor registration in ProxyFactoryBean

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactoryBean.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactoryBean.java
@@ -48,6 +48,7 @@ import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -522,8 +523,13 @@ public class ProxyFactoryBean extends ProxyCreatorSupport
 				BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, Advisor.class);
 		String[] globalInterceptorNames =
 				BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, Interceptor.class);
-		List<Object> beans = new ArrayList<>(globalAdvisorNames.length + globalInterceptorNames.length);
-		Map<Object, String> names = new HashMap<>(beans.size());
+		if(ObjectUtils.isEmpty(globalAdvisorNames) && ObjectUtils.isEmpty(globalInterceptorNames)){
+			return;
+		}
+		int expectedSize = globalAdvisorNames.length + globalInterceptorNames.length;
+		List<Object> beans = new ArrayList<>(expectedSize);
+		int initialCapacity = (int) ((float) expectedSize / 0.75F + 1.0F);
+		Map<Object, String> names = new HashMap<>(initialCapacity);
 		for (String name : globalAdvisorNames) {
 			Object bean = beanFactory.getBean(name);
 			beans.add(bean);

--- a/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactoryBean.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/ProxyFactoryBean.java
@@ -48,7 +48,6 @@ import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
 /**


### PR DESCRIPTION
In the source code, `Map<Object, String> names = new HashMap<>(beans.size());`, `beans.size()` actually equal `0`. This problem will cause the hashMap to resize multiple times in subsequent `put` operations. This operation of resize is expensive when the expected size is large. So, I think we can set a suitable `initialCapacity` value to `names`  of  `HashMap` type, doing this prevents `resize`.


