### PR TITLE
Refactor ConcurrentBeanWrapperTests to use @RepeatedTest

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/ConcurrentBeanWrapperTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/ConcurrentBeanWrapperTests.java
@@ -26,7 +26,9 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,11 +46,9 @@ public class ConcurrentBeanWrapperTests {
 
 	private Throwable ex = null;
 
-	@Test
+	@RepeatedTest(100)
 	public void testSingleThread() {
-		for (int i = 0; i < 100; i++) {
-			performSet();
-		}
+		performSet();
 	}
 
 	@Test


### PR DESCRIPTION
Problem:

No problem is found in this test. This is a refactoring suggestion that simplifies test design by eliminating a repetition structure whose increment was not being used during the repetition and can be replaced by an annotation.

Solution:

The `@RepeatedTest` annotation provides the total number of repetitions desired. Each invocation of a repeated test behaves like the execution of a regular `@Test` method with full support for the same lifecycle callbacks and extensions, which improves test design, eases future maintenance activities when needed, and better informs which repetition failed.