### PR TITLE
Improve RequestPartMethodArgumentResolver Javadoc

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestPartMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestPartMethodArgumentResolver.java
@@ -58,8 +58,9 @@ import org.springframework.web.multipart.support.RequestPartServletServerHttpReq
  * it is derived from the name of the method argument.
  *
  * <p>Automatic validation may be applied if the argument is annotated with
- * {@code @javax.validation.Valid}. In case of validation failure, a {@link MethodArgumentNotValidException}
- * is raised and a 400 response status code returned if
+ * {@code @javax.validation.Valid}, Spring's {@link org.springframework.validation.annotation.Validated}
+ * or custom annotations whose name starts with "Valid". In case of validation failure,
+ * a {@link MethodArgumentNotValidException} is raised and a 400 response status code returned if
  * {@link org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver} is configured.
  *
  * @author Rossen Stoyanchev


### PR DESCRIPTION
The Javadoc for `org.springframework.web.servlet.mvc.method.annotation.RequestPartMethodArgumentResolver` should mention that validation is performed not only for `@javax.validation.Valid` but also for 
Spring's `@org.springframework.validation.annotation.Validated` or custom annotations whose name starts with `Valid`.