### PR TITLE
SpEL: cannot call methods declared in `java.lang.Object` on a JDK proxy

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveMethodResolver.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectiveMethodResolver.java
@@ -19,13 +19,7 @@ package org.springframework.expression.spel.support;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.springframework.core.BridgeMethodResolver;
 import org.springframework.core.MethodParameter;
@@ -269,7 +263,13 @@ public class ReflectiveMethodResolver implements MethodResolver {
 	 * @since 3.1.1
 	 */
 	protected Method[] getMethods(Class<?> type) {
-		return type.getMethods();
+		Set<Method> methods=new HashSet<>();
+		methods.addAll(Arrays.asList(type.getMethods()));
+		//Add all methods of Object to have methods like toString on Proxy-Objects
+		methods.addAll(Arrays.asList(Object.class.getMethods()));
+
+		Method[] methods1 = methods.toArray(new Method[0]);
+		return methods1;
 	}
 
 	/**

--- a/spring-expression/src/test/java/org/springframework/expression/spel/support/ReflectionHelperTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/support/ReflectionHelperTests.java
@@ -18,21 +18,21 @@ package org.springframework.expression.spel.support;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.convert.TypeDescriptor;
-import org.springframework.expression.EvaluationContext;
-import org.springframework.expression.ParseException;
-import org.springframework.expression.PropertyAccessor;
-import org.springframework.expression.TypedValue;
+import org.springframework.expression.*;
 import org.springframework.expression.spel.AbstractExpressionTests;
 import org.springframework.expression.spel.SpelUtilities;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.support.ReflectionHelper.ArgumentsMatchKind;
+import org.springframework.util.Assert;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -364,6 +364,19 @@ public class ReflectionHelperTests extends AbstractExpressionTests {
 				field.write(ctx, tester, "field", null));
 	}
 
+	@Test
+	void testReflectiveMethodResolver() throws AccessException {
+		MethodResolver resolver=new ReflectiveMethodResolver();
+		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
+		Object obj= Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class<?>[]{Runnable.class}, new InvocationHandler() {
+			@Override
+			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+				return null;
+			}
+		});
+		MethodExecutor mexec=resolver.resolve(evaluationContext,obj,"toString",new ArrayList<>());
+		Assert.notNull(mexec,"MethodExecutor should not be empty.");
+	}
 
 	/**
 	 * Used to validate the match returned from a compareArguments call.


### PR DESCRIPTION
Hello, I built a fix for my problem with SpEL and proxy objects as described in #23369.

Now I want to contribute my changes.

Regards

Florian