### PR TITLE
Improve UriComponents.sanitizeSource()

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponents.java
@@ -276,7 +276,8 @@ public abstract class UriComponents implements Serializable {
 	 */
 	private static String sanitizeSource(String source) {
 		int level = 0;
-		StringBuilder sb = new StringBuilder();
+		int lastCharIndex = 0;
+		char[] chars = new char[source.length()];
 		for (char c : source.toCharArray()) {
 			if (c == '{') {
 				level++;
@@ -287,9 +288,9 @@ public abstract class UriComponents implements Serializable {
 			if (level > 1 || (level == 1 && c == '}')) {
 				continue;
 			}
-			sb.append(c);
+			chars[lastCharIndex++] = c;
 		}
-		return sb.toString();
+		return new String(chars, 0, lastCharIndex);
 	}
 
 	private static String getVariableName(String match) {


### PR DESCRIPTION
The length of sanitized URI is either the same, or less than original one, so we can use `char[]` to reduce overhead brought by `StringBuilder`.