### PR TITLE
Fix execution order of @AfterReturning and @After methods in ReflectiveAspectJAdvisorFactory

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/ReflectiveAspectJAdvisorFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/ReflectiveAspectJAdvisorFactory.java
@@ -74,7 +74,7 @@ public class ReflectiveAspectJAdvisorFactory extends AbstractAspectJAdvisorFacto
 	static {
 		Comparator<Method> adviceKindComparator = new ConvertingComparator<>(
 				new InstanceComparator<>(
-						Around.class, Before.class, After.class, AfterReturning.class, AfterThrowing.class),
+						Around.class, Before.class, AfterReturning.class, AfterThrowing.class, After.class),
 				(Converter<Method, Annotation>) method -> {
 					AspectJAnnotation<?> annotation =
 						AbstractAspectJAdvisorFactory.findAspectJAnnotationOnMethod(method);


### PR DESCRIPTION
When using the `@AfterReturning` and `@After` to implement AOP function, the program always  call the method annotated by `@After` before the method annotated by `@AfterReturning`. It's opposite to the normal execution order of AOP function implemented by the XML.

By tracing and debugging, I found the reason is that the annotated methods is sorted by a wrong comparator which was not constructed correctly in the process of parsing annotations. Finally, the problem was fixed by adjusting the order of parameters (annotation classes) when the comparator be constructed. It was be verified after repair and compilation. So, I created this commit . If I misunderstand something, please tell me. thanks !
