### PR TITLE
Fix wrong reference in UrlPathHelper.removeSemicolonContentInternal()

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -618,9 +618,9 @@ public class UrlPathHelper {
 		}
 		StringBuilder sb = new StringBuilder(requestUri);
 		while (semicolonIndex != -1) {
-			int slashIndex = requestUri.indexOf('/', semicolonIndex + 1);
+			int slashIndex = sb.indexOf("/", semicolonIndex + 1);
 			if (slashIndex == -1) {
-				slashIndex = sb.length();
+				return sb.substring(0, semicolonIndex);
 			}
 			sb.delete(semicolonIndex, slashIndex);
 			semicolonIndex = sb.indexOf(";", semicolonIndex);

--- a/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
@@ -115,6 +115,9 @@ public class UrlPathHelperTests {
 		request.setRequestURI("/foo;f=F;o=O;o=O/bar;b=B;a=A;r=R");
 		assertThat(helper.getRequestUri(request)).isEqualTo("/foo/bar");
 
+		request.setRequestURI("/foo;f=F;o=O;o=O/bar;b=B;a=A;r=R/baz;test");
+		assertThat(helper.getRequestUri(request)).isEqualTo("/foo/bar/baz");
+
 		// SPR-13455
 		request.setRequestURI("/foo/;test/1");
 		request.setServletPath("/foo/1");


### PR DESCRIPTION
This PR fixes a wrong reference in `UrlPathHelper.removeSemicolonContentInternal()`.

This PR also changes to short-circuit when `slashIndex` is -1.