### PR TITLE
Simplify XMLEventStreamWriter.writeEndElement()

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/xml/XMLEventStreamWriter.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/XMLEventStreamWriter.java
@@ -161,9 +161,8 @@ class XMLEventStreamWriter implements XMLStreamWriter {
 	public void writeEndElement() throws XMLStreamException {
 		closeEmptyElementIfNecessary();
 		int last = this.endElements.size() - 1;
-		EndElement lastEndElement = this.endElements.get(last);
+		EndElement lastEndElement = this.endElements.remove(last);
 		this.eventWriter.add(lastEndElement);
-		this.endElements.remove(last);
 	}
 
 	@Override


### PR DESCRIPTION
`List.get(i)` and `List.remove(i)` could be merged into `List.remove(i)` if the instance is not modified between them.