### PR TITLE
Use String.startsWith() instead of String.substring() in PatternMatchUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/PatternMatchUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/PatternMatchUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public abstract class PatternMatchUtils {
 		}
 
 		return (str.length() >= firstIndex &&
-				pattern.substring(0, firstIndex).equals(str.substring(0, firstIndex)) &&
+				pattern.startsWith(str.substring(0, firstIndex)) &&
 				simpleMatch(pattern.substring(firstIndex), str.substring(firstIndex)));
 	}
 


### PR DESCRIPTION
Instead of allocating a new substring at each call we can use `String.startsWith()`