### PR TITLE
Improve javadoc in RollbackRuleAttribute regarding nested classes

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/RollbackRuleAttribute.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/RollbackRuleAttribute.java
@@ -54,7 +54,7 @@ public class RollbackRuleAttribute implements Serializable{
 	/**
 	 * Create a new instance of the {@code RollbackRuleAttribute} class.
 	 * <p>This is the preferred way to construct a rollback rule that matches
-	 * the supplied {@link Exception} class (and subclasses).
+	 * the supplied {@link Exception} class (, subclasses and enclosed class).
 	 * @param clazz throwable class; must be {@link Throwable} or a subclass
 	 * of {@code Throwable}
 	 * @throws IllegalArgumentException if the supplied {@code clazz} is

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/RollbackRuleAttribute.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/RollbackRuleAttribute.java
@@ -54,7 +54,7 @@ public class RollbackRuleAttribute implements Serializable{
 	/**
 	 * Create a new instance of the {@code RollbackRuleAttribute} class.
 	 * <p>This is the preferred way to construct a rollback rule that matches
-	 * the supplied {@link Exception} class (, subclasses and enclosed class).
+	 * the supplied {@link Exception} class, its subclasses, and its nested classes.
 	 * @param clazz throwable class; must be {@link Throwable} or a subclass
 	 * of {@code Throwable}
 	 * @throws IllegalArgumentException if the supplied {@code clazz} is

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
@@ -98,7 +98,7 @@ public class RollbackRuleTests {
 	static class EnclosingException extends RuntimeException {
 
 		@SuppressWarnings("serial")
-		static class EnclosedException extends RuntimeException{
+		static class EnclosedException extends RuntimeException {
 
 		}
 	}

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
@@ -88,4 +88,17 @@ public class RollbackRuleTests {
 				new RollbackRuleAttribute((String) null));
 	}
 
+	@Test
+	public void foundEnclosedExceptionWithEnclosingException() {
+		RollbackRuleAttribute rr = new RollbackRuleAttribute(EnclosingException.class);
+		assertThat(rr.getDepth(new EnclosingException.EnclosedException())).isEqualTo(0);
+	}
+
+	static class EnclosingException extends RuntimeException{
+
+		static class EnclosedException extends RuntimeException{
+
+		}
+	}
+
 }

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
@@ -94,8 +94,10 @@ public class RollbackRuleTests {
 		assertThat(rr.getDepth(new EnclosingException.EnclosedException())).isEqualTo(0);
 	}
 
+	@SuppressWarnings("serial")
 	static class EnclosingException extends RuntimeException{
 
+		@SuppressWarnings("serial")
 		static class EnclosedException extends RuntimeException{
 
 		}

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
@@ -95,7 +95,7 @@ public class RollbackRuleTests {
 	}
 
 	@SuppressWarnings("serial")
-	static class EnclosingException extends RuntimeException{
+	static class EnclosingException extends RuntimeException {
 
 		@SuppressWarnings("serial")
 		static class EnclosedException extends RuntimeException{


### PR DESCRIPTION
In `public RollbackRuleAttribute(Class<?> clazz) `, only store the class name of the specified class, and in `private int getDepth(Class<?> exceptionClass, int depth) `, matching logic is by
`exceptionClass.getName().contains(this.exceptionName)`.
So, the enclosed class of the specified parameter of `public RollbackRuleAttribute(Class<?> clazz)` also can be match.
Suggest Improve javadoc in corresponding method.
