### PR TITLE
Allow `PropertySourcesPlaceholderConfigurer` subclass to customize `PropertyResolver`

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/PropertySourcesPlaceholderConfigurer.java
+++ b/spring-context/src/main/java/org/springframework/context/support/PropertySourcesPlaceholderConfigurer.java
@@ -154,8 +154,15 @@ public class PropertySourcesPlaceholderConfigurer extends PlaceholderConfigurerS
 			}
 		}
 
-		processProperties(beanFactory, new PropertySourcesPropertyResolver(this.propertySources));
+		processProperties(beanFactory, getPropertyResolver(this.propertySources));
 		this.appliedPropertySources = this.propertySources;
+	}
+
+	/**
+	 * Construct and provide a PropertyResolver from the given properties.
+	 */
+	public ConfigurablePropertyResolver getPropertyResolver(MutablePropertySources propertySources){
+		return new PropertySourcesPropertyResolver(propertySources);
 	}
 
 	/**


### PR DESCRIPTION
## Background

Prior to Spring 5.2, when we need to customize the PropertiesLoader, we can subclass `PropertyPlaceholderConfigurer`, and override the `resolvePlaceholder` method.

Now with `PropertySourcesPlaceholderConfigurer` deprecated `PropertyPlaceholderConfigurer`, the `resolvePlaceholder` method has been moved out of the `PlaceHolderConfigurer` and into a separate `PropertyResolver`.

Somehow the `PropertyResolver` is hardcoded [*]: https://github.com/spring-projects/spring-framework/blob/01bea34569cd3dd00e8691a08ab1a2fc53d6c13e/spring-context/src/main/java/org/springframework/context/support/PropertySourcesPlaceholderConfigurer.java#L157

Due to the hardcode, the only way left for developers to override the `resolvePlaceholder` now becomes to duplicate the whole `postProcessBeanFactory` method and then provide custom `PropertyResolver`.

## Changes

Instead of hardcoding a `PropertyResolver` as existing and make it very difficult to customize, this PR will point to a factory method to provide the `PropertyResolver` as needed.

I believe there is no side effect on this. It only adds the flexibility for customization which has been lost.

#### Note [*]

Even though `PropertyPlaceholderConfigurer` was also using a hardcoded class, https://github.com/spring-projects/spring-framework/blob/01bea34569cd3dd00e8691a08ab1a2fc53d6c13e/spring-beans/src/main/java/org/springframework/beans/factory/config/PropertyPlaceholderConfigurer.java#L210

It's a private inner class, which even doesn't allow override. However, after several redirects, it eventually points to the `resolvePlaceholder` of the current class implementation
https://github.com/spring-projects/spring-framework/blob/01bea34569cd3dd00e8691a08ab1a2fc53d6c13e/spring-beans/src/main/java/org/springframework/beans/factory/config/PropertyPlaceholderConfigurer.java#L250
