### PR TITLE
Resolves gh-25140

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
@@ -482,9 +482,8 @@ public abstract class CollectionUtils {
 
 		@Override
 		@Nullable
-		public V getFirst(K key) {
-			List<V> values = this.map.get(key);
-			return (values != null ? values.get(0) : null);
+		public V getFirst(@Nullable K key) {
+			return firstElement(this.map.get(key));
 		}
 
 		@Override
@@ -521,7 +520,7 @@ public abstract class CollectionUtils {
 		@Override
 		public Map<K, V> toSingleValueMap() {
 			LinkedHashMap<K, V> singleValueMap = new LinkedHashMap<>(this.map.size());
-			this.map.forEach((key, value) -> singleValueMap.put(key, value.get(0)));
+			this.map.forEach((key, value) -> singleValueMap.put(key, firstElement(value)));
 			return singleValueMap;
 		}
 
@@ -603,5 +602,4 @@ public abstract class CollectionUtils {
 			return this.map.toString();
 		}
 	}
-
 }

--- a/spring-core/src/test/java/org/springframework/util/CollectionUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/CollectionUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -208,6 +209,20 @@ class CollectionUtilsTests {
 
 		list = new LinkedList<>();
 		assertThat(CollectionUtils.hasUniqueObject(list)).isFalse();
+	}
+
+	@Test
+	void noArrayIndexOutOfBoundsException() {
+		HashMap<String, List<Object>> mostlyEmptyMap = new HashMap<>();
+		mostlyEmptyMap.put("test", new ArrayList<>());
+
+		MultiValueMap<String, Object> multiValueMap = CollectionUtils.toMultiValueMap(mostlyEmptyMap);
+		Assertions.assertAll(
+				() -> assertThat(multiValueMap.getFirst(null)).isNull(),
+				() -> assertThat(multiValueMap.getFirst("test")).isNull(),
+				() -> assertThat(multiValueMap.toSingleValueMap().get(null)).isNull(),
+				() -> assertThat(multiValueMap.toSingleValueMap().get("test")).isNull()
+		);
 	}
 
 


### PR DESCRIPTION
Simple fix for GH-25140

Just to be sure, the call 

```
multiValueMap.addAll("some-key", null);
```

will fail with NullPointer. 

```
multiValueMap.addAll("some-other-key", Collections.emptyList());
```

produces

```
multiValueMap.getFirst("some-other-key") == null
```