### PR TITLE
Avoid exceptions when evaluating validation hints

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/ValidationUtils.java
+++ b/spring-context/src/main/java/org/springframework/validation/ValidationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-context/src/main/java/org/springframework/validation/ValidationUtils.java
+++ b/spring-context/src/main/java/org/springframework/validation/ValidationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,17 @@
 
 package org.springframework.validation;
 
+import java.lang.annotation.Annotation;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Utility class offering convenient methods for invoking a {@link Validator}
@@ -253,6 +257,42 @@ public abstract class ValidationUtils {
 		if (value == null ||!StringUtils.hasText(value.toString())) {
 			errors.rejectValue(field, errorCode, errorArgs, defaultMessage);
 		}
+	}
+
+	/**
+	 * Determine any validation hints by the given annotation.
+	 * <p>This implementation checks for {@code @javax.validation.Valid},
+	 * Spring's {@link org.springframework.validation.annotation.Validated},
+	 * and custom annotations whose name starts with "Valid".
+	 * @param ann the annotation (potentially a validation annotation)
+	 * @return the validation hints to apply (possibly an empty array),
+	 * or {@code null} if this annotation does not trigger any validation
+	 * @since 5.3.6
+	 */
+	@Nullable
+	public static Object[] determineValidationHints(Annotation ann) {
+		String annotationName = ann.annotationType().getName();
+		if ("javax.validation.Valid".equals(annotationName)) {
+			return new Object[0];
+		}
+		Validated validatedAnn = AnnotationUtils.getAnnotation(ann, Validated.class);
+		if (validatedAnn != null) {
+			Object hints = validatedAnn.value();
+			return convertValidationHints(hints);
+		}
+		int offset = annotationName.lastIndexOf('.');
+		if (annotationName.startsWith("Valid", Math.max(offset, 0))) {
+			Object hints = AnnotationUtils.getValue(ann);
+			return convertValidationHints(hints);
+		}
+		return null;
+	}
+
+	private static Object[] convertValidationHints(@Nullable Object hints) {
+		if (hints == null) {
+			return new Object[0];
+		}
+		return (hints instanceof Object[] ? (Object[]) hints : new Object[]{hints});
 	}
 
 }

--- a/spring-context/src/main/java/org/springframework/validation/ValidationUtils.java
+++ b/spring-context/src/main/java/org/springframework/validation/ValidationUtils.java
@@ -16,17 +16,13 @@
 
 package org.springframework.validation;
 
-import java.lang.annotation.Annotation;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.validation.annotation.Validated;
 
 /**
  * Utility class offering convenient methods for invoking a {@link Validator}
@@ -257,42 +253,6 @@ public abstract class ValidationUtils {
 		if (value == null ||!StringUtils.hasText(value.toString())) {
 			errors.rejectValue(field, errorCode, errorArgs, defaultMessage);
 		}
-	}
-
-	/**
-	 * Determine any validation hints by the given annotation.
-	 * <p>This implementation checks for {@code @javax.validation.Valid},
-	 * Spring's {@link org.springframework.validation.annotation.Validated},
-	 * and custom annotations whose name starts with "Valid".
-	 * @param ann the annotation (potentially a validation annotation)
-	 * @return the validation hints to apply (possibly an empty array),
-	 * or {@code null} if this annotation does not trigger any validation
-	 * @since 5.3.6
-	 */
-	@Nullable
-	public static Object[] determineValidationHints(Annotation ann) {
-		String annotationName = ann.annotationType().getName();
-		if ("javax.validation.Valid".equals(annotationName)) {
-			return new Object[0];
-		}
-		Validated validatedAnn = AnnotationUtils.getAnnotation(ann, Validated.class);
-		if (validatedAnn != null) {
-			Object hints = validatedAnn.value();
-			return convertValidationHints(hints);
-		}
-		int offset = annotationName.lastIndexOf('.');
-		if (annotationName.startsWith("Valid", Math.max(offset, 0))) {
-			Object hints = AnnotationUtils.getValue(ann);
-			return convertValidationHints(hints);
-		}
-		return null;
-	}
-
-	private static Object[] convertValidationHints(@Nullable Object hints) {
-		if (hints == null) {
-			return new Object[0];
-		}
-		return (hints instanceof Object[] ? (Object[]) hints : new Object[]{hints});
 	}
 
 }

