### PR TITLE
Remove leftover Javadoc from WebClient

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -187,13 +187,6 @@ public interface WebClient {
 		Builder baseUrl(String baseUrl);
 
 		/**
-		 * Configure default URI variable values that will be used when expanding
-		 * URI templates using a {@link Map}.
-		 * @param defaultUriVariables the default values to use
-		 * @see #baseUrl(String)
-		 * @see #uriBuilderFactory(UriBuilderFactory)
-		 */
-		/**
 		 * Configure default URL variable values to use when expanding URI
 		 * templates with a {@link Map}. Effectively a shortcut for:
 		 * <p>


### PR DESCRIPTION
This redundant Javadoc is from commit 5f1e4ffc4f986469c9f665e681bb34e8a7dd09e8

See https://github.com/spring-projects/spring-framework/issues/24611