### PR TITLE
added possibility to extend ModelAttributeMethodArgumentResolver 

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java
@@ -233,7 +233,7 @@ public class ModelAttributeMethodArgumentResolver extends HandlerMethodArgumentR
 		}
 
 		// A single data class constructor -> resolve constructor arguments from request parameters.
-		return WebExchangeDataBinder.extractValuesToBind(exchange).map(bindValues -> {
+		return extractValuesToBind(exchange).map(bindValues -> {
 			ConstructorProperties cp = ctor.getAnnotation(ConstructorProperties.class);
 			String[] paramNames = (cp != null ? cp.value() : parameterNameDiscoverer.getParameterNames(ctor));
 			Assert.state(paramNames != null, () -> "Cannot resolve parameter names for constructor " + ctor);
@@ -269,6 +269,10 @@ public class ModelAttributeMethodArgumentResolver extends HandlerMethodArgumentR
 			}
 			return BeanUtils.instantiateClass(ctor, args);
 		});
+	}
+
+	protected Mono<Map<String, Object>> extractValuesToBind(ServerWebExchange exchange) {
+		return WebExchangeDataBinder.extractValuesToBind(exchange);
 	}
 
 	private boolean hasErrorsArgument(MethodParameter parameter) {


### PR DESCRIPTION
Added possibility to extend ModelAttributeMethodArgumentResolver , in order to populate objects in same way, but with different set of data.

Example use-cases: 
- I want to populate object with data from headers, instead of common set of fields for model attribute resolution;
- I want to manipulate with field values before set them to POJO in controller in case of custom annotated object

This is pretty much available in non-flux ModelAttributeMethodProcessor (since we can extend that and override some methods)

Logic in this class pretty much complicated to copy-paste or write own resolver, so I guess it's better to allow reuse code with possibility to add own data to bind.