### PR TITLE
Fix MockHttpServletRequest reference in Javadoc

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletMapping.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletMapping.java
@@ -24,7 +24,7 @@ import org.springframework.lang.Nullable;
 /**
  * Mock implementation of {@link HttpServletMapping}.
  *
- * <p>Currently not exposed in {@link MockHttpServletMapping} as a setter to
+ * <p>Currently not exposed in {@link MockHttpServletRequest} as a setter to
  * avoid issues for Maven builds in applications with a Servlet 3.1 runtime
  * requirement.
  *


### PR DESCRIPTION
This PR fixes `MockHttpServletRequest` reference in Javadoc.