--- a/spring-context/src/main/java/org/springframework/validation/annotation/ValidationAnnotationUtils.java
+++ b/spring-context/src/main/java/org/springframework/validation/annotation/ValidationAnnotationUtils.java
@@ -42,7 +42,8 @@ public abstract class ValidationAnnotationUtils {
 	 */
 	@Nullable
 	public static Object[] determineValidationHints(Annotation ann) {
-		String annotationName = ann.annotationType().getName();
+		Class<? extends Annotation> annotationType = ann.annotationType();
+		String annotationName = annotationType.getName();
 		if ("javax.validation.Valid".equals(annotationName)) {
 			return new Object[0];
 		}
@@ -51,8 +52,7 @@ public abstract class ValidationAnnotationUtils {
 			Object hints = validatedAnn.value();
 			return convertValidationHints(hints);
 		}
-		int offset = annotationName.lastIndexOf('.');
-		if (annotationName.startsWith("Valid", Math.max(offset, 0))) {
+		if (annotationType.getSimpleName().startsWith("Valid")) {
 			Object hints = AnnotationUtils.getValue(ann);
 			return convertValidationHints(hints);
 		}

--- a/spring-context/src/main/java/org/springframework/validation/annotation/ValidationAnnotationUtils.java
+++ b/spring-context/src/main/java/org/springframework/validation/annotation/ValidationAnnotationUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.validation.annotation;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.lang.Nullable;
+
+/**
+ * Utility class for handling validation annotations.
+ * Mainly for internal use within the framework.
+ *
+ * @author Christoph Dreis
+ * @since 5.3.7
+ */
+public abstract class ValidationAnnotationUtils {
+
+	/**
+	 * Determine any validation hints by the given annotation.
+	 * <p>This implementation checks for {@code @javax.validation.Valid},
+	 * Spring's {@link org.springframework.validation.annotation.Validated},
+	 * and custom annotations whose name starts with "Valid".
+	 * @param ann the annotation (potentially a validation annotation)
+	 * @return the validation hints to apply (possibly an empty array),
+	 * or {@code null} if this annotation does not trigger any validation
+	 * @since 5.3.7
+	 */
+	@Nullable
+	public static Object[] determineValidationHints(Annotation ann) {
+		String annotationName = ann.annotationType().getName();
+		if ("javax.validation.Valid".equals(annotationName)) {
+			return new Object[0];
+		}
+		Validated validatedAnn = AnnotationUtils.getAnnotation(ann, Validated.class);
+		if (validatedAnn != null) {
+			Object hints = validatedAnn.value();
+			return convertValidationHints(hints);
+		}
+		int offset = annotationName.lastIndexOf('.');
+		if (annotationName.startsWith("Valid", Math.max(offset, 0))) {
+			Object hints = AnnotationUtils.getValue(ann);
+			return convertValidationHints(hints);
+		}
+		return null;
+	}
+
+	private static Object[] convertValidationHints(@Nullable Object hints) {
+		if (hints == null) {
+			return new Object[0];
+		}
+		return (hints instanceof Object[] ? (Object[]) hints : new Object[]{hints});
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/ModelAttributeMethodProcessor.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/ModelAttributeMethodProcessor.java
@@ -44,8 +44,8 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.validation.SmartValidator;
-import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
+import org.springframework.validation.annotation.ValidationAnnotationUtils;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -361,7 +361,7 @@ public class ModelAttributeMethodProcessor implements HandlerMethodArgumentResol
 	 */
 	protected void validateIfApplicable(WebDataBinder binder, MethodParameter parameter) {
 		for (Annotation ann : parameter.getParameterAnnotations()) {
-			Object[] validationHints = ValidationUtils.determineValidationHints(ann);
+			Object[] validationHints = ValidationAnnotationUtils.determineValidationHints(ann);
 			if (validationHints != null) {
 				binder.validate(validationHints);
 				break;
@@ -387,7 +387,7 @@ public class ModelAttributeMethodProcessor implements HandlerMethodArgumentResol
 			Class<?> targetType, String fieldName, @Nullable Object value) {
 
 		for (Annotation ann : parameter.getParameterAnnotations()) {
-			Object[] validationHints = ValidationUtils.determineValidationHints(ann);
+			Object[] validationHints = ValidationAnnotationUtils.determineValidationHints(ann);
 			if (validationHints != null) {
 				for (Validator validator : binder.getValidators()) {
 					if (validator instanceof SmartValidator) {

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/ModelAttributeMethodProcessor.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/ModelAttributeMethodProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.core.MethodParameter;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -45,8 +44,8 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.validation.SmartValidator;
+import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -362,7 +361,7 @@ public class ModelAttributeMethodProcessor implements HandlerMethodArgumentResol
 	 */
 	protected void validateIfApplicable(WebDataBinder binder, MethodParameter parameter) {
 		for (Annotation ann : parameter.getParameterAnnotations()) {
-			Object[] validationHints = determineValidationHints(ann);
+			Object[] validationHints = ValidationUtils.determineValidationHints(ann);
 			if (validationHints != null) {
 				binder.validate(validationHints);
 				break;
@@ -388,7 +387,7 @@ public class ModelAttributeMethodProcessor implements HandlerMethodArgumentResol
 			Class<?> targetType, String fieldName, @Nullable Object value) {
 
 		for (Annotation ann : parameter.getParameterAnnotations()) {
-			Object[] validationHints = determineValidationHints(ann);
+			Object[] validationHints = ValidationUtils.determineValidationHints(ann);
 			if (validationHints != null) {
 				for (Validator validator : binder.getValidators()) {
 					if (validator instanceof SmartValidator) {
@@ -404,26 +403,6 @@ public class ModelAttributeMethodProcessor implements HandlerMethodArgumentResol
 				break;
 			}
 		}
-	}
-
-	/**
-	 * Determine any validation triggered by the given annotation.
-	 * @param ann the annotation (potentially a validation annotation)
-	 * @return the validation hints to apply (possibly an empty array),
-	 * or {@code null} if this annotation does not trigger any validation
-	 * @since 5.1
-	 */
-	@Nullable
-	private Object[] determineValidationHints(Annotation ann) {
-		Validated validatedAnn = AnnotationUtils.getAnnotation(ann, Validated.class);
-		if (validatedAnn != null || ann.annotationType().getSimpleName().startsWith("Valid")) {
-			Object hints = (validatedAnn != null ? validatedAnn.value() : AnnotationUtils.getValue(ann));
-			if (hints == null) {
-				return new Object[0];
-			}
-			return (hints instanceof Object[] ? (Object[]) hints : new Object[] {hints});
-		}
-		return null;
 	}
 
 	/**

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageReaderArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageReaderArgumentResolver.java
@@ -43,8 +43,8 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
+import org.springframework.validation.annotation.ValidationAnnotationUtils;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.bind.support.WebExchangeDataBinder;
 import org.springframework.web.reactive.BindingContext;
@@ -239,7 +239,7 @@ public abstract class AbstractMessageReaderArgumentResolver extends HandlerMetho
 	private Object[] extractValidationHints(MethodParameter parameter) {
 		Annotation[] annotations = parameter.getParameterAnnotations();
 		for (Annotation ann : annotations) {
-			Object[] hints = ValidationUtils.determineValidationHints(ann);
+			Object[] hints = ValidationAnnotationUtils.determineValidationHints(ann);
 			if (hints != null) {
 				return hints;
 			}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageReaderArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageReaderArgumentResolver.java
@@ -31,7 +31,6 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.ReactiveAdapter;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.ResolvableType;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.codec.DecodingException;
 import org.springframework.core.codec.Hints;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -44,8 +43,8 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.bind.support.WebExchangeDataBinder;
 import org.springframework.web.reactive.BindingContext;
@@ -240,10 +239,9 @@ public abstract class AbstractMessageReaderArgumentResolver extends HandlerMetho
 	private Object[] extractValidationHints(MethodParameter parameter) {
 		Annotation[] annotations = parameter.getParameterAnnotations();
 		for (Annotation ann : annotations) {
-			Validated validatedAnn = AnnotationUtils.getAnnotation(ann, Validated.class);
-			if (validatedAnn != null || ann.annotationType().getSimpleName().startsWith("Valid")) {
-				Object hints = (validatedAnn != null ? validatedAnn.value() : AnnotationUtils.getValue(ann));
-				return (hints instanceof Object[] ? (Object[]) hints : new Object[] {hints});
+			Object[] hints = ValidationUtils.determineValidationHints(ann);
+			if (hints != null) {
+				return hints;
 			}
 		}
 		return null;

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,14 +30,13 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.ReactiveAdapter;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.ResolvableType;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.ui.Model;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
-import org.springframework.validation.annotation.Validated;
+import org.springframework.validation.ValidationUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.bind.support.WebExchangeDataBinder;
@@ -270,16 +269,9 @@ public class ModelAttributeMethodArgumentResolver extends HandlerMethodArgumentR
 
 	private void validateIfApplicable(WebExchangeDataBinder binder, MethodParameter parameter) {
 		for (Annotation ann : parameter.getParameterAnnotations()) {
-			Validated validatedAnn = AnnotationUtils.getAnnotation(ann, Validated.class);
-			if (validatedAnn != null || ann.annotationType().getSimpleName().startsWith("Valid")) {
-				Object hints = (validatedAnn != null ? validatedAnn.value() : AnnotationUtils.getValue(ann));
-				if (hints != null) {
-					Object[] validationHints = (hints instanceof Object[] ? (Object[]) hints : new Object[] {hints});
-					binder.validate(validationHints);
-				}
-				else {
-					binder.validate();
-				}
+			Object[] validationHints = ValidationUtils.determineValidationHints(ann);
+			if (validationHints != null) {
+				binder.validate(validationHints);
 			}
 		}
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
-import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.annotation.ValidationAnnotationUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.bind.support.WebExchangeDataBinder;
@@ -269,7 +269,7 @@ public class ModelAttributeMethodArgumentResolver extends HandlerMethodArgumentR
 
 	private void validateIfApplicable(WebExchangeDataBinder binder, MethodParameter parameter) {
 		for (Annotation ann : parameter.getParameterAnnotations()) {
-			Object[] validationHints = ValidationUtils.determineValidationHints(ann);
+			Object[] validationHints = ValidationAnnotationUtils.determineValidationHints(ann);
 			if (validationHints != null) {
 				binder.validate(validationHints);
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
@@ -36,7 +36,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ResolvableType;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.log.LogFormatUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
@@ -52,7 +51,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 import org.springframework.validation.Errors;
-import org.springframework.validation.annotation.Validated;
+import org.springframework.validation.ValidationUtils;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -241,10 +240,8 @@ public abstract class AbstractMessageConverterMethodArgumentResolver implements 
 	protected void validateIfApplicable(WebDataBinder binder, MethodParameter parameter) {
 		Annotation[] annotations = parameter.getParameterAnnotations();
 		for (Annotation ann : annotations) {
-			Validated validatedAnn = AnnotationUtils.getAnnotation(ann, Validated.class);
-			if (validatedAnn != null || ann.annotationType().getSimpleName().startsWith("Valid")) {
-				Object hints = (validatedAnn != null ? validatedAnn.value() : AnnotationUtils.getValue(ann));
-				Object[] validationHints = (hints instanceof Object[] ? (Object[]) hints : new Object[] {hints});
+			Object[] validationHints = ValidationUtils.determineValidationHints(ann);
+			if (validationHints != null) {
 				binder.validate(validationHints);
 				break;
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
@@ -51,7 +51,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 import org.springframework.validation.Errors;
-import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.annotation.ValidationAnnotationUtils;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -240,7 +240,7 @@ public abstract class AbstractMessageConverterMethodArgumentResolver implements 
 	protected void validateIfApplicable(WebDataBinder binder, MethodParameter parameter) {
 		Annotation[] annotations = parameter.getParameterAnnotations();
 		for (Annotation ann : annotations) {
-			Object[] validationHints = ValidationUtils.determineValidationHints(ann);
+			Object[] validationHints = ValidationAnnotationUtils.determineValidationHints(ann);
 			if (validationHints != null) {
 				binder.validate(validationHints);
 				break;


### PR DESCRIPTION
Hi,

we noticed in one of our loadtests that a substantial amount of "hidden" `NoSuchMethodException`s is being thrown when using `@javax.validation.Valid` on controller methods.
```
@PostMapping("test")
public void test(@RequestBody @Valid @NotNull TestRequest request) {
     // Some code
}
```

This is caused by calling `AnnotationUtils.getValue()` on this annotation, which has no such property. This PR bypasses the annotation utility call. I also took the freedom to refactor this logic into a common place in `ValidationUtils` to avoid copy-paste throughout the different modules.

An isolated JMH benchmark shows the following results when dealing with `@Valid`:
```
Benchmark                                         Mode  Cnt     Score     Error   Units
MyBenchmark.testNew                               avgt   10     6,253 ±   0,312   ns/op
MyBenchmark.testOld                               avgt   10  1761,995 ±  92,262   ns/op
```

As a workaround you can use `org.springframework.validation.annotation.Validated` of course, but I would prefer not to have such a drawback when using `javax.validation.Valid`.

Let me know what you think.

Cheers,
Christoph