### PR TITLE
Reduce byte array allocations in StompEncoder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ configure(allprojects) { project ->
 				}
 			}
 
+			dependency "com.squareup.okio:okio:1.17.2"
 			dependencySet(group: 'com.squareup.okhttp3', version: '3.14.7') {
 				entry 'okhttp'
 				entry 'mockwebserver'

--- a/spring-messaging/spring-messaging.gradle
+++ b/spring-messaging/spring-messaging.gradle
@@ -16,6 +16,7 @@ dependencies {
 	optional("com.google.protobuf:protobuf-java-util")
 	optional("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 	optional("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+	optional("com.squareup.okio:okio")
 	testCompile(project(":kotlin-coroutines"))
 	testCompile(testFixtures(project(":spring-core")))
 	testCompile("javax.inject:javax.inject-tck")


### PR DESCRIPTION
The use of an `okio.Buffer` instead of an `ByteArrayOutputStream` will reduce
the amount of allocated byte arrays by 50% to 66%.

With the current `ByteArrayOutputStream`-based implementation, 2-3 byte arrays
are allocated. One when the stream is created, one when `toByteArray()` is called
and maybe a third one, when the stream must grow because the overhead(headers) exeeds 128 bytes.

With an `okio.Buffer`, only one byte array has to be allocated, when `readByteArray()` is called.
All other needed arrays will be taken from Okio's internal Segment Pool.

The pattern of conditionally using classes, when they are present on the classpath
is inspired by RestTemplate.

I've choosen this older okio version, because its the same version that would be pulled by the already managed okhttp version.

### Context
While profiling our application we noticed that a considerable amount of byte arrays is created in `org.springframework.messaging.simp.stomp.StompEncoder.encode`:
![stomp-profiling](https://user-images.githubusercontent.com/6069961/76651526-fe8cd980-6564-11ea-80ef-1d1f8a8aa63a.png)

In other parts of our application, we already made good experience with using `okio.Buffer`s instead of `ByteArrayOutputStream`s

