### PR TITLE
Support allowedOriginPatterns in SockJS config

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
@@ -73,6 +73,8 @@ public class SockJsServiceRegistration {
 
 	private final List<String> allowedOrigins = new ArrayList<>();
 
+	private final List<String> allowedOriginPatterns = new ArrayList<>();
+
 	@Nullable
 	private Boolean suppressCors;
 
@@ -233,6 +235,18 @@ public class SockJsServiceRegistration {
 	}
 
 	/**
+	 * Configure allowed {@code Origin} pattern header values.
+	 * @since 5.3.2
+	 */
+	protected SockJsServiceRegistration setAllowedOriginPatterns(String... allowedOriginPatterns) {
+		this.allowedOriginPatterns.clear();
+		if (!ObjectUtils.isEmpty(allowedOriginPatterns)) {
+			this.allowedOriginPatterns.addAll(Arrays.asList(allowedOriginPatterns));
+		}
+		return this;
+	}
+
+	/**
 	 * This option can be used to disable automatic addition of CORS headers for
 	 * SockJS requests.
 	 * <p>The default value is "false".
@@ -284,6 +298,7 @@ public class SockJsServiceRegistration {
 			service.setSuppressCors(this.suppressCors);
 		}
 		service.setAllowedOrigins(this.allowedOrigins);
+		service.setAllowedOriginPatterns(this.allowedOriginPatterns);
 
 		if (this.messageCodec != null) {
 			service.setMessageCodec(this.messageCodec);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/StompWebSocketEndpointRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/StompWebSocketEndpointRegistration.java
@@ -61,4 +61,11 @@ public interface StompWebSocketEndpointRegistration {
 	 */
 	StompWebSocketEndpointRegistration setAllowedOrigins(String... origins);
 
+	/**
+	 * Configure allowed {@code Origin} header values.
+	 *
+	 * @see org.springframework.web.cors.CorsConfiguration#setAllowedOriginPatterns(java.util.List)
+	 */
+	StompWebSocketEndpointRegistration setAllowedOriginPatterns(String... originPatterns);
+
 }

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistration.java
@@ -132,7 +132,13 @@ public class WebMvcStompWebSocketEndpointRegistration implements StompWebSocketE
 	protected HandshakeInterceptor[] getInterceptors() {
 		List<HandshakeInterceptor> interceptors = new ArrayList<>(this.interceptors.size() + 1);
 		interceptors.addAll(this.interceptors);
-		interceptors.add(new OriginHandshakeInterceptor(this.allowedOrigins));
+		OriginHandshakeInterceptor originHandshakeInterceptor = new OriginHandshakeInterceptor(this.allowedOrigins);
+		interceptors.add(originHandshakeInterceptor);
+
+		if (!ObjectUtils.isEmpty(this.allowedOriginPatterns)) {
+			originHandshakeInterceptor.setAllowedOriginPatterns(this.allowedOriginPatterns);
+		}
+
 		return interceptors.toArray(new HandshakeInterceptor[0]);
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistration.java
@@ -58,6 +58,8 @@ public class WebMvcStompWebSocketEndpointRegistration implements StompWebSocketE
 
 	private final List<String> allowedOrigins = new ArrayList<>();
 
+	private final List<String> allowedOriginPatterns = new ArrayList<>();
+
 	@Nullable
 	private SockJsServiceRegistration registration;
 
@@ -98,6 +100,15 @@ public class WebMvcStompWebSocketEndpointRegistration implements StompWebSocketE
 	}
 
 	@Override
+	public StompWebSocketEndpointRegistration setAllowedOriginPatterns(String... allowedOriginPatterns) {
+		this.allowedOriginPatterns.clear();
+		if (!ObjectUtils.isEmpty(allowedOriginPatterns)) {
+			this.allowedOriginPatterns.addAll(Arrays.asList(allowedOriginPatterns));
+		}
+		return this;
+	}
+
+	@Override
 	public SockJsServiceRegistration withSockJS() {
 		this.registration = new SockJsServiceRegistration();
 		this.registration.setTaskScheduler(this.sockJsTaskScheduler);
@@ -111,6 +122,9 @@ public class WebMvcStompWebSocketEndpointRegistration implements StompWebSocketE
 		}
 		if (!this.allowedOrigins.isEmpty()) {
 			this.registration.setAllowedOrigins(StringUtils.toStringArray(this.allowedOrigins));
+		}
+		if (!this.allowedOriginPatterns.isEmpty()) {
+			this.registration.setAllowedOriginPatterns(StringUtils.toStringArray(this.allowedOriginPatterns));
 		}
 		return this.registration;
 	}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
