### PR TITLE
Update Server Requesters IAW observed behavior

### DIFF
--- a/src/docs/asciidoc/rsocket.adoc
+++ b/src/docs/asciidoc/rsocket.adoc
@@ -454,27 +454,31 @@ decoupled from handling. For example:
 			.subscribe(bar -> { // <1>
 				// ...
 			});
-		return ... // <2>
+		// ... <2>
+		return null; // <3>
 	}
 ----
 <1> Start the request asynchronously, independent from handling.
-<2> Perform handling and return completion `Mono<Void>`.
+<2> Perform handling.
+<3> Return null. Any other return value results in connection failure with RejectedSetupException.
 
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin
 ----
 	@ConnectMapping
-	suspend fun handle(requester: RSocketRequester) {
+	suspend fun handle(requester: RSocketRequester): Mono<Void>? {
 		GlobalScope.launch {
 			requester.route("status").data("5").retrieveFlow<StatusReport>().collect { // <1>
 				// ...
 			}
 		}
-		/// ... <2>
+		// ... <2>
+		return null <3>
 	}
 ----
 <1> Start the request asynchronously, independent from handling.
 <2> Perform handling in the suspending function.
+<3> Return null. Any other return value results in connection failure with RejectedSetupException.
 
 
 


### PR DESCRIPTION
In spring-messaging-5.2.5-RELEASE, I observed in the debugger that to successfully complete the connection setup after intercepting and caching a Server Requester, the Kotlin @ConnectMapping method must declare a return type of Mono<Void>? and then return null.
Any other declared return type or a non-null return value, including Mono.empty(), caused AbstractEncoderMethodReturnValueHandler.handleReturnValue(...) to fall through to the code after this `if` block:

```
		if (returnValue == null) {
			return handleNoContent(returnType, message);
		}
```
and that resulted in a failure to establish the connection with a RejectedSetupException.