### PR TITLE
Introduce onlyNumbers() method in StringUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -70,6 +70,8 @@ public abstract class StringUtils {
 
 	private static final String CURRENT_PATH = ".";
 
+	private static final String ONLY_NUMBERS_REGEX = "\\D+";
+
 	private static final char EXTENSION_SEPARATOR = '.';
 
 
@@ -429,6 +431,15 @@ public abstract class StringUtils {
 		// append any characters to the right of a match
 		sb.append(inString, pos, inString.length());
 		return sb.toString();
+	}
+
+	/**
+	 * Replace all not numbers to empity String
+	 * @param str the original {@code String}
+	 * @return the resulting {@code String}
+	 */
+	public static String onlyNumbers(String str) {
+		return str.replaceAll(ONLY_NUMBERS_REGEX, "");
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -22,8 +22,7 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Rod Johnson
@@ -242,6 +241,15 @@ class StringUtilsTests {
 		// Null old pattern: should ignore
 		s = StringUtils.replace(inString, null, newPattern);
 		assertThat(s).as("Replace non-matched is returned as-is").isSameAs(inString);
+	}
+
+	@Test
+	void onlyNumbers() {
+		assertThat(StringUtils.onlyNumbers("111.222.333-44").equals("11122233344")).isTrue();
+		assertThat(StringUtils.onlyNumbers("(11) 2 3333-4444").equals("11233334444")).isTrue();
+		assertThat(StringUtils.onlyNumbers("1111@2222").equals("11112222")).isTrue();
+		assertThat(StringUtils.onlyNumbers("!1@2#3$4%5ˆ6&7*8(9)0").equals("1234567890")).isTrue();
+		assertThat(StringUtils.onlyNumbers("AbCdE123WuEd456").equals("123456")).isTrue();
 	}
 
 	@Test

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -22,7 +22,8 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * @author Rod Johnson


### PR DESCRIPTION
Hi!

I create a new static method on SpringUtils

Sometimes I need to compare Strings or their size in a condition and for that I create a useful in the project itself for this, but I saw that this is very common among the projects that I passed or know, so I decided to create this method so that it is more accessible to everyone and reuse the same code.

I love the spring, congrats to the team!