### PR TITLE
Deprecate HandlerInterceptorAdapter

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/HandlerInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/HandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,6 @@ import org.springframework.web.method.HandlerMethod;
  * @author Juergen Hoeller
  * @since 20.06.2003
  * @see HandlerExecutionChain#getInterceptors
- * @see org.springframework.web.servlet.handler.HandlerInterceptorAdapter
  * @see org.springframework.web.servlet.handler.AbstractHandlerMapping#setInterceptors
  * @see org.springframework.web.servlet.handler.UserRoleAuthorizationInterceptor
  * @see org.springframework.web.servlet.i18n.LocaleChangeInterceptor

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
@@ -560,7 +560,7 @@ public abstract class AbstractHandlerMapping extends WebApplicationObjectSupport
 	}
 
 
-	private class CorsInterceptor extends HandlerInterceptorAdapter implements CorsConfigurationSource {
+	private class CorsInterceptor implements HandlerInterceptor, CorsConfigurationSource {
 
 		@Nullable
 		private final CorsConfiguration config;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
  * Abstract base class for URL-mapped {@link org.springframework.web.servlet.HandlerMapping}
@@ -399,7 +400,7 @@ public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping i
 	 * {@link AbstractUrlHandlerMapping#PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE} attribute.
 	 * @see AbstractUrlHandlerMapping#exposePathWithinMapping
 	 */
-	private class PathExposingHandlerInterceptor extends HandlerInterceptorAdapter {
+	private class PathExposingHandlerInterceptor implements HandlerInterceptor {
 
 		private final String bestMatchingPattern;
 
@@ -425,7 +426,7 @@ public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping i
 	 * {@link AbstractUrlHandlerMapping#URI_TEMPLATE_VARIABLES_ATTRIBUTE} attribute.
 	 * @see AbstractUrlHandlerMapping#exposePathWithinMapping
 	 */
-	private class UriTemplateVariablesHandlerInterceptor extends HandlerInterceptorAdapter {
+	private class UriTemplateVariablesHandlerInterceptor implements HandlerInterceptor {
 
 		private final Map<String, String> uriTemplateVariables;
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/ConversionServiceExposingInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/ConversionServiceExposingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.core.convert.ConversionService;
 import org.springframework.util.Assert;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
  * Interceptor that places the configured {@link ConversionService} in request scope
@@ -36,7 +37,7 @@ import org.springframework.util.Assert;
  * @author Keith Donald
  * @since 3.0.1
  */
-public class ConversionServiceExposingInterceptor extends HandlerInterceptorAdapter {
+public class ConversionServiceExposingInterceptor implements HandlerInterceptor {
 
 	private final ConversionService conversionService;
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/HandlerInterceptorAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/HandlerInterceptorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,7 @@
 
 package org.springframework.web.servlet.handler;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Abstract adapter class for the {@link AsyncHandlerInterceptor} interface,
@@ -29,41 +24,9 @@ import org.springframework.web.servlet.ModelAndView;
  *
  * @author Juergen Hoeller
  * @since 05.12.2003
+ * @deprecated as of 5.3 in favor of {@link AsyncHandlerInterceptor}
  */
+@Deprecated
 public abstract class HandlerInterceptorAdapter implements AsyncHandlerInterceptor {
-
-	/**
-	 * This implementation always returns {@code true}.
-	 */
-	@Override
-	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
-			throws Exception {
-
-		return true;
-	}
-
-	/**
-	 * This implementation is empty.
-	 */
-	@Override
-	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
-			@Nullable ModelAndView modelAndView) throws Exception {
-	}
-
-	/**
-	 * This implementation is empty.
-	 */
-	@Override
-	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
-			@Nullable Exception ex) throws Exception {
-	}
-
-	/**
-	 * This implementation is empty.
-	 */
-	@Override
-	public void afterConcurrentHandlingStarted(HttpServletRequest request, HttpServletResponse response,
-			Object handler) throws Exception {
-	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/UserRoleAuthorizationInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/UserRoleAuthorizationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.lang.Nullable;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
  * Interceptor that checks the authorization of the current user via the
@@ -32,7 +33,7 @@ import org.springframework.lang.Nullable;
  * @since 20.06.2003
  * @see javax.servlet.http.HttpServletRequest#isUserInRole
  */
-public class UserRoleAuthorizationInterceptor extends HandlerInterceptorAdapter {
+public class UserRoleAuthorizationInterceptor implements HandlerInterceptor {
 
 	@Nullable
 	private String[] authorizedRoles;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/LocaleChangeInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/LocaleChangeInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.LocaleResolver;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import org.springframework.web.servlet.support.RequestContextUtils;
 
 /**
@@ -41,7 +41,7 @@ import org.springframework.web.servlet.support.RequestContextUtils;
  * @since 20.06.2003
  * @see org.springframework.web.servlet.LocaleResolver
  */
-public class LocaleChangeInterceptor extends HandlerInterceptorAdapter {
+public class LocaleChangeInterceptor implements HandlerInterceptor {
 
 	/**
 	 * Default name of the locale specification parameter: "locale".

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceUrlProviderExposingInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceUrlProviderExposingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.util.Assert;
 import org.springframework.web.bind.ServletRequestBindingException;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
  * An interceptor that exposes the {@link ResourceUrlProvider} instance it
@@ -30,7 +30,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  * @author Rossen Stoyanchev
  * @since 4.1
  */
-public class ResourceUrlProviderExposingInterceptor extends HandlerInterceptorAdapter {
+public class ResourceUrlProviderExposingInterceptor implements HandlerInterceptor {
 
 	/**
 	 * Name of the request attribute that holds the {@link ResourceUrlProvider}.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/ThemeChangeInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/ThemeChangeInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ThemeResolver;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import org.springframework.web.servlet.support.RequestContextUtils;
 
 /**
@@ -32,7 +32,7 @@ import org.springframework.web.servlet.support.RequestContextUtils;
  * @since 20.06.2003
  * @see org.springframework.web.servlet.ThemeResolver
  */
-public class ThemeChangeInterceptor extends HandlerInterceptorAdapter {
+public class ThemeChangeInterceptor implements HandlerInterceptor {
 
 	/**
 	 * Default name of the theme specification parameter: "theme".

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import org.springframework.web.servlet.handler.MappedInterceptor;
 import org.springframework.web.servlet.mvc.condition.ConsumesRequestCondition;
 import org.springframework.web.servlet.mvc.condition.HeadersRequestCondition;
@@ -218,7 +217,7 @@ public class RequestMappingInfoHandlerMappingTests {
 	@Test
 	public void getHandlerMappedInterceptors() throws Exception {
 		String path = "/foo";
-		HandlerInterceptor interceptor = new HandlerInterceptorAdapter() {};
+		HandlerInterceptor interceptor = new HandlerInterceptor() {};
 		MappedInterceptor mappedInterceptor = new MappedInterceptor(new String[] {path}, interceptor);
 
 		TestRequestMappingInfoHandlerMapping mapping = new TestRequestMappingInfoHandlerMapping();


### PR DESCRIPTION
This PR deprecates `HandlerInterceptorAdapter`, as `(Async)HandlerInterceptor` provide the same convenience by themselves with default methods. Additionally, existing `HandlerInterceptorAdapter` subclasses have been reworked to implement `(Async)HandlerInterceptor`.