### PR TITLE
Recursively copy directory with symbolic link

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/FileSystemUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileSystemUtils.java
@@ -24,8 +24,10 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.EnumSet;
 
 import org.springframework.lang.Nullable;
+import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 
 /**
  * Utility methods for working with the file system.


### PR DESCRIPTION
The following modification will also recursively traverse the directory that the symbolic link points to.
This modification is not proposed for deleteRecursively, since it can be harmful if not intended.

This modification relates to the following commit:
Consistent use of NIO.2 for file read/write interactions
Issue: SPR-15748
spring-projects@12114a9