### PR TITLE
Optimize hard code in PropertiesBeanDefinitionReader

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReader.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReader.java
@@ -455,11 +455,11 @@ public class PropertiesBeanDefinitionReader extends AbstractBeanDefinitionReader
 				}
 				else if (property.startsWith(CONSTRUCTOR_ARG_PREFIX)) {
 					if (property.endsWith(REF_SUFFIX)) {
-						int index = Integer.parseInt(property.substring(1, property.length() - REF_SUFFIX.length()));
+						int index = Integer.parseInt(property.substring(CONSTRUCTOR_ARG_PREFIX.length(), property.length() - REF_SUFFIX.length()));
 						cas.addIndexedArgumentValue(index, new RuntimeBeanReference(entry.getValue().toString()));
 					}
 					else {
-						int index = Integer.parseInt(property.substring(1));
+						int index = Integer.parseInt(property.substring(CONSTRUCTOR_ARG_PREFIX.length()));
 						cas.addIndexedArgumentValue(index, readValue(entry));
 					}
 				}
@@ -521,7 +521,7 @@ public class PropertiesBeanDefinitionReader extends AbstractBeanDefinitionReader
 			// If it starts with a reference prefix...
 			if (strVal.startsWith(REF_PREFIX)) {
 				// Expand the reference.
-				String targetName = strVal.substring(1);
+				String targetName = strVal.substring(REF_PREFIX.length());
 				if (targetName.startsWith(REF_PREFIX)) {
 					// Escaped prefix -> use plain value.
 					val = targetName;


### PR DESCRIPTION
This PR removes some hard codes. 
Please see my PR changes, although `CONSTRUCTOR_ARG_PREFIX` is final, but it is still possible to update iteratively, although it is unlikely, but it is still recommended to modify the hard code.


