### PR TITLE
Avoid ClassCastException for CoyoteInputStream in TomcatHttpHandlerAdapter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/TomcatHttpHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/TomcatHttpHandlerAdapter.java
@@ -131,12 +131,15 @@ public class TomcatHttpHandlerAdapter extends ServletHttpHandlerAdapter {
 
 		@Override
 		protected DataBuffer readFromInputStream() throws IOException {
+			ServletRequest request = getNativeRequest();
+			if (!(request instanceof CoyoteInputStream)) {
+				return super.readFromInputStream();
+			}
 			boolean release = true;
 			int capacity = this.bufferSize;
 			DataBuffer dataBuffer = this.factory.allocateBuffer(capacity);
 			try {
 				ByteBuffer byteBuffer = dataBuffer.asByteBuffer(0, capacity);
-				ServletRequest request = getNativeRequest();
 				int read = ((CoyoteInputStream) request.getInputStream()).read(byteBuffer);
 				logBytesRead(read);
 				if (read > 0) {


### PR DESCRIPTION
Servlet filter added in Spring Boot's `org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer` may override `HttpServletRequestWrapper.getInputStream()` and return an object derived from `ServletInputStream` that is not assignment compatible with Tomcat's `CoyoteInputStream`.