### PR TITLE
Fix implementation of isOpen() in ReactorNettyWebSocketSession

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/adapter/ReactorNettyWebSocketSession.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/adapter/ReactorNettyWebSocketSession.java
@@ -100,7 +100,7 @@ public class ReactorNettyWebSocketSession
 	public boolean isOpen() {
 		DisposedCallback callback = new DisposedCallback();
 		getDelegate().getInbound().withConnection(callback);
-		return callback.isDisposed();
+		return !callback.isDisposed();
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes the error described in #26332.