### PR TITLE
Method chaining - AbstractDriverBasedDataSource

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/AbstractDriverBasedDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/AbstractDriverBasedDataSource.java
@@ -56,8 +56,9 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * Set the JDBC URL to use for connecting through the Driver.
 	 * @see java.sql.Driver#connect(String, java.util.Properties)
 	 */
-	public void setUrl(@Nullable String url) {
+	public AbstractDriverBasedDataSource setUrl(@Nullable String url) {
 		this.url = (url != null ? url.trim() : null);
+		return this;
 	}
 
 	/**
@@ -72,8 +73,9 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * Set the JDBC username to use for connecting through the Driver.
 	 * @see java.sql.Driver#connect(String, java.util.Properties)
 	 */
-	public void setUsername(@Nullable String username) {
+	public AbstractDriverBasedDataSource setUsername(@Nullable String username) {
 		this.username = username;
+		return this;
 	}
 
 	/**
@@ -88,8 +90,9 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * Set the JDBC password to use for connecting through the Driver.
 	 * @see java.sql.Driver#connect(String, java.util.Properties)
 	 */
-	public void setPassword(@Nullable String password) {
+	public AbstractDriverBasedDataSource setPassword(@Nullable String password) {
 		this.password = password;
+		return this;
 	}
 
 	/**
@@ -105,8 +108,9 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * @since 4.3.2
 	 * @see Connection#setCatalog
 	 */
-	public void setCatalog(@Nullable String catalog) {
+	public AbstractDriverBasedDataSource setCatalog(@Nullable String catalog) {
 		this.catalog = catalog;
+		return this;
 	}
 
 	/**
@@ -123,8 +127,9 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * @since 4.3.2
 	 * @see Connection#setSchema
 	 */
-	public void setSchema(@Nullable String schema) {
+	public AbstractDriverBasedDataSource setSchema(@Nullable String schema) {
 		this.schema = schema;
+		return this;
 	}
 
 	/**
@@ -144,8 +149,9 @@ public abstract class AbstractDriverBasedDataSource extends AbstractDataSource {
 	 * DataSource will override the corresponding connection properties.
 	 * @see java.sql.Driver#connect(String, java.util.Properties)
 	 */
-	public void setConnectionProperties(@Nullable Properties connectionProperties) {
+	public AbstractDriverBasedDataSource setConnectionProperties(@Nullable Properties connectionProperties) {
 		this.connectionProperties = connectionProperties;
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
Make it more convenient for callers when using multiple set methods in a row by allowing method chaining.

My pull request would make the following sample code possible:
var datasource = new SimpleDriverDataSource()
  .setDriver(new org.postgresql.Driver())
  .setUrl("jdbc:postgresql:my_database")
  .setUsername("postgres")
  .setPassword("whatever");

My motivation for this pull request was that I was writing some sample code, and I was tired of constantly having to add "object.method" for each set call like this:
var datasource = new SimpleDriverDataSource();
datasource.setDriver(new org.postgresql.Driver())
datasource.setUrl("jdbc:postgresql:my_database")
datasource.setUsername("postgres")
datasource.setPassword("whatever");

Trying to reduce code writing while having the same functionality, and to make it look more elegant and readable. 

If my request was approved and merged, the "object.method" way of doing it would still work (backwards-compatible) AND also allow method chaining.