### PR TITLE
Introduce createContext() factory method in AbstractGenericContextLoader

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/support/AbstractGenericContextLoader.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/AbstractGenericContextLoader.java
@@ -112,7 +112,7 @@ public abstract class AbstractGenericContextLoader extends AbstractContextLoader
 
 		validateMergedContextConfiguration(mergedConfig);
 
-		GenericApplicationContext context = new GenericApplicationContext();
+		GenericApplicationContext context = createContext();
 
 		ApplicationContext parent = mergedConfig.getParentApplicationContext();
 		if (parent != null) {
@@ -128,6 +128,15 @@ public abstract class AbstractGenericContextLoader extends AbstractContextLoader
 		context.refresh();
 		context.registerShutdownHook();
 		return context;
+	}
+
+	/**
+	 * Creates instance of application context used by this {@code ContextLoader}
+	 *
+	 * @return new Instance of application context
+	 */
+	protected GenericApplicationContext createContext() {
+		return new GenericApplicationContext();
 	}
 
 	/**
@@ -184,7 +193,7 @@ public abstract class AbstractGenericContextLoader extends AbstractContextLoader
 			logger.debug(String.format("Loading ApplicationContext for locations [%s].",
 				StringUtils.arrayToCommaDelimitedString(locations)));
 		}
-		GenericApplicationContext context = new GenericApplicationContext();
+		GenericApplicationContext context = createContext();
 		prepareContext(context);
 		customizeBeanFactory(context.getDefaultListableBeanFactory());
 		createBeanDefinitionReader(context).loadBeanDefinitions(locations);


### PR DESCRIPTION
We have customized `DefaultListableBeanFactory` and are using it already in `AnnotationConfigWebApplicationContext` for production.

Now we would like to customize the `DefaultListableBeanFactory` for integration tests as well, but in order to archive that we need a new factory method in `AbstractGenericContextLoader`.