### PR TITLE
Fail MethodFilter.and() immediately when null is passed

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -831,9 +831,11 @@ public abstract class ReflectionUtils {
 		 * <p>If this filter does not match, the next filter will not be applied.
 		 * @param next the next {@code MethodFilter}
 		 * @return a composite {@code MethodFilter}
+		 * @throws IllegalArgumentException if method's argument is {@code null}
 		 * @since 5.3.2
 		 */
 		default MethodFilter and(MethodFilter next) {
+			Assert.notNull(next, "Next MethodFilter must not be null!");
 			return method -> matches(method) && next.matches(method);
 		}
 	}


### PR DESCRIPTION
Current when one passes `null` into `MethodFilter.and()` probable NPE is deferred making it less convenient to detect the reason. I think we should check incoming param immediately.