### PR TITLE
Improve readability of MessageSourceSupport Javadoc

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/MessageSourceSupport.java
+++ b/spring-context/src/main/java/org/springframework/context/support/MessageSourceSupport.java
@@ -64,7 +64,7 @@ public abstract class MessageSourceSupport {
 	 * Set this to "true" to enforce MessageFormat for all messages,
 	 * expecting all message texts to be written with MessageFormat escaping.
 	 * <p>For example, MessageFormat expects a single quote to be escaped
-	 * as "''". If your message texts are all written with such escaping,
+	 * as <code>"''"</code>. If your message texts are all written with such escaping,
 	 * even when not defining argument placeholders, you need to set this
 	 * flag to "true". Else, only message texts with actual arguments
 	 * are supposed to be written with MessageFormat escaping.


### PR DESCRIPTION
The Javadoc of  [org.springframework.context.support.MessageSourceSupport](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/support/MessageSourceSupport.html#setAlwaysUseMessageFormat-boolean-) class contains unreadable piece of text for method *setAlwaysUseMessageFormat(boolean)*.
We need to replace """ with `"''"`.