### PR TITLE
Spring-Aspects: @Configurable declare parents have non reproducible builds

### DIFF
--- a/spring-aspects/src/main/java/org/springframework/beans/factory/aspectj/AnnotationBeanConfigurerAspect.aj
+++ b/spring-aspects/src/main/java/org/springframework/beans/factory/aspectj/AnnotationBeanConfigurerAspect.aj
@@ -89,6 +89,6 @@ public aspect AnnotationBeanConfigurerAspect extends AbstractInterfaceDrivenDepe
 	 * This declaration shouldn't be needed,
 	 * except for an AspectJ bug (https://bugs.eclipse.org/bugs/show_bug.cgi?id=214559)
 	 */
-	declare parents: @Configurable Serializable+ implements ConfigurableDeserializationSupport;
+	declare parents: @Configurable Serializable+ implements ConfigurableObject, ConfigurableDeserializationSupport;
 
 }


### PR DESCRIPTION
In an attempt to make our builds reproducible, I noticed that this declare parents seem to apply in different orders, resulting in different bytecode.
There are 3 declare parents (including the parent class) involved around @Configurable and seem to be applied in different orders.
It seems to me since Interfaces can have static state with initialisers aspectJ cannot reorder them. Therefore the declare parents must be written in a way that the order is defined.
The exact root cause is not quite clear to me, if someone could enlighten me, thank you.

Sample project here:
https://github.com/ls-urs-keller/spring-aspects-reproducible-build
Run `./test.sh` add the root of the project, it will repeat building the project until the resulting bytecode differs.

You should see something like:

```
run 11
[INFO] Scanning for projects...
[INFO]
[INFO] ----------------------< org.example:aspectj-test >----------------------
[INFO] Building aspectj-test 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ aspectj-test ---
[INFO] Deleting /project/target
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ aspectj-test ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /project/src/main/resources
[INFO]
[INFO] --- aspectj-maven-plugin:1.12.1:compile (ajc-compile) @ aspectj-test ---
[INFO] Showing AJC message detail for messages of types: [error, warning, fail]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.303 s
[INFO] Finished at: 2020-10-19T07:36:43Z
[INFO] ------------------------------------------------------------------------
Binary files target/classes/com/example/Operation.class and classes/com/example/Operation.class differ
diff -r target/classes/com/example/Operation.javap classes/com/example/Operation.javap
2c2
< public abstract class com.example.Operation implements java.io.Serializable,org.springframework.beans.factory.aspectj.AbstractInterfaceDrivenDependencyInjectionAspect$ConfigurableDeserializationSupport,org.springframework.beans.factory.aspectj.ConfigurableObject {
---
> public abstract class com.example.Operation implements java.io.Serializable,org.springframework.beans.factory.aspectj.ConfigurableObject,org.springframework.beans.factory.aspectj.AbstractInterfaceDrivenDependencyInjectionAspect$ConfigurableDeserializationSupport {

```