### PR TITLE
Remove reference to Joda Time support in @DateTimeFormat Javadoc

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/annotation/DateTimeFormat.java
+++ b/spring-context/src/main/java/org/springframework/format/annotation/DateTimeFormat.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  *
  * <p>Supports formatting by style pattern, ISO date time pattern, or custom format pattern string.
  * Can be applied to {@link java.util.Date}, {@link java.util.Calendar}, {@link Long} (for
- * millisecond timestamps) as well as JSR-310 {@code java.time} and Joda-Time value types.
+ * millisecond timestamps) as well as JSR-310 {@code java.time}.
  *
  * <p>For style-based formatting, set the {@link #style} attribute to the desired style pattern code.
  * The first character of the code is the date style, and the second character is the time style.


### PR DESCRIPTION
According to #25736 and to be compatible with official documentation it would be great to remove mention of Joda Time support.