### PR TITLE
Fix typo in web docs example

### DIFF
--- a/src/docs/asciidoc/web/webflux.adoc
+++ b/src/docs/asciidoc/web/webflux.adoc
@@ -1521,7 +1521,7 @@ segments. For example `/resources/{*path}` matches all files under `/resources/`
 `"path"` variable captures the complete relative path.
 
 The syntax `{varName:regex}` declares a URI variable with a regular expression that has the
-syntax: `{varName:regex}`. For example, given a URL of `/spring-web-3.0.5 .jar`, the following method
+syntax: `{varName:regex}`. For example, given a URL of `/spring-web-3.0.5.jar`, the following method
 extracts the name, version, and file extension:
 
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]

--- a/src/docs/asciidoc/web/webmvc.adoc
+++ b/src/docs/asciidoc/web/webmvc.adoc
@@ -1618,7 +1618,7 @@ leave that detail out if the names are the same and your code is compiled with d
 information or with the `-parameters` compiler flag on Java 8.
 
 The syntax `{varName:regex}` declares a URI variable with a regular expression that has
-syntax of `{varName:regex}`. For example, given URL `"/spring-web-3.0.5 .jar"`, the following method
+syntax of `{varName:regex}`. For example, given URL `"/spring-web-3.0.5.jar"`, the following method
 extracts the name, version, and file extension:
 
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]


### PR DESCRIPTION
Polish webmvc/webflux docs example
Did not work due to unnecessary space