### PR TITLE
Update FormatterRegistry interface in reference manual

### DIFF
--- a/src/docs/asciidoc/core/core-validation.adoc
+++ b/src/docs/asciidoc/core/core-validation.adoc
@@ -1492,13 +1492,17 @@ The following listing shows the `FormatterRegistry` SPI:
 
 	public interface FormatterRegistry extends ConverterRegistry {
 
-		void addFormatterForFieldType(Class<?> fieldType, Printer<?> printer, Parser<?> parser);
+		void addPrinter(Printer<?> printer);
+
+		void addParser(Parser<?> parser);
+
+		void addFormatter(Formatter<?> formatter);
 
 		void addFormatterForFieldType(Class<?> fieldType, Formatter<?> formatter);
 
-		void addFormatterForFieldType(Formatter<?> formatter);
+		void addFormatterForFieldType(Class<?> fieldType, Printer<?> printer, Parser<?> parser);
 
-		void addFormatterForAnnotation(AnnotationFormatterFactory<?> factory);
+		void addFormatterForFieldAnnotation(AnnotationFormatterFactory<? extends Annotation> annotationFormatterFactory);
 	}
 ----
 


### PR DESCRIPTION
The official documentation contains incorrect description of interface *org.springframework.format.FormatterRegistry*.
Please check api [https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/format/FormatterRegistry.html](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/format/FormatterRegistry.html)