### PR TITLE
Add Javadoc `@since` to `BeanDefinitionBuilder.setSynthetic()`

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/BeanDefinitionBuilder.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/BeanDefinitionBuilder.java
@@ -334,6 +334,7 @@ public final class BeanDefinitionBuilder {
 	/**
 	 * Set whether this bean is 'synthetic', that is, not defined by
 	 * the application itself.
+	 * @since 5.3.9
 	 */
 	public BeanDefinitionBuilder setSynthetic(boolean synthetic) {
 		this.beanDefinition.setSynthetic(synthetic);


### PR DESCRIPTION
This PR adds Javadoc `@since` tag to `BeanDefinitionBuilder.setSynthetic()`.