### PR TITLE
Support for customization of 404 response when RouterFunctionWebHandler finds no routes

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctions.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctions.java
@@ -30,10 +30,12 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.codec.HttpMessageWriter;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.util.Assert;
 import org.springframework.web.reactive.result.view.ViewResolver;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebHandler;
 import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
@@ -1007,9 +1009,6 @@ public abstract class RouterFunctions {
 
 	private static class RouterFunctionWebHandler implements WebHandler {
 
-		private static final HandlerFunction<ServerResponse> NOT_FOUND_HANDLER =
-				request -> ServerResponse.notFound().build();
-
 		private final HandlerStrategies strategies;
 
 		private final RouterFunction<?> routerFunction;
@@ -1025,7 +1024,7 @@ public abstract class RouterFunctions {
 				ServerRequest request = new DefaultServerRequest(exchange, this.strategies.messageReaders());
 				addAttributes(exchange, request);
 				return this.routerFunction.route(request)
-						.defaultIfEmpty(notFound())
+						.switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND)))
 						.flatMap(handlerFunction -> wrapException(() -> handlerFunction.handle(request)))
 						.flatMap(response -> wrapException(() -> response.writeTo(exchange,
 								new HandlerStrategiesResponseContext(this.strategies))));
@@ -1035,11 +1034,6 @@ public abstract class RouterFunctions {
 		private void addAttributes(ServerWebExchange exchange, ServerRequest request) {
 			Map<String, Object> attributes = exchange.getAttributes();
 			attributes.put(REQUEST_ATTRIBUTE, request);
-		}
-
-		@SuppressWarnings("unchecked")
-		private static <T extends ServerResponse> HandlerFunction<T> notFound() {
-			return (HandlerFunction<T>) NOT_FOUND_HANDLER;
 		}
 
 		private static <T> Mono<T> wrapException(Supplier<Mono<T>> supplier) {


### PR DESCRIPTION
**Context**
Next to the default WebServer a service starts another server to handle admin requests on a different port. The admin webserver is connected to the `HttpHandler` created by `RouterFunctions.toHttpHandler`.

When the admin server processes a request for a path not mapped to any `RouterFunction` then the admin server responds with a 404 NotFound status code and an empty response body.

Currently it is not possible to have a different response body. 

Changing the `RouterFunctionWebHandler` to return a `Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND))` instead of `ServerResponse.notFound().build()`  allows clients to implement an exception handler that customizes the response body.

Default behavior does not change because `WebFluxResponseStatusExceptionHandler` is the default handler.