### PR TITLE
Fix Javadoc formatting errors

### DIFF
--- a/spring-aspects/src/main/java/org/springframework/context/annotation/aspectj/SpringConfiguredConfiguration.java
+++ b/spring-aspects/src/main/java/org/springframework/context/annotation/aspectj/SpringConfiguredConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Role;
 /**
  * {@code @Configuration} class that registers an {@code AnnotationBeanConfigurerAspect}
  * capable of performing dependency injection services for non-Spring managed objects
- * annotated with @{@link org.springframework.beans.factory.annotation.Configurable
+ * annotated with {@link org.springframework.beans.factory.annotation.Configurable
  * Configurable}.
  *
  * <p>This configuration class is automatically imported when using the

--- a/spring-context/src/main/java/org/springframework/cache/annotation/CachingConfigurer.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/CachingConfigurer.java
@@ -23,13 +23,13 @@ import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.lang.Nullable;
 
 /**
- * Interface to be implemented by @{@link org.springframework.context.annotation.Configuration
- * Configuration} classes annotated with @{@link EnableCaching} that wish or need to
+ * Interface to be implemented by {@link org.springframework.context.annotation.Configuration
+ * Configuration} classes annotated with {@link EnableCaching} that wish or need to
  * specify explicitly how caches are resolved and how keys are generated for annotation-driven
  * cache management. Consider extending {@link CachingConfigurerSupport}, which provides a
  * stub implementation of all interface methods.
  *
- * <p>See @{@link EnableCaching} for general examples and context; see
+ * <p>See {@link EnableCaching} for general examples and context; see
  * {@link #cacheManager()}, {@link #cacheResolver()} and {@link #keyGenerator()}
  * for detailed instructions.
  *
@@ -61,7 +61,7 @@ public interface CachingConfigurer {
 	 *     // ...
 	 * }
 	 * </pre>
-	 * See @{@link EnableCaching} for more complete examples.
+	 * See {@link EnableCaching} for more complete examples.
 	 */
 	@Nullable
 	CacheManager cacheManager();
@@ -107,7 +107,7 @@ public interface CachingConfigurer {
 	 *     // ...
 	 * }
 	 * </pre>
-	 * See @{@link EnableCaching} for more complete examples.
+	 * See {@link EnableCaching} for more complete examples.
 	 */
 	@Nullable
 	KeyGenerator keyGenerator();
@@ -130,7 +130,7 @@ public interface CachingConfigurer {
 	 *     // ...
 	 * }
 	 * </pre>
-	 * See @{@link EnableCaching} for more complete examples.
+	 * See {@link EnableCaching} for more complete examples.
 	 */
 	@Nullable
 	CacheErrorHandler errorHandler();

--- a/spring-context/src/main/java/org/springframework/cache/annotation/EnableCaching.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/EnableCaching.java
@@ -29,7 +29,7 @@ import org.springframework.core.Ordered;
 /**
  * Enables Spring's annotation-driven cache management capability, similar to the
  * support found in Spring's {@code <cache:*>} XML namespace. To be used together
- * with @{@link org.springframework.context.annotation.Configuration Configuration}
+ * with {@link org.springframework.context.annotation.Configuration Configuration}
  * classes as follows:
  *
  * <pre class="code">

--- a/spring-context/src/main/java/org/springframework/context/annotation/AspectJAutoProxyRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/AspectJAutoProxyRegistrar.java
@@ -24,7 +24,7 @@ import org.springframework.core.type.AnnotationMetadata;
 /**
  * Registers an {@link org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator
  * AnnotationAwareAspectJAutoProxyCreator} against the current {@link BeanDefinitionRegistry}
- * as appropriate based on a given @{@link EnableAspectJAutoProxy} annotation.
+ * as appropriate based on a given {@link EnableAspectJAutoProxy} annotation.
  *
  * @author Chris Beams
  * @author Juergen Hoeller
@@ -35,7 +35,7 @@ class AspectJAutoProxyRegistrar implements ImportBeanDefinitionRegistrar {
 
 	/**
 	 * Register, escalate, and configure the AspectJ auto proxy creator based on the value
-	 * of the @{@link EnableAspectJAutoProxy#proxyTargetClass()} attribute on the importing
+	 * of the {@link EnableAspectJAutoProxy#proxyTargetClass()} attribute on the importing
 	 * {@code @Configuration} class.
 	 */
 	@Override

--- a/spring-context/src/main/java/org/springframework/context/annotation/Bean.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/Bean.java
@@ -171,7 +171,7 @@ import org.springframework.core.annotation.AliasFor;
  *
  * <h3>Bootstrapping</h3>
  *
- * <p>See the @{@link Configuration} javadoc for further details including how to bootstrap
+ * <p>See the {@link Configuration} javadoc for further details including how to bootstrap
  * the container using {@link AnnotationConfigApplicationContext} and friends.
  *
  * <h3>{@code BeanFactoryPostProcessor}-returning {@code @Bean} methods</h3>

