### PR TITLE
CaffeineCache with LoadingCache

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCache.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCache.java
@@ -29,6 +29,10 @@ import org.springframework.util.Assert;
  * Spring {@link org.springframework.cache.Cache} adapter implementation
  * on top of a Caffeine {@link com.github.benmanes.caffeine.cache.Cache} instance.
  *
+ * <p>IMPORTANT!
+ * <p>You can pass also a {@link com.github.benmanes.caffeine.cache.LoadingCache} to CaffeineCache, but
+ * using LoadingCache is incompatible with the @Cacheable pattern!
+ *
  * <p>Requires Caffeine 2.1 or higher.
  *
  * @author Ben Manes
@@ -91,6 +95,17 @@ public class CaffeineCache extends AbstractValueAdaptingCache {
 			return toValueWrapper(value);
 		}
 		return super.get(key);
+	}
+
+	@Nullable
+	@SuppressWarnings("unchecked")
+	public <T> T get(Object key, @Nullable Class<T> type) {
+		if (this.cache instanceof LoadingCache) {
+			Object value = this.fromStoreValue(((LoadingCache<Object, Object>) this.cache).get(key));
+			verifyValueType(type, value);
+			return (T) value;
+		}
+		return super.get(key, type);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-context-support/src/test/java/org/springframework/cache/caffeine/CaffeineCacheTests.java
+++ b/spring-context-support/src/test/java/org/springframework/cache/caffeine/CaffeineCacheTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cache.Cache;
+import org.springframework.cache.Cache.ValueWrapper;
 import org.springframework.context.testfixture.cache.AbstractValueAdaptingCacheTests;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,4 +80,29 @@ public class CaffeineCacheTests extends AbstractValueAdaptingCacheTests<Caffeine
 		assertThat(cache.get(key).get()).isEqualTo(value);
 	}
 
+	@Test
+	void testLoadingCacheGet() {
+		Object key = new Object();
+		Object value = new Object();
+
+		CaffeineCache loadingCaffeineCache = new CaffeineCache(CACHE_NAME, Caffeine.newBuilder()
+				.build(x -> value));
+
+		ValueWrapper valueFromCache = loadingCaffeineCache.get(key);
+		assertThat(valueFromCache).isNotNull();
+		assertThat(valueFromCache.get()).isEqualTo(value);
+	}
+
+	@Test
+	void testLoadingCacheGetWithType() {
+		String key = "key";
+		String value = "value";
+
+		CaffeineCache loadingCaffeineCache = new CaffeineCache(CACHE_NAME, Caffeine.newBuilder()
+				.build(x -> value));
+
+		String valueFromCache = loadingCaffeineCache.get(key, String.class);
+		assertThat(valueFromCache).isNotNull();
+		assertThat(valueFromCache).isEqualTo(value);
+	}
 }

--- a/spring-context/src/main/java/org/springframework/cache/support/AbstractValueAdaptingCache.java
+++ b/spring-context/src/main/java/org/springframework/cache/support/AbstractValueAdaptingCache.java
@@ -64,11 +64,15 @@ public abstract class AbstractValueAdaptingCache implements Cache {
 	@Nullable
 	public <T> T get(Object key, @Nullable Class<T> type) {
 		Object value = fromStoreValue(lookup(key));
+		verifyValueType(type, value);
+		return (T) value;
+	}
+
+	protected  <T> void verifyValueType(@Nullable Class<T> type, @Nullable Object value) {
 		if (value != null && type != null && !type.isInstance(value)) {
 			throw new IllegalStateException(
 					"Cached value is not of required type [" + type.getName() + "]: " + value);
 		}
-		return (T) value;
 	}
 
 	/**


### PR DESCRIPTION
When CaffeineCache is created with a LoadingCache, the LoadingCache is
used with the method `public ValueWrapper get(Object key)` but not
with method `public <T> T get(Object key, @Nullable Class<T> type)`.
Using LoadingCache is incompatible with @Cacheable pattern but
consistently call the LoadingCache in both methods is better than now.
Removing the usage is a backward-incompatible change.

Closes gh-25173