### PR TITLE
Add extra test case of creating bean

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -53,17 +53,7 @@ import org.springframework.beans.PropertyEditorRegistry;
 import org.springframework.beans.PropertyValue;
 import org.springframework.beans.TypeConverter;
 import org.springframework.beans.TypeMismatchException;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
-import org.springframework.beans.factory.config.AutowiredPropertyMarker;
-import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.BeanExpressionContext;
-import org.springframework.beans.factory.config.BeanExpressionResolver;
-import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.beans.factory.config.ConstructorArgumentValues;
-import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor;
-import org.springframework.beans.factory.config.PropertiesFactoryBean;
-import org.springframework.beans.factory.config.RuntimeBeanReference;
-import org.springframework.beans.factory.config.TypedStringValue;
+import org.springframework.beans.factory.config.*;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -105,6 +95,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.springframework.beans.factory.config.AutowireCapableBeanFactory.AUTOWIRE_CONSTRUCTOR;
 
 /**
  * Tests properties population and autowire behavior.
@@ -2119,6 +2110,14 @@ class DefaultListableBeanFactoryTests {
 		assertThat(tb.getBeanFactory()).isSameAs(lbf);
 		lbf.destroyBean(tb);
 		assertThat(tb.wasDestroyed()).isTrue();
+	}
+
+	@Test
+	void createBeanWithDependencyCheck(){
+		TestBean tb = (TestBean) lbf.createBean(TestBean.class,AUTOWIRE_CONSTRUCTOR,true );
+		assertThat(tb.getBeanFactory()).isSameAs(lbf);
+		lbf.destroyBean(tb);
+//		assertThat(tb.wasDestroyed()).isTrue();
 	}
 
 	@Test

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -134,6 +134,10 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	private ResponseEntity(@Nullable T body, @Nullable MultiValueMap<String, String> headers, Object status) {
 		super(body, headers);
 		Assert.notNull(status, "HttpStatus must not be null");
+		if(status == HttpStatus.NO_CONTENT || status == HttpStatus.NOT_MODIFIED || status == HttpStatus.CHECKPOINT ||
+		status == HttpStatus.CONTINUE || status == HttpStatus.PROCESSING || status == HttpStatus.SWITCHING_PROTOCOLS){
+			Assert.isNull(body, "All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not include a message body");
+		}
 		this.status = status;
 	}
 


### PR DESCRIPTION
I've noticed the method 
_public Object createBean(Class<?> beanClass, int autowireMode, boolean dependencyCheck) throws BeansException_  at line 256in _java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java_
is not covered in the current test suit, and hence I added a simple unit test in order to improve the coverage.