### PR TITLE
Fix broken link in Javadoc for DynamicPropertySource

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/DynamicPropertySource.java
+++ b/spring-test/src/main/java/org/springframework/test/context/DynamicPropertySource.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  * to add <em>name-value</em> pairs to the {@code Environment}'s set of
  * {@code PropertySources}. Values are dynamic and provided via a
  * {@link java.util.function.Supplier} which is only invoked when the property
- * is resolved. Typically, method references are used to supply values,as in the
+ * is resolved. Typically, method references are used to supply values, as in the
  * following example.
  *
  * <h3>Example</h3>

--- a/spring-test/src/main/java/org/springframework/test/context/DynamicPropertySource.java
+++ b/spring-test/src/main/java/org/springframework/test/context/DynamicPropertySource.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * <p>Methods annotated with {@code @DynamicPropertySource} must be {@code static}
  * and must have a single {@link DynamicPropertyRegistry} argument which is used
  * to add <em>name-value</em> pairs to the {@code Environment}'s set of
- * {@code PropertySources}. Values are dynamic and provided via a {@link Supplier}
+ * {@code PropertySources}. Values are dynamic and provided via a {@link java.util.function.Supplier}
  * which is only invoked when the property is resolved. Typically, method references
  * are used to supply values, as in the following example.
  *

--- a/spring-test/src/main/java/org/springframework/test/context/DynamicPropertySource.java
+++ b/spring-test/src/main/java/org/springframework/test/context/DynamicPropertySource.java
@@ -36,9 +36,10 @@ import java.lang.annotation.Target;
  * <p>Methods annotated with {@code @DynamicPropertySource} must be {@code static}
  * and must have a single {@link DynamicPropertyRegistry} argument which is used
  * to add <em>name-value</em> pairs to the {@code Environment}'s set of
- * {@code PropertySources}. Values are dynamic and provided via a {@link java.util.function.Supplier}
- * which is only invoked when the property is resolved. Typically, method references
- * are used to supply values, as in the following example.
+ * {@code PropertySources}. Values are dynamic and provided via a
+ * {@link java.util.function.Supplier} which is only invoked when the property
+ * is resolved. Typically, method references are used to supply values,as in the
+ * following example.
  *
  * <h3>Example</h3>
  *


### PR DESCRIPTION
The `{@link Supplier}` can not be referenced, because there is no `import java.util.function.Supplier;` So suggest introducing the package name in `Supplier` link.

