### PR TITLE
Simplify conversion of ByteArrayOutputStream to String

### DIFF
--- a/spring-context-indexer/src/main/java/org/springframework/context/index/processor/SortedProperties.java
+++ b/spring-context-indexer/src/main/java/org/springframework/context/index/processor/SortedProperties.java
@@ -88,7 +88,7 @@ class SortedProperties extends Properties {
 	public void store(OutputStream out, String comments) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		super.store(baos, (this.omitComments ? null : comments));
-		String contents = new String(baos.toByteArray(), StandardCharsets.ISO_8859_1);
+		String contents = baos.toString(StandardCharsets.ISO_8859_1.name());
 		for (String line : contents.split(EOL)) {
 			if (!(this.omitComments && line.startsWith("#"))) {
 				out.write((line + EOL).getBytes(StandardCharsets.ISO_8859_1));

--- a/spring-core/src/main/java/org/springframework/core/SortedProperties.java
+++ b/spring-core/src/main/java/org/springframework/core/SortedProperties.java
@@ -90,7 +90,7 @@ class SortedProperties extends Properties {
 	public void store(OutputStream out, @Nullable String comments) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		super.store(baos, (this.omitComments ? null : comments));
-		String contents = new String(baos.toByteArray(), StandardCharsets.ISO_8859_1);
+		String contents = baos.toString(StandardCharsets.ISO_8859_1.name());
 		for (String line : contents.split(EOL)) {
 			if (!(this.omitComments && line.startsWith("#"))) {
 				out.write((line + EOL).getBytes(StandardCharsets.ISO_8859_1));

--- a/spring-messaging/src/main/java/org/springframework/messaging/converter/ProtobufMessageConverter.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/converter/ProtobufMessageConverter.java
@@ -183,7 +183,7 @@ public class ProtobufMessageConverter extends AbstractMessageConverter {
 			else if (this.protobufFormatSupport != null) {
 				ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 				this.protobufFormatSupport.print(message, outputStream, contentType, charset);
-				payload = new String(outputStream.toByteArray(), charset);
+				payload = outputStream.toString(charset.name());
 			}
 		}
 		catch (IOException ex) {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransport.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransport.java
@@ -252,15 +252,14 @@ public class RestTemplateXhrTransport extends AbstractXhrTransport {
 			return null;
 		}
 
-		private void handleFrame(ByteArrayOutputStream os) {
-			byte[] bytes = os.toByteArray();
+		private void handleFrame(ByteArrayOutputStream os) throws IOException {
+			String content = os.toString(SockJsFrame.CHARSET.toString());
 			os.reset();
-			String content = new String(bytes, SockJsFrame.CHARSET);
 			if (logger.isTraceEnabled()) {
 				logger.trace("XHR receive content: " + content);
 			}
 			if (!PRELUDE.equals(content)) {
-				this.sockJsSession.handleFrame(new String(bytes, SockJsFrame.CHARSET));
+				this.sockJsSession.handleFrame(content);
 			}
 		}
 	}


### PR DESCRIPTION
Currently we often convert BAOS to String as
```java
String contents = new String(baos.toByteArray(), StandardCharsets.ISO_8859_1);
```
which can be made more simple and effective as
```java
String contents = baos.toString(StandardCharsets.ISO_8859_1.name());
```
`BAOS.toByteArray()` creates a copy of underlying array which is later decoded inside of `String` constructor, while `BAOS.toString()` doesn't create intermediate copy making convertion more memory-effective.

For JDK 8 I've got following results:
```
Benchmark                                                        (length)  Mode     Score     Error   Units
ByteArrayOutputStreamBenchmark.newString                               10  avgt    97.420 ±   7.340   ns/op
ByteArrayOutputStreamBenchmark.newString                              100  avgt   480.689 ±  20.615   ns/op
ByteArrayOutputStreamBenchmark.newString                             1000  avgt  4717.681 ± 175.550   ns/op

ByteArrayOutputStreamBenchmark.toString                                10  avgt    85.578 ±   5.233   ns/op
ByteArrayOutputStreamBenchmark.toString                               100  avgt   533.850 ±  23.902   ns/op
ByteArrayOutputStreamBenchmark.toString                              1000  avgt  4703.280 ± 113.713   ns/op

ByteArrayOutputStreamBenchmark.newString:·gc.alloc.rate.norm           10  avgt   134.400 ±  15.271    B/op
ByteArrayOutputStreamBenchmark.newString:·gc.alloc.rate.norm          100  avgt   722.401 ±  10.494    B/op
ByteArrayOutputStreamBenchmark.newString:·gc.alloc.rate.norm         1000  avgt  6380.016 ±  46.441    B/op

ByteArrayOutputStreamBenchmark.toString:·gc.alloc.rate.norm            10  avgt   109.600 ±  14.586    B/op
ByteArrayOutputStreamBenchmark.toString:·gc.alloc.rate.norm           100  avgt   664.002 ±  16.986    B/op
ByteArrayOutputStreamBenchmark.toString:·gc.alloc.rate.norm          1000  avgt  5433.618 ±  39.002    B/op