### PR TITLE
MimeTypeUtils no longer cache MediaType.MULTIPART_FORM_DATA_VALUE

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -190,7 +190,8 @@ public abstract class MimeTypeUtils {
 	 * @return whether need cache
 	 */
 	private static boolean ensureMimeTypeRequiredCache(String mimeType){
-		if(mimeType.startsWith(MediaType.MULTIPART_FORM_DATA_VALUE + ";"))
+		// TODO constant
+		if(mimeType.startsWith("multipart/form-data;"))
 			return false;
 		return true;
 	}

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -35,7 +35,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
 
 /**


### PR DESCRIPTION
For example "multipart/form-data; boundary=----WebKitFormBoundarymKzwdDkWNDNzQFP0", this mimeType with random characters, wastes LRU cache space, resulting in severe performance degradation.

This pull-request fixed it