### PR TITLE
Add BeanPostProcessors in bulk

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/ConfigurableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/ConfigurableBeanFactory.java
@@ -18,6 +18,7 @@ package org.springframework.beans.factory.config;
 
 import java.beans.PropertyEditor;
 import java.security.AccessControlContext;
+import java.util.List;
 
 import org.springframework.beans.PropertyEditorRegistrar;
 import org.springframework.beans.PropertyEditorRegistry;
@@ -243,6 +244,20 @@ public interface ConfigurableBeanFactory extends HierarchicalBeanFactory, Single
 	 * @param beanPostProcessor the post-processor to register
 	 */
 	void addBeanPostProcessor(BeanPostProcessor beanPostProcessor);
+
+	/**
+	 * Add new BeanPostProcessors that will get applied to beans created
+	 * by this factory. To be invoked during factory configuration.
+	 * <p>Note: Post-processors submitted here will be applied in the order of
+	 * registration; any ordering semantics expressed through implementing the
+	 * {@link org.springframework.core.Ordered} interface will be ignored. Note
+	 * that autodetected post-processors (e.g. as beans in an ApplicationContext)
+	 * will always be applied after programmatically registered ones.
+	 * @param beanPostProcessors the post-processors to register
+	 */
+	default void addBeanPostProcessors(List<BeanPostProcessor> beanPostProcessors) {
+		beanPostProcessors.forEach(this::addBeanPostProcessor);
+	}
 
 	/**
 	 * Return the current number of registered BeanPostProcessors, if any.

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -931,6 +931,23 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 	}
 
 	@Override
+	public void addBeanPostProcessors(List<BeanPostProcessor> beanPostProcessors) {
+		this.beanPostProcessors.removeAll(beanPostProcessors);
+
+		for (BeanPostProcessor beanPostProcessor : beanPostProcessors) {
+			Assert.notNull(beanPostProcessor, "BeanPostProcessor must not be null");
+			// Track whether it is instantiation/destruction aware
+			if (beanPostProcessor instanceof InstantiationAwareBeanPostProcessor) {
+				this.hasInstantiationAwareBeanPostProcessors = true;
+			}
+			if (beanPostProcessor instanceof DestructionAwareBeanPostProcessor) {
+				this.hasDestructionAwareBeanPostProcessors = true;
+			}
+		}
+		this.beanPostProcessors.addAll(beanPostProcessors);
+	}
+
+	@Override
 	public int getBeanPostProcessorCount() {
 		return this.beanPostProcessors.size();
 	}

--- a/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java
+++ b/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java
@@ -220,7 +220,7 @@ final class PostProcessorRegistrationDelegate {
 
 		// First, register the BeanPostProcessors that implement PriorityOrdered.
 		sortPostProcessors(priorityOrderedPostProcessors, beanFactory);
-		registerBeanPostProcessors(beanFactory, priorityOrderedPostProcessors);
+		beanFactory.addBeanPostProcessors(priorityOrderedPostProcessors);
 
 		// Next, register the BeanPostProcessors that implement Ordered.
 		List<BeanPostProcessor> orderedPostProcessors = new ArrayList<>(orderedPostProcessorNames.size());
@@ -232,7 +232,7 @@ final class PostProcessorRegistrationDelegate {
 			}
 		}
 		sortPostProcessors(orderedPostProcessors, beanFactory);
-		registerBeanPostProcessors(beanFactory, orderedPostProcessors);
+		beanFactory.addBeanPostProcessors(orderedPostProcessors);
 
 		// Now, register all regular BeanPostProcessors.
 		List<BeanPostProcessor> nonOrderedPostProcessors = new ArrayList<>(nonOrderedPostProcessorNames.size());
@@ -243,11 +243,11 @@ final class PostProcessorRegistrationDelegate {
 				internalPostProcessors.add(pp);
 			}
 		}
-		registerBeanPostProcessors(beanFactory, nonOrderedPostProcessors);
+		beanFactory.addBeanPostProcessors(nonOrderedPostProcessors);
 
 		// Finally, re-register all internal BeanPostProcessors.
 		sortPostProcessors(internalPostProcessors, beanFactory);
-		registerBeanPostProcessors(beanFactory, internalPostProcessors);
+		beanFactory.addBeanPostProcessors(internalPostProcessors);
 
 		// Re-register post-processor for detecting inner beans as ApplicationListeners,
 		// moving it to the end of the processor chain (for picking up proxies etc).
@@ -286,18 +286,6 @@ final class PostProcessorRegistrationDelegate {
 			postProcessor.postProcessBeanFactory(beanFactory);
 		}
 	}
-
-	/**
-	 * Register the given BeanPostProcessor beans.
-	 */
-	private static void registerBeanPostProcessors(
-			ConfigurableListableBeanFactory beanFactory, List<BeanPostProcessor> postProcessors) {
-
-		for (BeanPostProcessor postProcessor : postProcessors) {
-			beanFactory.addBeanPostProcessor(postProcessor);
-		}
-	}
-
 
 	/**
 	 * BeanPostProcessor that logs an info message when a bean is created during


### PR DESCRIPTION
In one of my applications there's about 50 post processors added in loop to `CopyOnWriteArrayList`. I think this can be improved by using bulk method where lock/unlock happens only once for all PP and less garbage is produced inside of `CopyOnWriteArrayList`.