### PR TITLE
Fix `@BootstrapWith` inheritance override issues

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/BootstrapUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/BootstrapUtils.java
@@ -167,8 +167,8 @@ abstract class BootstrapUtils {
 			return annotations.iterator().next().value();
 		}
 
-		// Allow directly-present annotation to override annotations that are meta-present.
-		BootstrapWith bootstrapWith = testClass.getDeclaredAnnotation(BootstrapWith.class);
+		// Allow annotation to override annotations that are meta-present.
+		BootstrapWith bootstrapWith = testClass.getAnnotation(BootstrapWith.class);
 		if (bootstrapWith != null) {
 			return bootstrapWith.value();
 		}

--- a/spring-test/src/test/java/org/springframework/test/context/BootstrapUtilsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/BootstrapUtilsTests.java
@@ -140,6 +140,14 @@ class BootstrapUtilsTests {
 		assertBootstrapper(LocalDeclarationAndMetaAnnotatedBootstrapWithAnnotationClass.class, EnigmaBootstrapper.class);
 	}
 
+	/**
+	 * @since XXX
+	 */
+	@Test
+	void resolveTestContextBootstrapperWithInheritedLocalDeclarationThatOverridesMetaBootstrapWithAnnotations() {
+		assertBootstrapper(InheritedLocalDeclarationAndMetaAnnotatedBootstrapWithAnnotationClass.class, EnigmaBootstrapper.class);
+	}
+
 	private void assertBootstrapper(Class<?> testClass, Class<?> expectedBootstrapper) {
 		BootstrapContext bootstrapContext = BootstrapTestUtils.buildBootstrapContext(testClass, delegate);
 		TestContextBootstrapper bootstrapper = resolveTestContextBootstrapper(bootstrapContext);
@@ -194,6 +202,9 @@ class BootstrapUtilsTests {
 	@BootWithBar
 	@BootstrapWith(EnigmaBootstrapper.class)
 	static class LocalDeclarationAndMetaAnnotatedBootstrapWithAnnotationClass {}
+
+	static class InheritedLocalDeclarationAndMetaAnnotatedBootstrapWithAnnotationClass
+			extends LocalDeclarationAndMetaAnnotatedBootstrapWithAnnotationClass {}
 
 	@org.springframework.test.context.web.WebAppConfiguration
 	static class WebAppConfigClass {


### PR DESCRIPTION
A `@BootstrapWith` annotation should be considered an override for `@BootstrapWith` meta-annotations not only when the `@BootstrapWith` annotation is _directly present_ on the test class but also if it is _present_ on the an ancestor of the test class.

----

It is common to use a base test class such as:

```java
@SpringBootTest
public abstract class BaseTest {
}
```

Annotating this `BaseTest` with `@BootstrapWith(XXX)` should not make tests extending this class fail with `java.lang.IllegalStateException: Configuration error: found multiple declarations of @BootstrapWith` but instead properly use the `@BootstrapWith` as an override of the bootstrap provided as a meta-annotation by `@SpringBootTest`.
