### PR TITLE
Improve performance of JdkDynamicAopProxy.getProxy(ClassLoader)

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/JdkDynamicAopProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/JdkDynamicAopProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.springframework.util.ClassUtils;
  * @author Juergen Hoeller
  * @author Rob Harrop
  * @author Dave Syer
+ * @author Sergey Tsypanov
  * @see java.lang.reflect.Proxy
  * @see AdvisedSupport
  * @see ProxyFactory
@@ -82,6 +83,8 @@ final class JdkDynamicAopProxy implements AopProxy, InvocationHandler, Serializa
 	/** Config used to configure this proxy. */
 	private final AdvisedSupport advised;
 
+	private final Class<?>[] proxiedInterfaces;
+
 	/**
 	 * Is the {@link #equals} method defined on the proxied interfaces?
 	 */
@@ -105,6 +108,8 @@ final class JdkDynamicAopProxy implements AopProxy, InvocationHandler, Serializa
 			throw new AopConfigException("No advisors and no TargetSource specified");
 		}
 		this.advised = config;
+		this.proxiedInterfaces = AopProxyUtils.completeProxiedInterfaces(this.advised, true);
+		findDefinedEqualsAndHashCodeMethods(this.proxiedInterfaces);
 	}
 
 
@@ -118,9 +123,7 @@ final class JdkDynamicAopProxy implements AopProxy, InvocationHandler, Serializa
 		if (logger.isTraceEnabled()) {
 			logger.trace("Creating JDK dynamic proxy: " + this.advised.getTargetSource());
 		}
-		Class<?>[] proxiedInterfaces = AopProxyUtils.completeProxiedInterfaces(this.advised, true);
-		findDefinedEqualsAndHashCodeMethods(proxiedInterfaces);
-		return Proxy.newProxyInstance(classLoader, proxiedInterfaces, this);
+		return Proxy.newProxyInstance(classLoader, this.proxiedInterfaces, this);
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -505,10 +505,13 @@ public abstract class ReflectionUtils {
 	 * @see java.lang.Object#equals(Object)
 	 */
 	public static boolean isEqualsMethod(@Nullable Method method) {
-		if (method == null || !method.getName().equals("equals")) {
+		if (method == null) {
 			return false;
 		}
 		if (method.getParameterCount() != 1) {
+			return false;
+		}
+		if (!method.getName().equals("equals")) {
 			return false;
 		}
 		return method.getParameterTypes()[0] == Object.class;
@@ -519,7 +522,7 @@ public abstract class ReflectionUtils {
 	 * @see java.lang.Object#hashCode()
 	 */
 	public static boolean isHashCodeMethod(@Nullable Method method) {
-		return (method != null && method.getName().equals("hashCode") && method.getParameterCount() == 0);
+		return method != null && method.getParameterCount() == 0 && method.getName().equals("hashCode");
 	}
 
 	/**
@@ -527,7 +530,7 @@ public abstract class ReflectionUtils {
 	 * @see java.lang.Object#toString()
 	 */
 	public static boolean isToStringMethod(@Nullable Method method) {
-		return (method != null && method.getName().equals("toString") && method.getParameterCount() == 0);
+		return (method != null && method.getParameterCount() == 0 && method.getName().equals("toString"));
 	}
 
 	/**


### PR DESCRIPTION
Hello, while profiling workload that creates lots of projections I've found out that about 33% of `ProxyFactory.getProxy()` are taken by `JdkDynamicAopProxy.findDefinedEqualsAndHashCodeMethods`, see attachment:
![](https://habrastorage.org/webt/r3/q1/zm/r3q1zmv_r76citavesjdutzvmx8.png)
The hot spot is here:
```java
@Override
public Object getProxy(@Nullable ClassLoader classLoader) {
	if (logger.isTraceEnabled()) {
		logger.trace("Creating JDK dynamic proxy: " + this.advised.getTargetSource());
	}
	Class<?>[] proxiedInterfaces = AopProxyUtils.completeProxiedInterfaces(this.advised, true);
	findDefinedEqualsAndHashCodeMethods(proxiedInterfaces);
	return Proxy.newProxyInstance(classLoader, proxiedInterfaces, this);
}
```

It looks like we don't need to call either `JdkDynamicAopProxy.findDefinedEqualsAndHashCodeMethods`, or `AopProxyUtils.completeProxiedInterfaces()` at each invocation of `JdkDynamicAopProxy.getProxy`, because their results don't depend on `ClassLoader` argument and can be calculated only once at obejct construction time, also `advised` field is declared final.

Also related methods of `ReflectionUtils` could also be trivially improved.