### PR TITLE
Polish StringHttpMessageConverter.getContentTypeCharset()

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/StringHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/StringHttpMessageConverter.java
@@ -143,7 +143,8 @@ public class StringHttpMessageConverter extends AbstractHttpMessageConverter<Str
 			Charset charset = contentType.getCharset();
 			if (charset != null) {
 				return charset;
-			} else if (contentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+			}
+			else if (contentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
 				// Matching to AbstractJackson2HttpMessageConverter#DEFAULT_CHARSET
 				return StandardCharsets.UTF_8;
 			}

--- a/spring-web/src/main/java/org/springframework/http/converter/StringHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/StringHttpMessageConverter.java
@@ -139,18 +139,18 @@ public class StringHttpMessageConverter extends AbstractHttpMessageConverter<Str
 	}
 
 	private Charset getContentTypeCharset(@Nullable MediaType contentType) {
-		if (contentType != null && contentType.getCharset() != null) {
-			return contentType.getCharset();
+		if (contentType != null) {
+			Charset charset = contentType.getCharset();
+			if (charset != null) {
+				return charset;
+			} else if (contentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+				// Matching to AbstractJackson2HttpMessageConverter#DEFAULT_CHARSET
+				return StandardCharsets.UTF_8;
+			}
 		}
-		else if (contentType != null && contentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
-			// Matching to AbstractJackson2HttpMessageConverter#DEFAULT_CHARSET
-			return StandardCharsets.UTF_8;
-		}
-		else {
-			Charset charset = getDefaultCharset();
-			Assert.state(charset != null, "No default charset");
-			return charset;
-		}
+		Charset charset = getDefaultCharset();
+		Assert.state(charset != null, "No default charset");
+		return charset;
 	}
 
 }


### PR DESCRIPTION
Bug: Possible null pointer dereference in org.springframework.http.converter.StringHttpMessageConverter.getContentTypeCharset(MediaType) due to return value of called method 
The return value from a method is dereferenced without a null check, and the return value of that method is one that should generally be checked for null.  This may lead to a NullPointerException when the code is executed.