### PR TITLE
UriBuilder - Overload queryParam to accept Optional and add only if value is present

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.MultiValueMap;
@@ -331,6 +332,12 @@ public class DefaultUriBuilderFactory implements UriBuilderFactory {
 		@Override
 		public DefaultUriBuilder queryParam(String name, Object... values) {
 			this.uriComponentsBuilder.queryParam(name, values);
+			return this;
+		}
+
+		@Override
+		public DefaultUriBuilder queryParam(String name, Optional<?> value) {
+			this.uriComponentsBuilder.queryParam(name, value);
 			return this;
 		}
 

--- a/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
@@ -19,6 +19,7 @@ package org.springframework.web.util;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.MultiValueMap;
@@ -184,6 +185,13 @@ public interface UriBuilder {
 	 * @see #queryParam(String, Collection)
 	 */
 	UriBuilder queryParam(String name, Object... values);
+
+	/**
+	 * Append the given query parameter if and only if the Optional is not empty.
+	 * @param name the query parameter name
+	 * @param value and Optional containing the query parameter value
+	 */
+	UriBuilder queryParam(String name, Optional<?> value);
 
 	/**
 	 * Variant of {@link #queryParam(String, Object...)} with a Collection.

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -27,6 +27,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -706,6 +707,11 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 		}
 		resetSchemeSpecificPart();
 		return this;
+	}
+
+	@Override
+	public UriComponentsBuilder queryParam(String name, Optional<?> value) {
+		return value.isPresent() ? queryParam(name, value.get()) : this;
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -756,6 +757,18 @@ class UriComponentsBuilderTests {
 		expectedQueryParams.add("baz", "42");
 		assertThat(result.getQueryParams()).isEqualTo(expectedQueryParams);
 	}
+
+	@Test
+	void queryParamAsOptional() {
+		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
+		UriComponents result = builder.queryParam("baz", Optional.of("qux")).queryParam("foo", Optional.empty()).build();
+
+		assertThat(result.getQuery()).isEqualTo("baz=qux");
+		MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>(1);
+		expectedQueryParams.add("baz", "qux");
+		assertThat(result.getQueryParams()).isEqualTo(expectedQueryParams);
+	}
+
 
 	@Test
 	void emptyQueryParam() {


### PR DESCRIPTION
This addresses a use-case in which a REST endpoint (A) has received an optional query param (as type Optional) and is delegating through WebClient to another service (B), probably with a similar uri structure.

Rather than have service (A) interrogate the parameter and branch its execution flow, it can merely include it in the chain of .queryParam() invocations on UriBuilder.  The parameter will be added in the downstream call to service (B) only if a value is present.

Without this change:

```
        Function<UriBuilder, URI> f = (b) -> {
            b = b.path("/eventdates");
            if(context.isPresent()) {
                b = b.queryParam("context", context);
            }
            b = b.queryParam("limit", 3);
            return b.build();
        };
        WebClient.ResponseSpec body = service.get().uri(f).accept(MediaType.APPLICATION_JSON).retrieve();
```

With this change (queryParam for "context" is passed an Optional):

```
        WebClient.ResponseSpec body = service.get().uri(b -> b.path("/eventdates").queryParam("context", context).queryParam("limit", 3).build()).accept(MediaType.APPLICATION_JSON).retrieve();
```
