### PR TITLE
Give `spring-core` access to `jdk.unsupported` for Objenesis support on WildFly

### DIFF
--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -75,6 +75,7 @@ dependencies {
 jar {
 	reproducibleFileOrder = true
 	preserveFileTimestamps = false // maybe not necessary here, but good for reproducibility
+	manifest.attributes["Dependencies"] = "jdk.unsupported" // JBoss modules
 
 	// Inline repackaged cglib classes directly into spring-core jar
 	dependsOn cglibRepackJar


### PR DESCRIPTION
Add a Dependencies manifest entry with the value jdk.unsupported to
spring-core.

Objenesis repackaged in Spring Core needs access to `sun.reflect.ReflectionFactory` located in the `jdk.unsupported` module. WildFly by default restricts applications from accessing the `jdk.unsupported` module ([WFCORE-4055](https://issues.redhat.com/browse/WFCORE-4055)). This leads to obscure exceptions like #21528. In our case the default constructor of a Spring Batch job scoped bean could not be found. This was confusing because the bean had an autowired non-default constructor. The problem and solution were not obvious to us.

To give Objenesis in spring-core access to the `jdk.unsupported` module users need to do either of the following:

- Add a [Dependencies](https://docs.wildfly.org/20/Developer_Guide.html#dependencies-manifest-entries) manifest entry to the application or module itself
- Use [jboss-deployment-structure.xml](https://docs.wildfly.org/20/Developer_Guide.html#jboss-deployment-structure-file)

As Spring Core uses a repackaged Objenesis we can instead add the `Dependencies` manifest header to spring-core itself making things "just work"(tm) for Spring users on WildFly.
