### PR TITLE
UriComponentsBuilder handles invalid port numbers correctly

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -85,7 +85,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 
 	private static final String HOST_PATTERN = "(" + HOST_IPV6_PATTERN + "|" + HOST_IPV4_PATTERN + ")";
 
-	private static final String PORT_PATTERN = "(\\d*(?:\\{[^/]+?})?)";
+	private static final String PORT_PATTERN = "(.[^/]*(?:\\{[^/]+?})?)";
 
 	private static final String PATH_PATTERN = "([^?#]*)";
 

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -38,6 +38,7 @@ import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Unit tests for {@link UriComponentsBuilder}.
@@ -1270,6 +1271,44 @@ class UriComponentsBuilderTests {
 	void verifyDoubleSlashReplacedWithSingleOne() {
 		String path = UriComponentsBuilder.fromPath("/home/").path("/path").build().getPath();
 		assertThat(path).isEqualTo("/home/path");
+	}
+
+
+	@Test
+	void verifyNonNumberPort() {
+		UriComponents numberPort = UriComponentsBuilder.fromUriString("http://localhost:8080/path").build();
+		assertThat(numberPort.getScheme()).isEqualTo("http");
+		assertThat(numberPort.getHost()).isEqualTo("localhost");
+		assertThat(numberPort.getPort()).isEqualTo(8080);
+		assertThat(numberPort.getPath()).isEqualTo("/path");
+
+		UriComponents stringPort = UriComponentsBuilder.fromUriString("http://localhost:port/path").build();
+		try{
+			stringPort.getPort();
+			fail("port must be a number");
+		}catch (NumberFormatException e){
+
+		}
+		assertThat(stringPort.getScheme()).isEqualTo("http");
+		assertThat(stringPort.getHost()).isEqualTo("localhost");
+		assertThat(stringPort.getPath()).isEqualTo("/path");
+
+		UriComponents httpNumberPort = UriComponentsBuilder.fromHttpUrl("http://localhost:8080/path").build();
+		assertThat(httpNumberPort.getScheme()).isEqualTo("http");
+		assertThat(httpNumberPort.getPort()).isEqualTo(8080);
+		assertThat(httpNumberPort.getHost()).isEqualTo("localhost");
+		assertThat(httpNumberPort.getPath()).isEqualTo("/path");
+
+		UriComponents httpStringPort=  UriComponentsBuilder.fromHttpUrl("http://localhost:port/path").build();
+		try{
+			httpStringPort.getPort();
+			fail("port must be a number");
+		}catch (NumberFormatException e){
+
+		}
+		assertThat(httpStringPort.getScheme()).isEqualTo("http");
+		assertThat(httpStringPort.getHost()).isEqualTo("localhost");
+		assertThat(httpStringPort.getPath()).isEqualTo("/path");
 	}
 
 }


### PR DESCRIPTION
Hello.
Fixed a bug in the'UriComponentBuilder' class.
The bug occurs in'UriComponentBuilder#fromUriString()'.
A bug occurs when the port of the argument is not a number.

This issue occurs with the 'PORT_PATTERN' regular expression.
If port is not a number, the regular expression is not captured.
This is a good regex, but it causes problems.

You can check the issue in the test code below.
```
UriComponents stringPort = UriComponentsBuilder.fromUriString("http://localhost:port/path").build();
assertThat(stringPort.getScheme()).isEqualTo("http");
assertThat(stringPort.getHost()).isEqualTo("localhost");
assertThat(stringPort.getPath()).isEqualTo("/path"); 
// expected: "/path", but was "port/path"
```

'PORT' that is not captured is captured by'PATH_PATTERN'.
`private static final String PATH_PATTERN = "([^?#]*)";`

I have fixed this bug.
Thank you.