### PR TITLE
Optimize HttpStatus value resolution from code

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatus.java
@@ -420,7 +420,7 @@ public enum HttpStatus {
 	/**
 	 * Index of array value is the same with HttpStatus code.
 	 * For example, CODE_TO_VALUE[404]==HttpStatus.NOT_FOUND
-	 * Missing values are null: = CODE_TO_VALUE[1]==null
+	 * Missing values are null: CODE_TO_VALUE[1]==null
 	 */
 	private static final HttpStatus[] CODE_TO_VALUE = getCodeToValueArray();
 

--- a/spring-web/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatus.java
@@ -18,6 +18,8 @@ package org.springframework.http;
 
 import org.springframework.lang.Nullable;
 
+import java.util.Arrays;
+
 /**
  * Enumeration of HTTP status codes.
  *
@@ -415,13 +417,12 @@ public enum HttpStatus {
 	 */
 	NETWORK_AUTHENTICATION_REQUIRED(511, Series.SERVER_ERROR, "Network Authentication Required");
 
-
-	private static final HttpStatus[] VALUES;
-
-	static {
-		VALUES = values();
-	}
-
+	/**
+	 * Index of array value is the same with HttpStatus code.
+	 * For example, CODE_TO_VALUE[404]==HttpStatus.NOT_FOUND
+	 * Missing values are null: = CODE_TO_VALUE[1]==null
+	 */
+	private static final HttpStatus[] CODE_TO_VALUE = getCodeToValueArray();
 
 	private final int value;
 
@@ -557,13 +558,29 @@ public enum HttpStatus {
 	 */
 	@Nullable
 	public static HttpStatus resolve(int statusCode) {
-		// Use cached VALUES instead of values() to prevent array allocation.
-		for (HttpStatus status : VALUES) {
-			if (status.value == statusCode) {
-				return status;
-			}
+		if(statusCode < 0 || statusCode >= CODE_TO_VALUE.length) {
+			return null;
 		}
-		return null;
+
+		return CODE_TO_VALUE[statusCode];
+	}
+
+	private static HttpStatus[] getCodeToValueArray() {
+		final HttpStatus[] enumValues = values();
+
+		//noinspection OptionalGetWithoutIsPresent - value is always present by design
+		final int maximumCode = Arrays.stream(enumValues)
+				.map(HttpStatus::value)
+				.max(Integer::compareTo)
+				.get();
+
+		final HttpStatus[] result = new HttpStatus[maximumCode + 1];
+
+		for (HttpStatus status : enumValues) {
+			result[status.value] = status;
+		}
+
+		return result;
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatus.java
@@ -577,7 +577,11 @@ public enum HttpStatus {
 		final HttpStatus[] result = new HttpStatus[maximumCode + 1];
 
 		for (HttpStatus status : enumValues) {
-			result[status.value] = status;
+			// all deprecated values are strictly after actual, which allows condition below
+			// See also test HttpStatusTests
+			if (result[status.value] == null) {
+				result[status.value] = status;
+			}
 		}
 
 		return result;

--- a/spring-web/src/test/java/org/springframework/http/HttpStatusTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpStatusTests.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -135,7 +137,19 @@ class HttpStatusTests {
 		for (HttpStatus status : HttpStatus.values()) {
 			HttpStatus.Series expectedSeries = HttpStatus.Series.valueOf(status.value());
 			assertThat(status.series()).isEqualTo(expectedSeries);
+			assertThat(HttpStatus.resolve(status.value())).isEqualTo(status);
+			assertThat(HttpStatus.valueOf(status.value())).isEqualTo(status);
 		}
 	}
 
+	@ParameterizedTest
+	@ValueSource(ints = {-1, 0, 999})
+		// six numbers
+	void outOfRangeStatusShouldNotBeResolved(final int invalidStatusCode) {
+		// when
+		final HttpStatus actualStatus = HttpStatus.resolve(invalidStatusCode);
+
+		// then
+		assertThat(actualStatus).isEqualTo(null);
+	}
 }

--- a/spring-web/src/test/java/org/springframework/http/HttpStatusTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpStatusTests.java
@@ -16,13 +16,13 @@
 
 package org.springframework.http;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -135,10 +135,14 @@ class HttpStatusTests {
 	void allStatusSeriesShouldMatchExpectations() {
 		// The Series of an HttpStatus is set manually, so we make sure it is the correct one.
 		for (HttpStatus status : HttpStatus.values()) {
-			HttpStatus.Series expectedSeries = HttpStatus.Series.valueOf(status.value());
+			final int value = status.value();
+			HttpStatus.Series expectedSeries = HttpStatus.Series.valueOf(value);
 			assertThat(status.series()).isEqualTo(expectedSeries);
-			assertThat(HttpStatus.resolve(status.value())).isEqualTo(status);
-			assertThat(HttpStatus.valueOf(status.value())).isEqualTo(status);
+
+			// verify that at least status codes are the same
+			// more deep verification is in fromEnumToMap
+			assertThat(HttpStatus.resolve(value).value()).isEqualTo(value);
+			assertThat(HttpStatus.valueOf(value).value()).isEqualTo(value);
 		}
 	}
 


### PR DESCRIPTION
The purpose - optimize function ```HttpStatus.resolve```. Previous version worked with O(N) complexity, new works with O(1) complexity and doesn't require any allocation.