### PR TITLE
Add Javadoc @since tag to TransactionSynchronizationUtils.unwrapResourceIfNecessary()

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationUtils.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationUtils.java
@@ -58,6 +58,7 @@ public abstract class TransactionSynchronizationUtils {
 	 * Unwrap the given resource handle if necessary; otherwise return
 	 * the given handle as-is.
 	 * @see org.springframework.core.InfrastructureProxy#getWrappedObject()
+	 * @since 5.3.4
 	 */
 	public static Object unwrapResourceIfNecessary(Object resource) {
 		Assert.notNull(resource, "Resource must not be null");


### PR DESCRIPTION
It has been changed to be `public` in 4a7a2258f9ad8771e9a8225f5a18db156372162a, but its Javadoc `@since` tag seems to be missed. This PR simply adds it.