### PR TITLE
Fix DelegatingWebMvcConfigurationTests.configurePathPatternParser()

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfigurationTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfigurationTests.java
@@ -340,7 +340,7 @@ public class DelegatingWebMvcConfigurationTests {
 
 		assertThat(beanNameMapping).isNotNull();
 		assertThat(beanNameMapping.getPatternParser()).isSameAs(patternParser);
-		configAssertion.accept(beanNameMapping.getUrlPathHelper(), mapping.getPathMatcher());
+		configAssertion.accept(beanNameMapping.getUrlPathHelper(), beanNameMapping.getPathMatcher());
 
 		assertThat(webMvcConfig.mvcResourceUrlProvider().getUrlPathHelper()).isSameAs(pathHelper);
 		assertThat(webMvcConfig.mvcResourceUrlProvider().getPathMatcher()).isSameAs(pathMatcher);


### PR DESCRIPTION
This PR fixes a variable reference in `DelegatingWebMvcConfigurationTests.configurePathPatternParser()` as it seems to be a wrong reference.