### PR TITLE
Remove unnecessary semicolon in BeanInfo example

### DIFF
--- a/src/docs/asciidoc/core/core-validation.adoc
+++ b/src/docs/asciidoc/core/core-validation.adoc
@@ -567,9 +567,10 @@ associates a `CustomNumberEditor` with the `age` property of the `Something` cla
 			try {
 				final PropertyEditor numberPE = new CustomNumberEditor(Integer.class, true);
 				PropertyDescriptor ageDescriptor = new PropertyDescriptor("age", Something.class) {
+				    @Override
 					public PropertyEditor createPropertyEditor(Object bean) {
 						return numberPE;
-					};
+					}
 				};
 				return new PropertyDescriptor[] { ageDescriptor };
 			}


### PR DESCRIPTION
The official documentation contains misleading using of java syntax.
There is redundant semicolon **";"** at the end of overridden method of anonymous class. As a result it looks like there is a mix of invocation of method or creation a new one. It complicates a lot of understanding the code.