### PR TITLE
Reduce String creation in BeanPropertyRowMapper

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
@@ -247,16 +247,14 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
 		if (!StringUtils.hasLength(name)) {
 			return "";
 		}
+
 		StringBuilder result = new StringBuilder();
-		result.append(lowerCaseName(name.substring(0, 1)));
-		for (int i = 1; i < name.length(); i++) {
-			String s = name.substring(i, i + 1);
-			String slc = lowerCaseName(s);
-			if (!s.equals(slc)) {
-				result.append("_").append(slc);
-			}
-			else {
-				result.append(s);
+		for (int i = 0; i < name.length(); i++) {
+			char s = name.charAt(i);
+			if (Character.isUpperCase(s)) {
+				result.append('_').append(Character.toLowerCase(s));
+			} else {
+				result.append(Character.toLowerCase(s));
 			}
 		}
 		return result.toString();


### PR DESCRIPTION
Prior to this commit the BeanPropertyRowMapper used
String.substring and String.toLowerCase to parse the
field names. This would generate more String than needed.

Instead one could iterate over the internal char[] of the
String and use the Character methods instead. This reduces
the String creation.