### PR TITLE
Fix JDK proxy causing controller to fail to register

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
@@ -266,7 +266,8 @@ public abstract class AbstractHandlerMethodMapping<T> extends AbstractHandlerMap
 			Object bean = null;
 			try {
 				bean = obtainApplicationContext().getBean(beanType);
-			} catch (BeansException ignore) {
+			}
+			catch (BeansException ignore) {
 			}
 			if (AopUtils.isJdkDynamicProxy(bean)) {
 				beanType = AopUtils.getTargetClass(bean);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
@@ -36,6 +36,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.MethodIntrospector;
@@ -262,7 +263,11 @@ public abstract class AbstractHandlerMethodMapping<T> extends AbstractHandlerMap
 			}
 		}
 		if (beanType != null ) {
-			Object bean = obtainApplicationContext().getBean(beanType);
+			Object bean = null;
+			try {
+				bean = obtainApplicationContext().getBean(beanType);
+			} catch (BeansException ignore) {
+			}
 			if (AopUtils.isJdkDynamicProxy(bean)) {
 				beanType = AopUtils.getTargetClass(bean);
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
@@ -261,8 +261,14 @@ public abstract class AbstractHandlerMethodMapping<T> extends AbstractHandlerMap
 				logger.trace("Could not resolve type for bean '" + beanName + "'", ex);
 			}
 		}
-		if (beanType != null && isHandler(beanType)) {
-			detectHandlerMethods(beanName);
+		if (beanType != null ) {
+			Object bean = obtainApplicationContext().getBean(beanType);
+			if (AopUtils.isJdkDynamicProxy(bean)) {
+				beanType = AopUtils.getTargetClass(bean);
+			}
+			if (isHandler(beanType)) {
+				detectHandlerMethods(beanName);
+			}
 		}
 	}
 


### PR DESCRIPTION
Some scenarios require JDK proxy, but the controller cannot be registered if JDK proxy is used. I have seen the problem mentioned in the previous issue, but the solution is to have the user change the configuration to force the cglib proxy to be enabled. I think this is not a good solution.