### PR TITLE
Update WebMvcConfigurationSupport javadoc for HandlerFunctionAdapter

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -145,6 +145,8 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * for processing requests with {@link HttpRequestHandler HttpRequestHandlers}.
  * <li>{@link SimpleControllerHandlerAdapter}
  * for processing requests with interface-based {@link Controller Controllers}.
+ * <li>{@link HandlerFunctionAdapter}
+ * for processing requests with {@linkplain org.springframework.web.servlet.function.RouterFunction router functions}.
  * </ul>
  *
  * <p>Registers a {@link HandlerExceptionResolverComposite} with this chain of


### PR DESCRIPTION
The Java Doc for **org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport** doesn't contain complete information about all **HandlerAdapter** classes registered with the aforementioned class.
According to source code of **WebMvcConfigurationSupport** it also creates **org.springframework.web.servlet.function.support.HandlerFunctionAdapter** handler adapter for routing functions.
