### PR TITLE
Fix typo in webflux-cors.adoc

### DIFF
--- a/src/docs/asciidoc/web/webflux-cors.adoc
+++ b/src/docs/asciidoc/web/webflux-cors.adoc
@@ -50,7 +50,7 @@ Each `HandlerMapping` can be
 {api-spring-framework}/web/reactive/handler/AbstractHandlerMapping.html#setCorsConfigurations-java.util.Map-[configured]
 individually with URL pattern-based `CorsConfiguration` mappings. In most cases, applications
 use the WebFlux Java configuration to declare such mappings, which results in a single,
-global map passed to all `HadlerMappping` implementations.
+global map passed to all `HandlerMapping` implementations.
 
 You can combine global CORS configuration at the `HandlerMapping` level with more
 fine-grained, handler-level CORS configuration. For example, annotated controllers can use


### PR DESCRIPTION
Hi, I'm reading WebFlux documentation. I've just found little typo so I create this PR to fix it. Thanks for your maintenance.