### PR TITLE
Add ApplicationEvent constructor for specifying timestamp

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/ApplicationEvent.java
+++ b/spring-context/src/main/java/org/springframework/context/ApplicationEvent.java
@@ -16,6 +16,7 @@
 
 package org.springframework.context;
 
+import java.time.Clock;
 import java.util.EventObject;
 
 /**
@@ -44,6 +45,17 @@ public abstract class ApplicationEvent extends EventObject {
 	public ApplicationEvent(Object source) {
 		super(source);
 		this.timestamp = System.currentTimeMillis();
+	}
+
+	/**
+	 * Create a new {@code ApplicationEvent} with a fixed timestamp.
+	 * @param source the object on which the event initially occurred or with
+	 * which the event is associated (never {@code null})
+	 * @param clock a clock which will provide the timestamp
+	 */
+	public ApplicationEvent(Object source, Clock clock) {
+		super(source);
+		this.timestamp = clock.millis();
 	}
 
 


### PR DESCRIPTION
Unit testing listener behaviour where the time between events is important is a pain because it is impossible to specify the time of the event.

I don't think there is a way to expose this behaviour in only test code, but I can do so if someone points out how.

Lastly, if the constructor is intentionally left out, it might be good to document this.