### PR TITLE
Add extra test case for creating bean

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -105,6 +105,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.springframework.beans.factory.support.AbstractBeanDefinition.AUTOWIRE_CONSTRUCTOR;
 
 /**
  * Tests properties population and autowire behavior.
@@ -1210,7 +1211,7 @@ class DefaultListableBeanFactoryTests {
 		lbf.registerSingleton("integer2", 5);
 
 		RootBeanDefinition rbd = new RootBeanDefinition(ArrayBean.class);
-		rbd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		rbd.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("arrayBean", rbd);
 		ArrayBean ab = (ArrayBean) lbf.getBean("arrayBean");
 
@@ -1221,7 +1222,7 @@ class DefaultListableBeanFactoryTests {
 	@Test
 	void arrayConstructorWithOptionalAutowiring() {
 		RootBeanDefinition rbd = new RootBeanDefinition(ArrayBean.class);
-		rbd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		rbd.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("arrayBean", rbd);
 		ArrayBean ab = (ArrayBean) lbf.getBean("arrayBean");
 
@@ -1236,7 +1237,7 @@ class DefaultListableBeanFactoryTests {
 		lbf.registerSingleton("resource2", new UrlResource("http://localhost:9090"));
 
 		RootBeanDefinition rbd = new RootBeanDefinition(ArrayBean.class);
-		rbd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		rbd.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("arrayBean", rbd);
 		ArrayBean ab = (ArrayBean) lbf.getBean("arrayBean");
 
@@ -1252,7 +1253,7 @@ class DefaultListableBeanFactoryTests {
 		lbf.registerSingleton("resource2", new UrlResource("http://localhost:9090"));
 
 		RootBeanDefinition rbd = new RootBeanDefinition(ArrayBean.class);
-		rbd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		rbd.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("arrayBean", rbd);
 		ArrayBean ab = (ArrayBean) lbf.getBean("arrayBean");
 
@@ -1528,7 +1529,7 @@ class DefaultListableBeanFactoryTests {
 		RootBeanDefinition bd1 = new RootBeanDefinition(HighPriorityTestBean.class);
 		RootBeanDefinition bd2 = new RootBeanDefinition(LowPriorityTestBean.class);
 		RootBeanDefinition bd3 = new RootBeanDefinition(NullTestBeanFactoryBean.class);
-		RootBeanDefinition bd4 = new RootBeanDefinition(TestBeanRecipient.class, RootBeanDefinition.AUTOWIRE_CONSTRUCTOR, false);
+		RootBeanDefinition bd4 = new RootBeanDefinition(TestBeanRecipient.class, AUTOWIRE_CONSTRUCTOR, false);
 		lbf.registerBeanDefinition("bd1", bd1);
 		lbf.registerBeanDefinition("bd2", bd2);
 		lbf.registerBeanDefinition("bd3", bd3);
@@ -2122,6 +2123,13 @@ class DefaultListableBeanFactoryTests {
 	}
 
 	@Test
+	void createBeanWithDependencyCheck(){
+		TestBean tb = (TestBean) lbf.createBean(TestBean.class,AUTOWIRE_CONSTRUCTOR,true );
+		assertThat(tb.getBeanFactory()).isSameAs(lbf);
+		lbf.destroyBean(tb);
+	}
+
+	@Test
 	void configureBean() {
 		MutablePropertyValues pvs = new MutablePropertyValues();
 		pvs.add("age", "99");
@@ -2172,7 +2180,7 @@ class DefaultListableBeanFactoryTests {
 	@Test
 	void circularReferenceThroughAutowiring() {
 		RootBeanDefinition bd = new RootBeanDefinition(ConstructorDependencyBean.class);
-		bd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		bd.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("test", bd);
 		assertThatExceptionOfType(UnsatisfiedDependencyException.class).isThrownBy(
 				lbf::preInstantiateSingletons);
@@ -2181,7 +2189,7 @@ class DefaultListableBeanFactoryTests {
 	@Test
 	void circularReferenceThroughFactoryBeanAutowiring() {
 		RootBeanDefinition bd = new RootBeanDefinition(ConstructorDependencyFactoryBean.class);
-		bd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		bd.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("test", bd);
 		assertThatExceptionOfType(UnsatisfiedDependencyException.class).isThrownBy(
 				lbf::preInstantiateSingletons);
@@ -2190,7 +2198,7 @@ class DefaultListableBeanFactoryTests {
 	@Test
 	void circularReferenceThroughFactoryBeanTypeCheck() {
 		RootBeanDefinition bd = new RootBeanDefinition(ConstructorDependencyFactoryBean.class);
-		bd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		bd.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("test", bd);
 		assertThatExceptionOfType(UnsatisfiedDependencyException.class).isThrownBy(() ->
 				lbf.getBeansOfType(String.class));
@@ -2199,10 +2207,10 @@ class DefaultListableBeanFactoryTests {
 	@Test
 	void avoidCircularReferenceThroughAutowiring() {
 		RootBeanDefinition bd = new RootBeanDefinition(ConstructorDependencyFactoryBean.class);
-		bd.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		bd.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("test", bd);
 		RootBeanDefinition bd2 = new RootBeanDefinition(String.class);
-		bd2.setAutowireMode(RootBeanDefinition.AUTOWIRE_CONSTRUCTOR);
+		bd2.setAutowireMode(AUTOWIRE_CONSTRUCTOR);
 		lbf.registerBeanDefinition("string", bd2);
 		lbf.preInstantiateSingletons();
 	}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -51,7 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @since 4.0.3
  * @see org.springframework.r2dbc.connection.init.ScriptUtils
- */
+ * **/
 public abstract class ScriptUtils {
 
 	/**
@@ -645,7 +645,14 @@ public abstract class ScriptUtils {
 		StringBuilder sb = new StringBuilder();
 		boolean inSingleQuote = false;
 		boolean inDoubleQuote = false;
+		boolean inDollarQuote = false;
 		boolean inEscape = false;
+		boolean foundStartTag = false;
+		boolean possibleEndTag = false;
+		int startTagIndex = -1;
+		int start = 0;
+		StringBuilder startTag = new StringBuilder();
+String a= "$a$I’m happy $a$";
 
 		for (int i = 0; i < script.length(); i++) {
 			char c = script.charAt(i);
@@ -660,11 +667,45 @@ public abstract class ScriptUtils {
 				sb.append(c);
 				continue;
 			}
-			if (!inDoubleQuote && (c == '\'')) {
+			if (!inDoubleQuote && (c == '\'') && !foundStartTag) {
 				inSingleQuote = !inSingleQuote;
 			}
 			else if (!inSingleQuote && (c == '"')) {
 				inDoubleQuote = !inDoubleQuote;
+			}else if ( c == '$' ){
+				if(foundStartTag){
+					if(possibleEndTag){
+						if(startTag.length() == startTagIndex){
+							//found end tag
+							sb.append(c);
+							statements.add(sb.toString());
+							sb = new StringBuilder();
+							foundStartTag = false;
+							possibleEndTag = false;
+							continue;
+						}else{
+							//not the end tag but the current & can be the start of the end tag we are looking for
+							// so reset the startTagIndex
+							startTagIndex = 0;
+						}
+					}else{
+						possibleEndTag = true;
+						startTagIndex = 0;
+					}
+				} else{
+
+					foundStartTag = true;
+
+				}
+			}else{
+				if(foundStartTag){
+					if(possibleEndTag){
+
+					} else {
+						startTag.append(c);
+					}
+				}
+
 			}
 			if (!inSingleQuote && !inDoubleQuote) {
 				if (script.startsWith(separator, i)) {
@@ -711,6 +752,15 @@ public abstract class ScriptUtils {
 				}
 			}
 			sb.append(c);
+			if(c != '$' && possibleEndTag){
+				if(startTagIndex >= startTag.length() || c != startTag.charAt(startTagIndex)){
+					//this is not the end tag we are looking for
+					possibleEndTag = false;
+					startTagIndex = -1;
+				}else{
+					startTagIndex++;
+				}
+			}
 		}
 
 		if (StringUtils.hasText(sb)) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -788,16 +788,6 @@ public abstract class ScriptUtils {
 		}
 	}
 
-//	private static String scanDollarQuote(){
-//		boolean scanningStartTag = false;
-//		boolean foundStartTag = false;
-//		boolean possibleEndTag = false;
-//		int startTagIndex = -1;
-//		StringBuilder startTag = new StringBuilder();
-//
-//
-//	}
-
 	private static boolean startsWithAny(String script, String[] prefixes, int offset) {
 		for (String prefix : prefixes) {
 			if (script.startsWith(prefix, offset)) {


### PR DESCRIPTION
I've noticed the method
public Object createBean(Class<?> beanClass, int autowireMode, boolean dependencyCheck) throws BeansException at line 256in java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
is not covered in the current test suit, and hence I added a simple unit test in order to improve the coverage.