--- a/spring-context/src/main/java/org/springframework/context/annotation/ComponentScan.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ComponentScan.java
@@ -28,7 +28,7 @@ import org.springframework.core.annotation.AliasFor;
 import org.springframework.core.type.filter.TypeFilter;
 
 /**
- * Configures component scanning directives for use with @{@link Configuration} classes.
+ * Configures component scanning directives for use with {@link Configuration} classes.
  * Provides support parallel with Spring XML's {@code <context:component-scan>} element.
  *
  * <p>Either {@link #basePackageClasses} or {@link #basePackages} (or its alias

--- a/spring-context/src/main/java/org/springframework/context/annotation/ComponentScanAnnotationParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ComponentScanAnnotationParser.java
@@ -43,7 +43,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * Parser for the @{@link ComponentScan} annotation.
+ * Parser for the {@link ComponentScan} annotation.
  *
  * @author Chris Beams
  * @author Juergen Hoeller

--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
@@ -158,7 +158,7 @@ final class ConfigurationClass {
 	}
 
 	/**
-	 * Return whether this configuration class was registered via @{@link Import} or
+	 * Return whether this configuration class was registered via {@link Import} or
 	 * automatically registered due to being nested within another configuration class.
 	 * @since 3.1.1
 	 * @see #getImportedBy()

--- a/spring-context/src/main/java/org/springframework/context/annotation/DeferredImportSelector.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/DeferredImportSelector.java
@@ -56,7 +56,7 @@ public interface DeferredImportSelector extends ImportSelector {
 	interface Group {
 
 		/**
-		 * Process the {@link AnnotationMetadata} of the importing @{@link Configuration}
+		 * Process the {@link AnnotationMetadata} of the importing {@link Configuration}
 		 * class using the specified {@link DeferredImportSelector}.
 		 */
 		void process(AnnotationMetadata metadata, DeferredImportSelector selector);

--- a/spring-context/src/main/java/org/springframework/context/annotation/EnableAspectJAutoProxy.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/EnableAspectJAutoProxy.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Enables support for handling components marked with AspectJ's {@code @Aspect} annotation,
  * similar to functionality found in Spring's {@code <aop:aspectj-autoproxy>} XML element.
- * To be used on @{@link Configuration} classes as follows:
+ * To be used on {@link Configuration} classes as follows:
  *
  * <pre class="code">
  * &#064;Configuration
@@ -90,7 +90,7 @@ import java.lang.annotation.Target;
  * &#064;Component
  * public class MyAspect { ... }</pre>
  *
- * Then use the @{@link ComponentScan} annotation to pick both up:
+ * Then use the {@link ComponentScan} annotation to pick both up:
  *
  * <pre class="code">
  * &#064;Configuration

--- a/spring-context/src/main/java/org/springframework/context/annotation/EnableLoadTimeWeaving.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/EnableLoadTimeWeaving.java
@@ -30,7 +30,7 @@ import org.springframework.instrument.classloading.LoadTimeWeaver;
  * a bean with the name "loadTimeWeaver", similar to the {@code <context:load-time-weaver>}
  * element in Spring XML.
  *
- * <p>To be used on @{@link org.springframework.context.annotation.Configuration Configuration} classes;
+ * <p>To be used on {@link org.springframework.context.annotation.Configuration Configuration} classes;
  * the simplest possible example of which follows:
  *
  * <pre class="code">

--- a/spring-context/src/main/java/org/springframework/context/annotation/ImportAware.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ImportAware.java
@@ -20,10 +20,10 @@ import org.springframework.beans.factory.Aware;
 import org.springframework.core.type.AnnotationMetadata;
 
 /**
- * Interface to be implemented by any @{@link Configuration} class that wishes
- * to be injected with the {@link AnnotationMetadata} of the @{@code Configuration}
+ * Interface to be implemented by any {@link Configuration} class that wishes
+ * to be injected with the {@link AnnotationMetadata} of the {@code Configuration}
  * class that imported it. Useful in conjunction with annotations that
- * use @{@link Import} as a meta-annotation.
+ * use {@link Import} as a meta-annotation.
  *
  * @author Chris Beams
  * @since 3.1
@@ -31,7 +31,7 @@ import org.springframework.core.type.AnnotationMetadata;
 public interface ImportAware extends Aware {
 
 	/**
-	 * Set the annotation metadata of the importing @{@code Configuration} class.
+	 * Set the annotation metadata of the importing {@code Configuration} class.
 	 */
 	void setImportMetadata(AnnotationMetadata importMetadata);
 

--- a/spring-context/src/main/java/org/springframework/context/annotation/ImportBeanDefinitionRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ImportBeanDefinitionRegistrar.java
@@ -23,11 +23,11 @@ import org.springframework.core.type.AnnotationMetadata;
 
 /**
  * Interface to be implemented by types that register additional bean definitions when
- * processing @{@link Configuration} classes. Useful when operating at the bean definition
+ * processing {@link Configuration} classes. Useful when operating at the bean definition
  * level (as opposed to {@code @Bean} method/instance level) is desired or necessary.
  *
  * <p>Along with {@code @Configuration} and {@link ImportSelector}, classes of this type
- * may be provided to the @{@link Import} annotation (or may also be returned from an
+ * may be provided to the {@link Import} annotation (or may also be returned from an
  * {@code ImportSelector}).
  *
  * <p>An {@link ImportBeanDefinitionRegistrar} may implement any of the following

--- a/spring-context/src/main/java/org/springframework/context/annotation/ImportSelector.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ImportSelector.java
@@ -22,7 +22,7 @@ import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.lang.Nullable;
 
 /**
- * Interface to be implemented by types that determine which @{@link Configuration}
+ * Interface to be implemented by types that determine which {@link Configuration}
  * class(es) should be imported based on a given selection criteria, usually one or
  * more annotation attributes.
  *
@@ -62,7 +62,7 @@ public interface ImportSelector {
 
 	/**
 	 * Select and return the names of which class(es) should be imported based on
-	 * the {@link AnnotationMetadata} of the importing @{@link Configuration} class.
+	 * the {@link AnnotationMetadata} of the importing {@link Configuration} class.
 	 * @return the class names, or an empty array if none
 	 */
 	String[] selectImports(AnnotationMetadata importingClassMetadata);

