### PR TITLE
Add maxAttempts to ExponentialBackOff

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/backoff/ExponentialBackOff.java
+++ b/spring-core/src/main/java/org/springframework/util/backoff/ExponentialBackOff.java
@@ -76,6 +76,9 @@ public class ExponentialBackOff implements BackOff {
 	 */
 	public static final long DEFAULT_MAX_ELAPSED_TIME = Long.MAX_VALUE;
 
+	/**
+	 * The default maximum attempts.
+	 */
 	public static final int DEFAULT_MAX_ATTEMPTS = Integer.MAX_VALUE;
 
 	private long initialInterval = DEFAULT_INITIAL_INTERVAL;
@@ -179,6 +182,7 @@ public class ExponentialBackOff implements BackOff {
 	 * The maximum number of attempts after which a call to
 	 * {@link BackOffExecution#nextBackOff()} returns {@link BackOffExecution#STOP}.
 	 * @param maxAttempts the maxAttempts.
+	 * @since 5.3.8
 	 * @see #setMaxElapsedTime(long)
 	 */
 	public void setMaxAttempts(int maxAttempts) {
@@ -189,10 +193,11 @@ public class ExponentialBackOff implements BackOff {
 	 * Return the maximum number of attempts after which a call to
 	 * {@link BackOffExecution#nextBackOff()} returns {@link BackOffExecution#STOP}.
 	 * @return the maxAttempts.
+	 * @since 5.3.8
 	 * @see #getMaxElapsedTime()
 	 */
 	public int getMaxAttempts() {
-		return maxAttempts;
+		return this.maxAttempts;
 	}
 
 	@Override

--- a/spring-core/src/test/java/org/springframework/util/ExponentialBackOffTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ExponentialBackOffTests.java
@@ -16,14 +16,14 @@
 
 package org.springframework.util;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.ExponentialBackOff;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;

--- a/spring-core/src/test/java/org/springframework/util/ExponentialBackOffTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ExponentialBackOffTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.ExponentialBackOff;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -129,6 +133,19 @@ class ExponentialBackOffTests {
 		assertThat(execution.toString()).isEqualTo("ExponentialBackOff{currentInterval=2000ms, multiplier=2.0}");
 		execution.nextBackOff();
 		assertThat(execution.toString()).isEqualTo("ExponentialBackOff{currentInterval=4000ms, multiplier=2.0}");
+	}
+
+	@Test
+	void maxAttempts() {
+		ExponentialBackOff bo = new ExponentialBackOff();
+		bo.setInitialInterval(1_000L);
+		bo.setMultiplier(2.0);
+		bo.setMaxInterval(10_000L);
+		bo.setMaxAttempts(6);
+		List<Long> delays = new ArrayList<>();
+		BackOffExecution boEx = bo.start();
+		IntStream.range(0, 7).forEach(i -> delays.add(boEx.nextBackOff()));
+		assertThat(delays).containsExactly(1_000L, 2_000L, 4_000L, 8_000L, 10_000L, 10_000L, -1L);
 	}
 
 }


### PR DESCRIPTION
If you wish to stop after a certain number of attempts with an
`ExponentialBackOff` you have to calculate the `maxElapsedTime`
corresponding to the number of attempts.

See https://github.com/spring-projects/spring-kafka/blob/0ee2d49ea525de038d315bc243b62f1004a26dc6/spring-kafka/src/main/java/org/springframework/kafka/support/ExponentialBackOffWithMaxRetries.java#L74-L84

Add a new property to make it more convenient to stop after a
certain number of attempts.