### PR TITLE
Remove the wrong @Nullable annotation in DynamicPropertiesContextCustomizer

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/support/DynamicPropertiesContextCustomizer.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DynamicPropertiesContextCustomizer.java
@@ -73,7 +73,6 @@ class DynamicPropertiesContextCustomizer implements ContextCustomizer {
 		sources.addFirst(new DynamicValuesPropertySource(PROPERTY_SOURCE_NAME, buildDynamicPropertiesMap()));
 	}
 
-	@Nullable
 	private Map<String, Supplier<Object>> buildDynamicPropertiesMap() {
 		Map<String, Supplier<Object>> map = new LinkedHashMap<>();
 		DynamicPropertyRegistry dynamicPropertyRegistry = (name, valueSupplier) -> {


### PR DESCRIPTION
The `buildDynamicPropertiesMap ` method may return an empty unmodifiableMap, but not null.