### PR TITLE
Fix javadoc link syntax

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/CorsRegistration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/CorsRegistration.java
@@ -60,7 +60,7 @@ public class CorsRegistration {
 	/**
 	 * Alternative to {@link #allowCredentials} that supports origins declared
 	 * via wildcard patterns. Please, see
-	 * @link CorsConfiguration#setAllowedOriginPatterns(List)} for details.
+	 * {@link CorsConfiguration#setAllowedOriginPatterns(List)} for details.
 	 * <p>By default this is not set.
 	 * @since 5.3
 	 */


### PR DESCRIPTION
Fix the javadoc `@link` syntax should in curly braces.

![image](https://user-images.githubusercontent.com/6624567/114013600-ab3da580-98a2-11eb-978b-4b0e69ce6416.png)

![image](https://user-images.githubusercontent.com/6624567/114013697-cc05fb00-98a2-11eb-8376-9023782e5c07.png)