### PR TITLE
AnnotationTypeMappings does not filter repeatable annotations

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
@@ -91,6 +91,9 @@ final class AnnotationTypeMappings {
 					.findRepeatedAnnotations(metaAnnotation);
 			if (repeatedAnnotations != null) {
 				for (Annotation repeatedAnnotation : repeatedAnnotations) {
+					if (!isMappable(source, repeatedAnnotation)) {
+						continue;
+					}
 					addIfPossible(queue, source, repeatedAnnotation);
 				}
 			}

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
@@ -91,9 +91,6 @@ final class AnnotationTypeMappings {
 					.findRepeatedAnnotations(metaAnnotation);
 			if (repeatedAnnotations != null) {
 				for (Annotation repeatedAnnotation : repeatedAnnotations) {
-					if (!isMappable(source, metaAnnotation)) {
-						continue;
-					}
 					addIfPossible(queue, source, repeatedAnnotation);
 				}
 			}

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
@@ -463,6 +463,14 @@ class AnnotationTypeMappingsTests {
 		assertThat(mapping.isEquivalentToDefaultValue(0, OutputStream.class, ReflectionUtils::invokeMethod)).isFalse();
 	}
 
+	@Test
+	void forAnnotationTypeWhenRepeatableMetaAnnotationIsFiltered() {
+		AnnotationTypeMappings mappings = AnnotationTypeMappings.forAnnotationType(WithRepeatedMetaAnnotations.class,
+			Repeating.class.getName()::equals);
+		assertThat(getAll(mappings)).flatExtracting(AnnotationTypeMapping::getAnnotationType)
+			.containsExactly(WithRepeatedMetaAnnotations.class);
+	}
+
 	private Method[] resolveMirrorSets(AnnotationTypeMapping mapping, Class<?> element,
 			Class<? extends Annotation> annotationClass) {
 		Annotation annotation = element.getAnnotation(annotationClass);
@@ -472,16 +480,6 @@ class AnnotationTypeMappingsTests {
 			result[i] = resolved[i] != -1 ? mapping.getAttributes().get(resolved[i]) : null;
 		}
 		return result;
-	}
-
-	@Test
-	void forAnnotationTypeWhenRepeatableMetaAnnotationFilterd() {
-		AnnotationTypeMappings mappings = AnnotationTypeMappings.forAnnotationType(WithRepeatedMetaAnnotations.class,
-		annotationType ->
-				ObjectUtils.nullSafeEquals(annotationType, Repeating.class.getName()));
-		assertThat(getAll(mappings)).flatExtracting(
-				AnnotationTypeMapping::getAnnotationType).containsExactly(
-				WithRepeatedMetaAnnotations.class);
 	}
 
 	@Nullable

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
@@ -474,6 +474,16 @@ class AnnotationTypeMappingsTests {
 		return result;
 	}
 
+	@Test
+	void forAnnotationTypeWhenRepeatableMetaAnnotationFilterd() {
+		AnnotationTypeMappings mappings = AnnotationTypeMappings.forAnnotationType(WithRepeatedMetaAnnotations.class,
+		annotationType ->
+				ObjectUtils.nullSafeEquals(annotationType, Repeating.class.getName()));
+		assertThat(getAll(mappings)).flatExtracting(
+				AnnotationTypeMapping::getAnnotationType).containsExactly(
+				WithRepeatedMetaAnnotations.class);
+	}
+
 	@Nullable
 	private Method getAliasMapping(AnnotationTypeMapping mapping, int attributeIndex) {
 		int mapped = mapping.getAliasMapping(attributeIndex);


### PR DESCRIPTION
since
`					if (!isMappable(source, metaAnnotation)) {
						continue;
					}`
is called before and 'source' ,'metaAnnotation' did not changed. 
The code should be deleted. 