### PR TITLE
24901 - Fix to handle static part of path variable URI mappings performance

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -633,6 +633,24 @@ public class AntPathMatcher implements PathMatcher {
 		return new AntPatternComparator(path);
 	}
 
+	@Override
+	public boolean isUriVariablePattern(String path) {
+		if (path == null) {
+			return false;
+		}
+		boolean uriVar = false;
+		for (int i = 0; i < path.length(); i++) {
+			char c = path.charAt(i);
+			if (c == '{') {
+				uriVar = true;
+				continue;
+			}
+			if (c == '}' && uriVar) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 	/**
 	 * Tests whether or not a string matches against a pattern via a {@link Pattern}.

--- a/spring-core/src/main/java/org/springframework/util/PathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/PathMatcher.java
@@ -46,6 +46,8 @@ public interface PathMatcher {
 	 */
 	boolean isPattern(String path);
 
+	boolean isUriVariablePattern(String path);
+
 	/**
 	 * Match the given {@code path} against the given {@code pattern},
 	 * according to this PathMatcher's matching strategy.

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/MvcNamespaceTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/MvcNamespaceTests.java
@@ -1085,6 +1085,11 @@ public class MvcNamespaceTests {
 		public String combine(String pattern1, String pattern2) {
 			return null;
 		}
+
+		@Override
+		public boolean isUriVariablePattern(String path) {
+			return false;
+		}
 	}
 
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/MappedInterceptorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/MappedInterceptorTests.java
@@ -164,5 +164,10 @@ public class MappedInterceptorTests {
 		public String combine(String pattern1, String pattern2) {
 			return null;
 		}
+
+		@Override
+		public boolean isUriVariablePattern(String path) {
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
Currently Spring webmvc looks up direct URLs and fall back to evaluating every URL mapped if there is no exact match based on direct URLs mappings. Due to this, URI with path variables, always go through larger look up evaluations poor performance. This PR stores static URIs as part of a MappingRegistry in a new Map to match incoming URIs to identify partial matches to cut down the mapping evaluations and hence improves performance