### PR TITLE
Declare proxyBeanMethods=false in JmsBootstrapConfiguration

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/annotation/JmsBootstrapConfiguration.java
+++ b/spring-jms/src/main/java/org/springframework/jms/annotation/JmsBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.springframework.jms.config.JmsListenerEndpointRegistry;
  * @see JmsListenerEndpointRegistry
  * @see EnableJms
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class JmsBootstrapConfiguration {
 


### PR DESCRIPTION
`@Bean` annotated methods are not explicitly called by other methods in `JmsBootstrapConfiguration`, so I think we can set `proxyBeansMethod` attribute of `@Configuration` to false to avoid CGLIB subclass processing.
This can improve performance, although not a lot.
