### PR TITLE
Expand relative URI for RestTemplate if possible

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -100,6 +100,7 @@ import org.springframework.web.util.UriTemplateHandler;
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Sebastien Deleuze
+ * @author Yanming Zhou
  * @since 3.0
  * @see HttpMessageConverter
  * @see RequestCallback
@@ -727,7 +728,8 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 			}
 		}
 		else {
-			return entity.getUrl();
+			URI url = entity.getUrl();
+			return url.isAbsolute() ? url : this.uriTemplateHandler.expand(url.toString());
 		}
 	}
 
@@ -800,7 +802,9 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 	@Nullable
 	public <T> T execute(URI url, HttpMethod method, @Nullable RequestCallback requestCallback,
 			@Nullable ResponseExtractor<T> responseExtractor) throws RestClientException {
-
+		if (!url.isAbsolute()) {
+			url = getUriTemplateHandler().expand(url.toString());
+		}
 		return doExecute(url, null, method, requestCallback, responseExtractor);
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
@@ -41,6 +41,7 @@ import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -79,6 +80,7 @@ import static org.springframework.http.MediaType.parseMediaType;
  * @author Rossen Stoyanchev
  * @author Brian Clozel
  * @author Sam Brannen
+ * @author Yanming Zhou
  */
 @SuppressWarnings("unchecked")
 class RestTemplateTests {
@@ -293,6 +295,36 @@ class RestTemplateTests {
 
 		String url = "https://example.com/hotels/{hotel}/pic/{publicpath}/size/{scale}";
 		template.getForObject(url, String.class, uriVariables);
+
+		verify(response).close();
+	}
+
+	@Test
+	void getForObjectWithCustomUriTemplateHandlerAndWithoutUriVariables() throws Exception {
+		DefaultUriBuilderFactory uriTemplateHandler = new DefaultUriBuilderFactory("https://example.com");
+		template.setUriTemplateHandler(uriTemplateHandler);
+		mockSentRequest(GET, "https://example.com/hotels/1/pic/logo.png/size/150x150");
+		mockResponseStatus(HttpStatus.OK);
+		given(response.getHeaders()).willReturn(new HttpHeaders());
+		given(response.getBody()).willReturn(InputStream.nullInputStream());
+
+		String url = "/hotels/1/pic/logo.png/size/150x150";
+		template.getForObject(URI.create(url), void.class);
+
+		verify(response).close();
+	}
+
+	@Test
+	void exchangeWithCustomUriTemplateHandlerAndWithoutUriVariables() throws Exception {
+		DefaultUriBuilderFactory uriTemplateHandler = new DefaultUriBuilderFactory("https://example.com");
+		template.setUriTemplateHandler(uriTemplateHandler);
+		mockSentRequest(GET, "https://example.com/hotels/1/pic/logo.png/size/150x150");
+		mockResponseStatus(HttpStatus.OK);
+		given(response.getHeaders()).willReturn(new HttpHeaders());
+		given(response.getBody()).willReturn(InputStream.nullInputStream());
+
+		String url = "/hotels/1/pic/logo.png/size/150x150";
+		template.exchange(RequestEntity.method(GET, URI.create(url)).build(), void.class);
 
 		verify(response).close();
 	}


### PR DESCRIPTION
```java
RestTemplate template = new RestTemplate();
template.setUriTemplateHandler(new DefaultUriBuilderFactory("http://localhost:8080"));
template.getForObject("/users/{id}", String.class, 1);
template.getForObject("/users/1", String.class);
// following will works as above after this commit
template.getForObject(URI.create("/users/1"), String.class);

template.exchange(RequestEntity.method(HttpMethod.GET, "/users/{id}", 1).build(), String.class);
template.exchange(RequestEntity.method(HttpMethod.GET, "/users/1").build(), String.class);
// following will works as above after this commit
template.exchange(RequestEntity.method(HttpMethod.GET, URI.create("/users/1")).build(), String.class);
```
It will make Spring Boot `TestRestTemplate` much more cleaner, save it from ubiquitous `applyRootUriIfNecessary`
https://github.com/spring-projects/spring-boot/blob/05a64ecb2ca237d963866665d3a0e7fd1920fee6/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java#L942-L948