### PR TITLE
Introduce SQL statement filter support in JDBC `ScriptUtils`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/InitSqlFilter.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/InitSqlFilter.java
@@ -1,0 +1,41 @@
+/* Copyright 2002-2017 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.springframework.jdbc.datasource.init;
+
+/**
+ * SPI for ignore some sql statements on DataSourceInitializer.
+ *
+ * @author qxo
+ * @since 5.3
+ */
+public interface InitSqlFilter {
+
+	/**
+	 * Check whether the sql should ignore before execute.
+	 *
+	 * @param sql
+	 * @return true if only the sql should ignored.
+	 */
+	boolean shouldIgnore(String sql);
+
+	/**
+	 * Check whether the sql should ignore when execute failed.
+	 *
+	 * @param sql
+	 * @return true if only the sql should ignored.
+	 */
+	boolean shouldIgnoreOnFailed(String sql);
+}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/InitSqlFilterDefault.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/InitSqlFilterDefault.java
@@ -1,0 +1,51 @@
+/* Copyright 2002-2017 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.springframework.jdbc.datasource.init;
+
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+
+public class InitSqlFilterDefault implements InitSqlFilter {
+
+	private boolean ignoreFailedDrops;
+	
+	private Pattern ignorePattern; 
+
+	@Override
+	public boolean shouldIgnore(String sql) {
+		if (ignorePattern != null) {
+			return ignorePattern.matcher(sql).matches();
+		}
+		return false;
+	}
+
+	@Override
+	public boolean shouldIgnoreOnFailed(String sql) {
+		if (ignoreFailedDrops) {
+			return StringUtils.startsWithIgnoreCase(sql.trim(), "drop");
+		}
+		return false;
+	}
+
+	public void setIgnoreFailedDrops(boolean ignoreFailedDrops) {
+		this.ignoreFailedDrops = ignoreFailedDrops;
+	}
+	
+	public void setIgnorePattern(String pattern) {
+		ignorePattern = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+	}
+}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ResourceDatabasePopulator.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ResourceDatabasePopulator.java
@@ -72,6 +72,7 @@ public class ResourceDatabasePopulator implements DatabasePopulator {
 
 	private boolean ignoreFailedDrops = false;
 
+	private String sqlIgnorePattern;
 
 	/**
 	 * Construct a new {@code ResourceDatabasePopulator} with default settings.
@@ -241,6 +242,21 @@ public class ResourceDatabasePopulator implements DatabasePopulator {
 		this.ignoreFailedDrops = ignoreFailedDrops;
 	}
 
+	/**
+	 * regex pattern for ignore sql statement.
+	 *
+	 * @param sqlIgnorePattern regex pattern for ignore
+	 */
+	public void setSqlIgnorePattern(String sqlIgnorePattern) {
+		this.sqlIgnorePattern = sqlIgnorePattern;
+	}
+
+	/**
+	 * ignore delete|drop|update SQL.
+	 */
+	public void ignoreDeleteUpdateDrop() {
+		setSqlIgnorePattern("^\\s*(delete|drop|update).+");
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -249,9 +265,14 @@ public class ResourceDatabasePopulator implements DatabasePopulator {
 	@Override
 	public void populate(Connection connection) throws ScriptException {
 		Assert.notNull(connection, "'connection' must not be null");
+		final InitSqlFilterDefault filter = new InitSqlFilterDefault();
+		filter.setIgnoreFailedDrops(ignoreFailedDrops);
+		if (sqlIgnorePattern != null) {
+			filter.setIgnorePattern(sqlIgnorePattern);
+		}
 		for (Resource script : this.scripts) {
 			EncodedResource encodedScript = new EncodedResource(script, this.sqlScriptEncoding);
-			ScriptUtils.executeSqlScript(connection, encodedScript, this.continueOnError, this.ignoreFailedDrops,
+			ScriptUtils.executeSqlScript(connection, encodedScript, this.continueOnError, filter,
 					this.commentPrefixes, this.separator, this.blockCommentStartDelimiter, this.blockCommentEndDelimiter);
 		}
 	}


### PR DESCRIPTION
so we can skip some sql statements by regex pattern,
such as: we do not want run delete/update/drop statements on production environment.
just call ResourceDatabasePopulator.ignoreDeleteUpdateDrop to lock sqlIgnorePattern=^\\s*(delete|drop|update).+

sorry for my poor english...and someone please help me fix  the english javadocs!