### PR TITLE
Prevent setting parent bean factory to self

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -769,6 +769,9 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 		if (this.parentBeanFactory != null && this.parentBeanFactory != parentBeanFactory) {
 			throw new IllegalStateException("Already associated with parent BeanFactory: " + this.parentBeanFactory);
 		}
+		if(this == parentBeanFactory) {
+			throw new IllegalStateException("Can not set parent bean factory to self.");
+		}
 		this.parentBeanFactory = parentBeanFactory;
 	}
 


### PR DESCRIPTION
If set parent bean factory to self, once try to get an undefined bean, 
bellow condition
if (parentBeanFactory != null && !containsBeanDefinition(beanName)) {
...
}
will always be true and  StackOverflowError will be thrown.
Sometimes, this issue is hard to detect during runtime, 
if self-reference is not allowed here, 
error will be found at the early time of startup.
Also, a self-reference parent bean factory is valueless.