### PR TITLE
Improve performance of `CompositePropertySource#getPropertyNames`

### DIFF
--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -66,6 +66,7 @@ dependencies {
 	testFixturesImplementation("org.junit.jupiter:junit-jupiter-params")
 	testFixturesImplementation("org.assertj:assertj-core")
 	testFixturesImplementation("org.xmlunit:xmlunit-assertj")
+    jmh("org.apache.commons:commons-lang3:3.12.0")
 }
 
 jar {

--- a/spring-core/src/jmh/java/org/springframework/core/env/CompositePropertySourceBenchmark.java
+++ b/spring-core/src/jmh/java/org/springframework/core/env/CompositePropertySourceBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.env;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks for {@link CompositePropertySource}.
+ *
+ * @author Yike Xiao
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+public class CompositePropertySourceBenchmark {
+
+	@Benchmark
+	public void getPropertyNames(BenchmarkState state, Blackhole blackhole) {
+		blackhole.consume(state.composite.getPropertyNames());
+	}
+
+	@State(Scope.Benchmark)
+	public static class BenchmarkState {
+
+		static final Object VALUE = new Object();
+
+		CompositePropertySource composite;
+
+		@Param({"2", "5", "10"})
+		int numberOfPropertySource;
+
+		@Param({"10", "100", "1000"})
+		int numberOfPropertyNamesPerSource;
+
+		@Setup(Level.Trial)
+		public void setUp() {
+			this.composite = new CompositePropertySource("benchmark");
+			for (int i = 0; i < this.numberOfPropertySource; i++) {
+				Map<String, Object> map = new HashMap<>(this.numberOfPropertyNamesPerSource);
+				for (int j = 0; j < this.numberOfPropertyNamesPerSource; j++) {
+					map.put(RandomStringUtils.randomAlphanumeric(5, 50), VALUE);
+				}
+				PropertySource<?> propertySource = new MapPropertySource("propertySource" + i, map);
+				this.composite.addPropertySource(propertySource);
+			}
+		}
+	}
+}

--- a/spring-core/src/main/java/org/springframework/core/env/CompositePropertySource.java
+++ b/spring-core/src/main/java/org/springframework/core/env/CompositePropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,15 +78,22 @@ public class CompositePropertySource extends EnumerablePropertySource<Object> {
 
 	@Override
 	public String[] getPropertyNames() {
-		Set<String> names = new LinkedHashSet<>();
+		List<String[]> namesList = new ArrayList<>(this.propertySources.size());
+		int total = 0;
 		for (PropertySource<?> propertySource : this.propertySources) {
 			if (!(propertySource instanceof EnumerablePropertySource)) {
 				throw new IllegalStateException(
 						"Failed to enumerate property names due to non-enumerable property source: " + propertySource);
 			}
-			names.addAll(Arrays.asList(((EnumerablePropertySource<?>) propertySource).getPropertyNames()));
+			String[] names = ((EnumerablePropertySource<?>) propertySource).getPropertyNames();
+			namesList.add(names);
+			total += names.length;
 		}
-		return StringUtils.toStringArray(names);
+		Set<String> allNames = new LinkedHashSet<>(total);
+		for (String[] names : namesList) {
+			allNames.addAll(Arrays.asList(names));
+		}
+		return StringUtils.toStringArray(allNames);
 	}
 
 


### PR DESCRIPTION
Create LinkedHashSet with a initialCapacity, prevent underhood table resize cost in continuous add operations.
Reduce bootstrap time in the situation with large properties.

Micro-Benchmark `CompositePropertySourceBenchmark` result (unit: ns/op):

numberOfPropertySource: 5
numberOfPropertyNamesPerSource: 1000
  | Baseline | New
-- | -- | --
  | 369339 | 265699
  | 372184 | 266577
  | 375854 | 267332
  | 375830 | 266348
  | 376366 | 265801
Avg | 373915 | 266352
Cost | 1 | 0.71


numberOfPropertySource: 10
numberOfPropertyNamesPerSource: 1000
  | Baseline | New
-- | -- | --
  | 794450 | 556300
  | 793987 | 611713
  | 799981 | 577572
  | 803261 | 554797
  | 807606 | 565953
Avg | 799857 | 573267
Cost | 1 | 0.72

