### PR TITLE
Improve support for port numbers in allowedOriginPattern of CorsConfiguration

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -177,7 +177,9 @@ public class CorsConfiguration {
 	 * it always sets the {@code Access-Control-Allow-Origin} response header to
 	 * the matched origin and never to {@code "*"}, nor to any other pattern, and
 	 * therefore can be used in combination with {@link #setAllowCredentials}
-	 * set to {@code true}.
+	 * set to {@code true}. Patterns also support list of allowed ports for origin,
+	 * e.g. {@code "https://*.domain1.com:[8080,8081]"}. Additionally wildcard is supported
+	 * in case any generic port should be allowed {@code "https://*.domain1.com:[*]"}.
 	 * <p>By default this is not set.
 	 * @since 5.3
 	 */

--- a/spring-web/src/test/java/org/springframework/web/cors/CorsConfigurationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/cors/CorsConfigurationTests.java
@@ -335,6 +335,15 @@ public class CorsConfigurationTests {
 		config.addAllowedOriginPattern("https://*.domain.com");
 		assertThat(config.checkOrigin("https://example.domain.com")).isEqualTo("https://example.domain.com");
 
+		config.addAllowedOriginPattern("https://*.port.domain.com:[*]");
+		assertThat(config.checkOrigin("https://example.port.domain.com")).isEqualTo("https://example.port.domain.com");
+		assertThat(config.checkOrigin("https://example.port.domain.com:1234")).isEqualTo("https://example.port.domain.com:1234");
+
+		config.addAllowedOriginPattern("https://*.specific.port.com:[8080,8081]");
+		assertThat(config.checkOrigin("https://example.specific.port.com:8080")).isEqualTo("https://example.specific.port.com:8080");
+		assertThat(config.checkOrigin("https://example.specific.port.com:8081")).isEqualTo("https://example.specific.port.com:8081");
+		assertThat(config.checkOrigin("https://example.specific.port.com:1234")).isNull();
+
 		config.setAllowCredentials(false);
 		assertThat(config.checkOrigin("https://example.domain.com")).isEqualTo("https://example.domain.com");
 	}
@@ -352,6 +361,9 @@ public class CorsConfigurationTests {
 
 		config.setAllowedOriginPatterns(new ArrayList<>());
 		assertThat(config.checkOrigin("https://domain.com")).isNull();
+
+		config.setAllowedOriginPatterns(Collections.singletonList("https://*.specific.port.com:[8080,8081]"));
+		assertThat(config.checkOrigin("https://example.specific.port.com:1234")).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
This is to support ports in cors origin patterns.
Closes gh-26926

Example:
```
https://*.example.com:[8080]
https://*.example.com:[8080,9000]
https://*.example.com:[*]
```