### PR TITLE
fix: Correct the condition about isEnforceReadOnly

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
@@ -369,7 +369,7 @@ public class R2dbcTransactionManager extends AbstractReactiveTransactionManager 
 
 		Mono<Void> prepare = Mono.empty();
 
-		if (isEnforceReadOnly() && definition.isReadOnly()) {
+		if (isEnforceReadOnly() || definition.isReadOnly()) {
 			prepare = Mono.from(con.createStatement("SET TRANSACTION READ ONLY").execute())
 					.flatMapMany(Result::getRowsUpdated)
 					.then();


### PR DESCRIPTION
Although isEnforceReadOly is true, Statement might be not READ ONLY if definition.isReadOnly is not true.
So I replaced && to || to use the flag as named "Enforced".
