### PR TITLE
Optimize some scenes which need not proxy

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/DefaultAopProxyFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/DefaultAopProxyFactory.java
@@ -61,6 +61,15 @@ public class DefaultAopProxyFactory implements AopProxyFactory, Serializable {
 			if (targetClass.isInterface() || Proxy.isProxyClass(targetClass)) {
 				return new JdkDynamicAopProxy(config);
 			}
+
+			// If cglib will proxy a final class. then return the target object to user.
+			if(java.lang.reflect.Modifier.isFinal(targetClass.getModifiers())){
+				try {
+					return new NeedNotProxy(config.targetSource.getTarget());
+				} catch (Exception e) {
+				}
+			}
+
 			return new ObjenesisCglibAopProxy(config);
 		}
 		else {

--- a/spring-aop/src/main/java/org/springframework/aop/framework/NeedNotProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/NeedNotProxy.java
@@ -1,0 +1,25 @@
+package org.springframework.aop.framework;
+
+/**
+ * The final class can not proxy by cglib. So return the target object.
+ * @author: caoxuhao
+ * @Date: 2021/5/10 14:09
+ */
+public class NeedNotProxy implements AopProxy{
+
+	Object target;
+
+	public NeedNotProxy(Object target){
+		this.target = target;
+	}
+
+	@Override
+	public Object getProxy() {
+		return target;
+	}
+
+	@Override
+	public Object getProxy(ClassLoader classLoader) {
+		return target;
+	}
+}


### PR DESCRIPTION
If using @target in the pointcut expression, spring will create proxy for the classed which are in maybe case and will check the aop when user call the functions of proxy class.
If there's a final class in these proxy functions. the project will start failed. 
So I return the target object, for these final class without proxy.