### PR TITLE
Simplify getInternalBeanFactoryForBean

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/target/AbstractBeanFactoryBasedTargetSourceCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/target/AbstractBeanFactoryBasedTargetSourceCreator.java
@@ -125,12 +125,7 @@ public abstract class AbstractBeanFactoryBasedTargetSourceCreator
 	 */
 	protected DefaultListableBeanFactory getInternalBeanFactoryForBean(String beanName) {
 		synchronized (this.internalBeanFactories) {
-			DefaultListableBeanFactory internalBeanFactory = this.internalBeanFactories.get(beanName);
-			if (internalBeanFactory == null) {
-				internalBeanFactory = buildInternalBeanFactory(this.beanFactory);
-				this.internalBeanFactories.put(beanName, internalBeanFactory);
-			}
-			return internalBeanFactory;
+			return this.internalBeanFactories.computeIfAbsent(beanName, k -> buildInternalBeanFactory(this.beanFactory));
 		}
 	}
 


### PR DESCRIPTION
This pull request simplifies `getInternalBeanFactoryForBean` in `AbstractBeanFactoryBasedTargetSourceCreator` and makes its intent more obvious.

The problem in https://github.com/spring-projects/spring-framework/issues/25801#issuecomment-698346498 does not apply to this patch since the mapping function in this patch does not modify/access the map itself.

This patch was generated automatically by the static analysis tool [Logifix](https://github.com/lyxell/logifix) as part of a research project.