### PR TITLE
Remove redundant Character.toLowerCase() in BeanPropertyRowMapper

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
@@ -255,7 +255,7 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
 				result.append('_').append(Character.toLowerCase(s));
 			}
 			else {
-				result.append(Character.toLowerCase(s));
+				result.append(s);
 			}
 		}
 		return result.toString();


### PR DESCRIPTION
This PR removes a redundant `Character.toLowerCase()` invocation in `BeanPropertyRowMapper.underscoreName()`.