### PR TITLE
Add awaitExchangeOrNull extension function to reactive webclient

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/client/WebClientExtensions.kt
@@ -92,6 +92,12 @@ suspend fun <T: Any> RequestHeadersSpec<out RequestHeadersSpec<*>>.awaitExchange
 		exchangeToMono { mono(Dispatchers.Unconfined) { responseHandler.invoke(it) } }.awaitSingle()
 
 /**
+ * Variant of [WebClient.RequestHeadersSpec.awaitExchange] that allows a nullable return
+ */
+suspend fun <T: Any> RequestHeadersSpec<out RequestHeadersSpec<*>>.awaitExchangeOrNull(responseHandler: suspend (ClientResponse) -> T?): T? =
+		exchangeToMono { mono(Dispatchers.Unconfined) { responseHandler.invoke(it) } }.awaitSingleOrNull()
+
+/**
  * Coroutines variant of [WebClient.RequestHeadersSpec.exchangeToFlux].
  *
  * @author Sebastien Deleuze

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/client/WebClientExtensionsTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/client/WebClientExtensionsTests.kt
@@ -104,6 +104,24 @@ class WebClientExtensionsTests {
 	}
 
 	@Test
+	fun `awaitExchangeOrNull returning null`() {
+		val foo = mockk<Foo>()
+		every { requestBodySpec.exchangeToMono(any<Function<ClientResponse, Mono<Foo?>>>()) } returns Mono.empty()
+		runBlocking {
+			assertThat(requestBodySpec.awaitExchangeOrNull { foo }).isEqualTo(null)
+		}
+	}
+
+	@Test
+	fun `awaitExchangeOrNull returning object`() {
+		val foo = mockk<Foo>()
+		every { requestBodySpec.exchangeToMono(any<Function<ClientResponse, Mono<Foo>>>()) } returns Mono.just(foo)
+		runBlocking {
+			assertThat(requestBodySpec.awaitExchangeOrNull { foo }).isEqualTo(foo)
+		}
+	}
+
+	@Test
 	fun exchangeToFlow() {
 		val foo = mockk<Foo>()
 		every { requestBodySpec.exchangeToFlux(any<Function<ClientResponse, Flux<Foo>>>()) } returns Flux.just(foo, foo)


### PR DESCRIPTION
## Background

When using the `awaitExchange` extension function on a Kotlin project, I've missed the presence of a `awaitExchangeOrNull` function, that would receive a function returning `T?`. I've added it to my project, but I think it would be nice to have it on the lib aswell, since I believe it is a usefull extension function.

## Changes

I've simple added a new extension function `awaitExchangeOrNull` and two test scenarios.

This is my first time attempting to contribute to an open source repository, so, feel free to correct me or suggest changes, I will gladly adhere to suggestions. And let me know if this isn't desired.