### PR TITLE
Fix kotlin example code which does not compile

### DIFF
--- a/src/docs/asciidoc/data-access.adoc
+++ b/src/docs/asciidoc/data-access.adoc
@@ -6805,7 +6805,7 @@ The following example extracts the `id` column and emits its value:
 .Kotlin
 ----
 	val names = client.sql("SELECT name FROM person")
-	        .map{ it.get("id", String.class) }
+	        .map{ row: Row -> row.get("id", String.class) }
 	        .flow()
 ----
 


### PR DESCRIPTION
This kotlin code does not compile:

Overload resolution ambiguity. All these functions match.

default <R> RowsFetchSpec<R> map(Function<Row, R> mappingFunction)

<R> RowsFetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);