### PR TITLE
Fix MethodMatcher API doc description

### DIFF
--- a/src/docs/asciidoc/core/core-aop-api.adoc
+++ b/src/docs/asciidoc/core/core-aop-api.adoc
@@ -57,11 +57,11 @@ The `MethodMatcher` interface is normally more important. The complete interface
 ----
 	public interface MethodMatcher {
 
-		boolean matches(Method m, Class targetClass);
+		boolean matches(Method m, Class<?> targetClass);
 
 		boolean isRuntime();
 
-		boolean matches(Method m, Class targetClass, Object[] args);
+		boolean matches(Method m, Class<?> targetClass, Object... args);
 	}
 ----
 


### PR DESCRIPTION
Chapter *6. Spring AOP APIs*, section *6.1.1. Concepts* contains incorrect API description for *org.springframework.aop.MethodMatcher* interface. Instead of array there should be varargs.