### PR TITLE
Drop unnecessary intermediate StringBuilder.toString() call in ServerSentEventHttpMessageReader

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageReader.java
@@ -175,7 +175,7 @@ public class ServerSentEventHttpMessageReader implements HttpMessageReader<Objec
 
 		if (shouldWrap) {
 			if (comment != null) {
-				sseBuilder.comment(comment.toString().substring(0, comment.length() - 1));
+				sseBuilder.comment(comment.substring(0, comment.length() - 1));
 			}
 			if (decodedData != null) {
 				sseBuilder.data(decodedData);


### PR DESCRIPTION
Apart from simplification this transformation is likely to bring faster code which consumes less memory.