### PR TITLE
Fixed grammar in ResponseEntity documentation

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -32,7 +32,7 @@ import org.springframework.util.ObjectUtils;
 
 /**
  * Extension of {@link HttpEntity} that adds a {@link HttpStatus} status code.
- * Used in {@code RestTemplate} as well {@code @Controller} methods.
+ * Used in {@code RestTemplate} as well as {@code @Controller} methods.
  *
  * <p>In {@code RestTemplate}, this class is returned by
  * {@link org.springframework.web.client.RestTemplate#getForEntity getForEntity()} and
@@ -44,7 +44,7 @@ import org.springframework.util.ObjectUtils;
  * HttpStatus statusCode = entity.getStatusCode();
  * </pre>
  *
- * <p>Can also be used in Spring MVC, as the return value from a @Controller method:
+ * <p>This can also be used in Spring MVC as the return value from a @Controller method:
  * <pre class="code">
  * &#64;RequestMapping("/handle")
  * public ResponseEntity&lt;String&gt; handle() {
@@ -81,7 +81,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 
 
 	/**
-	 * Create a new {@code ResponseEntity} with the given status code, and no body nor headers.
+	 * Create a new {@code ResponseEntity} with the given status code, but no body or headers.
 	 * @param status the status code
 	 */
 	public ResponseEntity(HttpStatus status) {
@@ -89,7 +89,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	}
 
 	/**
-	 * Create a new {@code ResponseEntity} with the given body and status code, and no headers.
+	 * Create a new {@code ResponseEntity} with the given body and status code, but no headers.
 	 * @param body the entity body
 	 * @param status the status code
 	 */
@@ -98,7 +98,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	}
 
 	/**
-	 * Create a new {@code HttpEntity} with the given headers and status code, and no body.
+	 * Create a new {@code HttpEntity} with the given headers and status code, but no body.
 	 * @param headers the entity headers
 	 * @param status the status code
 	 */


### PR DESCRIPTION
Fixed some grammatical mistakes or instances that were somewhat more
difficult to read clearly in the ResponseEntity javadoc comments.

I have checked for issues mentioning this file, but if I have missed anything that already covers this, just let me know.