### PR TITLE
Avoid multiple volatile reads/writes in a row where only one is enough

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/MethodInvocationProceedingJoinPoint.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/MethodInvocationProceedingJoinPoint.java
@@ -221,10 +221,11 @@ public class MethodInvocationProceedingJoinPoint implements ProceedingJoinPoint,
 		@Override
 		@Nullable
 		public String[] getParameterNames() {
-			if (this.parameterNames == null) {
-				this.parameterNames = parameterNameDiscoverer.getParameterNames(getMethod());
+			String[] parameterNames = this.parameterNames;
+			if (parameterNames == null) {
+				this.parameterNames = parameterNames = parameterNameDiscoverer.getParameterNames(getMethod());
 			}
-			return this.parameterNames;
+			return parameterNames;
 		}
 
 		@Override

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
@@ -644,21 +644,20 @@ public class AutowiredAnnotationBeanPostProcessor implements SmartInstantiationA
 				}
 				synchronized (this) {
 					if (!this.cached) {
+						Object cachedFieldValue = null;
 						if (value != null || this.required) {
-							this.cachedFieldValue = desc;
+							cachedFieldValue = desc;
 							registerDependentBeans(beanName, autowiredBeanNames);
 							if (autowiredBeanNames.size() == 1) {
 								String autowiredBeanName = autowiredBeanNames.iterator().next();
 								if (beanFactory.containsBean(autowiredBeanName) &&
 										beanFactory.isTypeMatch(autowiredBeanName, field.getType())) {
-									this.cachedFieldValue = new ShortcutDependencyDescriptor(
+									cachedFieldValue = new ShortcutDependencyDescriptor(
 											desc, autowiredBeanName, field.getType());
 								}
 							}
 						}
-						else {
-							this.cachedFieldValue = null;
-						}
+						this.cachedFieldValue = cachedFieldValue;
 						this.cached = true;
 					}
 				}

--- a/spring-context/src/main/java/org/springframework/cache/support/AbstractCacheManager.java
+++ b/spring-context/src/main/java/org/springframework/cache/support/AbstractCacheManager.java
@@ -155,8 +155,7 @@ public abstract class AbstractCacheManager implements CacheManager, Initializing
 	 * @param name the name of the cache to be added
 	 */
 	private void updateCacheNames(String name) {
-		Set<String> cacheNames = new LinkedHashSet<>(this.cacheNames.size() + 1);
-		cacheNames.addAll(this.cacheNames);
+		Set<String> cacheNames = new LinkedHashSet<>(this.cacheNames);
 		cacheNames.add(name);
 		this.cacheNames = Collections.unmodifiableSet(cacheNames);
 	}


### PR DESCRIPTION
- in `MethodInvocationProceedingJoinPoint` use the same approach as in `InjectionPoint.getAnnotations()` to do only one volatile read for all calls after field initialization instead of two.
- in `AutowiredAnnotationBeanPostProcessor` we are guareded by `synchronized`
- `AbstractCacheManager` newly created `LinkedHashSet` always has some extra capacity, so calculation of it's size +1 is redundant