### PR TITLE
Add RouterFunctionMapping to Javadoc for WebMvcConfigurationSupport

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -129,6 +129,8 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * ordered at 1 to map URL paths directly to view names.
  * <li>{@link BeanNameUrlHandlerMapping}
  * ordered at 2 to map URL paths to controller bean names.
+ * <li>{@link RouterFunctionMapping}
+ * ordered at 3 to map {@linkplain org.springframework.web.servlet.function.RouterFunction router functions}.
  * <li>{@link HandlerMapping}
  * ordered at {@code Integer.MAX_VALUE-1} to serve static resource requests.
  * <li>{@link HandlerMapping}


### PR DESCRIPTION
https://github.com/spring-projects/spring-framework/blob/1ee9223348c81c903a1d53d3378032beb16c3cbe/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java#L543-L572

I updated the Javadoc to document RouterFunctionMapping, which was missing.