### PR TITLE
SPR-8389 condense BeanCreationException exception message

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/NestedCheckedException.java
+++ b/spring-core/src/main/java/org/springframework/core/NestedCheckedException.java
@@ -74,7 +74,7 @@ public abstract class NestedCheckedException extends Exception {
 	@Override
 	@Nullable
 	public String getMessage() {
-		return NestedExceptionUtils.buildMessage(super.getMessage(), getCause());
+		return NestedExceptionUtils.buildMessage(this, super.getMessage(), getCause());
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/NestedExceptionUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/NestedExceptionUtils.java
@@ -16,6 +16,8 @@
 
 package org.springframework.core;
 
+import java.util.Arrays;
+
 import org.springframework.lang.Nullable;
 
 /**
@@ -41,7 +43,15 @@ public abstract class NestedExceptionUtils {
 	 * @return the full exception message
 	 */
 	@Nullable
-	public static String buildMessage(@Nullable String message, @Nullable Throwable cause) {
+	public static String buildMessage(Throwable nestedException, @Nullable String message, @Nullable Throwable cause) {
+		boolean foundThrowablePrintStackTrace = Arrays.stream(nestedException.getStackTrace())
+				.anyMatch( stackTraceElement ->
+					"java.lang.Throwable".equals(stackTraceElement.getClassName()) &&
+					"printStackTrace".equals(stackTraceElement.getMethodName())
+				);
+		if (foundThrowablePrintStackTrace) {
+			return message;
+		}
 		if (cause == null) {
 			return message;
 		}

--- a/spring-core/src/main/java/org/springframework/core/NestedIOException.java
+++ b/spring-core/src/main/java/org/springframework/core/NestedIOException.java
@@ -73,7 +73,7 @@ public class NestedIOException extends IOException {
 	@Override
 	@Nullable
 	public String getMessage() {
-		return NestedExceptionUtils.buildMessage(super.getMessage(), getCause());
+		return NestedExceptionUtils.buildMessage(this, super.getMessage(), getCause());
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/NestedRuntimeException.java
+++ b/spring-core/src/main/java/org/springframework/core/NestedRuntimeException.java
@@ -74,7 +74,7 @@ public abstract class NestedRuntimeException extends RuntimeException {
 	@Override
 	@Nullable
 	public String getMessage() {
-		return NestedExceptionUtils.buildMessage(super.getMessage(), getCause());
+		return NestedExceptionUtils.buildMessage(this, super.getMessage(), getCause());
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/web/server/ResponseStatusException.java
+++ b/spring-web/src/main/java/org/springframework/web/server/ResponseStatusException.java
@@ -122,7 +122,7 @@ public class ResponseStatusException extends NestedRuntimeException {
 	@Override
 	public String getMessage() {
 		String msg = this.status + (this.reason != null ? " \"" + this.reason + "\"" : "");
-		return NestedExceptionUtils.buildMessage(msg, getCause());
+		return NestedExceptionUtils.buildMessage(this, msg, getCause());
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/web/util/NestedServletException.java
+++ b/spring-web/src/main/java/org/springframework/web/util/NestedServletException.java
@@ -79,7 +79,7 @@ public class NestedServletException extends ServletException {
 	@Override
 	@Nullable
 	public String getMessage() {
-		return NestedExceptionUtils.buildMessage(super.getMessage(), getCause());
+		return NestedExceptionUtils.buildMessage(this, super.getMessage(), getCause());
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/util/NestedServletExceptionTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/util/NestedServletExceptionTests.java
@@ -34,7 +34,7 @@ public class NestedServletExceptionTests {
 	public void testNestedServletExceptionStringThrowable() {
 		Throwable cause = new RuntimeException();
 		NestedServletException exception = new NestedServletException("foo", cause);
-		assertThat(exception.getMessage()).isEqualTo(NestedExceptionUtils.buildMessage("foo", cause));
+		assertThat(exception.getMessage()).isEqualTo(NestedExceptionUtils.buildMessage(exception,"foo", cause));
 		assertThat(exception.getCause()).isEqualTo(cause);
 	}
 


### PR DESCRIPTION
https://github.com/spring-projects/spring-framework/issues/8389

The root cause is the message for NestedException included the cause (by concatenating by `; nested exception is ...`), which is NestedException as well, so its message will include its own `nested exception` again, thus the horrible long exception messages. We don't need to include the cause message for stack trace will output its enclosed content at the `Caused by:` section.
My approach is to only return the basic message excluding cause message in `getMessage` overridden method, via runtime stack trace inspection.