### PR TITLE
Using entrySet iterator in ServletServerHttpRequest#getBodyFromServle…

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/ServletServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/ServletServerHttpRequest.java
@@ -29,10 +29,7 @@ import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
-import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -244,24 +241,21 @@ public class ServletServerHttpRequest implements ServerHttpRequest {
 		Writer writer = new OutputStreamWriter(bos, FORM_CHARSET);
 
 		Map<String, String[]> form = request.getParameterMap();
-		for (Iterator<String> nameIterator = form.keySet().iterator(); nameIterator.hasNext();) {
-			String name = nameIterator.next();
-			List<String> values = Arrays.asList(form.get(name));
-			for (Iterator<String> valueIterator = values.iterator(); valueIterator.hasNext();) {
-				String value = valueIterator.next();
-				writer.write(URLEncoder.encode(name, FORM_CHARSET.name()));
+		StringBuilder sb = new StringBuilder();
+		for (Map.Entry<String, String[]> entry : form.entrySet()) {
+			String name = entry.getKey();
+			String[] values = entry.getValue();
+			for (String value : values) {
+				sb.append('&');
+				sb.append(URLEncoder.encode(name, FORM_CHARSET.name()));
 				if (value != null) {
-					writer.write('=');
-					writer.write(URLEncoder.encode(value, FORM_CHARSET.name()));
-					if (valueIterator.hasNext()) {
-						writer.write('&');
-					}
+					sb.append('=');
+					sb.append(URLEncoder.encode(value, FORM_CHARSET.name()));
 				}
 			}
-			if (nameIterator.hasNext()) {
-				writer.append('&');
-			}
 		}
+
+		writer.write(sb.length() > 0 ? sb.substring(1) : sb.toString());
 		writer.flush();
 
 		return new ByteArrayInputStream(bos.toByteArray());

--- a/spring-web/src/test/java/org/springframework/http/server/ServletServerHttpRequestTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/ServletServerHttpRequestTests.java
@@ -175,4 +175,15 @@ public class ServletServerHttpRequestTests {
 		assertThat(result).as("Invalid content returned").isEqualTo(content);
 	}
 
+	@Test
+	void getEmptyFormBody() throws IOException {
+		// Charset (SPR-8676)
+		mockRequest.setContentType("application/x-www-form-urlencoded; charset=UTF-8");
+		mockRequest.setMethod("POST");
+
+		byte[] result = FileCopyUtils.copyToByteArray(request.getBody());
+		byte[] content = "".getBytes(StandardCharsets.UTF_8);
+		assertThat(result).as("Invalid content returned").isEqualTo(content);
+	}
+
 }


### PR DESCRIPTION
Using entrySet iterator can avoid the Map.get(key) lookup, which is more efficient