### PR TITLE
Bugfix/webflux Fix a support method logic of ServerResponseResultHandler .

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/ServerResponseResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/ServerResponseResultHandler.java
@@ -84,7 +84,7 @@ public class ServerResponseResultHandler implements HandlerResultHandler, Initia
 
 	@Override
 	public boolean supports(HandlerResult result) {
-		return result.getReturnType().getGeneric().toClass() == ServerResponse.class;
+		return ServerResponse.class.isAssignableFrom(result.getReturnType().getGeneric().toClass());
 	}
 
 	@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/ServerResponseResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/ServerResponseResultHandler.java
@@ -84,7 +84,7 @@ public class ServerResponseResultHandler implements HandlerResultHandler, Initia
 
 	@Override
 	public boolean supports(HandlerResult result) {
-		return (result.getReturnValue() instanceof ServerResponse);
+		return result.getReturnType().getGeneric().toClass() == ServerResponse.class;
 	}
 
 	@Override


### PR DESCRIPTION
`org.springframework.web.reactive.function.server.support.ServerResponseResultHandler.java` can NOT handle `Mono<ServerResponse> or Flux<ServerResponse>`.

`public boolean supports(HandlerResult result)` always return false.
**because it check a returnValue type of HandlerResult .**
need to replace a return type with a generic type of it.
see below error code.
```
	@Override
	public boolean supports(HandlerResult result) {
		return (result.getReturnValue() instanceof ServerResponse);
	}
```

fix like below
it has to compare with a generic type of returnType
```
	@Override
	public boolean supports(HandlerResult result) {
		return ServerResponse.class.isAssignableFrom(result.getReturnType().getGeneric().toClass());
	}

```

Related: [https://github.com/spring-projects/spring-framework/issues/27266](url)