### PR TITLE
Removes absolute URI check to support Unix Domain Socket URIs

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
@@ -100,10 +100,6 @@ public class ReactorClientHttpConnector implements ClientHttpConnector {
 	public Mono<ClientHttpResponse> connect(HttpMethod method, URI uri,
 			Function<? super ClientHttpRequest, Mono<Void>> requestCallback) {
 
-		if (!uri.isAbsolute()) {
-			return Mono.error(new IllegalArgumentException("URI is not absolute: " + uri));
-		}
-
 		AtomicReference<ReactorClientHttpResponse> responseRef = new AtomicReference<>();
 
 		return this.httpClient


### PR DESCRIPTION
With support coming for [Unix Domain Sockets from io.projectreactor.netty](https://projectreactor.io/docs/netty/1.0.0-RC2/reference/index.html#_unix_domain_sockets_4) URIs no longer need to be absolute.