### PR TITLE
Update ref docs regarding RequiredAnnotationBeanPostProcessor registration

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -4689,10 +4689,7 @@ references and values even when you use the class outside of a container.
 [TIP]
 ====
 The {api-spring-framework}/beans/factory/annotation/RequiredAnnotationBeanPostProcessor.html[`RequiredAnnotationBeanPostProcessor`]
-must be registered as a bean to enable support for the `@Required` annotation. Note,
-however, that a `RequiredAnnotationBeanPostProcessor` bean is registered automatically
-when using the `<context:annotation-config/>` or `<context:component-scan/>` XML
-namespace elements.
+must be registered as a bean to enable support for the `@Required` annotation.
 ====
 
 [NOTE]


### PR DESCRIPTION
No *RequiredAnnotationBeanPostProcessor* is automatically registered.
According to source code of *AnnotationConfigBeanDefinitionParser* class we see that there is a using of *AnnotationConfigUtils* class. Investigating the code of letter one we see that there is registration of 5 BeanPostProcessor and BeanFactoryPostProcessor classes.