### PR TITLE
Clear `Statement` warnings in `ScriptUtils.executeSqlScript()`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -263,6 +263,7 @@ public abstract class ScriptUtils {
 						if (logger.isDebugEnabled()) {
 							logger.debug(rowsAffected + " returned as update count for SQL: " + statement);
 							SQLWarning warningToLog = stmt.getWarnings();
+							stmt.clearWarnings();
 							while (warningToLog != null) {
 								logger.debug("SQLWarning ignored: SQL state '" + warningToLog.getSQLState() +
 										"', error code '" + warningToLog.getErrorCode() +


### PR DESCRIPTION
executeSqlScript use only one Statement to execute sql, so the getWarnings of Statement will contains pre warning

Ps: Maybe creating new Statement for every sql is better