### PR TITLE
Aggregate TestExecutionListener orders

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/SpringTestExecutionListenerOrder.java
+++ b/spring-test/src/main/java/org/springframework/test/context/SpringTestExecutionListenerOrder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context;
+
+/**
+ * Aggregates the orders of the {@link TestExecutionListener}s
+ * defined by the Spring TestContext Framework.
+ *
+ * @author Andrei Dragnea
+ * @since 5.2.6
+ * @see org.springframework.core.Ordered
+ * @see TestExecutionListener
+ */
+public enum SpringTestExecutionListenerOrder {
+
+	/**
+	 * Order of {@link org.springframework.test.context.web.ServletTestExecutionListener}.
+	 */
+	SERVLET(1_000),
+
+	/**
+	 * Order of {@link org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener}.
+	 */
+	DIRTIES_CONTEXT_BEFORE_MODES(1_500),
+
+	/**
+	 * Order of {@link org.springframework.test.context.support.DependencyInjectionTestExecutionListener}.
+	 */
+	DEPENDENCY_INJECTION(2_000),
+
+	/**
+	 * Order of {@link org.springframework.test.context.support.DirtiesContextTestExecutionListener}.
+	 */
+	DIRTIES_CONTEXT(3_000),
+
+	/**
+	 * Order of {@link org.springframework.test.context.transaction.TransactionalTestExecutionListener}.
+	 */
+	TRANSACTIONAL(4_000),
+
+	/**
+	 * Order of {@link org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener}.
+	 */
+	SQL_SCRIPTS(5_000),
+
+	/**
+	 * Order of {@link org.springframework.test.context.event.EventPublishingTestExecutionListener}.
+	 */
+	EVENT_PUBLISHING(10_000);
+
+	private final int value;
+
+	SpringTestExecutionListenerOrder(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+}

--- a/spring-test/src/main/java/org/springframework/test/context/event/EventPublishingTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/event/EventPublishingTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.test.context.event;
 
+import org.springframework.test.context.SpringTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -81,7 +82,7 @@ public class EventPublishingTestExecutionListener extends AbstractTestExecutionL
 	 */
 	@Override
 	public final int getOrder() {
-		return 10_000;
+		return SpringTestExecutionListenerOrder.EVENT_PUBLISHING.getValue();
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
+import org.springframework.test.context.SpringTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.context.jdbc.SqlConfig.ErrorMode;
@@ -105,7 +106,7 @@ public class SqlScriptsTestExecutionListener extends AbstractTestExecutionListen
 	 */
 	@Override
 	public final int getOrder() {
-		return 5000;
+		return SpringTestExecutionListenerOrder.SQL_SCRIPTS.getValue();
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/support/DependencyInjectionTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DependencyInjectionTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.core.Conventions;
+import org.springframework.test.context.SpringTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 
 /**
@@ -59,7 +60,7 @@ public class DependencyInjectionTestExecutionListener extends AbstractTestExecut
 	 */
 	@Override
 	public final int getOrder() {
-		return 2000;
+		return SpringTestExecutionListenerOrder.DEPENDENCY_INJECTION.getValue();
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextBeforeModesTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextBeforeModesTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
+import org.springframework.test.context.SpringTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListeners;
 
@@ -59,7 +60,7 @@ public class DirtiesContextBeforeModesTestExecutionListener extends AbstractDirt
 	 */
 	@Override
 	public final int getOrder() {
-		return 1500;
+		return SpringTestExecutionListenerOrder.DIRTIES_CONTEXT_BEFORE_MODES.getValue();
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
+import org.springframework.test.context.SpringTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListeners;
 
@@ -59,7 +60,7 @@ public class DirtiesContextTestExecutionListener extends AbstractDirtiesContextT
 	 */
 	@Override
 	public final int getOrder() {
-		return 3000;
+		return SpringTestExecutionListenerOrder.DIRTIES_CONTEXT.getValue();
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.test.annotation.Commit;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.SpringTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -156,7 +157,7 @@ public class TransactionalTestExecutionListener extends AbstractTestExecutionLis
 	 */
 	@Override
 	public final int getOrder() {
-		return 4000;
+		return SpringTestExecutionListenerOrder.TRANSACTIONAL.getValue();
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/context/web/ServletTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/web/ServletTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.context.SpringTestExecutionListenerOrder;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -116,7 +117,7 @@ public class ServletTestExecutionListener extends AbstractTestExecutionListener 
 	 */
 	@Override
 	public final int getOrder() {
-		return 1000;
+		return SpringTestExecutionListenerOrder.SERVLET.getValue();
 	}
 
 	/**


### PR DESCRIPTION
Aggregated `TestExecutionListener` orders into `SpringTestExecutionListenerOrder`, in order to help third-party integrators when choosing the order for a new listener.

I have done two similar PRs in [spring-boot](https://github.com/spring-projects/spring-boot/pull/21133) and [spring-security](https://github.com/spring-projects/spring-security/pull/8436) projects.