### PR TITLE
fix DateTimeFormat annotation description

### DIFF
--- a/src/docs/asciidoc/core/core-validation.adoc
+++ b/src/docs/asciidoc/core/core-validation.adoc
@@ -1452,7 +1452,7 @@ example shows:
 A portable format annotation API exists in the `org.springframework.format.annotation`
 package. You can use `@NumberFormat` to format `Number` fields such as `Double` and
 `Long`, and `@DateTimeFormat` to format `java.util.Date`, `java.util.Calendar`, `Long`
-(for millisecond timestamps) as well as JSR-310 `java.time`.
+(for millisecond timestamps) as well as JSR-310 `java.time`and Joda-Time value types.
 
 The following example uses `@DateTimeFormat` to format a `java.util.Date` as an ISO Date
 (yyyy-MM-dd):

--- a/src/docs/asciidoc/core/core-validation.adoc
+++ b/src/docs/asciidoc/core/core-validation.adoc
@@ -1452,7 +1452,7 @@ example shows:
 A portable format annotation API exists in the `org.springframework.format.annotation`
 package. You can use `@NumberFormat` to format `Number` fields such as `Double` and
 `Long`, and `@DateTimeFormat` to format `java.util.Date`, `java.util.Calendar`, `Long`
-(for millisecond timestamps) as well as JSR-310 `java.time`and Joda-Time value types.
+(for millisecond timestamps) as well as JSR-310 `java.time` and Joda-Time value types.
 
 The following example uses `@DateTimeFormat` to format a `java.util.Date` as an ISO Date
 (yyyy-MM-dd):


### PR DESCRIPTION
The official documentation contains partial information about using of *@DateTimeFormat* annotation.
According to JavaDocs and source code of *org.springframework.format.support.DefaultFormattingConversionService* class there is support for Joda-Time value types.
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/format/annotation/DateTimeFormat.html