### PR TITLE
Allow builder to set constructor detector for object mapper

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
@@ -163,6 +164,9 @@ public class Jackson2ObjectMapperBuilder {
 
 	@Nullable
 	private ApplicationContext applicationContext;
+
+	@Nullable
+	private ConstructorDetector constructorDetector;
 
 	@Nullable
 	private Boolean defaultUseWrapper;
@@ -644,6 +648,14 @@ public class Jackson2ObjectMapperBuilder {
 	}
 
 	/**
+	 * Set the {@link ConstructorDetector} method to be used by Jackson during deserialization.
+	 */
+	public Jackson2ObjectMapperBuilder constructorDetector(ConstructorDetector constructorDetector) {
+		this.constructorDetector = constructorDetector;
+		return this;
+	}
+
+	/**
 	 * An option to apply additional customizations directly to the
 	 * {@code ObjectMapper} instances at the end, after all other config
 	 * properties of the builder have been applied.
@@ -756,6 +768,10 @@ public class Jackson2ObjectMapperBuilder {
 		else if (this.applicationContext != null) {
 			objectMapper.setHandlerInstantiator(
 					new SpringHandlerInstantiator(this.applicationContext.getAutowireCapableBeanFactory()));
+		}
+
+		if (this.constructorDetector != null) {
+			objectMapper.setConstructorDetector(this.constructorDetector);
 		}
 
 		if (this.configurer != null) {

--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBean.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBean.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
@@ -454,6 +455,14 @@ public class Jackson2ObjectMapperFactoryBean implements FactoryBean<ObjectMapper
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) {
 		this.builder.applicationContext(applicationContext);
+	}
+
+	/**
+	 * Set the method to detect constructors for Jackson deserialization.
+	 * @see com.fasterxml.jackson.databind.cfg.ConstructorDetector
+	 */
+	public void setConstructorDetector(ConstructorDetector constructorDetector) {
+		this.builder.constructorDetector(constructorDetector);
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
@@ -56,6 +56,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.cfg.DeserializerFactoryConfig;
 import com.fasterxml.jackson.databind.cfg.SerializerFactoryConfig;
 import com.fasterxml.jackson.databind.deser.BasicDeserializerFactory;
@@ -574,6 +575,20 @@ class Jackson2ObjectMapperBuilderTests {
 		assertThat(json).contains("property1");
 		assertThat(json).contains("property2");
 		assertThat(json).doesNotContain("property3");
+	}
+
+	@Test
+	void constructorDetector() {
+		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json()
+				.constructorDetector(ConstructorDetector.USE_DELEGATING
+						.withAllowJDKTypeConstructors(true)
+						.withRequireAnnotation(true))
+				.build();
+
+		ConstructorDetector constructorDetector = objectMapper.getDeserializationConfig().getConstructorDetector();
+		assertThat(constructorDetector.allowJDKTypeConstructors()).isTrue();
+		assertThat(constructorDetector.requireCtorAnnotation()).isTrue();
+		assertThat(constructorDetector.singleArgMode()).isEqualTo(ConstructorDetector.SingleArgConstructor.DELEGATING);
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperFactoryBeanTests.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.cfg.DeserializerFactoryConfig;
 import com.fasterxml.jackson.databind.cfg.SerializerFactoryConfig;
 import com.fasterxml.jackson.databind.deser.BasicDeserializerFactory;
@@ -389,6 +390,20 @@ public class Jackson2ObjectMapperFactoryBeanTests {
 		assertThat(this.factory.getObject()).isNotNull();
 		assertThat(this.factory.isSingleton()).isTrue();
 		assertThat(this.factory.getObject().getFactory().getClass()).isEqualTo(SmileFactory.class);
+	}
+
+	@Test
+	public void setConstructorDetector() {
+		this.factory.setConstructorDetector(ConstructorDetector.USE_PROPERTIES_BASED
+				.withAllowJDKTypeConstructors(true)
+				.withRequireAnnotation(false));
+		this.factory.afterPropertiesSet();
+		ObjectMapper objectMapper = this.factory.getObject();
+
+		ConstructorDetector constructorDetector = objectMapper.getDeserializationConfig().getConstructorDetector();
+		assertThat(constructorDetector.allowJDKTypeConstructors()).isTrue();
+		assertThat(constructorDetector.requireCtorAnnotation()).isFalse();
+		assertThat(constructorDetector.singleArgMode()).isEqualTo(ConstructorDetector.SingleArgConstructor.PROPERTIES);
 	}
 
 


### PR DESCRIPTION
This is to allow the Jackson Object Mapper Builder to be able to accept a constructor detector. The idea is that it can then be used by [this](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java#L145) to configure it via properties.

see [gh-27178](https://github.com/spring-projects/spring-boot/issues/27178)