### PR TITLE
Document that class-level @ResponseStatus is inherited by @ExceptionHandler methods

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/ResponseStatus.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/ResponseStatus.java
@@ -46,7 +46,7 @@ import org.springframework.http.HttpStatus;
  *
  * <p>Note that a controller class may also be annotated with
  * {@code @ResponseStatus} and is then inherited by all {@code @RequestMapping}
- * methods.
+ * and {@code @ExceptionHandler} methods.
  *
  * @author Arjen Poutsma
  * @author Sam Brannen


### PR DESCRIPTION
The [Javadoc](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/ResponseStatus.html) of `@ResponseStatus` doesn't mention that when `@ResponseStatus` is applied to a class then it is inherited also by `@ExceptionHandler` annotated methods.

