### PR TITLE
FileUrlResource isWritable method returns true if URL protocol is not indicating a file

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/FileUrlResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/FileUrlResource.java
@@ -91,8 +91,14 @@ public class FileUrlResource extends UrlResource implements WritableResource {
 	public boolean isWritable() {
 		try {
 			URL url = getURL();
-			File file = getFile();
-			return (file.canWrite() && !file.isDirectory());
+			if (ResourceUtils.isFileURL(url)) {
+				// Proceed with file system resolution
+				File file = getFile();
+				return (file.canWrite() && !file.isDirectory());
+			}
+			else {
+				return false;
+			}
 		}
 		catch (IOException ex) {
 			return false;

--- a/spring-core/src/main/java/org/springframework/core/io/FileUrlResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/FileUrlResource.java
@@ -59,6 +59,7 @@ public class FileUrlResource extends UrlResource implements WritableResource {
 	 */
 	public FileUrlResource(URL url) {
 		super(url);
+		Assert.isTrue(ResourceUtils.isFileURL(url),"url's protocol must be file or start with vfs");
 	}
 
 	/**
@@ -90,14 +91,8 @@ public class FileUrlResource extends UrlResource implements WritableResource {
 	public boolean isWritable() {
 		try {
 			URL url = getURL();
-			if (ResourceUtils.isFileURL(url)) {
-				// Proceed with file system resolution
-				File file = getFile();
-				return (file.canWrite() && !file.isDirectory());
-			}
-			else {
-				return true;
-			}
+			File file = getFile();
+			return (file.canWrite() && !file.isDirectory());
 		}
 		catch (IOException ex) {
 			return false;

--- a/spring-core/src/test/java/org/springframework/core/io/ResourceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/ResourceTests.java
@@ -330,4 +330,11 @@ class ResourceTests {
 				new ClassPathResource("Resource.class", getClass()).createRelative("X").readableChannel());
 	}
 
+	@Test
+	void fileUrlResourceTest() throws IOException {
+		assertThatIllegalArgumentException().isThrownBy(() -> {
+			new FileUrlResource(new URL("https://spring.io/"));
+		});
+	}
+
 }


### PR DESCRIPTION
if add testcase
`	@Test
	void test() throws IOException {
		Resource resource = new FileUrlResource(new URL("https://spring.io/"));
		assertThat(resource.isReadable()).isFalse();
	}
`
the former code cannot pass.
Then I restricted   FileUrlResource must be contructed with a URL about file.
