### PR TITLE
Fix link to Javadoc API

### DIFF
--- a/src/docs/asciidoc/core/core-validation.adoc
+++ b/src/docs/asciidoc/core/core-validation.adoc
@@ -215,7 +215,7 @@ as the following example shows:
 Validation errors are reported to the `Errors` object passed to the validator. In the case
 of Spring Web MVC, you can use the `<spring:bind/>` tag to inspect the error messages, but
 you can also inspect the `Errors` object yourself. More information about the
-methods it offers can be found in the {api-spring-framework}validation/Errors.html[javadoc].
+methods it offers can be found in the {api-spring-framework}/validation/Errors.html[javadoc].
 
 
 


### PR DESCRIPTION
Fix broken link in Spring Docs section "3.1. Validation by Using Spring’s Validator Interface".

> More information about the methods it offers can be found in the javadoc.
https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#validator