### PR TITLE
Allow passing Class<?> to resolveMethodByExceptionType in ExceptionHandlerMethodResolver

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java
@@ -143,17 +143,27 @@ public class ExceptionHandlerMethodResolver {
 	/**
 	 * Find a {@link Method} to handle the given exception type. This can be
 	 * useful if an {@link Exception} instance is not available (e.g. for tools).
-	 * @param exceptionType the exception type
+	 * @param clazz the exception type
 	 * @return a Method to handle the exception, or {@code null} if none found
+	 * @throws IllegalArgumentException if the clazz parameter is not assignable to Throwable
 	 */
 	@Nullable
-	public Method resolveMethodByExceptionType(Class<? extends Throwable> exceptionType) {
-		Method method = this.exceptionLookupCache.get(exceptionType);
+	public Method resolveMethodByExceptionType(Class<?> clazz) {
+		Method method = this.exceptionLookupCache.get(clazz);
 		if (method == null) {
-			method = getMappedMethod(exceptionType);
-			this.exceptionLookupCache.put(exceptionType, method);
+			Class<? extends Throwable> castExceptionType = castToThrowableClass(clazz);
+			method = getMappedMethod(castExceptionType);
+			this.exceptionLookupCache.put(castExceptionType, method);
 		}
 		return method;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Class<? extends Throwable> castToThrowableClass(Class<?> clazz) {
+		if(Throwable.class.isAssignableFrom(clazz)) {
+			return (Class<? extends Throwable>)clazz;
+		}
+		throw new IllegalArgumentException("Given " + clazz + " is not assignable to " + Throwable.class);
 	}
 
 	/**

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 /**
  * Test fixture for {@link ExceptionHandlerMethodResolver} tests.
@@ -88,6 +89,20 @@ public class ExceptionHandlerMethodResolverTests {
 		Exception exception = new Exception(new Exception(new Exception(bindException)));
 
 		assertThat(resolver.resolveMethod(exception).getName()).isEqualTo("handleSocketException");
+	}
+
+	@Test
+	public void resolveMethodExceptionType() {
+		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(ExceptionController.class);
+		assertThat(resolver.resolveMethodByExceptionType(IOException.class).getName()).isEqualTo("handleIOException");
+	}
+
+	@Test
+	public void resolveMethodNonExceptionType() {
+		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(ExceptionController.class);
+		assertThatThrownBy(() -> resolver.resolveMethodByExceptionType(Object.class))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Given class java.lang.Object is not assignable to class java.lang.Throwable");
 	}
 
 	@Test


### PR DESCRIPTION
This fits better to the return value of `java.lang.reflect.Method.getExceptionTypes` which only returns items of `Class<?>` and not of `Class<? extends Throwable>` (which I don't know why that's the case, but we should just cope with this)

A real world usage of `ExceptionHandlerMethodResolver#resolveMethodByExceptionType` is [here](https://github.com/qaware/openapi-generator-for-spring/blob/master/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app32/App32Configuration.java#L50).

This PR would remove this ugly uncheckedCast for users of `ExceptionHandlerMethodResolver`. Still the method `resolveMethodByExceptionType` throws `IllegalArgumentException` if anything else than Class<? extends Throwable> is passed to the method.

I've also added some test cases to show that it works as expected.