### PR TITLE
Add `@since` tag to WebClient.ResponseSpec.awaitBodyOrNull()

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
@@ -148,6 +148,7 @@ suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBody() : T =
  * Coroutines variant of [WebClient.ResponseSpec.bodyToMono].
  *
  * @author Valentin Shakhov
+ * @since 5.3.6
  */
 suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBodyOrNull() : T? =
 	when (T::class) {


### PR DESCRIPTION
This PR adds `@since` tag to `WebClient.ResponseSpec.awaitBodyOrNull()` that has been introduced in https://github.com/spring-projects/spring-framework/pull/26731.