### PR TITLE
Fix missing response body in UnknownHttpStatusCodeException instances

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
@@ -102,12 +102,13 @@ public class DefaultResponseErrorHandler implements ResponseErrorHandler {
 	public void handleError(ClientHttpResponse response) throws IOException {
 		HttpStatus statusCode = HttpStatus.resolve(response.getRawStatusCode());
 		if (statusCode == null) {
+			byte[] responseBody = getResponseBody(response);
 			String message = getErrorMessage(
 					response.getRawStatusCode(), response.getStatusText(),
-					getResponseBody(response), getCharset(response));
+					responseBody, getCharset(response));
 			throw new UnknownHttpStatusCodeException(message,
 					response.getRawStatusCode(), response.getStatusText(),
-					response.getHeaders(), getResponseBody(response), getCharset(response));
+					response.getHeaders(), responseBody, getCharset(response));
 		}
 		handleError(response, statusCode);
 	}


### PR DESCRIPTION
This bug surfaced during spring-boot 2.1 -> 2.2 migration.