### PR TITLE
Re-use the isVariableName method

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
@@ -351,15 +351,7 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 	}
 
 	private static boolean isVariableName(String name) {
-		if (!Character.isJavaIdentifierStart(name.charAt(0))) {
-			return false;
-		}
-		for (int i = 1; i < name.length(); i++) {
-			if (!Character.isJavaIdentifierPart(name.charAt(i))) {
-				return false;
-			}
-		}
-		return true;
+		return AspectJProxyUtils.isVariableName(name);
 	}
 
 

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJAdviceParameterNameDiscoverer.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJAdviceParameterNameDiscoverer.java
@@ -470,22 +470,10 @@ public class AspectJAdviceParameterNameDiscoverer implements ParameterNameDiscov
 	 */
 	@Nullable
 	private String maybeExtractVariableName(@Nullable String candidateToken) {
-		if (!StringUtils.hasLength(candidateToken)) {
-			return null;
-		}
-		if (Character.isJavaIdentifierStart(candidateToken.charAt(0)) &&
-				Character.isLowerCase(candidateToken.charAt(0))) {
-			for (int i = 1; i < candidateToken.length(); i++) {
-				char tokenChar = candidateToken.charAt(i);
-				if (!Character.isJavaIdentifierPart(tokenChar)) {
-					return null;
-				}
-			}
+		if (AspectJProxyUtils.isVariableName(candidateToken)) {
 			return candidateToken;
 		}
-		else {
-			return null;
-		}
+		return null;
 	}
 
 	/**

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJProxyUtils.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJProxyUtils.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.PointcutAdvisor;
 import org.springframework.aop.interceptor.ExposeInvocationInterceptor;
+import org.springframework.util.StringUtils;
 
 /**
  * Utility methods for working with AspectJ proxies.
@@ -73,4 +74,18 @@ public abstract class AspectJProxyUtils {
 						((PointcutAdvisor) advisor).getPointcut() instanceof AspectJExpressionPointcut));
 	}
 
+	static boolean isVariableName(String name) {
+		if (!StringUtils.hasLength(name)) {
+			return false;
+		}
+		if (!Character.isJavaIdentifierStart(name.charAt(0))) {
+			return false;
+		}
+		for (int i = 1; i < name.length(); i++) {
+			if (!Character.isJavaIdentifierPart(name.charAt(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
Prior to this change the checks for isVariableName were duplicated
in 2 different locations. The logic has been moved to a utility class
to allow for re-use in those places and so that it benefits from any
optimizations that are done.