### PR TITLE
provide way to configure websoscket parameters outside

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/upgrade/ReactorNettyRequestUpgradeStrategy.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/upgrade/ReactorNettyRequestUpgradeStrategy.java
@@ -21,6 +21,8 @@ import java.util.function.Supplier;
 
 import reactor.core.publisher.Mono;
 import reactor.netty.http.server.HttpServerResponse;
+import reactor.netty.http.server.WebsocketServerSpec;
+import reactor.netty.http.server.WebsocketServerSpec.Builder;
 
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import org.springframework.http.server.reactive.AbstractServerHttpResponse;
@@ -29,75 +31,34 @@ import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
 import org.springframework.lang.Nullable;
 import org.springframework.web.reactive.socket.HandshakeInfo;
 import org.springframework.web.reactive.socket.WebSocketHandler;
-import org.springframework.web.reactive.socket.adapter.NettyWebSocketSessionSupport;
 import org.springframework.web.reactive.socket.adapter.ReactorNettyWebSocketSession;
 import org.springframework.web.reactive.socket.server.RequestUpgradeStrategy;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
  * A {@link RequestUpgradeStrategy} for use with Reactor Netty.
- *
  * @author Rossen Stoyanchev
  * @since 5.0
  */
 public class ReactorNettyRequestUpgradeStrategy implements RequestUpgradeStrategy {
 
-	private int maxFramePayloadLength = NettyWebSocketSessionSupport.DEFAULT_FRAME_MAX_SIZE;
-
-	private boolean handlePing = false;
-
+	private Builder websocketServerSpec = WebsocketServerSpec.builder();
 
 	/**
-	 * Configure the maximum allowable frame payload length. Setting this value
-	 * to your application's requirement may reduce denial of service attacks
-	 * using long data frames.
-	 * <p>Corresponds to the argument with the same name in the constructor of
-	 * {@link io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory
-	 * WebSocketServerHandshakerFactory} in Netty.
-	 * <p>By default set to 65536 (64K).
-	 * @param maxFramePayloadLength the max length for frames.
-	 * @since 5.1
+	 * Configure websocket specification {@link WebsocketServerSpec}
+	 * @param websocketServerSpecBuilder websocket server parameters (ping, compression, maxFramePayloadLength)
+	 * @since 5.2.6
 	 */
-	public void setMaxFramePayloadLength(Integer maxFramePayloadLength) {
-		this.maxFramePayloadLength = maxFramePayloadLength;
+	public void setWebsocketServerSpecBuilder(final Builder websocketServerSpecBuilder) {
+		this.websocketServerSpec = websocketServerSpecBuilder;
 	}
-
-	/**
-	 * Return the configured max length for frames.
-	 * @since 5.1
-	 */
-	public int getMaxFramePayloadLength() {
-		return this.maxFramePayloadLength;
-	}
-
-	/**
-	 * Configure whether to let ping frames through to be handled by the
-	 * {@link WebSocketHandler} given to the upgrade method. By default, Reactor
-	 * Netty automatically replies with pong frames in response to pings. This is
-	 * useful in a proxy for allowing ping and pong frames through.
-	 * <p>By default this is set to {@code false} in which case ping frames are
-	 * handled automatically by Reactor Netty. If set to {@code true}, ping
-	 * frames will be passed through to the {@link WebSocketHandler}.
-	 * @param handlePing whether to let Ping frames through for handling
-	 * @since 5.2.4
-	 */
-	public void setHandlePing(boolean handlePing) {
-		this.handlePing = handlePing;
-	}
-
-	/**
-	 * Return the configured {@link #setHandlePing(boolean)}.
-	 * @since 5.2.4
-	 */
-	public boolean getHandlePing() {
-		return this.handlePing;
-	}
-
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public Mono<Void> upgrade(ServerWebExchange exchange, WebSocketHandler handler,
-			@Nullable String subProtocol, Supplier<HandshakeInfo> handshakeInfoFactory) {
+	public Mono<Void> upgrade(
+			ServerWebExchange exchange, WebSocketHandler handler,
+			@Nullable String subProtocol, Supplier<HandshakeInfo> handshakeInfoFactory
+	) {
 
 		ServerHttpResponse response = exchange.getResponse();
 		HttpServerResponse reactorResponse = getNativeResponse(response);
@@ -107,29 +68,29 @@ public class ReactorNettyRequestUpgradeStrategy implements RequestUpgradeStrateg
 		// Trigger WebFlux preCommit actions and upgrade
 		return response.setComplete()
 				.then(Mono.defer(() -> reactorResponse.sendWebsocket(
-						subProtocol,
-						this.maxFramePayloadLength,
-						this.handlePing,
 						(in, out) -> {
 							ReactorNettyWebSocketSession session =
 									new ReactorNettyWebSocketSession(
-											in, out, handshakeInfo, bufferFactory, this.maxFramePayloadLength);
+											in,
+											out,
+											handshakeInfo,
+											bufferFactory,
+											this.websocketServerSpec.build()
+													.maxFramePayloadLength());
 							URI uri = exchange.getRequest().getURI();
-							return handler.handle(session).checkpoint(uri + " [ReactorNettyRequestUpgradeStrategy]");
-						})));
+							return handler.handle(session)
+									.checkpoint(uri + " [ReactorNettyRequestUpgradeStrategy]");
+						}, this.websocketServerSpec.protocols(subProtocol).build())));
 	}
 
 	private static HttpServerResponse getNativeResponse(ServerHttpResponse response) {
 		if (response instanceof AbstractServerHttpResponse) {
 			return ((AbstractServerHttpResponse) response).getNativeResponse();
-		}
-		else if (response instanceof ServerHttpResponseDecorator) {
+		} else if (response instanceof ServerHttpResponseDecorator) {
 			return getNativeResponse(((ServerHttpResponseDecorator) response).getDelegate());
-		}
-		else {
+		} else {
 			throw new IllegalArgumentException(
 					"Couldn't find native response in " + response.getClass().getName());
 		}
 	}
-
 }


### PR DESCRIPTION
replaced deprecated invocation with recommended method
This is required to enable websocket server compression. By default builder has compression=false parameter and it is not possible to override it (factory could not be setup from anywhere)