### PR TITLE
StatusAssertion value methods fail when used with custom status code

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/StatusAssertions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/StatusAssertions.java
@@ -205,7 +205,7 @@ public class StatusAssertions {
 	 * @since 5.1
 	 */
 	public WebTestClient.ResponseSpec value(Matcher<? super Integer> matcher) {
-		int value = this.exchangeResult.getStatus().value();
+		int value = this.exchangeResult.getRawStatusCode();
 		this.exchangeResult.assertWithDiagnostics(() -> MatcherAssert.assertThat("Response status", value, matcher));
 		return this.responseSpec;
 	}
@@ -216,7 +216,7 @@ public class StatusAssertions {
 	 * @since 5.1
 	 */
 	public WebTestClient.ResponseSpec value(Consumer<Integer> consumer) {
-		int value = this.exchangeResult.getStatus().value();
+		int value = this.exchangeResult.getRawStatusCode();
 		this.exchangeResult.assertWithDiagnostics(() -> consumer.accept(value));
 		return this.responseSpec;
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/StatusAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/StatusAssertionTests.java
@@ -147,6 +147,10 @@ class StatusAssertionTests {
 				assertions.value(equalTo(200)));
 	}
 
+	@Test
+	void matchesWithCustomStatus() {
+		statusAssertions(600).value(equalTo(600));
+	}
 
 	private StatusAssertions statusAssertions(HttpStatus status) {
 		return statusAssertions(status.value());


### PR DESCRIPTION
StatusAssertion value methods used for status assertions with custom matchers fail when returned status code is not one of states recognized by Spring Framework. Problem is that HttpStatus is retrieved and then converted back to integer instead of retrieving raw status directly.

Change will make behaviour consistent with isEqualTo method.