### PR TITLE
fix : fix invalid annotation on reference doc

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -6642,7 +6642,7 @@ annotated classes. The following example shows how to do so:
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]
 .Java
 ----
-	@Component
+	@Configuration
 	public class FactoryMethodComponent {
 
 		@Bean
@@ -6659,7 +6659,7 @@ annotated classes. The following example shows how to do so:
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin
 ----
-	@Component
+	@Configuration
 	class FactoryMethodComponent {
 
 		@Bean


### PR DESCRIPTION
https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#beans-factorybeans-annotations
At first example of 1.10.5. Defining Bean Metadata within Components,
`@Component` should be `@Configuration`.
