### PR TITLE
Preserve Http Response Info When MessageConverter Not Found Case

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestClientResponseException.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClientResponseException.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 
+
 /**
  * Common base class for exceptions that contain actual HTTP response data.
  *
@@ -66,6 +67,15 @@ public class RestClientResponseException extends RestClientException {
 		this.responseHeaders = responseHeaders;
 		this.responseBody = (responseBody != null ? responseBody : new byte[0]);
 		this.responseCharset = (responseCharset != null ? responseCharset.name() : null);
+	}
+
+	public RestClientResponseException(String message, int statusCode, String statusText, @Nullable HttpHeaders responseHeaders, Throwable ex){
+		super(message, ex);
+		this.rawStatusCode = statusCode;
+		this.statusText = statusText;
+		this.responseHeaders = responseHeaders;
+		this.responseBody = new byte[0];
+		this.responseCharset = null;
 	}
 
 
@@ -125,4 +135,33 @@ public class RestClientResponseException extends RestClientException {
 		}
 	}
 
+	/**
+	 * {@link RestClientResponseException} for can not find suitable message converter to extract body.
+	 * @since 5.2.7
+	 */
+	@SuppressWarnings("serial")
+	public static final class MessageConverterNotFound extends RestClientResponseException {
+
+		public MessageConverterNotFound(String message, int statusCode, String statusText, HttpHeaders responseHeaders, @Nullable byte[] responseBody, @Nullable Charset responseCharset) {
+
+			super(message, statusCode, statusText, responseHeaders, responseBody, responseCharset);
+		}
+
+		public MessageConverterNotFound(String message, int statusCode, String statusText, HttpHeaders responseHeaders, Throwable ex) {
+
+			super(message, statusCode, statusText, responseHeaders, ex);
+		}
+	}
+
+	/**
+	 * {@link RestClientResponseException} for exception raised when read body stream to extract body.
+	 * @since 5.2.7
+	 */
+	@SuppressWarnings("serial")
+	public static final class FailedToReadResponseBody extends RestClientResponseException {
+
+		public FailedToReadResponseBody(String message, int statusCode, String statusText, HttpHeaders responseHeaders, Throwable ex) {
+			super(message, statusCode, statusText, responseHeaders, ex);
+		}
+	}
 }

--- a/spring-web/src/test/java/org/springframework/web/client/HttpMessageConverterExtractorTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/HttpMessageConverterExtractorTests.java
@@ -145,7 +145,8 @@ public class HttpMessageConverterExtractorTests {
 		given(response.getHeaders()).willReturn(responseHeaders);
 		given(response.getBody()).willReturn(new ByteArrayInputStream("Foobar".getBytes()));
 		given(converter.canRead(String.class, contentType)).willReturn(false);
-		assertThatExceptionOfType(RestClientException.class).isThrownBy(() -> extractor.extractData(response));
+		assertThatExceptionOfType(RestClientResponseException.class).isThrownBy(() -> extractor.extractData(response))
+			.withMessageContaining("Could not find suitable HttpMessageConverter to extract response for response type [class java.lang.String] and content type [text/plain]");
 	}
 
 	@Test
@@ -177,7 +178,7 @@ public class HttpMessageConverterExtractorTests {
 		given(response.getBody()).willReturn(new ByteArrayInputStream("Foobar".getBytes()));
 		given(converter.canRead(String.class, contentType)).willReturn(true);
 		given(converter.read(eq(String.class), any(HttpInputMessage.class))).willThrow(IOException.class);
-		assertThatExceptionOfType(RestClientException.class).isThrownBy(() -> extractor.extractData(response))
+		assertThatExceptionOfType(RestClientResponseException.class).isThrownBy(() -> extractor.extractData(response))
 			.withMessageContaining("Error while extracting response for type [class java.lang.String] and content type [text/plain]")
 			.withCauseInstanceOf(IOException.class);
 	}
@@ -189,7 +190,7 @@ public class HttpMessageConverterExtractorTests {
 		given(response.getHeaders()).willReturn(responseHeaders);
 		given(response.getBody()).willReturn(new ByteArrayInputStream("Foobar".getBytes()));
 		given(converter.canRead(String.class, contentType)).willThrow(HttpMessageNotReadableException.class);
-		assertThatExceptionOfType(RestClientException.class).isThrownBy(() -> extractor.extractData(response))
+		assertThatExceptionOfType(RestClientResponseException.class).isThrownBy(() -> extractor.extractData(response))
 			.withMessageContaining("Error while extracting response for type [class java.lang.String] and content type [text/plain]")
 			.withCauseInstanceOf(HttpMessageNotReadableException.class);
 	}


### PR DESCRIPTION
And Introduce Detail Purpose When Response Could Not Extract

https://github.com/spring-projects/spring-framework/issues/24964
