### PR TITLE
Optimize some scenes which need not proxy

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Field;
 import org.aspectj.weaver.ReferenceType;
 import org.aspectj.weaver.ReferenceTypeDelegate;
 import org.aspectj.weaver.ResolvedType;
+import org.aspectj.weaver.UnresolvedType;
 import org.aspectj.weaver.ast.And;
 import org.aspectj.weaver.ast.Call;
 import org.aspectj.weaver.ast.FieldGetCall;

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/RuntimeTestWalker.java
@@ -285,12 +285,10 @@ class RuntimeTestWalker {
 
 		@Override
 		public void visit(HasAnnotation hasAnn) {
-			// If you thought things were bad before, now we sink to new levels of horror...
 			ReflectionVar v = (ReflectionVar) hasAnn.getVar();
-			int varType = getVarType(v);
-			if (varType == AT_THIS_VAR || varType == AT_TARGET_VAR || varType == AT_ANNOTATION_VAR) {
-				this.testsSubtypeSensitiveVars = true;
-			}
+			ResolvedType targetType = v.getType();
+			UnresolvedType annotationType = hasAnn.getAnnotationType();
+			this.testsSubtypeSensitiveVars = !targetType.hasAnnotation(annotationType);
 		}
 	}
 


### PR DESCRIPTION
If using @target in the pointcut expression, spring will create proxy for the classes which are in maybe case and will check the aop when user call the functions of proxy class.
If there's a final class in these proxy functions and use cglib proxy . the project will start failed. 
So I return the target object, for these final class without cglib proxy.