### PR TITLE
Correctly set auto-growing array's element

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -305,8 +305,10 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 					Class<?> componentType = propValue.getClass().getComponentType();
 					Object newArray = Array.newInstance(componentType, arrayIndex + 1);
 					System.arraycopy(propValue, 0, newArray, 0, length);
-					setPropertyValue(tokens.actualName, newArray);
-					propValue = getPropertyValue(tokens.actualName);
+					int lastKeyIndex = tokens.canonicalName.lastIndexOf('[');
+					String propName = tokens.canonicalName.substring(0, lastKeyIndex);
+					setPropertyValue(propName, newArray);
+					propValue = getPropertyValue(propName);
 				}
 				Array.set(propValue, arrayIndex, convertedValue);
 			}

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperAutoGrowingTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperAutoGrowingTests.java
@@ -100,6 +100,12 @@ public class BeanWrapperAutoGrowingTests {
 	}
 
 	@Test
+	public void setPropertyValueAutoGrowMultiDimensionalArray() {
+		wrapper.setPropertyValue("multiArray[2][3]", new Bean());
+		assertThat(bean.getMultiArray()[2][3]).isInstanceOf(Bean.class);
+	}
+
+	@Test
 	public void getPropertyValueAutoGrowList() {
 		assertNotNull(wrapper.getPropertyValue("list[0]"));
 		assertThat(bean.getList().size()).isEqualTo(1);


### PR DESCRIPTION
The implementation of `AbstractNestablePropertyAccessor.processKeyedProperty` results in a `java.lang.IllegalArgumentException: array element type mismatch` when the property expression has more than one property key and the last key causes the array to grow automatically. 

For example, given a property `int[][] multiArray = new int[2][2]` and property expression  `multiArray[1][3]`, the `processKeyedProperty` method creates a new array object and assigns it to `multiArray`; whereas, the new array object should be assigned to `multiArray[1]`.