### PR TITLE
Add support for batch operations (R2DBC)

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
@@ -22,8 +22,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Parameter;
 import io.r2dbc.spi.Readable;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Row;
@@ -211,6 +213,13 @@ public interface DatabaseClient extends ConnectionAccessor {
 		GenericExecuteSpec bindProperties(Object source);
 
 		/**
+		 * Bind values from the given mapping function.
+		 * @param paramsFunction a function that maps from {@link Params} to {@link Params} with new bindings
+		 * @since 6.1
+		 */
+		GenericExecuteSpec bind(UnaryOperator<Params> paramsFunction);
+
+		/**
 		 * Add the given filter to the end of the filter chain.
 		 * <p>Filter functions are typically used to invoke methods on the Statement
 		 * before it is executed. For example:
@@ -298,6 +307,53 @@ public interface DatabaseClient extends ConnectionAccessor {
 		 * @return a {@link Mono} ignoring its payload (actively dropping)
 		 */
 		Mono<Void> then();
+	}
+
+	/**
+	 * Interface that defines common functionality for parameter binding.
+	 */
+	interface Params {
+		/**
+		 * See {@link GenericExecuteSpec#bind(String, Object)}.
+		 */
+		Params bind(String name, Object value);
+
+		/**
+		 * See {@link GenericExecuteSpec#bind(int, Object)}.
+		 */
+		Params bind(int index, Object value);
+
+		/**
+		 * See {@link GenericExecuteSpec#bindNull(String, Class)}.
+		 */
+		Params bindNull(String name, Class<?> type);
+
+		/**
+		 * See {@link GenericExecuteSpec#bind(int, Object)}.
+		 */
+		Params bindNull(int index, Class<?> type);
+
+		/**
+		 * See {@link GenericExecuteSpec#bindValues(Map)}.
+		 */
+		Params bindValues(Map<String, ?> source);
+
+		/**
+		 * See {@link GenericExecuteSpec#bindProperties(Object)}.
+		 */
+		Params bindProperties(Object source);
+
+		/**
+		 * Get bindings by index.
+		 * @return index based params
+		 */
+		Map<Integer, Parameter> byIndex();
+
+		/**
+		 * Get bindings by name.
+		 * @return name based params
+		 */
+		Map<String, Parameter> byName();
 	}
 
 }

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultParamsImpl.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultParamsImpl.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.core;
+
+import io.r2dbc.spi.Parameters;
+import io.r2dbc.spi.Parameter;
+import org.springframework.beans.BeanUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.r2dbc.core.DatabaseClient.Params;
+
+import java.beans.PropertyDescriptor;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Default {@link DatabaseClient.Params} implementation.
+ *
+ * @param byIndex index based bindings
+ * @param byName  name based bindings
+ * @author Mark Shiryaev
+ * @since 6.1
+ */
+record DefaultParamsImpl(Map<Integer, Parameter> byIndex, Map<String, Parameter> byName) implements Params {
+	public static final DefaultParamsImpl EMPTY_PARAMS = new DefaultParamsImpl(
+			Collections.emptyMap(), Collections.emptyMap());
+
+	@Override
+	public Params bind(String name, Object value) {
+		Assert.hasText(name, "Parameter name must not be null or empty");
+		Assert.notNull(value, () -> String.format(
+				"Value for parameter %s must not be null. Use bindNull(…) instead.", name));
+
+		Map<String, Parameter> byName = new LinkedHashMap<>(this.byName);
+		byName.put(name, resolveParameter(value));
+		return new DefaultParamsImpl(this.byIndex, byName);
+	}
+
+	@Override
+	public Params bind(int index, Object value) {
+		Assert.notNull(value, () -> String.format(
+				"Value at index %d must not be null. Use bindNull(…) instead.", index));
+
+		Map<Integer, Parameter> byIndex = new LinkedHashMap<>(this.byIndex);
+		byIndex.put(index, resolveParameter(value));
+
+		return new DefaultParamsImpl(byIndex, this.byName);
+	}
+
+	@Override
+	public Params bindNull(String name, Class<?> type) {
+		Assert.hasText(name, "Parameter name must not be null or empty");
+
+		Map<String, Parameter> byName = new LinkedHashMap<>(this.byName);
+		byName.put(name, Parameters.in(type));
+
+		return new DefaultParamsImpl(this.byIndex, byName);
+	}
+
+	@Override
+	public Params bindNull(int index, Class<?> type) {
+		Map<Integer, Parameter> byIndex = new LinkedHashMap<>(this.byIndex);
+		byIndex.put(index, Parameters.in(type));
+
+		return new DefaultParamsImpl(byIndex, this.byName);
+	}
+
+	@Override
+	public Map<Integer, Parameter> byIndex() {
+		return this.byIndex;
+	}
+
+	@Override
+	public Map<String, Parameter> byName() {
+		return this.byName;
+	}
+
+	@Override
+	public Params bindValues(Map<String, ?> source) {
+		Assert.notNull(source, "Parameter source must not be null");
+
+		Map<String, Parameter> byName = new LinkedHashMap<>(this.byName);
+		source.forEach((name, value) -> byName.put(name, resolveParameter(value)));
+
+		return new DefaultParamsImpl(this.byIndex, byName);
+	}
+
+	@Override
+	public Params bindProperties(Object source) {
+		Assert.notNull(source, "Parameter source must not be null");
+
+		Map<String, Parameter> byName = new LinkedHashMap<>(this.byName);
+		for (PropertyDescriptor pd : BeanUtils.getPropertyDescriptors(source.getClass())) {
+			if (pd.getReadMethod() != null && pd.getReadMethod().getDeclaringClass() != Object.class) {
+				ReflectionUtils.makeAccessible(pd.getReadMethod());
+				Object value = ReflectionUtils.invokeMethod(pd.getReadMethod(), source);
+				byName.put(pd.getName(), (value != null ? Parameters.in(value) : Parameters.in(pd.getPropertyType())));
+			}
+		}
+
+		return new DefaultParamsImpl(this.byIndex, byName);
+	}
+
+	@SuppressWarnings("deprecation")
+	private Parameter resolveParameter(Object value) {
+		if (value instanceof Parameter param) {
+			return param;
+		} else if (value instanceof org.springframework.r2dbc.core.Parameter param) {
+			Object paramValue = param.getValue();
+			return (paramValue != null ? Parameters.in(paramValue) : Parameters.in(param.getType()));
+		} else {
+			return Parameters.in(value);
+		}
+	}
+}

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractDatabaseClientIntegrationTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractDatabaseClientIntegrationTests.java
@@ -143,16 +143,14 @@ abstract class AbstractDatabaseClientIntegrationTests {
 		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
 
 		databaseClient.sql("INSERT INTO legoset (id, name, manual) VALUES(:id, :name, :manual)")
-				.bind("id", 42055)
-				.bind("name", "SCHAUFELRADBAGGER")
-				.bindNull("manual", Integer.class)
-				.add()
-				.bind("id", 2021)
-				.bind("name", "TOM")
-				.bindNull("manual", Integer.class)
+				.bind(params -> params
+						.bind("id", 42055)
+						.bind("name", "SCHAUFELRADBAGGER")
+						.bindNull("manual", Integer.class))
+				.bind(params -> params.bind("id", 2021).bind("name", "TOM").bindNull("manual", Integer.class))
 				.fetch().rowsUpdated()
 				.as(StepVerifier::create)
-				.expectNextMatches(updatedRows -> updatedRows.equals(2))
+				.expectNextMatches(updatedRows -> updatedRows.equals(2L))
 				.verifyComplete();
 
 		databaseClient.sql("SELECT id FROM legoset")
@@ -172,8 +170,7 @@ abstract class AbstractDatabaseClientIntegrationTests {
 		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
 
 		databaseClient.sql("INSERT INTO legoset (id, name, manual) VALUES(:my_list)")
-				.bind("my_list", Arrays.asList(1, "Bob", 1))
-				.add()
+				.bind(params -> params.bind("my_list", Arrays.asList(1, "Bob", 1)))
 				.bind("my_list", Arrays.asList(2, "Alice", 1, "next"))
 				.fetch().rowsUpdated()
 				.as(StepVerifier::create)

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientUnitTests.java
@@ -218,6 +218,31 @@ class DefaultDatabaseClientUnitTests {
 	}
 
 	@Test
+	void executeBatchShouldBindValues() {
+		Statement statement = mockStatementFor("INSERT INTO table VALUES ($1)");
+
+		DatabaseClient databaseClient = databaseClientBuilder.build();
+
+		databaseClient.sql("INSERT INTO table VALUES ($1)")
+				.bind(0, Parameter.from("foo"))
+				.add()
+				.bind(0, Parameter.from("bar"))
+				.then().as(StepVerifier::create).verifyComplete();
+
+		verify(statement).bind(0, "foo");
+		verify(statement).bind(0, "bar");
+
+		databaseClient.sql("INSERT INTO table VALUES ($1)")
+				.bind("$1", "foo")
+				.add()
+				.bind("$1", "bar")
+				.then().as(StepVerifier::create).verifyComplete();
+
+		verify(statement).bind("$1", "foo");
+		verify(statement).bind("$1", "bar");
+	}
+
+	@Test
 	void executeShouldBindNamedValuesByIndex() {
 		Statement statement = mockStatementFor("SELECT * FROM table WHERE key = $1");
 		DatabaseClient databaseClient = databaseClientBuilder.build();

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientUnitTests.java
@@ -224,22 +224,20 @@ class DefaultDatabaseClientUnitTests {
 		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.sql("INSERT INTO table VALUES ($1)")
-				.bind(0, Parameter.from("foo"))
-				.add()
-				.bind(0, Parameter.from("bar"))
+				.bind(params -> params.bind(0, Parameters.in("foo")))
+				.bind(params -> params.bind(0, Parameters.in("bar")))
 				.then().as(StepVerifier::create).verifyComplete();
 
-		verify(statement).bind(0, "foo");
-		verify(statement).bind(0, "bar");
+		verify(statement).bind(0, Parameters.in("foo"));
+		verify(statement).bind(0, Parameters.in("bar"));
 
 		databaseClient.sql("INSERT INTO table VALUES ($1)")
-				.bind("$1", "foo")
-				.add()
-				.bind("$1", "bar")
+				.bind(params -> params.bind("$1", "foo"))
+				.bind(params -> params.bind("$1", "bar"))
 				.then().as(StepVerifier::create).verifyComplete();
 
-		verify(statement).bind("$1", "foo");
-		verify(statement).bind("$1", "bar");
+		verify(statement).bind("$1", Parameters.in("foo"));
+		verify(statement).bind("$1", Parameters.in("bar"));
 	}
 
 	@Test


### PR DESCRIPTION
Add support for batch operations to the [DefaultDatabaseClient](https://github.com/spring-projects/spring-framework/blob/main/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClient.java):

```java
databaseClient.sql("INSERT INTO legoset (id, name, manual) VALUES(:id, :name, :manual)")
				.bind("id", 42055)
				.bind("name", "SCHAUFELRADBAGGER")
				.bindNull("manual", Integer.class)
				.add()
				.bind("id", 2021)
				.bind("name", "TOM")
				.bindNull("manual", Integer.class)
				.fetch().rowsUpdated()
```
Closes [#259](https://github.com/spring-projects/spring-data-r2dbc/issues/259)

Demo app: [springR2dbcBatchExample.tar.gz](https://github.com/spring-projects/spring-framework/files/6906384/springR2dbcBatchExample.tar.gz)
