### PR TITLE
fix lazy inject of prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out
 test-output
 atlassian-ide-plugin.xml
 .gradletasknamecache
+
+# VS Code
+.vscode/

--- a/spring-context/src/main/java/org/springframework/context/annotation/ContextAnnotationAutowireCandidateResolver.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ContextAnnotationAutowireCandidateResolver.java
@@ -91,14 +91,15 @@ public class ContextAnnotationAutowireCandidateResolver extends QualifierAnnotat
 			public boolean isStatic() {
 				return false;
 			}
+			@Nullable
 			@Override
 			public synchronized Object getTarget() {
-				if (target != null) {
-					return target;
+				if (this.target != null) {
+					return this.target;
 				}
 				Set<String> autowiredBeanNames = (beanName != null ? new LinkedHashSet<>(1) : null);
-				target = dlbf.doResolveDependency(descriptor, beanName, autowiredBeanNames, null);
-				if (target == null) {
+				this.target = dlbf.doResolveDependency(descriptor, beanName, autowiredBeanNames, null);
+				if (this.target == null) {
 					Class<?> type = getTargetClass();
 					if (Map.class == type) {
 						return Collections.emptyMap();
@@ -119,7 +120,7 @@ public class ContextAnnotationAutowireCandidateResolver extends QualifierAnnotat
 						}
 					}
 				}
-				return target;
+				return this.target;
 			}
 			@Override
 			public void releaseTarget(Object target) {

--- a/spring-context/src/main/java/org/springframework/context/annotation/ContextAnnotationAutowireCandidateResolver.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ContextAnnotationAutowireCandidateResolver.java
@@ -81,6 +81,8 @@ public class ContextAnnotationAutowireCandidateResolver extends QualifierAnnotat
 		final DefaultListableBeanFactory dlbf = (DefaultListableBeanFactory) beanFactory;
 
 		TargetSource ts = new TargetSource() {
+			@Nullable
+			private Object target;
 			@Override
 			public Class<?> getTargetClass() {
 				return descriptor.getDependencyType();
@@ -90,9 +92,12 @@ public class ContextAnnotationAutowireCandidateResolver extends QualifierAnnotat
 				return false;
 			}
 			@Override
-			public Object getTarget() {
+			public synchronized Object getTarget() {
+				if (target != null) {
+					return target;
+				}
 				Set<String> autowiredBeanNames = (beanName != null ? new LinkedHashSet<>(1) : null);
-				Object target = dlbf.doResolveDependency(descriptor, beanName, autowiredBeanNames, null);
+				target = dlbf.doResolveDependency(descriptor, beanName, autowiredBeanNames, null);
 				if (target == null) {
 					Class<?> type = getTargetClass();
 					if (Map.class == type) {

--- a/spring-context/src/test/java/org/springframework/context/annotation/LazyAutowiredAnnotationBeanPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/LazyAutowiredAnnotationBeanPostProcessorTests.java
@@ -89,6 +89,23 @@ public class LazyAutowiredAnnotationBeanPostProcessorTests {
 	}
 
 	@Test
+	public void testLazyPrototypeResourceInjectionWithField() {
+		AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext();
+		RootBeanDefinition abd = new RootBeanDefinition(FieldResourceInjectionBean.class);
+		abd.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+		ac.registerBeanDefinition("annotatedBean", abd);
+		RootBeanDefinition tbd = new RootBeanDefinition(TestBean.class);
+		tbd.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+		ac.registerBeanDefinition("testBean", tbd);
+		ac.refresh();
+
+		FieldResourceInjectionBean bean = ac.getBean("annotatedBean", FieldResourceInjectionBean.class);
+		TestBean tb = bean.getTestBean();
+		tb.setName("tb");
+		assertThat(tb.getName()).isSameAs("tb");
+	}
+
+	@Test
 	public void testLazyResourceInjectionWithFieldAndCustomAnnotation() {
 		doTestLazyResourceInjection(FieldResourceInjectionBeanWithCompositeAnnotation.class);
 	}


### PR DESCRIPTION
No need to invoke `doResolveDependency()` repeatedly since target is already created.