### PR TITLE
javadoc: remove a comment documented a limitation on @Lookup annotation

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Lookup.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/Lookup.java
@@ -42,9 +42,7 @@ import java.lang.annotation.Target;
  * from factory methods where we cannot dynamically provide a subclass for them.
  *
  * <p><b>Concrete limitations in typical Spring configuration scenarios:</b>
- * When used with component scanning or any other mechanism that filters out abstract
- * beans, provide stub implementations of your lookup methods to be able to declare
- * them as concrete classes. And please remember that lookup methods won't work on
+ * Please remember that lookup methods won't work on
  * beans returned from {@code @Bean} methods in configuration classes; you'll have
  * to resort to {@code @Inject Provider<TargetBean>} or the like instead.
  *


### PR DESCRIPTION
The documentation on @Lookup annotation reads:

> When used with component scanning or any other mechanism that filters out abstract
> beans, provide stub implementations of your lookup methods to be able to declare
> them as concrete classes.

However it looks like it's possible to define an abstract class, annotated with @Component, with an abstract @Lookup-annotated method, and have Spring replace it with a concrete implementation. So this limitation doesn't seem to hold any longer.
