### PR TITLE
Fix comments to match behaviour in Tokenizer#lexNumericLiteral

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -322,7 +322,6 @@ class Tokenizer {
 	}
 
 	// REAL_LITERAL :
-	// ('.' (DECIMAL_DIGIT)+ (EXPONENT_PART)? (REAL_TYPE_SUFFIX)?) |
 	// ((DECIMAL_DIGIT)+ '.' (DECIMAL_DIGIT)+ (EXPONENT_PART)? (REAL_TYPE_SUFFIX)?) |
 	// ((DECIMAL_DIGIT)+ (EXPONENT_PART) (REAL_TYPE_SUFFIX)?) |
 	// ((DECIMAL_DIGIT)+ (REAL_TYPE_SUFFIX));
@@ -330,10 +329,10 @@ class Tokenizer {
 	// fragment HEX_DIGIT :
 	// '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'|'A'|'B'|'C'|'D'|'E'|'F'|'a'|'b'|'c'|'d'|'e'|'f';
 	//
-	// fragment EXPONENT_PART : 'e' (SIGN)* (DECIMAL_DIGIT)+ | 'E' (SIGN)*
-	// (DECIMAL_DIGIT)+ ;
+	// fragment EXPONENT_PART : 'e' (SIGN)? (DECIMAL_DIGIT)+ | 'E' (SIGN)? (DECIMAL_DIGIT)+ ;
 	// fragment SIGN : '+' | '-' ;
 	// fragment REAL_TYPE_SUFFIX : 'F' | 'f' | 'D' | 'd';
+	//
 	// INTEGER_LITERAL
 	// : (DECIMAL_DIGIT)+ (INTEGER_TYPE_SUFFIX)?;
 


### PR DESCRIPTION
Real numbers must have leading digits. And SIGN should occur 0 or 1 time at EXPONENT_PART.