### PR TITLE
Fix asciidoctor syntax for source

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -320,7 +320,7 @@ To send multipart data, you need to provide a `MultiValueMap<String, Object>` wh
 may be an `Object` for part content, a `Resource` for a file part, or an `HttpEntity` for
 part content with headers. For example:
 
-[source,java,intent=0]
+[source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
@@ -341,7 +341,7 @@ explicitly provide the `MediaType` with an `HttpEntity` wrapper.
 
 Once the `MultiValueMap` is ready, you can pass it to the `RestTemplate`, as show below:
 
-[source,java,intent=0]
+[source,java,indent=0]
 [subs="verbatim,quotes"]
 ----
 	MultiValueMap<String, Object> parts = ...;


### PR DESCRIPTION
[Asciidoctor User Manual: Normalize Block Indentation](https://asciidoctor.org/docs/user-manual/#normalize-block-indentation)

![image](https://user-images.githubusercontent.com/2121467/89483826-98347c00-d7cf-11ea-884d-4a6dc8ac3692.png)

