### PR TITLE
Handle removal of query param when a single (null) value is sent to `replaceQueryParam`

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
@@ -360,6 +360,12 @@ public class DefaultUriBuilderFactory implements UriBuilderFactory {
 		}
 
 		@Override
+		public DefaultUriBuilder replaceQueryParam(String name, @Nullable Object value) {
+			this.uriComponentsBuilder.replaceQueryParam(name, value);
+			return this;
+		}
+
+		@Override
 		public DefaultUriBuilder replaceQueryParam(String name, @Nullable Collection<?> values) {
 			this.uriComponentsBuilder.replaceQueryParam(name, values);
 			return this;

--- a/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
@@ -223,8 +223,22 @@ public interface UriBuilder {
 	 * @param name the query parameter name
 	 * @param values the query parameter values
 	 * @see #replaceQueryParam(String, Collection)
+	 * @see #replaceQueryParam(String, Object)
 	 */
 	UriBuilder replaceQueryParam(String name, Object... values);
+
+	/**
+	 * Set the query parameter value replacing existing values, or if null
+	 * value is provided, the query parameter is removed.
+	 * <p><strong>Note: </strong> please, review the Javadoc of
+	 * {@link #queryParam(String, Object...)} for further notes on the treatment
+	 * and encoding of individual query parameters.
+	 * @param name the query parameter name
+	 * @param value the query parameter value
+	 * @see #replaceQueryParam(String, Collection)
+	 * @see #replaceQueryParam(String, Object...)
+	 */
+	UriBuilder replaceQueryParam(String name, @Nullable Object value);
 
 	/**
 	 * Variant of {@link #replaceQueryParam(String, Object...)} with a Collection.
@@ -235,6 +249,7 @@ public interface UriBuilder {
 	 * @param values the query parameter values
 	 * @since 5.2
 	 * @see #replaceQueryParam(String, Object...)
+	 * @see #replaceQueryParam(String, Object)
 	 */
 	UriBuilder replaceQueryParam(String name, @Nullable Collection<?> values);
 

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -762,6 +763,15 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 		}
 		resetSchemeSpecificPart();
 		return this;
+	}
+
+	@Override
+	public UriComponentsBuilder replaceQueryParam(String name, @Nullable Object value) {
+		Collection<?> values = null;
+		if (!ObjectUtils.isEmpty(value)) {
+			values = Collections.singleton(value);
+		}
+		return replaceQueryParam(name, values);
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -856,6 +856,21 @@ class UriComponentsBuilderTests {
 	}
 
 	@Test
+	void replaceQueryParamWithNullValue() {
+		UriComponentsBuilder builder = UriComponentsBuilder.newInstance().queryParam("baz", "qux", 42);
+		builder.replaceQueryParam("baz", 40);
+		UriComponents result = builder.build();
+
+		assertThat(result.getQuery()).isEqualTo("baz=40");
+
+		Object obj = null;
+		builder.replaceQueryParam("baz", obj);
+		result = builder.build();
+
+		assertThat(result.getQuery()).as("Query param should have been deleted").isNull();
+	}
+
+	@Test
 	void replaceQueryParams() {
 		UriComponentsBuilder builder = UriComponentsBuilder.newInstance().queryParam("baz", Arrays.asList("qux", 42));
 		builder.replaceQueryParam("baz", Arrays.asList("xuq", 24));


### PR DESCRIPTION
The earlier definition of `replaceQueryParam(String name, Object... values)` didn't  remove the query param if the passed value is null. So, `replaceQueryParam("param1" , null)` would still lead to presence of queryparam `param1` in the URI. 

So if value is null, one would need to write this piece of code:
`
if(value== null) {
replaceQueryParam("param1");
} else {
replaceQueryParam("param1", value);
}
`

Hence added a new definition of the function which takes in a single argument `Object value`.