### PR TITLE
Avoid unnecessary boxing/unboxing of primitives

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/propertyeditors/CharacterEditor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/propertyeditors/CharacterEditor.java
@@ -82,7 +82,7 @@ public class CharacterEditor extends PropertyEditorSupport {
 			setAsUnicode(text);
 		}
 		else if (text.length() == 1) {
-			setValue(Character.valueOf(text.charAt(0)));
+			setValue(text.charAt(0));
 		}
 		else {
 			throw new IllegalArgumentException("String [" + text + "] with length " +
@@ -103,7 +103,7 @@ public class CharacterEditor extends PropertyEditorSupport {
 
 	private void setAsUnicode(String text) {
 		int code = Integer.parseInt(text.substring(UNICODE_PREFIX.length()), 16);
-		setValue(Character.valueOf((char) code));
+		setValue((char) code);
 	}
 
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/config/TaskExecutorFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/config/TaskExecutorFactoryBean.java
@@ -128,7 +128,7 @@ public class TaskExecutorFactoryBean implements
 					}
 				}
 				else {
-					Integer value = Integer.valueOf(this.poolSize);
+					int value = Integer.parseInt(this.poolSize);
 					corePoolSize = value;
 					maxPoolSize = value;
 				}

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
@@ -1254,7 +1254,7 @@ public class Enhancer extends AbstractClassGenerator {
 			}
 
 			public int getOriginalModifiers(MethodInfo method) {
-				return (Integer) originalModifiers.get(method);
+				return ((Integer) originalModifiers.get(method)).intValue();
 			}
 
 			public int getIndex(MethodInfo method) {

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
@@ -1254,11 +1254,11 @@ public class Enhancer extends AbstractClassGenerator {
 			}
 
 			public int getOriginalModifiers(MethodInfo method) {
-				return ((Integer) originalModifiers.get(method)).intValue();
+				return (Integer) originalModifiers.get(method);
 			}
 
 			public int getIndex(MethodInfo method) {
-				return ((Integer) indexes.get(method)).intValue();
+				return (Integer) indexes.get(method);
 			}
 
 			public void emitCallback(CodeEmitter e, int index) {

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
@@ -1258,7 +1258,7 @@ public class Enhancer extends AbstractClassGenerator {
 			}
 
 			public int getIndex(MethodInfo method) {
-				return (Integer) indexes.get(method);
+				return ((Integer) indexes.get(method)).intValue();
 			}
 
 			public void emitCallback(CodeEmitter e, int index) {

--- a/spring-web/src/main/java/org/springframework/http/converter/ResourceRegionHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ResourceRegionHttpMessageConverter.java
@@ -148,7 +148,7 @@ public class ResourceRegionHttpMessageConverter extends AbstractGenericHttpMessa
 
 		long start = region.getPosition();
 		long end = start + region.getCount() - 1;
-		Long resourceLength = region.getResource().contentLength();
+		long resourceLength = region.getResource().contentLength();
 		end = Math.min(end, resourceLength - 1);
 		long rangeLength = end - start + 1;
 		responseHeaders.add("Content-Range", "bytes " + start + '-' + end + '/' + resourceLength);
@@ -201,10 +201,10 @@ public class ResourceRegionHttpMessageConverter extends AbstractGenericHttpMessa
 				print(out, "--" + boundaryString);
 				println(out);
 				if (contentType != null) {
-					print(out, "Content-Type: " + contentType.toString());
+					print(out, "Content-Type: " + contentType);
 					println(out);
 				}
-				Long resourceLength = region.getResource().contentLength();
+				long resourceLength = region.getResource().contentLength();
 				end = Math.min(end, resourceLength - inputStreamPosition - 1);
 				print(out, "Content-Range: bytes " +
 						region.getPosition() + '-' + (region.getPosition() + region.getCount() - 1) +

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParser.java
@@ -208,7 +208,7 @@ class AnnotationDrivenBeanDefinitionParser implements BeanDefinitionParser {
 		handlerMappingDef.getPropertyValues().add("contentNegotiationManager", contentNegotiationManager);
 
 		if (element.hasAttribute("enable-matrix-variables")) {
-			Boolean enableMatrixVariables = Boolean.valueOf(element.getAttribute("enable-matrix-variables"));
+			boolean enableMatrixVariables = Boolean.parseBoolean(element.getAttribute("enable-matrix-variables"));
 			handlerMappingDef.getPropertyValues().add("removeSemicolonContent", !enableMatrixVariables);
 		}
 


### PR DESCRIPTION
Wrapping primitives is pointless for the cases primitive can be used (e.g. in concatenation of arithmetics).