### PR TITLE
Use autoboxing instead of explicit wrapping

### DIFF
--- a/spring-aop/src/test/java/org/springframework/aop/support/MethodMatchersTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/support/MethodMatchersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,12 +83,12 @@ public class MethodMatchersTests {
 		MethodMatcher intersection = MethodMatchers.intersection(mm1, mm2);
 		assertThat(intersection.isRuntime()).as("Intersection is a dynamic matcher").isTrue();
 		assertThat(intersection.matches(ITESTBEAN_SETAGE, TestBean.class)).as("2Matched setAge method").isTrue();
-		assertThat(intersection.matches(ITESTBEAN_SETAGE, TestBean.class, new Integer(5))).as("3Matched setAge method").isTrue();
+		assertThat(intersection.matches(ITESTBEAN_SETAGE, TestBean.class, 5)).as("3Matched setAge method").isTrue();
 		// Knock out dynamic part
 		intersection = MethodMatchers.intersection(intersection, new TestDynamicMethodMatcherWhichDoesNotMatch());
 		assertThat(intersection.isRuntime()).as("Intersection is a dynamic matcher").isTrue();
 		assertThat(intersection.matches(ITESTBEAN_SETAGE, TestBean.class)).as("2Matched setAge method").isTrue();
-		assertThat(intersection.matches(ITESTBEAN_SETAGE, TestBean.class, new Integer(5))).as("3 - not Matched setAge method").isFalse();
+		assertThat(intersection.matches(ITESTBEAN_SETAGE, TestBean.class, 5)).as("3 - not Matched setAge method").isFalse();
 	}
 
 	@Test

