### PR TITLE
Call StartupStep.end in finally block

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -300,9 +300,9 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 				markBeanAsCreated(beanName);
 			}
 
+			StartupStep beanCreation = this.applicationStartup.start("spring.beans.instantiate")
+					.tag("beanName", name);
 			try {
-				StartupStep beanCreation = this.applicationStartup.start("spring.beans.instantiate")
-						.tag("beanName", name);
 				if (requiredType != null) {
 					beanCreation.tag("beanType", requiredType::toString);
 				}
@@ -383,11 +383,15 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 						throw new ScopeNotActiveException(beanName, scopeName, ex);
 					}
 				}
-				beanCreation.end();
 			}
 			catch (BeansException ex) {
+				beanCreation.tag("exception", ex.getClass().toString());
+				beanCreation.tag("message", ex.getMessage());
 				cleanupAfterBeanCreationFailure(beanName);
 				throw ex;
+			}
+			finally {
+				beanCreation.end();
 			}
 		}
 


### PR DESCRIPTION
Prior to this commit it was possible that a StartupStep was
started but never ended. This was the case when an exception
occured during bean initializing. To always call the method
regardless of the outcome, the call to StartupStep.end has
been moved to a finally block.

When an exception occurs the StartupStep is also enriched with
the exception class and message for diagnostic purposes.

Related: spring-projects/spring-boot#22776