### PR TITLE
ClassLoader.getResource can throw IllegalArgumentException

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/ClassPathResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/ClassPathResource.java
@@ -148,14 +148,19 @@ public class ClassPathResource extends AbstractFileResolvingResource {
 	 */
 	@Nullable
 	protected URL resolveURL() {
-		if (this.clazz != null) {
-			return this.clazz.getResource(this.path);
+		try {
+			if (this.clazz != null) {
+				return this.clazz.getResource(this.path);
+			}
+			else if (this.classLoader != null) {
+				return this.classLoader.getResource(this.path);
+			}
+			else {
+				return ClassLoader.getSystemResource(this.path);
+			}
 		}
-		else if (this.classLoader != null) {
-			return this.classLoader.getResource(this.path);
-		}
-		else {
-			return ClassLoader.getSystemResource(this.path);
+		catch (IllegalArgumentException ex) {
+			return null;
 		}
 	}
 


### PR DESCRIPTION
`ClassLoader.getResource` can throw `IllegalArgumentException` if a malformed URL is provided to it.

According to its javadoc, `resolveURL` should return null if not resolvable, so catch the `IllegalArgumentException` and return null.

Example stack trace produced by `new org.springframework.core.io.DefaultResourceLoader().getResource("C:/users/candrews/example").exists()`
```
java.lang.IllegalArgumentException: name
        at java.base/jdk.internal.loader.URLClassPath$Loader.findResource(URLClassPath.java:600)
        at java.base/jdk.internal.loader.URLClassPath.findResource(URLClassPath.java:291)
        at java.base/java.net.URLClassLoader$2.run(URLClassLoader.java:655)
        at java.base/java.net.URLClassLoader$2.run(URLClassLoader.java:653)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/java.net.URLClassLoader.findResource(URLClassLoader.java:652)
        at org.springframework.boot.loader.LaunchedURLClassLoader.findResource(LaunchedURLClassLoader.java:100)
        at java.base/java.lang.ClassLoader.getResource(ClassLoader.java:1401)
        at org.springframework.core.io.ClassPathResource.resolveURL(ClassPathResource.java:155)
        at org.springframework.core.io.ClassPathResource.exists(ClassPathResource.java:142)
```