### PR TITLE
Fix typo in URI Encoding section of reference docs

### DIFF
--- a/src/docs/asciidoc/web/web-uris.adoc
+++ b/src/docs/asciidoc/web/web-uris.adoc
@@ -318,7 +318,7 @@ the approach to encoding, based on one of the below encoding modes:
 the first option in the earlier list, to pre-encode the URI template and strictly encode URI variables when
 expanded.
 * `VALUES_ONLY`: Does not encode the URI template and, instead, applies strict encoding
-to URI variables through `UriUtils#encodeUriUriVariables` prior to expanding them into the
+to URI variables through `UriUtils#encodeUriVariables` prior to expanding them into the
 template.
 * `URI_COMPONENT`: Uses `UriComponents#encode()`, corresponding to the second option in the earlier list, to
 encode URI component value _after_ URI variables are expanded.


### PR DESCRIPTION
> VALUES_ONLY: Does not encode the URI template and, instead, applies strict encoding to URI variables through UriUtils#encodeUriUriVariables prior to expanding them into the template.

I fixed `UriUtils#encodeUriUriVariables` into `UriUtils#encodeUriVariables` in  "[1.5.3. URI Encoding](https://docs.spring.io/spring-framework/docs/current/reference/html/web.html#web-uri-encoding)" section of reference docs.