### PR TITLE
Pass the exception to the HandlerExecutionChain

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -1153,8 +1153,8 @@ public class DispatcherServlet extends FrameworkServlet {
 		}
 
 		if (mappedHandler != null) {
-			// Exception (if any) is already handled..
-			mappedHandler.triggerAfterCompletion(request, response, null);
+			// Exception (if any) is already handled, but passed in case of any business logic needs..
+			mappedHandler.triggerAfterCompletion(request, response, exception);
 		}
 	}
 


### PR DESCRIPTION
Hello,

If an exception is thrown, it should be passed to the `HandlerExecutionChain` which in turn passed it to any existing `HandlerInterceptor` that can used it for any business logic inside `afterCompletion()` method.

In fact, when an exception is thrown and handled, the `afterCompletion()` method of the interceptor (aka. `HandlerInterceptorAdapter`) has no clue on that exception since the `DispatcherServlet` pass `null` even if there is an exception.

A business case that can use this exception is statistics or logging (mail, jms, ...).

Thank you.