### PR TITLE
Improve AdvisedSupport.getAdvisors()

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/Advised.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/Advised.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -222,5 +222,13 @@ public interface Advised extends TargetClassAware {
 	 * @return a string description of the proxy configuration
 	 */
 	String toProxyConfigString();
+
+	/**
+	 * Equivalent to {@code getAdvisors().length}
+	 * @return count of advisors of this advised
+	 */
+	default int getAdvisorCount() {
+		return getAdvisors().length;
+	}
 
 }

--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,12 +94,6 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 	 * in an Advisor before being added to this List.
 	 */
 	private List<Advisor> advisors = new ArrayList<>();
-
-	/**
-	 * Array updated on changes to the advisors list, which is easier
-	 * to manipulate internally.
-	 */
-	private Advisor[] advisorArray = new Advisor[0];
 
 
 	/**
@@ -244,7 +238,7 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 
 	@Override
 	public final Advisor[] getAdvisors() {
-		return this.advisorArray;
+		return this.advisors.toArray(new Advisor[0]);
 	}
 
 	@Override
@@ -292,7 +286,6 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 			}
 		}
 
-		updateAdvisorArray();
 		adviceChanged();
 	}
 
@@ -339,7 +332,6 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 				Assert.notNull(advisor, "Advisor must not be null");
 				this.advisors.add(advisor);
 			}
-			updateAdvisorArray();
 			adviceChanged();
 		}
 	}
@@ -363,26 +355,17 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 					"Illegal position " + pos + " in advisor list with size " + this.advisors.size());
 		}
 		this.advisors.add(pos, advisor);
-		updateAdvisorArray();
 		adviceChanged();
 	}
 
 	/**
-	 * Bring the array up to date with the list.
-	 */
-	protected final void updateAdvisorArray() {
-		this.advisorArray = this.advisors.toArray(new Advisor[0]);
-	}
-
-	/**
 	 * Allows uncontrolled access to the {@link List} of {@link Advisor Advisors}.
-	 * <p>Use with care, and remember to {@link #updateAdvisorArray() refresh the advisor array}
-	 * and {@link #adviceChanged() fire advice changed events} when making any modifications.
+	 * <p>Use with care, and remember to {@link #adviceChanged() fire advice changed events}
+	 * when making any modifications.
 	 */
 	protected final List<Advisor> getAdvisorsInternal() {
 		return this.advisors;
 	}
-
 
 	@Override
 	public void addAdvice(Advice advice) throws AopConfigException {
@@ -521,7 +504,6 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 			Assert.notNull(advisor, "Advisor must not be null");
 			this.advisors.add(advisor);
 		}
-		updateAdvisorArray();
 		adviceChanged();
 	}
 
@@ -536,7 +518,6 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 		copy.advisorChainFactory = this.advisorChainFactory;
 		copy.interfaces = this.interfaces;
 		copy.advisors = this.advisors;
-		copy.updateAdvisorArray();
 		return copy;
 	}
 
@@ -553,6 +534,10 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 		this.methodCache = new ConcurrentHashMap<>(32);
 	}
 
+	@Override
+	public int getAdvisorCount() {
+		return advisors.size();
+	}
 
 	@Override
 	public String toProxyConfigString() {

--- a/spring-aop/src/main/java/org/springframework/aop/framework/AopProxyUtils.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AopProxyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,7 @@ public abstract class AopProxyUtils {
 	 * Check equality of the advisors behind the given AdvisedSupport objects.
 	 */
 	public static boolean equalsAdvisors(AdvisedSupport a, AdvisedSupport b) {
-		return Arrays.equals(a.getAdvisors(), b.getAdvisors());
+		return a.getAdvisorCount() == b.getAdvisorCount() && Arrays.equals(a.getAdvisors(), b.getAdvisors());
 	}
 
 

--- a/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/CglibAopProxy.java
@@ -125,7 +125,7 @@ class CglibAopProxy implements AopProxy, Serializable {
 	 */
 	public CglibAopProxy(AdvisedSupport config) throws AopConfigException {
 		Assert.notNull(config, "AdvisedSupport must not be null");
-		if (config.getAdvisors().length == 0 && config.getTargetSource() == AdvisedSupport.EMPTY_TARGET_SOURCE) {
+		if (config.getAdvisorCount() == 0 && config.getTargetSource() == AdvisedSupport.EMPTY_TARGET_SOURCE) {
 			throw new AopConfigException("No advisors and no TargetSource specified");
 		}
 		this.advised = config;
@@ -942,11 +942,11 @@ class CglibAopProxy implements AopProxy, Serializable {
 			}
 			// Advice instance identity is unimportant to the proxy class:
 			// All that matters is type and ordering.
-			Advisor[] thisAdvisors = this.advised.getAdvisors();
-			Advisor[] thatAdvisors = otherAdvised.getAdvisors();
-			if (thisAdvisors.length != thatAdvisors.length) {
+			if (this.advised.getAdvisorCount() != otherAdvised.getAdvisorCount()) {
 				return false;
 			}
+			Advisor[] thisAdvisors = this.advised.getAdvisors();
+			Advisor[] thatAdvisors = otherAdvised.getAdvisors();
 			for (int i = 0; i < thisAdvisors.length; i++) {
 				Advisor thisAdvisor = thisAdvisors[i];
 				Advisor thatAdvisor = thatAdvisors[i];

--- a/spring-aop/src/main/java/org/springframework/aop/framework/JdkDynamicAopProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/JdkDynamicAopProxy.java
@@ -104,7 +104,7 @@ final class JdkDynamicAopProxy implements AopProxy, InvocationHandler, Serializa
 	 */
 	public JdkDynamicAopProxy(AdvisedSupport config) throws AopConfigException {
 		Assert.notNull(config, "AdvisedSupport must not be null");
-		if (config.getAdvisors().length == 0 && config.getTargetSource() == AdvisedSupport.EMPTY_TARGET_SOURCE) {
+		if (config.getAdvisorCount() == 0 && config.getTargetSource() == AdvisedSupport.EMPTY_TARGET_SOURCE) {
 			throw new AopConfigException("No advisors and no TargetSource specified");
 		}
 		this.advised = config;


### PR DESCRIPTION
In some scenarios `AdvisedSupport.updateAdvisorArray()` takes about 30% of `AdvisedSupport.addAdvisor()` (see attachment) and is pointless in fact, as the only place where we use `advisorArray` is `AdvisedSupport.getAdvisors()`. So we can rewrite the code to retrieve the array from the `advisors` list only when it is necessary instead of rewriting it on each addition or removal of advice.

This allows to simplify code and remove `advisorArray`. In order to reduce allocation rate I've also introduced `AdvisedSupport.getAdvisorCount()`.

![Screenshot from 2020-11-02 09-43-52](https://user-images.githubusercontent.com/10835776/97843430-f18a4980-1cf1-11eb-916f-9494a3a40820.png)
