### PR TITLE
skip the null value copies

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -618,6 +618,7 @@ public abstract class BeanUtils {
 								readMethod.setAccessible(true);
 							}
 							Object value = readMethod.invoke(source);
+							if(value==null)continue;
 							if (!Modifier.isPublic(writeMethod.getDeclaringClass().getModifiers())) {
 								writeMethod.setAccessible(true);
 							}


### PR DESCRIPTION
when we copy some property ,for example : 

```java
private Integer status;//source 

private int status;//target
```

if the source property is null, then throw new FatalBeanException(
									"Could not copy property '" + targetPd.getName() + "' from source to target", ex);

to fix it , maybe need to skip the null value