### PR TITLE
remove-repeat-get-handlerMappings

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/DefaultNamespaceHandlerResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/DefaultNamespaceHandlerResolver.java
@@ -154,7 +154,6 @@ public class DefaultNamespaceHandlerResolver implements NamespaceHandlerResolver
 		Map<String, Object> handlerMappings = this.handlerMappings;
 		if (handlerMappings == null) {
 			synchronized (this) {
-				handlerMappings = this.handlerMappings;
 				if (handlerMappings == null) {
 					if (logger.isTraceEnabled()) {
 						logger.trace("Loading NamespaceHandler mappings from [" + this.handlerMappingsLocation + "]");


### PR DESCRIPTION
org.springframework.beans.factory.xml.DefaultNamespaceHandlerResolver#getHandlerMappings code line 157:
    I think maybe don't need assign this.handlerMappings to handlerMappings,because visibility can be guaranteed with volatile and synchronized。