### PR TITLE
Fix SpelEvaluationException with example code

### DIFF
--- a/src/docs/asciidoc/core/core-expressions.adoc
+++ b/src/docs/asciidoc/core/core-expressions.adoc
@@ -1675,7 +1675,7 @@ The following example shows how to use the Elvis operator:
 ----
 	ExpressionParser parser = new SpelExpressionParser();
 
-	String name = parser.parseExpression("name?:'Unknown'").getValue(String.class);
+	String name = parser.parseExpression("name?:'Unknown'").getValue(new Inventor(), String.class);
 	System.out.println(name);  // 'Unknown'
 ----
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
@@ -1683,7 +1683,7 @@ The following example shows how to use the Elvis operator:
 ----
 	val parser = SpelExpressionParser()
 
-	val name = parser.parseExpression("name?:'Unknown'").getValue(String::class.java)
+	val name = parser.parseExpression("name?:'Unknown'").getValue(Inventor(), String::class.java)
 	println(name)  // 'Unknown'
 ----
 


### PR DESCRIPTION
org.springframework.expression.spel.SpelEvaluationException: EL1007E: Property or field 'name' cannot be found on null