### PR TITLE
Polish PORT_PATTERN in UriComponentsBuilder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -85,7 +85,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 
 	private static final String HOST_PATTERN = "(" + HOST_IPV6_PATTERN + "|" + HOST_IPV4_PATTERN + ")";
 
-	private static final String PORT_PATTERN = "(.[^/?#]*(?:\\{[^/]+?})?)";
+	private static final String PORT_PATTERN = "([^/?#]*)";
 
 	private static final String PATH_PATTERN = "([^?#]*)";
 


### PR DESCRIPTION
This PR polishes `PORT_PATTERN` in `UriComponentsBuilder` by removing some parts that don't seem to be necessary.

I might be missing something. If it's intentional, it would good to have some tests that demonstrate why they are necessary as the current tests including `UriComponentsBuilderTests` pass without them.