### PR TITLE
specify null and zero length data

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToCharacterConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToCharacterConverter.java
@@ -28,10 +28,7 @@ final class StringToCharacterConverter implements Converter<String, Character> {
 
 	@Override
 	public Character convert(String source) {
-		if (source.isEmpty()) {
-			return null;
-		}
-		if (source.length() > 1) {
+		if (source.length() != 1) {
 			throw new IllegalArgumentException(
 					"Can only convert a [String] with length of 1 to a [Character]; string value '" + source + "'  has length of " + source.length());
 		}


### PR DESCRIPTION
String: length of zero and null value are not same.
but, this code return null when string has length of zero.

So, I think it need to be more specific.
if the parameter String(source) value is null -> then NullPointException is occured (automatically).
and if String length is not valid (that is length is not 1) -> then IllegalArgumentException ocurred by the code.

Please check and leave a comment. thank you.
