### PR TITLE
Bug Fix the port regular expression in'UriComponentsBuilder'.

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -85,7 +85,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 
 	private static final String HOST_PATTERN = "(" + HOST_IPV6_PATTERN + "|" + HOST_IPV4_PATTERN + ")";
 
-	private static final String PORT_PATTERN = "(.[^/]*(?:\\{[^/]+?})?)";
+	private static final String PORT_PATTERN = "(.[^/?#]*(?:\\{[^/]+?})?)";
 
 	private static final String PATH_PATTERN = "([^?#]*)";
 

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -1281,6 +1281,12 @@ class UriComponentsBuilderTests {
 				.isInstanceOf(NumberFormatException.class);
 		assertThatThrownBy(() -> UriComponentsBuilder.fromHttpUrl(url).build().toUri())
 				.isInstanceOf(NumberFormatException.class);
+
+		String url2 = "http://localhost:8080#summary";
+		assertThat(UriComponentsBuilder.fromUriString(url2).build().getPort()).isEqualTo(8080);
+
+		String url3 = "http://localhost:8080?hello=world";
+		assertThat(UriComponentsBuilder.fromUriString(url3).build().getPort()).isEqualTo(8080);
 	}
 
 }


### PR DESCRIPTION
Sorry
I've checked a bug in a commit I've fixed earlier.(https://github.com/spring-projects/spring-framework/pull/26905)
This bug was reported in #26910.
If there are'Url Query' and'Url Fragments', it is a normal case, but a bug occurs.
I have fix this.