### PR TITLE
Add tests for MessageBodyClientHttpResponseWrapper

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/mail/MailAuthenticationException.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/MailAuthenticationException.java
@@ -50,4 +50,5 @@ public class MailAuthenticationException extends MailException {
 		super("Authentication failed", cause);
 	}
 
+
 }

--- a/spring-web/src/test/java/org/springframework/web/client/MessageBodyClientHttpResponseWrapperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/MessageBodyClientHttpResponseWrapperTests.java
@@ -1,0 +1,98 @@
+package org.springframework.web.client;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Unit tests for {MessageBodyClientHttpResponseWrapper}.
+ *
+ * @author Yin-Jui Liao
+ */
+public class MessageBodyClientHttpResponseWrapperTests {
+
+
+	@Test
+	public void testMessageBodyNotExist() throws IOException {
+
+		ClientHttpResponse response = new ClientHttpResponse() {
+			@Override
+			public HttpStatus getStatusCode() throws IOException {
+				return HttpStatus.NO_CONTENT;
+			}
+
+			@Override
+			public int getRawStatusCode() throws IOException {
+				return 204;
+			}
+
+			@Override
+			public String getStatusText() throws IOException {
+				return null;
+			}
+
+			@Override
+			public void close() {
+
+			}
+
+			@Override
+			public InputStream getBody() throws IOException {
+				return null;
+			}
+
+			@Override
+			public HttpHeaders getHeaders() {
+				return null;
+			}
+		};
+		MessageBodyClientHttpResponseWrapper responseWrapper = new MessageBodyClientHttpResponseWrapper(response);
+		assertThat(responseWrapper.hasEmptyMessageBody()).isTrue();
+	}
+
+	@Test
+	public void testMessageBodyExist() throws IOException {
+
+		ClientHttpResponse response = new ClientHttpResponse() {
+			@Override
+			public HttpStatus getStatusCode() throws IOException {
+				return HttpStatus.ACCEPTED;
+			}
+
+			@Override
+			public int getRawStatusCode() throws IOException {
+				return 202;
+			}
+
+			@Override
+			public String getStatusText() throws IOException {
+				return null;
+			}
+
+			@Override
+			public void close() {
+
+			}
+
+			@Override
+			public InputStream getBody() throws IOException {
+				String body = "Accepted request";
+				InputStream stream = new ByteArrayInputStream(body.getBytes());
+				return stream;
+			}
+
+			@Override
+			public HttpHeaders getHeaders() {
+				return null;
+			}
+		};
+		MessageBodyClientHttpResponseWrapper responseWrapper = new MessageBodyClientHttpResponseWrapper(response);
+		assertThat(responseWrapper.hasEmptyMessageBody()).isFalse();
+	}
+}

--- a/spring-web/src/test/java/org/springframework/web/client/MessageBodyClientHttpResponseWrapperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/MessageBodyClientHttpResponseWrapperTests.java
@@ -1,10 +1,28 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.web.client;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -15,83 +33,22 @@ import java.io.InputStream;
  *
  * @author Yin-Jui Liao
  */
-public class MessageBodyClientHttpResponseWrapperTests {
+class MessageBodyClientHttpResponseWrapperTests {
 
+	private final ClientHttpResponse response = mock(ClientHttpResponse.class);
 
 	@Test
-	public void testMessageBodyNotExist() throws IOException {
-
-		ClientHttpResponse response = new ClientHttpResponse() {
-			@Override
-			public HttpStatus getStatusCode() throws IOException {
-				return HttpStatus.NO_CONTENT;
-			}
-
-			@Override
-			public int getRawStatusCode() throws IOException {
-				return 204;
-			}
-
-			@Override
-			public String getStatusText() throws IOException {
-				return null;
-			}
-
-			@Override
-			public void close() {
-
-			}
-
-			@Override
-			public InputStream getBody() throws IOException {
-				return null;
-			}
-
-			@Override
-			public HttpHeaders getHeaders() {
-				return null;
-			}
-		};
+	void testMessageBodyNotExist() throws IOException {
+		given(response.getBody()).willReturn(null);
 		MessageBodyClientHttpResponseWrapper responseWrapper = new MessageBodyClientHttpResponseWrapper(response);
 		assertThat(responseWrapper.hasEmptyMessageBody()).isTrue();
 	}
 
 	@Test
-	public void testMessageBodyExist() throws IOException {
-
-		ClientHttpResponse response = new ClientHttpResponse() {
-			@Override
-			public HttpStatus getStatusCode() throws IOException {
-				return HttpStatus.ACCEPTED;
-			}
-
-			@Override
-			public int getRawStatusCode() throws IOException {
-				return 202;
-			}
-
-			@Override
-			public String getStatusText() throws IOException {
-				return null;
-			}
-
-			@Override
-			public void close() {
-
-			}
-
-			@Override
-			public InputStream getBody() throws IOException {
-				String body = "Accepted request";
-				InputStream stream = new ByteArrayInputStream(body.getBytes());
-				return stream;
-			}
-
-			@Override
-			public HttpHeaders getHeaders() {
-				return null;
-			}
-		};
+	void testMessageBodyExist() throws IOException {
+		String body = "Accepted request";
+		InputStream stream = new ByteArrayInputStream(body.getBytes());
+		given(response.getBody()).willReturn(stream);
 		MessageBodyClientHttpResponseWrapper responseWrapper = new MessageBodyClientHttpResponseWrapper(response);
 		assertThat(responseWrapper.hasEmptyMessageBody()).isFalse();
 	}


### PR DESCRIPTION
Adding two test cases to test the correctness of hasEmptyMessageBody in MessageBodyClientHttpResponseWrapper class, which improves the method coverage.