### PR TITLE
Improve ref docs regarding @Bean method visibility constraints

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -8385,7 +8385,7 @@ annotation, as the following example shows:
 === Using the `@Configuration` annotation
 
 `@Configuration` is a class-level annotation indicating that an object is a source of
-bean definitions. `@Configuration` classes declare beans through public `@Bean` annotated
+bean definitions. `@Configuration` classes declare beans through `@Bean` annotated
 methods. Calls to `@Bean` methods on `@Configuration` classes can also be used to define
 inter-bean dependencies. See <<beans-java-basic-concepts>> for a general introduction.
 


### PR DESCRIPTION
There are 2 main approaches how to use `@Configuration` annotation:

1. When `proxyBeanMethods` attribute is `true` then a *CGLIB* proxy is created. In this case the visibility of a `@Bean` annotated method can be anything except `private`. 
2. When `proxyBeanMethods` attribute is `false` then no *CGLIB* proxy is created. In this case the visibility of a `@Bean` annotated method can be anything including `private`.