### PR TITLE
Use correct link to MaxInMemorySize

### DIFF
--- a/src/docs/asciidoc/web/webflux.adoc
+++ b/src/docs/asciidoc/web/webflux.adoc
@@ -835,7 +835,7 @@ exposes a `maxInMemorySize` property and if so the Javadoc will have details abo
 values. On the server side, `ServerCodecConfigurer` provides a single place from where to
 set all codecs, see <<webflux-config-message-codecs>>. On the client side, the limit for
 all codecs can be changed in
-<<web-reactive.adoc#webflux-client-builder-maxinmemorysize, WebClient.Builder>>.
+<<webflux-webclient.adoc#webflux-client-builder-maxinmemorysize, WebClient.Builder>>.
 
 For <<webflux-codecs-multipart,Multipart parsing>> the `maxInMemorySize` property limits
 the size of non-file parts. For file parts, it determines the threshold at which the part


### PR DESCRIPTION
This PR fixes a broken link to the "MaxInMemorySize" section.