### PR TITLE
Drop explicit zeroing at instantiation of Atomic* objects

### DIFF
--- a/integration-tests/src/test/java/org/springframework/scheduling/annotation/ScheduledAndTransactionalAnnotationIntegrationTests.java
+++ b/integration-tests/src/test/java/org/springframework/scheduling/annotation/ScheduledAndTransactionalAnnotationIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,7 +182,7 @@ class ScheduledAndTransactionalAnnotationIntegrationTests {
 	@Aspect
 	public static class MyAspect {
 
-		private final AtomicInteger count = new AtomicInteger(0);
+		private final AtomicInteger count = new AtomicInteger();
 
 		@org.aspectj.lang.annotation.Before("execution(* scheduled())")
 		public void checkTransaction() {
@@ -200,7 +200,7 @@ class ScheduledAndTransactionalAnnotationIntegrationTests {
 	@Repository
 	static class MyRepositoryImpl implements MyRepository {
 
-		private final AtomicInteger count = new AtomicInteger(0);
+		private final AtomicInteger count = new AtomicInteger();
 
 		@Transactional
 		@Scheduled(fixedDelay = 5)
@@ -226,7 +226,7 @@ class ScheduledAndTransactionalAnnotationIntegrationTests {
 	@Repository
 	static class MyRepositoryWithScheduledMethodImpl implements MyRepositoryWithScheduledMethod {
 
-		private final AtomicInteger count = new AtomicInteger(0);
+		private final AtomicInteger count = new AtomicInteger();
 
 		@Autowired(required = false)
 		private MyAspect myAspect;

--- a/spring-aop/src/main/java/org/springframework/aop/support/ControlFlowPointcut.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/ControlFlowPointcut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class ControlFlowPointcut implements Pointcut, ClassFilter, MethodMatcher
 	@Nullable
 	private final String methodName;
 
-	private final AtomicInteger evaluations = new AtomicInteger(0);
+	private final AtomicInteger evaluations = new AtomicInteger();
 
 
 	/**

--- a/spring-beans/src/test/java/org/springframework/beans/factory/FactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/FactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,7 +286,7 @@ public class FactoryBeanTests {
 			}
 			AtomicInteger c = count.get(beanName);
 			if (c == null) {
-				c = new AtomicInteger(0);
+				c = new AtomicInteger();
 				count.put(beanName, c);
 			}
 			c.incrementAndGet();

--- a/spring-context/src/test/java/org/springframework/cache/interceptor/CacheProxyFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/interceptor/CacheProxyFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,7 @@ public class CacheProxyFactoryBeanTests {
 
 	static class SimpleGreeter implements Greeter {
 
-		private final AtomicBoolean cacheMiss = new AtomicBoolean(false);
+		private final AtomicBoolean cacheMiss = new AtomicBoolean();
 
 		@Override
 		public boolean isCacheMiss() {

--- a/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
+++ b/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
@@ -474,7 +474,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 		 * The total number of references contained in this segment. This includes chained
 		 * references and references that have been garbage collected but not purged.
 		 */
-		private final AtomicInteger count = new AtomicInteger(0);
+		private final AtomicInteger count = new AtomicInteger();
 
 		/**
 		 * The threshold when resizing of the references should occur. When {@code count}

--- a/spring-core/src/main/java/org/springframework/util/CustomizableThreadCreator.java
+++ b/spring-core/src/main/java/org/springframework/util/CustomizableThreadCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class CustomizableThreadCreator implements Serializable {
 	@Nullable
 	private ThreadGroup threadGroup;
 
-	private final AtomicInteger threadCount = new AtomicInteger(0);
+	private final AtomicInteger threadCount = new AtomicInteger();
 
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/SimpleIdGenerator.java
+++ b/spring-core/src/main/java/org/springframework/util/SimpleIdGenerator.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class SimpleIdGenerator implements IdGenerator {
 
-	private final AtomicLong leastSigBits = new AtomicLong(0);
+	private final AtomicLong leastSigBits = new AtomicLong();
 
 
 	@Override

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/SpelExpression.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/SpelExpression.java
@@ -71,11 +71,11 @@ public class SpelExpression implements Expression {
 
 	// Count of many times as the expression been interpreted - can trigger compilation
 	// when certain limit reached
-	private final AtomicInteger interpretedCount = new AtomicInteger(0);
+	private final AtomicInteger interpretedCount = new AtomicInteger();
 
 	// The number of times compilation was attempted and failed - enables us to eventually
 	// give up trying to compile it when it just doesn't seem to be possible.
-	private final AtomicInteger failedAttempts = new AtomicInteger(0);
+	private final AtomicInteger failedAttempts = new AtomicInteger();
 
 
 	/**

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/AbstractBrokerMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/AbstractBrokerMessageHandler.java
@@ -63,7 +63,7 @@ public abstract class AbstractBrokerMessageHandler
 	@Nullable
 	private ApplicationEventPublisher eventPublisher;
 
-	private AtomicBoolean brokerAvailable = new AtomicBoolean(false);
+	private AtomicBoolean brokerAvailable = new AtomicBoolean();
 
 	private final BrokerAvailabilityEvent availableEvent = new BrokerAvailabilityEvent(true, this);
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/OrderedMessageChannelDecorator.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/OrderedMessageChannelDecorator.java
@@ -52,7 +52,7 @@ public class OrderedMessageChannelDecorator implements MessageChannel {
 
 	private final Queue<Message<?>> messages = new ConcurrentLinkedQueue<>();
 
-	private final AtomicBoolean sendInProgress = new AtomicBoolean(false);
+	private final AtomicBoolean sendInProgress = new AtomicBoolean();
 
 
 	public OrderedMessageChannelDecorator(MessageChannel channel, Log logger) {

--- a/spring-messaging/src/test/java/org/springframework/messaging/rsocket/DefaultRSocketRequesterTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/rsocket/DefaultRSocketRequesterTests.java
@@ -185,7 +185,7 @@ public class DefaultRSocketRequesterTests {
 
 	@Test
 	public void retrieveMonoVoid() {
-		AtomicBoolean consumed = new AtomicBoolean(false);
+		AtomicBoolean consumed = new AtomicBoolean();
 		Mono<Payload> mono = Mono.delay(MILLIS_10).thenReturn(toPayload("bodyA")).doOnSuccess(p -> consumed.set(true));
 		this.rsocket.setPayloadMonoToReturn(mono);
 		this.requester.route("").data("").retrieveMono(Void.class).block(Duration.ofSeconds(5));
@@ -215,7 +215,7 @@ public class DefaultRSocketRequesterTests {
 
 	@Test
 	public void retrieveFluxVoid() {
-		AtomicBoolean consumed = new AtomicBoolean(false);
+		AtomicBoolean consumed = new AtomicBoolean();
 		Flux<Payload> flux = Flux.just("bodyA", "bodyB")
 				.delayElements(MILLIS_10).map(this::toPayload).doOnComplete(() -> consumed.set(true));
 		this.rsocket.setPayloadFluxToReturn(flux);

--- a/spring-messaging/src/test/java/org/springframework/messaging/rsocket/RSocketClientToServerIntegrationTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/rsocket/RSocketClientToServerIntegrationTests.java
@@ -317,9 +317,9 @@ public class RSocketClientToServerIntegrationTests {
 
 		private RSocket delegate;
 
-		private final AtomicInteger fireAndForgetCount = new AtomicInteger(0);
+		private final AtomicInteger fireAndForgetCount = new AtomicInteger();
 
-		private final AtomicInteger metadataPushCount = new AtomicInteger(0);
+		private final AtomicInteger metadataPushCount = new AtomicInteger();
 
 
 		public int getFireAndForgetCount() {

--- a/spring-messaging/src/test/java/org/springframework/messaging/support/ChannelInterceptorTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/support/ChannelInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,8 +86,8 @@ public class ChannelInterceptorTests {
 
 	@Test
 	public void postSendInterceptorMessageWasSent() {
-		final AtomicBoolean preSendInvoked = new AtomicBoolean(false);
-		final AtomicBoolean completionInvoked = new AtomicBoolean(false);
+		final AtomicBoolean preSendInvoked = new AtomicBoolean();
+		final AtomicBoolean completionInvoked = new AtomicBoolean();
 		this.channel.addInterceptor(new ChannelInterceptor() {
 			@Override
 			public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
@@ -119,8 +119,8 @@ public class ChannelInterceptorTests {
 				return false;
 			}
 		};
-		final AtomicBoolean preSendInvoked = new AtomicBoolean(false);
-		final AtomicBoolean completionInvoked = new AtomicBoolean(false);
+		final AtomicBoolean preSendInvoked = new AtomicBoolean();
+		final AtomicBoolean completionInvoked = new AtomicBoolean();
 		testChannel.addInterceptor(new ChannelInterceptor() {
 			@Override
 			public void postSend(Message<?> message, MessageChannel channel, boolean sent) {

--- a/spring-orm/src/test/java/org/springframework/orm/jpa/support/OpenEntityManagerInViewTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/jpa/support/OpenEntityManagerInViewTests.java
@@ -351,7 +351,7 @@ public class OpenEntityManagerInViewTests {
 		final OpenEntityManagerInViewFilter filter2 = new OpenEntityManagerInViewFilter();
 		filter2.init(filterConfig2);
 
-		final AtomicInteger count = new AtomicInteger(0);
+		final AtomicInteger count = new AtomicInteger();
 
 		final FilterChain filterChain = (servletRequest, servletResponse) -> {
 			assertThat(TransactionSynchronizationManager.hasResource(factory)).isTrue();
@@ -359,7 +359,7 @@ public class OpenEntityManagerInViewTests {
 			count.incrementAndGet();
 		};
 
-		final AtomicInteger count2 = new AtomicInteger(0);
+		final AtomicInteger count2 = new AtomicInteger();
 
 		final FilterChain filterChain2 = (servletRequest, servletResponse) -> {
 			assertThat(TransactionSynchronizationManager.hasResource(factory2)).isTrue();

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ class TransactionContext {
 	@Nullable
 	private TransactionStatus transactionStatus;
 
-	private final AtomicInteger transactionsStarted = new AtomicInteger(0);
+	private final AtomicInteger transactionsStarted = new AtomicInteger();
 
 
 	TransactionContext(TestContext testContext, PlatformTransactionManager transactionManager,

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpSessionTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpSessionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ class MockHttpSessionTests {
 	private static class CountingHttpSessionBindingListener
 			implements HttpSessionBindingListener {
 
-		private final AtomicInteger counter = new AtomicInteger(0);
+		private final AtomicInteger counter = new AtomicInteger();
 
 		@Override
 		public void valueBound(HttpSessionBindingEvent event) {

--- a/spring-test/src/test/java/org/springframework/test/context/cache/ClassLevelDirtiesContextTestNGTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/cache/ClassLevelDirtiesContextTestNGTests.java
@@ -52,8 +52,8 @@ import static org.springframework.test.context.cache.ContextCacheTestUtils.reset
  */
 class ClassLevelDirtiesContextTestNGTests {
 
-	private static final AtomicInteger cacheHits = new AtomicInteger(0);
-	private static final AtomicInteger cacheMisses = new AtomicInteger(0);
+	private static final AtomicInteger cacheHits = new AtomicInteger();
+	private static final AtomicInteger cacheMisses = new AtomicInteger();
 
 
 	@BeforeAll

--- a/spring-test/src/test/java/org/springframework/test/context/cache/ClassLevelDirtiesContextTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/cache/ClassLevelDirtiesContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,8 +51,8 @@ import static org.springframework.test.context.junit4.JUnitTestingUtils.runTests
  */
 class ClassLevelDirtiesContextTests {
 
-	private static final AtomicInteger cacheHits = new AtomicInteger(0);
-	private static final AtomicInteger cacheMisses = new AtomicInteger(0);
+	private static final AtomicInteger cacheHits = new AtomicInteger();
+	private static final AtomicInteger cacheMisses = new AtomicInteger();
 
 
 	@BeforeAll

--- a/spring-test/src/test/java/org/springframework/test/context/configuration/interfaces/DirtiesContextInterfaceTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/configuration/interfaces/DirtiesContextInterfaceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,8 @@ import static org.springframework.test.context.junit4.JUnitTestingUtils.runTests
  */
 class DirtiesContextInterfaceTests {
 
-	private static final AtomicInteger cacheHits = new AtomicInteger(0);
-	private static final AtomicInteger cacheMisses = new AtomicInteger(0);
+	private static final AtomicInteger cacheHits = new AtomicInteger();
+	private static final AtomicInteger cacheMisses = new AtomicInteger();
 
 
 	@BeforeAll

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/spr/HttpOptionsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/spr/HttpOptionsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public class HttpOptionsTests {
 	@Controller
 	private static class MyController {
 
-		private AtomicInteger counter = new AtomicInteger(0);
+		private AtomicInteger counter = new AtomicInteger();
 
 
 		@RequestMapping(value = "/myUrl", method = RequestMethod.OPTIONS)

--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/AbstractReactiveTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/AbstractReactiveTransactionManager.java
@@ -431,7 +431,7 @@ public abstract class AbstractReactiveTransactionManager implements ReactiveTran
 	private Mono<Void> processCommit(TransactionSynchronizationManager synchronizationManager,
 			GenericReactiveTransaction status) throws TransactionException {
 
-		AtomicBoolean beforeCompletionInvoked = new AtomicBoolean(false);
+		AtomicBoolean beforeCompletionInvoked = new AtomicBoolean();
 
 		Mono<Object> commit = prepareForCommit(synchronizationManager, status)
 				.then(triggerBeforeCommit(synchronizationManager, status))

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpResponse.java
@@ -62,7 +62,7 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 	private final NettyDataBufferFactory bufferFactory;
 
 	// 0 - not subscribed, 1 - subscribed, 2 - cancelled via connector (before subscribe)
-	private final AtomicInteger state = new AtomicInteger(0);
+	private final AtomicInteger state = new AtomicInteger();
 
 	private final String logPrefix;
 

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/SynchronossPartHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/SynchronossPartHttpMessageReader.java
@@ -339,7 +339,7 @@ public class SynchronossPartHttpMessageReader extends LoggingCodecSupport implem
 
 		private final LimitedPartBodyStreamStorageFactory storageFactory;
 
-		private final AtomicInteger terminated = new AtomicInteger(0);
+		private final AtomicInteger terminated = new AtomicInteger();
 
 		FluxSinkAdapterListener(
 				FluxSink<Part> sink, MultipartContext context, LimitedPartBodyStreamStorageFactory factory) {

--- a/spring-web/src/main/java/org/springframework/http/server/ServletServerHttpAsyncRequestControl.java
+++ b/spring-web/src/main/java/org/springframework/http/server/ServletServerHttpAsyncRequestControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class ServletServerHttpAsyncRequestControl implements ServerHttpAsyncRequ
 	@Nullable
 	private AsyncContext asyncContext;
 
-	private AtomicBoolean asyncCompleted = new AtomicBoolean(false);
+	private AtomicBoolean asyncCompleted = new AtomicBoolean();
 
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
@@ -48,7 +48,7 @@ import org.springframework.util.MultiValueMap;
  */
 class ReactorServerHttpRequest extends AbstractServerHttpRequest {
 
-	private static final AtomicLong logPrefixIndex = new AtomicLong(0);
+	private static final AtomicLong logPrefixIndex = new AtomicLong();
 
 
 	private final HttpServerRequest request;

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/StandardServletAsyncWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/StandardServletAsyncWebRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class StandardServletAsyncWebRequest extends ServletWebRequest implements
 
 	private AsyncContext asyncContext;
 
-	private AtomicBoolean asyncCompleted = new AtomicBoolean(false);
+	private AtomicBoolean asyncCompleted = new AtomicBoolean();
 
 	private final List<Runnable> timeoutHandlers = new ArrayList<>();
 

--- a/spring-web/src/test/java/org/springframework/http/client/reactive/ReactorResourceFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/reactive/ReactorResourceFactoryTests.java
@@ -61,7 +61,7 @@ public class ReactorResourceFactoryTests {
 	@Test
 	void globalResourcesWithConsumer() throws Exception {
 
-		AtomicBoolean invoked = new AtomicBoolean(false);
+		AtomicBoolean invoked = new AtomicBoolean();
 
 		this.resourceFactory.addGlobalResourcesConsumer(httpResources -> invoked.set(true));
 		this.resourceFactory.afterPropertiesSet();

--- a/spring-web/src/test/java/org/springframework/http/codec/support/ClientCodecConfigurerTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/support/ClientCodecConfigurerTests.java
@@ -75,7 +75,7 @@ public class ClientCodecConfigurerTests {
 
 	private final ClientCodecConfigurer configurer = new DefaultClientCodecConfigurer();
 
-	private final AtomicInteger index = new AtomicInteger(0);
+	private final AtomicInteger index = new AtomicInteger();
 
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/http/codec/support/CodecConfigurerTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/support/CodecConfigurerTests.java
@@ -73,7 +73,7 @@ class CodecConfigurerTests {
 
 	private final CodecConfigurer configurer = new TestCodecConfigurer();
 
-	private final AtomicInteger index = new AtomicInteger(0);
+	private final AtomicInteger index = new AtomicInteger();
 
 
 	@Test
@@ -374,7 +374,7 @@ class CodecConfigurerTests {
 	@SuppressWarnings("deprecation")
 	@Test
 	void withDefaultCodecConfig() {
-		AtomicBoolean callbackCalled = new AtomicBoolean(false);
+		AtomicBoolean callbackCalled = new AtomicBoolean();
 		this.configurer.defaultCodecs().enableLoggingRequestDetails(true);
 		this.configurer.customCodecs().withDefaultCodecConfig(config -> {
 			assertThat(config.isEnableLoggingRequestDetails()).isTrue();

--- a/spring-web/src/test/java/org/springframework/http/codec/support/ServerCodecConfigurerTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/support/ServerCodecConfigurerTests.java
@@ -77,7 +77,7 @@ public class ServerCodecConfigurerTests {
 
 	private final ServerCodecConfigurer configurer = new DefaultServerCodecConfigurer();
 
-	private final AtomicInteger index = new AtomicInteger(0);
+	private final AtomicInteger index = new AtomicInteger();
 
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/ContextPathCompositeHandlerTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/ContextPathCompositeHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ public class ContextPathCompositeHandlerTests {
 	@Test // SPR-17144
 	public void notFoundWithCommitAction() {
 
-		AtomicBoolean commitInvoked = new AtomicBoolean(false);
+		AtomicBoolean commitInvoked = new AtomicBoolean();
 
 		ServerHttpRequest request = MockServerHttpRequest.get("/unknown/path").build();
 		ServerHttpResponse response = new MockServerHttpResponse();

--- a/spring-web/src/test/java/org/springframework/web/server/adapter/WebHttpHandlerBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/adapter/WebHttpHandlerBuilderTests.java
@@ -123,7 +123,7 @@ public class WebHttpHandlerBuilderTests {
 		BiFunction<ServerHttpRequest, String, ServerHttpRequest> mutator =
 				(req, value) -> req.mutate().headers(headers -> headers.add("My-Header", value)).build();
 
-		AtomicBoolean success = new AtomicBoolean(false);
+		AtomicBoolean success = new AtomicBoolean();
 		HttpHandler httpHandler = WebHttpHandlerBuilder
 				.webHandler(exchange -> {
 					HttpHeaders headers = exchange.getRequest().getHeaders();

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/DefaultTransportRequest.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/DefaultTransportRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ class DefaultTransportRequest implements TransportRequest {
 
 		private final SettableListenableFuture<WebSocketSession> future;
 
-		private final AtomicBoolean handled = new AtomicBoolean(false);
+		private final AtomicBoolean handled = new AtomicBoolean();
 
 		public ConnectCallback(WebSocketHandler handler, SettableListenableFuture<WebSocketSession> future) {
 			this.handler = handler;

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/WebSocketTransport.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/WebSocketTransport.java
@@ -145,7 +145,7 @@ public class WebSocketTransport implements Transport, Lifecycle {
 
 		private final WebSocketClientSockJsSession sockJsSession;
 
-		private final AtomicBoolean connected = new AtomicBoolean(false);
+		private final AtomicBoolean connected = new AtomicBoolean();
 
 		public ClientSockJsWebSocketHandler(WebSocketClientSockJsSession session) {
 			Assert.notNull(session, "Session must not be null");

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/SockJsWebSocketHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/SockJsWebSocketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class SockJsWebSocketHandler extends TextWebSocketHandler implements SubP
 
 	private final List<String> subProtocols;
 
-	private final AtomicInteger sessionCount = new AtomicInteger(0);
+	private final AtomicInteger sessionCount = new AtomicInteger();
 
 
 	public SockJsWebSocketHandler(SockJsServiceConfig serviceConfig, WebSocketHandler webSocketHandler,


### PR DESCRIPTION
Often fields of atomic types e.g. AtomicInteger are explicitly zeroed at initialization, which is redundant and slower than relying on default values:
```java
@State(Scope.Thread)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@BenchmarkMode(value = Mode.AverageTime)
public class AtomicBenchmark {
  @Benchmark
  public Object defaultValue() {
    return new AtomicInteger();
  }
  @Benchmark
  public Object explicitValue() {
    return new AtomicInteger(0);
  }
}
```
Semantically both new AtomicInteger() and new AtomicInteger(0) are the same, but explicitValue() is much slower:
```java
Benchmark                      Mode  Cnt   Score   Error  Units
AtomicBenchmark.defaultValue   avgt   30   4.778 ± 0.403  ns/op
AtomicBenchmark.explicitValue  avgt   30  11.846 ± 0.273  ns/op
```
This is related to https://github.com/spring-projects/spring-framework/pull/25261