### PR TITLE
BeanDefinitionDsl: get environment property in a nice way

### DIFF
--- a/spring-context/src/main/kotlin/org/springframework/context/support/BeanDefinitionDsl.kt
+++ b/spring-context/src/main/kotlin/org/springframework/context/support/BeanDefinitionDsl.kt
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.getBeanProvider
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.Environment
 import org.springframework.core.env.Profiles
 import java.util.function.Supplier
 
@@ -1107,6 +1108,19 @@ open class BeanDefinitionDsl internal constructor (private val init: BeanDefinit
 		inline fun <reified T : Any> ref(name: String? = null) : T = when (name) {
 			null -> context.getBean(T::class.java)
 			else -> context.getBean(name, T::class.java)
+		}
+
+		/**
+		 * Get environment property by key
+		 * `prop<Foo>()` or `prop<Foo>("foo.key")`. When leveraging Kotlin type inference
+		 * it could be as short as `prop()` or `prop("foo.key")`.
+		 * @param key the name of the property key in the current environment
+		 * @param T type of the property value associated with the given key, converted to the given
+		 * @throws IllegalStateException if the key cannot be resolved
+		 */
+		inline fun <reified T : Any> prop(key: String) : T {
+			val environment = ref<Environment>()
+			return environment.getRequiredProperty(key, T::class.java)
 		}
 
 		/**

--- a/spring-context/src/test/kotlin/org/springframework/context/support/BeanDefinitionDslTests.kt
+++ b/spring-context/src/test/kotlin/org/springframework/context/support/BeanDefinitionDslTests.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.getBean
 import org.springframework.context.support.BeanDefinitionDsl.*
+import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.SimpleCommandLinePropertySource
 import org.springframework.core.env.get
 import org.springframework.core.testfixture.env.MockPropertySource
@@ -43,11 +44,29 @@ class BeanDefinitionDslTests {
 			beans.initialize(this)
 			refresh()
 		}
-		
+
 		context.getBean<Foo>()
 		context.getBean<Bar>("bar")
 		assertThat(context.isPrototype("bar")).isTrue()
 		context.getBean<Baz>()
+	}
+
+	@Test
+	fun `Retrieve environment property with the functional Kotlin DSL`() {
+		val propertyKey = "prop.key"
+		val beans = beans {
+			bean { FooFoo(prop(propertyKey)) }
+		}
+
+		val context = GenericApplicationContext().apply {
+			environment.propertySources.addFirst(
+					MapPropertySource("source", mapOf(propertyKey to "foofoo"))
+			)
+			beans.initialize(this)
+			refresh()
+		}
+
+		assertThat(context.getBean<FooFoo>().name).isEqualTo("foofoo")
 	}
 
 	@Test
@@ -164,7 +183,7 @@ class BeanDefinitionDslTests {
 		}
 		context.getBean<Baz>()
 	}
-	
+
 
 	@Test
 	fun `Declare beans with accepted profiles`() {


### PR DESCRIPTION
With this PR I'd like to open a discussion about a way to easily access Environment properties in `BeanDefinitionDsl`.