### PR TITLE
ModelAndView.status does not work with RedirectView

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -1404,6 +1404,7 @@ public class DispatcherServlet extends FrameworkServlet {
 		}
 		try {
 			if (mv.getStatus() != null) {
+				request.setAttribute(View.RESPONSE_STATUS_ATTRIBUTE, mv.getStatus());
 				response.setStatus(mv.getStatus().value());
 			}
 			view.render(mv.getModelInternal(), request, response);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletAnnotationControllerHandlerMethodTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletAnnotationControllerHandlerMethodTests.java
@@ -1855,6 +1855,18 @@ public class ServletAnnotationControllerHandlerMethodTests extends AbstractServl
 		assertThat(response.getForwardedUrl()).isEqualTo("view");
 	}
 
+	@PathPatternsParameterizedTest
+	void modelAndViewWithStatusForRedirect(boolean usePathPatterns) throws Exception {
+		initDispatcherServlet(ModelAndViewController.class, usePathPatterns);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/redirect");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		getServlet().service(request, response);
+
+		assertThat(response.getStatus()).isEqualTo(307);
+		assertThat(response.getRedirectedUrl()).isEqualTo("/path");
+	}
+
 	@PathPatternsParameterizedTest // SPR-14796
 	void modelAndViewWithStatusInExceptionHandler(boolean usePathPatterns) throws Exception {
 		initDispatcherServlet(ModelAndViewController.class, usePathPatterns);
@@ -3757,6 +3769,11 @@ public class ServletAnnotationControllerHandlerMethodTests extends AbstractServl
 		@RequestMapping("/path")
 		public ModelAndView methodWithHttpStatus(MyEntity object) {
 			return new ModelAndView("view", HttpStatus.UNPROCESSABLE_ENTITY);
+		}
+
+		@RequestMapping("/redirect")
+		public ModelAndView methodWithHttpStatusForRedirect(MyEntity object) {
+			return new ModelAndView("redirect:/path", HttpStatus.TEMPORARY_REDIRECT);
 		}
 
 		@RequestMapping("/exception")


### PR DESCRIPTION
When setting a redirect view name and a status code to ModelAndView, the status code is ignored.

```
@PostMapping("/modelandviewredirect1")
public ModelAndView modelandviewredirect1(UserBean user) {
    return new ModelAndView("redirect:/result", HttpStatus.TEMPORARY_REDIRECT); // set:<307>, but was:<302>
}
```

The workarounds for this problem are as follows:

```
// 1: use RedirectView#setStatusCode(..)
@PostMapping("/modelandviewredirectview1")
public ModelAndView modelandviewredirectview1(UserBean user) {
    RedirectView view = new RedirectView("/result", true);
    view.setStatusCode(HttpStatus.TEMPORARY_REDIRECT);
    return new ModelAndView(view);
}

// 2: use the RESPONSE_STATUS_ATTRIBUTE request attribute
@PostMapping("/modelandviewredirect2")
public ModelAndView modelandviewredirect2(UserBean user, HttpServletRequest request) {
    request.setAttribute(View.RESPONSE_STATUS_ATTRIBUTE, HttpStatus.TEMPORARY_REDIRECT);
    return new ModelAndView("redirect:/result");
}
```

@ResponseStatus is supported with RedirectView as result of #10812 and #17800 resolution.
I think ModelAndView.status should be supported with RedirectView as well as @ResponseStatus.

This PR fixes the problem by passing ModelAndView.status to the `RESPONSE_STATUS_ATTRIBUTE` request attribute.

## Related issues
[#10812 @ResponseStatus annotation is ignored in an @Controller redirect (RedirectView) [SPR-6144]](https://github.com/spring-projects/spring-framework/issues/10812)
[#17800 Make RedirectViews use RESPONSE_STATUS_ATTRIBUTE as a response status if defined [SPR-13208]](https://github.com/spring-projects/spring-framework/issues/17800)
[#18136 ability to set response status on ModelAndView [SPR-13560]](https://github.com/spring-projects/spring-framework/issues/18136)
[#19362 ModelAndView's setStatus does not work for @ExceptionHandler methods [SPR-14796]](https://github.com/spring-projects/spring-framework/issues/19362)