### PR TITLE
Add missing nullable annotation to ResponseEntity ok convenience method

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -242,7 +242,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	 * @return the created {@code ResponseEntity}
 	 * @since 4.1
 	 */
-	public static <T> ResponseEntity<T> ok(T body) {
+	public static <T> ResponseEntity<T> ok(@Nullable T body) {
 		return ok().body(body);
 	}
 


### PR DESCRIPTION
I noticed that the convenience method ResponseEntity.ok which also takes a body and delegates it to ResponseEntity.body is missing the nullable annotation which let to a sonarqube warning in my codebase when passing a null value to this convenience method.