### PR TITLE
Fix syntax for RequestEntity headers example in ref docs

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -163,7 +163,7 @@ You can use the `exchange()` methods to specify request headers, as the followin
 	URI uri = UriComponentsBuilder.fromUriString(uriTemplate).build(42);
 
 	RequestEntity<Void> requestEntity = RequestEntity.get(uri)
-			.header(("MyRequestHeader", "MyValue")
+			.header("MyRequestHeader", "MyValue")
 			.build();
 
 	ResponseEntity<String> response = template.exchange(requestEntity, String.class);


### PR DESCRIPTION
Hi. There is an additional parenthesis in reference document about spring integration - RestTempate Headers part