### PR TITLE
Improve PathResourceResolverTests to remove the last occurrence of 'springframework'

### DIFF
--- a/spring-webflux/src/test/java/org/springframework/web/reactive/resource/PathResourceResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/resource/PathResourceResolverTests.java
@@ -130,7 +130,7 @@ public class PathResourceResolverTests {
 	@Test // SPR-12624
 	public void checkRelativeLocation() throws Exception {
 		String locationUrl= new UrlResource(getClass().getResource("./test/")).getURL().toExternalForm();
-		Resource location = new UrlResource(locationUrl.replace("/springframework","/../org/springframework"));
+		Resource location = new UrlResource(locationUrl.replace("springframework(?!.*springframework)", "/../org/springframework"));
 		List<Resource> locations = singletonList(location);
 		assertThat(this.resolver.resolveResource(null, "main.css", locations, null).block(TIMEOUT)).isNotNull();
 	}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/resource/PathResourceResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/resource/PathResourceResolverTests.java
@@ -130,7 +130,7 @@ public class PathResourceResolverTests {
 	@Test // SPR-12624
 	public void checkRelativeLocation() throws Exception {
 		String locationUrl= new UrlResource(getClass().getResource("./test/")).getURL().toExternalForm();
-		Resource location = new UrlResource(locationUrl.replace("springframework(?!.*springframework)", "/../org/springframework"));
+		Resource location = new UrlResource(locationUrl.replace("/springframework(?!.*springframework)", "/../org/springframework"));
 		List<Resource> locations = singletonList(location);
 		assertThat(this.resolver.resolveResource(null, "main.css", locations, null).block(TIMEOUT)).isNotNull();
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/PathResourceResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/PathResourceResolverTests.java
@@ -126,7 +126,7 @@ public class PathResourceResolverTests {
 	@Test // SPR-12624
 	public void checkRelativeLocation() throws Exception {
 		String locationUrl= new UrlResource(getClass().getResource("./test/")).getURL().toExternalForm();
-		Resource location = new UrlResource(locationUrl.replace("/springframework","/../org/springframework"));
+		Resource location = new UrlResource(locationUrl.replace("springframework(?!.*springframework)", "/../org/springframework"));
 
 		assertThat(this.resolver.resolveResource(null, "main.css", Collections.singletonList(location), null)).isNotNull();
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/PathResourceResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/PathResourceResolverTests.java
@@ -126,7 +126,7 @@ public class PathResourceResolverTests {
 	@Test // SPR-12624
 	public void checkRelativeLocation() throws Exception {
 		String locationUrl= new UrlResource(getClass().getResource("./test/")).getURL().toExternalForm();
-		Resource location = new UrlResource(locationUrl.replace("springframework(?!.*springframework)", "/../org/springframework"));
+		Resource location = new UrlResource(locationUrl.replace("/springframework(?!.*springframework)", "/../org/springframework"));
 
 		assertThat(this.resolver.resolveResource(null, "main.css", Collections.singletonList(location), null)).isNotNull();
 	}


### PR DESCRIPTION
English is not my native language, please excuse typing errors.
I build spring-framework source code locally. When I execute 'gradlew build' command, it shows test case failed. I found it because my code path contain a fragment 'springframework', and I think put source code in a path contain 'springframework' is pretty normal, so I fixed this by use a regular expression.