### PR TITLE
Non-public Kotlin beans can't be instantiated

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -38,6 +38,7 @@ import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KFunction;
 import kotlin.reflect.KParameter;
 import kotlin.reflect.full.KClasses;
+import kotlin.reflect.jvm.KCallablesJvm;
 import kotlin.reflect.jvm.ReflectJvmMapping;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -780,6 +781,11 @@ public abstract class BeanUtils {
 			if (kotlinConstructor == null) {
 				return ctor.newInstance(args);
 			}
+
+			if ((!Modifier.isPublic(ctor.getModifiers()) || !Modifier.isPublic(ctor.getDeclaringClass().getModifiers()))) {
+				KCallablesJvm.setAccessible(kotlinConstructor, true);
+			}
+
 			List<KParameter> parameters = kotlinConstructor.getParameters();
 			Map<KParameter, Object> argParameters = new HashMap<>(parameters.size());
 			Assert.isTrue(args.length <= parameters.size(),

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -96,6 +96,12 @@ class BeanUtilsTests {
 	}
 
 	@Test
+	void testInstantiateClassWithPrivateConstructor() throws NoSuchMethodException {
+		Constructor<PrivateBeanWithPrivateConstructor> ctor = PrivateBeanWithPrivateConstructor.class.getDeclaredConstructor();
+		PrivateBeanWithPrivateConstructor bean = BeanUtils.instantiateClass(ctor);
+	}
+
+	@Test
 	void testGetPropertyDescriptors() throws Exception {
 		PropertyDescriptor[] actual = Introspector.getBeanInfo(TestBean.class).getPropertyDescriptors();
 		PropertyDescriptor[] descriptors = BeanUtils.getPropertyDescriptors(TestBean.class);
@@ -552,6 +558,12 @@ class BeanUtilsTests {
 
 		public String getValue() {
 			return value;
+		}
+	}
+
+	private static class PrivateBeanWithPrivateConstructor {
+
+		private PrivateBeanWithPrivateConstructor() {
 		}
 	}
 

--- a/spring-beans/src/test/kotlin/org/springframework/beans/KotlinBeanUtilsTests.kt
+++ b/spring-beans/src/test/kotlin/org/springframework/beans/KotlinBeanUtilsTests.kt
@@ -18,6 +18,7 @@ package org.springframework.beans
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.core.KotlinDetector
 
 /**
  * Kotlin tests for {@link BeanUtils}.
@@ -74,6 +75,22 @@ class KotlinBeanUtilsTests {
 		assertThat(baz.param2).isEqualTo(12)
 	}
 
+	@Test
+	fun `Instantiate class with private constructor`() {
+		assertThat(KotlinDetector.isKotlinReflectPresent()).isTrue()
+		BeanUtils.instantiateClass(PrivateConstructor::class.java.getDeclaredConstructor())
+	}
+
+	@Test
+	fun `Instantiate class with protected constructor`() {
+		BeanUtils.instantiateClass(ProtectedConstructor::class.java.getDeclaredConstructor())
+	}
+
+	@Test
+	fun `Instantiate private class`() {
+		BeanUtils.instantiateClass(PrivateClass::class.java.getDeclaredConstructor())
+	}
+
 	class Foo(val param1: String, val param2: Int)
 
 	class Bar(val param1: String, val param2: Int = 12)
@@ -106,4 +123,9 @@ class KotlinBeanUtilsTests {
 		constructor(param1: String)
 	}
 
+	class PrivateConstructor private constructor()
+
+	class ProtectedConstructor protected constructor()
+
+	private class PrivateClass
 }


### PR DESCRIPTION
When a bean definition from an XML file is instantiated, and the bean class is a Kotlin class that is not public (e.g. protected), or a non-public constructor is used, this fails with an `IllegalAccessException: class kotlin.reflect.jvm.internal.calls.CallerImpl$Constructor cannot access a member of class MyKotlinClass with modifiers "protected"`. 

This works fine for Java classes, so I believe that this should also work for Kotlin classes.

I managed to locate and fix the cause of this problem. It is in `BeanUtils.instantiateClass(Constructor<T> ctor, Object... args)`. 

Here, the provided constructor object is made accessible before it is being used to instantiate the bean. 

Then, if the class that declares the constructor is a Kotlin class (and the `kotlin-reflect` jar is on the classpath; another prerequisite for this problem), the Kotlin `KFunction` object representing the Java constructor is obtained, and used to instantiate the bean.

Unfortunately, when this Kotlin constructor is used, the accessibility flag that was set on the original Java constructor object is not set. This is because the original Java constructor object is not the same object as the Java constructor object that is buried deep down in the Kotlin constructor object, what you might expect.

My fix sets the accessibility flag on the Kotlin constructor object itself, in a similar way as it is done for Java constructors.

I've added a test to `BeanUtilsTests` to ensure that a private Java class with a private constructor can be instantiated without problems. A few tests are added to `KotlinBeanUtilsTests` to ensure that this fix allows private and protected classes and constructors to be used.

I'm looking forward to your feedback. 
Regards,
Tom