### PR TITLE
Fix empty domain handling in ResponseCookie

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseCookie.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseCookie.java
@@ -248,7 +248,7 @@ public final class ResponseCookie extends HttpCookie {
 				if (lenient && !StringUtils.isEmpty(domain)) {
 					String s = domain.trim();
 					if (s.startsWith("\"") && s.endsWith("\"")) {
-						if (s.substring(1, domain.length() - 1).trim().isEmpty()) {
+						if (s.substring(1, s.length() - 1).trim().isEmpty()) {
 							return null;
 						}
 					}

--- a/spring-web/src/test/java/org/springframework/http/ResponseCookieTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ResponseCookieTests.java
@@ -86,7 +86,7 @@ public class ResponseCookieTests {
 
 		Arrays.asList("\"\"", "\t\"\" ", " \" \t \"\t")
 				.forEach(domain -> {
-					ResponseCookie cookie = ResponseCookie.fromClientResponse("id", "1fWa").domain("\"\"").build();
+					ResponseCookie cookie = ResponseCookie.fromClientResponse("id", "1fWa").domain(domain).build();
 					assertThat(cookie.getDomain()).isNull();
 				});
 


### PR DESCRIPTION
This PR fixes empty domain handling in `ResponseCookie`.

This PR also updates its test to use its intended inputs.