### PR TITLE
Modified the code to format the nested exception stack trace

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/NestedExceptionUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/NestedExceptionUtils.java
@@ -17,13 +17,15 @@
 package org.springframework.core;
 
 import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
 
 /**
- * Helper class for implementing exception classes which are capable of
- * holding nested exceptions. Necessary because we can't share a base
- * class among different exception types.
+ * Helper class for implementing exception classes which are capable of holding
+ * nested exceptions. Necessary because we can't share a base class among
+ * different exception types.
  *
- * <p>Mainly for use within the framework.
+ * <p>
+ * Mainly for use within the framework.
  *
  * @author Juergen Hoeller
  * @since 2.0
@@ -41,7 +43,8 @@ public abstract class NestedExceptionUtils {
 	 * @return the full exception message
 	 */
 	@Nullable
-	public static String buildMessage(@Nullable String message, @Nullable Throwable cause) {
+	public static String buildMessage(@Nullable String message,
+			@Nullable Throwable cause) {
 		if (cause == null) {
 			return message;
 		}
@@ -50,7 +53,7 @@ public abstract class NestedExceptionUtils {
 			sb.append(message).append("; ");
 		}
 		sb.append("nested exception is ").append(cause);
-		return sb.toString();
+		return formatMessage(formatMessage(sb.toString(), ":"), ";");
 	}
 
 	/**
@@ -74,10 +77,11 @@ public abstract class NestedExceptionUtils {
 	}
 
 	/**
-	 * Retrieve the most specific cause of the given exception, that is,
-	 * either the innermost cause (root cause) or the exception itself.
-	 * <p>Differs from {@link #getRootCause} in that it falls back
-	 * to the original exception if there is no root cause.
+	 * Retrieve the most specific cause of the given exception, that is, either
+	 * the innermost cause (root cause) or the exception itself.
+	 * <p>
+	 * Differs from {@link #getRootCause} in that it falls back to the original
+	 * exception if there is no root cause.
 	 * @param original the original exception to introspect
 	 * @return the most specific cause (never {@code null})
 	 * @since 4.3.9
@@ -85,6 +89,29 @@ public abstract class NestedExceptionUtils {
 	public static Throwable getMostSpecificCause(Throwable original) {
 		Throwable rootCause = getRootCause(original);
 		return (rootCause != null ? rootCause : original);
+	}
+
+	/**
+	 * This method is used to format the stack trace into multiple lines for
+	 * better readabilitys
+	 * @param msg Raw exception stack trace log generated
+	 * @param splitChar String based on which the message needs to be split
+	 * @return Formatted message which is easily readable without scrolling.
+	 */
+	private static String formatMessage(String msg, String splitChar) {
+		String formattedMessage = msg;
+
+		if (StringUtils.hasLength(formattedMessage)) {
+			int charIndex = formattedMessage.indexOf(splitChar);
+			if (charIndex >= 0) {
+				formattedMessage = formattedMessage.substring(0, charIndex + 1).concat(
+						"\n").concat(
+								formatMessage(formattedMessage.substring(charIndex + 1),
+										splitChar));
+			}
+
+		}
+		return formattedMessage;
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/NestedExceptionTests.java
+++ b/spring-core/src/test/java/org/springframework/core/NestedExceptionTests.java
@@ -21,7 +21,10 @@ import java.io.PrintWriter;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.util.StringUtils;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Rod Johnson
@@ -34,7 +37,8 @@ class NestedExceptionTests {
 	void nestedRuntimeExceptionWithNoRootCause() {
 		String mesg = "mesg of mine";
 		// Making a class abstract doesn't _really_ prevent instantiation :-)
-		NestedRuntimeException nex = new NestedRuntimeException(mesg) {};
+		NestedRuntimeException nex = new NestedRuntimeException(mesg) {
+		};
 		assertThat(nex.getCause()).isNull();
 		assertThat(mesg).isEqualTo(nex.getMessage());
 
@@ -53,9 +57,11 @@ class NestedExceptionTests {
 		String rootCauseMsg = "this is the obscure message of the root cause";
 		Exception rootCause = new Exception(rootCauseMsg);
 		// Making a class abstract doesn't _really_ prevent instantiation :-)
-		NestedRuntimeException nex = new NestedRuntimeException(myMessage, rootCause) {};
+		NestedRuntimeException nex = new NestedRuntimeException(myMessage, rootCause) {
+		};
 		assertThat(rootCause).isEqualTo(nex.getCause());
 		assertThat(nex.getMessage().contains(myMessage)).isTrue();
+		assertEquals(StringUtils.countOccurrencesOf(nex.getMessage(), "\n"), 2);
 		assertThat(nex.getMessage().endsWith(rootCauseMsg)).isTrue();
 
 		// check PrintStackTrace
@@ -72,7 +78,8 @@ class NestedExceptionTests {
 	void nestedCheckedExceptionWithNoRootCause() {
 		String mesg = "mesg of mine";
 		// Making a class abstract doesn't _really_ prevent instantiation :-)
-		NestedCheckedException nex = new NestedCheckedException(mesg) {};
+		NestedCheckedException nex = new NestedCheckedException(mesg) {
+		};
 		assertThat(nex.getCause()).isNull();
 		assertThat(mesg).isEqualTo(nex.getMessage());
 
@@ -91,7 +98,8 @@ class NestedExceptionTests {
 		String rootCauseMsg = "this is the obscure message of the root cause";
 		Exception rootCause = new Exception(rootCauseMsg);
 		// Making a class abstract doesn't _really_ prevent instantiation :-)
-		NestedCheckedException nex = new NestedCheckedException(myMessage, rootCause) {};
+		NestedCheckedException nex = new NestedCheckedException(myMessage, rootCause) {
+		};
 		assertThat(rootCause).isEqualTo(nex.getCause());
 		assertThat(nex.getMessage().contains(myMessage)).isTrue();
 		assertThat(nex.getMessage().endsWith(rootCauseMsg)).isTrue();


### PR DESCRIPTION
This PR fixes https://github.com/spring-projects/spring-framework/issues/23227 .

As part of this fix , added a new function in `NestedExceptionUtils.java` which formats the nested exception stack trace based on **semi-colon** `;` and **colon** `:` .

P.S : As this is my first PR , please help with the eclipse code formatting file as my current commit has some changes to the lines that were not intended to change for this fix ( just formatting based on eclipse settings). It will help if I can get hold of a .preferences file that I can import locally in my eclipse , re-apply formatting and push the change.