### PR TITLE
WebSocketTransportRegistration: javadoc typo

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebSocketTransportRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebSocketTransportRegistration.java
@@ -92,7 +92,7 @@ public class WebSocketTransportRegistration {
 	 * is used by default on Tomcat 8. If you must use blocking IO consider
 	 * customizing OS-level TCP settings, for example
 	 * {@code /proc/sys/net/ipv4/tcp_retries2} on Linux.
-	 * <p>The default value is 10 seconds (i.e. 10 * 10000).
+	 * <p>The default value is 10 seconds (i.e. 10 * 1000).
 	 * @param timeLimit the timeout value in milliseconds; the value must be
 	 * greater than 0, otherwise it is ignored.
 	 */


### PR DESCRIPTION
The documentation written for the method `WebSocketTransportRegistration.setSendTimeLimit(int timeLimit)` mentions that, if no time limit is specified, a default value of 10 seconds is used; however, later on the exact default value employed is incorrectly typed as 10 * 10000 ms, which would result in 100 seconds instead.
The javadoc has been updated in order to show the correct value in milliseconds (10 * 1000).