### PR TITLE
Extending the incoming Stomp sessionId as an attribute in TcpClient

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,6 +42,7 @@ import org.springframework.messaging.simp.SimpLogging;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.messaging.tcp.TcpConnection;
+import org.springframework.messaging.tcp.TcpConnectionConfiguration;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.AlternativeJdkIdGenerator;
 import org.springframework.util.Assert;
@@ -378,6 +380,13 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 
 
 	// TcpConnectionHandler
+
+	@Override
+	public void beforeConnect(final TcpConnectionConfiguration connectionConfiguration) {
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put(StompBrokerRelayMessageHandler.SESSION_ID_KEY, getSessionId());
+		connectionConfiguration.attributes(Collections.unmodifiableMap(attributes));
+	}
 
 	@Override
 	public void afterConnected(TcpConnection<byte[]> connection) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
@@ -18,6 +18,7 @@ package org.springframework.messaging.simp.stomp;
 
 import java.security.Principal;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -41,6 +42,7 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.messaging.support.MessageHeaderInitializer;
 import org.springframework.messaging.tcp.FixedIntervalReconnectStrategy;
 import org.springframework.messaging.tcp.TcpConnection;
+import org.springframework.messaging.tcp.TcpConnectionConfiguration;
 import org.springframework.messaging.tcp.TcpConnectionHandler;
 import org.springframework.messaging.tcp.TcpOperations;
 import org.springframework.messaging.tcp.reactor.ReactorNettyCodec;
@@ -80,6 +82,11 @@ import org.springframework.util.concurrent.ListenableFutureTask;
  * @since 4.0
  */
 public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler {
+
+	/**
+	 * The name of the key to hold the identifier of the Stomp session.
+	 */
+	public static final String SESSION_ID_KEY = "sessionId";
 
 	/**
 	 * The system session ID.
@@ -382,6 +389,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 
 	/**
 	 * Return a String describing internal state and counters.
+	 * Return a String describing internal state and counters.
 	 * Effectively {@code toString()} on {@link #getStats() getStats()}.
 	 */
 	public String getStatsInfo() {
@@ -616,6 +624,13 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 		@Nullable
 		protected TcpConnection<byte[]> getTcpConnection() {
 			return this.tcpConnection;
+		}
+
+		@Override
+		public void beforeConnect(final TcpConnectionConfiguration connectionConfiguration) {
+			Map<String, String> attributes = new HashMap<>();
+			attributes.put(StompBrokerRelayMessageHandler.SESSION_ID_KEY, getSessionId());
+			connectionConfiguration.attributes(Collections.unmodifiableMap(attributes));
 		}
 
 		@Override

--- a/spring-messaging/src/main/java/org/springframework/messaging/tcp/TcpConnectionConfiguration.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/tcp/TcpConnectionConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.messaging.tcp;
+
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Allows specifying some configuration to setup the TCP connection.
+ *
+ * @author Ruben Perez
+ * @see TcpConnectionHandler
+ */
+public interface TcpConnectionConfiguration {
+	/**
+	 * Specifies the attributes to pass on to the TCP client for setting up the TCP connection.
+	 * @param settings a @{@link Map} of attributes
+	 */
+	void attributes(@Nonnull Map<String, String> settings);
+}

--- a/spring-messaging/src/main/java/org/springframework/messaging/tcp/TcpConnectionHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/tcp/TcpConnectionHandler.java
@@ -27,6 +27,11 @@ import org.springframework.messaging.Message;
  * @param <P> the type of payload for in and outbound messages
  */
 public interface TcpConnectionHandler<P> {
+	/**
+	 *	Invoked before connect.
+	 *	@param connectionConfiguration allows extending the functionality of the TCP client
+	 */
+	void beforeConnect(TcpConnectionConfiguration connectionConfiguration);
 
 	/**
 	 * Invoked after a connection is successfully established.


### PR DESCRIPTION
The final idea is to be able to balance the load of the Stomp cluster, by grouping all sessions from the same user in the same Stomp Broker Relay server.

In order to achieve this, the very bare minimum is to gain access to the session Id at the TcpClient#doOnConnect callbacks, in order to customize from there the specific instance of the TcpClient#remoteAddress supplier.

Of course, passing on the whole StompHeaderAccessor from StompBrokerRelayMessageHandler#handleMessageInternal to ReactorNettyTcpClient may be better for my case, but it may perhaps make the average usages a bit more complicated.

I am very much open for suggestions or discussions on this matter.

This solves #25889 .