--- a/spring-context/src/main/java/org/springframework/context/annotation/Primary.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/Primary.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * {@code primary} attribute in Spring XML.
  *
  * <p>May be used on any class directly or indirectly annotated with
- * {@code @Component} or on methods annotated with @{@link Bean}.
+ * {@code @Component} or on methods annotated with {@link Bean}.
  *
  * <h2>Example</h2>
  * <pre class="code">

--- a/spring-context/src/main/java/org/springframework/context/annotation/PropertySource.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/PropertySource.java
@@ -29,7 +29,7 @@ import org.springframework.core.io.support.PropertySourceFactory;
  * Annotation providing a convenient and declarative mechanism for adding a
  * {@link org.springframework.core.env.PropertySource PropertySource} to Spring's
  * {@link org.springframework.core.env.Environment Environment}. To be used in
- * conjunction with @{@link Configuration} classes.
+ * conjunction with {@link Configuration} classes.
  *
  * <h3>Example usage</h3>
  *

--- a/spring-context/src/main/java/org/springframework/context/annotation/Role.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/Role.java
@@ -36,8 +36,8 @@ import org.springframework.beans.factory.config.BeanDefinition;
  *
  * <p>If Role is present on a {@link Configuration @Configuration} class,
  * this indicates the role of the configuration class bean definition and
