### PR TITLE
CloseStatus implements Serializable

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/CloseStatus.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/CloseStatus.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.socket;
 
+import java.io.Serializable;
+
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -30,7 +32,9 @@ import org.springframework.util.ObjectUtils;
  * @author Rossen Stoyanchev
  * @since 4.0
  */
-public final class CloseStatus {
+public final class CloseStatus implements Serializable {
+
+	private static final long serialVersionUID = 5199057709285570947L;
 
 	/**
 	 * "1000 indicates a normal closure, meaning that the purpose for which the connection


### PR DESCRIPTION
I wanted to use `CloseStatus` in another serializable class and noticed that it wasn't serializable.

There's no harm in making it serializable... so why not :)