### PR TITLE
Fix a broken Asciidoctor syntax in core-resources.adoc

### DIFF
--- a/src/docs/asciidoc/core/core-resources.adoc
+++ b/src/docs/asciidoc/core/core-resources.adoc
@@ -563,7 +563,7 @@ files named `services.xml` and `daos.xml` (which are on the classpath) can be in
 	val ctx = ClassPathXmlApplicationContext(arrayOf("services.xml", "daos.xml"), MessengerService::class.java)
 ----
 
-See the api-spring-framework}/context/support/ClassPathXmlApplicationContext.html[`ClassPathXmlApplicationContext`]
+See the {api-spring-framework}/context/support/ClassPathXmlApplicationContext.html[`ClassPathXmlApplicationContext`]
 javadoc for details on the various constructors.
 
 


### PR DESCRIPTION
This PR fixes a broken Asciidoctor syntax in the `core-resources.adoc` file.