### PR TITLE
Introduce `reverse` methods in AOP `MethodMatchers` and `ClassFilters`

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/support/ClassFilters.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/ClassFilters.java
@@ -85,6 +85,17 @@ public abstract class ClassFilters {
 		return new IntersectionClassFilter(classFilters);
 	}
 
+	/**
+	 * reverse the given ClassFilter match.
+	 * @param cf the ClassFilter
+	 * @return a distinct ClassFilter that not matches classes
+	 * of the given ClassFilter match
+	 */
+	public static ClassFilter reversion(ClassFilter cf) {
+		Assert.notNull(cf, "ClassFilter must not be null");
+		return new ReversionClassFilter(cf);
+	}
+
 
 	/**
 	 * ClassFilter implementation for a union of the given ClassFilters.
@@ -167,4 +178,39 @@ public abstract class ClassFilters {
 
 	}
 
+
+	/**
+	 * ClassFilter implementation for an reversion of the given ClassFilter.
+	 */
+	@SuppressWarnings("serial")
+	private static class ReversionClassFilter implements ClassFilter, Serializable {
+
+		private final ClassFilter filter;
+
+		ReversionClassFilter(ClassFilter filter) {
+			this.filter = filter;
+		}
+
+		@Override
+		public boolean matches(Class<?> clazz) {
+			return !filter.matches(clazz);
+		}
+
+		@Override
+		public boolean equals(@Nullable Object other) {
+			return (this == other || (other instanceof ReversionClassFilter &&
+					this.filter.equals(((ReversionClassFilter)other).filter)));
+		}
+
+		@Override
+		public int hashCode() {
+			return 37 * this.filter.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getName() + ": " + this.filter;
+		}
+
+	}
 }

--- a/spring-aop/src/main/java/org/springframework/aop/support/ClassFilters.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/ClassFilters.java
@@ -213,4 +213,5 @@ public abstract class ClassFilters {
 		}
 
 	}
+	
 }

--- a/spring-aop/src/main/java/org/springframework/aop/support/ClassFilters.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/ClassFilters.java
@@ -193,7 +193,7 @@ public abstract class ClassFilters {
 
 		@Override
 		public boolean matches(Class<?> clazz) {
-			return !filter.matches(clazz);
+			return !this.filter.matches(clazz);
 		}
 
 		@Override

--- a/spring-aop/src/main/java/org/springframework/aop/support/MethodMatchers.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/MethodMatchers.java
@@ -82,6 +82,16 @@ public abstract class MethodMatchers {
 	}
 
 	/**
+	 * reverse the given MethodMatcher match.
+	 * @param mm the MethodMatcher
+	 * @return a distinct MethodMatcher that not matches methods
+	 * of the given MethodMatcher match
+	 */
+	public static MethodMatcher reversion(MethodMatcher mm) {
+		return  new ReversionMethodMatcher(mm);
+	}
+
+	/**
 	 * Apply the given MethodMatcher to the given Method, supporting an
 	 * {@link org.springframework.aop.IntroductionAwareMethodMatcher}
 	 * (if applicable).
@@ -349,6 +359,59 @@ public abstract class MethodMatchers {
 			return (MethodMatchers.matches(this.mm1, method, targetClass, hasIntroductions) &&
 					MethodMatchers.matches(this.mm2, method, targetClass, hasIntroductions));
 		}
+	}
+
+
+	/**
+	 * MethodMatcher implementation for an reversion of the given MethodMatcher.
+	 */
+	@SuppressWarnings("serial")
+	private static class ReversionMethodMatcher implements MethodMatcher, Serializable {
+
+		protected final MethodMatcher mm;
+
+		public ReversionMethodMatcher(MethodMatcher mm) {
+			Assert.notNull(mm, "MethodMatcher must not be null");
+			this.mm = mm;
+		}
+
+		@Override
+		public boolean matches(Method method, Class<?> targetClass) {
+			return !this.mm.matches(method, targetClass);
+		}
+
+		@Override
+		public boolean isRuntime() {
+			return this.mm.isRuntime();
+		}
+
+		@Override
+		public boolean matches(Method method, Class<?> targetClass, Object... args) {
+			return !this.mm.matches(method, targetClass, args);
+		}
+
+		@Override
+		public boolean equals(@Nullable Object other) {
+			if (this == other) {
+				return true;
+			}
+			if (!(other instanceof ReversionMethodMatcher)) {
+				return false;
+			}
+			ReversionMethodMatcher that = (ReversionMethodMatcher) other;
+			return this.mm.equals(that.mm);
+		}
+
+		@Override
+		public int hashCode() {
+			return 37 * this.mm.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getName() + ": " + this.mm;
+		}
+		
 	}
 
 }

--- a/spring-aop/src/test/java/org/springframework/aop/support/ClassFiltersTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/support/ClassFiltersTests.java
@@ -66,4 +66,13 @@ class ClassFiltersTests {
 			.matches("^.+IntersectionClassFilter: \\[.+RootClassFilter: .+Exception, .+RootClassFilter: .+NestedRuntimeException\\]$");
 	}
 
+	@Test
+	void reversion() {
+		assertThat(exceptionFilter.matches(RuntimeException.class)).isTrue();
+		ClassFilter reversion = ClassFilters.reversion(exceptionFilter);
+		assertThat(reversion.matches(RuntimeException.class)).isFalse();
+		assertThat(reversion.toString())
+				.matches("^.+ReversionClassFilter: .+RootClassFilter: .+Exception$");
+	}
+	
 }

--- a/spring-aop/src/test/java/org/springframework/aop/support/MethodMatchersTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/support/MethodMatchersTests.java
@@ -111,6 +111,19 @@ public class MethodMatchersTests {
 		assertThat(second.equals(first)).isTrue();
 	}
 
+	@Test
+	public void testDynamicAndStaticMethodMatcherReversion() throws Exception {
+		MethodMatcher getterMatcher = new StartsWithMatcher("get");
+		MethodMatcher reversion = MethodMatchers.reversion(getterMatcher);
+		assertThat(reversion.isRuntime()).as("Reversion is a static matcher").isFalse();
+		assertThat(reversion.matches(ITESTBEAN_GETAGE, TestBean.class)).as("Didn't matched getAge method").isFalse();
+		assertThat(reversion.matches(IOTHER_ABSQUATULATE, TestBean.class)).as("Matched absquatulate method").isTrue();
+		reversion = MethodMatchers.reversion(new TestDynamicMethodMatcherWhichDoesNotMatch());
+		assertThat(reversion.isRuntime()).as("Intersection is a dynamic matcher").isTrue();
+		assertThat(reversion.matches(ITESTBEAN_SETAGE, TestBean.class)).as("Didn't matched setAge method").isFalse();
+		assertThat(reversion.matches(ITESTBEAN_SETAGE, TestBean.class, 5)).as("Matched setAge method").isTrue();
+	}
+
 
 	public static class StartsWithMatcher extends StaticMethodMatcher {
 


### PR DESCRIPTION
Add reverse methed in MethodMatchers and ClassFilters.

Add support for MethodMatchers and ClassFilters to reverse the given MethodMatcher and ClassFilter.
It is convenient in some complex conditions,Or is there another way to do it?Thanks.