### PR TITLE
Convert JSR310 to SQL type if possible

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/StatementCreatorUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/StatementCreatorUtils.java
@@ -26,6 +26,9 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -405,6 +408,15 @@ public abstract class StatementCreatorUtils {
 			else if (inValue instanceof Calendar) {
 				Calendar cal = (Calendar) inValue;
 				ps.setTimestamp(paramIndex, new java.sql.Timestamp(cal.getTime().getTime()), cal);
+			}
+			else if (inValue instanceof LocalDateTime) {
+				ps.setTimestamp(paramIndex, java.sql.Timestamp.valueOf((LocalDateTime) inValue));
+			}
+			else if (inValue instanceof LocalDate) {
+				ps.setDate(paramIndex, java.sql.Date.valueOf((LocalDate) inValue));
+			}
+			else if (inValue instanceof LocalTime) {
+				ps.setTime(paramIndex, java.sql.Time.valueOf((LocalTime) inValue));
 			}
 			else {
 				// Fall back to generic setObject call without SQL type specified.


### PR DESCRIPTION
Some driver can not infer the SQL type from JSR310 type in `setObject` method, we should convert JSR310 type to SQL type via  corresponding `valueOf` method.

postgresql-42.2.9.jar:
```
Caused by: org.postgresql.util.PSQLException: Can't infer the SQL type to use for an instance of java.time.LocalDateTime. Use setObject() with an explicit Types value to specify the type to use.
	at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:971) ~[postgresql-42.2.9.jar:42.2.9.jre7]
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.setObject(HikariProxyPreparedStatement.java) ~[HikariCP-3.4.1.jar:?]
	at org.springframework.jdbc.core.StatementCreatorUtils.setValue(StatementCreatorUtils.java:415) ~[classes/:5.2.2.RELEASE]
	at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValueInternal(StatementCreatorUtils.java:233) ~[classes/:5.2.2.RELEASE]
	at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValue(StatementCreatorUtils.java:147) ~[classes/:5.2.2.RELEASE]
	at org.springframework.jdbc.core.PreparedStatementCreatorFactory$PreparedStatementCreatorImpl.setValues(PreparedStatementCreatorFactory.java:285) ~[spring-jdbc-5.2.2.jar:5.2.2.RELEASE]
	at org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate$2.setValues(NamedParameterJdbcTemplate.java:372) ~[spring-jdbc-5.2.2.jar:5.2.2.RELEASE]
	at org.springframework.jdbc.core.JdbcTemplate.lambda$batchUpdate$2(JdbcTemplate.java:944) ~[spring-jdbc-5.2.2.jar:5.2.2.RELEASE]
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:617) ~[spring-jdbc-5.2.2.jar:5.2.2.RELEASE]
```