### PR TITLE
Improve documentation for SpEL constructor support

### DIFF
--- a/src/docs/asciidoc/core/core-expressions.adoc
+++ b/src/docs/asciidoc/core/core-expressions.adoc
@@ -1366,7 +1366,7 @@ to use the `T` operator:
 === Constructors
 
 You can invoke constructors by using the `new` operator. You should use the fully qualified class name
-for all but the primitive types (`int`, `float`, and so on) and String. The following
+for all but the types located in the core package `java.lang`. The following
 example shows how to use the `new` operator to invoke constructors:
 
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]


### PR DESCRIPTION
Chapter *4 Spring Expression Language (SpEL)*, section *4.3.9. Constructors* of official documentation contains incorrect description of default behavior.
According to source code of *org.springframework.expression.spel.support.StandardEvaluationContext* there is a use of *org.springframework.expression.spel.support.StandardTypeLocator* class. According to the source code of letter class the core package '*java.lang*' is registered by default.