### PR TITLE
new interface exposes inner response for testing

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultEntityResponseBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultEntityResponseBuilder.java
@@ -208,7 +208,7 @@ final class DefaultEntityResponseBuilder<T> implements EntityResponse.Builder<T>
 			return new CompletionStageEntityResponse(this.status, this.headers, this.cookies,
 					completionStage, this.entityType);
 		}
-		else if (AsyncServerResponse.reactiveStreamsPresent) {
+		else if (DefaultAsyncServerResponse.reactiveStreamsPresent) {
 			ReactiveAdapter adapter = ReactiveAdapterRegistry.getSharedInstance().getAdapter(this.entity.getClass());
 			if (adapter != null) {
 				Publisher<T> publisher = adapter.toPublisher(this.entity);
@@ -363,7 +363,7 @@ final class DefaultEntityResponseBuilder<T> implements EntityResponse.Builder<T>
 				Context context) throws ServletException, IOException {
 
 			DeferredResult<?> deferredResult = createDeferredResult(servletRequest, servletResponse, context);
-			AsyncServerResponse.writeAsync(servletRequest, servletResponse, deferredResult);
+			DefaultAsyncServerResponse.writeAsync(servletRequest, servletResponse, deferredResult);
 			return null;
 		}
 
@@ -411,7 +411,7 @@ final class DefaultEntityResponseBuilder<T> implements EntityResponse.Builder<T>
 				Context context) throws ServletException, IOException {
 
 			DeferredResult<?> deferredResult = new DeferredResult<>();
-			AsyncServerResponse.writeAsync(servletRequest, servletResponse, deferredResult);
+			DefaultAsyncServerResponse.writeAsync(servletRequest, servletResponse, deferredResult);
 
 			entity().subscribe(new DeferredResultSubscriber(servletRequest, servletResponse, context, deferredResult));
 			return null;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
@@ -241,7 +241,7 @@ public interface ServerResponse {
 	 * @since 5.3
 	 */
 	static ServerResponse async(Object asyncResponse) {
-		return AsyncServerResponse.create(asyncResponse, null);
+		return DefaultAsyncServerResponse.create(asyncResponse, null);
 	}
 
 	/**
@@ -267,7 +267,7 @@ public interface ServerResponse {
 	 * @since 5.3.2
 	 */
 	static ServerResponse async(Object asyncResponse, Duration timeout) {
-		return AsyncServerResponse.create(asyncResponse, timeout);
+		return DefaultAsyncServerResponse.create(asyncResponse, timeout);
 	}
 
 


### PR DESCRIPTION
In my production setup, I use `ServerResponse.async`, and in tests, I need to access the wrapped 
 `CompletableFuture<ServerResponse>`. right now the only way to access is through reflection, and that depends on the field name remaining the same in the future.

This pull requests introduces interface `AsyncServerResponse` with access to inner `futureResponse`. and the class previously called AsyncServerResponse, is now `DefaultAsyncServerResponse`.

This is the same as with `EntityResponse`. that exposes the entity, of a `DefaultEntityResponse<T>`.

I realize that a user of this interface can act upon the inner future response, but to get at it, the user will have to manually cast to `AsyncServerResponse` and by that, take responsibility for their actions.
