### PR TITLE
Allow auto grow for entries without default constructor in SpEL

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
@@ -728,7 +728,8 @@ public class Indexer extends SpelNodeImpl {
 		Constructor<?> getConstructor(Class<?> type) {
 			try {
 				return ReflectionUtils.accessibleConstructor(type);
-			} catch (Throwable ex) {
+			}
+			catch (Throwable ex) {
 				return null;
 			}
 		}

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
@@ -712,16 +712,24 @@ public class Indexer extends SpelNodeImpl {
 				}
 				TypeDescriptor elementType = this.collectionEntryDescriptor.getElementTypeDescriptor();
 				try {
-					Constructor<?> ctor = ReflectionUtils.accessibleConstructor(elementType.getType());
+					Constructor<?> ctor = getConstructor(elementType.getType());
 					int newElements = this.index - this.collection.size();
 					while (newElements >= 0) {
-						this.collection.add(ctor.newInstance());
+						this.collection.add(ctor == null ? null : ctor.newInstance());
 						newElements--;
 					}
 				}
 				catch (Throwable ex) {
 					throw new SpelEvaluationException(getStartPosition(), ex, SpelMessage.UNABLE_TO_GROW_COLLECTION);
 				}
+			}
+		}
+
+		Constructor<?> getConstructor(Class<?> type) {
+			try {
+				return ReflectionUtils.accessibleConstructor(type);
+			} catch (Throwable ex) {
+				return null;
 			}
 		}
 

--- a/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
@@ -211,6 +211,17 @@ public class IndexingTests {
 	}
 
 	@Test
+	public void indexIntoPropertyContainingNullList() {
+		this.decimals = new ArrayList<>();
+		this.decimals.add(null);
+		this.decimals.add(BigDecimal.ONE);
+		SpelExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
+		parser.parseExpression("decimals[0]").setValue(this, "9876.5");
+		assertThat(decimals.get(0)).isEqualTo(BigDecimal.valueOf(9876.5));
+		assertThat(decimals.get(1)).isEqualTo(BigDecimal.ONE);
+	}
+
+	@Test
 	public void indexIntoPropertyContainingList() {
 		List<Integer> property = new ArrayList<>();
 		property.add(3);

--- a/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
@@ -20,6 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -197,6 +198,16 @@ public class IndexingTests {
 		catch (EvaluationException ex) {
 			assertThat(ex.getMessage().startsWith("EL1053E")).isTrue();
 		}
+	}
+
+	public List<BigDecimal> decimals;
+
+	@Test
+	public void autoGrowWithoutDefaultConstructor() {
+		this.decimals = new ArrayList<>();
+		SpelExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
+		parser.parseExpression("decimals[0]").setValue(this, "123.4");
+		assertThat(decimals.get(0)).isEqualTo(BigDecimal.valueOf(123.4));
 	}
 
 	@Test

--- a/src/docs/asciidoc/core/core-expressions.adoc
+++ b/src/docs/asciidoc/core/core-expressions.adoc
@@ -339,8 +339,12 @@ index into an array or collection and the element at the specified index is `nul
 you can automatically create the element. This is useful when using expressions made up of a
 chain of property references. If you index into an array or list
 and specifying an index that is beyond the end of the current size of the array or
-list, you can automatically grow the array or list to accommodate that index. The following
-example demonstrates how to automatically grow the list:
+list, you can automatically grow the array or list to accommodate that index. In order to add
+an element at the specified index, SpEL will try to create the element using a default
+constructor before setting the specified value. If the element type does not have a default
+constructor, `null` will be added. Note if there is no built-in or custom converter, that knows
+how to set the value, `null` will remain in the array or list at the specified index.
+The following example demonstrates how to automatically grow the list:
 
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]
 .Java


### PR DESCRIPTION
Hi,

I wanted to add a `BigDecimal` to a list using SpEL. Auto grow only works for element types with a default constructor and since `BigDecimal` does not have a default constructor auto grow does not work with my list.

Here is an example:

```java
public class SpelTest {

    public List<BigDecimal> values;
    
    SpelExpressionParser parser;

    @Before
    public void setup() {
        values = new ArrayList<>();
        parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
    }

    @Test
    public void shouldChangeValue() {
        values.add(BigDecimal.ONE);

        parser.parseExpression("values[0]").setValue(this, "123.4");

        assertThat(values.get(0)).isEqualTo(BigDecimal.valueOf(123.4)); // passes
    }

    @Test
    public void shouldAddValue() {
        parser.parseExpression("values[0]").setValue(this, "123.4");

        assertThat(values.get(0)).isEqualTo(BigDecimal.valueOf(123.4)); // fails
    }
}
```
Changing the first entry passes but adding an entry fails with

```
Caused by: java.lang.NoSuchMethodException: java.math.BigDecimal.<init>()
    at java.base/java.lang.Class.getConstructor0(Class.java:3349)
    at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2553)
    at org.springframework.util.ReflectionUtils.accessibleConstructor(ReflectionUtils.java:185)
    at org.springframework.expression.spel.ast.Indexer$CollectionIndexingValueRef.growCollectionIfNecessary(Indexer.java:715)
    ... 55 more
```

My solution inserts `null` when no default constructor can be found for the element type. Not sure if this is a good solution but at least it does not seem to break any tests. Please be nice :-)