### PR TITLE
Fix explanation on default settings for content negotiation in reference doc

### DIFF
--- a/src/docs/asciidoc/web/webmvc.adoc
+++ b/src/docs/asciidoc/web/webmvc.adoc
@@ -5366,12 +5366,10 @@ The following example shows how to achieve the same configuration in XML:
 You can configure how Spring MVC determines the requested media types from the request
 (for example, `Accept` header, URL path extension, query parameter, and others).
 
-By default, the URL path extension is checked first -- with `json`, `xml`, `rss`, and `atom`
-registered as known extensions (depending on classpath dependencies). The `Accept` header
-is checked second.
+By default, only the `Accept` header is checked.
 
-Consider changing those defaults to `Accept` header only, and, if you must use URL-based
-content type resolution, consider using the query parameter strategy over path extensions. See
+If you must use URL-based content type resolution, consider using the query parameten
+strategy over path extensions. See
 <<mvc-ann-requestmapping-suffix-pattern-match>> and <<mvc-ann-requestmapping-rfd>> for
 more details.
 


### PR DESCRIPTION
The official documentation "**Web on Servlet Stack**" contains paragraph "**1.11.6. Content Types**" that contains incorrect description of default strategy to determine the requested media types from the request.
According to source code of "**org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport**" the **PathExtensionContentNegotiationStrategy** is deprecated and is not used as a default strategy.