### PR TITLE
spring-webflux: ServerRequestWrapper is not passed on from RouterFunctionDsl filter function

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/RouterFunctionDsl.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/RouterFunctionDsl.kt
@@ -652,7 +652,7 @@ class RouterFunctionDsl internal constructor (private val init: RouterFunctionDs
 	fun filter(filterFunction: (ServerRequest, (ServerRequest) -> Mono<ServerResponse>) -> Mono<ServerResponse>) {
 		builder.filter { request, next ->
 			filterFunction(request) {
-				next.handle(request)
+				next.handle(it)
 			}
 		}
 	}


### PR DESCRIPTION
When a filter function creates a ServerRequestWrapper from the ServerRequest passed to it, and passes the wrapper into the next() function, then the RouterFunctionDsl passes on the original ServerRequest, not the wrapper.
This PR fixes the issue and verifies with a test.