### PR TITLE
Improve performance of StringUtils#cleanPath

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -701,6 +701,10 @@ public abstract class StringUtils {
 			}
 		}
 
+		// All path elements stayed the same - shortcut
+		if (pathArray.length == pathElements.size()) {
+			return prefix + pathToUse;
+		}
 		// Remaining top paths need to be retained.
 		for (int i = 0; i < tops; i++) {
 			pathElements.add(0, TOP_PATH);

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -388,6 +388,7 @@ class StringUtilsTests {
 		assertThat(StringUtils.cleanPath("file:../")).isEqualTo("file:../");
 		assertThat(StringUtils.cleanPath("file:./../")).isEqualTo("file:../");
 		assertThat(StringUtils.cleanPath("file:.././")).isEqualTo("file:../");
+		assertThat(StringUtils.cleanPath("file:/mypath/spring.factories")).isEqualTo("file:/mypath/spring.factories");
 		assertThat(StringUtils.cleanPath("file:///c:/some/../path/the%20file.txt")).isEqualTo("file:///c:/path/the%20file.txt");
 	}
 


### PR DESCRIPTION
Hi,

I noticed an optimization opportunity in `StringUtils#cleanPath` while profiling one of our apps. I noticed that a lot of times, strings like `file:/Users/christoph.dreis/project/xyz/build/resources/main/META-INF/spring.factories` or similar absolute file paths are passed. E.g. in `ClassPathResource` (which is called 100.000 times in the mentioned app). For those strings we can shortcut a bit earlier and save the overhead from `collectionToDelimitedString`.

```
Benchmark                                          Mode  Cnt     Score     Error   Units
MyBenchmark.testNew                               thrpt   10  2188,511 ±  64,208  ops/ms
MyBenchmark.testNew:·gc.alloc.rate                thrpt   10  2561,819 ±  75,078  MB/sec
MyBenchmark.testNew:·gc.alloc.rate.norm           thrpt   10  1536,000 ±   0,001    B/op
MyBenchmark.testNew:·gc.churn.G1_Eden_Space       thrpt   10  2558,410 ± 141,016  MB/sec
MyBenchmark.testNew:·gc.churn.G1_Eden_Space.norm  thrpt   10  1533,735 ±  57,896    B/op
MyBenchmark.testNew:·gc.churn.G1_Old_Gen          thrpt   10     0,002 ±   0,001  MB/sec
MyBenchmark.testNew:·gc.churn.G1_Old_Gen.norm     thrpt   10     0,001 ±   0,001    B/op
MyBenchmark.testNew:·gc.count                     thrpt   10   145,000            counts
MyBenchmark.testNew:·gc.time                      thrpt   10    84,000                ms
MyBenchmark.testOld                               thrpt   10  1345,572 ±  52,746  ops/ms
MyBenchmark.testOld:·gc.alloc.rate                thrpt   10  2264,133 ±  88,387  MB/sec
MyBenchmark.testOld:·gc.alloc.rate.norm           thrpt   10  2208,000 ±   0,001    B/op
MyBenchmark.testOld:·gc.churn.G1_Eden_Space       thrpt   10  2263,917 ± 116,378  MB/sec
MyBenchmark.testOld:·gc.churn.G1_Eden_Space.norm  thrpt   10  2208,212 ± 102,736    B/op
MyBenchmark.testOld:·gc.churn.G1_Old_Gen          thrpt   10     0,003 ±   0,005  MB/sec
MyBenchmark.testOld:·gc.churn.G1_Old_Gen.norm     thrpt   10     0,003 ±   0,005    B/op
MyBenchmark.testOld:·gc.count                     thrpt   10   158,000            counts
MyBenchmark.testOld:·gc.time                      thrpt   10    85,000                ms
```

Let me know what you think.
Cheers,
Christoph