### PR TITLE
Missing nullability declarations for package web.socket.server.jetty

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/jetty/JettyRequestUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/jetty/JettyRequestUpgradeStrategy.java
@@ -39,6 +39,7 @@ import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
@@ -67,15 +68,18 @@ public class JettyRequestUpgradeStrategy implements RequestUpgradeStrategy, Serv
 	private static final ThreadLocal<WebSocketHandlerContainer> containerHolder =
 			new NamedThreadLocal<>("WebSocketHandlerContainer");
 
-
+	@Nullable
 	private WebSocketPolicy policy;
 
+	@Nullable
 	private WebSocketServerFactory factory;
 
+	@Nullable
 	private ServletContext servletContext;
 
 	private volatile boolean running = false;
 
+	@Nullable
 	private volatile List<WebSocketExtension> supportedExtensions;
 
 
@@ -196,7 +200,7 @@ public class JettyRequestUpgradeStrategy implements RequestUpgradeStrategy, Serv
 
 	@Override
 	public void upgrade(ServerHttpRequest request, ServerHttpResponse response,
-			String selectedProtocol, List<WebSocketExtension> selectedExtensions, Principal user,
+			@Nullable String selectedProtocol, List<WebSocketExtension> selectedExtensions, @Nullable Principal user,
 			WebSocketHandler wsHandler, Map<String, Object> attributes) throws HandshakeFailureException {
 
 		Assert.isInstanceOf(ServletServerHttpRequest.class, request, "ServletServerHttpRequest required");

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/jetty/package-info.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/jetty/package-info.java
@@ -1,4 +1,9 @@
 /**
  * Server-side support for the Jetty 9+ WebSocket API.
  */
+@NonNullApi
+@NonNullFields
 package org.springframework.web.socket.server.jetty;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;


### PR DESCRIPTION
Introduce `@NonNullApi`,`@NonNullFields` to package-info to help tools understand something about nullability.
