### PR TITLE
Improve RequestResponseBodyMethodProcessor Javadoc

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessor.java
@@ -51,7 +51,8 @@ import org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolv
  * to the body of the request or response with an {@link HttpMessageConverter}.
  *
  * <p>An {@code @RequestBody} method argument is also validated if it is annotated
- * with {@code @javax.validation.Valid}. In case of validation failure,
+ * with {@code @javax.validation.Valid}, Spring's {@link org.springframework.validation.annotation.Validated}
+ * or custom annotations whose name starts with "Valid". In case of validation failure,
  * {@link MethodArgumentNotValidException} is raised and results in an HTTP 400
  * response status code if {@link DefaultHandlerExceptionResolver} is configured.
  *


### PR DESCRIPTION
The Javadoc for `org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor` should mention that validation is performed not only for `@javax.validation.Valid` but also for 
Spring's `@org.springframework.validation.annotation.Validated` or custom annotations whose name starts with `Valid`.