### PR TITLE
Fix punctuation typo in javadoc for ResponseExtractor

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/ResponseExtractor.java
+++ b/spring-web/src/main/java/org/springframework/web/client/ResponseExtractor.java
@@ -23,7 +23,7 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.lang.Nullable;
 
 /**
- * Generic callback interface used by {@link RestTemplate}'s retrieval methods
+ * Generic callback interface used by {@link RestTemplate}'s retrieval methods.
  * Implementations of this interface perform the actual work of extracting data
  * from a {@link ClientHttpResponse}, but don't need to worry about exception
  * handling or closing resources.


### PR DESCRIPTION
Fix punctuation typo in javadoc for ResponseExtractor.