@@ -99,6 +99,8 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 
 	protected final Set<String> allowedOrigins = new LinkedHashSet<>();
 
+	protected final Set<String> allowedOriginPatterns = new LinkedHashSet<>();
+
 	private final SockJsRequestHandler infoHandler = new InfoHandler();
 
 	private final SockJsRequestHandler iframeHandler = new IframeHandler();
@@ -320,12 +322,32 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 	}
 
 	/**
+	 * Configure allowed {@code Origin} header values.
+	 *
+	 * @see org.springframework.web.cors.CorsConfiguration#setAllowedOriginPatterns(java.util.List)
+	 */
+	public void setAllowedOriginPatterns(Collection<String> allowedOriginPatterns) {
+		Assert.notNull(allowedOriginPatterns, "Allowed origin patterns Collection must not be null");
+		this.allowedOriginPatterns.clear();
+		this.allowedOriginPatterns.addAll(allowedOriginPatterns);
+	}
+
+	/**
 	 * Return configure allowed {@code Origin} header values.
 	 * @since 4.1.2
 	 * @see #setAllowedOrigins
 	 */
 	public Collection<String> getAllowedOrigins() {
 		return Collections.unmodifiableSet(this.allowedOrigins);
+	}
+
+	/**
+	 * Return configure allowed {@code Origin} pattern header values.
+	 * @since 5.3.2
+	 * @see #setAllowedOriginPatterns
+	 */
+	public Collection<String> getAllowedOriginPatterns() {
+		return Collections.unmodifiableSet(this.allowedOriginPatterns);
 	}
 
 
@@ -498,6 +520,7 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 		if (!this.suppressCors && (request.getHeader(HttpHeaders.ORIGIN) != null)) {
 			CorsConfiguration config = new CorsConfiguration();
 			config.setAllowedOrigins(new ArrayList<>(this.allowedOrigins));
+			config.setAllowedOriginPatterns(new ArrayList<>(this.allowedOriginPatterns));
 			config.addAllowedMethod("*");
 			config.setAllowCredentials(true);
 			config.setMaxAge(ONE_YEAR);

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistrationTests.java
@@ -135,6 +135,32 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 		assertThat(sockJsService.shouldSuppressCors()).isFalse();
 	}
 
+	@Test
+	public void allowedOriginPatterns() {
+		WebMvcStompWebSocketEndpointRegistration registration =
+				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
+
+		String origin = "https://*.mydomain.com";
+		registration.setAllowedOriginPatterns(origin).withSockJS();
+
+		MultiValueMap<HttpRequestHandler, String> mappings = registration.getMappings();
+		assertThat(mappings.size()).isEqualTo(1);
+		SockJsHttpRequestHandler requestHandler = (SockJsHttpRequestHandler)mappings.entrySet().iterator().next().getKey();
+		assertThat(requestHandler.getSockJsService()).isNotNull();
+		DefaultSockJsService sockJsService = (DefaultSockJsService)requestHandler.getSockJsService();
+		assertThat(sockJsService.getAllowedOriginPatterns().contains(origin)).isTrue();
+
+		registration =
+				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
+		registration.withSockJS().setAllowedOriginPatterns(origin);
+		mappings = registration.getMappings();
+		assertThat(mappings.size()).isEqualTo(1);
+		requestHandler = (SockJsHttpRequestHandler)mappings.entrySet().iterator().next().getKey();
+		assertThat(requestHandler.getSockJsService()).isNotNull();
+		sockJsService = (DefaultSockJsService)requestHandler.getSockJsService();
+		assertThat(sockJsService.getAllowedOriginPatterns().contains(origin)).isTrue();
+	}
+
 	@Test  // SPR-12283
 	public void disableCorsWithSockJsService() {
 		WebMvcStompWebSocketEndpointRegistration registration =


### PR DESCRIPTION
Now you can also add allowed origin patterns to the websocket CORS config.