### PR TITLE
Ensure content-length header is only written once

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -759,14 +759,6 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 	protected void setHeaders(HttpServletResponse response, Resource resource, @Nullable MediaType mediaType)
 			throws IOException {
 
-		long length = resource.contentLength();
-		if (length > Integer.MAX_VALUE) {
-			response.setContentLengthLong(length);
-		}
-		else {
-			response.setContentLength((int) length);
-		}
-
 		if (mediaType != null) {
 			response.setContentType(mediaType.toString());
 		}


### PR DESCRIPTION
- undertow sends all content-length headers back to the client causing browser issues
- more comments on the issue in #26330

Fixes #26330

Investigative PR