### PR TITLE
Treat RowSet column labels as case-insensitive

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/rowset/ResultSetWrappingSqlRowSet.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/rowset/ResultSetWrappingSqlRowSet.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import org.springframework.jdbc.InvalidResultSetAccessException;
 import org.springframework.lang.Nullable;
-import org.springframework.util.CollectionUtils;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 
 /**
  * The default implementation of Spring's {@link SqlRowSet} interface, wrapping a
@@ -97,7 +97,7 @@ public class ResultSetWrappingSqlRowSet implements SqlRowSet {
 			ResultSetMetaData rsmd = resultSet.getMetaData();
 			if (rsmd != null) {
 				int columnCount = rsmd.getColumnCount();
-				this.columnLabelMap = CollectionUtils.newHashMap(columnCount);
+				this.columnLabelMap = new LinkedCaseInsensitiveMap<>(columnCount);
 				for (int i = 1; i <= columnCount; i++) {
 					String key = rsmd.getColumnLabel(i);
 					// Make sure to preserve first matching column for any given name,

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/rowset/ColumnLabelTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/rowset/ColumnLabelTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.support.rowset;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Maksym Navolochka
+ */
+public class ColumnLabelTests {
+
+	@Test
+	public void shouldBeCaseInsensitive() throws SQLException {
+		ResultSetMetaData metaData = mock(ResultSetMetaData.class);
+		// "select 0 as Name"
+		given(metaData.getColumnCount()).willReturn(1);
+		given(metaData.getColumnLabel(1)).willReturn("Name");
+		ResultSet resultSet = mock(ResultSet.class);
+		given(resultSet.getMetaData()).willReturn(metaData);
+		// com.sun.rowset.CachedRowSetImpl
+		given(resultSet.findColumn("name")).willThrow(new SQLException("Invalid column name"));
+		ResultSetWrappingSqlRowSet rowSet = new ResultSetWrappingSqlRowSet(resultSet);
+
+		Assertions.assertEquals(
+			1,
+			rowSet.findColumn("name"),
+			"Should be served from cache, no fallback to underlied ResultSet"
+		);
+	}
+}


### PR DESCRIPTION
CachedRowSetImpl doesn't allow for column label use (SPR-7506).

Looking up values by labels in RowSet is supported by ResultSetWrappingSqlRowSet, with fallback to wrapped ResultSet if nothing found. Unfortunately it works in case-sensitive manner (HashMap<String,Integer>).

Assume there is a table:
CREATE TABLE T(col int)

And code:
SqlRowSet srs = jdbcTemplate.queryForRowSet(query);
if ( srs.next() ) srs.getInt("col"); // do smth with value

Queries:
1. select col from T -- ok, column name here, and column name == column label
2. select 0 as col from T -- ok, column label, cache in ResultSetWrappingSqlRowSet handle this
3. select 0 as Col from T -- error, column name != column label, + cache miss 
3.1. column name != column label
3.2. code in ResultSetWrappingSqlRowSet can't find column by label, because "col" != "Col"
3.3. wrapped ResultSet (RowSet, CachedRowSetImpl) can't find column by name, because there is no column name

This commit change column-label treatment to case-insensitive.