### PR TITLE
Fix typo in Regular Expression Pointcuts docs

### DIFF
--- a/src/docs/asciidoc/core/core-aop-api.adoc
+++ b/src/docs/asciidoc/core/core-aop-api.adoc
@@ -170,7 +170,7 @@ expression pointcut that uses the regular expression support in the JDK.
 
 With the `JdkRegexpMethodPointcut` class, you can provide a list of pattern strings. If
 any of these is a match, the pointcut evaluates to `true`. (So, the result is
-effectively the union of these pointcuts.)
+effectively the union of these patterns.)
 
 The following example shows how to use `JdkRegexpMethodPointcut`:
 


### PR DESCRIPTION
The paragraph describes the behavior of one pointcut, so it's obviously a typo here.