### PR TITLE
Avoid ClassCastException on IllegalArgumentException when invoking sync get cache method

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
@@ -382,9 +382,11 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 					return wrapCacheValue(method, cache.get(key, () -> unwrapReturnValue(invokeOperation(invoker))));
 				}
 				catch (Cache.ValueRetrievalException ex) {
-					// The invoker wraps any Throwable in a ThrowableWrapper instance so we
-					// can just make sure that one bubbles up the stack.
-					throw (CacheOperationInvoker.ThrowableWrapper) ex.getCause();
+					// Wraps any Throwable in a ThrowableWrapper instance
+					Throwable cause = ex.getCause();
+					throw cause instanceof CacheOperationInvoker.ThrowableWrapper ?
+							(CacheOperationInvoker.ThrowableWrapper) cause :
+							new CacheOperationInvoker.ThrowableWrapper(cause);
 				}
 			}
 			else {


### PR DESCRIPTION
## Avoid some exception cause ClassCastException

Let's take a look at ConcurrentMapCache.java

```

	@Override
	@Nullable
	public <T> T get(Object key, Callable<T> valueLoader) {
		return (T) fromStoreValue(this.store.computeIfAbsent(key, k -> {
			try {
				return toStoreValue(valueLoader.call());
			}
			catch (Throwable ex) {
				throw new ValueRetrievalException(key, valueLoader, ex);
			}
		}));
	}

	@Override
	protected Object fromStoreValue(@Nullable Object storeValue) {
		if (storeValue != null && this.serialization != null) {
			try {
				return super.fromStoreValue(deserializeValue(this.serialization, storeValue));
			}
			catch (Throwable ex) {
				throw new IllegalArgumentException("Failed to deserialize cache value '" + storeValue + "'", ex);
			}
		}
		else {
			return super.fromStoreValue(storeValue);
		}

	}
```

It will throw IllegalArgumentException when there is a problem with deserialization, but not ThrowableWrapper class type, when cast to ThrowableWrapper it will cause another exception (java.lang.ClassCastException: java.lang.IllegalArgumentException cannot be cast to org.springframework.cache.interceptor.CacheOperationInvoker$ThrowableWrapper)

So we need a wrap code on this.


