### PR TITLE
Fix parameter bug of handler that Kotlin DSL defines as a parameter for the filterFunction.

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/CoRouterFunctionDsl.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/CoRouterFunctionDsl.kt
@@ -531,8 +531,8 @@ class CoRouterFunctionDsl internal constructor (private val init: (CoRouterFunct
 	fun filter(filterFunction: suspend (ServerRequest, suspend (ServerRequest) -> ServerResponse) -> ServerResponse) {
 		builder.filter { serverRequest, handlerFunction ->
 			mono(Dispatchers.Unconfined) {
-				filterFunction(serverRequest) {
-					handlerFunction.handle(serverRequest).awaitSingle()
+				filterFunction(serverRequest) { handlerRequest ->
+					handlerFunction.handle(handlerRequest).awaitSingle()
 				}
 			}
 		}

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/CoRouterFunctionDslTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/CoRouterFunctionDslTests.kt
@@ -152,6 +152,16 @@ class CoRouterFunctionDslTests {
 		}
 	}
 
+	@Test
+	fun filtering() {
+		val mockRequest = get("https://example.com/filter").build()
+		val request = DefaultServerRequest(MockServerWebExchange.from(mockRequest), emptyList())
+		StepVerifier.create(sampleRouter().route(request).flatMap { it.handle(request) })
+			.expectNextMatches { response ->
+				response.headers().getFirst("foo") == "bar"
+			}
+			.verifyComplete()
+	}
 
 	private fun sampleRouter() = coRouter {
 		(GET("/foo/") or GET("/foos/")) { req -> handle(req) }
@@ -186,6 +196,18 @@ class CoRouterFunctionDslTests {
 		path("/baz", ::handle)
 		GET("/rendering") { RenderingResponse.create("index").buildAndAwait() }
 		add(otherRouter)
+		add(filterRouter)
+	}
+
+	private val filterRouter = coRouter {
+		"/filter" { request ->
+			ok().header("foo", request.headers().firstHeader("foo")).buildAndAwait()
+		}
+
+		filter { request, next ->
+			val newRequest = ServerRequest.from(request).apply { header("foo", "bar") }.build()
+			next(newRequest)
+		}
 	}
 
 	private val otherRouter = router {

--- a/spring-webmvc/src/main/kotlin/org/springframework/web/servlet/function/RouterFunctionDsl.kt
+++ b/spring-webmvc/src/main/kotlin/org/springframework/web/servlet/function/RouterFunctionDsl.kt
@@ -649,8 +649,8 @@ class RouterFunctionDsl internal constructor (private val init: (RouterFunctionD
 	 */
 	fun filter(filterFunction: (ServerRequest, (ServerRequest) -> ServerResponse) -> ServerResponse) {
 		builder.filter { request, next ->
-			filterFunction(request) {
-				next.handle(request)
+			filterFunction(request) { handlerRequest ->
+				next.handle(handlerRequest)
 			}
 		}
 	}


### PR DESCRIPTION
Resolve #26838 
This PR fixes following bug.

https://github.com/spring-projects/spring-framework/blob/5b1ab31559798df83f1e8d54d2b754f12c69c14e/spring-webmvc/src/main/kotlin/org/springframework/web/servlet/function/RouterFunctionDsl.kt#L650-L655

https://github.com/spring-projects/spring-framework/blob/5b1ab31559798df83f1e8d54d2b754f12c69c14e/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/CoRouterFunctionDsl.kt#L531-L539

1. Function `filterFunction` takes `serverRequest` and function `handler` as parameters. (I just named them.)
2. Function `handler` also takes `serverRequest` as parameter.
3. These DSLs define `handler`.
4. Function `handler`s that these DSLs defined  are now using mistakenly `filterFunction`'s `serverRequest`, not their own `serverRequest` parameters, which makes their own parameters meaningless.

This bug only exists in Kotlin DSL. 

You can see java codes have no problem as follows.

https://github.com/spring-projects/spring-framework/blob/01e50fb60ad0d82f96fe4df6054ed6029e2f6a12/spring-webmvc/src/main/java/org/springframework/web/servlet/function/HandlerFilterFunction.java#L46

https://github.com/spring-projects/spring-framework/blob/01e50fb60ad0d82f96fe4df6054ed6029e2f6a12/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/HandlerFilterFunction.java#L48

In java you can override filter something like

```java
ServerRequest newRequest = someOperation(request)
return next.handle(newRequest)
```

but in Kotlin DSL, even if you write 
```kotlin
filter { serverRequest, handlerFunction ->
    val newServerRequest = someOperation(serverRequest)
    handlerFunction(newServerRequest)
}
```
handlerFunction will use original serverRequest, not the newServerRequest