### PR TITLE
Simplify AstUtils.getPropertyAccessorsToTry()

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/AstUtils.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/AstUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,10 +54,9 @@ public abstract class AstUtils {
 			}
 			else {
 				if (targetType != null) {
-					int pos = 0;
 					for (Class<?> clazz : targets) {
 						if (clazz == targetType) {  // put exact matches on the front to be tried first?
-							specificAccessors.add(pos++, resolver);
+							specificAccessors.add(resolver);
 						}
 						else if (clazz.isAssignableFrom(targetType)) {  // put supertype matches at the end of the
 							// specificAccessor list


### PR DESCRIPTION
If the `index` is always `list.length() - 1` we can drop it, as the object passed into `list.add()` is always the last one inserted. 