### PR TITLE
Fix encoding problem when loading bean definition from properties file

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReader.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReader.java
@@ -18,7 +18,7 @@ package org.springframework.beans.factory.support;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -254,11 +254,13 @@ public class PropertiesBeanDefinitionReader extends AbstractBeanDefinitionReader
 
 		Properties props = new Properties();
 		try {
-			try (InputStream is = encodedResource.getResource().getInputStream()) {
-				if (encodedResource.getEncoding() != null) {
-					getPropertiesPersister().load(props, new InputStreamReader(is, encodedResource.getEncoding()));
+			if (encodedResource.requiresReader()) {
+				try (Reader reader = encodedResource.getReader()) {
+					getPropertiesPersister().load(props, reader);
 				}
-				else {
+			}
+			else {
+				try (InputStream is = encodedResource.getResource().getInputStream()) {
 					getPropertiesPersister().load(props, is);
 				}
 			}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReaderTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReaderTests.java
@@ -20,6 +20,11 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.testfixture.beans.TestBean;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.EncodedResource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,6 +59,24 @@ public class PropertiesBeanDefinitionReaderTests {
 		TestBean bean = (TestBean) this.beanFactory.getBean("testBean");
 		assertThat(bean.getName()).isEqualTo("Rob Harrop");
 		assertThat(bean.getAge()).isEqualTo(23);
+	}
+
+	private void withEncodedResource(Function<Resource, EncodedResource> function) {
+		final ClassPathResource resource = new ClassPathResource("encodedResource.properties", getClass());
+		final EncodedResource encodedResource = function.apply(resource);
+		this.reader.loadBeanDefinitions(encodedResource);
+		TestBean bean = (TestBean) this.beanFactory.getBean("testBean");
+		assertThat(bean.getName()).isEqualTo("刘福来");
+	}
+
+	@Test
+	public void withEncodedResourceWithEncoding() {
+		this.withEncodedResource(resource -> new EncodedResource(resource, "UTF-8"));
+	}
+
+	@Test
+	public void withEncodedResourceWithCharset() {
+		this.withEncodedResource(resource -> new EncodedResource(resource, StandardCharsets.UTF_8));
 	}
 
 }

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/support/encodedResource.properties
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/support/encodedResource.properties
@@ -1,0 +1,2 @@
+testBean.(class)=org.springframework.beans.testfixture.beans.TestBean
+testBean.name=刘福来


### PR DESCRIPTION
Fixed the encoding problem when loading an EncodedResource target with specified charset, not encoding.