### PR TITLE
Fix LocaleEditor description and formatting in reference manual

### DIFF
--- a/src/docs/asciidoc/core/core-validation.adoc
+++ b/src/docs/asciidoc/core/core-validation.adoc
@@ -500,8 +500,9 @@ the various `PropertyEditor` implementations that Spring provides:
 
 | `LocaleEditor`
 | Can resolve strings to `Locale` objects and vice-versa (the string format is
-  `[language]_[country]_[variant]`, same as the `toString()` method of
-  `Locale`). By default, registered by `BeanWrapperImpl`.
+  `[language]\_[country]_[variant]`, same as the `toString()` method of
+  `Locale`). Also accepts spaces as separators, as alternative to underscores.
+  By default, registered by `BeanWrapperImpl`.
 
 | `PatternEditor`
 | Can resolve strings to `java.util.regex.Pattern` objects and vice-versa.


### PR DESCRIPTION
The official documentation contains incorrect description of *LocaleEditor* class (page 244 of pdf):
1) The language part is missing. The problem lies in incorrect formatting.
2) We can also use spaces as separators instead of underscores. We can see it from source code of *StringUtils* class.