### PR TITLE
Update Etag validator

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/ShallowEtagHeaderFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/ShallowEtagHeaderFilter.java
@@ -235,13 +235,9 @@ public class ShallowEtagHeaderFilter extends OncePerRequestFilter {
 				return false;
 			}
 
-			if (isWeakETag(requestETag)) {
-				requestETag = requestETag.substring(WEAK_PREFIX.length());
-			}
-			if (isWeakETag(responseETag)) {
-				responseETag = responseETag.substring(WEAK_PREFIX.length());
-			}
-			return requestETag.equals(responseETag);
+			String requestETagOpaque = extractOpaqueTag(requestETag);
+			String responseETagOpaque = extractOpaqueTag(responseETag);
+			return requestETagOpaque.equals(responseETagOpaque);
 		}
 	}
 
@@ -261,5 +257,13 @@ public class ShallowEtagHeaderFilter extends OncePerRequestFilter {
 
 	private static boolean isWeakETag(String eTag) {
 		return eTag.startsWith(WEAK_PREFIX);
+	}
+
+	private static String extractOpaqueTag(String eTag) {
+		if (!isWeakETag(eTag)) {
+			return eTag;
+		}
+
+		return eTag.substring(WEAK_PREFIX.length());
 	}
 }

--- a/spring-web/src/test/java/org/springframework/web/filter/ShallowEtagHeaderFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/ShallowEtagHeaderFilterTests.java
@@ -122,7 +122,7 @@ public class ShallowEtagHeaderFilterTests {
 	public void filterMatchWeakEtag() throws Exception {
 		final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/hotels");
 		String etag = "\"0b10a8db164e0754105b7a99be72e3fe5\"";
-		request.addHeader("If-None-Match", "W/" + etag);
+		request.addHeader("If-None-Match", etag);
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		FilterChain filterChain = (filterRequest, filterResponse) -> {


### PR DESCRIPTION
On [RFC7232-2.3.2](https://datatracker.ietf.org/doc/html/rfc7232#section-2.3.2), `StrongValidator` and `WeakValidator` get different comparison result.

>    o  Strong comparison: two entity-tags are equivalent if both are not
>       weak and their opaque-tags match character-by-character.
> 
>    o  Weak comparison: two entity-tags are equivalent if their
>       opaque-tags match character-by-character, regardless of either or
>       both being tagged as "weak".

![image](https://user-images.githubusercontent.com/29394651/118699877-fdcc9300-b84c-11eb-8b91-d63cba2b7b65.png)

But, `ShallowEtagHeaderFilter.java` always compare the ETag like `Weak Comparison` even if `isWriteWeakETag()` is `false`.

How about adding `Validator` in `ShallowEtagHeaderFilter.java`, and using suitable implementation(`StrongValidator` or `WeakValidator`)?

---

**Sorry, I worked on old wrong branch, I'll check it again.**