### PR TITLE
DefaultResponseErrorHandler should check #read return value

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
@@ -148,11 +148,12 @@ public class DefaultResponseErrorHandler implements ResponseErrorHandler {
 			return preface + "[" + new String(responseBody, charset) + "]";
 		}
 
-		try {
-			Reader reader = new InputStreamReader(new ByteArrayInputStream(responseBody), charset);
+		try (Reader reader = new InputStreamReader(new ByteArrayInputStream(responseBody), charset)) {
 			CharBuffer buffer = CharBuffer.allocate(maxChars);
-			reader.read(buffer);
-			reader.close();
+			int r;
+			do {
+				r = reader.read(buffer);
+			} while (r > 0 && buffer.hasRemaining());
 			buffer.flip();
 			return preface + "[" + buffer.toString() + "... (" + responseBody.length + " bytes)]";
 		}


### PR DESCRIPTION
DefaultResponseErrorHandler calls Reader#read without checking its
return value. It assumes that Reader#read fills as much of the buffer
as possible however the API contract makes no such guarantees.