### PR TITLE
Avoid unnecessary String instantiation in StringUtils.deleteAny()

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -461,6 +461,9 @@ public abstract class StringUtils {
 				result[lastCharIndex++] = c;
 			}
 		}
+		if (lastCharIndex == inString.length()) {
+			return inString;
+		}
 		return new String(result, 0, lastCharIndex);
 	}
 


### PR DESCRIPTION
When I was reading https://github.com/spring-projects/spring-framework/pull/24870, I noticed that `String` instantiation in `StringUtils.deleteAny()` isn't necessary when nothing is deleted. So this PR changes to avoid it.

This is a straightforward change, but I just ran [the same benchmark](https://github.com/izeye/samples-jmh-gradle/blob/d193de7d08ce7d8de71dc6ba724cb89018501d20/src/jmh/java/com/izeye/samples/jmh/SpringStringUtilsDeleteAnyBenchmark.java) used in https://github.com/spring-projects/spring-framework/pull/24870. The result is as follows:

```
Benchmark                                                                                                    Mode  Cnt     Score   Error   Units
SpringStringUtilsDeleteAnyBenchmark.original                                                                 avgt         68.215           ns/op
SpringStringUtilsDeleteAnyBenchmark.original:·gc.alloc.rate                                                  avgt       1384.675          MB/sec
SpringStringUtilsDeleteAnyBenchmark.original:·gc.alloc.rate.norm                                             avgt        104.000            B/op
SpringStringUtilsDeleteAnyBenchmark.original:·gc.churn.PS_Eden_Space                                         avgt       1359.258          MB/sec
SpringStringUtilsDeleteAnyBenchmark.original:·gc.churn.PS_Eden_Space.norm                                    avgt        102.091            B/op
SpringStringUtilsDeleteAnyBenchmark.original:·gc.churn.PS_Survivor_Space                                     avgt          0.048          MB/sec
SpringStringUtilsDeleteAnyBenchmark.original:·gc.churn.PS_Survivor_Space.norm                                avgt          0.004            B/op
SpringStringUtilsDeleteAnyBenchmark.original:·gc.count                                                       avgt         21.000          counts
SpringStringUtilsDeleteAnyBenchmark.original:·gc.time                                                        avgt         12.000              ms
SpringStringUtilsDeleteAnyBenchmark.patched                                                                  avgt         20.938           ns/op
SpringStringUtilsDeleteAnyBenchmark.patched:·gc.alloc.rate                                                   avgt       4510.715          MB/sec
SpringStringUtilsDeleteAnyBenchmark.patched:·gc.alloc.rate.norm                                              avgt        104.000            B/op
SpringStringUtilsDeleteAnyBenchmark.patched:·gc.churn.PS_Eden_Space                                          avgt       4477.181          MB/sec
SpringStringUtilsDeleteAnyBenchmark.patched:·gc.churn.PS_Eden_Space.norm                                     avgt        103.227            B/op
SpringStringUtilsDeleteAnyBenchmark.patched:·gc.churn.PS_Survivor_Space                                      avgt          0.074          MB/sec
SpringStringUtilsDeleteAnyBenchmark.patched:·gc.churn.PS_Survivor_Space.norm                                 avgt          0.002            B/op
SpringStringUtilsDeleteAnyBenchmark.patched:·gc.count                                                        avgt         69.000          counts
SpringStringUtilsDeleteAnyBenchmark.patched:·gc.time                                                         avgt         38.000              ms
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted                                   avgt         13.284           ns/op
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted:·gc.alloc.rate                    avgt       2734.452          MB/sec
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted:·gc.alloc.rate.norm               avgt         40.000            B/op
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted:·gc.churn.PS_Eden_Space           avgt       2788.360          MB/sec
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted:·gc.churn.PS_Eden_Space.norm      avgt         40.789            B/op
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted:·gc.churn.PS_Survivor_Space       avgt          0.036          MB/sec
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted:·gc.churn.PS_Survivor_Space.norm  avgt          0.001            B/op
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted:·gc.count                         avgt         43.000          counts
SpringStringUtilsDeleteAnyBenchmark.patchedSkipNewStringWhenNothingDeleted:·gc.time                          avgt         22.000              ms
```