### PR TITLE
Improve performance of StringUtils.deleteAny()

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -453,16 +453,16 @@ public abstract class StringUtils {
 			return inString;
 		}
 
-		StringBuilder sb = new StringBuilder(inString.length());
+		int lastCharIndex = 0;
+		char[] result = new char[inString.length()];
 		for (int i = 0; i < inString.length(); i++) {
 			char c = inString.charAt(i);
 			if (charsToDelete.indexOf(c) == -1) {
-				sb.append(c);
+				result[lastCharIndex++] = c;
 			}
 		}
-		return sb.toString();
+		return new String(result, 0, lastCharIndex);
 	}
-
 
 	//---------------------------------------------------------------------
 	// Convenience methods for working with formatted Strings

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -306,7 +306,7 @@ class StringUtilsTests {
 	void quoteIfString() {
 		assertThat(StringUtils.quoteIfString("myString")).isEqualTo("'myString'");
 		assertThat(StringUtils.quoteIfString("")).isEqualTo("''");
-		assertThat(StringUtils.quoteIfString(5)).isEqualTo(Integer.valueOf(5));
+		assertThat(StringUtils.quoteIfString(5)).isEqualTo(5);
 		assertThat(StringUtils.quoteIfString(null)).isNull();
 	}
 
@@ -498,7 +498,7 @@ class StringUtilsTests {
 	void tokenizeToStringArrayWithNotIgnoreEmptyTokens() {
 		String[] sa = StringUtils.tokenizeToStringArray("a,b , ,c", ",", true, false);
 		assertThat(sa.length).isEqualTo(4);
-		assertThat(sa[0].equals("a") && sa[1].equals("b") && sa[2].equals("") && sa[3].equals("c")).as("components are correct").isTrue();
+		assertThat(sa[0].equals("a") && sa[1].equals("b") && sa[2].isEmpty() && sa[3].equals("c")).as("components are correct").isTrue();
 	}
 
 	@Test
@@ -539,7 +539,7 @@ class StringUtilsTests {
 	}
 
 	@Test
-	void delimitedListToStringArrayWithEmptyString() {
+	void delimitedListToStringArrayWithEmptyDelimiter() {
 		String[] sa = StringUtils.delimitedListToStringArray("a,b", "");
 		assertThat(sa.length).isEqualTo(3);
 		assertThat(sa[0]).isEqualTo("a");
@@ -601,7 +601,7 @@ class StringUtilsTests {
 		// Could read these from files
 		String[] sa = StringUtils.commaDelimitedListToStringArray("a,,b");
 		assertThat(sa.length).as("a,,b produces array length 3").isEqualTo(3);
-		assertThat(sa[0].equals("a") && sa[1].equals("") && sa[2].equals("b")).as("components are correct").isTrue();
+		assertThat(sa[0].equals("a") && sa[1].isEmpty() && sa[2].equals("b")).as("components are correct").isTrue();
 
 		sa = new String[] {"", "", "a", ""};
 		doTestCommaDelimitedListToStringArrayLegalMatch(sa);


### PR DESCRIPTION
`StringUtils.deleteAny()` can be improved in a trivial way to reduce bounds check and possible reallocations in `StringBuilder` by using `char[]`. This simple change demonstrates significant improvement.
Benchmark:
```java
@State(Scope.Thread)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(jvmArgsAppend = {"-Xms2g", "-Xmx2g", "-XX:+UseParallelGC"})
public class DeleteAnyBenchmark {

  @Benchmark
  public String original() {
    return deleteAny("key1=value1 ", "\"");
  }

  @Benchmark
  public String patched() {
    return deleteAnyPatched("key1=value1 ", "\"");
  }

  private static String deleteAny(String inString, String charsToDelete) {
    StringBuilder sb = new StringBuilder(inString.length());
    for (int i = 0; i < inString.length(); i++) {
      char c = inString.charAt(i);
      if (charsToDelete.indexOf(c) == -1) {
        sb.append(c);
      }
    }
    return sb.toString();
  }

  private static String deleteAnyPatched(String inString, String charsToDelete) {
    int lastCharIndex = 0;
    char[] result = new char[inString.length()];
    for (int i = 0; i < inString.length(); i++) {
      char c = inString.charAt(i);
      if (charsToDelete.indexOf(c) == -1) {
        result[lastCharIndex++] = c;
      }
    }
    return new String(result, 0, lastCharIndex);
  }

}
```
and its results for Java 8
```
Benchmark                                                     Mode  Cnt     Score     Error   Units
DeleteAnyBenchmark.original                                   avgt   50    90.203 ±   4.317   ns/op
DeleteAnyBenchmark.original:·gc.alloc.rate                    avgt   50   738.784 ±  31.462  MB/sec
DeleteAnyBenchmark.original:·gc.alloc.rate.norm               avgt   50   104.000 ±   0.001    B/op
DeleteAnyBenchmark.original:·gc.churn.PS_Eden_Space           avgt   50   750.517 ± 107.126  MB/sec
DeleteAnyBenchmark.original:·gc.churn.PS_Eden_Space.norm      avgt   50   105.389 ±  14.303    B/op
DeleteAnyBenchmark.original:·gc.churn.PS_Survivor_Space       avgt   50     0.030 ±   0.015  MB/sec
DeleteAnyBenchmark.original:·gc.churn.PS_Survivor_Space.norm  avgt   50     0.004 ±   0.002    B/op
DeleteAnyBenchmark.original:·gc.count                         avgt   50    83.000            counts
DeleteAnyBenchmark.original:·gc.time                          avgt   50    84.000                ms
DeleteAnyBenchmark.patched                                    avgt   50    25.391 ±   1.118   ns/op
DeleteAnyBenchmark.patched:·gc.alloc.rate                     avgt   50  2622.055 ± 107.408  MB/sec
DeleteAnyBenchmark.patched:·gc.alloc.rate.norm                avgt   50   104.000 ±   0.001    B/op
DeleteAnyBenchmark.patched:·gc.churn.PS_Eden_Space            avgt   50  2606.384 ± 126.905  MB/sec
DeleteAnyBenchmark.patched:·gc.churn.PS_Eden_Space.norm       avgt   50   103.466 ±   3.549    B/op
DeleteAnyBenchmark.patched:·gc.churn.PS_Survivor_Space        avgt   50     0.066 ±   0.015  MB/sec
DeleteAnyBenchmark.patched:·gc.churn.PS_Survivor_Space.norm   avgt   50     0.003 ±   0.001    B/op
DeleteAnyBenchmark.patched:·gc.count                          avgt   50   287.000            counts
DeleteAnyBenchmark.patched:·gc.time                           avgt   50   260.000                ms
```