### PR TITLE
URL and HTTP method in rest client exception message

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateIntegrationTests.java
@@ -243,6 +243,7 @@ class RestTemplateIntegrationTests extends AbstractMockWebServerTests {
 				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 				assertThat(ex.getStatusText()).isNotNull();
 				assertThat(ex.getResponseBodyAsString()).isNotNull();
+				assertThat(ex.getMessage()).isEqualTo("404 Client Error after GET http://localhost:" + port + "/status/notfound : [no body]");
 			});
 	}
 
@@ -254,7 +255,7 @@ class RestTemplateIntegrationTests extends AbstractMockWebServerTests {
 				template.execute(baseUrl + "/status/badrequest", HttpMethod.GET, null, null))
 			.satisfies(ex -> {
 				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-				assertThat(ex.getMessage()).isEqualTo("400 Client Error: [no body]");
+				assertThat(ex.getMessage()).isEqualTo("400 Client Error after GET http://localhost:" + port + "/status/badrequest : [no body]");
 			});
 	}
 
@@ -268,6 +269,7 @@ class RestTemplateIntegrationTests extends AbstractMockWebServerTests {
 				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 				assertThat(ex.getStatusText()).isNotNull();
 				assertThat(ex.getResponseBodyAsString()).isNotNull();
+				assertThat(ex.getMessage()).isEqualTo("500 Server Error after GET http://localhost:" + port + "/status/server : [no body]");
 			});
 	}
 


### PR DESCRIPTION
Dear team,

This is a followup of a discussion in a past PR: https://github.com/spring-projects/spring-framework/pull/1956

The rest client exception contains a preview of the body, which is great, and it helps a lot to quickly diagnose errors.

Now, the stacktrace looks like this:
```
Caused by: org.springframework.web.client.HttpServerErrorException$InternalServerError: 500 Server Error: [no body]
	at org.springframework.web.client.HttpServerErrorException.create(HttpServerErrorException.java:101)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:238)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:147)
```

I'd like to add the HTTP method and URL to the error, so that the stacktrace looks like this:
```
Caused by: org.springframework.web.client.HttpServerErrorException$InternalServerError: 500 Server Error after GET http://localhost:49709/status/server : [no body]
	at org.springframework.web.client.HttpServerErrorException.create(HttpServerErrorException.java:101)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:238)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:147)
```

Thank you! 