### PR TITLE
remove not necessary judge and fields

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/DefaultBeanDefinitionDocumentReader.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/DefaultBeanDefinitionDocumentReader.java
@@ -277,25 +277,22 @@ public class DefaultBeanDefinitionDocumentReader implements BeanDefinitionDocume
 	protected void processAliasRegistration(Element ele) {
 		String name = ele.getAttribute(NAME_ATTRIBUTE);
 		String alias = ele.getAttribute(ALIAS_ATTRIBUTE);
-		boolean valid = true;
+
 		if (!StringUtils.hasText(name)) {
 			getReaderContext().error("Name must not be empty", ele);
-			valid = false;
 		}
 		if (!StringUtils.hasText(alias)) {
 			getReaderContext().error("Alias must not be empty", ele);
-			valid = false;
 		}
-		if (valid) {
-			try {
-				getReaderContext().getRegistry().registerAlias(name, alias);
-			}
-			catch (Exception ex) {
-				getReaderContext().error("Failed to register alias '" + alias +
-						"' for bean with name '" + name + "'", ele, ex);
-			}
-			getReaderContext().fireAliasRegistered(name, alias, extractSource(ele));
+
+		try {
+			getReaderContext().getRegistry().registerAlias(name, alias);
 		}
+		catch (Exception ex) {
+			getReaderContext().error("Failed to register alias '" + alias +
+					"' for bean with name '" + name + "'", ele, ex);
+		}
+		getReaderContext().fireAliasRegistered(name, alias, extractSource(ele));
 	}
 
 	/**


### PR DESCRIPTION
Because of the method of getReaderContext().error() will throw BeanDefinitionParsingException, and the following code will not be executed if an exception is thrown,So I think maybe can remove valid flag and judge.