### PR TITLE
Improve Javadoc in AutoProxyRegistrar

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/AutoProxyRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/AutoProxyRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-context/src/main/java/org/springframework/context/annotation/AutoProxyRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/AutoProxyRegistrar.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.aop.config.AopConfigUtils;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 
@@ -34,7 +33,7 @@ import org.springframework.core.type.AnnotationMetadata;
  *
  * @author Chris Beams
  * @since 3.1
- * @see EnableCaching
+ * @see org.springframework.cache.annotation.EnableCaching
  */
 public class AutoProxyRegistrar implements ImportBeanDefinitionRegistrar {
 

--- a/spring-context/src/main/java/org/springframework/context/annotation/AutoProxyRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/AutoProxyRegistrar.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.aop.config.AopConfigUtils;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 
@@ -33,7 +34,7 @@ import org.springframework.core.type.AnnotationMetadata;
  *
  * @author Chris Beams
  * @since 3.1
- * @see EnableAspectJAutoProxy
+ * @see EnableCaching
  */
 public class AutoProxyRegistrar implements ImportBeanDefinitionRegistrar {
 

--- a/spring-context/src/main/java/org/springframework/context/annotation/AutoProxyRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/AutoProxyRegistrar.java
@@ -34,6 +34,7 @@ import org.springframework.core.type.AnnotationMetadata;
  * @author Chris Beams
  * @since 3.1
  * @see org.springframework.cache.annotation.EnableCaching
+ * @see org.springframework.transaction.annotation.EnableTransactionManagement
  */
 public class AutoProxyRegistrar implements ImportBeanDefinitionRegistrar {
 


### PR DESCRIPTION
`EnableAspectJAutoProxy` doesn't have `mode` attribute, a bit mismatch with the logic of `registerBeanDefinitions` method in `AutoProxyRegistrar`. Suggest adjusting `EnableAspectJAutoProxy` to `EnableCaching `.
