### PR TITLE
Simplify code in AbstractFallbackJCacheOperationSource

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/jcache/interceptor/AbstractFallbackJCacheOperationSource.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/jcache/interceptor/AbstractFallbackJCacheOperationSource.java
@@ -96,9 +96,7 @@ public abstract class AbstractFallbackJCacheOperationSource implements JCacheOpe
 		if (specificMethod != method) {
 			// Fallback is to look at the original method.
 			operation = findCacheOperation(method, targetClass);
-			if (operation != null) {
-				return operation;
-			}
+			return operation;
 		}
 		return null;
 	}


### PR DESCRIPTION
I found that `operation` has been judged not to be null before, so it can be returned directly