### PR TITLE
Use @SafeVarargs in Jackson builder and factory

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
@@ -595,8 +595,8 @@ public class Jackson2ObjectMapperBuilder {
 	 * @see #modulesToInstall(Module...)
 	 * @see com.fasterxml.jackson.databind.Module
 	 */
-	@SuppressWarnings("unchecked")
-	public Jackson2ObjectMapperBuilder modulesToInstall(Class<? extends Module>... modules) {
+	@SafeVarargs
+	public final Jackson2ObjectMapperBuilder modulesToInstall(Class<? extends Module>... modules) {
 		this.moduleClasses = modules;
 		this.findWellKnownModules = true;
 		return this;

--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBean.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBean.java
@@ -409,8 +409,8 @@ public class Jackson2ObjectMapperFactoryBean implements FactoryBean<ObjectMapper
 	 * @since 4.0.1
 	 * @see com.fasterxml.jackson.databind.Module
 	 */
-	@SuppressWarnings("unchecked")
-	public void setModulesToInstall(Class<? extends Module>... modules) {
+	@SafeVarargs
+	public final void setModulesToInstall(Class<? extends Module>... modules) {
 		this.builder.modulesToInstall(modules);
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
@@ -242,7 +242,6 @@ class Jackson2ObjectMapperBuilderTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	void modulesToInstallByClass() {
 		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json()
 				.modulesToInstall(CustomIntegerModule.class)
@@ -292,7 +291,6 @@ class Jackson2ObjectMapperBuilderTests {
 	}
 
 	@Test  // SPR-12634
-	@SuppressWarnings("unchecked")
 	void customizeWellKnownModulesWithModuleClass()
 			throws JsonProcessingException, UnsupportedEncodingException {
 

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
@@ -213,7 +213,6 @@ public class Jackson2ObjectMapperFactoryBeanTests {
 	}
 
 	@Test // SPR-12634
-	@SuppressWarnings("unchecked")
 	public void customizeDefaultModulesWithModuleClass() throws JsonProcessingException, UnsupportedEncodingException {
 		this.factory.setModulesToInstall(CustomIntegerModule.class);
 		this.factory.afterPropertiesSet();


### PR DESCRIPTION
Using @SafeVarargs in Jackson mapper builder and factory bean classes
allows the varargs methods to be used without a compiler warning. The
implementations of these methods do not perform unsafe operations on
their varargs parameter. It is therefore safe to add this annotation.

The following two methods are changed:

- add @SafeVarargs to Jackson2ObjectMapperBuilder#modulesToInstall
  and make it final
- add @SafeVarargs to
  Jackson2ObjectMapperFactoryBean#setModulesToInstall and make it final

This is a backwards incompatible change as these methods now have to be
declared final. Existing subclasses that override one of these methods
will break.

Closes gh-25293