### PR TITLE
Simplify conversion of DataBuffer to String

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DefaultDataBuffer.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DefaultDataBuffer.java
@@ -191,8 +191,8 @@ public class DefaultDataBuffer implements DataBuffer {
 		if (newCapacity > oldCapacity) {
 			ByteBuffer oldBuffer = this.byteBuffer;
 			ByteBuffer newBuffer = allocate(newCapacity, oldBuffer.isDirect());
-			((Buffer) oldBuffer).position(0).limit(oldBuffer.capacity());
-			((Buffer) newBuffer).position(0).limit(oldBuffer.capacity());
+			oldBuffer.position(0).limit(oldBuffer.capacity());
+			newBuffer.position(0).limit(oldBuffer.capacity());
 			newBuffer.put(oldBuffer);
 			newBuffer.clear();
 			setNativeBuffer(newBuffer);
@@ -205,8 +205,8 @@ public class DefaultDataBuffer implements DataBuffer {
 					writePosition = newCapacity;
 					writePosition(writePosition);
 				}
-				((Buffer) oldBuffer).position(readPosition).limit(writePosition);
-				((Buffer) newBuffer).position(readPosition).limit(writePosition);
+				oldBuffer.position(readPosition).limit(writePosition);
+				newBuffer.position(readPosition).limit(writePosition);
 				newBuffer.put(oldBuffer);
 				newBuffer.clear();
 			}
@@ -265,7 +265,7 @@ public class DefaultDataBuffer implements DataBuffer {
 
 		ByteBuffer tmp = this.byteBuffer.duplicate();
 		int limit = this.readPosition + length;
-		((Buffer) tmp).clear().position(this.readPosition).limit(limit);
+		tmp.clear().position(this.readPosition).limit(limit);
 		tmp.get(destination, offset, length);
 
 		this.readPosition += length;
@@ -295,7 +295,7 @@ public class DefaultDataBuffer implements DataBuffer {
 
 		ByteBuffer tmp = this.byteBuffer.duplicate();
 		int limit = this.writePosition + length;
-		((Buffer) tmp).clear().position(this.writePosition).limit(limit);
+		tmp.clear().position(this.writePosition).limit(limit);
 		tmp.put(source, offset, length);
 
 		this.writePosition += length;
@@ -324,7 +324,7 @@ public class DefaultDataBuffer implements DataBuffer {
 		int length = source.remaining();
 		ByteBuffer tmp = this.byteBuffer.duplicate();
 		int limit = this.writePosition + source.remaining();
-		((Buffer) tmp).clear().position(this.writePosition).limit(limit);
+		tmp.clear().position(this.writePosition).limit(limit);
 		tmp.put(source);
 		this.writePosition += length;
 	}
@@ -340,7 +340,7 @@ public class DefaultDataBuffer implements DataBuffer {
 			buffer.position(index);
 			ByteBuffer slice = this.byteBuffer.slice();
 			// Explicit cast for compatibility with covariant return type on JDK 9's ByteBuffer
-			((Buffer) slice).limit(length);
+			slice.limit(length);
 			return new SlicedDefaultDataBuffer(slice, this.dataBufferFactory, length);
 		}
 		finally {

--- a/spring-core/src/testFixtures/java/org/springframework/core/testfixture/codec/AbstractEncoderTests.java
+++ b/spring-core/src/testFixtures/java/org/springframework/core/testfixture/codec/AbstractEncoderTests.java
@@ -249,10 +249,8 @@ public abstract class AbstractEncoderTests<E extends Encoder<?>> extends Abstrac
 	 */
 	protected Consumer<DataBuffer> expectString(String expected) {
 		return dataBuffer -> {
-			byte[] resultBytes = new byte[dataBuffer.readableByteCount()];
-			dataBuffer.read(resultBytes);
+			String actual = dataBuffer.toString(UTF_8);
 			release(dataBuffer);
-			String actual = new String(resultBytes, UTF_8);
 			assertThat(actual).isEqualTo(expected);
 		};
 

--- a/spring-core/src/testFixtures/java/org/springframework/core/testfixture/io/buffer/DataBufferTestUtils.java
+++ b/spring-core/src/testFixtures/java/org/springframework/core/testfixture/io/buffer/DataBufferTestUtils.java
@@ -54,9 +54,9 @@ public abstract class DataBufferTestUtils {
 	 * @return the string representation of the given data buffer
 	 */
 	public static String dumpString(DataBuffer buffer, Charset charset) {
+		Assert.notNull(buffer, "'buffer' must not be null");
 		Assert.notNull(charset, "'charset' must not be null");
-		byte[] bytes = dumpBytes(buffer);
-		return new String(bytes, charset);
+		return buffer.toString(charset);
 	}
 
 }

--- a/spring-test/src/main/java/org/springframework/mock/http/client/reactive/MockClientHttpRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/client/reactive/MockClientHttpRequest.java
@@ -48,9 +48,9 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public class MockClientHttpRequest extends AbstractClientHttpRequest {
 
-	private HttpMethod httpMethod;
+	private final HttpMethod httpMethod;
 
-	private URI url;
+	private final URI url;
 
 	private final DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
 
@@ -160,9 +160,7 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest {
 
 	private static String bufferToString(DataBuffer buffer, Charset charset) {
 		Assert.notNull(charset, "'charset' must not be null");
-		byte[] bytes = new byte[buffer.readableByteCount()];
-		buffer.read(bytes);
-		return new String(bytes, charset);
+		return buffer.toString(charset);
 	}
 
 }

--- a/spring-test/src/main/java/org/springframework/mock/http/client/reactive/MockClientHttpResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/client/reactive/MockClientHttpResponse.java
@@ -134,9 +134,7 @@ public class MockClientHttpResponse implements ClientHttpResponse {
 
 	private static String dumpString(DataBuffer buffer, Charset charset) {
 		Assert.notNull(charset, "'charset' must not be null");
-		byte[] bytes = new byte[buffer.readableByteCount()];
-		buffer.read(bytes);
-		return new String(bytes, charset);
+		return buffer.toString(charset);
 	}
 
 	private Charset getCharset() {

--- a/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpResponse.java
@@ -153,10 +153,9 @@ public class MockServerHttpResponse extends AbstractServerHttpResponse {
 
 	private static String bufferToString(DataBuffer buffer, Charset charset) {
 		Assert.notNull(charset, "'charset' must not be null");
-		byte[] bytes = new byte[buffer.readableByteCount()];
-		buffer.read(bytes);
+		String str = buffer.toString(charset);
 		DataBufferUtils.release(buffer);
-		return new String(bytes, charset);
+		return str;
 	}
 
 }

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/reactive/MockClientHttpRequest.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/reactive/MockClientHttpRequest.java
@@ -48,9 +48,9 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public class MockClientHttpRequest extends AbstractClientHttpRequest {
 
-	private HttpMethod httpMethod;
+	private final HttpMethod httpMethod;
 
-	private URI url;
+	private final URI url;
 
 	private final DataBufferFactory bufferFactory = new DefaultDataBufferFactory();
 
@@ -160,9 +160,7 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest {
 
 	private static String bufferToString(DataBuffer buffer, Charset charset) {
 		Assert.notNull(charset, "'charset' must not be null");
-		byte[] bytes = new byte[buffer.readableByteCount()];
-		buffer.read(bytes);
-		return new String(bytes, charset);
+		return buffer.toString(charset);
 	}
 
 }

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/reactive/MockClientHttpResponse.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/reactive/MockClientHttpResponse.java
@@ -134,9 +134,7 @@ public class MockClientHttpResponse implements ClientHttpResponse {
 
 	private static String dumpString(DataBuffer buffer, Charset charset) {
 		Assert.notNull(charset, "'charset' must not be null");
-		byte[] bytes = new byte[buffer.readableByteCount()];
-		buffer.read(bytes);
-		return new String(bytes, charset);
+		return buffer.toString(charset);
 	}
 
 	private Charset getCharset() {

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/server/reactive/MockServerHttpResponse.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/server/reactive/MockServerHttpResponse.java
@@ -153,10 +153,9 @@ public class MockServerHttpResponse extends AbstractServerHttpResponse {
 
 	private static String bufferToString(DataBuffer buffer, Charset charset) {
 		Assert.notNull(charset, "'charset' must not be null");
-		byte[] bytes = new byte[buffer.readableByteCount()];
-		buffer.read(bytes);
+		String s = buffer.toString(charset);
 		DataBufferUtils.release(buffer);
-		return new String(bytes, charset);
+		return s;
 	}
 
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/WebSocketMessage.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/WebSocketMessage.java
@@ -84,9 +84,7 @@ public class WebSocketMessage {
 	 * @since 5.0.5
 	 */
 	public String getPayloadAsText(Charset charset) {
-		byte[] bytes = new byte[this.payload.readableByteCount()];
-		this.payload.read(bytes);
-		return new String(bytes, charset);
+		return this.payload.toString(charset);
 	}
 
 	/**


### PR DESCRIPTION
This PR is similar to https://github.com/spring-projects/spring-framework/pull/24785

Also there's one more place about which I'm not sure:
This code
```java
return DataBufferUtils.join(flux)
		.map(buffer -> {
			byte[] result = new byte[buffer.readableByteCount()];
			buffer.read(result);
			DataBufferUtils.release(buffer);
			return DigestUtils.md5DigestAsHex(result);
		});
```
could be rewritten as 
```java
return DataBufferUtils.join(flux)
		.map(buffer -> {
			try (InputStream inputStream = buffer.asInputStream(true)) {
				return DigestUtils.md5DigestAsHex(inputStream);
			} catch (Exception e) {
				throw new RuntimeException(e);
			}
		});
```
But I'm not sure whether it is worth the effort.