### PR TITLE
Optimize some scenes which need not proxy

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/DefaultAopProxyFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/DefaultAopProxyFactory.java
@@ -61,6 +61,16 @@ public class DefaultAopProxyFactory implements AopProxyFactory, Serializable {
 			if (targetClass.isInterface() || Proxy.isProxyClass(targetClass)) {
 				return new JdkDynamicAopProxy(config);
 			}
+
+			// If cglib will proxy a final class. then return the target object to user.
+			if(java.lang.reflect.Modifier.isFinal(targetClass.getModifiers())){
+				try {
+					return new NeedNotProxy(config.targetSource.getTarget());
+				}
+				catch (Exception ex) {
+				}
+			}
+
 			return new ObjenesisCglibAopProxy(config);
 		}
 		else {

--- a/spring-aop/src/main/java/org/springframework/aop/framework/NeedNotProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/NeedNotProxy.java
@@ -19,7 +19,7 @@ package org.springframework.aop.framework;
 /**
  * The final class can not proxy by cglib. So return the target object.
  *
- * @author caoxuhao
+ * @author Eric Cao
  * @since 05.11.2021
  */
 public class NeedNotProxy implements AopProxy{

--- a/spring-aop/src/main/java/org/springframework/aop/framework/NeedNotProxy.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/NeedNotProxy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+/**
+ * The final class can not proxy by cglib. So return the target object.
+ *
+ * @author caoxuhao
+ * @since 05.11.2021
+ */
+public class NeedNotProxy implements AopProxy{
+
+	Object target;
+
+	public NeedNotProxy(Object target){
+		this.target = target;
+	}
+
+	@Override
+	public Object getProxy() {
+		return this.target;
+	}
+
+	@Override
+	public Object getProxy(ClassLoader classLoader) {
+		return this.target;
+	}
+}


### PR DESCRIPTION
If using @target in the pointcut expression, spring will create proxy for the classed which are in maybe case and will check the aop when user call the functions of proxy class.
If there's a final class in these proxy functions. the project will start failed. 
So I return the target object, for these final class without proxy.
