### PR TITLE
Remove unnecessary setter in DefaultServerRequest

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerRequest.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerRequest.java
@@ -486,11 +486,6 @@ class DefaultServerRequest implements ServerRequest {
 		}
 
 		@Override
-		public void setStatus(int sc, String sm) {
-			this.status = sc;
-		}
-
-		@Override
 		public int getStatus() {
 			return this.status;
 		}


### PR DESCRIPTION
I propose to remove `public void setStatus(int sc, String sm)` setter method in `class CheckNotModifiedResponse`.

Because setting status message code is not being used in `public void setStatus(int sc, String sm)`.
ex) `this.statusMsg = sm;`

And I know `public void setStatus(int sc, String sm)` in HttpServletResponse is deprecated.

There is an explanation about this in https://tomcat.apache.org/tomcat-5.5-doc/servletapi/javax/servlet/http/HttpServletResponse.html#setStatus(int,%20java.lang.String)

`As of version 2.1, due to ambiguous meaning of the message parameter. To set a status code use setStatus(int), to send an error with a description use sendError(int, String). Sets the status code and message for this response.`

Thank you for reading my PR!