### PR TITLE
Add a missing space in exception message from CorsConfiguration.validateAllowCredentials()

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -451,7 +451,7 @@ public class CorsConfiguration {
 				this.allowedOrigins != null && this.allowedOrigins.contains(ALL)) {
 
 			throw new IllegalArgumentException(
-					"When allowCredentials is true, allowedOrigins cannot contain the special value \"*\"" +
+					"When allowCredentials is true, allowedOrigins cannot contain the special value \"*\" " +
 							"since that cannot be set on the \"Access-Control-Allow-Origin\" response header. " +
 							"To allow credentials to a set of origins, list them explicitly " +
 							"or consider using \"allowedOriginPatterns\" instead.");


### PR DESCRIPTION
This PR adds a missing space in exception message from `CorsConfiguration.validateAllowCredentials()`.