### PR TITLE
Improve @EventListener documentation in reference manual

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -10652,7 +10652,7 @@ architectures that build upon the well-known Spring programming model.
 [[context-functionality-events-annotation]]
 ==== Annotation-based Event Listeners
 
-As of Spring 4.2, you can register an event listener on any public method of a managed
+As of Spring 4.2, you can register an event listener on any method of a managed
 bean by using the `@EventListener` annotation. The `BlockedListNotifier` can be rewritten as
 follows:
 
@@ -10793,7 +10793,7 @@ NOTE: This feature is not supported for
 <<context-functionality-events-async, asynchronous listeners>>.
 
 This new method publishes a new `ListUpdateEvent` for every `BlockedListEvent` handled by the
-method above. If you need to publish several events, you can return a `Collection` of events
+method above. If you need to publish several events, you can return a `Collection` or an `array` of events
 instead.
 
 


### PR DESCRIPTION
1) According to a source code of *ApplicationListenerMethodAdapter* class we can see that return type of a method annotated with *@EventListener* can be not only a *Collection<?>* but also *array*.
2) Method annotated with *@EventListener* can have any visibility (public, protected, package-private and private) and can be final and static.