### PR TITLE
fix aop @target bug 

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Field;
 import org.aspectj.weaver.ReferenceType;
 import org.aspectj.weaver.ReferenceTypeDelegate;
 import org.aspectj.weaver.ResolvedType;
+import org.aspectj.weaver.UnresolvedType;
 import org.aspectj.weaver.ast.And;
 import org.aspectj.weaver.ast.Call;
 import org.aspectj.weaver.ast.FieldGetCall;

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
@@ -285,12 +285,10 @@ class RuntimeTestWalker {
 
 		@Override
 		public void visit(HasAnnotation hasAnn) {
-			// If you thought things were bad before, now we sink to new levels of horror...
 			ReflectionVar v = (ReflectionVar) hasAnn.getVar();
-			int varType = getVarType(v);
-			if (varType == AT_THIS_VAR || varType == AT_TARGET_VAR || varType == AT_ANNOTATION_VAR) {
-				this.testsSubtypeSensitiveVars = true;
-			}
+			ResolvedType targetType = v.getType();
+			UnresolvedType annotationType = hasAnn.getAnnotationType();
+			this.testsSubtypeSensitiveVars = !targetType.hasAnnotation(annotationType);
 		}
 	}
 


### PR DESCRIPTION
**1. Problem Describe**
I found spring will proxy some classes without the designated annotation , when I use @target in the pointcut expression.

For example:

    //this is my annotation
    @Target({ElementType.METHOD, ElementType.TYPE})
    @Retention(RetentionPolicy.RUNTIME)
    public @interface PrivilegeCheck {
        int[] roleTypes() default {};
    }
    
    //this is my aop 
    @Component
    @Aspect
    public class AopTest {
        @Around("@target(com.cxh.PrivilegeCheck)")
	    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
		    System.out.println("before aop");
		    return joinPoint.proceed();
	    }
    }
    
    //this is my target class
    @Component
    @PrivilegeCheck
    public class Father {
	    public int id = 1;
	    public int getId() {
		    return id;
	    }
    }
    
    //this is a normal final class without @PrivilegeCheck
    @Component
    public final class FinalClz {
	  public int get(){
		  return 1;
	  }
    }

The FinalClz class with also proxy, when i use the @target(com.cxh.PrivilegeCheck). But there isn't @PrivilegeCheck on the FinalClz class.  If FinalClz is not a final class, the problem just wast a little time. But if the FinalClz class is a final class, as we known the cglib can not proxy final class, so the project will start fail.

**2. My Solution**
    Because of the method findResidueInternal in ThisOrTargetAnnotationPointcut.class set the var  to shadow.getTargetVar() instead of shadow.getTargetAnnotationVar, the method visit(HasAnnotation hasAnn) of the SubtypeSensitiveVarTypeTestVisitor class in RuntimeTestWalker.class in the spring source code has an error.
    So I use the method hasAnnotation(UnresolvedType ofType) of ReferenceType to solve this problem.

