### PR TITLE
Fix handling of "file:" paths to non-existent files on Windows

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/propertyeditors/PathEditor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/propertyeditors/PathEditor.java
@@ -97,7 +97,7 @@ public class PathEditor extends PropertyEditorSupport {
 		if (resource == null) {
 			setValue(null);
 		}
-		else if (!resource.exists() && nioPathCandidate) {
+		else if (!resource.isFile() && !resource.exists() && nioPathCandidate) {
 			setValue(Paths.get(text).normalize());
 		}
 		else {

--- a/spring-beans/src/test/java/org/springframework/beans/propertyeditors/PathEditorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/propertyeditors/PathEditorTests.java
@@ -77,6 +77,30 @@ public class PathEditorTests {
 	}
 
 	@Test
+	public void testWindowsAbsolutePath() throws Exception {
+		PropertyEditor pathEditor = new PathEditor();
+		pathEditor.setAsText("C:\\no_way_this_file_is_found.doc");
+		Object value = pathEditor.getValue();
+		boolean condition1 = value instanceof Path;
+		assertThat(condition1).isTrue();
+		Path path = (Path) value;
+		boolean condition = !path.toFile().exists();
+		assertThat(condition).isTrue();
+	}
+
+	@Test
+	public void testWindowsAbsoluteFilePath() throws Exception {
+		PropertyEditor pathEditor = new PathEditor();
+		pathEditor.setAsText("file://C:\\no_way_this_file_is_found.doc");
+		Object value = pathEditor.getValue();
+		boolean condition1 = value instanceof Path;
+		assertThat(condition1).isTrue();
+		Path path = (Path) value;
+		boolean condition = !path.toFile().exists();
+		assertThat(condition).isTrue();
+	}
+
+	@Test
 	public void testUnqualifiedPathNameFound() throws Exception {
 		PropertyEditor pathEditor = new PathEditor();
 		String fileName = ClassUtils.classPackageAsResourcePath(getClass()) + "/" +


### PR DESCRIPTION
On Windows, for `setAsText`, if the text argument is a `file:` URL for a path that does not exist, `Paths.get(text)` is called where text is a `file:` URL, which doesn't work - the result is an `InvalidPathException`. The Windows part is important - this issue only manifests when running on Windows.

To fix this issue, also check that the resource isn't a file before calling `Paths.get()`. That way, resources that are files skip to the other branch.