### PR TITLE
Remove unnecessary assignments

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinition.java
@@ -189,9 +189,9 @@ public abstract class AbstractBeanDefinition extends BeanMetadataAttributeAccess
 	@Nullable
 	private String destroyMethodName;
 
-	private boolean enforceInitMethod = true;
+	private boolean enforceInitMethod;
 
-	private boolean enforceDestroyMethod = true;
+	private boolean enforceDestroyMethod;
 
 	private boolean synthetic = false;
 


### PR DESCRIPTION
The setting methods of the two fields declare that the default value is `false`. So, maybe the assignments should be removed.