### PR TITLE
Copy httpHandlerDecorator in copy constructor for WebHttpHandlerBuilder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/adapter/WebHttpHandlerBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/WebHttpHandlerBuilder.java
@@ -124,6 +124,7 @@ public final class WebHttpHandlerBuilder {
 		this.codecConfigurer = other.codecConfigurer;
 		this.localeContextResolver = other.localeContextResolver;
 		this.forwardedHeaderTransformer = other.forwardedHeaderTransformer;
+		this.httpHandlerDecorator = other.httpHandlerDecorator;
 	}
 
 
@@ -356,7 +357,7 @@ public final class WebHttpHandlerBuilder {
 	 * the entire chain and likewise the ability to observe the result of
 	 * the entire chain.
 	 * @param handlerDecorator the decorator to apply
-	 * @since 5.1
+	 * @since 5.3
 	 */
 	public WebHttpHandlerBuilder httpHandlerDecorator(Function<HttpHandler, HttpHandler> handlerDecorator) {
 		this.httpHandlerDecorator = (this.httpHandlerDecorator != null ?
@@ -365,10 +366,9 @@ public final class WebHttpHandlerBuilder {
 	}
 
 	/**
-	 * Whether a {@code ForwardedHeaderTransformer} is configured or not, either
-	 * detected from an {@code ApplicationContext} or explicitly configured via
-	 * {@link #forwardedHeaderTransformer(ForwardedHeaderTransformer)}.
-	 * @since 5.1
+	 * Whether a decorator for {@link HttpHandler} is configured or not via
+	 * {@link #httpHandlerDecorator(Function)}.
+	 * @since 5.3
 	 */
 	public boolean hasHttpHandlerDecorator() {
 		return (this.httpHandlerDecorator != null);


### PR DESCRIPTION
This PR changes to copy `httpHandlerDecorator` in copy constructor for `WebHttpHandlerBuilder` as it seems to be missed accidentally in 21d25b23d95d0b6ccb582cae0d53691b651d9a8e.

This PR also polishes its Javadoc and fixes its test along the way.