### PR TITLE
Fix formatting for PersonValidator Kotlin example in ref docs

### DIFF
--- a/src/docs/asciidoc/core/core-validation.adoc
+++ b/src/docs/asciidoc/core/core-validation.adoc
@@ -103,7 +103,7 @@ example implements `Validator` for `Person` instances:
 ----
 	class PersonValidator : Validator {
 
-		/**
+		/\**
 		 * This Validator validates only Person instances
 		 */
 		override fun supports(clazz: Class<*>): Boolean {


### PR DESCRIPTION
The official documentation contains incorrect Kotlin code example (page 237 of pdf).
As a result we have weird parameter `clazz: Class<>` instead of `clazz: Class<*>`. Also we have simple comment instead of JavaDoc comment.