### PR TITLE
Avoid using regex matching for static patterns

### DIFF
--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -130,6 +130,9 @@ class AntPathMatcherTests {
 		assertThat(pathMatcher.match("", "")).isTrue();
 
 		assertThat(pathMatcher.match("/{bla}.*", "/testing.html")).isTrue();
+
+		// Test that sending the same pattern will not match (gh #24887)
+		assertThat(pathMatcher.match("/bla/{foo:[0-9]}", "/bla/{foo:[0-9]}")).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
This fixes the issue #24873

As of now, `AntPathStringMatcher` uses regex matching even when:
- the pattern is a constant. In such cases, it should be enough to use strings comparison
- the pattern is `.*`. In such cases it is always a positive match

Applying such optimizations increased `PatternsRequestCondition` evaluation (on my machine) from ~440 ops/ms to ~700 ops/ms

`AntPathStringMatcher` is used not only for URL matching, so it would be nice to double-check carefully
