### PR TITLE
UriComponentsBuilder when with port and query or fragment but no path

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -64,6 +64,7 @@ import org.springframework.web.util.UriComponents.UriTemplateVariables;
  * @author Brian Clozel
  * @author Sebastien Deleuze
  * @author Sam Brannen
+ * @author Nguyen Bao Sach
  * @since 3.1
  * @see #newInstance()
  * @see #fromPath(String)
@@ -85,7 +86,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 
 	private static final String HOST_PATTERN = "(" + HOST_IPV6_PATTERN + "|" + HOST_IPV4_PATTERN + ")";
 
-	private static final String PORT_PATTERN = "(.[^/]*(?:\\{[^/]+?})?)";
+	private static final String PORT_PATTERN = "(.[^/?]*(?:\\{[^/]+?})?)";
 
 	private static final String PATH_PATTERN = "([^?#]*)";
 

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -86,7 +86,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 
 	private static final String HOST_PATTERN = "(" + HOST_IPV6_PATTERN + "|" + HOST_IPV4_PATTERN + ")";
 
-	private static final String PORT_PATTERN = "(.[^/?]*(?:\\{[^/]+?})?)";
+	private static final String PORT_PATTERN = "(.[^/?#]*(?:\\{[^/]+?})?)";
 
 	private static final String PATH_PATTERN = "([^?#]*)";
 

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -1298,4 +1298,18 @@ class UriComponentsBuilderTests {
 		assertThat(result.getFragment()).isNull();
 	}
 
+	@Test
+	void fromUriStringNoPathWithPortAndFragment() {
+		String url = "http://localhost:8080#foo";
+		UriComponents result = UriComponentsBuilder.fromUriString(url).build();
+		assertThat(result.getScheme()).isEqualTo("http");
+		assertThat(result.getUserInfo()).isNull();
+		assertThat(result.getHost()).isEqualTo("localhost");
+		assertThat(result.getPort()).isEqualTo(8080);
+		assertThat(result.getPath()).isNullOrEmpty();
+		assertThat(result.getPathSegments()).isEmpty();
+		assertThat(result.getQuery()).isNull();
+		assertThat(result.getFragment()).isEqualTo("foo");
+	}
+
 }

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author David Eckel
+ * @author Nguyen Bao Sach
  */
 class UriComponentsBuilderTests {
 
@@ -1281,6 +1282,20 @@ class UriComponentsBuilderTests {
 				.isInstanceOf(NumberFormatException.class);
 		assertThatThrownBy(() -> UriComponentsBuilder.fromHttpUrl(url).build().toUri())
 				.isInstanceOf(NumberFormatException.class);
+	}
+
+	@Test
+	void fromUriStringNoPathWithPortAndQuery() {
+		String url = "http://localhost:8080?foo=bar";
+		UriComponents result = UriComponentsBuilder.fromUriString(url).build();
+		assertThat(result.getScheme()).isEqualTo("http");
+		assertThat(result.getUserInfo()).isNull();
+		assertThat(result.getHost()).isEqualTo("localhost");
+		assertThat(result.getPort()).isEqualTo(8080);
+		assertThat(result.getPath()).isNullOrEmpty();
+		assertThat(result.getPathSegments()).isEmpty();
+		assertThat(result.getQuery()).isEqualTo("foo=bar");
+		assertThat(result.getFragment()).isNull();
 	}
 
 }


### PR DESCRIPTION
When there is a port, a query, or a fragment but there is no path in URI String, UriComponentsBuilder#fromUriString() will result in a bug.

Example: 
- with `http://localhost:8080?foo=bar` URI, after running UriComponentsBuilder#fromUriString(), the port will be `8080?foo=bar`.
- with `http://localhost:8080#foo` URI, after running UriComponentsBuilder#fromUriString(), the port will be `8080#foo`.

It seems that this change #26905 affected UriComponentsBuilder#fromUriString().
