### PR TITLE
Reduce visibility of constructors in ScriptException

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptException.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptException.java
@@ -33,7 +33,7 @@ public abstract class ScriptException extends DataAccessException {
 	 * Create a new {@code ScriptException}.
 	 * @param message the detail message
 	 */
-	public ScriptException(String message) {
+	protected ScriptException(String message) {
 		super(message);
 	}
 
@@ -42,7 +42,7 @@ public abstract class ScriptException extends DataAccessException {
 	 * @param message the detail message
 	 * @param cause the root cause
 	 */
-	public ScriptException(String message, @Nullable Throwable cause) {
+	protected ScriptException(String message, @Nullable Throwable cause) {
 		super(message, cause);
 	}
 


### PR DESCRIPTION
Reduce the visibility of the constructors in `org.springframework.jdbc.datasource.init.ScriptException`.

There is currently no need to use `public` visibility here.