### PR TITLE
Make imported config always override the one found by package scan

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/AbstractCircularImportDetectionTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/AbstractCircularImportDetectionTests.java
@@ -40,7 +40,7 @@ public abstract class AbstractCircularImportDetectionTests {
 	public void simpleCircularImportIsDetected() throws Exception {
 		boolean threw = false;
 		try {
-			newParser().parse(loadAsConfigurationSource(A.class), "A");
+			newParser().parse(loadAsConfigurationSource(A.class), "A", false);
 		}
 		catch (BeanDefinitionParsingException ex) {
 			assertThat(ex.getMessage().contains(
@@ -55,7 +55,7 @@ public abstract class AbstractCircularImportDetectionTests {
 	public void complexCircularImportIsDetected() throws Exception {
 		boolean threw = false;
 		try {
-			newParser().parse(loadAsConfigurationSource(X.class), "X");
+			newParser().parse(loadAsConfigurationSource(X.class), "X", false);
 		}
 		catch (BeanDefinitionParsingException ex) {
 			assertThat(ex.getMessage().contains(

--- a/spring-context/src/test/java/org/springframework/context/annotation/componentscan/ordered/SiblingImportingConfigA.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/componentscan/ordered/SiblingImportingConfigA.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.componentscan.ordered;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * gh #24643
+ *
+ * @author Vladislav Kisel
+ */
+@Configuration
+@Import(SiblingImportingConfigB.class)
+public class SiblingImportingConfigA {
+
+	@Bean(name = "a-imports-b")
+	String bean() {
+		return "valueFromA";
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/componentscan/ordered/SiblingImportingConfigB.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/componentscan/ordered/SiblingImportingConfigB.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.componentscan.ordered;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * gh #24643
+ *
+ * @author Vladislav Kisel
+ */
+@Configuration
+public class SiblingImportingConfigB {
+
+	@Bean(name = "a-imports-b")
+	String bean() {
+		return "valueFromB";
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/componentscan/ordered/SiblingReversedImportingConfigA.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/componentscan/ordered/SiblingReversedImportingConfigA.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.componentscan.ordered;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * gh #24643
+ *
+ * @author Vladislav Kisel
+ */
+@Configuration
+public class SiblingReversedImportingConfigA {
+
+	@Bean(name = "b-imports-a")
+	String bean() {
+		return "valueFromAR";
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/componentscan/ordered/SiblingReversedImportingConfigB.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/componentscan/ordered/SiblingReversedImportingConfigB.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.componentscan.ordered;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * gh #24643
+ *
+ * @author Vladislav Kisel
+ */
+@Configuration
+@Import(SiblingReversedImportingConfigA.class)
+public class SiblingReversedImportingConfigB {
+
+	@Bean(name = "b-imports-a")
+	String bean() {
+		return "valueFromBR";
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/ImportTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/ImportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ConfigurationClassPostProcessor;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.componentscan.ordered.SiblingImportingConfigA;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Chris Beams
  * @author Juergen Hoeller
+ * @author Vladislav Kisel
  */
 public class ImportTests {
 
@@ -354,6 +356,22 @@ public class ImportTests {
 		int configClasses = 2;
 		int beansInClasses = 2;
 		assertBeanDefinitionCount((configClasses + beansInClasses), ConfigurationWithImportAnnotation.class);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * An imported config must override a scanned one, thus bean definitions from the imported class is overridden by its importer.
+	 * gh #24643
+	 */
+	@Test
+	public void importedConfigOverridesScannedOne() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.scan(SiblingImportingConfigA.class.getPackage().getName());
+		ctx.refresh();
+
+		assertThat(ctx.getBean("a-imports-b")).isEqualTo("valueFromA");
+		assertThat(ctx.getBean("b-imports-a")).isEqualTo("valueFromBR");
 	}
 
 }


### PR DESCRIPTION
Fixes #24643

**Current state**

Whether imported user config class will override a scanned one depends on its names.
Unit test which is reproducing it: 
`ImportTests#importedConfigOverridesScannedOne`

During nested configs processing (`ConfigurationClassParser#processMemberClasses`), all nested configs are being overridden by its scanned version loosing `importedBy` information. This is not intended behavior according to the documentation of import feature. But this accidentally made it work, because otherwise the config would have been registered twice: first by package scan, then by `ConfigurationClassBeanDefinitionReader#loadBeanDefinitionsForConfigurationClass`. 

Unit test which is reproducing it: `ComponentScanAnnotationIntegrationTests#viaContextRegistration_WithComposedAnnotation`

**Fixed version**

Change in `ConfigurationClassParser` is needed to make imported configs always override the scanned ones, preserving `importedBy` info. Due to preserving `importedBy` I had to change `ConfigurationClassBeanDefinitionReader` as well, which registers imported configs, but it did not expect that it could have been already registered (during package scanning). I used `AnnotationBeanNameGenerator` for naming to make it 100% backward compatible by preserving configs bean names.