### PR TITLE
Suppress deprecation warning in AnnotationMetadata#from

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/type/StandardAnnotationMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/StandardAnnotationMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@ public class StandardAnnotationMetadata extends StandardClassMetadata implements
 				AnnotatedElementUtils.isAnnotated(method, annotationName);
 	}
 
-
+	@SuppressWarnings("deprecation")
 	static AnnotationMetadata from(Class<?> introspectedClass) {
 		return new StandardAnnotationMetadata(introspectedClass, true);
 	}


### PR DESCRIPTION
From the Javadoc of `StandardAnnotationMetadata `'s constructor,  the reason `StandardAnnotationMetadata` is marked as `@Deprecated` is `since 5.2 in favor of the factory method {@link AnnotationMetadata # introspect (Class)}`. However,`AnnotationMetadata.introspect` is delegated to` StandardAnnotationMetadata.from`, consider suppressing deprecation warnings of `AnnotationMetadata.from`.


