### PR TITLE
Support cookies with Expires attribute but no Max-Age attribute in MockHttpServletResponse

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -386,7 +386,8 @@ public class MockHttpServletResponse implements HttpServletResponse {
 				headers.setExpires(maxAge > 0 ? System.currentTimeMillis() + 1000L * maxAge : 0);
 				buf.append(headers.getFirst(HttpHeaders.EXPIRES));
 			}
-		} else if (expires != null) {
+		}
+		else if (expires != null) {
 			buf.append("; Expires=");
 			buf.append(expires.format(DateTimeFormatter.RFC_1123_DATE_TIME));
 		}

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -374,10 +374,10 @@ public class MockHttpServletResponse implements HttpServletResponse {
 			buf.append("; Domain=").append(cookie.getDomain());
 		}
 		int maxAge = cookie.getMaxAge();
+		ZonedDateTime expires = (cookie instanceof MockCookie ? ((MockCookie) cookie).getExpires() : null);
 		if (maxAge >= 0) {
 			buf.append("; Max-Age=").append(maxAge);
 			buf.append("; Expires=");
-			ZonedDateTime expires = (cookie instanceof MockCookie ? ((MockCookie) cookie).getExpires() : null);
 			if (expires != null) {
 				buf.append(expires.format(DateTimeFormatter.RFC_1123_DATE_TIME));
 			}
@@ -386,7 +386,11 @@ public class MockHttpServletResponse implements HttpServletResponse {
 				headers.setExpires(maxAge > 0 ? System.currentTimeMillis() + 1000L * maxAge : 0);
 				buf.append(headers.getFirst(HttpHeaders.EXPIRES));
 			}
+		} else if (expires != null) {
+			buf.append("; Expires=");
+			buf.append(expires.format(DateTimeFormatter.RFC_1123_DATE_TIME));
 		}
+
 
 		if (cookie.getSecure()) {
 			buf.append("; Secure");

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
@@ -417,6 +417,17 @@ class MockHttpServletResponseTests {
 		assertThat(header).startsWith("SESSION=123; Path=/; Max-Age=100; Expires=");
 	}
 
+	/**
+	 * @since 5.1.12
+	 */
+	@Test
+	void addCookieHeaderWithOnlyExpiresAttribute() {
+		String cookieValue = "SESSION=123; Path=/; Expires=Tue, 8 Oct 2019 19:50:00 GMT";
+		response.addHeader(SET_COOKIE, cookieValue);
+		assertNumCookies(1);
+		assertThat(response.getHeader(SET_COOKIE)).isEqualTo(cookieValue);
+	}
+
 	@Test
 	void addCookie() {
 		MockCookie mockCookie = new MockCookie("SESSION", "123");


### PR DESCRIPTION
According to the spec it is allowed to have cookies that only use the `Expires` attribute (even though it's really old style).

`MockHttpServletResponse` didn't previously support that properly.

So, added a testcase and made it work.