### PR TITLE
Introduce ResponseEntity.internalServerError()

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -317,6 +317,16 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 		return status(HttpStatus.UNPROCESSABLE_ENTITY);
 	}
 
+	/**
+	 * Create a builder with an
+	 * {@linkplain HttpStatus#INTERNAL_SERVER_ERROR INTERNAL_SERVER_ERROR} status.
+	 * @return the created builder
+	 * @since 5.3.8
+	 */
+	public static BodyBuilder internalServerError() {
+		return status(HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
 
 	/**
 	 * Defines a builder that adds headers to the response entity.

--- a/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
@@ -160,6 +160,15 @@ public class ResponseEntityTests {
 	}
 
 	@Test
+	public void internalServerError() throws URISyntaxException {
+		ResponseEntity<String> responseEntity = ResponseEntity.internalServerError().body("error");
+
+		assertThat(responseEntity).isNotNull();
+		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+		assertThat(responseEntity.getBody()).isEqualTo("error");
+	}
+
+	@Test
 	public void headers() throws URISyntaxException {
 		URI location = new URI("location");
 		long contentLength = 67890;


### PR DESCRIPTION
Hi,

this PR introduces a new convenience method `ResponseEntity.internalServerError()`.

In our code we have this sort of construct once in a while:

```java
		try {
			doSomething();
		} catch (SomethingNotFoundException ex) {
			return ResponseEntity.notFound().build();
		} catch (Exception ex) {
			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
		}
		return ResponseEntity.noContent().build();
```

That obviously works but I'm always looking for the convenience method to handle the 500 status code, which doesn't exist.

Let me know what you think.

Cheers,
Christoph