### PR TITLE
Use an import instead of FQCN in StaxEventXMLReader

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/xml/StaxEventXMLReader.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/StaxEventXMLReader.java
@@ -292,7 +292,7 @@ class StaxEventXMLReader extends AbstractStaxXMLReader {
 
 	private void handleDtd(DTD dtd) throws SAXException {
 		if (getLexicalHandler() != null) {
-			javax.xml.stream.Location location = dtd.getLocation();
+			Location location = dtd.getLocation();
 			getLexicalHandler().startDTD(null, location.getPublicId(), location.getSystemId());
 		}
 		if (getLexicalHandler() != null) {


### PR DESCRIPTION
In #1927, `handleDtd()` was modified but `handleDtd(Dtd dtd)` was not.
I changed not to use FQCN in the latter method.