### PR TITLE
Model.set() Kotlin extension method does not allow null value

### DIFF
--- a/spring-context/src/main/kotlin/org/springframework/ui/ModelExtensions.kt
+++ b/spring-context/src/main/kotlin/org/springframework/ui/ModelExtensions.kt
@@ -26,6 +26,6 @@ package org.springframework.ui
  * @author Mario Arias
  * @since 5.0
  */
-operator fun Model.set(attributeName: String, attributeValue: Any) {
+operator fun Model.set(attributeName: String, attributeValue: Any?) {
 	this.addAttribute(attributeName, attributeValue)
 }


### PR DESCRIPTION
This parameter is `@Nullable` in the underlying addAttribute method