### PR TITLE
Optimize StringUtils trimLeading/Trailing methods

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -271,11 +271,11 @@ public abstract class StringUtils {
 			return str;
 		}
 
-		StringBuilder sb = new StringBuilder(str);
-		while (sb.length() > 0 && Character.isWhitespace(sb.charAt(0))) {
-			sb.deleteCharAt(0);
+		int beginIdx = 0;
+		while (beginIdx < str.length() && Character.isWhitespace(str.charAt(beginIdx))) {
+			beginIdx++;
 		}
-		return sb.toString();
+		return str.substring(beginIdx);
 	}
 
 	/**
@@ -289,11 +289,11 @@ public abstract class StringUtils {
 			return str;
 		}
 
-		StringBuilder sb = new StringBuilder(str);
-		while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1))) {
-			sb.deleteCharAt(sb.length() - 1);
+		int endIdx = str.length() - 1;
+		while (endIdx >= 0 && Character.isWhitespace(str.charAt(endIdx))) {
+			endIdx--;
 		}
-		return sb.toString();
+		return str.substring(0, endIdx + 1);
 	}
 
 	/**
@@ -307,11 +307,11 @@ public abstract class StringUtils {
 			return str;
 		}
 
-		StringBuilder sb = new StringBuilder(str);
-		while (sb.length() > 0 && sb.charAt(0) == leadingCharacter) {
-			sb.deleteCharAt(0);
+		int beginIdx = 0;
+		while (beginIdx < str.length() && leadingCharacter == str.charAt(beginIdx)) {
+			beginIdx++;
 		}
-		return sb.toString();
+		return str.substring(beginIdx);
 	}
 
 	/**
@@ -325,11 +325,11 @@ public abstract class StringUtils {
 			return str;
 		}
 
-		StringBuilder sb = new StringBuilder(str);
-		while (sb.length() > 0 && sb.charAt(sb.length() - 1) == trailingCharacter) {
-			sb.deleteCharAt(sb.length() - 1);
+		int endIdx = str.length() - 1;
+		while (endIdx >= 0 && trailingCharacter == str.charAt(endIdx)) {
+			endIdx--;
 		}
-		return sb.toString();
+		return str.substring(0, endIdx + 1);
 	}
 
 	/**


### PR DESCRIPTION
This PR includes some StringUtils methods optimization. The problem is that trimLeading/TrailingCharacter and trimLeading/TrailingWhitespace methods create a StringBuilder object as a local var instead of using String.substring method. Such approach is leading to unnecessary object creation on every method invocation. Also it runs slower because of internal StringBuilder operations and conversions String->StringBuilder->String. According to simple JMH benchmark, substring is x2/x3 faster on avg scenarios. The situation with long strings that are not changed at all(if the method returns an equal string) is especially dramatic for StringBuilder (but substring will return its param instead of new a string creation)
Also found out that trimWhitespace(String str) method is already implemented in similar style.