--- a/spring-aop/src/test/java/org/springframework/aop/support/PointcutsTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/support/PointcutsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,20 +121,20 @@ public class PointcutsTests {
 
 	@Test
 	public void testTrue() {
-		assertThat(Pointcuts.matches(Pointcut.TRUE, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isTrue();
+		assertThat(Pointcuts.matches(Pointcut.TRUE, TEST_BEAN_SET_AGE, TestBean.class, 6)).isTrue();
 		assertThat(Pointcuts.matches(Pointcut.TRUE, TEST_BEAN_GET_AGE, TestBean.class)).isTrue();
 		assertThat(Pointcuts.matches(Pointcut.TRUE, TEST_BEAN_ABSQUATULATE, TestBean.class)).isTrue();
-		assertThat(Pointcuts.matches(Pointcut.TRUE, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isTrue();
+		assertThat(Pointcuts.matches(Pointcut.TRUE, TEST_BEAN_SET_AGE, TestBean.class, 6)).isTrue();
 		assertThat(Pointcuts.matches(Pointcut.TRUE, TEST_BEAN_GET_AGE, TestBean.class)).isTrue();
 		assertThat(Pointcuts.matches(Pointcut.TRUE, TEST_BEAN_ABSQUATULATE, TestBean.class)).isTrue();
 	}
 
 	@Test
 	public void testMatches() {
-		assertThat(Pointcuts.matches(allClassSetterPointcut, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isTrue();
+		assertThat(Pointcuts.matches(allClassSetterPointcut, TEST_BEAN_SET_AGE, TestBean.class, 6)).isTrue();
 		assertThat(Pointcuts.matches(allClassSetterPointcut, TEST_BEAN_GET_AGE, TestBean.class)).isFalse();
 		assertThat(Pointcuts.matches(allClassSetterPointcut, TEST_BEAN_ABSQUATULATE, TestBean.class)).isFalse();
-		assertThat(Pointcuts.matches(allClassGetterPointcut, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isFalse();
+		assertThat(Pointcuts.matches(allClassGetterPointcut, TEST_BEAN_SET_AGE, TestBean.class, 6)).isFalse();
 		assertThat(Pointcuts.matches(allClassGetterPointcut, TEST_BEAN_GET_AGE, TestBean.class)).isTrue();
 		assertThat(Pointcuts.matches(allClassGetterPointcut, TEST_BEAN_ABSQUATULATE, TestBean.class)).isFalse();
 	}
@@ -145,7 +145,7 @@ public class PointcutsTests {
 	@Test
 	public void testUnionOfSettersAndGetters() {
 		Pointcut union = Pointcuts.union(allClassGetterPointcut, allClassSetterPointcut);
-		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isTrue();
+		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, 6)).isTrue();
 		assertThat(Pointcuts.matches(union, TEST_BEAN_GET_AGE, TestBean.class)).isTrue();
 		assertThat(Pointcuts.matches(union, TEST_BEAN_ABSQUATULATE, TestBean.class)).isFalse();
 	}
@@ -153,7 +153,7 @@ public class PointcutsTests {
 	@Test
 	public void testUnionOfSpecificGetters() {
 		Pointcut union = Pointcuts.union(allClassGetAgePointcut, allClassGetNamePointcut);
-		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isFalse();
+		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, 6)).isFalse();
 		assertThat(Pointcuts.matches(union, TEST_BEAN_GET_AGE, TestBean.class)).isTrue();
 		assertThat(Pointcuts.matches(allClassGetAgePointcut, TEST_BEAN_GET_NAME, TestBean.class)).isFalse();
 		assertThat(Pointcuts.matches(union, TEST_BEAN_GET_NAME, TestBean.class)).isTrue();
@@ -161,13 +161,13 @@ public class PointcutsTests {
 
 		// Union with all setters
 		union = Pointcuts.union(union, allClassSetterPointcut);
-		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isTrue();
+		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, 6)).isTrue();
 		assertThat(Pointcuts.matches(union, TEST_BEAN_GET_AGE, TestBean.class)).isTrue();
 		assertThat(Pointcuts.matches(allClassGetAgePointcut, TEST_BEAN_GET_NAME, TestBean.class)).isFalse();
 		assertThat(Pointcuts.matches(union, TEST_BEAN_GET_NAME, TestBean.class)).isTrue();
 		assertThat(Pointcuts.matches(union, TEST_BEAN_ABSQUATULATE, TestBean.class)).isFalse();
 
-		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isTrue();
+		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, 6)).isTrue();
 	}
 
 	/**
@@ -176,16 +176,16 @@ public class PointcutsTests {
 	 */
 	@Test
 	public void testUnionOfAllSettersAndSubclassSetters() {
-		assertThat(Pointcuts.matches(myTestBeanSetterPointcut, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isFalse();
-		assertThat(Pointcuts.matches(myTestBeanSetterPointcut, TEST_BEAN_SET_AGE, MyTestBean.class, new Integer(6))).isTrue();
+		assertThat(Pointcuts.matches(myTestBeanSetterPointcut, TEST_BEAN_SET_AGE, TestBean.class, 6)).isFalse();
+		assertThat(Pointcuts.matches(myTestBeanSetterPointcut, TEST_BEAN_SET_AGE, MyTestBean.class, 6)).isTrue();
 		assertThat(Pointcuts.matches(myTestBeanSetterPointcut, TEST_BEAN_GET_AGE, TestBean.class)).isFalse();
 
 		Pointcut union = Pointcuts.union(myTestBeanSetterPointcut, allClassGetterPointcut);
 		assertThat(Pointcuts.matches(union, TEST_BEAN_GET_AGE, TestBean.class)).isTrue();
 		assertThat(Pointcuts.matches(union, TEST_BEAN_GET_AGE, MyTestBean.class)).isTrue();
 		// Still doesn't match superclass setter
-		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, MyTestBean.class, new Integer(6))).isTrue();
-		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isFalse();
+		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, MyTestBean.class, 6)).isTrue();
+		assertThat(Pointcuts.matches(union, TEST_BEAN_SET_AGE, TestBean.class, 6)).isFalse();
 	}
 
 	/**
@@ -241,7 +241,7 @@ public class PointcutsTests {
 	@Test
 	public void testSimpleIntersection() {
 		Pointcut intersection = Pointcuts.intersection(allClassGetterPointcut, allClassSetterPointcut);
-		assertThat(Pointcuts.matches(intersection, TEST_BEAN_SET_AGE, TestBean.class, new Integer(6))).isFalse();
+		assertThat(Pointcuts.matches(intersection, TEST_BEAN_SET_AGE, TestBean.class, 6)).isFalse();
 		assertThat(Pointcuts.matches(intersection, TEST_BEAN_GET_AGE, TestBean.class)).isFalse();
 		assertThat(Pointcuts.matches(intersection, TEST_BEAN_ABSQUATULATE, TestBean.class)).isFalse();
 	}

--- a/spring-beans/src/test/java/org/springframework/beans/AbstractPropertyAccessorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/AbstractPropertyAccessorTests.java
@@ -300,7 +300,7 @@ public abstract class AbstractPropertyAccessorTests {
 
 		AbstractPropertyAccessor accessor = createAccessor(target);
 		accessor.setPropertyValue("spouse", kerry);
-		accessor.setPropertyValue("spouse.age", new Integer(35));
+		accessor.setPropertyValue("spouse.age", 35);
 		accessor.setPropertyValue("spouse.name", "Kerry");
 		accessor.setPropertyValue("spouse.company", "Lewisham");
 		assertThat(kerry.getName().equals("Kerry")).as("kerry name is Kerry").isTrue();
@@ -389,7 +389,7 @@ public abstract class AbstractPropertyAccessorTests {
 		ITestBean target = new TestBean("rod", 31);
 		AbstractPropertyAccessor accessor = createAccessor(target);
 		assertThatExceptionOfType(NullValueInNestedPathException.class).isThrownBy(() ->
-				accessor.setPropertyValue("spouse.age", new Integer(31)))
+				accessor.setPropertyValue("spouse.age", 31))
 			.satisfies(ex -> assertThat(ex.getPropertyName()).isEqualTo("spouse"));
 	}
 
@@ -482,7 +482,7 @@ public abstract class AbstractPropertyAccessorTests {
 		int newAge = 65;
 		String newTouchy = "valid";
 		AbstractPropertyAccessor accessor = createAccessor(target);
-		accessor.setPropertyValue("age", new Integer(newAge));
+		accessor.setPropertyValue("age", newAge);
 		accessor.setPropertyValue(new PropertyValue("name", newName));
 		accessor.setPropertyValue(new PropertyValue("touchy", newTouchy));
 		assertThat(target.getName().equals(newName)).as("Name property should have changed").isTrue();
@@ -618,13 +618,13 @@ public abstract class AbstractPropertyAccessorTests {
 	public void setNumberPropertiesWithCoercion() {
 		NumberTestBean target = new NumberTestBean();
 		AbstractPropertyAccessor accessor = createAccessor(target);
-		accessor.setPropertyValue("short2", new Integer(2));
-		accessor.setPropertyValue("int2", new Long(8));
+		accessor.setPropertyValue("short2", 2);
+		accessor.setPropertyValue("int2", 8L);
 		accessor.setPropertyValue("long2", new BigInteger("6"));
-		accessor.setPropertyValue("bigInteger", new Integer(3));
-		accessor.setPropertyValue("float2", new Double(8.1));
+		accessor.setPropertyValue("bigInteger", 3L);
+		accessor.setPropertyValue("float2", 8.1D);
 		accessor.setPropertyValue("double2", new BigDecimal(6.1));
-		accessor.setPropertyValue("bigDecimal", new Float(4.0));
+		accessor.setPropertyValue("bigDecimal", 4.0F);
 		assertThat(new Short("2").equals(accessor.getPropertyValue("short2"))).as("Correct short2 value").isTrue();
 		assertThat(new Short("2").equals(target.getShort2())).as("Correct short2 value").isTrue();
 		assertThat(new Integer("8").equals(accessor.getPropertyValue("int2"))).as("Correct int2 value").isTrue();
@@ -886,14 +886,14 @@ public abstract class AbstractPropertyAccessorTests {
 		result.add(target.intArray[0]);
 		result.add(target.intArray[1]);
 		result.add(target.intArray[2]);
-		assertThat(result.contains(new Integer(4)) && result.contains(new Integer(5)) &&
-		result.contains(new Integer(3))).as("correct values").isTrue();
+		assertThat(result.contains(4) && result.contains(5) &&
+		result.contains(3)).as("correct values").isTrue();
 
 		accessor.setPropertyValue("intArray", new Integer[] {1});
 		assertThat(target.intArray.length == 1).as("intArray length = 4").isTrue();
 		assertThat(target.intArray[0] == 1).as("correct values").isTrue();
 
-		accessor.setPropertyValue("intArray", new Integer(1));
+		accessor.setPropertyValue("intArray", 1);
 		assertThat(target.intArray.length == 1).as("intArray length = 4").isTrue();
 		assertThat(target.intArray[0] == 1).as("correct values").isTrue();
 
@@ -913,7 +913,7 @@ public abstract class AbstractPropertyAccessorTests {
 		accessor.registerCustomEditor(int.class, new PropertyEditorSupport() {
 			@Override
 			public void setAsText(String text) {
-				setValue(new Integer(Integer.parseInt(text) + 1));
+				setValue(Integer.parseInt(text) + 1);
 			}
 		});
 
@@ -927,7 +927,7 @@ public abstract class AbstractPropertyAccessorTests {
 		assertThat(target.intArray[0] == 4 && target.intArray[1] == 5 &&
 		target.intArray[2] == 2 && target.intArray[3] == 3).as("correct values").isTrue();
 
-		accessor.setPropertyValue("intArray", new Integer(1));
+		accessor.setPropertyValue("intArray", 1);
 		assertThat(target.intArray.length == 1).as("intArray length = 4").isTrue();
 		assertThat(target.intArray[0] == 1).as("correct values").isTrue();
 
@@ -1022,7 +1022,7 @@ public abstract class AbstractPropertyAccessorTests {
 			@Override
 			public void setValue(Object value) {
 				if (value instanceof Integer) {
-					super.setValue(new Integer((Integer) value + 1));
+					super.setValue((Integer) value + 1);
 				}
 			}
 		});
@@ -1041,7 +1041,7 @@ public abstract class AbstractPropertyAccessorTests {
 			@Override
 			public void setValue(Object value) {
 				if (value instanceof Integer) {
-					super.setValue(new Integer((Integer) value + 1));
+					super.setValue((Integer) value + 1);
 				}
 			}
 		});
@@ -1210,16 +1210,16 @@ public abstract class AbstractPropertyAccessorTests {
 		AbstractPropertyAccessor accessor = createAccessor(target);
 		Collection<Integer> coll = new HashSet<>();
 		coll.add(0);
-		accessor.setPropertyValue("collection", new Integer(0));
+		accessor.setPropertyValue("collection", 0);
 		List<Integer> set = new LinkedList<>();
 		set.add(1);
-		accessor.setPropertyValue("set", new Integer(1));
+		accessor.setPropertyValue("set", 1);
 		List<Integer> sortedSet = new ArrayList<>();
 		sortedSet.add(2);
-		accessor.setPropertyValue("sortedSet", new Integer(2));
+		accessor.setPropertyValue("sortedSet", 2);
 		Set<Integer> list = new HashSet<>();
 		list.add(3);
-		accessor.setPropertyValue("list", new Integer(3));
+		accessor.setPropertyValue("list", 3);
 		assertThat(target.getCollection().size()).isEqualTo(1);
 		assertThat(target.getCollection().containsAll(coll)).isTrue();
 		assertThat(target.getSet().size()).isEqualTo(1);

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperEnumTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperEnumTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,8 +158,8 @@ public class BeanWrapperEnumTests {
 		map.put("VALUE_2", 2);
 		bw.setPropertyValue("standardEnumMap", map);
 		assertThat(gb.getStandardEnumMap().size()).isEqualTo(2);
-		assertThat(gb.getStandardEnumMap().get(CustomEnum.VALUE_1)).isEqualTo(new Integer(1));
-		assertThat(gb.getStandardEnumMap().get(CustomEnum.VALUE_2)).isEqualTo(new Integer(2));
+		assertThat(gb.getStandardEnumMap().get(CustomEnum.VALUE_1)).isEqualTo(1);
+		assertThat(gb.getStandardEnumMap().get(CustomEnum.VALUE_2)).isEqualTo(2);
 	}
 
 	@Test
@@ -170,7 +170,7 @@ public class BeanWrapperEnumTests {
 		assertThat(gb.getStandardEnumMap()).isNull();
 		bw.setPropertyValue("standardEnumMap[VALUE_1]", 1);
 		assertThat(gb.getStandardEnumMap().size()).isEqualTo(1);
-		assertThat(gb.getStandardEnumMap().get(CustomEnum.VALUE_1)).isEqualTo(new Integer(1));
+		assertThat(gb.getStandardEnumMap().get(CustomEnum.VALUE_1)).isEqualTo(1);
 	}
 
 	@Test

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperGenericsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperGenericsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,8 +57,8 @@ public class BeanWrapperGenericsTests {
 		input.add("4");
 		input.add("5");
 		bw.setPropertyValue("integerSet", input);
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
 	}
 
 	@Test
@@ -70,8 +70,8 @@ public class BeanWrapperGenericsTests {
 		input.add("4");
 		input.add("5");
 		bw.setPropertyValue("numberSet", input);
-		assertThat(gb.getNumberSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getNumberSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getNumberSet().contains(4)).isTrue();
+		assertThat(gb.getNumberSet().contains(5)).isTrue();
 	}
 
 	@Test
@@ -114,8 +114,8 @@ public class BeanWrapperGenericsTests {
 		input.put("4", "5");
 		input.put("6", "7");
 		bw.setPropertyValue("shortMap", input);
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 	}
 
 	@Test
@@ -124,8 +124,8 @@ public class BeanWrapperGenericsTests {
 		gb.setShortMap(new HashMap<>());
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("shortMap[4]", "5");
-		assertThat(bw.getPropertyValue("shortMap[4]")).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
+		assertThat(bw.getPropertyValue("shortMap[4]")).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
 	}
 
 	@Test
@@ -136,8 +136,8 @@ public class BeanWrapperGenericsTests {
 		input.put("4", "5");
 		input.put("6", "7");
 		bw.setPropertyValue("longMap", input);
-		assertThat(gb.getLongMap().get(new Long("4"))).isEqualTo("5");
-		assertThat(gb.getLongMap().get(new Long("6"))).isEqualTo("7");
+		assertThat(gb.getLongMap().get(4L)).isEqualTo("5");
+		assertThat(gb.getLongMap().get(6L)).isEqualTo("7");
 	}
 
 	@Test
@@ -157,15 +157,15 @@ public class BeanWrapperGenericsTests {
 		bw.registerCustomEditor(Number.class, new CustomNumberEditor(Integer.class, false));
 		Map<String, Collection<?>> input = new HashMap<>();
 		HashSet<Integer> value1 = new HashSet<>();
-		value1.add(new Integer(1));
+		value1.add(1);
 		input.put("1", value1);
 		ArrayList<Boolean> value2 = new ArrayList<>();
 		value2.add(Boolean.TRUE);
 		input.put("2", value2);
 		bw.setPropertyValue("collectionMap", input);
-		boolean condition1 = gb.getCollectionMap().get(new Integer(1)) instanceof HashSet;
+		boolean condition1 = gb.getCollectionMap().get(1) instanceof HashSet;
 		assertThat(condition1).isTrue();
-		boolean condition = gb.getCollectionMap().get(new Integer(2)) instanceof ArrayList;
+		boolean condition = gb.getCollectionMap().get(2) instanceof ArrayList;
 		assertThat(condition).isTrue();
 	}
 
@@ -176,9 +176,9 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.registerCustomEditor(Number.class, new CustomNumberEditor(Integer.class, false));
 		HashSet<Integer> value1 = new HashSet<>();
-		value1.add(new Integer(1));
+		value1.add(1);
 		bw.setPropertyValue("collectionMap[1]", value1);
-		boolean condition = gb.getCollectionMap().get(new Integer(1)) instanceof HashSet;
+		boolean condition = gb.getCollectionMap().get(1) instanceof HashSet;
 		assertThat(condition).isTrue();
 	}
 
@@ -190,8 +190,8 @@ public class BeanWrapperGenericsTests {
 		input.setProperty("4", "5");
 		input.setProperty("6", "7");
 		bw.setPropertyValue("shortMap", input);
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 	}
 
 	@Test
@@ -201,9 +201,9 @@ public class BeanWrapperGenericsTests {
 		list.add(new LinkedList<>());
 		gb.setListOfLists(list);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
-		bw.setPropertyValue("listOfLists[0][0]", new Integer(5));
-		assertThat(bw.getPropertyValue("listOfLists[0][0]")).isEqualTo(new Integer(5));
-		assertThat(gb.getListOfLists().get(0).get(0)).isEqualTo(new Integer(5));
+		bw.setPropertyValue("listOfLists[0][0]", 5);
+		assertThat(bw.getPropertyValue("listOfLists[0][0]")).isEqualTo(5);
+		assertThat(gb.getListOfLists().get(0).get(0)).isEqualTo(5);
 	}
 
 	@Test
@@ -214,8 +214,8 @@ public class BeanWrapperGenericsTests {
 		gb.setListOfLists(list);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("listOfLists[0][0]", "5");
-		assertThat(bw.getPropertyValue("listOfLists[0][0]")).isEqualTo(new Integer(5));
-		assertThat(gb.getListOfLists().get(0).get(0)).isEqualTo(new Integer(5));
+		assertThat(bw.getPropertyValue("listOfLists[0][0]")).isEqualTo(5);
+		assertThat(gb.getListOfLists().get(0).get(0)).isEqualTo(5);
 	}
 
 	@Test
@@ -295,24 +295,24 @@ public class BeanWrapperGenericsTests {
 	public void testGenericMapOfLists() throws MalformedURLException {
 		GenericBean<String> gb = new GenericBean<>();
 		Map<Integer, List<Integer>> map = new HashMap<>();
-		map.put(new Integer(1), new LinkedList<>());
+		map.put(1, new LinkedList<>());
 		gb.setMapOfLists(map);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
-		bw.setPropertyValue("mapOfLists[1][0]", new Integer(5));
-		assertThat(bw.getPropertyValue("mapOfLists[1][0]")).isEqualTo(new Integer(5));
-		assertThat(gb.getMapOfLists().get(new Integer(1)).get(0)).isEqualTo(new Integer(5));
+		bw.setPropertyValue("mapOfLists[1][0]", 5);
+		assertThat(bw.getPropertyValue("mapOfLists[1][0]")).isEqualTo(5);
+		assertThat(gb.getMapOfLists().get(1).get(0)).isEqualTo(5);
 	}
 
 	@Test
 	public void testGenericMapOfListsWithElementConversion() throws MalformedURLException {
 		GenericBean<String> gb = new GenericBean<>();
 		Map<Integer, List<Integer>> map = new HashMap<>();
-		map.put(new Integer(1), new LinkedList<>());
+		map.put(1, new LinkedList<>());
 		gb.setMapOfLists(map);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("mapOfLists[1][0]", "5");
-		assertThat(bw.getPropertyValue("mapOfLists[1][0]")).isEqualTo(new Integer(5));
-		assertThat(gb.getMapOfLists().get(new Integer(1)).get(0)).isEqualTo(new Integer(5));
+		assertThat(bw.getPropertyValue("mapOfLists[1][0]")).isEqualTo(5);
+		assertThat(gb.getMapOfLists().get(1).get(0)).isEqualTo(5);
 	}
 
 	@Test
@@ -391,7 +391,7 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(holder);
 		bw.setPropertyValue("genericMap", inputMap);
 
-		assertThat(holder.getGenericMap().keySet().iterator().next().get(0)).isEqualTo(new Integer(1));
+		assertThat(holder.getGenericMap().keySet().iterator().next().get(0)).isEqualTo(1);
 		assertThat(holder.getGenericMap().values().iterator().next().get(0)).isEqualTo(new Long(10));
 	}
 
@@ -408,7 +408,7 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(holder);
 		bw.setPropertyValue("genericMap", inputMap);
 
-		assertThat(holder.getGenericMap().keySet().iterator().next().get(0)).isEqualTo(new Integer(1));
+		assertThat(holder.getGenericMap().keySet().iterator().next().get(0)).isEqualTo(1);
 		assertThat(holder.getGenericMap().values().iterator().next().get(0)).isEqualTo(new Long(10));
 	}
 
@@ -421,7 +421,7 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(holder);
 		bw.setPropertyValue("genericIndexedMap[1]", inputValue);
 
-		assertThat(holder.getGenericIndexedMap().keySet().iterator().next()).isEqualTo(new Integer(1));
+		assertThat(holder.getGenericIndexedMap().keySet().iterator().next()).isEqualTo(1);
 		assertThat(holder.getGenericIndexedMap().values().iterator().next().get(0)).isEqualTo(new Long(10));
 	}
 
@@ -434,7 +434,7 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(holder);
 		bw.setPropertyValue("genericIndexedMap[1]", inputValue);
 
-		assertThat(holder.getGenericIndexedMap().keySet().iterator().next()).isEqualTo(new Integer(1));
+		assertThat(holder.getGenericIndexedMap().keySet().iterator().next()).isEqualTo(1);
 		assertThat(holder.getGenericIndexedMap().values().iterator().next().get(0)).isEqualTo(new Long(10));
 	}
 
@@ -447,7 +447,7 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(holder);
 		bw.setPropertyValue("derivedIndexedMap[1]", inputValue);
 
-		assertThat(holder.getDerivedIndexedMap().keySet().iterator().next()).isEqualTo(new Integer(1));
+		assertThat(holder.getDerivedIndexedMap().keySet().iterator().next()).isEqualTo(1);
 		assertThat(holder.getDerivedIndexedMap().values().iterator().next().get(0)).isEqualTo(new Long(10));
 	}
 
@@ -460,7 +460,7 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(holder);
 		bw.setPropertyValue("derivedIndexedMap[1]", inputValue);
 
-		assertThat(holder.getDerivedIndexedMap().keySet().iterator().next()).isEqualTo(new Integer(1));
+		assertThat(holder.getDerivedIndexedMap().keySet().iterator().next()).isEqualTo(1);
 		assertThat(holder.getDerivedIndexedMap().values().iterator().next().get(0)).isEqualTo(new Long(10));
 	}
 
@@ -470,9 +470,9 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("genericProperty", "10");
 		bw.setPropertyValue("genericListProperty", new String[] {"20", "30"});
-		assertThat(gb.getGenericProperty()).isEqualTo(new Integer(10));
-		assertThat(gb.getGenericListProperty().get(0)).isEqualTo(new Integer(20));
-		assertThat(gb.getGenericListProperty().get(1)).isEqualTo(new Integer(30));
+		assertThat(gb.getGenericProperty()).isEqualTo(10);
+		assertThat(gb.getGenericListProperty().get(0)).isEqualTo(20);
+		assertThat(gb.getGenericListProperty().get(1)).isEqualTo(30);
 	}
 
 	@Test
@@ -481,9 +481,9 @@ public class BeanWrapperGenericsTests {
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("genericProperty", "10");
 		bw.setPropertyValue("genericListProperty", new String[] {"20", "30"});
-		assertThat(gb.getGenericProperty().iterator().next()).isEqualTo(new Integer(10));
-		assertThat(gb.getGenericListProperty().get(0).iterator().next()).isEqualTo(new Integer(20));
-		assertThat(gb.getGenericListProperty().get(1).iterator().next()).isEqualTo(new Integer(30));
+		assertThat(gb.getGenericProperty().iterator().next()).isEqualTo(10);
+		assertThat(gb.getGenericListProperty().get(0).iterator().next()).isEqualTo(20);
+		assertThat(gb.getGenericListProperty().get(1).iterator().next()).isEqualTo(30);
 	}
 
 	@Test

--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1216,16 +1216,16 @@ class DefaultListableBeanFactoryTests {
 
 	@Test
 	void arrayConstructorWithAutowiring() {
-		lbf.registerSingleton("integer1", new Integer(4));
-		lbf.registerSingleton("integer2", new Integer(5));
+		lbf.registerSingleton("integer1",4);
+		lbf.registerSingleton("integer2", 5);
 
 		RootBeanDefinition rbd = new RootBeanDefinition(ArrayBean.class);
 		rbd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("arrayBean", rbd);
 		ArrayBean ab = (ArrayBean) lbf.getBean("arrayBean");
 
-		assertThat(ab.getIntegerArray()[0]).isEqualTo(new Integer(4));
-		assertThat(ab.getIntegerArray()[1]).isEqualTo(new Integer(5));
+		assertThat(ab.getIntegerArray()[0]).isEqualTo(4);
+		assertThat(ab.getIntegerArray()[1]).isEqualTo(5);
 	}
 
 	@Test
@@ -1240,8 +1240,8 @@ class DefaultListableBeanFactoryTests {
 
 	@Test
 	void doubleArrayConstructorWithAutowiring() throws MalformedURLException {
-		lbf.registerSingleton("integer1", new Integer(4));
-		lbf.registerSingleton("integer2", new Integer(5));
+		lbf.registerSingleton("integer1", 4);
+		lbf.registerSingleton("integer2", 5);
 		lbf.registerSingleton("resource1", new UrlResource("http://localhost:8080"));
 		lbf.registerSingleton("resource2", new UrlResource("http://localhost:9090"));
 
@@ -1250,8 +1250,8 @@ class DefaultListableBeanFactoryTests {
 		lbf.registerBeanDefinition("arrayBean", rbd);
 		ArrayBean ab = (ArrayBean) lbf.getBean("arrayBean");
 
-		assertThat(ab.getIntegerArray()[0]).isEqualTo(new Integer(4));
-		assertThat(ab.getIntegerArray()[1]).isEqualTo(new Integer(5));
+		assertThat(ab.getIntegerArray()[0]).isEqualTo(4);
+		assertThat(ab.getIntegerArray()[1]).isEqualTo(5);
 		assertThat(ab.getResourceArray()[0]).isEqualTo(new UrlResource("http://localhost:8080"));
 		assertThat(ab.getResourceArray()[1]).isEqualTo(new UrlResource("http://localhost:9090"));
 	}
@@ -2721,7 +2721,7 @@ class DefaultListableBeanFactoryTests {
 	private void doTestFieldSettingWithInstantiationAwarePostProcessor(final boolean skipPropertyPopulation) {
 		RootBeanDefinition bd = new RootBeanDefinition(TestBean.class);
 		int ageSetByPropertyValue = 27;
-		bd.getPropertyValues().addPropertyValue(new PropertyValue("age", new Integer(ageSetByPropertyValue)));
+		bd.getPropertyValues().addPropertyValue(new PropertyValue("age", ageSetByPropertyValue));
 		lbf.registerBeanDefinition("test", bd);
 		final String nameSetOnField = "nameSetOnField";
 		lbf.addBeanPostProcessor(new InstantiationAwareBeanPostProcessorAdapter() {
@@ -3232,7 +3232,7 @@ class DefaultListableBeanFactoryTests {
 				}
 			}
 			else if (value instanceof String && int.class.isAssignableFrom(requiredType)) {
-				return new Integer(5);
+				return 5;
 			}
 			else {
 				return value;

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/FieldRetrievingFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/FieldRetrievingFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class FieldRetrievingFactoryBeanTests {
 		FieldRetrievingFactoryBean fr = new FieldRetrievingFactoryBean();
 		fr.setStaticField("java.sql.Connection.TRANSACTION_SERIALIZABLE");
 		fr.afterPropertiesSet();
-		assertThat(fr.getObject()).isEqualTo(new Integer(Connection.TRANSACTION_SERIALIZABLE));
+		assertThat(fr.getObject()).isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
 	}
 
 	@Test
@@ -49,7 +49,7 @@ public class FieldRetrievingFactoryBeanTests {
 		FieldRetrievingFactoryBean fr = new FieldRetrievingFactoryBean();
 		fr.setStaticField("  java.sql.Connection.TRANSACTION_SERIALIZABLE  ");
 		fr.afterPropertiesSet();
-		assertThat(fr.getObject()).isEqualTo(new Integer(Connection.TRANSACTION_SERIALIZABLE));
+		assertThat(fr.getObject()).isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class FieldRetrievingFactoryBeanTests {
 		fr.setTargetClass(Connection.class);
 		fr.setTargetField("TRANSACTION_SERIALIZABLE");
 		fr.afterPropertiesSet();
-		assertThat(fr.getObject()).isEqualTo(new Integer(Connection.TRANSACTION_SERIALIZABLE));
+		assertThat(fr.getObject()).isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
 	}
 
 	@Test
@@ -76,7 +76,7 @@ public class FieldRetrievingFactoryBeanTests {
 		FieldRetrievingFactoryBean fr = new FieldRetrievingFactoryBean();
 		fr.setBeanName("java.sql.Connection.TRANSACTION_SERIALIZABLE");
 		fr.afterPropertiesSet();
-		assertThat(fr.getObject()).isEqualTo(new Integer(Connection.TRANSACTION_SERIALIZABLE));
+		assertThat(fr.getObject()).isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
 	}
 
 	@Test
@@ -127,8 +127,8 @@ public class FieldRetrievingFactoryBeanTests {
 				qualifiedResource(FieldRetrievingFactoryBeanTests.class, "context.xml"));
 
 		TestBean testBean = (TestBean) bf.getBean("testBean");
-		assertThat(testBean.getSomeIntegerArray()[0]).isEqualTo(new Integer(Connection.TRANSACTION_SERIALIZABLE));
-		assertThat(testBean.getSomeIntegerArray()[1]).isEqualTo(new Integer(Connection.TRANSACTION_SERIALIZABLE));
+		assertThat(testBean.getSomeIntegerArray()[0]).isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
+		assertThat(testBean.getSomeIntegerArray()[1]).isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
 	}
 
 

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/PropertyPathFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/PropertyPathFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,9 @@ public class PropertyPathFactoryBeanTests {
 	public void testPropertyPathFactoryBeanWithSingletonResult() {
 		DefaultListableBeanFactory xbf = new DefaultListableBeanFactory();
 		new XmlBeanDefinitionReader(xbf).loadBeanDefinitions(CONTEXT);
-		assertThat(xbf.getBean("propertyPath1")).isEqualTo(new Integer(12));
-		assertThat(xbf.getBean("propertyPath2")).isEqualTo(new Integer(11));
-		assertThat(xbf.getBean("tb.age")).isEqualTo(new Integer(10));
+		assertThat(xbf.getBean("propertyPath1")).isEqualTo(12);
+		assertThat(xbf.getBean("propertyPath2")).isEqualTo(11);
+		assertThat(xbf.getBean("tb.age")).isEqualTo(10);
 		assertThat(xbf.getType("otb.spouse")).isEqualTo(ITestBean.class);
 		Object result1 = xbf.getBean("otb.spouse");
 		Object result2 = xbf.getBean("otb.spouse");

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/PropertyResourceConfigurerTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/PropertyResourceConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -414,7 +414,7 @@ public class PropertyResourceConfigurerTests {
 		assertThat(tb2.getSomeSet().size()).isEqualTo(3);
 		assertThat(tb2.getSomeSet().contains("na98me")).isTrue();
 		assertThat(tb2.getSomeSet().contains(tb2)).isTrue();
-		assertThat(tb2.getSomeSet().contains(new Integer(98))).isTrue();
+		assertThat(tb2.getSomeSet().contains(98)).isTrue();
 		assertThat(tb2.getSomeMap().size()).isEqualTo(6);
 		assertThat(tb2.getSomeMap().get("key98")).isEqualTo("98");
 		assertThat(tb2.getSomeMap().get("key98ref")).isEqualTo(tb2);

--- a/spring-beans/src/test/java/org/springframework/beans/factory/support/BeanDefinitionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/support/BeanDefinitionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,19 +73,19 @@ public class BeanDefinitionTests {
 	public void beanDefinitionEqualityWithConstructorArguments() {
 		RootBeanDefinition bd = new RootBeanDefinition(TestBean.class);
 		bd.getConstructorArgumentValues().addGenericArgumentValue("test");
-		bd.getConstructorArgumentValues().addIndexedArgumentValue(1, new Integer(5));
+		bd.getConstructorArgumentValues().addIndexedArgumentValue(1, 5);
 		RootBeanDefinition otherBd = new RootBeanDefinition(TestBean.class);
 		otherBd.getConstructorArgumentValues().addGenericArgumentValue("test");
 		boolean condition3 = !bd.equals(otherBd);
 		assertThat(condition3).isTrue();
 		boolean condition2 = !otherBd.equals(bd);
 		assertThat(condition2).isTrue();
-		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, new Integer(9));
+		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, 9);
 		boolean condition1 = !bd.equals(otherBd);
 		assertThat(condition1).isTrue();
 		boolean condition = !otherBd.equals(bd);
 		assertThat(condition).isTrue();
-		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, new Integer(5));
+		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, 5);
 		assertThat(bd.equals(otherBd)).isTrue();
 		assertThat(otherBd.equals(bd)).isTrue();
 		assertThat(bd.hashCode() == otherBd.hashCode()).isTrue();
@@ -95,20 +95,20 @@ public class BeanDefinitionTests {
 	public void beanDefinitionEqualityWithTypedConstructorArguments() {
 		RootBeanDefinition bd = new RootBeanDefinition(TestBean.class);
 		bd.getConstructorArgumentValues().addGenericArgumentValue("test", "int");
-		bd.getConstructorArgumentValues().addIndexedArgumentValue(1, new Integer(5), "long");
+		bd.getConstructorArgumentValues().addIndexedArgumentValue(1, 5, "long");
 		RootBeanDefinition otherBd = new RootBeanDefinition(TestBean.class);
 		otherBd.getConstructorArgumentValues().addGenericArgumentValue("test", "int");
-		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, new Integer(5));
+		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, 5);
 		boolean condition3 = !bd.equals(otherBd);
 		assertThat(condition3).isTrue();
 		boolean condition2 = !otherBd.equals(bd);
 		assertThat(condition2).isTrue();
-		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, new Integer(5), "int");
+		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, 5, "int");
 		boolean condition1 = !bd.equals(otherBd);
 		assertThat(condition1).isTrue();
 		boolean condition = !otherBd.equals(bd);
 		assertThat(condition).isTrue();
-		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, new Integer(5), "long");
+		otherBd.getConstructorArgumentValues().addIndexedArgumentValue(1, 5, "long");
 		assertThat(bd.equals(otherBd)).isTrue();
 		assertThat(otherBd.equals(bd)).isTrue();
 		assertThat(bd.hashCode() == otherBd.hashCode()).isTrue();
@@ -160,7 +160,7 @@ public class BeanDefinitionTests {
 	public void beanDefinitionMerging() {
 		RootBeanDefinition bd = new RootBeanDefinition(TestBean.class);
 		bd.getConstructorArgumentValues().addGenericArgumentValue("test");
-		bd.getConstructorArgumentValues().addIndexedArgumentValue(1, new Integer(5));
+		bd.getConstructorArgumentValues().addIndexedArgumentValue(1, 5);
 		bd.getPropertyValues().add("name", "myName");
 		bd.getPropertyValues().add("age", "99");
 		bd.setQualifiedElement(getClass());
@@ -174,8 +174,8 @@ public class BeanDefinitionTests {
 		assertThat(mergedBd.getPropertyValues().size()).isEqualTo(2);
 		assertThat(mergedBd).isEqualTo(bd);
 
-		mergedBd.getConstructorArgumentValues().getArgumentValue(1, null).setValue(new Integer(9));
-		assertThat(bd.getConstructorArgumentValues().getArgumentValue(1, null).getValue()).isEqualTo(new Integer(5));
+		mergedBd.getConstructorArgumentValues().getArgumentValue(1, null).setValue(9);
+		assertThat(bd.getConstructorArgumentValues().getArgumentValue(1, null).getValue()).isEqualTo(5);
 		assertThat(bd.getQualifiedElement()).isEqualTo(getClass());
 	}
 

--- a/spring-beans/src/test/java/org/springframework/beans/factory/support/BeanFactoryGenericsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/support/BeanFactoryGenericsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,8 +80,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
 	}
 
 	@Test
@@ -159,8 +159,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 	}
 
 	@Test
@@ -191,23 +191,23 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
 	}
 
 	@Test
 	public void testGenericSetConstructorWithAutowiring() {
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
-		bf.registerSingleton("integer1", new Integer(4));
-		bf.registerSingleton("integer2", new Integer(5));
+		bf.registerSingleton("integer1", 4);
+		bf.registerSingleton("integer2", 5);
 
 		RootBeanDefinition rbd = new RootBeanDefinition(GenericBean.class);
 		rbd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
 	}
 
 	@Test
@@ -239,8 +239,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
 		assertThat(gb.getResourceList().get(0)).isEqualTo(new UrlResource("http://localhost:8080"));
 		assertThat(gb.getResourceList().get(1)).isEqualTo(new UrlResource("http://localhost:9090"));
 	}
@@ -248,8 +248,8 @@ public class BeanFactoryGenericsTests {
 	@Test
 	public void testGenericSetListConstructorWithAutowiring() throws Exception {
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
-		bf.registerSingleton("integer1", new Integer(4));
-		bf.registerSingleton("integer2", new Integer(5));
+		bf.registerSingleton("integer1", 4);
+		bf.registerSingleton("integer2", 5);
 		bf.registerSingleton("resource1", new UrlResource("http://localhost:8080"));
 		bf.registerSingleton("resource2", new UrlResource("http://localhost:9090"));
 
@@ -258,8 +258,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
 		assertThat(gb.getResourceList().get(0)).isEqualTo(new UrlResource("http://localhost:8080"));
 		assertThat(gb.getResourceList().get(1)).isEqualTo(new UrlResource("http://localhost:9090"));
 	}
@@ -296,10 +296,10 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 	}
 
 	@Test
@@ -316,8 +316,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 		assertThat(gb.getResourceList().get(0)).isEqualTo(new UrlResource("http://localhost:8080"));
 	}
 
@@ -343,8 +343,8 @@ public class BeanFactoryGenericsTests {
 		assertThat(gb.getPlainMap().get("1")).isEqualTo("0");
 		assertThat(gb.getPlainMap().get("2")).isEqualTo("3");
 		assertThat(gb.getShortMap().size()).isEqualTo(2);
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 	}
 
 	@Test
@@ -366,8 +366,8 @@ public class BeanFactoryGenericsTests {
 		assertThat(gb.getPlainMap().get("1")).isEqualTo("0");
 		assertThat(gb.getPlainMap().get("2")).isEqualTo("3");
 		assertThat(gb.getShortMap().size()).isEqualTo(2);
-		assertThat(gb.getShortMap().get(new Short("1"))).isEqualTo(new Integer(0));
-		assertThat(gb.getShortMap().get(new Short("2"))).isEqualTo(new Integer(3));
+		assertThat(gb.getShortMap().get(new Short("1"))).isEqualTo(0);
+		assertThat(gb.getShortMap().get(new Short("2"))).isEqualTo(3);
 	}
 
 	@Test
@@ -376,8 +376,8 @@ public class BeanFactoryGenericsTests {
 		RootBeanDefinition rbd = new RootBeanDefinition(GenericBean.class);
 
 		Map<Short, Integer> input = new HashMap<>();
-		input.put(new Short((short) 1), new Integer(0));
-		input.put(new Short((short) 2), new Integer(3));
+		input.put(new Short((short) 1), 0);
+		input.put(new Short((short) 2), 3);
 		rbd.getConstructorArgumentValues().addGenericArgumentValue(input);
 		rbd.getConstructorArgumentValues().addGenericArgumentValue(input);
 
@@ -386,8 +386,8 @@ public class BeanFactoryGenericsTests {
 
 		assertThat(gb.getShortMap()).isSameAs(gb.getPlainMap());
 		assertThat(gb.getShortMap().size()).isEqualTo(2);
-		assertThat(gb.getShortMap().get(new Short("1"))).isEqualTo(new Integer(0));
-		assertThat(gb.getShortMap().get(new Short("2"))).isEqualTo(new Integer(3));
+		assertThat(gb.getShortMap().get(new Short("1"))).isEqualTo(0);
+		assertThat(gb.getShortMap().get(new Short("2"))).isEqualTo(3);
 	}
 
 	@Test
@@ -403,8 +403,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getLongMap().get(new Long("4"))).isEqualTo("5");
-		assertThat(gb.getLongMap().get(new Long("6"))).isEqualTo("7");
+		assertThat(gb.getLongMap().get(4L)).isEqualTo("5");
+		assertThat(gb.getLongMap().get(6L)).isEqualTo("7");
 	}
 
 	@Test
@@ -420,7 +420,7 @@ public class BeanFactoryGenericsTests {
 
 		Map<String, AbstractCollection<?>> input = new HashMap<>();
 		HashSet<Integer> value1 = new HashSet<>();
-		value1.add(new Integer(1));
+		value1.add(1);
 		input.put("1", value1);
 		ArrayList<Boolean> value2 = new ArrayList<>();
 		value2.add(Boolean.TRUE);
@@ -431,9 +431,9 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		boolean condition1 = gb.getCollectionMap().get(new Integer(1)) instanceof HashSet;
+		boolean condition1 = gb.getCollectionMap().get(1) instanceof HashSet;
 		assertThat(condition1).isTrue();
-		boolean condition = gb.getCollectionMap().get(new Integer(2)) instanceof ArrayList;
+		boolean condition = gb.getCollectionMap().get(2) instanceof ArrayList;
 		assertThat(condition).isTrue();
 	}
 
@@ -452,8 +452,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
 	}
 
 	@Test
@@ -474,8 +474,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
 		assertThat(gb.getResourceList().get(0)).isEqualTo(new UrlResource("http://localhost:8080"));
 		assertThat(gb.getResourceList().get(1)).isEqualTo(new UrlResource("http://localhost:9090"));
 	}
@@ -498,10 +498,10 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getIntegerSet().contains(new Integer(4))).isTrue();
-		assertThat(gb.getIntegerSet().contains(new Integer(5))).isTrue();
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getIntegerSet().contains(4)).isTrue();
+		assertThat(gb.getIntegerSet().contains(5)).isTrue();
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 	}
 
 	@Test
@@ -519,8 +519,8 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 		assertThat(gb.getResourceList().get(0)).isEqualTo(new UrlResource("http://localhost:8080"));
 	}
 
@@ -544,8 +544,8 @@ public class BeanFactoryGenericsTests {
 
 		assertThat(gb.getPlainMap().get("1")).isEqualTo("0");
 		assertThat(gb.getPlainMap().get("2")).isEqualTo("3");
-		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(new Integer(5));
-		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(new Integer(7));
+		assertThat(gb.getShortMap().get(new Short("4"))).isEqualTo(5);
+		assertThat(gb.getShortMap().get(new Short("6"))).isEqualTo(7);
 	}
 
 	@Test
@@ -580,7 +580,7 @@ public class BeanFactoryGenericsTests {
 
 		Map<String, AbstractCollection<?>> input = new HashMap<>();
 		HashSet<Integer> value1 = new HashSet<>();
-		value1.add(new Integer(1));
+		value1.add(1);
 		input.put("1", value1);
 		ArrayList<Boolean> value2 = new ArrayList<>();
 		value2.add(Boolean.TRUE);
@@ -591,9 +591,9 @@ public class BeanFactoryGenericsTests {
 		bf.registerBeanDefinition("genericBean", rbd);
 		GenericBean<?> gb = (GenericBean<?>) bf.getBean("genericBean");
 
-		boolean condition1 = gb.getCollectionMap().get(new Integer(1)) instanceof HashSet;
+		boolean condition1 = gb.getCollectionMap().get(1) instanceof HashSet;
 		assertThat(condition1).isTrue();
-		boolean condition = gb.getCollectionMap().get(new Integer(2)) instanceof ArrayList;
+		boolean condition = gb.getCollectionMap().get(2) instanceof ArrayList;
 		assertThat(condition).isTrue();
 	}
 
@@ -624,7 +624,7 @@ public class BeanFactoryGenericsTests {
 				new ClassPathResource("genericBeanTests.xml", getClass()));
 		Map<?, ?> map = (Map<?, ?>) bf.getBean("map");
 		assertThat(map.size()).isEqualTo(1);
-		assertThat(map.keySet().iterator().next()).isEqualTo(new Integer(10));
+		assertThat(map.keySet().iterator().next()).isEqualTo(10);
 		assertThat(map.values().iterator().next()).isEqualTo(new URL("http://localhost:8080"));
 	}
 
@@ -634,9 +634,9 @@ public class BeanFactoryGenericsTests {
 		new XmlBeanDefinitionReader(bf).loadBeanDefinitions(
 				new ClassPathResource("genericBeanTests.xml", getClass()));
 		GenericIntegerBean gb = (GenericIntegerBean) bf.getBean("integerBean");
-		assertThat(gb.getGenericProperty()).isEqualTo(new Integer(10));
-		assertThat(gb.getGenericListProperty().get(0)).isEqualTo(new Integer(20));
-		assertThat(gb.getGenericListProperty().get(1)).isEqualTo(new Integer(30));
+		assertThat(gb.getGenericProperty()).isEqualTo(10);
+		assertThat(gb.getGenericListProperty().get(0)).isEqualTo(20);
+		assertThat(gb.getGenericListProperty().get(1)).isEqualTo(30);
 	}
 
 	@Test
@@ -645,9 +645,9 @@ public class BeanFactoryGenericsTests {
 		new XmlBeanDefinitionReader(bf).loadBeanDefinitions(
 				new ClassPathResource("genericBeanTests.xml", getClass()));
 		GenericSetOfIntegerBean gb = (GenericSetOfIntegerBean) bf.getBean("setOfIntegerBean");
-		assertThat(gb.getGenericProperty().iterator().next()).isEqualTo(new Integer(10));
-		assertThat(gb.getGenericListProperty().get(0).iterator().next()).isEqualTo(new Integer(20));
-		assertThat(gb.getGenericListProperty().get(1).iterator().next()).isEqualTo(new Integer(30));
+		assertThat(gb.getGenericProperty().iterator().next()).isEqualTo(10);
+		assertThat(gb.getGenericListProperty().get(0).iterator().next()).isEqualTo(20);
+		assertThat(gb.getGenericListProperty().get(1).iterator().next()).isEqualTo(30);
 	}
 
 	@Test

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/CollectionsWithDefaultTypesTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/CollectionsWithDefaultTypesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,8 +85,8 @@ public class CollectionsWithDefaultTypesTests {
 		List l = (List) jumble.getJumble();
 		assertThat(l.get(0).equals("literal")).isTrue();
 		Integer[] array1 = (Integer[]) l.get(1);
-		assertThat(array1[0].equals(new Integer(2))).isTrue();
-		assertThat(array1[1].equals(new Integer(4))).isTrue();
+		assertThat(array1[0].equals(2)).isTrue();
+		assertThat(array1[1].equals(4)).isTrue();
 		int[] array2 = (int[]) l.get(2);
 		assertThat(array2[0] == 3).isTrue();
 		assertThat(array2[1] == 5).isTrue();

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/FactoryMethodTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/FactoryMethodTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -288,7 +288,7 @@ public class FactoryMethodTests {
 		assertThat(fm2.getTestBean()).isSameAs(fm2.getTestBean());
 		assertThat(fm2).isNotSameAs(fm1);
 
-		FactoryMethods fm3 = (FactoryMethods) xbf.getBean("testBeanOnlyPrototype", tbArg2, new Integer(1), "myName");
+		FactoryMethods fm3 = (FactoryMethods) xbf.getBean("testBeanOnlyPrototype", tbArg2, 1, "myName");
 		assertThat(fm3.getNum()).isEqualTo(1);
 		assertThat(fm3.getName()).isEqualTo("myName");
 		assertThat(fm3.getTestBean().getName()).isEqualTo("arg2");

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/XmlBeanCollectionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/XmlBeanCollectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,16 +201,16 @@ public class XmlBeanCollectionTests {
 	public void testMapWithLiteralsAndReferences() throws Exception {
 		HasMap hasMap = (HasMap) this.beanFactory.getBean("mixedMap");
 		assertThat(hasMap.getMap().size() == 5).isTrue();
-		assertThat(hasMap.getMap().get("foo").equals(new Integer(10))).isTrue();
+		assertThat(hasMap.getMap().get("foo").equals(10)).isTrue();
 		TestBean jenny = (TestBean) this.beanFactory.getBean("jenny");
 		assertThat(hasMap.getMap().get("jenny") == jenny).isTrue();
-		assertThat(hasMap.getMap().get(new Integer(5)).equals("david")).isTrue();
+		assertThat(hasMap.getMap().get(5).equals("david")).isTrue();
 		boolean condition1 = hasMap.getMap().get("bar") instanceof Long;
 		assertThat(condition1).isTrue();
-		assertThat(hasMap.getMap().get("bar").equals(new Long(100))).isTrue();
+		assertThat(hasMap.getMap().get("bar").equals(100L)).isTrue();
 		boolean condition = hasMap.getMap().get("baz") instanceof Integer;
 		assertThat(condition).isTrue();
-		assertThat(hasMap.getMap().get("baz").equals(new Integer(200))).isTrue();
+		assertThat(hasMap.getMap().get("baz").equals(200)).isTrue();
 	}
 
 	@Test

--- a/spring-beans/src/test/java/org/springframework/beans/propertyeditors/BeanInfoTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/propertyeditors/BeanInfoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,12 @@ public class BeanInfoTests {
 	public void testComplexObject() {
 		ValueBean bean = new ValueBean();
 		BeanWrapper bw = new BeanWrapperImpl(bean);
-		Integer value = new Integer(1);
+		Integer value = 1;
 
 		bw.setPropertyValue("value", value);
 		assertThat(value).as("value not set correctly").isEqualTo(bean.getValue());
 
-		value = new Integer(2);
+		value = 2;
 		bw.setPropertyValue("value", value.toString());
 		assertThat(value).as("value not converted").isEqualTo(bean.getValue());
 

--- a/spring-beans/src/test/java/org/springframework/beans/propertyeditors/CustomCollectionEditorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/propertyeditors/CustomCollectionEditorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,9 +63,9 @@ public class CustomCollectionEditorTests {
 		assertThat(condition).isTrue();
 		List<?> list = (List<?>) value;
 		assertThat(list.size()).as("There must be 3 elements in the converted collection").isEqualTo(3);
-		assertThat(list.get(0)).isEqualTo(new Integer(0));
-		assertThat(list.get(1)).isEqualTo(new Integer(1));
-		assertThat(list.get(2)).isEqualTo(new Integer(2));
+		assertThat(list.get(0)).isEqualTo(0);
+		assertThat(list.get(1)).isEqualTo(1);
+		assertThat(list.get(2)).isEqualTo(2);
 	}
 
 	@Test

--- a/spring-beans/src/test/java/org/springframework/beans/propertyeditors/CustomEditorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/propertyeditors/CustomEditorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public class CustomEditorTests {
 		BeanWrapper bw = new BeanWrapperImpl(tb);
 		bw.registerCustomEditor(ITestBean.class, new TestBeanEditor());
 		MutablePropertyValues pvs = new MutablePropertyValues();
-		pvs.addPropertyValue(new PropertyValue("age", new Integer(55)));
+		pvs.addPropertyValue(new PropertyValue("age", 55));
 		pvs.addPropertyValue(new PropertyValue("name", newName));
 		pvs.addPropertyValue(new PropertyValue("touchy", "valid"));
 		pvs.addPropertyValue(new PropertyValue("spouse", tbString));
@@ -94,7 +94,7 @@ public class CustomEditorTests {
 		bw.setExtractOldValueForEditor(true);
 		bw.registerCustomEditor(ITestBean.class, new OldValueAccessingTestBeanEditor());
 		MutablePropertyValues pvs = new MutablePropertyValues();
-		pvs.addPropertyValue(new PropertyValue("age", new Integer(55)));
+		pvs.addPropertyValue(new PropertyValue("age", 55));
 		pvs.addPropertyValue(new PropertyValue("name", newName));
 		pvs.addPropertyValue(new PropertyValue("touchy", "valid"));
 		pvs.addPropertyValue(new PropertyValue("spouse", tbString));
@@ -756,7 +756,7 @@ public class CustomEditorTests {
 	public void testCustomNumberEditor() {
 		CustomNumberEditor editor = new CustomNumberEditor(Integer.class, false);
 		editor.setAsText("5");
-		assertThat(editor.getValue()).isEqualTo(new Integer(5));
+		assertThat(editor.getValue()).isEqualTo(5);
 		assertThat(editor.getAsText()).isEqualTo("5");
 		editor.setValue(null);
 		assertThat(editor.getValue()).isEqualTo(null);
@@ -767,14 +767,14 @@ public class CustomEditorTests {
 	public void testCustomNumberEditorWithHex() {
 		CustomNumberEditor editor = new CustomNumberEditor(Integer.class, false);
 		editor.setAsText("0x" + Integer.toHexString(64));
-		assertThat(editor.getValue()).isEqualTo(new Integer(64));
+		assertThat(editor.getValue()).isEqualTo(64);
 	}
 
 	@Test
 	public void testCustomNumberEditorWithEmptyAsNull() {
 		CustomNumberEditor editor = new CustomNumberEditor(Integer.class, true);
 		editor.setAsText("5");
-		assertThat(editor.getValue()).isEqualTo(new Integer(5));
+		assertThat(editor.getValue()).isEqualTo(5);
 		assertThat(editor.getAsText()).isEqualTo("5");
 		editor.setAsText("");
 		assertThat(editor.getValue()).isEqualTo(null);

--- a/spring-context/src/test/java/org/springframework/aop/framework/ProxyFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/ProxyFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -10,7 +10,7 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * See the License for the specific languaspring-context/src/test/java/org/springframework/context/annotation/ReflectionUtilsIntegrationTests.javage governing permissions and
  * limitations under the License.
  */
 
@@ -709,7 +709,7 @@ public class ProxyFactoryBeanTests {
 		@Override
 		public Object invoke(MethodInvocation mi) throws Throwable {
 			if (mi.getMethod().getDeclaringClass().equals(AddedGlobalInterface.class)) {
-				return new Integer(-1);
+				return -1;
 			}
 			return mi.proceed();
 		}

--- a/spring-context/src/test/java/org/springframework/context/annotation/ReflectionUtilsIntegrationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ReflectionUtilsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class ReflectionUtilsIntegrationTests {
 		@Override
 		@Bean
 		public Integer m1() {
-			return new Integer(42);
+			return 42;
 		}
 	}
 

--- a/spring-context/src/test/java/org/springframework/context/support/StaticMessageSourceTests.java
+++ b/spring-context/src/test/java/org/springframework/context/support/StaticMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public class StaticMessageSourceTests extends AbstractApplicationContextTests {
 	@Test
 	public void getMessageWithMessageAlreadyLookedFor() {
 		Object[] arguments = {
-			new Integer(7), new Date(System.currentTimeMillis()),
+			7, new Date(System.currentTimeMillis()),
 			"a disturbance in the Force"
 		};
 
@@ -105,7 +105,7 @@ public class StaticMessageSourceTests extends AbstractApplicationContextTests {
 						contains("there was \"a disturbance in the Force\" on planet 7.")).as("2nd search within MsgFormat cache returned expected message for Locale.US").isTrue();
 
 		Object[] newArguments = {
-			new Integer(8), new Date(System.currentTimeMillis()),
+			8, new Date(System.currentTimeMillis()),
 			"a disturbance in the Force"
 		};
 
@@ -120,7 +120,7 @@ public class StaticMessageSourceTests extends AbstractApplicationContextTests {
 	@Test
 	public void getMessageWithNoDefaultPassedInAndFoundInMsgCatalog() {
 		Object[] arguments = {
-			new Integer(7), new Date(System.currentTimeMillis()),
+			7, new Date(System.currentTimeMillis()),
 			"a disturbance in the Force"
 		};
 

--- a/spring-context/src/test/java/org/springframework/format/support/FormattingConversionServiceTests.java
+++ b/spring-context/src/test/java/org/springframework/format/support/FormattingConversionServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ public class FormattingConversionServiceTests {
 		String formatted = formattingService.convert(3, String.class);
 		assertThat(formatted).isEqualTo("3");
 		Integer i = formattingService.convert("3", Integer.class);
-		assertThat(i).isEqualTo(new Integer(3));
+		assertThat(i).isEqualTo(3);
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/jmx/export/NotificationListenerTests.java
+++ b/spring-context/src/test/java/org/springframework/jmx/export/NotificationListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,7 +192,7 @@ public class NotificationListenerTests extends AbstractMBeanServerTests {
 		String ageAttribute = "Age";
 
 		server.setAttribute(objectName, new Attribute(nameAttribute, "Rob Harrop"));
-		server.setAttribute(objectName, new Attribute(ageAttribute, new Integer(90)));
+		server.setAttribute(objectName, new Attribute(ageAttribute, 90));
 
 		assertThat(listener.getCount(nameAttribute)).as("Listener not notified for Name").isEqualTo(1);
 		assertThat(listener.getCount(ageAttribute)).as("Listener incorrectly notified for Age").isEqualTo(0);
@@ -231,7 +231,7 @@ public class NotificationListenerTests extends AbstractMBeanServerTests {
 		start(exporter);
 		assertIsRegistered("Should have registered MBean", objectName);
 
-		server.setAttribute(objectName, new Attribute("Age", new Integer(77)));
+		server.setAttribute(objectName, new Attribute("Age", 77));
 		assertThat(listener.getCount("Age")).as("Listener not notified").isEqualTo(1);
 	}
 
@@ -262,7 +262,7 @@ public class NotificationListenerTests extends AbstractMBeanServerTests {
 		start(exporter);
 		assertIsRegistered("Should have registered MBean", objectName);
 
-		server.setAttribute(objectName, new Attribute("Age", new Integer(77)));
+		server.setAttribute(objectName, new Attribute("Age", 77));
 		assertThat(listener.getCount("Age")).as("Listener not notified").isEqualTo(1);
 	}
 
@@ -294,7 +294,7 @@ public class NotificationListenerTests extends AbstractMBeanServerTests {
 		start(exporter);
 		assertIsRegistered("Should have registered MBean", objectName);
 
-		server.setAttribute(objectName, new Attribute("Age", new Integer(77)));
+		server.setAttribute(objectName, new Attribute("Age", 77));
 		assertThat(listener.getCount("Age")).as("Listener should have been notified exactly once").isEqualTo(1);
 	}
 
@@ -326,7 +326,7 @@ public class NotificationListenerTests extends AbstractMBeanServerTests {
 		start(exporter);
 		assertIsRegistered("Should have registered MBean", objectName);
 
-		server.setAttribute(objectName, new Attribute("Age", new Integer(77)));
+		server.setAttribute(objectName, new Attribute("Age", 77));
 		assertThat(listener.getCount("Age")).as("Listener should have been notified exactly once").isEqualTo(1);
 	}
 
@@ -367,10 +367,10 @@ public class NotificationListenerTests extends AbstractMBeanServerTests {
 		assertIsRegistered("Should have registered MBean", objectName1);
 		assertIsRegistered("Should have registered MBean", objectName2);
 
-		server.setAttribute(ObjectNameManager.getInstance(objectName1), new Attribute("Age", new Integer(77)));
+		server.setAttribute(ObjectNameManager.getInstance(objectName1), new Attribute("Age", 77));
 		assertThat(listener.getCount("Age")).as("Listener not notified for testBean1").isEqualTo(1);
 
-		server.setAttribute(ObjectNameManager.getInstance(objectName2), new Attribute("Age", new Integer(33)));
+		server.setAttribute(ObjectNameManager.getInstance(objectName2), new Attribute("Age", 33));
 		assertThat(listener.getCount("Age")).as("Listener not notified for testBean2").isEqualTo(2);
 	}
 
@@ -462,10 +462,10 @@ public class NotificationListenerTests extends AbstractMBeanServerTests {
 
 				if (currentCount != null) {
 					int count = currentCount.intValue() + 1;
-					this.attributeCounts.put(attributeName, new Integer(count));
+					this.attributeCounts.put(attributeName, count);
 				}
 				else {
-					this.attributeCounts.put(attributeName, new Integer(1));
+					this.attributeCounts.put(attributeName, 1);
 				}
 
 				this.attributeHandbacks.put(attributeName, handback);

--- a/spring-context/src/test/java/org/springframework/jndi/JndiObjectFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/jndi/JndiObjectFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ public class JndiObjectFactoryBeanTests {
 		jof.setExpectedType(Integer.class);
 		jof.setDefaultObject("5");
 		jof.afterPropertiesSet();
-		assertThat(jof.getObject()).isEqualTo(new Integer(5));
+		assertThat(jof.getObject()).isEqualTo(5);
 	}
 
 	@Test
@@ -189,7 +189,7 @@ public class JndiObjectFactoryBeanTests {
 		jof.setDefaultObject("5");
 		jof.setBeanFactory(new DefaultListableBeanFactory());
 		jof.afterPropertiesSet();
-		assertThat(jof.getObject()).isEqualTo(new Integer(5));
+		assertThat(jof.getObject()).isEqualTo(5);
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/scheduling/config/SchedulerBeanDefinitionParserTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/config/SchedulerBeanDefinitionParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,14 +44,14 @@ public class SchedulerBeanDefinitionParserTests {
 	public void defaultScheduler() {
 		ThreadPoolTaskScheduler scheduler = (ThreadPoolTaskScheduler) this.context.getBean("defaultScheduler");
 		Integer size = (Integer) new DirectFieldAccessor(scheduler).getPropertyValue("poolSize");
-		assertThat(size).isEqualTo(new Integer(1));
+		assertThat(size).isEqualTo(1);
 	}
 
 	@Test
 	public void customScheduler() {
 		ThreadPoolTaskScheduler scheduler = (ThreadPoolTaskScheduler) this.context.getBean("customScheduler");
 		Integer size = (Integer) new DirectFieldAccessor(scheduler).getPropertyValue("poolSize");
-		assertThat(size).isEqualTo(new Integer(42));
+		assertThat(size).isEqualTo(42);
 	}
 
 	@Test

--- a/spring-context/src/test/java/org/springframework/validation/DataBinderTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/DataBinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -332,7 +332,7 @@ public class DataBinderTests {
 		MutablePropertyValues pvs = new MutablePropertyValues();
 		pvs.add("object", "1");
 		binder.bind(pvs);
-		assertThat(tb.getObject()).isEqualTo(new Integer(1));
+		assertThat(tb.getObject()).isEqualTo(1);
 	}
 
 	@Test
@@ -460,7 +460,7 @@ public class DataBinderTests {
 		LocaleContextHolder.setLocale(Locale.GERMAN);
 		try {
 			binder.bind(pvs);
-			assertThat(tb.getIntegerList().get(0)).isEqualTo(new Integer(1));
+			assertThat(tb.getIntegerList().get(0)).isEqualTo(1);
 			assertThat(binder.getBindingResult().getFieldValue("integerList[0]")).isEqualTo("1");
 		}
 		finally {
@@ -932,7 +932,7 @@ public class DataBinderTests {
 		binder.registerCustomEditor(int.class, "age", new PropertyEditorSupport() {
 			@Override
 			public void setAsText(String text) throws IllegalArgumentException {
-				setValue(new Integer(99));
+				setValue(99);
 			}
 			@Override
 			public String getAsText() {
@@ -1231,7 +1231,7 @@ public class DataBinderTests {
 		assertThat((errors.getFieldErrors("age").get(0)).getCode()).isEqualTo("TOO_YOUNG");
 		assertThat((errors.getFieldErrors("age").get(0)).getObjectName()).isEqualTo("tb");
 		assertThat((errors.getFieldErrors("age").get(0)).getField()).isEqualTo("age");
-		assertThat((errors.getFieldErrors("age").get(0)).getRejectedValue()).isEqualTo(new Integer(0));
+		assertThat((errors.getFieldErrors("age").get(0)).getRejectedValue()).isEqualTo(0);
 		assertThat((errors.getFieldErrors("age").get(1)).getCode()).isEqualTo("AGE_NOT_ODD");
 
 		assertThat(errors.hasFieldErrors("name")).isTrue();
@@ -1248,7 +1248,7 @@ public class DataBinderTests {
 		assertThat(errors.getFieldErrorCount("spouse.age")).isEqualTo(1);
 		assertThat(errors.getFieldError("spouse.age").getCode()).isEqualTo("TOO_YOUNG");
 		assertThat((errors.getFieldErrors("spouse.age").get(0)).getObjectName()).isEqualTo("tb");
-		assertThat((errors.getFieldErrors("spouse.age").get(0)).getRejectedValue()).isEqualTo(new Integer(0));
+		assertThat((errors.getFieldErrors("spouse.age").get(0)).getRejectedValue()).isEqualTo(0);
 	}
 
 	@Test
@@ -1303,7 +1303,7 @@ public class DataBinderTests {
 		assertThat((errors.getFieldErrors("age").get(0)).getCode()).isEqualTo("validation.TOO_YOUNG");
 		assertThat((errors.getFieldErrors("age").get(0)).getObjectName()).isEqualTo("tb");
 		assertThat((errors.getFieldErrors("age").get(0)).getField()).isEqualTo("age");
-		assertThat((errors.getFieldErrors("age").get(0)).getRejectedValue()).isEqualTo(new Integer(0));
+		assertThat((errors.getFieldErrors("age").get(0)).getRejectedValue()).isEqualTo(0);
 		assertThat((errors.getFieldErrors("age").get(1)).getCode()).isEqualTo("validation.AGE_NOT_ODD");
 
 		assertThat(errors.hasFieldErrors("name")).isTrue();
@@ -1320,7 +1320,7 @@ public class DataBinderTests {
 		assertThat(errors.getFieldErrorCount("spouse.age")).isEqualTo(1);
 		assertThat(errors.getFieldError("spouse.age").getCode()).isEqualTo("validation.TOO_YOUNG");
 		assertThat((errors.getFieldErrors("spouse.age").get(0)).getObjectName()).isEqualTo("tb");
-		assertThat((errors.getFieldErrors("spouse.age").get(0)).getRejectedValue()).isEqualTo(new Integer(0));
+		assertThat((errors.getFieldErrors("spouse.age").get(0)).getRejectedValue()).isEqualTo(0);
 	}
 
 	@Test
@@ -1374,9 +1374,9 @@ public class DataBinderTests {
 		boolean condition = tb.getSet() instanceof TreeSet;
 		assertThat(condition).isTrue();
 		assertThat(tb.getSet().size()).isEqualTo(3);
-		assertThat(tb.getSet().contains(new Integer(10))).isTrue();
-		assertThat(tb.getSet().contains(new Integer(20))).isTrue();
-		assertThat(tb.getSet().contains(new Integer(30))).isTrue();
+		assertThat(tb.getSet().contains(10)).isTrue();
+		assertThat(tb.getSet().contains(20)).isTrue();
+		assertThat(tb.getSet().contains(30)).isTrue();
 
 		pvs = new MutablePropertyValues();
 		pvs.add("set", null);
@@ -1840,7 +1840,7 @@ public class DataBinderTests {
 		assertThat(ex2.getGlobalError().getCode()).isEqualTo("invalid");
 		assertThat(ex2.hasFieldErrors("age")).isTrue();
 		assertThat(ex2.getFieldError("age").getCode()).isEqualTo("invalidField");
-		assertThat(ex2.getFieldValue("age")).isEqualTo(new Integer(99));
+		assertThat(ex2.getFieldValue("age")).isEqualTo(99);
 
 		ex2.rejectValue("name", "invalidField", "someMessage");
 		assertThat(ex2.hasFieldErrors("name")).isTrue();

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SelectionAndProjectionTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SelectionAndProjectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,11 +140,11 @@ public class SelectionAndProjectionTests {
 		assertThat(typedValue.getTypeDescriptor().getElementTypeDescriptor().getType()).isEqualTo(Integer.class);
 		Integer[] array = (Integer[]) value;
 		assertThat(array.length).isEqualTo(5);
-		assertThat(array[0]).isEqualTo(new Integer(0));
-		assertThat(array[1]).isEqualTo(new Integer(1));
-		assertThat(array[2]).isEqualTo(new Integer(2));
-		assertThat(array[3]).isEqualTo(new Integer(3));
-		assertThat(array[4]).isEqualTo(new Integer(4));
+		assertThat(array[0]).isEqualTo(0);
+		assertThat(array[1]).isEqualTo(1);
+		assertThat(array[2]).isEqualTo(2);
+		assertThat(array[3]).isEqualTo(3);
+		assertThat(array[4]).isEqualTo(4);
 	}
 
 	@Test
@@ -177,11 +177,11 @@ public class SelectionAndProjectionTests {
 		assertThat(typedValue.getTypeDescriptor().getElementTypeDescriptor().getType()).isEqualTo(Integer.class);
 		Integer[] array = (Integer[]) value;
 		assertThat(array.length).isEqualTo(5);
-		assertThat(array[0]).isEqualTo(new Integer(0));
-		assertThat(array[1]).isEqualTo(new Integer(1));
-		assertThat(array[2]).isEqualTo(new Integer(2));
-		assertThat(array[3]).isEqualTo(new Integer(3));
-		assertThat(array[4]).isEqualTo(new Integer(4));
+		assertThat(array[0]).isEqualTo(0);
+		assertThat(array[1]).isEqualTo(1);
+		assertThat(array[2]).isEqualTo(2);
+		assertThat(array[3]).isEqualTo(3);
+		assertThat(array[4]).isEqualTo(4);
 	}
 
 	@Test
@@ -298,9 +298,9 @@ public class SelectionAndProjectionTests {
 		assertThat(typedValue.getTypeDescriptor().getElementTypeDescriptor().getType()).isEqualTo(Number.class);
 		Number[] array = (Number[]) value;
 		assertThat(array.length).isEqualTo(3);
-		assertThat(array[0]).isEqualTo(new Integer(5));
+		assertThat(array[0]).isEqualTo(5);
 		assertThat(array[1]).isEqualTo(5.9f);
-		assertThat(array[2]).isEqualTo(new Integer(7));
+		assertThat(array[2]).isEqualTo(7);
 	}
 
 

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -457,7 +457,7 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 		expression = parser.parseExpression("T(Integer).valueOf(42)");
 		expression.getValue(Integer.class);
 		assertCanCompile(expression);
-		assertThat(expression.getValue(Integer.class)).isEqualTo(new Integer(42));
+		assertThat(expression.getValue(Integer.class)).isEqualTo(42);
 
 		// Code gen is different for -1 .. 6 because there are bytecode instructions specifically for those values
 
@@ -4024,7 +4024,7 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 		assertThat(tc.s).isEqualTo("foo");
 		assertCanCompile(expression);
 		tc.reset();
-		tc.obj=new Integer(42);
+		tc.obj=42;
 		assertThatExceptionOfType(SpelEvaluationException.class).isThrownBy(() ->
 				expression.getValue(tc))
 			.withCauseInstanceOf(ClassCastException.class);
@@ -4035,7 +4035,7 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 		assertThat(expression.getValue("abc")).isEqualTo('a');
 		assertCanCompile(expression);
 		assertThatExceptionOfType(SpelEvaluationException.class).isThrownBy(() ->
-				expression.getValue(new Integer(42)))
+				expression.getValue(42))
 			.withCauseInstanceOf(ClassCastException.class);
 	}
 
@@ -4072,10 +4072,10 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 	@Test
 	public void methodReference_simpleInstanceMethodNoArgReturnPrimitive() throws Exception {
 		expression = parser.parseExpression("intValue()");
-		int resultI = expression.getValue(new Integer(42), Integer.TYPE);
+		int resultI = expression.getValue(42, Integer.TYPE);
 		assertThat(resultI).isEqualTo(42);
 		assertCanCompile(expression);
-		int resultC = expression.getValue(new Integer(42), Integer.TYPE);
+		int resultC = expression.getValue(42, Integer.TYPE);
 		assertThat(resultC).isEqualTo(42);
 	}
 

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelReproTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelReproTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -628,12 +628,12 @@ public class SpelReproTests extends AbstractExpressionTests {
 			}
 		}
 
-		final Integer INTEGER = Integer.valueOf(7);
+		final Integer INTEGER = 7;
 
 		EvaluationContext emptyEvalContext = new StandardEvaluationContext();
 
 		List<TypeDescriptor> args = new ArrayList<>();
-		args.add(TypeDescriptor.forObject(new Integer(42)));
+		args.add(TypeDescriptor.forObject(42));
 
 		ConversionPriority1 target = new ConversionPriority1();
 		MethodExecutor me = new ReflectiveMethodResolver(true).resolve(emptyEvalContext, target, "getX", args);
@@ -1485,10 +1485,10 @@ public class SpelReproTests extends AbstractExpressionTests {
 		SpelExpressionParser parser = new SpelExpressionParser();
 		Expression expression = parser.parseExpression("T(org.springframework.expression.spel.SpelReproTests.DistanceEnforcer).from(#no)");
 		StandardEvaluationContext sec = new StandardEvaluationContext();
-		sec.setVariable("no", new Integer(1));
+		sec.setVariable("no", 1);
 		assertThat(expression.getValue(sec).toString().startsWith("Integer")).isTrue();
 		sec = new StandardEvaluationContext();
-		sec.setVariable("no", new Float(1.0));
+		sec.setVariable("no", 1.0F);
 		assertThat(expression.getValue(sec).toString().startsWith("Number")).isTrue();
 		sec = new StandardEvaluationContext();
 		sec.setVariable("no", "1.0");
@@ -1694,7 +1694,7 @@ public class SpelReproTests extends AbstractExpressionTests {
 		}
 
 		public Integer tryToInvokeWithNull2(int i) {
-			return new Integer(i);
+			return i;
 		}
 
 		public String tryToInvokeWithNull3(Integer value, String... strings) {

--- a/spring-jms/src/test/java/org/springframework/jms/listener/adapter/MessageListenerAdapterTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/listener/adapter/MessageListenerAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class MessageListenerAdapterTests {
 
 	private static final String TEXT = "I fancy a good cuppa right now";
 
-	private static final Integer NUMBER = new Integer(1);
+	private static final Integer NUMBER = 1;
 
 	private static final SerializableObject OBJECT = new SerializableObject();
 

--- a/spring-jms/src/test/java/org/springframework/jms/support/SimpleMessageConverterTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/support/SimpleMessageConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ public class SimpleMessageConverterTests {
 		Session session = mock(Session.class);
 		ObjectMessage message = mock(ObjectMessage.class);
 
-		Integer content = new Integer(5);
+		Integer content = 5;
 
 		given(session.createObjectMessage(content)).willReturn(message);
 		given(message.getObject()).willReturn(content);

--- a/spring-messaging/src/test/java/org/springframework/messaging/MessageHeadersTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/MessageHeadersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ public class MessageHeadersTests {
 
 	@Test
 	public void testNonTypedAccessOfHeaderValue() {
-		Integer value = new Integer(123);
+		Integer value = 123;
 		Map<String, Object> map = new HashMap<>();
 		map.put("test", value);
 		MessageHeaders headers = new MessageHeaders(map);
@@ -116,7 +116,7 @@ public class MessageHeadersTests {
 
 	@Test
 	public void testTypedAccessOfHeaderValue() {
-		Integer value = new Integer(123);
+		Integer value = 123;
 		Map<String, Object> map = new HashMap<>();
 		map.put("test", value);
 		MessageHeaders headers = new MessageHeaders(map);
@@ -125,7 +125,7 @@ public class MessageHeadersTests {
 
 	@Test
 	public void testHeaderValueAccessWithIncorrectType() {
-		Integer value = new Integer(123);
+		Integer value = 123;
 		Map<String, Object> map = new HashMap<>();
 		map.put("test", value);
 		MessageHeaders headers = new MessageHeaders(map);
@@ -151,7 +151,7 @@ public class MessageHeadersTests {
 	public void testHeaderKeys() {
 		Map<String, Object> map = new HashMap<>();
 		map.put("key1", "val1");
-		map.put("key2", new Integer(123));
+		map.put("key2", 123);
 		MessageHeaders headers = new MessageHeaders(map);
 		Set<String> keys = headers.keySet();
 		assertThat(keys.contains("key1")).isTrue();

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/DefaultContentTypeResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/DefaultContentTypeResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class DefaultContentTypeResolverTests {
 	@Test
 	public void resolveUnknownHeaderType() {
 		Map<String, Object> map = new HashMap<>();
-		map.put(MessageHeaders.CONTENT_TYPE, new Integer(1));
+		map.put(MessageHeaders.CONTENT_TYPE, 1);
 		MessageHeaders headers = new MessageHeaders(map);
 		assertThatIllegalArgumentException().isThrownBy(() ->
 				this.resolver.resolve(headers));

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/MessageMethodArgumentResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/MessageMethodArgumentResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class MessageMethodArgumentResolverTests {
 
 		assertThat(actual).isNotNull();
 		assertThat(actual.getHeaders()).isSameAs(message.getHeaders());
-		assertThat(actual.getPayload()).isEqualTo(new Integer(4));
+		assertThat(actual.getPayload()).isEqualTo(4);
 	}
 
 	@Test

--- a/spring-messaging/src/test/java/org/springframework/messaging/support/MessageBuilderTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/support/MessageBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class MessageBuilderTests {
 				.setHeader("count", 123)
 				.build();
 		assertThat(message.getHeaders().get("foo", String.class)).isEqualTo("bar");
-		assertThat(message.getHeaders().get("count", Integer.class)).isEqualTo(new Integer(123));
+		assertThat(message.getHeaders().get("count", Integer.class)).isEqualTo(123);
 	}
 
 	@Test

--- a/spring-test/src/test/java/org/springframework/mock/jndi/SimpleNamingContextTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/jndi/SimpleNamingContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ class SimpleNamingContextTests {
 		assertThat(context2.getEnvironment() != env2).as("Correct environment").isTrue();
 		assertThat("value1".equals(context2.getEnvironment().get("key1"))).as("Correct key1").isTrue();
 
-		Integer i = new Integer(0);
+		Integer i = 0;
 		context1.rebind("myinteger", i);
 		String s = "";
 		context2.bind("mystring", s);

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
@@ -287,7 +287,7 @@ public class Jackson2ObjectMapperBuilderTests {
 				.build();
 		DateTime dateTime = new DateTime(1322903730000L, DateTimeZone.UTC);
 		assertThat(new String(objectMapper.writeValueAsBytes(dateTime), "UTF-8")).isEqualTo("1322903730000");
-		assertThat(new String(objectMapper.writeValueAsBytes(new Integer(4)), "UTF-8")).contains("customid");
+		assertThat(new String(objectMapper.writeValueAsBytes(4), "UTF-8")).contains("customid");
 	}
 
 	@Test  // SPR-12634
@@ -300,7 +300,7 @@ public class Jackson2ObjectMapperBuilderTests {
 				.build();
 		DateTime dateTime = new DateTime(1322903730000L, DateTimeZone.UTC);
 		assertThat(new String(objectMapper.writeValueAsBytes(dateTime), "UTF-8")).isEqualTo("1322903730000");
-		assertThat(new String(objectMapper.writeValueAsBytes(new Integer(4)), "UTF-8")).contains("customid");
+		assertThat(new String(objectMapper.writeValueAsBytes(4), "UTF-8")).contains("customid");
 	}
 
 	@Test  // SPR-12634
@@ -311,7 +311,7 @@ public class Jackson2ObjectMapperBuilderTests {
 				.serializerByType(Integer.class, new CustomIntegerSerializer()).build();
 		DateTime dateTime = new DateTime(1322903730000L, DateTimeZone.UTC);
 		assertThat(new String(objectMapper.writeValueAsBytes(dateTime), "UTF-8")).isEqualTo("1322903730000");
-		assertThat(new String(objectMapper.writeValueAsBytes(new Integer(4)), "UTF-8")).contains("customid");
+		assertThat(new String(objectMapper.writeValueAsBytes(4), "UTF-8")).contains("customid");
 	}
 
 	@Test  // gh-22576

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,7 +221,7 @@ public class Jackson2ObjectMapperFactoryBeanTests {
 
 		DateTime dateTime = new DateTime(1322903730000L, DateTimeZone.UTC);
 		assertThat(new String(objectMapper.writeValueAsBytes(dateTime), "UTF-8")).isEqualTo("1322903730000");
-		assertThat(new String(objectMapper.writeValueAsBytes(new Integer(4)), "UTF-8")).contains("customid");
+		assertThat(new String(objectMapper.writeValueAsBytes(4), "UTF-8")).contains("customid");
 	}
 
 	@Test // SPR-12634
@@ -235,7 +235,7 @@ public class Jackson2ObjectMapperFactoryBeanTests {
 
 		DateTime dateTime = new DateTime(1322903730000L, DateTimeZone.UTC);
 		assertThat(new String(objectMapper.writeValueAsBytes(dateTime), "UTF-8")).isEqualTo("1322903730000");
-		assertThat(new String(objectMapper.writeValueAsBytes(new Integer(4)), "UTF-8")).contains("customid");
+		assertThat(new String(objectMapper.writeValueAsBytes(4), "UTF-8")).contains("customid");
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/web/bind/ServletRequestUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/ServletRequestUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class ServletRequestUtilsTests {
 		request.addParameter("param2", "e");
 		request.addParameter("paramEmpty", "");
 
-		assertThat(ServletRequestUtils.getIntParameter(request, "param1")).isEqualTo(new Integer(5));
+		assertThat(ServletRequestUtils.getIntParameter(request, "param1")).isEqualTo(5);
 		assertThat(ServletRequestUtils.getIntParameter(request, "param1", 6)).isEqualTo(5);
 		assertThat(ServletRequestUtils.getRequiredIntParameter(request, "param1")).isEqualTo(5);
 

--- a/spring-web/src/test/java/org/springframework/web/context/request/ServletRequestAttributesTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/ServletRequestAttributesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,12 +163,12 @@ public class ServletRequestAttributesTests {
 
 	@Test
 	public void skipImmutableInteger() {
-		doSkipImmutableValue(new Integer(1));
+		doSkipImmutableValue(1);
 	}
 
 	@Test
 	public void skipImmutableFloat() {
-		doSkipImmutableValue(new Float(1.1));
+		doSkipImmutableValue(1.1F);
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityReferencesTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityReferencesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ public class HtmlCharacterEntityReferencesTests {
 		while (entityIterator.hasNext()) {
 			int character = entityIterator.getReferredCharacter();
 			String entityName = entityIterator.nextEntry();
-			referencedCharactersMap.put(new Integer(character), entityName);
+			referencedCharactersMap.put(character, entityName);
 		}
 		return referencedCharactersMap;
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/CheckboxTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/CheckboxTagTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -686,7 +686,7 @@ public class CheckboxTagTests extends AbstractFormTagTests {
 		this.bean.setJedi(true);
 		this.bean.setSomeBoolean(Boolean.TRUE);
 		this.bean.setStringArray(new String[] {"bar", "foo"});
-		this.bean.setSomeIntegerArray(new Integer[] {new Integer(2), new Integer(1)});
+		this.bean.setSomeIntegerArray(new Integer[] {2, 1});
 		this.bean.setOtherColours(colours);
 		this.bean.setPets(pets);
 		this.bean.setSomeList(someList);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/CheckboxesTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/CheckboxesTagTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -767,7 +767,7 @@ public class CheckboxesTagTests extends AbstractFormTagTests {
 		this.bean.setJedi(true);
 		this.bean.setSomeBoolean(Boolean.TRUE);
 		this.bean.setStringArray(new String[] {"bar", "foo"});
-		this.bean.setSomeIntegerArray(new Integer[] {new Integer(2), new Integer(1)});
+		this.bean.setSomeIntegerArray(new Integer[] {2, 1});
 		this.bean.setOtherColours(colours);
 		this.bean.setPets(pets);
 		this.bean.setSomeSet(someObjects);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/RadioButtonsTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/RadioButtonsTagTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -614,7 +614,7 @@ public class RadioButtonsTagTests extends AbstractFormTagTests {
 		this.bean.setJedi(true);
 		this.bean.setSomeBoolean(Boolean.TRUE);
 		this.bean.setStringArray(new String[] {"bar", "foo"});
-		this.bean.setSomeIntegerArray(new Integer[] {new Integer(2), new Integer(1)});
+		this.bean.setSomeIntegerArray(new Integer[] {2, 1});
 		this.bean.setOtherColours(colours);
 		this.bean.setPets(pets);
 		List list = new ArrayList();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/SelectTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/SelectTagTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -392,7 +392,7 @@ public class SelectTagTests extends AbstractFormTagTests {
 		this.tag.setPath("someIntegerArray");
 		Integer[] array = new Integer[50];
 		for (int i = 0; i < array.length; i++) {
-			array[i] = new Integer(i);
+			array[i] = i;
 		}
 		this.tag.setItems(array);
 		int result = this.tag.doStartTag();
@@ -1012,7 +1012,7 @@ public class SelectTagTests extends AbstractFormTagTests {
 		this.bean.setCountry("UK");
 		this.bean.setSex("M");
 		this.bean.setMyFloat(new Float("12.34"));
-		this.bean.setSomeIntegerArray(new Integer[]{new Integer(12), new Integer(34)});
+		this.bean.setSomeIntegerArray(new Integer[]{12, 34});
 		return this.bean;
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,7 +227,7 @@ public class ViewResolverTests {
 		props.setProperty("key1", "value1");
 		vr.setAttributes(props);
 		Map<String, Object> map = new HashMap<>();
-		map.put("key2", new Integer(2));
+		map.put("key2", 2);
 		vr.setAttributesMap(map);
 		vr.setApplicationContext(this.wac);
 
@@ -236,14 +236,14 @@ public class ViewResolverTests {
 		assertThat(((InternalResourceView) view).getUrl()).as("Correct URL").isEqualTo("example1");
 		Map<String, Object> attributes = ((InternalResourceView) view).getStaticAttributes();
 		assertThat(attributes.get("key1")).isEqualTo("value1");
-		assertThat(attributes.get("key2")).isEqualTo(new Integer(2));
+		assertThat(attributes.get("key2")).isEqualTo(2);
 
 		view = vr.resolveViewName("example2", Locale.getDefault());
 		assertThat(view).isInstanceOf(JstlView.class);
 		assertThat(((InternalResourceView) view).getUrl()).as("Correct URL").isEqualTo("example2");
 		attributes = ((InternalResourceView) view).getStaticAttributes();
 		assertThat(attributes.get("key1")).isEqualTo("value1");
-		assertThat(attributes.get("key2")).isEqualTo(new Integer(2));
+		assertThat(attributes.get("key2")).isEqualTo(2);
 
 		this.request.setAttribute(DispatcherServlet.WEB_APPLICATION_CONTEXT_ATTRIBUTE, this.wac);
 		this.request.setAttribute(DispatcherServlet.LOCALE_RESOLVER_ATTRIBUTE, new AcceptHeaderLocaleResolver());
@@ -255,7 +255,7 @@ public class ViewResolverTests {
 		assertThat(tb.equals(this.request.getAttribute("tb"))).as("Correct tb attribute").isTrue();
 		assertThat(this.request.getAttribute("rc") == null).as("Correct rc attribute").isTrue();
 		assertThat(this.request.getAttribute("key1")).isEqualTo("value1");
-		assertThat(this.request.getAttribute("key2")).isEqualTo(new Integer(2));
+		assertThat(this.request.getAttribute("key2")).isEqualTo(2);
 	}
 
 	@Test
@@ -268,7 +268,7 @@ public class ViewResolverTests {
 		props.setProperty("key1", "value1");
 		vr.setAttributes(props);
 		Map<String, Object> map = new HashMap<>();
-		map.put("key2", new Integer(2));
+		map.put("key2", 2);
 		vr.setAttributesMap(map);
 		vr.setExposeContextBeansAsAttributes(true);
 		vr.setApplicationContext(this.wac);
@@ -281,7 +281,7 @@ public class ViewResolverTests {
 					public void forward(ServletRequest forwardRequest, ServletResponse forwardResponse) {
 						assertThat(forwardRequest.getAttribute("rc") == null).as("Correct rc attribute").isTrue();
 						assertThat(forwardRequest.getAttribute("key1")).isEqualTo("value1");
-						assertThat(forwardRequest.getAttribute("key2")).isEqualTo(new Integer(2));
+						assertThat(forwardRequest.getAttribute("key2")).isEqualTo(2);
 						assertThat(forwardRequest.getAttribute("myBean")).isSameAs(wac.getBean("myBean"));
 						assertThat(forwardRequest.getAttribute("myBean2")).isSameAs(wac.getBean("myBean2"));
 					}
@@ -304,7 +304,7 @@ public class ViewResolverTests {
 		props.setProperty("key1", "value1");
 		vr.setAttributes(props);
 		Map<String, Object> map = new HashMap<>();
-		map.put("key2", new Integer(2));
+		map.put("key2", 2);
 		vr.setAttributesMap(map);
 		vr.setExposedContextBeanNames(new String[] {"myBean2"});
 		vr.setApplicationContext(this.wac);
@@ -317,7 +317,7 @@ public class ViewResolverTests {
 					public void forward(ServletRequest forwardRequest, ServletResponse forwardResponse) {
 						assertThat(forwardRequest.getAttribute("rc") == null).as("Correct rc attribute").isTrue();
 						assertThat(forwardRequest.getAttribute("key1")).isEqualTo("value1");
-						assertThat(forwardRequest.getAttribute("key2")).isEqualTo(new Integer(2));
+						assertThat(forwardRequest.getAttribute("key2")).isEqualTo(2);
 						assertThat(forwardRequest.getAttribute("myBean")).isNull();
 						assertThat(forwardRequest.getAttribute("myBean2")).isSameAs(wac.getBean("myBean2"));
 					}


### PR DESCRIPTION
This PR is considering using auto Box/Unbox instead of manual, because constructors like `new Integer(1)` have been `deprecated` since JDK 9.

There are a lot of changes in this PR.

I already ran `./gradlew check` and got a successful result, so I hope this will reduce your workload. 

