### PR TITLE
Add support for java.util.Optional to GenericHttpMessageConverter #24498

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/AbstractGenericHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/AbstractGenericHttpMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Sebastien Deleuze
  * @author Juergen Hoeller
+ * @author Vladislav Kisel
  * @since 4.2
  * @param <T> the converted object type
  */
@@ -84,8 +85,9 @@ public abstract class AbstractGenericHttpMessageConverter<T> extends AbstractHtt
 	public final void write(final T t, @Nullable final Type type, @Nullable MediaType contentType,
 			HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
 
+		final T unboxed = unboxIfNeeded(t);
 		final HttpHeaders headers = outputMessage.getHeaders();
-		addDefaultHeaders(headers, t, contentType);
+		addDefaultHeaders(headers, unboxed, contentType);
 
 		if (outputMessage instanceof StreamingHttpOutputMessage streamingOutputMessage) {
 			streamingOutputMessage.setBody(outputStream -> writeInternal(t, type, new HttpOutputMessage() {
@@ -100,7 +102,7 @@ public abstract class AbstractGenericHttpMessageConverter<T> extends AbstractHtt
 			}));
 		}
 		else {
-			writeInternal(t, type, outputMessage);
+			writeInternal(unboxed, type, outputMessage);
 			outputMessage.getBody().flush();
 		}
 	}

--- a/spring-web/src/test/java/org/springframework/http/converter/AbstractHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/AbstractHttpMessageConverterTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.converter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.MockHttpOutputMessage;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Test cases for {@link AbstractHttpMessageConverter} class.
+ *
+ * @author Vladislav Kisel
+ */
+public class AbstractHttpMessageConverterTests {
+
+	@Test
+	public void testValueUnboxingWhenTypeIsObject() throws IOException {
+		TestConverterWithObjectType converter = new TestConverterWithObjectType();
+		converter.write(Optional.of("123"), MediaType.ALL, new MockHttpOutputMessage());
+
+		Assertions.assertEquals("123", converter.t);
+	}
+
+	@Test
+	public void testValueUnboxingWhenValueIsNull() throws IOException {
+		TestConverterWithObjectType converter = new TestConverterWithObjectType();
+		converter.write(Optional.empty(), MediaType.ALL, new MockHttpOutputMessage());
+
+		Assertions.assertEquals(Optional.empty(), converter.t);
+	}
+
+	@Test
+	public void testValueUnboxingWhenTypeIsOptional() throws IOException {
+		TestConverterWithOptionalType converter = new TestConverterWithOptionalType();
+		converter.write(Optional.of("123"), MediaType.ALL, new MockHttpOutputMessage());
+
+		Assertions.assertEquals(Optional.of("123"), converter.t);
+	}
+
+	@Test
+	public void testValueUnboxingWhenTypeIsUnknown() throws IOException {
+		GenericTestConverter<Optional<String>> converter = new GenericTestConverter<>();
+		converter.write(Optional.of("123"), MediaType.ALL, new MockHttpOutputMessage());
+
+		Assertions.assertEquals(Optional.of("123"), converter.t);
+	}
+
+	private static class GenericTestConverter<T> extends AbstractHttpMessageConverter<T> {
+
+		T t;
+
+		@Override
+		protected boolean supports(Class<?> clazz) {
+			return true;
+		}
+
+		@Override
+		protected T readInternal(Class<? extends T> clazz, HttpInputMessage inputMessage) throws HttpMessageNotReadableException {
+			return t;
+		}
+
+		@Override
+		protected void writeInternal(T t, HttpOutputMessage outputMessage) throws HttpMessageNotWritableException {
+			this.t = t;
+		}
+	}
+
+	private static class TestConverterWithOptionalType extends GenericTestConverter<Optional<String>> {
+	}
+
+	private static class TestConverterWithObjectType extends GenericTestConverter<Object> {
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/http/converter/ObjectToStringHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/ObjectToStringHttpMessageConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  *
  * @author <a href="mailto:dmitry.katsubo@gmail.com">Dmitry Katsubo</a>
  * @author Rossen Stoyanchev
+ * @author Vladislav Kisel
  */
 public class ObjectToStringHttpMessageConverterTests {
 
@@ -171,6 +173,22 @@ public class ObjectToStringHttpMessageConverterTests {
 	public void testConversionServiceRequired() {
 		assertThatIllegalArgumentException().isThrownBy(() ->
 				new ObjectToStringHttpMessageConverter(null));
+	}
+
+	@Test
+	public void testWriteAndReadOptional() throws IOException {
+		MediaType contentType = new MediaType("text", "plain");
+		String value = "stringValue";
+		this.converter.write(Optional.of(value), contentType, this.response);
+
+		assertThat(this.servletResponse.getContentAsString()).isEqualTo(value);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setContentType(MediaType.TEXT_PLAIN_VALUE);
+		request.setCharacterEncoding("UTF-8");
+		request.setContent(value.getBytes());
+
+		assertThat(this.converter.read(String.class, new ServletServerHttpRequest(request))).isEqualTo(value);
 	}
 
 }


### PR DESCRIPTION
Fixes #24498

Added unboxing of  `java.util.Optional`  to `AbstractHttpMessageConverter` and `AbstractGenericHttpMessageConverter`. If the object is not unboxed, the underlying message converter receives an instance of `java.util.Optional`, which was causing an issue described in the #24498 in case of Jackson converter. It will also allow to use `Optional<*>` in other message converters without explicitly registering a type converter. 