### PR TITLE
Declare MessagePostProcessor as a @FunctionalInterface

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/core/MessagePostProcessor.java
+++ b/spring-jms/src/main/java/org/springframework/jms/core/MessagePostProcessor.java
@@ -32,6 +32,7 @@ import javax.jms.Message;
  * @see JmsTemplate#convertAndSend(javax.jms.Destination, Object, MessagePostProcessor)
  * @see org.springframework.jms.support.converter.MessageConverter
  */
+@FunctionalInterface
 public interface MessagePostProcessor {
 
 	/**

--- a/spring-messaging/src/main/java/org/springframework/messaging/core/MessagePostProcessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/core/MessagePostProcessor.java
@@ -28,6 +28,7 @@ import org.springframework.messaging.Message;
  * @see MessageSendingOperations
  * @see MessageRequestReplyOperations
  */
+@FunctionalInterface
 public interface MessagePostProcessor {
 
 	/**


### PR DESCRIPTION
Add the FunctionalInterface annotation to the MessagePostProcessor
interfaces in the spring-jms and spring-messaging projects.