### PR TITLE
BeanDefinitionDsl composition

### DIFF
--- a/spring-context/src/main/kotlin/org/springframework/context/support/BeanDefinitionDsl.kt
+++ b/spring-context/src/main/kotlin/org/springframework/context/support/BeanDefinitionDsl.kt
@@ -1141,6 +1141,15 @@ open class BeanDefinitionDsl internal constructor (private val init: BeanDefinit
 	}
 
 	/**
+	 * Take in account pre-defined bean definitions.
+	 * @param beans bean definitions
+	 * @since 5.3
+	 */
+	fun beans(beans: BeanDefinitionDsl) {
+		children.add(beans)
+	}
+
+	/**
 	 * Register the bean defined via the DSL on the provided application context.
 	 * @param context The `ApplicationContext` to use for registering the beans
 	 */

--- a/spring-context/src/test/kotlin/org/springframework/context/support/BeanDefinitionDslTests.kt
+++ b/spring-context/src/test/kotlin/org/springframework/context/support/BeanDefinitionDslTests.kt
@@ -37,17 +37,21 @@ class BeanDefinitionDslTests {
 			bean<Foo>()
 			bean<Bar>("bar", scope = Scope.PROTOTYPE)
 			bean { Baz(ref("bar")) }
+			beans(beans {
+				bean { FooFoo("f") }
+			})
 		}
 
 		val context = GenericApplicationContext().apply {
 			beans.initialize(this)
 			refresh()
 		}
-		
+
 		context.getBean<Foo>()
 		context.getBean<Bar>("bar")
 		assertThat(context.isPrototype("bar")).isTrue()
 		context.getBean<Baz>()
+		context.getBean<FooFoo>()
 	}
 
 	@Test
@@ -164,7 +168,7 @@ class BeanDefinitionDslTests {
 		}
 		context.getBean<Baz>()
 	}
-	
+
 
 	@Test
 	fun `Declare beans with accepted profiles`() {


### PR DESCRIPTION
Added new `beans` method to BeanDefinitionDsl, to allow nesting beans definitions. Currently it's not possible.