### PR TITLE
Provide option to switch threads for WebFlux controller methods

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/BlockingPredicate.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/BlockingPredicate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.result.method;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Help to predicate the controller method blocking or not.
+ * it's default non-blocking in webflux.
+ *
+ *  @author Gui Fu
+ *  @since 5.3.8
+ */
+public class BlockingPredicate implements Predicate<Method> {
+	@Override
+	public boolean test(Method method) {
+		return false;
+	}
+
+	public Scheduler getScheduler(Method method) {
+		return Schedulers.boundedElastic();
+	}
+}


### PR DESCRIPTION
If the controller method return type is not asynchronous, it should be running in Elastic thread pool.

In WebFlux, we should support asynchronous and synchronous both.  if the controller method's return type is Mono/Flux/Future/CompleteableFuture, we should runnint this controller in synchronous(IO) thread, but if they just not want running in Asychronous Mode, they may invoke database or something else (IO operation), they just not return Mono/Flux type, and we throw them into elastic thread pool.

It's very helpful to many projects, to gain asynchronous and synchronous advances. 