### PR TITLE
Refactoring for MockServerHttpRequest

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpRequest.java
@@ -452,7 +452,8 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
 		protected DefaultBodyBuilder(String methodValue, URI url) {
 			Assert.isTrue(StringUtils.hasLength(methodValue) &&
-					StringUtils.hasLength(methodValue.trim()), "HTTP methodValue must not be empty");
+					StringUtils.hasLength(methodValue.trim()), "HttpMethod is required. " +
+					"Please initialize it to non empty value");
 			this.methodValue = methodValue.trim();
 			this.url = url;
 		}

--- a/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpRequest.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MimeType;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -55,11 +56,10 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
-	@Nullable
-	private final HttpMethod httpMethod;
-
-	@Nullable
-	private final String customHttpMethod;
+	/**
+	 * String representation of one of {@link HttpMethod} or not empty custom method (e.g. <i>CONNECT</i>).
+	 */
+	private final String httpMethodValue;
 
 	private final MultiValueMap<String, HttpCookie> cookies;
 
@@ -74,16 +74,13 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
 	private final Flux<DataBuffer> body;
 
-
-	private MockServerHttpRequest(@Nullable HttpMethod httpMethod, @Nullable String customHttpMethod,
+	private MockServerHttpRequest(String httpMethodValue,
 			URI uri, @Nullable String contextPath, HttpHeaders headers, MultiValueMap<String, HttpCookie> cookies,
 			@Nullable InetSocketAddress remoteAddress, @Nullable InetSocketAddress localAddress,
 			@Nullable SslInfo sslInfo, Publisher<? extends DataBuffer> body) {
 
 		super(uri, contextPath, headers);
-		Assert.isTrue(httpMethod != null || customHttpMethod != null, "HTTP method must not be null");
-		this.httpMethod = httpMethod;
-		this.customHttpMethod = customHttpMethod;
+		this.httpMethodValue = httpMethodValue;
 		this.cookies = cookies;
 		this.remoteAddress = remoteAddress;
 		this.localAddress = localAddress;
@@ -93,14 +90,15 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
 
 	@Override
+	@Nullable
 	public HttpMethod getMethod() {
-		return this.httpMethod;
+		return HttpMethod.resolve(httpMethodValue);
 	}
 
 	@Override
 	@SuppressWarnings("ConstantConditions")
 	public String getMethodValue() {
-		return (this.httpMethod != null ? this.httpMethod.name() : this.customHttpMethod);
+		return httpMethodValue;
 	}
 
 	@Override
@@ -232,24 +230,23 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 	 * @return the created builder
 	 */
 	public static BodyBuilder method(HttpMethod method, String urlTemplate, Object... vars) {
-		Assert.notNull(method, "HttpMethod is required. If testing a custom HTTP method, " +
-				"please use the variant that accepts a String based HTTP method.");
 		URI url = UriComponentsBuilder.fromUriString(urlTemplate).buildAndExpand(vars).encode().toUri();
 		return new DefaultBodyBuilder(method, url);
 	}
 
 	/**
-	 * Create a builder with a raw HTTP method value that is outside the range
+	 * Create a builder with a raw HTTP methodValue value that is outside the range
 	 * of {@link HttpMethod} enum values.
-	 * @param method the HTTP method value
+	 * @param methodValue the HTTP methodValue value
 	 * @param urlTemplate the URL template
 	 * @param vars variables to expand into the template
 	 * @return the created builder
+	 * @throws IllegalArgumentException if methodValue is null, empty String or contains only white characters
 	 * @since 5.2.7
 	 */
-	public static BodyBuilder method(String method, String urlTemplate, Object... vars) {
+	public static BodyBuilder method(String methodValue, String urlTemplate, Object... vars) {
 		URI url = UriComponentsBuilder.fromUriString(urlTemplate).buildAndExpand(vars).encode().toUri();
-		return new DefaultBodyBuilder(method, url);
+		return new DefaultBodyBuilder(methodValue, url);
 	}
 
 
@@ -431,12 +428,7 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
 		private static final DataBufferFactory BUFFER_FACTORY = new DefaultDataBufferFactory();
 
-
-		@Nullable
-		private final HttpMethod method;
-
-		@Nullable
-		private final String customMethod;
+		private final String methodValue;
 
 		private final URI url;
 
@@ -458,23 +450,17 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 		@Nullable
 		private SslInfo sslInfo;
 
-
-		DefaultBodyBuilder(HttpMethod method, URI url) {
-			this.method = method;
-			this.customMethod = null;
+		protected DefaultBodyBuilder(String methodValue, URI url) {
+			Assert.isTrue(StringUtils.hasLength(methodValue) &&
+					StringUtils.hasLength(methodValue.trim()), "HTTP methodValue must not be empty");
+			this.methodValue = methodValue.trim();
 			this.url = url;
 		}
 
-		DefaultBodyBuilder(String method, URI url) {
-			HttpMethod resolved = HttpMethod.resolve(method);
-			if (resolved != null) {
-				this.method = resolved;
-				this.customMethod = null;
-			}
-			else {
-				this.method = null;
-				this.customMethod = method;
-			}
+		protected DefaultBodyBuilder(HttpMethod method, URI url) {
+			Assert.notNull(method, "HttpMethod is required. If testing a custom HTTP method, " +
+					"please use the variant that accepts a String based HTTP method.");
+			this.methodValue = method.name();
 			this.url = url;
 		}
 
@@ -611,7 +597,7 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 		@Override
 		public MockServerHttpRequest body(Publisher<? extends DataBuffer> body) {
 			applyCookiesIfNecessary();
-			return new MockServerHttpRequest(this.method, this.customMethod, getUrlToUse(), this.contextPath,
+			return new MockServerHttpRequest(this.methodValue, getUrlToUse(), this.contextPath,
 					this.headers, this.cookies, this.remoteAddress, this.localAddress, this.sslInfo, body);
 		}
 

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/server/reactive/MockServerHttpRequest.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/server/reactive/MockServerHttpRequest.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MimeType;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -55,11 +56,10 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
-	@Nullable
-	private final HttpMethod httpMethod;
-
-	@Nullable
-	private final String customHttpMethod;
+	/**
+	 * String representation of one of {@link HttpMethod} or not empty custom method (e.g. <i>CONNECT</i>).
+	 */
+	private final String httpMethodValue;
 
 	private final MultiValueMap<String, HttpCookie> cookies;
 
@@ -74,16 +74,13 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
 	private final Flux<DataBuffer> body;
 
-
-	private MockServerHttpRequest(@Nullable HttpMethod httpMethod, @Nullable String customHttpMethod,
-			URI uri, @Nullable String contextPath, HttpHeaders headers, MultiValueMap<String, HttpCookie> cookies,
-			@Nullable InetSocketAddress remoteAddress, @Nullable InetSocketAddress localAddress,
-			@Nullable SslInfo sslInfo, Publisher<? extends DataBuffer> body) {
+	private MockServerHttpRequest(String httpMethodValue,
+								  URI uri, @Nullable String contextPath, HttpHeaders headers, MultiValueMap<String, HttpCookie> cookies,
+								  @Nullable InetSocketAddress remoteAddress, @Nullable InetSocketAddress localAddress,
+								  @Nullable SslInfo sslInfo, Publisher<? extends DataBuffer> body) {
 
 		super(uri, contextPath, headers);
-		Assert.isTrue(httpMethod != null || customHttpMethod != null, "HTTP method must not be null");
-		this.httpMethod = httpMethod;
-		this.customHttpMethod = customHttpMethod;
+		this.httpMethodValue = httpMethodValue;
 		this.cookies = cookies;
 		this.remoteAddress = remoteAddress;
 		this.localAddress = localAddress;
@@ -93,14 +90,15 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
 
 	@Override
+	@Nullable
 	public HttpMethod getMethod() {
-		return this.httpMethod;
+		return HttpMethod.resolve(httpMethodValue);
 	}
 
 	@Override
 	@SuppressWarnings("ConstantConditions")
 	public String getMethodValue() {
-		return (this.httpMethod != null ? this.httpMethod.name() : this.customHttpMethod);
+		return httpMethodValue;
 	}
 
 	@Override
@@ -232,24 +230,23 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 	 * @return the created builder
 	 */
 	public static BodyBuilder method(HttpMethod method, String urlTemplate, Object... vars) {
-		Assert.notNull(method, "HttpMethod is required. If testing a custom HTTP method, " +
-				"please use the variant that accepts a String based HTTP method.");
 		URI url = UriComponentsBuilder.fromUriString(urlTemplate).buildAndExpand(vars).encode().toUri();
 		return new DefaultBodyBuilder(method, url);
 	}
 
 	/**
-	 * Create a builder with a raw HTTP method value that is outside the range
+	 * Create a builder with a raw HTTP methodValue value that is outside the range
 	 * of {@link HttpMethod} enum values.
-	 * @param method the HTTP method value
+	 * @param methodValue the HTTP methodValue value
 	 * @param urlTemplate the URL template
 	 * @param vars variables to expand into the template
 	 * @return the created builder
+	 * @throws IllegalArgumentException if methodValue is null, empty String or contains only white characters
 	 * @since 5.2.7
 	 */
-	public static BodyBuilder method(String method, String urlTemplate, Object... vars) {
+	public static BodyBuilder method(String methodValue, String urlTemplate, Object... vars) {
 		URI url = UriComponentsBuilder.fromUriString(urlTemplate).buildAndExpand(vars).encode().toUri();
-		return new DefaultBodyBuilder(method, url);
+		return new DefaultBodyBuilder(methodValue, url);
 	}
 
 
@@ -431,12 +428,7 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 
 		private static final DataBufferFactory BUFFER_FACTORY = new DefaultDataBufferFactory();
 
-
-		@Nullable
-		private final HttpMethod method;
-
-		@Nullable
-		private final String customMethod;
+		private final String methodValue;
 
 		private final URI url;
 
@@ -458,23 +450,18 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 		@Nullable
 		private SslInfo sslInfo;
 
-
-		DefaultBodyBuilder(HttpMethod method, URI url) {
-			this.method = method;
-			this.customMethod = null;
+		protected DefaultBodyBuilder(String methodValue, URI url) {
+			Assert.isTrue(StringUtils.hasLength(methodValue) &&
+					StringUtils.hasLength(methodValue.trim()), "HttpMethod is required. " +
+					"Please initialize it to non empty value");
+			this.methodValue = methodValue.trim();
 			this.url = url;
 		}
 
-		DefaultBodyBuilder(String method, URI url) {
-			HttpMethod resolved = HttpMethod.resolve(method);
-			if (resolved != null) {
-				this.method = resolved;
-				this.customMethod = null;
-			}
-			else {
-				this.method = null;
-				this.customMethod = method;
-			}
+		protected DefaultBodyBuilder(HttpMethod method, URI url) {
+			Assert.notNull(method, "HttpMethod is required. If testing a custom HTTP method, " +
+					"please use the variant that accepts a String based HTTP method.");
+			this.methodValue = method.name();
 			this.url = url;
 		}
 
@@ -611,7 +598,7 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 		@Override
 		public MockServerHttpRequest body(Publisher<? extends DataBuffer> body) {
 			applyCookiesIfNecessary();
-			return new MockServerHttpRequest(this.method, this.customMethod, getUrlToUse(), this.contextPath,
+			return new MockServerHttpRequest(this.methodValue, getUrlToUse(), this.contextPath,
 					this.headers, this.cookies, this.remoteAddress, this.localAddress, this.sslInfo, body);
 		}
 


### PR DESCRIPTION
Created a small refactoring for gh-25109. 

Changed: 

1. Field duplication
2. Set DefaultBodyBuilder as protected, to allow children from other packages to call constructor (it seemed very constrictive to allow the call of the contructor only from the existing package)
3. Moved the 
```
Assert.notNull(method, "HttpMethod is required. If testing a custom HTTP method, " +
					"please use the variant that accepts a String based HTTP method.");
```  
to DefaultBodyContructor to also catch the contructor call 
```
public static BodyBuilder method(HttpMethod method, URI url) {
		return new DefaultBodyBuilder(method, url);
	}
```
to leave the main constructor easier to understand and failfast when constructing he builder.
Also, messages when calling the 
``` 
MockServerHttpRequest.method(null, *any URI*)
```
would have failed with another kind of assertion message than 
```
MockServerHttpRequest.method(null, urlTemplate, param1, param2)
```

3. Extended the check for the string value of HttpMethod to exclude the set of HttpMethod to only whitespaces, as this, imho, makes no sense