### PR TITLE
Remove never use code in AbstractNestablePropertyAccessor

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -397,17 +397,9 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 		}
 
 		if (propValue == null) {
-			// null map value case
-			if (isAutoGrowNestedPaths()) {
-				int lastKeyIndex = tokens.canonicalName.lastIndexOf('[');
-				getterTokens.canonicalName = tokens.canonicalName.substring(0, lastKeyIndex);
-				propValue = setDefaultValue(getterTokens);
-			}
-			else {
-				throw new NullValueInNestedPathException(getRootClass(), this.nestedPath + tokens.canonicalName,
-						"Cannot access indexed value in property referenced " +
-						"in indexed property path '" + tokens.canonicalName + "': returned null");
-			}
+			throw new NullValueInNestedPathException(getRootClass(), this.nestedPath + tokens.canonicalName,
+					"Cannot access indexed value in property referenced " +
+					"in indexed property path '" + tokens.canonicalName + "': returned null");
 		}
 		return propValue;
 	}


### PR DESCRIPTION
'if (propValue == null)' ,' isAutoGrowNestedPaths()' always returns false.  So remove the never accessable code, direct throw exception.