### PR TITLE
Fall back on awaitToBodylessEntity when awaitBody is used with Unit

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
@@ -138,7 +138,16 @@ inline fun <reified T : Any> WebClient.ResponseSpec.bodyToFlow(): Flow<T> =
  * @since 5.2
  */
 suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBody() : T =
-		bodyToMono<T>().awaitSingle()
+	when (T::class) {
+		Unit::class -> awaitBodilessEntity().let { Unit as T }
+		else -> bodyToMono<T>().awaitSingle()
+	}
+
+/**
+ * Coroutines variant of [WebClient.ResponseSpec.toBodilessEntity].
+ */
+suspend inline fun WebClient.ResponseSpec.awaitBodilessEntity() =
+	toBodilessEntity().awaitSingle()
 
 /**
  * Extension for [WebClient.ResponseSpec.toEntity] providing a `toEntity<Foo>()` variant

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/client/WebClientExtensionsTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/client/WebClientExtensionsTests.kt
@@ -126,6 +126,24 @@ class WebClientExtensionsTests {
 	}
 
 	@Test
+	fun `awaitBody of type Unit`() {
+		val spec = mockk<WebClient.ResponseSpec>()
+		every { spec.toBodilessEntity() } returns Mono.empty()
+		runBlocking {
+			assertThat(spec.awaitBody<Unit>()).isEqualTo(Unit)
+		}
+	}
+
+	@Test
+	fun awaitBodilessEntity() {
+		val spec = mockk<WebClient.ResponseSpec>()
+		every { spec.toBodilessEntity() } returns Mono.empty()
+		runBlocking {
+			assertThat(spec.awaitBodilessEntity()).isEqualTo(Unit)
+		}
+	}
+
+	@Test
 	fun `ResponseSpec#toEntity with reified type parameters`() {
 		responseSpec.toEntity<List<Foo>>()
 		verify { responseSpec.toEntity(object : ParameterizedTypeReference<List<Foo>>() {}) }


### PR DESCRIPTION
allow WebClient.ResponseSpec.awaitBody()
to be used in combination with Type "Unit"