### PR TITLE
awaitBodyOrNull function to handle empty body

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
@@ -144,6 +144,17 @@ suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBody() : T =
 	}
 
 /**
+ * Coroutines variant of [WebClient.ResponseSpec.bodyToMono].
+ *
+ * @author Valentin Shakhov
+ */
+suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBodyOrNull() : T? =
+	when (T::class) {
+		Unit::class -> awaitBodilessEntity().let { Unit as T }
+		else -> bodyToMono<T>().awaitSingleOrNull()
+	}
+
+/**
  * Coroutines variant of [WebClient.ResponseSpec.toBodilessEntity].
  */
 suspend fun WebClient.ResponseSpec.awaitBodilessEntity() =


### PR DESCRIPTION
Created awaitBodyOrNull function to handle empty body

`suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBody() : T `
does not handle nullable body

`suspend fun WebClient.ResponseSpec.awaitBodilessEntity()`
ignores body completely even when the content-length is above zero