### PR TITLE
Remove unnecessary sorting in PostProcessorRegistrationDelegate

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java
+++ b/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java
@@ -45,6 +45,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Juergen Hoeller
  * @author Sam Brannen
+ * @author Qimiao Chen
  * @since 4.0
  */
 final class PostProcessorRegistrationDelegate {
@@ -247,7 +248,6 @@ final class PostProcessorRegistrationDelegate {
 		registerBeanPostProcessors(beanFactory, nonOrderedPostProcessors);
 
 		// Finally, re-register all internal BeanPostProcessors.
-		sortPostProcessors(internalPostProcessors, beanFactory);
 		registerBeanPostProcessors(beanFactory, internalPostProcessors);
 
 		// Re-register post-processor for detecting inner beans as ApplicationListeners,


### PR DESCRIPTION
I think the sorting is unnecessary, because `internalPostProcessors ` has been sorted in every previous stage of traversing `ppNames`.
Secondly, this sorting will break some rules, For example, it will cause nonOrderedPostProcessors to sort by `@Order`. But in JavaDoc of BeanPostProcessor ,this is not allowed.

The Ordering section of the class-level Javadoc for BeanPostProcessor states the following.
> > `BeanPostProcessor` beans that are autodetected in an `ApplicationContext` will be ordered according to `PriorityOrdered` and `Ordered` semantics. In contrast, `BeanPostProcessor` beans that are registered programmatically with a `BeanFactory` will be applied in the order of registration; any ordering semantics expressed through implementing the `PriorityOrdered` or `Ordered` interface will be ignored for programmatically registered post-processors. Furthermore, the `@Order` annotation is not taken into account for `BeanPostProcessor` beans.





