### PR TITLE
Allow overriding invokeSuspendingFunction

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
@@ -20,6 +20,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import org.jetbrains.annotations.NotNull;
+import org.reactivestreams.Publisher;
+
 import org.springframework.core.CoroutinesUtils;
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.KotlinDetector;
@@ -192,7 +195,7 @@ public class InvocableHandlerMethod extends HandlerMethod {
 		ReflectionUtils.makeAccessible(method);
 		try {
 			if (KotlinDetector.isSuspendingFunction(method)) {
-				return CoroutinesUtils.invokeSuspendingFunction(method, getBean(), args);
+				return invokeSuspendingFunction(method, args);
 			}
 			return method.invoke(getBean(), args);
 		}
@@ -217,6 +220,14 @@ public class InvocableHandlerMethod extends HandlerMethod {
 				throw new IllegalStateException(formatInvokeError("Invocation failure", args), targetException);
 			}
 		}
+	}
+
+	/**
+	 * Invokes Kotlin coroutine suspended function.
+	 */
+	@NotNull
+	protected Publisher<?> invokeSuspendingFunction(Method method, Object[] args) {
+		return CoroutinesUtils.invokeSuspendingFunction(method, getBean(), args);
 	}
 
 }


### PR DESCRIPTION
In case someone needs to specify default CoroutineContext for all
WebMvc calls, he can use this [trick](https://stackoverflow.com/questions/68437892/configure-default-kotlin-coroutine-context-in-spring-mvc). If we can override invokeSuspendingFunction, we do not have to
duplicate so much code.