### PR TITLE
Add factory method to create a NamedThreadLocal with an initial value

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/SimpleThreadScope.java
+++ b/spring-context/src/main/java/org/springframework/context/support/SimpleThreadScope.java
@@ -55,7 +55,7 @@ public class SimpleThreadScope implements Scope {
 
 	private static final Log logger = LogFactory.getLog(SimpleThreadScope.class);
 
-	private final ThreadLocal<Map<String, Object>> threadScope = NamedThreadLocal.withInitial("SimpleThreadScope" , HashMap::new);
+	private final ThreadLocal<Map<String, Object>> threadScope = NamedThreadLocal.withInitial("SimpleThreadScope", HashMap::new);
 
 	@Override
 	public Object get(String name, ObjectFactory<?> objectFactory) {

--- a/spring-context/src/main/java/org/springframework/context/support/SimpleThreadScope.java
+++ b/spring-context/src/main/java/org/springframework/context/support/SimpleThreadScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,14 +55,7 @@ public class SimpleThreadScope implements Scope {
 
 	private static final Log logger = LogFactory.getLog(SimpleThreadScope.class);
 
-	private final ThreadLocal<Map<String, Object>> threadScope =
-			new NamedThreadLocal<Map<String, Object>>("SimpleThreadScope") {
-				@Override
-				protected Map<String, Object> initialValue() {
-					return new HashMap<>();
-				}
-			};
-
+	private final ThreadLocal<Map<String, Object>> threadScope = NamedThreadLocal.withInitial("SimpleThreadScope" , HashMap::new);
 
 	@Override
 	public Object get(String name, ObjectFactory<?> objectFactory) {

--- a/spring-core/src/main/java/org/springframework/core/NamedThreadLocal.java
+++ b/spring-core/src/main/java/org/springframework/core/NamedThreadLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 package org.springframework.core;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+
 import org.springframework.util.Assert;
 
 /**
@@ -23,6 +26,7 @@ import org.springframework.util.Assert;
  * as {@link #toString()} result (allowing for introspection).
  *
  * @author Juergen Hoeller
+ * @author Qimiao Chen
  * @since 2.5.2
  * @param <T> the value type
  * @see NamedInheritableThreadLocal
@@ -41,9 +45,44 @@ public class NamedThreadLocal<T> extends ThreadLocal<T> {
 		this.name = name;
 	}
 
+	/**
+	 * Creates a named thread local variable. The initial value of the variable is
+	 * determined by invoking the {@code get} method on the {@code Supplier}.
+	 *
+	 * @param <S> the type of the named thread local's value
+	 * @param supplier the supplier to be used to determine the initial value
+	 * @return a new named thread local variable
+	 * @throws NullPointerException if the specified supplier is null
+	 * @since 5.2.5
+	 */
+	public static <S> ThreadLocal<S> withInitial(String name ,Supplier<? extends S> supplier) {
+		return new SuppliedNamedThreadLocal<>(name, supplier);
+	}
+
 	@Override
 	public String toString() {
 		return this.name;
+	}
+
+
+	/**
+	 * An extension of NamedThreadLocal that obtains its initial value from
+	 * the specified {@code Supplier}.
+	 * @param <T> the type of the named thread local's value
+	 */
+	static final class SuppliedNamedThreadLocal<T> extends NamedThreadLocal<T> {
+
+		private final Supplier<? extends T> supplier;
+
+		SuppliedNamedThreadLocal(String name ,Supplier<? extends T> supplier) {
+			super(name);
+			this.supplier = Objects.requireNonNull(supplier);
+		}
+
+		@Override
+		protected T initialValue() {
+			return this.supplier.get();
+		}
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/NamedThreadLocal.java
+++ b/spring-core/src/main/java/org/springframework/core/NamedThreadLocal.java
@@ -55,7 +55,7 @@ public class NamedThreadLocal<T> extends ThreadLocal<T> {
 	 * @throws NullPointerException if the specified supplier is null
 	 * @since 5.2.5
 	 */
-	public static <S> ThreadLocal<S> withInitial(String name ,Supplier<? extends S> supplier) {
+	public static <S> ThreadLocal<S> withInitial(String name, Supplier<? extends S> supplier) {
 		return new SuppliedNamedThreadLocal<>(name, supplier);
 	}
 
@@ -74,7 +74,7 @@ public class NamedThreadLocal<T> extends ThreadLocal<T> {
 
 		private final Supplier<? extends T> supplier;
 
-		SuppliedNamedThreadLocal(String name ,Supplier<? extends T> supplier) {
+		SuppliedNamedThreadLocal(String name, Supplier<? extends T> supplier) {
 			super(name);
 			this.supplier = Objects.requireNonNull(supplier);
 		}


### PR DESCRIPTION
If we need a `NamedThreadLocal` with an initialization value, it will be very convenient to use the `withInitial` method of this PR, like this:

```java
NamedThreadLocal.withInitial("SimpleThreadScope", HashMap::new);
```

It's just a suggestion. If you think it's okay, I hope it can be absorbed into this project.