### PR TITLE
Fix reference to Optional.isPresent() in ObjectUtils.isEmpty()

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -114,7 +114,7 @@ public abstract class ObjectUtils {
 	 * Determine whether the given object is empty.
 	 * <p>This method supports the following object types.
 	 * <ul>
-	 * <li>{@code Optional}: considered empty if {@link Optional#isEmpty()}</li>
+	 * <li>{@code Optional}: considered empty if not {@link Optional#isPresent()}</li>
 	 * <li>{@code Array}: considered empty if its length is zero</li>
 	 * <li>{@link CharSequence}: considered empty if its length is zero</li>
 	 * <li>{@link Collection}: delegates to {@link Collection#isEmpty()}</li>
@@ -137,7 +137,7 @@ public abstract class ObjectUtils {
 		}
 
 		if (obj instanceof Optional) {
-			return ((Optional<?>) obj).isEmpty();
+			return !((Optional<?>) obj).isPresent();
 		}
 		if (obj instanceof CharSequence) {
 			return ((CharSequence) obj).length() == 0;

--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -114,7 +114,7 @@ public abstract class ObjectUtils {
 	 * Determine whether the given object is empty.
 	 * <p>This method supports the following object types.
 	 * <ul>
-	 * <li>{@code Optional}: considered empty if {@link Optional#empty()}</li>
+	 * <li>{@code Optional}: considered empty if {@link Optional#isEmpty()}</li>
 	 * <li>{@code Array}: considered empty if its length is zero</li>
 	 * <li>{@link CharSequence}: considered empty if its length is zero</li>
 	 * <li>{@link Collection}: delegates to {@link Collection#isEmpty()}</li>
@@ -137,7 +137,7 @@ public abstract class ObjectUtils {
 		}
 
 		if (obj instanceof Optional) {
-			return !((Optional<?>) obj).isPresent();
+			return ((Optional<?>) obj).isEmpty();
 		}
 		if (obj instanceof CharSequence) {
 			return ((CharSequence) obj).length() == 0;


### PR DESCRIPTION
`ObjectUtils.isEmpty()` Javadoc mentions `Optional.empty()`, whereas `empty()` returns an empty `Optional` and `Optional.isPresent()` checks if `Optional` indeed is not empty.  