### PR TITLE
Introduce SPI for automatic bean definition profile registration

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/AbstractEnvironment.java
+++ b/spring-core/src/main/java/org/springframework/core/env/AbstractEnvironment.java
@@ -16,14 +16,8 @@
 
 package org.springframework.core.env;
 
-import java.security.AccessControlException;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import jdk.internal.joptsimple.internal.Strings;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.core.SpringProperties;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.io.support.AdditionalProfileLoader;
@@ -32,6 +26,10 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+
+import java.security.AccessControlException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Abstract base class for {@link Environment} implementations. Supports the notion of
@@ -48,9 +46,9 @@ import org.springframework.util.StringUtils;
  *
  * @author Chris Beams
  * @author Juergen Hoeller
- * @since 3.1
  * @see ConfigurableEnvironment
  * @see StandardEnvironment
+ * @since 3.1
  */
 public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 
@@ -62,6 +60,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * resolvable otherwise. Consider switching this flag to "true" if you experience
 	 * log warnings from {@code getenv} calls coming from Spring, e.g. on WebSphere
 	 * with strict SecurityManager settings and AccessControlExceptions warnings.
+	 *
 	 * @see #suppressGetenvAccess()
 	 */
 	public static final String IGNORE_GETENV_PROPERTY_NAME = "spring.getenv.ignore";
@@ -73,6 +72,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * character in variable names. Assuming that Spring's {@link SystemEnvironmentPropertySource}
 	 * is in use, this property may be specified as an environment variable as
 	 * {@code SPRING_PROFILES_ACTIVE}.
+	 *
 	 * @see ConfigurableEnvironment#setActiveProfiles
 	 */
 	public static final String ACTIVE_PROFILES_PROPERTY_NAME = "spring.profiles.active";
@@ -84,6 +84,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * character in variable names. Assuming that Spring's {@link SystemEnvironmentPropertySource}
 	 * is in use, this property may be specified as an environment variable as
 	 * {@code SPRING_PROFILES_DEFAULT}.
+	 *
 	 * @see ConfigurableEnvironment#setDefaultProfiles
 	 */
 	public static final String DEFAULT_PROFILES_PROPERTY_NAME = "spring.profiles.default";
@@ -92,6 +93,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * Name of reserved default profile name: {@value}. If no default profile names are
 	 * explicitly and no active profile names are explicitly set, this profile will
 	 * automatically be activated by default.
+	 *
 	 * @see #getReservedDefaultProfiles
 	 * @see ConfigurableEnvironment#setDefaultProfiles
 	 * @see ConfigurableEnvironment#setActiveProfiles
