### PR TITLE
Update reference to deprecated CronSequenceGenerator

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -85,7 +85,7 @@ public @interface Scheduled {
 	 * trigger, primarily meant for externally specified values resolved by a
 	 * <code>${...}</code> placeholder.
 	 * @return an expression that can be parsed to a cron schedule
-	 * @see org.springframework.scheduling.support.CronSequenceGenerator
+	 * @see org.springframework.scheduling.support.CronExpression#parse(String)
 	 */
 	String cron() default "";
 


### PR DESCRIPTION
Scheduled#cron() was pointing to CronSequenceGenerator for an explanation of the cron string format. This class however is deprecated, and has been replaced with CronExpression. This PR updates the JavaDoc accordingly.