### PR TITLE
Improve Random seed in SocketUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/SocketUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/SocketUtils.java
@@ -54,7 +54,7 @@ public class SocketUtils {
 	public static final int PORT_RANGE_MAX = 65535;
 
 
-	private static final Random random = new Random(System.currentTimeMillis());
+	private static Random random = new Random(System.currentTimeMillis());
 
 
 	/**
@@ -76,6 +76,13 @@ public class SocketUtils {
 	public SocketUtils() {
 	}
 
+	/**
+	 * Set custom random source.
+	 * Default uses {@code System.currentTimeMillis()} instead of {@code Random}'s default.
+	 */
+	public static void setRandom(Random random) {
+		SocketUtils.random = random;
+	}
 
 	/**
 	 * Find an available TCP port randomly selected from the range


### PR DESCRIPTION
I had an issue where `System.currentTimeMillis()` was a bad seed when a few tests were running in parallel. I want to be able to override the random to use `nanoTime()`.