@@ -118,6 +120,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * {@link #customizePropertySources(MutablePropertySources)} during construction to
 	 * allow subclasses to contribute or manipulate {@link PropertySource} instances as
 	 * appropriate.
+	 *
 	 * @see #customizePropertySources(MutablePropertySources)
 	 */
 	public AbstractEnvironment() {
@@ -207,6 +210,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * Return the set of reserved default profile names. This implementation returns
 	 * {@value #RESERVED_DEFAULT_PROFILE_NAME}. Subclasses may override in order to
 	 * customize the set of reserved names.
+	 *
 	 * @see #RESERVED_DEFAULT_PROFILE_NAME
 	 * @see #doGetDefaultProfiles()
 	 */
@@ -230,6 +234,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * is empty, check for the presence of the {@value #ACTIVE_PROFILES_PROPERTY_NAME}
 	 * property or {@link AdditionalProfileLoader} from {@code spring.factories}
 	 * and assign its value to the set of active profiles.
+	 *
 	 * @see #getActiveProfiles()
 	 * @see #ACTIVE_PROFILES_PROPERTY_NAME
 	 */
@@ -253,8 +258,9 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 
 	private String getAdditionalProfiles() {
 		List<AdditionalProfileLoader> additionalProfileLoader = SpringFactoriesLoader.loadFactories(AdditionalProfileLoader.class, null);
-		List<String> additionalProfiles = additionalProfileLoader.stream().map(AdditionalProfileLoader::useAdditionalProfile).collect(Collectors.toList());
-		return Strings.join(additionalProfiles, ",");
+		return additionalProfileLoader.stream().
+				map(AdditionalProfileLoader::useAdditionalProfile).
+				collect(Collectors.joining(","));
 	}
 
 	@Override
@@ -297,6 +303,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * profiles}, then check for the presence of the
 	 * {@value #DEFAULT_PROFILES_PROPERTY_NAME} property and assign its value (if any)
 	 * to the set of default profiles.
+	 *
 	 * @see #AbstractEnvironment()
 	 * @see #getDefaultProfiles()
 	 * @see #DEFAULT_PROFILES_PROPERTY_NAME
@@ -320,6 +327,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * are explicitly made active through {@link #setActiveProfiles}.
 	 * <p>Calling this method removes overrides any reserved default profiles
 	 * that may have been added during construction of the environment.
+	 *
 	 * @see #AbstractEnvironment()
 	 * @see #getReservedDefaultProfiles()
 	 */
@@ -344,8 +352,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 				if (!isProfileActive(profile.substring(1))) {
 					return true;
 				}
-			}
-			else if (isProfileActive(profile)) {
+			} else if (isProfileActive(profile)) {
 				return true;
 			}
 		}
@@ -361,6 +368,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	/**
 	 * Return whether the given profile is active, or if active profiles are empty
 	 * whether the profile should be active by default.
+	 *
 	 * @throws IllegalArgumentException per {@link #validateProfile(String)}
 	 */
 	protected boolean isProfileActive(String profile) {
@@ -374,8 +382,9 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * Validate the given profile, called internally prior to adding to the set of
 	 * active or default profiles.
 	 * <p>Subclasses may override to impose further restrictions on profile syntax.
+	 *
 	 * @throws IllegalArgumentException if the profile is null, empty, whitespace-only or
-	 * begins with the profile NOT operator (!).
+	 *                                  begins with the profile NOT operator (!).
 	 * @see #acceptsProfiles
 	 * @see #addActiveProfile
 	 * @see #setDefaultProfiles
@@ -399,16 +408,14 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	public Map<String, Object> getSystemProperties() {
 		try {
 			return (Map) System.getProperties();
-		}
-		catch (AccessControlException ex) {
+		} catch (AccessControlException ex) {
 			return (Map) new ReadOnlySystemAttributesMap() {
 				@Override
 				@Nullable
 				protected String getSystemAttribute(String attributeName) {
 					try {
 						return System.getProperty(attributeName);
-					}
-					catch (AccessControlException ex) {
+					} catch (AccessControlException ex) {
 						if (logger.isInfoEnabled()) {
 							logger.info("Caught AccessControlException when accessing system property '" +
 									attributeName + "'; its value will be returned [null]. Reason: " + ex.getMessage());
@@ -428,16 +435,14 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 		}
 		try {
 			return (Map) System.getenv();
-		}
-		catch (AccessControlException ex) {
+		} catch (AccessControlException ex) {
 			return (Map) new ReadOnlySystemAttributesMap() {
 				@Override
 				@Nullable
 				protected String getSystemAttribute(String attributeName) {
 					try {
 						return System.getenv(attributeName);
-					}
-					catch (AccessControlException ex) {
+					} catch (AccessControlException ex) {
 						if (logger.isInfoEnabled()) {
 							logger.info("Caught AccessControlException when accessing system environment variable '" +
 									attributeName + "'; its value will be returned [null]. Reason: " + ex.getMessage());
@@ -457,6 +462,7 @@ public abstract class AbstractEnvironment implements ConfigurableEnvironment {
 	 * and therefore avoiding security manager warnings (if any).
 	 * <p>The default implementation checks for the "spring.getenv.ignore" system property,
 	 * returning {@code true} if its value equals "true" in any case.
+	 *
 	 * @see #IGNORE_GETENV_PROPERTY_NAME
 	 * @see SpringProperties#getFlag
 	 */

--- a/spring-core/src/main/java/org/springframework/core/io/support/AdditionalProfileLoader.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/AdditionalProfileLoader.java
@@ -8,9 +8,13 @@ package org.springframework.core.io.support;
  * with configured properties for e.g. multiple stages, you can implement this interface, so spring will include
  * the defined profile in its active profiles.
  *
+ * If you want to order your profiles (like you would do with {@code spring.profiles.active}) you can annotate your
+ * class with {@link org.springframework.core.annotation.Order}. Implementations without annotation will get implicitly
+ * the lowest precedence by {@link SpringFactoriesLoader}.
+ *
  * Example implementation:
  * <pre class="code">
- * class AdditionalCommonProfileLoader implements AdditionalProfilesLoader {
+ * class AdditionalCommonProfileLoader implements AdditionalProfileLoader {
  *
  *     &#064;Override
  *     public String useAdditionalProfile() {
@@ -22,7 +26,12 @@ package org.springframework.core.io.support;
  * Add the following line to the spring-boot-starters {@code spring.factories}:
  * <pre class="code">org.springframework.core.io.support.AdditionalProfileLoader=example.AdditionalCommonProfileLoader</pre>
  *
+ * Spring would now load an additional file "application-commons.yaml".
+ *
  * @author Kevin Raddatz
+ *
+ * @see org.springframework.core.annotation.Order
+ * @see SpringFactoriesLoader
  */
 public interface AdditionalProfileLoader {
 

--- a/spring-core/src/main/java/org/springframework/core/io/support/AdditionalProfileLoader.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/AdditionalProfileLoader.java
@@ -1,0 +1,30 @@
+package org.springframework.core.io.support;
+
+/**
+ * Load additional profiles using {@link SpringFactoriesLoader}
+ * <p>
+ * Example:
+ * In this special scenario, where you have a spring-boot-starter with its own application.properties
+ * with configured properties for e.g. multiple stages, you can implement this interface, so spring will include
+ * the defined profile in its active profiles.
+ *
+ * Example implementation:
+ * <pre class="code">
+ * class AdditionalCommonProfileLoader implements AdditionalProfilesLoader {
+ *
+ *     &#064;Override
+ *     public String useAdditionalProfile() {
+ *         return "commons";
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * Add the following line to the spring-boot-starters {@code spring.factories}:
+ * <pre class="code">org.springframework.core.io.support.AdditionalProfileLoader=example.AdditionalCommonProfileLoader</pre>
+ *
+ * @author Kevin Raddatz
+ */
+public interface AdditionalProfileLoader {
+
+	String useAdditionalProfile();
+}


### PR DESCRIPTION
In our project we created a starter which contains most general stuff, like database, feign clients and so on. 
Now we want to configure this starter with different properties per stage. 
Currently we created a file "application-commons.yaml" in our starter and include this "profile" at `spring.profiles.active`, but this does not really scale well if we create more starters, or more applications. We would have to keep in mind to add all the profiles to all the services.

With this PR we are able to implement an `AdditionalProfileLoader`, which returns the name of the starters "profile", and then add the class to the `spring.factories`: `org.springframework.core.io.support.AdditionalProfileLoader=com.example.AdditionalCommonProfile`

This PR relates to https://github.com/spring-projects/spring-boot/pull/25033 which adds the ability to load additional files like `commons.yaml`, `commons-local.yaml` and so on.