### PR TITLE
Resolve Principal argument only when not annotated

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletRequestMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletRequestMethodArgumentResolver.java
@@ -84,12 +84,13 @@ public class ServletRequestMethodArgumentResolver implements HandlerMethodArgume
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
 		Class<?> paramType = parameter.getParameterType();
+		final Annotation[] parameterAnnotations = parameter.getParameterAnnotations();
 		return (WebRequest.class.isAssignableFrom(paramType) ||
 				ServletRequest.class.isAssignableFrom(paramType) ||
 				MultipartRequest.class.isAssignableFrom(paramType) ||
 				HttpSession.class.isAssignableFrom(paramType) ||
 				(pushBuilder != null && pushBuilder.isAssignableFrom(paramType)) ||
-				Principal.class.isAssignableFrom(paramType) ||
+				(Principal.class.isAssignableFrom(paramType) && parameterAnnotations.length == 0) ||
 				InputStream.class.isAssignableFrom(paramType) ||
 				Reader.class.isAssignableFrom(paramType) ||
 				HttpMethod.class == paramType ||

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletRequestMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletRequestMethodArgumentResolver.java
@@ -19,6 +19,7 @@ package org.springframework.web.servlet.mvc.method.annotation;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.lang.annotation.Annotation;
 import java.security.Principal;
 import java.time.ZoneId;
 import java.util.Locale;

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletRequestMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletRequestMethodArgumentResolverTests.java
@@ -16,24 +16,6 @@
 
 package org.springframework.web.servlet.mvc.method.annotation;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.core.MethodParameter;
-import org.springframework.http.HttpMethod;
-import org.springframework.web.context.request.ServletWebRequest;
-import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.method.support.ModelAndViewContainer;
-import org.springframework.web.multipart.MultipartRequest;
-import org.springframework.web.servlet.DispatcherServlet;
-import org.springframework.web.servlet.i18n.FixedLocaleResolver;
-import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
-import org.springframework.web.testfixture.servlet.MockHttpServletResponse;
-import org.springframework.web.testfixture.servlet.MockHttpSession;
-
-import javax.servlet.ServletRequest;
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.PushBuilder;
 import java.io.InputStream;
 import java.io.Reader;
 import java.lang.annotation.ElementType;
@@ -45,6 +27,26 @@ import java.security.Principal;
 import java.time.ZoneId;
 import java.util.Locale;
 import java.util.TimeZone;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.PushBuilder;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.multipart.MultipartRequest;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.i18n.FixedLocaleResolver;
+import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
+import org.springframework.web.testfixture.servlet.MockHttpServletResponse;
+import org.springframework.web.testfixture.servlet.MockHttpSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
`ServletRequestMethodArgumentResolver` happend early in the `ArgumentResolver` chain. One of his ability is to resolve `Principal`, that's great and it works well.

But when a parameter of type `Principal` is annotated we don't want to get the `Principal` from the `HttpServletRequest.getUserPrincipal()`.
This feature is even in conflict with the **spring-security** documentation and the [`@AuthenticationPrincipal`](https://docs.spring.io/spring-security/site/docs/4.2.15.RELEASE/apidocs/org/springframework/security/web/bind/annotation/AuthenticationPrincipal.html) annotation which is supposed to resolve the Principal from Authentication.getPrincipal().

Having the `ServletRequestMethodArgumentResolver` resolving annotated `Principal` makes the `@AuthenticationPrincipal` and `AuthenticationPrincipalArgumentResolver` useless and missleading.

Fix spring-projects/spring-security#4151