### PR TITLE
Fix infinite loop bug in AnnotationScanner

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java
@@ -146,14 +146,14 @@ abstract class AnnotationsScanner {
 			Class<?> root = source;
 			while (source != null && source != Object.class && remaining > 0 &&
 					!hasPlainJavaAnnotationsOnly(source)) {
+				R result = processor.doWithAggregate(context, aggregateIndex);
+				if (result != null) {
+					return result;
+				}
 				if (isFiltered(source, context, classFilter)) {
 					source = source.getSuperclass();
 					aggregateIndex++;
 					continue;
-				}
-				R result = processor.doWithAggregate(context, aggregateIndex);
-				if (result != null) {
-					return result;
 				}
 				Annotation[] declaredAnnotations =
 						getDeclaredAnnotations(context, source, classFilter, true);

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java
@@ -146,12 +146,14 @@ abstract class AnnotationsScanner {
 			Class<?> root = source;
 			while (source != null && source != Object.class && remaining > 0 &&
 					!hasPlainJavaAnnotationsOnly(source)) {
+				if (isFiltered(source, context, classFilter)) {
+					source = source.getSuperclass();
+					aggregateIndex++;
+					continue;
+				}
 				R result = processor.doWithAggregate(context, aggregateIndex);
 				if (result != null) {
 					return result;
-				}
-				if (isFiltered(source, context, classFilter)) {
-					continue;
 				}
 				Annotation[] declaredAnnotations =
 						getDeclaredAnnotations(context, source, classFilter, true);

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationsScannerTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationsScannerTests.java
@@ -499,6 +499,22 @@ class AnnotationsScannerTests {
 		assertThat(result).isEqualTo("OK");
 	}
 
+	@Test
+	void scanWithFilteredAll() {
+		List<Integer> indexes = new ArrayList<>();
+		String result = AnnotationsScanner.scan(this, WithSingleSuperclass.class,
+				SearchStrategy.INHERITED_ANNOTATIONS,
+				(context, aggregateIndex, source, annotations) -> {
+					indexes.add(aggregateIndex);
+					return "";
+				},
+				(context,cls)->{
+					return true;
+				}
+				);
+		assertThat(result).isNull();
+	}
+
 
 	private Method methodFrom(Class<?> type) {
 		return ReflectionUtils.findMethod(type, "method");


### PR DESCRIPTION
The original code
`isFiltered(source, context, classFilter)` when true,
 would cause  dead circle.
Maybe new code is right.