### PR TITLE
Fixes #25829 by changing the check away from instanceof. Now checking…

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/multipart/support/RequestPartServletServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/support/RequestPartServletServerHttpRequest.java
@@ -20,8 +20,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-
+import java.util.Collection;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Part;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -81,7 +83,13 @@ public class RequestPartServletServerHttpRequest extends ServletServerHttpReques
 
 	@Override
 	public InputStream getBody() throws IOException {
-		if (this.multipartRequest instanceof StandardMultipartHttpServletRequest) {
+		Collection<Part> parts = null;
+		try {
+			parts = this.multipartRequest.getParts();
+		} catch (ServletException e) {
+			//ignoring this as it might be a non multipart/form-data Content-Type
+		}
+		if (parts != null && !parts.isEmpty()) {
 			try {
 				return this.multipartRequest.getPart(this.partName).getInputStream();
 			}


### PR DESCRIPTION
Fixes #25829 by changing the check away from instanceof. Now checking…… if the request has parts. If this is the case we extract them otherwise use getFile(). Test is added for verification.