### PR TITLE
Fix cross reference in ref docs for `@Bean` method autowiring

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -8027,8 +8027,7 @@ parameter, as the following example shows:
 ----
 
 
-The resolution mechanism is pretty much identical to constructor-based dependency
-injection. See <<beans-constructor-injection, the relevant section>> for more details.
+The resolution mechanism is pretty much identical as used in constructor-type autowiring. See <<beans-factory-autowiring-modes-tbl, the relevant section>> for more details.
 
 
 [[beans-java-lifecycle-callbacks]]


### PR DESCRIPTION
I am still studying spring technology, so perhaps I don't understand this concept. However I think the resolution mechanism is more comparable with constructor mode autowiring than with constructor based dependency injection (argument matching)?