### PR TITLE
Update documentation for <context:annotation-config/>

### DIFF
--- a/src/docs/asciidoc/core/core-appendix.adoc
+++ b/src/docs/asciidoc/core/core-appendix.adoc
@@ -568,8 +568,9 @@ is a convenience mechanism that sets up a <<core.adoc#beans-factory-placeholderc
 This element activates the Spring infrastructure to detect annotations in bean classes:
 
 * Spring's <<core.adoc#beans-factory-metadata, `@Configuration`>> model
-* <<core.adoc#beans-annotation-config, `@Autowired`/`@Inject`>> and `@Value`
+* <<core.adoc#beans-annotation-config, `@Autowired`/`@Inject`>>, `@Value` and `@Lookup`
 * JSR-250's `@Resource`, `@PostConstruct` and `@PreDestroy` (if available)
+* JAX-WS `@WebServiceRef` and EJB3 `@EJB` (if available)
 * JPA's `@PersistenceContext` and `@PersistenceUnit` (if available)
 * Spring's <<core.adoc#context-functionality-events-annotation, `@EventListener`>>
 

--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -4628,10 +4628,11 @@ configuration (notice the inclusion of the `context` namespace):
 ----
 
 (The implicitly registered post-processors include
+{api-spring-framework}/context/annotation/ConfigurationClassPostProcessor.html[`ConfigurationClassPostProcessor`]
 {api-spring-framework}/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.html[`AutowiredAnnotationBeanPostProcessor`],
 {api-spring-framework}/context/annotation/CommonAnnotationBeanPostProcessor.html[`CommonAnnotationBeanPostProcessor`],
 {api-spring-framework}/orm/jpa/support/PersistenceAnnotationBeanPostProcessor.html[`PersistenceAnnotationBeanPostProcessor`], and
-{api-spring-framework}/beans/factory/annotation/RequiredAnnotationBeanPostProcessor.html[`RequiredAnnotationBeanPostProcessor`].)
+{api-spring-framework}/context/event/EventListenerMethodProcessor.html[`EventListenerMethodProcessor.html`].)
 
 [NOTE]
 ====


### PR DESCRIPTION
The official documentation contains incorrect description on `<context:annotation-config/>`:
1) No *RequiredAnnotationBeanPostProcessor* is automatically registered. 
According to source code of *AnnotationConfigBeanDefinitionParser* class we see that there is a using of  *AnnotationConfigUtils* class. Investigating the code of letter one we see that there is registration of 5 BeanPostProcessor and BeanFactoryPostProcessor classes.
2) There are 2 additional processor that are registered when using  aforementioned annotation
3) *AutowiredAnnotationBeanPostProcessor* also processes *@Lookup* annotation.
4) *CommonAnnotationBeanPostProcessor* also processes JAX-WS *@WebServiceRef* and EJB3 *@EJB* annotations