### PR TITLE
UriBuilder - Correct the treatment of Optional types.

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
@@ -169,6 +169,8 @@ public interface UriBuilder {
 	 * contain URI template variables to be expanded later from values. If no
 	 * values are given, the resulting URI will contain the query parameter name
 	 * only, e.g. {@code "?foo"} instead of {@code "?foo=bar"}.
+	 * If the only values given are {@code Optional} instances for which {@code isPresent()} returns {@code false}
+	 * then the query parameter name will not be added.
 	 * <p><strong>Note:</strong> encoding, if applied, will only encode characters
 	 * that are illegal in a query parameter name or value such as {@code "="}
 	 * or {@code "&"}. All others that are legal as per syntax rules in

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -27,6 +27,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -697,15 +698,36 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 		Assert.notNull(name, "Name must not be null");
 		if (!ObjectUtils.isEmpty(values)) {
 			for (Object value : values) {
-				String valueAsString = (value != null ? value.toString() : null);
-				this.queryParams.add(name, valueAsString);
+				if (value instanceof Optional) {
+					// only add the query param if the optional value is present
+					Optional<?> optionalValue = (Optional<?>) value;
+					if (optionalValue.isPresent()) {
+						addQueryParam(name, optionalValue.get());
+					}
+					else {
+						// do not add the param with a null value since the incoming value type is Optional
+					}
+				}
+				else {
+					addQueryParam(name, value);
+				}
 			}
 		}
 		else {
-			this.queryParams.add(name, null);
+			addQueryParam(name, null);
 		}
 		resetSchemeSpecificPart();
 		return this;
+	}
+
+	/**
+	 * Add a query param, explicitly adding null if the passed value is itself null
+	 * @param name
+	 * @param value
+	 */
+	protected void addQueryParam(String name, Object value) {
+		String valueAsString = (value != null ? value.toString() : null);
+		this.queryParams.add(name, valueAsString);
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -202,6 +203,18 @@ class UriComponentsBuilderTests {
 		URI uri = UriComponentsBuilder.fromUriString(httpUrl).build(true).toUri();
 
 		assertThat(uri.toString()).isEqualTo(httpUrl);
+	}
+
+
+	@Test
+	void queryParamAsOptional() {
+		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
+		UriComponents result = builder.queryParam("baz", Optional.of("qux")).queryParam("foo", Optional.empty()).build();
+
+		assertThat(result.getQuery()).isEqualTo("baz=qux");
+		MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>(1);
+		expectedQueryParams.add("baz", "qux");
+		assertThat(result.getQueryParams()).isEqualTo(expectedQueryParams);
 	}
 
 	@Test  // SPR-10539


### PR DESCRIPTION
This PR is an alternative to #25925 and all the discussion on that PR remains relevant.

This PR is an improvement because:
1. it retains the existing public API without alteration, and
2. it applies a consistent treatment even when an Optional is included amongst a list of arguments (varargs).

I have taken the liberty of updating the interface documentation.

It previously stated

`If no values are given, the resulting URI will contain the query parameter name only, ...`

I have complimented this by stating that 

`If the only values given are {@code Optional} instances for which {@code isPresent()} returns {@code false} then the query parameter name will not be added.`

My justification is that calling the method with an explicit null (no parameters are given) is deliberately different from calling the method with one or more instances of Optional.empty.

Furthermore, please note that the current implementation is deficient when invoked with one or more Optionals as arguments, in that the text written to the URL is the .toString() of the Optional instance and not the .toString() of the value it contains; invoke queryParam("name", Optional.of("value")) and what is added to the URL is "?name=Optional[value]", not the expected "?name=value".

Something needs to be done, and I believe this PR (which omits the queryParam entirely if all passed values are Optional.empty) is the correct solution.
