### PR TITLE
Close Body after reading

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
@@ -216,6 +216,11 @@ public abstract class AbstractMessageConverterMethodArgumentResolver implements 
 		catch (IOException ex) {
 			throw new HttpMessageNotReadableException("I/O error while reading input message", ex, inputMessage);
 		}
+		finally {
+			if (message.hasBody()) {
+				message.getBody().close();
+			}
+		}
 
 		if (body == NO_VALUE) {
 			if (httpMethod == null || !SUPPORTED_METHODS.contains(httpMethod) ||


### PR DESCRIPTION
readWithMessageConverters opens a FileInputStream but does not ensure it closes after reading from it.
Ensure the FileInputStream is closed.

Solves Issue:
https://github.com/spring-projects/spring-framework/issues/25896