### PR TITLE
Support Optional for query parameters in UriBuilder and UriComponentsBuilder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
@@ -336,8 +336,8 @@ public class DefaultUriBuilderFactory implements UriBuilderFactory {
 		}
 
 		@Override
-		public DefaultUriBuilder optionalQueryParam(String name, Optional<?> optionalValue) {
-			this.uriComponentsBuilder.optionalQueryParam(name, optionalValue);
+		public DefaultUriBuilder queryParamIfPresent(String name, Optional<?> optionalValue) {
+			this.uriComponentsBuilder.queryParamIfPresent(name, optionalValue);
 			return this;
 		}
 

--- a/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.MultiValueMap;
@@ -331,6 +332,12 @@ public class DefaultUriBuilderFactory implements UriBuilderFactory {
 		@Override
 		public DefaultUriBuilder queryParam(String name, Object... values) {
 			this.uriComponentsBuilder.queryParam(name, values);
+			return this;
+		}
+
+		@Override
+		public DefaultUriBuilder optionalQueryParam(String name, Optional<?> optionalValue) {
+			this.uriComponentsBuilder.optionalQueryParam(name, optionalValue);
 			return this;
 		}
 

--- a/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
@@ -19,6 +19,7 @@ package org.springframework.web.util;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.MultiValueMap;
@@ -184,6 +185,15 @@ public interface UriBuilder {
 	 * @see #queryParam(String, Collection)
 	 */
 	UriBuilder queryParam(String name, Object... values);
+
+	/**
+	 * Append the given query parameter and value if and only if a value is present in the Optional.
+	 * No action will be taken, and the query parameter name will not be added, if the passed Optional is empty.
+	 * @param name the query parameter name
+	 * @param optionalValue an Optional, either empty or holding the query parameter value.
+	 * @return
+	 */
+	UriBuilder optionalQueryParam(String name, Optional<?> optionalValue);
 
 	/**
 	 * Variant of {@link #queryParam(String, Object...)} with a Collection.

--- a/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
@@ -187,13 +187,13 @@ public interface UriBuilder {
 	UriBuilder queryParam(String name, Object... values);
 
 	/**
-	 * Append the given query parameter and value if and only if a value is present in the Optional.
-	 * No action will be taken, and the query parameter name will not be added, if the passed Optional is empty.
+	 * Delegates to {@link #queryParam(String, Object...)} or {@link #queryParam(String, Object...)} if and only if optionalValue has a value.
+	 * No action will be taken, and the query parameter name will not be added, if optionalValue is empty.
 	 * @param name the query parameter name
 	 * @param optionalValue an Optional, either empty or holding the query parameter value.
 	 * @return
 	 */
-	UriBuilder optionalQueryParam(String name, Optional<?> optionalValue);
+	UriBuilder queryParamIfPresent(String name, Optional<?> optionalValue);
 
 	/**
 	 * Variant of {@link #queryParam(String, Object...)} with a Collection.

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -27,6 +27,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -705,6 +706,14 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 			this.queryParams.add(name, null);
 		}
 		resetSchemeSpecificPart();
+		return this;
+	}
+
+	@Override
+	public UriComponentsBuilder optionalQueryParam(String name, Optional<?> optionalValue) {
+		if (optionalValue.isPresent()) {
+			queryParam(name, optionalValue.get());
+		}
 		return this;
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -710,9 +710,15 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	}
 
 	@Override
-	public UriComponentsBuilder optionalQueryParam(String name, Optional<?> optionalValue) {
+	public UriComponentsBuilder queryParamIfPresent(String name, Optional<?> optionalValue) {
 		if (optionalValue.isPresent()) {
-			queryParam(name, optionalValue.get());
+			Object value = optionalValue.get();
+			if (value instanceof Collection) {
+				queryParam(name, (Collection) value);
+			}
+			else {
+				queryParam(name, value);
+			}
 		}
 		return this;
 	}

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -202,6 +203,18 @@ class UriComponentsBuilderTests {
 		URI uri = UriComponentsBuilder.fromUriString(httpUrl).build(true).toUri();
 
 		assertThat(uri.toString()).isEqualTo(httpUrl);
+	}
+
+
+	@Test
+	void queryParamAsOptional() {
+		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
+		UriComponents result = builder.optionalQueryParam("baz", Optional.of("qux")).optionalQueryParam("foo", Optional.empty()).build();
+
+		assertThat(result.getQuery()).isEqualTo("baz=qux");
+		MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>(1);
+		expectedQueryParams.add("baz", "qux");
+		assertThat(result.getQueryParams()).isEqualTo(expectedQueryParams);
 	}
 
 	@Test  // SPR-10539

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -18,6 +18,7 @@ package org.springframework.web.util;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -207,13 +208,28 @@ class UriComponentsBuilderTests {
 
 
 	@Test
-	void queryParamAsOptional() {
+	void queryParamIfPresent() {
 		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
-		UriComponents result = builder.optionalQueryParam("baz", Optional.of("qux")).optionalQueryParam("foo", Optional.empty()).build();
+		UriComponents result = builder.queryParamIfPresent("baz", Optional.of("qux")).queryParamIfPresent("foo", Optional.empty()).build();
 
 		assertThat(result.getQuery()).isEqualTo("baz=qux");
 		MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>(1);
 		expectedQueryParams.add("baz", "qux");
+		assertThat(result.getQueryParams()).isEqualTo(expectedQueryParams);
+	}
+
+	@Test
+	void queryParamIfPresentCollection() {
+		Collection<String> c = new ArrayList<>();
+		c.add("foo");
+		c.add("bar");
+		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
+		UriComponents result = builder.queryParamIfPresent("baz", Optional.of(c)).build();
+
+		assertThat(result.getQuery()).isEqualTo("baz=foo&baz=bar");
+		MultiValueMap<String, String> expectedQueryParams = new LinkedMultiValueMap<>(1);
+		expectedQueryParams.add("baz", "foo");
+		expectedQueryParams.add("baz", "bar");
 		assertThat(result.getQueryParams()).isEqualTo(expectedQueryParams);
 	}
 


### PR DESCRIPTION
Add a method optionalQueryParam(String, Optional) to the UriBuilder interface.

The implementation adds the query parameter contained by the optional to the URL.  If the optional is empty then no action is taken; specifically the query parameter name is not added to the URL.

This PR replaces #25925 and #25950.