### PR TITLE
Avoid calling executeBatch() with 0 batch size

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1045,7 +1045,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 						}
 						ps.addBatch();
 					}
-					return ps.executeBatch();
+					return batchSize > 0 ? ps.executeBatch() : new int[] {};
 				}
 				else {
 					List<Integer> rowsAffected = new ArrayList<>();

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
@@ -517,6 +517,34 @@ public class JdbcTemplateTests {
 	}
 
 	@Test
+	public void testBatchUpdateWithPreparedStatementWithEmptyData() throws Exception {
+		final String sql = "UPDATE NOSUCHTABLE SET DATE_DISPATCHED = SYSDATE WHERE ID = ?";
+		final int[] ids = new int[] {};
+		final int[] rowsAffected = new int[] {};
+
+		given(this.preparedStatement.executeBatch()).willReturn(rowsAffected);
+		mockDatabaseMetaData(true);
+
+		BatchPreparedStatementSetter setter = new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				ps.setInt(1, ids[i]);
+			}
+			@Override
+			public int getBatchSize() {
+				return ids.length;
+			}
+		};
+
+		JdbcTemplate template = new JdbcTemplate(this.dataSource, false);
+
+		int[] actualRowsAffected = template.batchUpdate(sql, setter);
+		assertThat(actualRowsAffected.length == 0).as("executed 0 updates").isTrue();
+
+		verify(this.preparedStatement, never()).executeBatch();
+	}
+
+	@Test
 	public void testInterruptibleBatchUpdate() throws Exception {
 		final String sql = "UPDATE NOSUCHTABLE SET DATE_DISPATCHED = SYSDATE WHERE ID = ?";
 		final int[] ids = new int[] {100, 200};


### PR DESCRIPTION
Now usign  `org.springframework.jdbc.core.JdbcTemplate#batchUpdate(java.lang.String, org.springframework.jdbc.core.BatchPreparedStatementSetter)` with empty data array may produce exception with some DBs. E. g. with HSQLDB it produce `java.sql.SQLException: statement is not in batch mode`. Suggest avoid it by batchSize checking.