### PR TITLE
Fix typo regarding Ordered interface in core-aop.adoc

### DIFF
--- a/src/docs/asciidoc/core/core-aop.adoc
+++ b/src/docs/asciidoc/core/core-aop.adoc
@@ -1649,7 +1649,7 @@ join point, unless you specify otherwise, the order of execution is undefined. Y
 control the order of execution by specifying precedence. This is done in the normal
 Spring way by either implementing the `org.springframework.core.Ordered` interface in
 the aspect class or annotating it with the `@Order` annotation. Given two aspects, the
-aspect returning the lower value from `Ordered.getValue()` (or the annotation value) has
+aspect returning the lower value from `Ordered.getOrder()` (or the annotation value) has
 the higher precedence.
 
 [NOTE]


### PR DESCRIPTION
I believe there is a typo in *core-aop.adoc*,  `org.springframework.core.Ordered` defines `getOrder`, not `getValue`.