### PR TITLE
Clarify that ClientRequest.from(..) also copies body

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientRequest.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientRequest.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientRequest.java
@@ -125,8 +125,8 @@ public interface ClientRequest {
 	// Static builder methods
 
 	/**
-	 * Create a builder with the method, URI, headers, and cookies of the given request.
-	 * @param other the request to copy the method, URI, headers, and cookies from
+	 * Create a builder with the method, URI, headers, cookies and body of the given request.
+	 * @param other the request to copy the method, URI, headers, cookies and body from
 	 * @return the created builder
 	 */
 	static Builder from(ClientRequest other) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientRequest.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientRequest.java
@@ -125,8 +125,8 @@ public interface ClientRequest {
 	// Static builder methods
 
 	/**
-	 * Create a builder with the method, URI, headers, cookies and body of the given request.
-	 * @param other the request to copy the method, URI, headers, cookies and body from
+	 * Create a builder with the method, URI, headers, cookies, attributes, and body of the given request.
+	 * @param other the request to copy the method, URI, headers, cookies, attributes, and body from
 	 * @return the created builder
 	 */
 	static Builder from(ClientRequest other) {

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilderTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilderTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilderTests.java
@@ -56,6 +56,8 @@ public class DefaultClientRequestBuilderTests {
 		ClientRequest other = ClientRequest.create(GET, URI.create("https://example.com"))
 				.header("foo", "bar")
 				.cookie("baz", "qux")
+				.attribute("attributeKey", "attributeValue")
+				.attribute("anotherAttributeKey", "anotherAttributeValue")
 				.httpRequest(request -> {})
 				.build();
 		ClientRequest result = ClientRequest.from(other)
@@ -69,6 +71,8 @@ public class DefaultClientRequestBuilderTests {
 		assertThat(result.cookies().size()).isEqualTo(1);
 		assertThat(result.cookies().getFirst("baz")).isEqualTo("quux");
 		assertThat(result.httpRequest()).isNotNull();
+		assertThat(result.attributes().get("attributeKey")).isEqualTo("attributeValue");
+		assertThat(result.attributes().get("anotherAttributeKey")).isEqualTo("anotherAttributeValue");
 	}
 
 	@Test


### PR DESCRIPTION
- Add to javadoc that ```ClientRequest.from(..)``` will also copy body from the given request.
- Add test to show that the body inserter will be copied over.