### PR TITLE
Improve usage of ByteArrayOutputStream/ByteArrayInputStream

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCache.java
+++ b/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,15 +202,10 @@ public class ConcurrentMapCache extends AbstractValueAdaptingCache {
 		}
 	}
 
-	private Object serializeValue(SerializationDelegate serialization, Object storeValue) throws IOException {
+	private static Object serializeValue(SerializationDelegate serialization, Object storeValue) throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		try {
-			serialization.serialize(storeValue, out);
-			return out.toByteArray();
-		}
-		finally {
-			out.close();
-		}
+		serialization.serialize(storeValue, out);
+		return out.toByteArray();
 	}
 
 	@Override
@@ -229,14 +224,9 @@ public class ConcurrentMapCache extends AbstractValueAdaptingCache {
 
 	}
 
-	private Object deserializeValue(SerializationDelegate serialization, Object storeValue) throws IOException {
+	private static Object deserializeValue(SerializationDelegate serialization, Object storeValue) throws IOException {
 		ByteArrayInputStream in = new ByteArrayInputStream((byte[]) storeValue);
-		try {
-			return serialization.deserialize(in);
-		}
-		finally {
-			in.close();
-		}
+		return serialization.deserialize(in);
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 
@@ -238,6 +239,24 @@ public abstract class StreamUtils {
 		return new NonClosingOutputStream(out);
 	}
 
+	/**
+	 * More effective equivalent of {@code new String(baos.toByteArray(), charset)}
+	 * As far as at invocation point {@code charset} is already available,
+	 * no exception is expected to be thrown.
+	 *
+	 * @param baos    {@link ByteArrayOutputStream} to be flushed into String
+	 * @param charset applicable {@link Charset}
+	 * @return String represenation of bytes stored in {@code baos}
+	 */
+	public static String baosToString(ByteArrayOutputStream baos, Charset charset) {
+		Assert.notNull(baos, "No ByteArrayOutputStream specified");
+		Assert.notNull(charset, "No Charset specified");
+		try {
+			return baos.toString(charset.name());
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
 	private static class NonClosingInputStream extends FilterInputStream {
 

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -774,7 +774,7 @@ public abstract class StringUtils {
 				bos.write(ch);
 			}
 		}
-		return (changed ? new String(bos.toByteArray(), charset) : source);
+		return changed ? StreamUtils.baosToString(bos, charset) : source;
 	}
 
 	/**

--- a/spring-core/src/testFixtures/java/org/springframework/core/testfixture/io/SerializationTestUtils.java
+++ b/spring-core/src/testFixtures/java/org/springframework/core/testfixture/io/SerializationTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,6 @@ public class SerializationTestUtils {
 			oos.writeObject(o);
 			oos.flush();
 		}
-		baos.flush();
 		byte[] bytes = baos.toByteArray();
 
 		ByteArrayInputStream is = new ByteArrayInputStream(bytes);

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
@@ -33,6 +33,7 @@ import org.springframework.messaging.support.MessageHeaderInitializer;
 import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StreamUtils;
 
 /**
  * Decodes one or more STOMP frames contained in a {@link ByteBuffer}.
@@ -216,7 +217,7 @@ public class StompDecoder {
 		while (byteBuffer.remaining() > 0 && !tryConsumeEndOfLine(byteBuffer)) {
 			command.write(byteBuffer.get());
 		}
-		return new String(command.toByteArray(), StandardCharsets.UTF_8);
+		return StreamUtils.baosToString(command, StandardCharsets.UTF_8);
 	}
 
 	private void readHeaders(ByteBuffer byteBuffer, StompHeaderAccessor headerAccessor) {
@@ -231,7 +232,7 @@ public class StompDecoder {
 				headerStream.write(byteBuffer.get());
 			}
 			if (headerStream.size() > 0 && headerComplete) {
-				String header = new String(headerStream.toByteArray(), StandardCharsets.UTF_8);
+				String header = StreamUtils.baosToString(headerStream, StandardCharsets.UTF_8);
 				int colonIndex = header.indexOf(':');
 				if (colonIndex <= 0) {
 					if (byteBuffer.remaining() > 0) {

--- a/spring-test/src/main/java/org/springframework/mock/http/MockHttpOutputMessage.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/MockHttpOutputMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpOutputMessage;
+import org.springframework.util.StreamUtils;
 
 /**
  * Mock implementation of {@link HttpOutputMessage}.
@@ -75,8 +76,7 @@ public class MockHttpOutputMessage implements HttpOutputMessage {
 	 * @param charset the charset to use to turn the body content to a String
 	 */
 	public String getBodyAsString(Charset charset) {
-		byte[] bytes = getBodyAsBytes();
-		return new String(bytes, charset);
+		return StreamUtils.baosToString(this.body, charset);
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.List;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StreamUtils;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -419,7 +420,7 @@ public final class ContentDisposition {
 				throw new IllegalArgumentException(INVALID_HEADER_FIELD_PARAMETER_FORMAT);
 			}
 		}
-		return new String(bos.toByteArray(), charset);
+		return StreamUtils.baosToString(bos, charset);
 	}
 
 	private static boolean isRFC5987AttrChar(byte c) {

--- a/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -36,6 +36,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -359,7 +360,7 @@ final class HierarchicalUriComponents extends UriComponents {
 				bos.write(hex2);
 			}
 		}
-		return new String(bos.toByteArray(), charset);
+		return StreamUtils.baosToString(bos, charset);
 	}
 
 	private Type getHostType() {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/JettyXhrTransport.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/JettyXhrTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.StreamUtils;
 import org.springframework.util.concurrent.SettableListenableFuture;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.socket.CloseStatus;
@@ -247,14 +248,13 @@ public class JettyXhrTransport extends AbstractXhrTransport implements Lifecycle
 		}
 
 		private void handleFrame() {
-			byte[] bytes = this.outputStream.toByteArray();
+			String content = StreamUtils.baosToString(this.outputStream, SockJsFrame.CHARSET);
 			this.outputStream.reset();
-			String content = new String(bytes, SockJsFrame.CHARSET);
 			if (logger.isTraceEnabled()) {
 				logger.trace("XHR content received: " + content);
 			}
 			if (!PRELUDE.equals(content)) {
-				this.sockJsSession.handleFrame(new String(bytes, SockJsFrame.CHARSET));
+				this.sockJsSession.handleFrame(content);
 			}
 		}
 


### PR DESCRIPTION
- `ByteArrayInputStream.flush()` is no-op method along with `ByteArrayInputStream.close()`, `ByteArrayOutputStream.flush()` and `ByteArrayOutputStream.close()`. So we can drop `try-with-resources` statements as well as explicit calls to `flush()`/`close()`
- `new String(BAOS.toByteArray(), charset)` replaced with call to `StreamUtils.baosToString(baos, charset)` to swallow `UnsupportedEncodingException` which is actually never thrown as `charset` is already available at invocation point

As of performance I've used more precise benchmark:
```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g", "-XX:+UseParallelGC"})
public class ByteArrayOutputStreamBenchmark {

  @Benchmark
  public String toString(Data data) throws UnsupportedEncodingException {
    return data.baos.toString(data.charset.name());
  }

  @Benchmark
  public String newString(Data data) {
    return new String(data.baos.toByteArray(), data.charset);
  }

  @Benchmark
  public String toString_noCS(Data data) {
    return data.baos.toString();
  }

  @Benchmark
  public String newString_noCS(Data data) {
    return new String(data.baos.toByteArray());
  }

  @State(Scope.Thread)
  public static class Data {

    @Param({"0", "10", "100", "1000"})
    private int length;

    private final Charset charset = Charset.defaultCharset();

    private ByteArrayOutputStream baos;

    @Setup
    public void setup() throws IOException {
      byte[] bytes = StringUtils.repeat('a', length).getBytes(charset);

      baos = new ByteArrayOutputStream(length);
      baos.write(bytes);
    }
  }

}
```
Which demonstrates improvement in both time and memory consumption
```
JDK 8
                                       (length)  Mode      Score     Error   Units

newString                                     0  avgt     66.084 ±   2.121   ns/op
toString                                      0  avgt     44.601 ±   0.656   ns/op
newString_noCS                                0  avgt     69.694 ±   1.949   ns/op
toString_noCS                                 0  avgt     43.758 ±   0.333   ns/op

newString                                    10  avgt     53.232 ±   1.569   ns/op
toString                                     10  avgt     45.151 ±   0.397   ns/op
newString_noCS                               10  avgt     52.005 ±   0.473   ns/op
toString_noCS                                10  avgt     45.657 ±   4.325   ns/op

newString                                   100  avgt     96.067 ±   1.466   ns/op
toString                                    100  avgt     77.924 ±   0.645   ns/op
newString_noCS                              100  avgt     94.716 ±   3.138   ns/op
toString_noCS                               100  avgt     80.460 ±   1.375   ns/op

newString                                  1000  avgt    667.188 ±  33.071   ns/op
toString                                   1000  avgt    511.302 ±   1.730   ns/op
newString_noCS                             1000  avgt    624.721 ±  20.786   ns/op
toString_noCS                              1000  avgt    530.833 ±  11.087   ns/op

newString:·gc.alloc.rate.norm                 0  avgt     96.000 ±   0.001    B/op
toString:·gc.alloc.rate.norm                  0  avgt     40.000 ±   0.001    B/op
newString_noCS:·gc.alloc.rate.norm            0  avgt     56.000 ±   0.001    B/op
toString_noCS:·gc.alloc.rate.norm             0  avgt     40.000 ±   0.001    B/op

newString:·gc.alloc.rate.norm                10  avgt    136.000 ±   0.001    B/op
toString:·gc.alloc.rate.norm                 10  avgt     64.000 ±   0.001    B/op
newString_noCS:·gc.alloc.rate.norm           10  avgt     96.000 ±   0.001    B/op
toString_noCS:·gc.alloc.rate.norm            10  avgt     64.000 ±   0.001    B/op

newString:·gc.alloc.rate.norm               100  avgt    400.000 ±   0.001    B/op
toString:·gc.alloc.rate.norm                100  avgt    240.000 ±   0.001    B/op
newString_noCS:·gc.alloc.rate.norm          100  avgt    360.000 ±   0.001    B/op
toString_noCS:·gc.alloc.rate.norm           100  avgt    240.000 ±   0.001    B/op

newString:·gc.alloc.rate.norm              1000  avgt   3096.001 ±   0.001    B/op
toString:·gc.alloc.rate.norm               1000  avgt   2040.001 ±   0.001    B/op
newString_noCS:·gc.alloc.rate.norm         1000  avgt   3056.001 ±   0.001    B/op
toString_noCS:·gc.alloc.rate.norm          1000  avgt   2040.001 ±   0.001    B/op
```