### PR TITLE
Add CompletionStageWrappingResponse for async support

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
@@ -413,6 +413,18 @@ public interface ServerResponse {
 		 * @return the built response
 		 */
 		ServerResponse render(String name, Map<String, ?> model);
+
+		/**
+		 * Create an asynchronous ServerResponse that writes when the completion stage completes.
+		 * This can be used to determine status headers and cookies, in the future.
+		 * In contrast with {@link org.springframework.web.servlet.function.DefaultEntityResponseBuilder}
+		 * CompletionStageEntityResponse where only the entity (body) can be create async,
+		 * where status headers and cookies are created and are final, in advance.
+		 *
+		 * @param responseCompletionStage a completion stage for a {@link ServerResponse}
+		 * @return a built response
+		 */
+		ServerResponse whenComplete(CompletionStage<ServerResponse> responseCompletionStage);
 	}
 
 


### PR DESCRIPTION
As part of a problem I ran into detailed in [this question from stackoverflow](https://stackoverflow.com/questions/63019544/springboot-functional-web-mvc-missing-a-way-to-return-completablefuturerespons?noredirect=1#comment111442460_63019544)
I created CompletionStageWrappingResponse for cases where a ServerResponse needs to be created in a completion stage (complete with status, headers and cookies).

Please take into consideration, that declarative webmvc has this feature with `CompletionStage<ResponseEntity<T>>`

I have added the whenComplete builder method to ServerResponse so now it will be possible for a user to do:

```java
RouterFunctions.route().route(RequestPredicates.path("/helloWorld/{option}"), x -> ServerResponse.whenComplete(service.futureFoo());
```

where the service will be able to in an asynchronous stream decide what response it wants to offer like so
```java
CompletionStage<ServerResponse> futureFoo(){
    return CompletableFuture.supplyAsync(()-> /* some async process returning a boolean */)
                  .thenApply(x-> x ? ServerResponse.ok().body("true") :  
                     ServerResponse.status(HttpStatus.FOUND).location(URI.create("/look/somewhere/else").build());
}
```

I have a use case for this behaviour in my production deployed application.
As a half measure I have created a 'mycompany-spring-extras' library with this functionality.

As I don't want to find myself in trouble when in the future migrating to newer versions of spring,
I humbly try to contribute this code.

Best regards,
Alex.