### PR TITLE
Added description for HandlerInterceptor

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/HandlerInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/HandlerInterceptor.java
@@ -102,6 +102,7 @@ public interface HandlerInterceptor {
 	/**
 	 * Intercept the execution of a handler. Called after HandlerAdapter actually
 	 * invoked the handler, but before the DispatcherServlet renders the view.
+	 * In addition does not run if handler throws exception.
 	 * Can expose additional model objects to the view via the given ModelAndView.
 	 * <p>DispatcherServlet processes a handler in an execution chain, consisting
 	 * of any number of interceptors, with the handler itself at the end.


### PR DESCRIPTION
Added description for HandlerInterceptor

I know that the posthandle is not intended to be executed when an error occurs in the handler .
But the docs didn't show that.
It says that called after HandlerAdapter actually invoked the handler, but it seems not enough.
If this explanation is added, I think it will be a better docs for users.

thank you
