### PR TITLE
Remove unnecessary condition in LocalVariableTableParameterNameDiscoverer

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/LocalVariableTableParameterNameDiscoverer.java
+++ b/spring-core/src/main/java/org/springframework/core/LocalVariableTableParameterNameDiscoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,13 +92,12 @@ public class LocalVariableTableParameterNameDiscoverer implements ParameterNameD
 	 */
 	private Map<Executable, String[]> inspectClass(Class<?> clazz) {
 		InputStream is = clazz.getResourceAsStream(ClassUtils.getClassFileName(clazz));
-		if (is == null) {
-			// We couldn't load the class file, which is not fatal as it
-			// simply means this method of discovering parameter names won't work.
-			if (logger.isDebugEnabled()) {
-				logger.debug("Cannot find '.class' file for class [" + clazz +
-						"] - unable to determine constructor/method parameter names");
-			}
+		
+		// We couldn't load the class file, which is not fatal as it
+		// simply means this method of discovering parameter names won't work.
+		if (is == null && logger.isDebugEnabled()) {
+			logger.debug("Cannot find '.class' file for class [" + clazz +
+					"] - unable to determine constructor/method parameter names");
 			return NO_DEBUG_INFO_MAP;
 		}
 		try {


### PR DESCRIPTION
I propose to remove unnecessary condition in `LocalVariableTableParameterNameDiscoverer`.