### PR TITLE
Make set operator for MapSqlParameterSource accept nullable value

### DIFF
--- a/spring-jdbc/src/main/kotlin/org/springframework/jdbc/core/namedparam/MapSqlParameterSourceExtensions.kt
+++ b/spring-jdbc/src/main/kotlin/org/springframework/jdbc/core/namedparam/MapSqlParameterSourceExtensions.kt
@@ -26,7 +26,7 @@ package org.springframework.jdbc.core.namedparam
  * @since 5.0
  *
  */
-operator fun MapSqlParameterSource.set(paramName: String, value: Any) {
+operator fun MapSqlParameterSource.set(paramName: String, value: Any?) {
 	this.addValue(paramName, value)
 }
 
@@ -40,7 +40,7 @@ operator fun MapSqlParameterSource.set(paramName: String, value: Any) {
  * @since 5.0
  *
  */
-operator fun MapSqlParameterSource.set(paramName: String, sqlType: Int, value: Any) {
+operator fun MapSqlParameterSource.set(paramName: String, sqlType: Int, value: Any?) {
 	this.addValue(paramName, value, sqlType)
 }
 
@@ -54,6 +54,6 @@ operator fun MapSqlParameterSource.set(paramName: String, sqlType: Int, value: A
  * @since 5.0
  *
  */
-operator fun MapSqlParameterSource.set(paramName: String, sqlType: Int, typeName: String, value: Any) {
+operator fun MapSqlParameterSource.set(paramName: String, sqlType: Int, typeName: String, value: Any?) {
 	this.addValue(paramName, value, sqlType, typeName)
 }


### PR DESCRIPTION
The addValue methods of MapSqlParameterSource explicitly allows null values (org.springframework.lang.Nullable), but you're not able to set it if you try to use the Kotlin extension methods.