### PR TITLE
Fix typo in AOP XML documentation

### DIFF
--- a/src/docs/asciidoc/core/core-aop.adoc
+++ b/src/docs/asciidoc/core/core-aop.adoc
@@ -2918,7 +2918,7 @@ an aspect weaving phase to your build script.
 If you have chosen to use Spring AOP, you have a choice of @AspectJ or XML style.
 There are various tradeoffs to consider.
 
-The XML style may most familiar to existing Spring users, and it is backed by genuine
+The XML style may be most familiar to existing Spring users, and it is backed by genuine
 POJOs. When using AOP as a tool to configure enterprise services, XML can be a good
 choice (a good test is whether you consider the pointcut expression to be a part of your
 configuration that you might want to change independently). With the XML style, it is


### PR DESCRIPTION
I think there is a missing word from this sentence:

    The XML style may most familiar to existing Spring users

Should be:

    The XML style may *be* most familiar to existing Spring users

