### PR TITLE
Fix Kotlin code formatting for Inline Maps section of ref docs

### DIFF
--- a/src/docs/asciidoc/core/core-expressions.adoc
+++ b/src/docs/asciidoc/core/core-expressions.adoc
@@ -958,11 +958,11 @@ following example shows how to do so:
 
 	Map mapOfMaps = (Map) parser.parseExpression("{name:{first:'Nikola',last:'Tesla'},dob:{day:10,month:'July',year:1856}}").getValue(context);
 ----
-[source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
+[source,kotlin,indent=0,subs="verbatim",role="secondary"]
 .Kotlin
 ----
 	// evaluates to a Java map containing the two entries
-	val inventorInfo = parser.parseExpression("{name:'Nikola',dob:'10-July-1856'}").getValue(context) as Map<\*, *>
+	val inventorInfo = parser.parseExpression("{name:'Nikola',dob:'10-July-1856'}").getValue(context) as Map<*, *>
 
 	val mapOfMaps = parser.parseExpression("{name:{first:'Nikola',last:'Tesla'},dob:{day:10,month:'July',year:1856}}").getValue(context) as Map<*, *>	
 ----

--- a/src/docs/asciidoc/core/core-expressions.adoc
+++ b/src/docs/asciidoc/core/core-expressions.adoc
@@ -962,7 +962,7 @@ following example shows how to do so:
 .Kotlin
 ----
 	// evaluates to a Java map containing the two entries
-	val inventorInfo = parser.parseExpression("{name:'Nikola',dob:'10-July-1856'}").getValue(context) as Map<*, *>
+	val inventorInfo = parser.parseExpression("{name:'Nikola',dob:'10-July-1856'}").getValue(context) as Map<\*, *>
 
 	val mapOfMaps = parser.parseExpression("{name:{first:'Nikola',last:'Tesla'},dob:{day:10,month:'July',year:1856}}").getValue(context) as Map<*, *>	
 ----


### PR DESCRIPTION
Official documentation contains incorrect Kotlin code example (page 292 of pdf).
There are `Map<*, >` instead of `Map<*, *>` and `Map<, *>` instead of `Map<*, *>`.
The cause of this issue is incorrect formatting.