### PR TITLE
Remove unnecessary null check in ConvertingEncoderDecoderSupport

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/standard/ConvertingEncoderDecoderSupport.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/standard/ConvertingEncoderDecoderSupport.java
@@ -85,7 +85,7 @@ public abstract class ConvertingEncoderDecoderSupport<T, M> {
 	 */
 	public void init(EndpointConfig config) {
 		ApplicationContext applicationContext = getApplicationContext();
-		if (applicationContext != null && applicationContext instanceof ConfigurableApplicationContext) {
+		if (applicationContext instanceof ConfigurableApplicationContext) {
 			ConfigurableListableBeanFactory beanFactory =
 					((ConfigurableApplicationContext) applicationContext).getBeanFactory();
 			beanFactory.autowireBean(this);


### PR DESCRIPTION
`instanceof` check contains `null check`, I think we can remove leading `null` check.