### PR TITLE
Simplify String construction in StringUtils.changeFirstCharacterCase()

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -566,7 +566,7 @@ public abstract class StringUtils {
 
 		char[] chars = str.toCharArray();
 		chars[0] = updatedChar;
-		return new String(chars, 0, chars.length);
+		return new String(chars);
 	}
 
 	/**


### PR DESCRIPTION
Just a tiny optimization allowing String constructor to skip array bounds check.