### PR TITLE
Support for X-Forwarded-Prefix in UrlComponentsBuilder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java
@@ -94,11 +94,6 @@ public class ForwardedHeaderTransformer implements Function<ServerHttpRequest, S
 			if (!this.removeOnly) {
 				URI uri = UriComponentsBuilder.fromHttpRequest(request).build(true).toUri();
 				builder.uri(uri);
-				String prefix = getForwardedPrefix(request);
-				if (prefix != null) {
-					builder.path(prefix + uri.getRawPath());
-					builder.contextPath(prefix);
-				}
 			}
 			removeForwardedHeaders(builder);
 			request = builder.build();

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -778,7 +778,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 
 				String prefixHeader = headers.getFirst("X-Forwarded-Prefix");
 				if (StringUtils.hasText(prefixHeader)) {
-					PathComponent pathComponent = pathBuilder.build();
+					PathComponent pathComponent = this.pathBuilder.build();
 					String path = (pathComponent != null ? pathComponent.getPath() : "");
 					String forwardedPath = StringUtils.tokenizeToStringArray(prefixHeader, ",")[0];
 					if (StringUtils.hasText(path)) {

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -775,6 +775,17 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 				if (StringUtils.hasText(portHeader)) {
 					port(Integer.parseInt(StringUtils.tokenizeToStringArray(portHeader, ",")[0]));
 				}
+
+				String prefixHeader = headers.getFirst("X-Forwarded-Prefix");
+				if (StringUtils.hasText(prefixHeader)) {
+					PathComponent pathComponent = pathBuilder.build();
+					String path = (pathComponent != null ? pathComponent.getPath() : "");
+					String forwardedPath = StringUtils.tokenizeToStringArray(prefixHeader, ",")[0];
+					if (StringUtils.hasText(path)) {
+						forwardedPath += path;
+					}
+					replacePath(forwardedPath);
+				}
 			}
 		}
 		catch (NumberFormatException ex) {

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -514,6 +514,54 @@ public class UriComponentsBuilderTests {
 		assertThat(result.toString()).isEqualTo("https://a.example.org/mvc-showcase");
 	}
 
+	@Test
+	public void fromHttpRequestWithForwardedHostAndPrefix() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setScheme("http");
+		request.setServerName("localhost");
+		request.setServerPort(8080);
+		request.setRequestURI("/mvc-showcase");
+		request.addHeader("X-Forwarded-Host", "a.example.org");
+		request.addHeader("X-Forwarded-Prefix", "/foo");
+
+		HttpRequest httpRequest = new ServletServerHttpRequest(request);
+		UriComponents result = UriComponentsBuilder.fromHttpRequest(httpRequest).build();
+
+		assertThat(result.toString()).isEqualTo("http://a.example.org/foo/mvc-showcase");
+	}
+
+	@Test
+	public void fromHttpRequestWithForwardedHostAndPrefixWithTrailingSlash() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setScheme("http");
+		request.setServerName("localhost");
+		request.setServerPort(8080);
+		request.setRequestURI("/mvc-showcase");
+		request.addHeader("X-Forwarded-Host", "a.example.org");
+		request.addHeader("X-Forwarded-Prefix", "/foo/");
+
+		HttpRequest httpRequest = new ServletServerHttpRequest(request);
+		UriComponents result = UriComponentsBuilder.fromHttpRequest(httpRequest).build();
+
+		assertThat(result.toString()).isEqualTo("http://a.example.org/foo/mvc-showcase");
+	}
+
+	@Test
+	public void fromHttpRequestWithMultipleForwardedHostAndPrefix() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setScheme("http");
+		request.setServerName("localhost");
+		request.setServerPort(8080);
+		request.setRequestURI("/mvc-showcase");
+		request.addHeader("X-Forwarded-Host", "a.example.org, b.example.org");
+		request.addHeader("X-Forwarded-Prefix", "/foo, /bar, /baz");
+
+		HttpRequest httpRequest = new ServletServerHttpRequest(request);
+		UriComponents result = UriComponentsBuilder.fromHttpRequest(httpRequest).build();
+
+		assertThat(result.toString()).isEqualTo("http://a.example.org/foo/mvc-showcase");
+	}
+
 	@Test  // SPR-12742
 	public void fromHttpRequestWithTrailingSlash() {
 		UriComponents before = UriComponentsBuilder.fromPath("/foo/").build();


### PR DESCRIPTION
Adds support in UriComponentsBuilder to handle X-Forwarded-Prefix header used by reverse proxies to specify the segment of the URL path that has been stripped by that reverse proxy. It is especially useful in conjunction with the X-Forwarded-Host header for building location-dependent content such as HATEOAS links, where the generated links should direct the client to further resources via the proxy rather than the target server.

The ForwardedHeaderTransformer does not need to handle the X-Forwarded-Prefix header as a special case as it is now handled by the UrlComponentsBuilder.

Closes #24723 