### PR TITLE
Add FullyQualifiedAnnotationBeanNameGenerator.INSTANCE

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
@@ -99,7 +99,7 @@ public class ConfigurationClassPostProcessor implements BeanDefinitionRegistryPo
 	 * @see #setBeanNameGenerator
 	 */
 	public static final AnnotationBeanNameGenerator IMPORT_BEAN_NAME_GENERATOR =
-			new FullyQualifiedAnnotationBeanNameGenerator();
+			FullyQualifiedAnnotationBeanNameGenerator.INSTANCE;
 
 	private static final String IMPORT_REGISTRY_BEAN_NAME =
 			ConfigurationClassPostProcessor.class.getName() + ".importRegistry";

--- a/spring-context/src/main/java/org/springframework/context/annotation/FullyQualifiedAnnotationBeanNameGenerator.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/FullyQualifiedAnnotationBeanNameGenerator.java
@@ -43,6 +43,14 @@ import org.springframework.util.Assert;
  */
 public class FullyQualifiedAnnotationBeanNameGenerator extends AnnotationBeanNameGenerator {
 
+	/**
+	 * A convenient constant for a default {@code FullyQualifiedAnnotationBeanNameGenerator} instance,
+	 * as used for configuration-level import purposes.
+	 */
+	public static final FullyQualifiedAnnotationBeanNameGenerator INSTANCE =
+			new FullyQualifiedAnnotationBeanNameGenerator();
+
+
 	@Override
 	protected String buildDefaultBeanName(BeanDefinition definition) {
 		String beanClassName = definition.getBeanClassName();


### PR DESCRIPTION
Spring 5.2.3 (b4c91e7dac91c6176a5412ed930d2c048cc5c42f) introduces the `FullyQualifiedAnnotationBeanNameGenerator`, but does not override/hide the static `INSTANCE` field from its parent, which seems confusing to me. Someone might access `FullyQualifiedAnnotationBeanNameGenerator.INSTANCE` and get a `AnnotationBeanNameGenerator` instead. Just like I did. 😅 

This PR aims to solve that by adding a static `INSTANCE` field to `FullyQualifiedAnnotationBeanNameGenerator`, like its parent does too.