- * does not cascade to all @{@code Bean} methods defined within. This behavior
- * is different than that of the @{@link Lazy} annotation, for example.
+ * does not cascade to all {@code Bean} methods defined within. This behavior
+ * is different than that of the {@link Lazy} annotation, for example.
  *
  * @author Chris Beams
  * @since 3.1

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncConfigurer.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncConfigurer.java
@@ -22,8 +22,8 @@ import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.lang.Nullable;
 
 /**
- * Interface to be implemented by @{@link org.springframework.context.annotation.Configuration
- * Configuration} classes annotated with @{@link EnableAsync} that wish to customize the
+ * Interface to be implemented by {@link org.springframework.context.annotation.Configuration
+ * Configuration} classes annotated with {@link EnableAsync} that wish to customize the
  * {@link Executor} instance used when processing async method invocations or the
  * {@link AsyncUncaughtExceptionHandler} instance used to process exception thrown from
  * async method with {@code void} return type.
@@ -33,7 +33,7 @@ import org.springframework.lang.Nullable;
  * of this interface will be insured in case new customization options are introduced
  * in the future.
  *
- * <p>See @{@link EnableAsync} for usage examples.
+ * <p>See {@link EnableAsync} for usage examples.
  *
  * @author Chris Beams
  * @author Stephane Nicoll

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableAsync.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableAsync.java
@@ -32,7 +32,7 @@ import org.springframework.core.Ordered;
  * Enables Spring's asynchronous method execution capability, similar to functionality
  * found in Spring's {@code <task:*>} XML namespace.
  *
- * <p>To be used together with @{@link Configuration Configuration} classes as follows,
+ * <p>To be used together with {@link Configuration Configuration} classes as follows,
  * enabling annotation-driven async processing for an entire Spring application context:
  *
  * <pre class="code">
@@ -165,7 +165,7 @@ public @interface EnableAsync {
 	/**
 	 * Indicate the 'async' annotation type to be detected at either class
 	 * or method level.
-	 * <p>By default, both Spring's @{@link Async} annotation and the EJB 3.1
+	 * <p>By default, both Spring's {@link Async} annotation and the EJB 3.1
 	 * {@code @javax.ejb.Asynchronous} annotation will be detected.
 	 * <p>This attribute exists so that developers can provide their own
 	 * custom annotation type to indicate that a method (or all methods of

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableScheduling.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableScheduling.java
@@ -31,7 +31,7 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 /**
  * Enables Spring's scheduled task execution capability, similar to
  * functionality found in Spring's {@code <task:*>} XML namespace. To be used
- * on @{@link Configuration} classes as follows:
+ * on {@link Configuration} classes as follows:
  *
  * <pre class="code">
  * &#064;Configuration
@@ -41,7 +41,7 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  *     // various &#064;Bean definitions
  * }</pre>
  *
- * This enables detection of @{@link Scheduled} annotations on any Spring-managed
+ * This enables detection of {@link Scheduled} annotations on any Spring-managed
  * bean in the container. For example, given a class {@code MyTask}
  *
  * <pre class="code">

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -37,7 +37,7 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  * <p>Processing of {@code @Scheduled} annotations is performed by
  * registering a {@link ScheduledAnnotationBeanPostProcessor}. This can be
  * done manually or, more conveniently, through the {@code <task:annotation-driven/>}
- * element or @{@link EnableScheduling} annotation.
+ * element or {@link EnableScheduling} annotation.
  *
  * <p>This annotation may be used as a <em>meta-annotation</em> to create custom
  * <em>composed annotations</em> with attribute overrides.

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -77,7 +77,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 
 /**
- * Bean post-processor that registers methods annotated with @{@link Scheduled}
+ * Bean post-processor that registers methods annotated with {@link Scheduled}
  * to be invoked by a {@link org.springframework.scheduling.TaskScheduler} according
  * to the "fixedRate", "fixedDelay", or "cron" expression provided via the annotation.
  *
@@ -88,7 +88,7 @@ import org.springframework.util.StringValueResolver;
  * <p>Autodetects any {@link SchedulingConfigurer} instances in the container,
  * allowing for customization of the scheduler to be used or for fine-grained
  * control over task registration (e.g. registration of {@link Trigger} tasks.
- * See the @{@link EnableScheduling} javadocs for complete usage details.
+ * See the {@link EnableScheduling} javadocs for complete usage details.
  *
  * @author Mark Fisher
  * @author Juergen Hoeller

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/SchedulingConfiguration.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/SchedulingConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.scheduling.config.TaskManagementConfigUtils;
 
 /**
  * {@code @Configuration} class that registers a {@link ScheduledAnnotationBeanPostProcessor}
- * bean capable of processing Spring's @{@link Scheduled} annotation.
+ * bean capable of processing Spring's {@link Scheduled} annotation.
  *
  * <p>This configuration class is automatically imported when using the
  * {@link EnableScheduling @EnableScheduling} annotation. See

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/SchedulingConfigurer.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/SchedulingConfigurer.java
@@ -19,17 +19,17 @@ package org.springframework.scheduling.annotation;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
 /**
- * Optional interface to be implemented by @{@link
+ * Optional interface to be implemented by {@link
  * org.springframework.context.annotation.Configuration Configuration} classes annotated
- * with @{@link EnableScheduling}. Typically used for setting a specific
+ * with {@link EnableScheduling}. Typically used for setting a specific
  * {@link org.springframework.scheduling.TaskScheduler TaskScheduler} bean to be used when
  * executing scheduled tasks or for registering scheduled tasks in a <em>programmatic</em>
- * fashion as opposed to the <em>declarative</em> approach of using the @{@link Scheduled}
+ * fashion as opposed to the <em>declarative</em> approach of using the {@link Scheduled}
  * annotation. For example, this may be necessary when implementing {@link
  * org.springframework.scheduling.Trigger Trigger}-based tasks, which are not supported by
  * the {@code @Scheduled} annotation.
  *
- * <p>See @{@link EnableScheduling} for detailed usage examples.
+ * <p>See {@link EnableScheduling} for detailed usage examples.
  *
  * @author Chris Beams
  * @since 3.1

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationAwareOrderComparator.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationAwareOrderComparator.java
@@ -80,8 +80,8 @@ public class AnnotationAwareOrderComparator extends OrderComparator {
 	}
 
 	/**
-	 * This implementation retrieves an @{@link javax.annotation.Priority}
-	 * value, allowing for additional semantics over the regular @{@link Order}
+	 * This implementation retrieves an {@link javax.annotation.Priority}
+	 * value, allowing for additional semantics over the regular {@link Order}
 	 * annotation: typically, selecting one object over another in case of
 	 * multiple matches but only one object to be returned.
 	 */

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
@@ -309,7 +309,7 @@ public abstract class AnnotationUtils {
 	 * <p>This method mimics the functionality of Java 8's
 	 * {@link java.lang.reflect.AnnotatedElement#getAnnotationsByType(Class)}
 	 * with support for automatic detection of a <em>container annotation</em>
-	 * declared via @{@link java.lang.annotation.Repeatable} (when running on
+	 * declared via {@link java.lang.annotation.Repeatable} (when running on
 	 * Java 8 or higher) and with additional support for meta-annotations.
 	 * <p>Handles both single annotations and annotations nested within a
 	 * <em>container annotation</em>.
@@ -354,7 +354,7 @@ public abstract class AnnotationUtils {
 	 * @param annotationType the annotation type to look for
 	 * @param containerAnnotationType the type of the container that holds
 	 * the annotations; may be {@code null} if a container is not supported
-	 * or if it should be looked up via @{@link java.lang.annotation.Repeatable}
+	 * or if it should be looked up via {@link java.lang.annotation.Repeatable}
 	 * when running on Java 8 or higher
 	 * @return the annotations found or an empty set (never {@code null})
 	 * @since 4.2
@@ -390,7 +390,7 @@ public abstract class AnnotationUtils {
 	 * <p>This method mimics the functionality of Java 8's
 	 * {@link java.lang.reflect.AnnotatedElement#getDeclaredAnnotationsByType(Class)}
 	 * with support for automatic detection of a <em>container annotation</em>
-	 * declared via @{@link java.lang.annotation.Repeatable} (when running on
+	 * declared via {@link java.lang.annotation.Repeatable} (when running on
 	 * Java 8 or higher) and with additional support for meta-annotations.
 	 * <p>Handles both single annotations and annotations nested within a
 	 * <em>container annotation</em>.
@@ -436,7 +436,7 @@ public abstract class AnnotationUtils {
 	 * @param annotationType the annotation type to look for
 	 * @param containerAnnotationType the type of the container that holds
 	 * the annotations; may be {@code null} if a container is not supported
-	 * or if it should be looked up via @{@link java.lang.annotation.Repeatable}
+	 * or if it should be looked up via {@link java.lang.annotation.Repeatable}
 	 * when running on Java 8 or higher
 	 * @return the annotations found or an empty set (never {@code null})
 	 * @since 4.2

--- a/spring-core/src/main/java/org/springframework/core/env/PropertySource.java
+++ b/spring-core/src/main/java/org/springframework/core/env/PropertySource.java
@@ -42,9 +42,9 @@ import org.springframework.util.ObjectUtils;
  * objects when in collection contexts. See operations in {@link MutablePropertySources}
  * as well as the {@link #named(String)} and {@link #toString()} methods for details.
  *
- * <p>Note that when working with @{@link
+ * <p>Note that when working with {@link
  * org.springframework.context.annotation.Configuration Configuration} classes that
- * the @{@link org.springframework.context.annotation.PropertySource PropertySource}
+ * the {@link org.springframework.context.annotation.PropertySource PropertySource}
  * annotation provides a convenient and declarative way of adding property sources to the
  * enclosing {@code Environment}.
  *

--- a/spring-jms/src/main/java/org/springframework/jms/annotation/JmsBootstrapConfiguration.java
+++ b/spring-jms/src/main/java/org/springframework/jms/annotation/JmsBootstrapConfiguration.java
@@ -25,10 +25,10 @@ import org.springframework.jms.config.JmsListenerEndpointRegistry;
 
 /**
  * {@code @Configuration} class that registers a {@link JmsListenerAnnotationBeanPostProcessor}
- * bean capable of processing Spring's @{@link JmsListener} annotation. Also register
+ * bean capable of processing Spring's {@link JmsListener} annotation. Also register
  * a default {@link JmsListenerEndpointRegistry}.
  *
- * <p>This configuration class is automatically imported when using the @{@link EnableJms}
+ * <p>This configuration class is automatically imported when using the {@link EnableJms}
  * annotation. See the {@link EnableJms} javadocs for complete usage details.
  *
  * @author Stephane Nicoll

--- a/spring-jms/src/main/java/org/springframework/jms/annotation/JmsListenerConfigurer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/annotation/JmsListenerConfigurer.java
@@ -24,9 +24,9 @@ import org.springframework.jms.config.JmsListenerEndpointRegistrar;
  * used to define the default {@link org.springframework.jms.config.JmsListenerContainerFactory
  * JmsListenerContainerFactory} to use or for registering JMS endpoints
  * in a <em>programmatic</em> fashion as opposed to the <em>declarative</em>
- * approach of using the @{@link JmsListener} annotation.
+ * approach of using the {@link JmsListener} annotation.
  *
- * <p>See @{@link EnableJms} for detailed usage examples.
+ * <p>See {@link EnableJms} for detailed usage examples.
  *
  * @author Stephane Nicoll
  * @since 4.1

--- a/spring-test/src/main/java/org/springframework/test/context/ContextConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/ContextConfiguration.java
@@ -158,7 +158,7 @@ public @interface ContextConfiguration {
 	 * created by the {@link SmartContextLoader} in use.
 	 * <p>{@code SmartContextLoader} implementations typically detect whether
 	 * Spring's {@link org.springframework.core.Ordered Ordered} interface has been
-	 * implemented or if the @{@link org.springframework.core.annotation.Order Order}
+	 * implemented or if the {@link org.springframework.core.annotation.Order Order}
 	 * annotation is present and sort instances accordingly prior to invoking them.
 	 * @since 3.2
 	 * @see org.springframework.context.ApplicationContextInitializer

--- a/spring-tx/src/main/java/org/springframework/dao/annotation/PersistenceExceptionTranslationPostProcessor.java
+++ b/spring-tx/src/main/java/org/springframework/dao/annotation/PersistenceExceptionTranslationPostProcessor.java
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
 
 /**
  * Bean post-processor that automatically applies persistence exception translation to any
- * bean marked with Spring's @{@link org.springframework.stereotype.Repository Repository}
+ * bean marked with Spring's {@link org.springframework.stereotype.Repository Repository}
  * annotation, adding a corresponding {@link PersistenceExceptionTranslationAdvisor} to
  * the exposed proxy (either an existing AOP proxy or a newly generated proxy that
  * implements all of the target's interfaces).

--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/TransactionManagementConfigurer.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/TransactionManagementConfigurer.java
@@ -19,15 +19,15 @@ package org.springframework.transaction.annotation;
 import org.springframework.transaction.TransactionManager;
 
 /**
- * Interface to be implemented by @{@link org.springframework.context.annotation.Configuration
- * Configuration} classes annotated with @{@link EnableTransactionManagement} that wish to
+ * Interface to be implemented by {@link org.springframework.context.annotation.Configuration
+ * Configuration} classes annotated with {@link EnableTransactionManagement} that wish to
  * (or need to) explicitly specify the default {@code PlatformTransactionManager} bean
  * (or {@code ReactiveTransactionManager} bean) to be used for annotation-driven
  * transaction management, as opposed to the default approach of a by-type lookup.
  * One reason this might be necessary is if there are two {@code PlatformTransactionManager}
  * beans (or two {@code ReactiveTransactionManager} beans) present in the container.
  *
- * <p>See @{@link EnableTransactionManagement} for general examples and context;
+ * <p>See {@link EnableTransactionManagement} for general examples and context;
  * see {@link #annotationDrivenTransactionManager()} for detailed instructions.
  *
  * <p>Note that in by-type lookup disambiguation cases, an alternative approach to

--- a/spring-tx/src/main/java/org/springframework/transaction/config/TransactionManagementConfigUtils.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/config/TransactionManagementConfigUtils.java
@@ -44,7 +44,7 @@ public abstract class TransactionManagementConfigUtils {
 			"org.springframework.transaction.aspectj.AnnotationTransactionAspect";
 
 	/**
-	 * The name of the AspectJ transaction management @{@code Configuration} class.
+	 * The name of the AspectJ transaction management {@code Configuration} class.
 	 */
 	public static final String TRANSACTION_ASPECT_CONFIGURATION_CLASS_NAME =
 			"org.springframework.transaction.aspectj.AspectJTransactionManagementConfiguration";
@@ -64,7 +64,7 @@ public abstract class TransactionManagementConfigUtils {
 			"org.springframework.transaction.aspectj.JtaAnnotationTransactionAspect";
 
 	/**
-	 * The name of the AspectJ transaction management @{@code Configuration} class for JTA.
+	 * The name of the AspectJ transaction management {@code Configuration} class for JTA.
 	 * @since 5.1
 	 */
 	public static final String JTA_TRANSACTION_ASPECT_CONFIGURATION_CLASS_NAME =

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionProxyFactoryBean.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionProxyFactoryBean.java
@@ -44,8 +44,8 @@ import org.springframework.transaction.PlatformTransactionManager;
  * section of the Spring reference documentation to understand modern options for managing
  * transactions in Spring applications. For these reasons, <strong>users should favor
  * the {@code tx:} XML namespace as well as
- * the @{@link org.springframework.transaction.annotation.Transactional Transactional}
- * and @{@link org.springframework.transaction.annotation.EnableTransactionManagement
+ * the {@link org.springframework.transaction.annotation.Transactional Transactional}
+ * and {@link org.springframework.transaction.annotation.EnableTransactionManagement
  * EnableTransactionManagement} annotations.</strong>
  *
  * <p>There are three main properties that need to be specified:

--- a/spring-web/src/main/java/org/springframework/web/SpringServletContainerInitializer.java
+++ b/spring-web/src/main/java/org/springframework/web/SpringServletContainerInitializer.java
@@ -116,7 +116,7 @@ public class SpringServletContainerInitializer implements ServletContainerInitia
 	/**
 	 * Delegate the {@code ServletContext} to any {@link WebApplicationInitializer}
 	 * implementations present on the application classpath.
-	 * <p>Because this class declares @{@code HandlesTypes(WebApplicationInitializer.class)},
+	 * <p>Because this class declares {@code HandlesTypes(WebApplicationInitializer.class)},
 	 * Servlet 3.0+ containers will automatically scan the classpath for implementations
 	 * of Spring's {@code WebApplicationInitializer} interface and provide the set of all
 	 * such types to the {@code webAppInitializerClasses} parameter of this method.
@@ -125,7 +125,7 @@ public class SpringServletContainerInitializer implements ServletContainerInitia
 	 * the user that the {@code ServletContainerInitializer} has indeed been invoked but that
 	 * no {@code WebApplicationInitializer} implementations were found.
 	 * <p>Assuming that one or more {@code WebApplicationInitializer} types are detected,
-	 * they will be instantiated (and <em>sorted</em> if the @{@link
+	 * they will be instantiated (and <em>sorted</em> if the {@link
 	 * org.springframework.core.annotation.Order @Order} annotation is present or
 	 * the {@link org.springframework.core.Ordered Ordered} interface has been
 	 * implemented). Then the {@link WebApplicationInitializer#onStartup(ServletContext)}

--- a/spring-web/src/main/java/org/springframework/web/WebApplicationInitializer.java
+++ b/spring-web/src/main/java/org/springframework/web/WebApplicationInitializer.java
@@ -97,7 +97,7 @@ import javax.servlet.ServletException;
  * the form of a {@code WebApplicationInitializer}, but the actual
  * {@code dispatcher-config.xml} Spring configuration remained XML-based.
  * {@code WebApplicationInitializer} is a perfect fit for use with Spring's code-based
- * {@code @Configuration} classes. See @{@link
+ * {@code @Configuration} classes. See {@link
  * org.springframework.context.annotation.Configuration Configuration} Javadoc for
  * complete details, but the following example demonstrates refactoring to use Spring's
  * {@link org.springframework.web.context.support.AnnotationConfigWebApplicationContext
@@ -142,7 +142,7 @@ import javax.servlet.ServletException;
  *
  * <h2>Ordering {@code WebApplicationInitializer} execution</h2>
  * {@code WebApplicationInitializer} implementations may optionally be annotated at the
- * class level with Spring's @{@link org.springframework.core.annotation.Order Order}
+ * class level with Spring's {@link org.springframework.core.annotation.Order Order}
  * annotation or may implement Spring's {@link org.springframework.core.Ordered Ordered}
  * interface. If so, the initializers will be ordered prior to invocation. This provides
  * a mechanism for users to ensure the order in which servlet container initialization

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestPart.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestPart.java
@@ -38,10 +38,10 @@ import org.springframework.web.multipart.MultipartResolver;
  * conjunction with Servlet 3.0 multipart requests, or otherwise for any other method
  * argument, the content of the part is passed through an {@link HttpMessageConverter}
  * taking into consideration the 'Content-Type' header of the request part. This is
- * analogous to what @{@link RequestBody} does to resolve an argument based on the
+ * analogous to what {@link RequestBody} does to resolve an argument based on the
  * content of a non-multipart regular request.
  *
- * <p>Note that @{@link RequestParam} annotation can also be used to associate the part
+ * <p>Note that {@link RequestParam} annotation can also be used to associate the part
  * of a "multipart/form-data" request with a method argument supporting the same method
  * argument types. The main difference is that when the method argument is not a String
  * or raw {@code MultipartFile} / {@code Part}, {@code @RequestParam} relies on type

--- a/spring-web/src/main/java/org/springframework/web/context/ContextLoader.java
+++ b/spring-web/src/main/java/org/springframework/web/context/ContextLoader.java
@@ -411,7 +411,7 @@ public class ContextLoader {
 	 * {@linkplain ApplicationContextInitializer#initialize invokes each} with the
 	 * given web application context.
 	 * <p>Any {@code ApplicationContextInitializers} implementing
-	 * {@link org.springframework.core.Ordered Ordered} or marked with @{@link
+	 * {@link org.springframework.core.Ordered Ordered} or marked with {@link
 	 * org.springframework.core.annotation.Order Order} will be sorted appropriately.
 	 * @param sc the current servlet context
 	 * @param wac the newly created application context

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/InitBinderDataBinderFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/InitBinderDataBinderFactory.java
@@ -58,7 +58,7 @@ public class InitBinderDataBinderFactory extends DefaultDataBinderFactory {
 	 * Initialize a WebDataBinder with {@code @InitBinder} methods.
 	 * <p>If the {@code @InitBinder} annotation specifies attributes names,
 	 * it is invoked only if the names include the target object name.
-	 * @throws Exception if one of the invoked @{@link InitBinder} methods fails
+	 * @throws Exception if one of the invoked {@link InitBinder} methods fails
 	 * @see #isBinderMethodApplicable
 	 */
 	@Override

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMapMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMapMethodArgumentResolver.java
@@ -40,7 +40,7 @@ import org.springframework.web.multipart.MultipartRequest;
 import org.springframework.web.multipart.support.MultipartResolutionDelegate;
 
 /**
- * Resolves {@link Map} method arguments annotated with an @{@link RequestParam}
+ * Resolves {@link Map} method arguments annotated with an {@link RequestParam}
  * where the annotation does not specify a request parameter name.
  *
  * <p>The created {@link Map} contains all request parameter name/value pairs,

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java
@@ -50,7 +50,7 @@ import org.springframework.web.multipart.support.MultipartResolutionDelegate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * Resolves method arguments annotated with @{@link RequestParam}, arguments of
+ * Resolves method arguments annotated with {@link RequestParam}, arguments of
  * type {@link MultipartFile} in conjunction with Spring's {@link MultipartResolver}
  * abstraction, and arguments of type {@code javax.servlet.http.Part} in conjunction
  * with Servlet 3.0 multipart requests. This resolver can also be created in default
@@ -118,9 +118,9 @@ public class RequestParamMethodArgumentResolver extends AbstractNamedValueMethod
 	 * <li>@RequestParam-annotated method arguments.
 	 * This excludes {@link Map} params where the annotation does not specify a name.
 	 * See {@link RequestParamMapMethodArgumentResolver} instead for such params.
-	 * <li>Arguments of type {@link MultipartFile} unless annotated with @{@link RequestPart}.
-	 * <li>Arguments of type {@code Part} unless annotated with @{@link RequestPart}.
-	 * <li>In default resolution mode, simple type arguments even if not with @{@link RequestParam}.
+	 * <li>Arguments of type {@link MultipartFile} unless annotated with {@link RequestPart}.
+	 * <li>Arguments of type {@code Part} unless annotated with {@link RequestPart}.
+	 * <li>In default resolution mode, simple type arguments even if not with {@link RequestParam}.
 	 * </ul>
 	 */
 	@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/PathVariableMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/PathVariableMethodArgumentResolver.java
@@ -34,9 +34,9 @@ import org.springframework.web.server.ServerErrorException;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
- * Resolves method arguments annotated with @{@link PathVariable}.
+ * Resolves method arguments annotated with {@link PathVariable}.
  *
- * <p>An @{@link PathVariable} is a named value that gets resolved from a URI
+ * <p>An {@link PathVariable} is a named value that gets resolved from a URI
  * template variable. It is always required and does not have a default value
  * to fall back on. See the base class
  * {@link org.springframework.web.method.annotation.AbstractNamedValueMethodArgumentResolver}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestAttributeMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestAttributeMethodArgumentResolver.java
@@ -30,7 +30,7 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.ServerWebInputException;
 
 /**
- * Resolves method arguments annotated with an @{@link RequestAttribute}.
+ * Resolves method arguments annotated with an {@link RequestAttribute}.
  *
  * @author Rossen Stoyanchev
  * @since 5.0

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMapping.java
@@ -129,7 +129,7 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 
 	/**
 	 * {@inheritDoc}
-	 * Expects a handler to have a type-level @{@link Controller} annotation.
+	 * Expects a handler to have a type-level {@link Controller} annotation.
 	 */
 	@Override
 	protected boolean isHandler(Class<?> beanType) {
@@ -138,7 +138,7 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 	}
 
 	/**
-	 * Uses method and type-level @{@link RequestMapping} annotations to create
+	 * Uses method and type-level {@link RequestMapping} annotations to create
 	 * the RequestMappingInfo.
 	 * @return the created RequestMappingInfo, or {@code null} if the method
 	 * does not have a {@code @RequestMapping} annotation.

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestParamMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestParamMethodArgumentResolver.java
@@ -32,11 +32,11 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.ServerWebInputException;
 
 /**
- * Resolver for method arguments annotated with @{@link RequestParam} from URI
+ * Resolver for method arguments annotated with {@link RequestParam} from URI
  * query string parameters.
  *
  * <p>This resolver can also be created in default resolution mode in which
- * simple types (int, long, etc.) not annotated with @{@link RequestParam} are
+ * simple types (int, long, etc.) not annotated with {@link RequestParam} are
  * also treated as request parameters with the parameter name derived from the
  * argument name.
  *

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/SessionAttributeMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/SessionAttributeMethodArgumentResolver.java
@@ -28,7 +28,7 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.ServerWebInputException;
 
 /**
- * Resolves method arguments annotated with an @{@link SessionAttribute}.
+ * Resolves method arguments annotated with an {@link SessionAttribute}.
  *
  * @author Rossen Stoyanchev
  * @since 5.0

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
@@ -33,7 +33,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.servlet.HandlerMapping;
 
 /**
- * Resolves {@link Map} method arguments annotated with an @{@link PathVariable}
+ * Resolves {@link Map} method arguments annotated with an {@link PathVariable}
  * where the annotation does not specify a path variable name. The created
  * {@link Map} contains all URI template name/value pairs.
  *

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMethodArgumentResolver.java
@@ -42,9 +42,9 @@ import org.springframework.web.servlet.View;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * Resolves method arguments annotated with an @{@link PathVariable}.
+ * Resolves method arguments annotated with an {@link PathVariable}.
  *
- * <p>An @{@link PathVariable} is a named value that gets resolved from a URI template variable.
+ * <p>An {@link PathVariable} is a named value that gets resolved from a URI template variable.
  * It is always required and does not have a default value to fall back on. See the base class
  * {@link org.springframework.web.method.annotation.AbstractNamedValueMethodArgumentResolver}
  * for more information on how named values are processed.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolver.java
@@ -29,7 +29,7 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.method.annotation.AbstractNamedValueMethodArgumentResolver;
 
 /**
- * Resolves method arguments annotated with an @{@link RequestAttribute}.
+ * Resolves method arguments annotated with an {@link RequestAttribute}.
  *
  * @author Rossen Stoyanchev
  * @since 4.3

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
@@ -249,8 +249,8 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 
 	/**
 	 * {@inheritDoc}
-	 * <p>Expects a handler to have either a type-level @{@link Controller}
-	 * annotation or a type-level @{@link RequestMapping} annotation.
+	 * <p>Expects a handler to have either a type-level {@link Controller}
+	 * annotation or a type-level {@link RequestMapping} annotation.
 	 */
 	@Override
 	protected boolean isHandler(Class<?> beanType) {
@@ -259,7 +259,7 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 	}
 
 	/**
-	 * Uses method and type-level @{@link RequestMapping} annotations to create
+	 * Uses method and type-level {@link RequestMapping} annotations to create
 	 * the RequestMappingInfo.
 	 * @return the created RequestMappingInfo, or {@code null} if the method
 	 * does not have a {@code @RequestMapping} annotation.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestPartMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestPartMethodArgumentResolver.java
@@ -44,14 +44,14 @@ import org.springframework.web.multipart.support.RequestPartServletServerHttpReq
 /**
  * Resolves the following method arguments:
  * <ul>
- * <li>Annotated with @{@link RequestPart}
+ * <li>Annotated with {@link RequestPart}
  * <li>Of type {@link MultipartFile} in conjunction with Spring's {@link MultipartResolver} abstraction
  * <li>Of type {@code javax.servlet.http.Part} in conjunction with Servlet 3.0 multipart requests
  * </ul>
  *
  * <p>When a parameter is annotated with {@code @RequestPart}, the content of the part is
  * passed through an {@link HttpMessageConverter} to resolve the method argument with the
- * 'Content-Type' of the request part in mind. This is analogous to what @{@link RequestBody}
+ * 'Content-Type' of the request part in mind. This is analogous to what {@link RequestBody}
  * does to resolve an argument based on the content of a regular request.
  *
  * <p>When a parameter is not annotated or the name of the part is not specified,

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SessionAttributeMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SessionAttributeMethodArgumentResolver.java
@@ -29,7 +29,7 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.method.annotation.AbstractNamedValueMethodArgumentResolver;
 
 /**
- * Resolves method arguments annotated with an @{@link SessionAttribute}.
+ * Resolves method arguments annotated with an {@link SessionAttribute}.
  *
  * @author Rossen Stoyanchev
  * @since 4.3

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HandlerMethodAnnotationDetectionTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HandlerMethodAnnotationDetectionTests.java
@@ -476,7 +476,7 @@ class HandlerMethodAnnotationDetectionTests {
 
 	/**
 	 * SPR-8248
-	 * <p>Support class contains all annotations. Subclass has type-level @{@link RequestMapping}.
+	 * <p>Support class contains all annotations. Subclass has type-level {@link RequestMapping}.
 	 */
 	@Controller
 	static class MappingSupportClass {


### PR DESCRIPTION
There are many document formatting errors in the project, causing some tools to parse the source code incorrectly when reading it