### PR TITLE
fix issue 26317

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java
@@ -131,11 +131,10 @@ public class ExceptionHandlerMethodResolver {
 	@Nullable
 	public Method resolveMethodByThrowable(Throwable exception) {
 		Method method = resolveMethodByExceptionType(exception.getClass());
-		if (method == null) {
-			Throwable cause = exception.getCause();
-			if (cause != null) {
-				method = resolveMethodByThrowable(cause);
-			}
+		Throwable cause = exception.getCause();
+		while (method == null && cause != null) {
+			method = resolveMethodByExceptionType(cause.getClass());
+			cause = cause.getCause();
 		}
 		return method;
 	}


### PR DESCRIPTION
fix 【@ExceptionHandler methods not invokable if matched on exception's cause level > 1 】
the cause is:
ExceptionHandlerMethodResolver#resolveMethodByThrowable Find a Method to handle the given Throwable
only find Exception.cause twice


it will not affect the order of looking up for exception handler methods (1.local exception handler method,2.global exception handler method)
it only affects ExceptionHandlerMethodResolver.resolveMethod that what we what

hope to adopt