### PR TITLE
Optimize memory allocations in StringUtils#cleanPath

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -695,7 +695,8 @@ public abstract class StringUtils {
 		}
 
 		String[] pathArray = delimitedListToStringArray(pathToUse, FOLDER_SEPARATOR);
-		Deque<String> pathElements = new ArrayDeque<>();
+		// we never require more elements than pathArray and in the common case the same number
+		Deque<String> pathElements = new ArrayDeque<>(pathArray.length);
 		int tops = 0;
 
 		for (int i = pathArray.length - 1; i >= 0; i--) {

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -733,7 +733,40 @@ public abstract class StringUtils {
 			pathElements.addFirst(CURRENT_PATH);
 		}
 
-		return prefix + collectionToDelimitedString(pathElements, FOLDER_SEPARATOR);
+		final String joined = joinStrings(pathElements, FOLDER_SEPARATOR);
+		// avoid string concatenation with empty prefix
+		return prefix.isEmpty() ? joined : prefix + joined;
+	}
+
+	/**
+	 * Convert a {@link Collection Collection&lt;String&gt;} to a delimited {@code String} (e.g. CSV).
+	 * <p>This is an optimized variant of {@link #collectionToDelimitedString(Collection, String)}, which does not
+	 * require dynamic resizing of the StringBuilder's backing array.
+	 * @param coll the {@code Collection Collection&lt;String&gt;} to convert (potentially {@code null} or empty)
+	 * @param delim the delimiter to use (typically a ",")
+	 * @return the delimited {@code String}
+	 */
+	private static String joinStrings(@Nullable Collection<String> coll, String delim) {
+
+		if (CollectionUtils.isEmpty(coll)) {
+			return "";
+		}
+
+		// precompute total length of resulting string
+		int totalLength = (coll.size() - 1) * delim.length();
+		for (String str : coll) {
+			totalLength += str.length();
+		}
+
+		StringBuilder sb = new StringBuilder(totalLength);
+		Iterator<?> it = coll.iterator();
+		while (it.hasNext()) {
+			sb.append(it.next());
+			if (it.hasNext()) {
+				sb.append(delim);
+			}
+		}
+		return sb.toString();
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -667,7 +667,9 @@ public abstract class StringUtils {
 		if (!hasLength(path)) {
 			return path;
 		}
-		String pathToUse = replace(path, WINDOWS_FOLDER_SEPARATOR, FOLDER_SEPARATOR);
+
+		String normalizedPath = replace(path, WINDOWS_FOLDER_SEPARATOR, FOLDER_SEPARATOR);
+		String pathToUse = normalizedPath;
 
 		// Shortcut if there is no work to do
 		if (pathToUse.indexOf('.') == -1) {
@@ -722,7 +724,7 @@ public abstract class StringUtils {
 
 		// All path elements stayed the same - shortcut
 		if (pathArray.length == pathElements.size()) {
-			return prefix + pathToUse;
+			return normalizedPath;
 		}
 		// Remaining top paths need to be retained.
 		for (int i = 0; i < tops; i++) {

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -402,6 +402,8 @@ class StringUtilsTests {
 		assertThat(StringUtils.cleanPath("file:.././")).isEqualTo("file:../");
 		assertThat(StringUtils.cleanPath("file:/mypath/spring.factories")).isEqualTo("file:/mypath/spring.factories");
 		assertThat(StringUtils.cleanPath("file:///c:/some/../path/the%20file.txt")).isEqualTo("file:///c:/path/the%20file.txt");
+		assertThat(StringUtils.cleanPath("jar:file:///c:\\some\\..\\path\\.\\the%20file.txt")).isEqualTo("jar:file:///c:/path/the%20file.txt");
+		assertThat(StringUtils.cleanPath("jar:file:///c:/some/../path/./the%20file.txt")).isEqualTo("jar:file:///c:/path/the%20file.txt");
 	}
 
 	@Test


### PR DESCRIPTION
Investigating once again slow Spring Boot start times, I played around with Java Mission Control profiler and found out that `StringUtils#cleanPath` alone is responsible for 7% of all CPU time spent during setup of the application context. Looking at the implementation I was able to identify some potential hotspots (e.g. LinkedList). The application is currently using Spring Framework 5.1.10 and I was happy to find that some of these issues have already been fixed in more recent versions of Spring.

However there are still a few more opportunities to avoid memory allocations and copying of data:

* Set a sensible initial capacity for lists and string builders: optimize for the common cases. We will sometimes allocate a few bytes more than required, but at least we avoid re-allocating the backing array. For the StringBuilder we need to iterate the collection twice to calculate the capacity beforehand. But iterating is a lot cheaper compared to allocating memory two or more times.
* Re-use strings instead of concatenating their parts again: an earlier optimization introduced short-circuiting for a common case. We have computed the return value already before splitting it, so return it directly.
* Do not concatenate with the empty string: Future JDKs might alleviate this, but at least with Java 11, `return "" + somestring;` is slower than `return somestring;`. Obviously it is more expensive memory-wise due to the construction of the newly resulting string.

This PR relates to and builds on #24674, #25650, #25552, #25553, and others.