### PR TITLE
Add test cases to SpEL's MapAccessorTests

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/expression/MapAccessorTests.java
+++ b/spring-context/src/test/java/org/springframework/context/expression/MapAccessorTests.java
@@ -67,6 +67,17 @@ public class MapAccessorTests {
 		assertThat(ex.getValue(sec,mapGetter)).isEqualTo("bar");
 		assertThat(SpelCompiler.compile(ex)).isTrue();
 		assertThat(ex.getValue(sec,mapGetter)).isEqualTo("bar");
+
+		// basic isWritable
+		ex = sep.parseExpression("foo");
+		assertThat(ex.isWritable(sec,testMap)).isTrue();
+
+		// basic write
+		ex = sep.parseExpression("foo2");
+		ex.setValue(sec, testMap, "bar2");
+		assertThat(ex.getValue(sec,testMap)).isEqualTo("bar2");
+		assertThat(SpelCompiler.compile(ex)).isTrue();
+		assertThat(ex.getValue(sec,testMap)).isEqualTo("bar2");
 	}
 
 	public static class MapGetter {


### PR DESCRIPTION
This PR is a simple addition of two test cases. It increases path coverage to two additional methods within the MapAccessor class.