### PR TITLE
SPR-8389 condense BeanCreationException exception message

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/NestedExceptionUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/NestedExceptionUtils.java
@@ -16,6 +16,8 @@
 
 package org.springframework.core;
 
+import java.util.Arrays;
+
 import org.springframework.lang.Nullable;
 
 /**
@@ -42,6 +44,14 @@ public abstract class NestedExceptionUtils {
 	 */
 	@Nullable
 	public static String buildMessage(@Nullable String message, @Nullable Throwable cause) {
+		boolean foundThrowablePrintStackTrace = Arrays.stream(Thread.currentThread().getStackTrace())
+				.anyMatch( stackTraceElement ->
+					"java.lang.Throwable".equals(stackTraceElement.getClassName()) &&
+					"printStackTrace".equals(stackTraceElement.getMethodName())
+				);
+		if (foundThrowablePrintStackTrace) {
+			return message;
+		}
 		if (cause == null) {
 			return message;
 		}

--- a/spring-core/src/test/java/org/springframework/core/NestedExceptionTests.java
+++ b/spring-core/src/test/java/org/springframework/core/NestedExceptionTests.java
@@ -106,4 +106,20 @@ class NestedExceptionTests {
 		assertThat(stackTrace.contains(rootCauseMsg)).isTrue();
 	}
 
+	@Test
+	void nestedExceptionMessageExcludeCauseWhenPrintStacktrace() {
+		String rootCauseMsg = "this is the message of the root cause";
+		NestedRuntimeException rootCause = new NestedRuntimeException(rootCauseMsg, null){};
+		NestedRuntimeException nex = new NestedRuntimeException("this is the message of cause", rootCause){};
+
+		// check PrintStackTrace
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PrintWriter pw = new PrintWriter(baos);
+		nex.printStackTrace(pw);
+		pw.flush();
+		String stackTrace = new String(baos.toByteArray());
+		assertThat(stackTrace).containsOnlyOnce(rootCause.getClass().getName());
+		assertThat(stackTrace).containsOnlyOnce(rootCauseMsg);
+	}
+
 }


### PR DESCRIPTION
#8389

The root cause is the message for `NestedException` included the cause (by concatenating by `; nested exception is ...`), which is `NestedException` as well, so its message will include its own nested exception again, thus the horrible long exception messages. We don't need to include the cause message for stack trace will output its enclosed content at the `Caused by: ` section.
My approach is to only return the basic message excluding cause message in getMessage overridden method, via runtime stack trace inspection.
Testing case created to demonstrate that cause information is only output once in stack trace result.