### PR TITLE
Allow multiple destinations per subscription in DefaultSubscriptionRegistry

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/DefaultSubscriptionRegistry.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/DefaultSubscriptionRegistry.java
@@ -216,7 +216,7 @@ public class DefaultSubscriptionRegistry extends AbstractSubscriptionRegistry {
 			SessionInfo info = this.sessionRegistry.getSession(sessionId);
 			if (info != null) {
 				for (String subscriptionId : subscriptionIds) {
-					info.getSubscription(subscriptionId).forEach(subscription -> {
+					info.getSubscriptions(subscriptionId).forEach(subscription -> {
 						if (evaluateExpression(subscription.getSelector(), message)) {
 							result.add(sessionId, subscription.getId());
 						}
@@ -420,7 +420,7 @@ public class DefaultSubscriptionRegistry extends AbstractSubscriptionRegistry {
 			return this.subscriptionMap.values().stream().flatMap(Set::stream);
 		}
 
-		public Stream<Subscription> getSubscription(String subscriptionId) {
+		public Stream<Subscription> getSubscriptions(String subscriptionId) {
 			return this.subscriptionMap.getOrDefault(subscriptionId, emptySet()).stream();
 		}
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/broker/DefaultSubscriptionRegistryTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/broker/DefaultSubscriptionRegistryTests.java
@@ -110,6 +110,27 @@ public class DefaultSubscriptionRegistryTests {
 		assertThat(actual.size()).isEqualTo(1);
 		assertThat(actual.get(sessId)).containsExactly(subId);
 	}
+	
+	@Test
+	public void registerSameSubscriptionForDifferentDestinations() {
+		String sessId = "sess01";
+		String subId = "subs01";
+		String dest1 = "/foo";
+		String dest2 = "user/foo";
+
+		this.registry.registerSubscription(subscribeMessage(sessId, subId, dest1));
+		this.registry.registerSubscription(subscribeMessage(sessId, subId, dest2));
+
+		MultiValueMap<String, String> actual = this.registry.findSubscriptions(createMessage(dest1));
+		assertThat(actual).isNotNull();
+		assertThat(actual.size()).isEqualTo(1);
+		assertThat(actual.get(sessId)).containsExactly(subId);
+		
+		actual = this.registry.findSubscriptions(createMessage(dest2));
+		assertThat(actual).isNotNull();
+		assertThat(actual.size()).isEqualTo(1);
+		assertThat(actual.get(sessId)).containsExactly(subId);
+	}
 
 	@Test
 	public void registerSubscriptionMultipleSessions() {


### PR DESCRIPTION
Issue #24395 broke "user" destinations because it made subscription-id->destination a one to one association whereas it is a one to many.

This restores such state while keeping the optimisations done in #24395.