### PR TITLE
DataClassRowMapper should not override Kotlin init properties

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/DataClassRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/DataClassRowMapper.java
@@ -21,6 +21,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.TypeConverter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.lang.Nullable;
@@ -127,4 +128,19 @@ public class DataClassRowMapper<T> extends BeanPropertyRowMapper<T> {
 		return rowMapper;
 	}
 
+	/**
+	 * Extract the values for all columns in the current row.
+	 * <p>Utilizes public setters and result set meta-data.
+	 * @see java.sql.ResultSetMetaData
+	 */
+	@Override
+	public T mapRow(ResultSet rs, int rowNumber) throws SQLException {
+		BeanWrapperImpl bw = new BeanWrapperImpl();
+		initBeanWrapper(bw);
+
+		T mappedObject = constructMappedInstance(rs, bw);
+		bw.setBeanInstance(mappedObject);
+
+		return mappedObject;
+	}
 }

--- a/spring-jdbc/src/test/kotlin/org/springframework/jdbc/core/KtDataClassRowMapperTests.kt
+++ b/spring-jdbc/src/test/kotlin/org/springframework/jdbc/core/KtDataClassRowMapperTests.kt
@@ -1,0 +1,40 @@
+package org.springframework.jdbc.core
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.test.ConstructorPerson
+import java.math.BigDecimal
+import java.util.*
+
+class KtDataClassRowMapperTests : AbstractRowMapperTests() {
+
+	@Test
+	fun testStaticQueryWithDataClass() {
+		val mock = Mock()
+		val result = mock.jdbcTemplate.query(
+			"select name, age, birth_date, balance from people",
+			DataClassRowMapper(ConstructorPerson::class.java)
+		)
+		Assertions.assertThat(result.size).isEqualTo(1)
+		verifyPerson(result[0])
+		mock.verifyClosed()
+	}
+
+	data class KotlinPerson(var name: String, val age: Long, val birth_date: Date, val balance: BigDecimal) {
+		init {
+			name += " appended by init"
+		}
+	}
+
+	@Test
+	fun testInitPropertiesAreNotOverriden() {
+		val mock = Mock()
+		val result = mock.jdbcTemplate.query(
+			"select name, age, birth_date, balance from people",
+			DataClassRowMapper(KotlinPerson::class.java)
+		)
+		Assertions.assertThat(result.size).isEqualTo(1)
+		Assertions.assertThat(result[0].name).isEqualTo("Bubba appended by init")
+	}
+}
+


### PR DESCRIPTION
Since Kotlin data classes are already constructed with values we don't want to override all the properties later on again.
Properties modified in the init { } block in a class would be reverted back to the value of the column again.

An example of this would be setting the default scale of a BigDecimal inside an init block. The init would be called and set the scale after constructing. However, after constructing the BeanPropertyRowMapper would override the BigDecimal again so the scale would be 0 again.

This commit fixes this issue for Kotlin data classes.