### PR TITLE
Add handleErrorFrame callback for STOMP handler

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
@@ -454,7 +454,7 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 					this.sessionHandler.afterConnected(this, headers);
 				}
 				else if (StompCommand.ERROR.equals(command)) {
-					invokeHandler(this.sessionHandler, message, headers);
+					invokeErrorFrameHandler(this.sessionHandler, message, headers);
 				}
 				else if (!isHeartbeat && logger.isTraceEnabled()) {
 					logger.trace("Message not handled.");
@@ -464,6 +464,10 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 		catch (Throwable ex) {
 			this.sessionHandler.handleException(this, command, headers, message.getPayload(), ex);
 		}
+	}
+
+	private void invokeErrorFrameHandler(StompSessionHandler handler, Message<byte[]> message, StompHeaders headers) {
+		handler.handleErrorFrame(headers, message.getPayload());
 	}
 
 	private void invokeHandler(StompFrameHandler handler, Message<byte[]> message, StompHeaders headers) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompFrameHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompFrameHandler.java
@@ -38,11 +38,18 @@ public interface StompFrameHandler {
 	/**
 	 * Handle a STOMP frame with the payload converted to the target type returned
 	 * from {@link #getPayloadType(StompHeaders)}.
+	 * Method {@link #handleErrorFrame(StompHeaders, byte[])} is invoked if the frame
+	 * is an error frame.
 	 * @param headers the headers of the frame
 	 * @param payload the payload, or {@code null} if there was no payload
 	 */
 	void handleFrame(StompHeaders headers, @Nullable Object payload);
 
+	/**
+	 * Handle a STOMP error frame received from server.
+	 * @param headers the headers of the frame
+	 * @param payload the payload, or {@code null} if there was no payload
+	 */
 	void handleErrorFrame(StompHeaders headers, @Nullable byte[] payload);
 
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompFrameHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompFrameHandler.java
@@ -43,4 +43,6 @@ public interface StompFrameHandler {
 	 */
 	void handleFrame(StompHeaders headers, @Nullable Object payload);
 
+	void handleErrorFrame(StompHeaders headers, @Nullable byte[] payload);
+
 }

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/DefaultStompSessionTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/DefaultStompSessionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/DefaultStompSessionTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/DefaultStompSessionTests.java
@@ -230,6 +230,7 @@ public class DefaultStompSessionTests {
 		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
 		accessor.setContentType(new MimeType("text", "plain", StandardCharsets.UTF_8));
 		accessor.addNativeHeader("foo", "bar");
+		accessor.setMessage("Error message");
 		accessor.setLeaveMutable(true);
 		String payload = "Oops";
 
@@ -239,39 +240,7 @@ public class DefaultStompSessionTests {
 		this.session.handleMessage(MessageBuilder.createMessage(
 				payload.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders()));
 
-		verify(this.sessionHandler).getPayloadType(stompHeaders);
-		verify(this.sessionHandler).handleFrame(stompHeaders, payload);
-		verifyNoMoreInteractions(this.sessionHandler);
-	}
-
-	@Test
-	public void handleErrorFrameWithEmptyPayload() {
-		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
-		accessor.addNativeHeader("foo", "bar");
-		accessor.setLeaveMutable(true);
-		this.session.handleMessage(MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders()));
-
-		StompHeaders stompHeaders = StompHeaders.readOnlyStompHeaders(accessor.getNativeHeaders());
-		verify(this.sessionHandler).handleFrame(stompHeaders, null);
-		verifyNoMoreInteractions(this.sessionHandler);
-	}
-
-	@Test
-	public void handleErrorFrameWithConversionException() {
-		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
-		accessor.setContentType(MimeTypeUtils.APPLICATION_JSON);
-		accessor.addNativeHeader("foo", "bar");
-		accessor.setLeaveMutable(true);
-		byte[] payload = "{'foo':'bar'}".getBytes(StandardCharsets.UTF_8);
-
-		StompHeaders stompHeaders = StompHeaders.readOnlyStompHeaders(accessor.getNativeHeaders());
-		given(this.sessionHandler.getPayloadType(stompHeaders)).willReturn(Map.class);
-
-		this.session.handleMessage(MessageBuilder.createMessage(payload, accessor.getMessageHeaders()));
-
-		verify(this.sessionHandler).getPayloadType(stompHeaders);
-		verify(this.sessionHandler).handleException(same(this.session), same(StompCommand.ERROR),
-				eq(stompHeaders), same(payload), any(MessageConversionException.class));
+		verify(this.sessionHandler).handleErrorFrame(stompHeaders, payload.getBytes());
 		verifyNoMoreInteractions(this.sessionHandler);
 	}
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/ReactorNettyTcpStompClientTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/ReactorNettyTcpStompClientTests.java
@@ -137,6 +137,11 @@ public class ReactorNettyTcpStompClientTests {
 
 		@Override
 		public void handleFrame(StompHeaders headers, @Nullable Object payload) {
+			logger.error("STOMP frame " + headers + " payload=" + payload);
+		}
+
+		@Override
+		public void handleErrorFrame(StompHeaders headers, byte[] payload) {
 			logger.error("STOMP error frame " + headers + " payload=" + payload);
 		}
 
@@ -177,6 +182,11 @@ public class ReactorNettyTcpStompClientTests {
 					@Override
 					public void handleFrame(StompHeaders headers, @Nullable Object payload) {
 						received.add((String) payload);
+					}
+
+					@Override
+					public void handleErrorFrame(StompHeaders headers, @Nullable byte[] payload) {
+						//nothing to do
 					}
 				});
 				subscription.addReceiptTask(subscriptionLatch::countDown);

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/WebSocketStompClientIntegrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/WebSocketStompClientIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/WebSocketStompClientIntegrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/WebSocketStompClientIntegrationTests.java
@@ -117,7 +117,7 @@ class WebSocketStompClientIntegrationTests {
 		this.stompClient.connect(url, testHandler);
 
 		assertThat(testHandler.awaitForMessageCount(1, 5000)).isTrue();
-		assertThat(testHandler.getReceived()).containsExactly("payload");
+		assertThat(testHandler.getErrorReceived()).containsExactly("payload");
 	}
 
 
@@ -149,6 +149,8 @@ class WebSocketStompClientIntegrationTests {
 
 		private final List<String> received = new ArrayList<>();
 
+		private final List<String> errorReceived = new ArrayList<>();
+
 
 		public TestHandler(String topic, Object payload) {
 			this.topic = topic;
@@ -158,6 +160,10 @@ class WebSocketStompClientIntegrationTests {
 
 		public List<String> getReceived() {
 			return this.received;
+		}
+
+		public List<String> getErrorReceived(){
+			return this.errorReceived;
 		}
 
 
@@ -171,6 +177,11 @@ class WebSocketStompClientIntegrationTests {
 				@Override
 				public void handleFrame(StompHeaders headers, @Nullable Object payload) {
 					received.add((String) payload);
+				}
+
+				@Override
+				public void handleErrorFrame(StompHeaders headers, byte[] payload) {
+					errorReceived.add(String.valueOf(payload));
 				}
 			});
 			try {
@@ -208,6 +219,11 @@ class WebSocketStompClientIntegrationTests {
 		@Override
 		public void handleFrame(StompHeaders headers, @Nullable Object payload) {
 			logger.error("STOMP error frame " + headers + " payload=" + payload);
+		}
+
+		@Override
+		public void handleErrorFrame(StompHeaders headers, byte[] payload) {
+
 		}
 
 		@Override


### PR DESCRIPTION
The previous implementation invoke handleFrame no matter the frame is "MESSAGE" nor "ERROR".  This commit add a new callback "handleErrorFrame" to the handler to separate from the message frame handling.

Reason:
1. The error frame is created by server and not following bussiness message frame format.
2. Otherwise the handler can not tell if the frame is business message or it's an error message.