### PR TITLE
Support `Iterable` in SpEL `Indexer`

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
@@ -189,8 +189,8 @@ public enum SpelMessage {
 	RUN_OUT_OF_ARGUMENTS(Kind.ERROR, 1051,
 			"Unexpectedly ran out of arguments"),
 
-	UNABLE_TO_GROW_COLLECTION(Kind.ERROR, 1052,
-			"Unable to grow collection"),
+	UNABLE_TO_GROW(Kind.ERROR, 1052,
+			"Unable to grow {0}"),
 
 	UNABLE_TO_GROW_COLLECTION_UNKNOWN_ELEMENT_TYPE(Kind.ERROR, 1053,
 			"Unable to grow collection: unable to determine list element type"),

--- a/spring-expression/src/test/java/org/springframework/expression/spel/EvaluationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/EvaluationTests.java
@@ -671,7 +671,7 @@ public class EvaluationTests extends AbstractExpressionTests {
 			e.setValue(ctx, "3");
 		}
 		catch (SpelEvaluationException see) {
-			assertThat(see.getMessageCode()).isEqualTo(SpelMessage.UNABLE_TO_GROW_COLLECTION);
+			assertThat(see.getMessageCode()).isEqualTo(SpelMessage.UNABLE_TO_GROW);
 			assertThat(instance.getFoo().size()).isEqualTo(3);
 		}
 	}

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -948,6 +949,28 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 		assertThat(((SpelNodeImpl) ((SpelExpression) expression).getAST()).isCompilable()).isTrue();
 		assertCanCompile(expression);
 		assertThat(expression.getValue(String.class)).isEqualTo("hey there");
+
+		expression = parser.parseExpression("#doFormat([0], 'there')");
+		context = new StandardEvaluationContext(new IterableItems(List.of("hey %s")));
+		context.registerFunction("doFormat",
+				DelegatingStringFormat.class.getDeclaredMethod("format", String.class, Object[].class));
+		((SpelExpression) expression).setEvaluationContext(context);
+
+		assertThat(expression.getValue(String.class)).isEqualTo("hey there");
+		assertThat(((SpelNodeImpl) ((SpelExpression) expression).getAST()).isCompilable()).isTrue();
+		assertCanCompile(expression);
+		assertThat(expression.getValue(String.class)).isEqualTo("hey there");
+
+		expression = parser.parseExpression("#doFormat([1], 'there')");
+		context = new StandardEvaluationContext(new IterableItems(List.of("hey %s", "there %s")));
+		context.registerFunction("doFormat",
+				DelegatingStringFormat.class.getDeclaredMethod("format", String.class, Object[].class));
+		((SpelExpression) expression).setEvaluationContext(context);
+
+		assertThat(expression.getValue(String.class)).isEqualTo("there there");
+		assertThat(((SpelNodeImpl) ((SpelExpression) expression).getAST()).isCompilable()).isTrue();
+		assertCanCompile(expression);
+		assertThat(expression.getValue(String.class)).isEqualTo("there there");
 
 		expression = parser.parseExpression("#doFormat([0], #arg)");
 		context = new StandardEvaluationContext(new Object[] {"hey %s"});
@@ -6253,6 +6276,20 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 			_valueL2 = value==null?null:new Long(value);
 			_valueD2 = value==null?null:new Double(value);
 			_valueF2 = value==null?null:new Float(value);
+		}
+	}
+
+	public class IterableItems implements Iterable<String> {
+
+		private List<String> items;
+
+		public IterableItems(List<String> items) {
+			this.items = items;
+		}
+
+		@Override
+		public Iterator<String> iterator() {
+			return items.iterator();
 		}
 	}
 


### PR DESCRIPTION
* make object implementing java.lang.Iterable accessible with SpEL
indexing
* only read access is possible, as we cannot write an iterable object
* make compiler compatible