### PR TITLE
Hoist Class.getName() from String concatenation to dodge an issue related to profile pollution

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/interceptor/AbstractMonitoringInterceptor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/interceptor/AbstractMonitoringInterceptor.java
@@ -103,7 +103,8 @@ public abstract class AbstractMonitoringInterceptor extends AbstractTraceInterce
 		if (this.logTargetClassInvocation && clazz.isInstance(invocation.getThis())) {
 			clazz = invocation.getThis().getClass();
 		}
-		return getPrefix() + clazz.getName() + '.' + method.getName() + getSuffix();
+		String clazzName = clazz.getName();
+		return getPrefix() + clazzName + '.' + method.getName() + getSuffix();
 	}
 
 }


### PR DESCRIPTION
This is a continuation of PR #24153.