### PR TITLE
Implement a MockReactiveRestServiceServer for WebClient testing

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/MockReactiveRestServiceServer.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/MockReactiveRestServiceServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-test/src/main/java/org/springframework/test/web/client/MockReactiveRestServiceServer.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/MockReactiveRestServiceServer.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.test.web.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.apache.commons.io.IOUtils;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseCookie.ResponseCookieBuilder;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.mock.http.client.reactive.MockClientHttpRequest;
+import org.springframework.mock.http.client.reactive.MockClientHttpResponse;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * A mock REST service server that can be used to verify requests from {@link WebClient} objects, and
+ * stub mock responses to provide to the client.
+ * <p>
+ * This acts as a drop-in replacement for {@link MockRestServiceServer} that provides support for reactive
+ * {@link WebClient} objects. While supporting a reactive client API underneath, the majority of this implementation
+ * works with the same components that {@link MockRestServiceServer} does.
+ * <p>
+ * This is relatively lightweight API to use, so can be initialized per test case if required. This does not open
+ * any network sockets.
+ * <p>
+ * Instances of this server can be created by calling either
+ * {@link #createServer()}, {@link #createServer(boolean)}, or {@link #createServer(RequestExpectationManager)}.
+ * {@link WebClient} instances that will communicate with this server can then be created using the
+ * {@link #createWebClient()} or {@link #createWebClientBuilder()} methods, respectively.
+ *
+ * @author Ashley Scopes
+ * @see StepVerifier
+ * @see RequestMatcher
+ * @see ResponseCreator
+ * @see MockRestRequestMatchers
+ * @see MockRestResponseCreators
+ */
+public final class MockReactiveRestServiceServer {
+	private final RequestExpectationManager expectationManager;
+
+	/**
+	 * Initialize the mock server with the desired expectation manager to use.
+	 *
+	 * @param expectationManager the expectation manager to use for requests.
+	 */
+	private MockReactiveRestServiceServer(@NonNull RequestExpectationManager expectationManager) {
+		this.expectationManager = expectationManager;
+	}
+
+	/**
+	 * Register an expectation for a request to occur exactly once. This is an alias for calling
+	 * {@link #expect(ExpectedCount, RequestMatcher)} with {@link ExpectedCount#once()} as the first
+	 * parameter.
+	 *
+	 * @param requestMatcher the request matcher to use.
+	 * @return the response actions builder to use to define how to respond to such requests.
+	 */
+	@NonNull
+	public ResponseActions expect(@NonNull RequestMatcher requestMatcher) {
+		return expect(ExpectedCount.once(), requestMatcher);
+	}
+
+	/**
+	 * Register an expectation for a request to occur a given number of times.
+	 *
+	 * @param count   the number of times the request should be made.
+	 * @param matcher the matcher for the request.
+	 * @return the response actions builder to use to define how to respond to such requests.
+	 */
+	@NonNull
+	public ResponseActions expect(@NonNull ExpectedCount count, @NonNull RequestMatcher matcher) {
+		return this.expectationManager.expectRequest(count, matcher);
+	}
+
+	/**
+	 * Verify that the expected requests have been performed. This is equivalent to calling
+	 * {@link #verify(Duration)} with {@link Duration#ZERO}.
+	 *
+	 * @throws AssertionError if the requests have not been performed as expected.
+	 */
+	public void verify() {
+		this.expectationManager.verify();
+	}
+
+	/**
+	 * Verify that the expected results get performed within the given timeout.
+	 *
+	 * @param timeout the maximum time to wait before failing.
+	 * @throws AssertionError if the request times out before the expected requests occur.
+	 */
+	@NonNull
+	public void verify(@NonNull Duration timeout) {
+		this.expectationManager.verify(timeout);
+	}
+
+	/**
+	 * Remove all expectations from this mock server.
+	 */
+	public void reset() {
+		this.expectationManager.reset();
+	}
+
+	/**
+	 * Create a new {@link WebClient} builder that is bound to this mock server.
+	 *
+	 * @return a {@code WebClient} builder that will pipe requests through this mock server instance.
+	 */
+	@NonNull
+	public WebClient.Builder createWebClientBuilder() {
+		return WebClient
+				.builder()
+				.clientConnector(new MockClientHttpConnector());
+	}
+
+	/**
+	 * Create a new {@link WebClient} that is bound to this mock server.
+	 *
+	 * @return a {@code WebClient} with default settings that pipes requests through this mock server instance.
+	 */
+	@NonNull
+	public WebClient createWebClient() {
+		return createWebClientBuilder().build();
+	}
+
+	/**
+	 * Create a new mock reactive REST service server with the given expectation manager.
+	 *
+	 * @param manager the expectation manager to use.
+	 * @return the new mock reactive REST service server.
+	 */
+	@NonNull
+	public static MockReactiveRestServiceServer createServer(@NonNull RequestExpectationManager manager) {
+		return new MockReactiveRestServiceServer(manager);
+	}
+
+	/**
+	 * Create a new mock reactive REST service server.
+	 *
+	 * @param ignoreRequestOrder true to ignore the order of requests, or false to require requests to
+	 *                           be performed in the order that they are registered.
+	 * @return the new mock reactive REST service server.
+	 */
+	@NonNull
+	public static MockReactiveRestServiceServer createServer(boolean ignoreRequestOrder) {
+		RequestExpectationManager manager = ignoreRequestOrder
+				? new UnorderedRequestExpectationManager()
+				: new SimpleRequestExpectationManager();
+
+		return createServer(manager);
+	}
+
+	/**
+	 * Create a new mock reactive REST service server that requires requests to be performed in the order that they
+	 * are registered.
+	 *
+	 * @return the new mock reactive REST service server to use.
+	 */
+	@NonNull
+	public static MockReactiveRestServiceServer createServer() {
+		return createServer(false);
+	}
+
+	/**
+	 * Internal mock connector for {@link WebClient} instances. This deals with converting reactive
+	 * {@link org.springframework.mock.http.client.reactive.MockClientHttpRequest} objects to non-reactive
+	 * {@link org.springframework.mock.http.client.MockClientHttpRequest} objects that the
+	 * {@link MockRestServiceServer} internals are compatible with. This also will handle converting non-reactive
+	 * {@link org.springframework.mock.http.client.MockClientHttpResponse} objects back to reactive
+	 * {@link org.springframework.mock.http.client.reactive.MockClientHttpResponse} objects for the response object
+	 * to use internally.
+	 *
+	 * @author Ashley Scopes
+	 */
+	private final class MockClientHttpConnector implements ClientHttpConnector {
+		@NonNull
+		public Mono<ClientHttpResponse> connect(
+				@NonNull HttpMethod method, @NonNull URI uri,
+				@NonNull Function<? super ClientHttpRequest, Mono<Void>> requestCallback) {
+
+			MockClientHttpRequest request = new MockClientHttpRequest(method, uri);
+
+			return Mono
+					.defer(() -> requestCallback.apply(request))
+					.thenReturn(request)
+					.flatMap(this::createRequest)
+					.map(this::performRequest)
+					.map(this::convertResponse)
+					.checkpoint("Request to " + method + " " + uri + " [MockReactiveRestServiceServer]")
+					.onErrorMap(ex -> ex.getCause() instanceof AssertionError
+							? Exceptions.bubble(ex.getCause())
+							: ex);
+		}
+
+		@NonNull
+		private Mono<org.springframework.http.client.ClientHttpRequest> createRequest(
+				@NonNull MockClientHttpRequest reactiveRequest) {
+
+			org.springframework.mock.http.client.MockClientHttpRequest proceduralRequest =
+					new org.springframework.mock.http.client.MockClientHttpRequest(
+							reactiveRequest.getMethod(), reactiveRequest.getURI());
+
+			proceduralRequest.getHeaders().putAll(reactiveRequest.getHeaders());
+
+			return DataBufferUtils
+					.join(reactiveRequest.getBody())
+					.doOnNext(dataBuffer -> {
+						byte[] arr = new byte[1024];
+						int c;
+
+						try {
+							InputStream input = dataBuffer.asInputStream();
+							OutputStream output = proceduralRequest.getBody();
+
+							while ((c = input.read(arr)) != -1) {
+								output.write(arr, 0, c);
+							}
+						}
+						catch (IOException ex) {
+							throw new RuntimeException(ex);
+						}
+					})
+					.thenReturn(proceduralRequest);
+		}
+
+		@NonNull
+		private org.springframework.http.client.ClientHttpResponse performRequest(
+				@NonNull org.springframework.http.client.ClientHttpRequest proceduralRequest) {
+
+			try {
+				return MockReactiveRestServiceServer
+						.this
+						.expectationManager
+						.validateRequest(proceduralRequest);
+			}
+			catch (IOException ex) {
+				throw new WebClientRequestException(
+						ex,
+						Objects.requireNonNull(proceduralRequest.getMethod()),
+						proceduralRequest.getURI(),
+						proceduralRequest.getHeaders()
+				);
+			}
+		}
+
+		@NonNull
+		private ClientHttpResponse convertResponse(
+				@NonNull org.springframework.http.client.ClientHttpResponse proceduralResponse) {
+
+			int status = -1;
+			String statusMessage = "Could not read response status";
+			HttpHeaders headers = null;
+
+			try {
+				status = proceduralResponse.getRawStatusCode();
+				statusMessage = proceduralResponse.getStatusText();
+				headers = proceduralResponse.getHeaders();
+				DataBuffer responseBody = DefaultDataBufferFactory
+						.sharedInstance
+						.wrap(IOUtils.toByteArray(proceduralResponse.getBody()));
+
+				MockClientHttpResponse reactiveResponse = new MockClientHttpResponse(status);
+				reactiveResponse.getHeaders().putAll(headers);
+				MultiValueMap<String, ResponseCookie> cookies = reactiveResponse.getCookies();
+
+				headers.getOrEmpty(HttpHeaders.SET_COOKIE)
+						.stream()
+						.filter(cookie -> cookie.contains("="))
+						.map(cookie -> ResponseCookie.fromClientResponse(
+								cookie.substring(0, cookie.indexOf('=')),
+								cookie.substring(cookie.indexOf('=') + 1)
+						))
+						.map(ResponseCookieBuilder::build)
+						.forEach(cookie -> cookies.add(cookie.getName(), cookie));
+
+				reactiveResponse.setBody(Flux.just(responseBody));
+
+				return reactiveResponse;
+			}
+			catch (IOException ex) {
+				throw new WebClientResponseException(status, statusMessage, headers, null, null);
+			}
+		}
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/web/client/MockReactiveRestServiceServerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/MockReactiveRestServiceServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-test/src/test/java/org/springframework/test/web/client/MockReactiveRestServiceServerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/MockReactiveRestServiceServerTests.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.web.client;
+
+import java.net.SocketException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.anything;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class MockReactiveRestServiceServerTests {
+	@Test
+	void buildAndVerifyOnceWithoutBody() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/foo"))
+				.andExpect(method(HttpMethod.GET))
+				.andRespond(withSuccess());
+
+		ResponseEntity<Void> response = assertSuccess(
+				webClient.get()
+						.uri("/foo")
+						.retrieve()
+						.toBodilessEntity());
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isNull();
+
+		server.verify();
+	}
+
+	@Test
+	void buildAndVerifyOnceWithBody() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/bar/baz"))
+				.andExpect(method(HttpMethod.POST))
+				.andRespond(withSuccess()
+						.contentType(MediaType.APPLICATION_JSON)
+						.body("{\"message\": \"hello, world!\"}"));
+
+		ResponseEntity<SimpleResponseMessage> response = assertSuccess(
+				webClient.post()
+						.uri("/bar/baz")
+						.retrieve()
+						.toEntity(SimpleResponseMessage.class));
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getMessage()).isNotNull().isEqualTo("hello, world!");
+
+		server.verify();
+	}
+
+	@Test
+	void ignoreRequestOrder() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer(true);
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint")).andRespond(withSuccess());
+		server.expect(requestTo("/another/coolEndpoint")).andRespond(withSuccess());
+		assertSuccess(webClient.get().uri("/another/coolEndpoint").retrieve().toBodilessEntity());
+		assertSuccess(webClient.get().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity());
+		server.verify();
+	}
+
+	@Test
+	void exactRequestOrder() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer(false);
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint")).andRespond(withSuccess());
+		server.expect(requestTo("/another/coolEndpoint")).andRespond(withSuccess());
+
+		assertAssertionError(webClient.get().uri("/another/coolEndpoint").retrieve().toBodilessEntity());
+	}
+
+	@Test
+	void resetAndReuseIgnoringRequestOrder() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer(true);
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint")).andRespond(withSuccess());
+		assertSuccess(webClient.get().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity());
+		server.verify();
+		server.reset();
+
+		server.expect(requestTo("/some/coolApiEndpoint")).andRespond(withSuccess());
+		server.expect(requestTo("/another/coolApiEndpoint")).andRespond(withSuccess());
+		assertSuccess(webClient.get().uri("/another/coolApiEndpoint").retrieve().toBodilessEntity());
+		assertSuccess(webClient.get().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity());
+		server.verify();
+	}
+
+	@Test
+	void resetClearsRequestFailures() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.GET))
+				.andRespond(withSuccess());
+		assertAssertionError(webClient.post().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity());
+		server.reset();
+
+		server.expect(requestTo("/yetAnotherEndpoint"))
+				.andExpect(method(HttpMethod.POST))
+				.andRespond(withSuccess());
+		assertSuccess(webClient.post().uri("/yetAnotherEndpoint").retrieve().toBodilessEntity());
+	}
+
+	@Test
+	void followUpRequestAfterFailure() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.GET))
+				.andRespond(res -> {
+					throw new SocketException("network error");
+				});
+
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.GET))
+				.andRespond(withSuccess());
+
+		StepVerifier
+				.create((webClient.get().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity()))
+				.expectErrorSatisfies(ex -> assertThat(ex)
+						.isInstanceOf(WebClientRequestException.class)
+						.getCause()
+						.isInstanceOf(SocketException.class))
+				.verify();
+
+		assertSuccess(webClient.get().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity());
+	}
+
+	@Test
+	void verifyShouldFailIfRequestsFailed() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer(true);
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.GET))
+				.andRespond(withSuccess());
+
+		assertAssertionError(webClient.post().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity());
+		assertSuccess(webClient.get().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity());
+
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(server::verify);
+	}
+
+	@Test
+	void verifyWithTimeoutShouldFailOnTimeout() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.GET))
+				.andRespond(withSuccess());
+
+		long start = System.nanoTime();
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> server.verify(Duration.ofSeconds(1)));
+		long end = System.nanoTime();
+
+		// Expect that it waits for at least 1,000,000ns (1 second).
+		assertThat(end - start).isGreaterThan(1_000_000L);
+
+		server.reset();
+
+		// This one should pass immediately.
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.GET))
+				.andRespond(withSuccess());
+		assertSuccess(webClient.get().uri("/some/coolApiEndpoint").retrieve().toBodilessEntity());
+
+		server.verify(Duration.ofSeconds(1));
+	}
+
+	@Test
+	void allRequestHeadersShouldBeSentToTheMockServer() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.GET))
+				.andExpect(header("X-Something-Or-Other", "12345678910", "12345"))
+				.andExpect(header("X-Another-Thing", "ayaya!"))
+				.andExpect(header("X-Duplicated", "first", "second"))
+				.andRespond(withSuccess());
+
+		assertSuccess(webClient.get()
+				.uri("/some/coolApiEndpoint")
+				.header("X-Something-Or-Other", "12345678910", "12345")
+				.header("X-Another-Thing", "ayaya!")
+				.header("X-Duplicated", "first")
+				.header("X-Duplicated", "second")
+				.retrieve()
+				.toBodilessEntity());
+
+		server.verify();
+	}
+
+	@Test
+	void allRequestCookiesShouldBeSentToTheMockServer() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.GET))
+				.andExpect(header(HttpHeaders.COOKIE, "session-cookie=1a2b3c4d", "fortune-cookie=you will meet a passing unit test"))
+				.andRespond(withSuccess());
+
+		assertSuccess(webClient.get()
+				.uri("/some/coolApiEndpoint")
+				.cookie("session-cookie", "1a2b3c4d")
+				.cookie("fortune-cookie", "you will meet a passing unit test")
+				.retrieve()
+				.toBodilessEntity());
+
+		server.verify();
+	}
+
+	@Test
+	void requestBodyShouldBeSentToTheServer() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/some/coolApiEndpoint"))
+				.andExpect(method(HttpMethod.POST))
+				.andExpect(jsonPath("$.greeting").value("Hello!"))
+				.andExpect(jsonPath("$.name").value("Spring WebFlux"))
+				.andRespond(withSuccess());
+
+		assertSuccess(webClient.post()
+				.uri("/some/coolApiEndpoint")
+				.bodyValue("{\"name\": \"Spring WebFlux\", \"greeting\": \"Hello!\"}")
+				.retrieve()
+				.toBodilessEntity());
+
+		server.verify();
+	}
+
+	@Test
+	void responseStatusShouldBeReturned() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/foo/bar/baz"))
+				.andRespond(withStatus(HttpStatus.ACCEPTED));
+
+		ResponseEntity<?> result = assertSuccess(webClient.get().uri("/foo/bar/baz").retrieve().toBodilessEntity());
+		server.verify();
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+	}
+
+	@Test
+	void responseHeadersShouldBeReturned() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		HttpHeaders responseHeaders = new HttpHeaders();
+		responseHeaders.add("X-Foo", "bar");
+		responseHeaders.add("X-Baz", "bork");
+		responseHeaders.add("X-Duplicated", "first");
+		responseHeaders.add("X-Duplicated", "second");
+
+		server.expect(requestTo("/foo/bar/baz"))
+				.andRespond(withSuccess().headers(responseHeaders));
+
+		ResponseEntity<?> result = assertSuccess(webClient.get().uri("/foo/bar/baz").retrieve().toBodilessEntity());
+		server.verify();
+
+		assertThat(result.getHeaders().get("X-Foo")).isNotNull().isEqualTo(Collections.singletonList("bar"));
+		assertThat(result.getHeaders().get("X-Baz")).isNotNull().isEqualTo(Collections.singletonList("bork"));
+		assertThat(result.getHeaders().get("X-Duplicated")).isNotNull().isEqualTo(Arrays.asList("first", "second"));
+	}
+
+	@SuppressWarnings("AssertBetweenInconvertibleTypes")  // false positive
+	@Test
+	void responseCookiesShouldBeReturned() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		HttpHeaders responseHeaders = new HttpHeaders();
+		responseHeaders.add(HttpHeaders.SET_COOKIE, "foo=bar");
+		responseHeaders.add(HttpHeaders.SET_COOKIE, "baz=bork");
+		responseHeaders.add(HttpHeaders.SET_COOKIE, "qux=lorem-ipsum");
+		responseHeaders.add(HttpHeaders.SET_COOKIE, "qux=dolor-sit-amet");
+
+		server.expect(requestTo("/foo/bar/baz"))
+				.andRespond(withSuccess().headers(responseHeaders));
+
+		MultiValueMap<String, ResponseCookie> cookies = assertSuccess(webClient.get().uri("/foo/bar/baz")
+				.exchangeToMono(res -> Mono.just(res.cookies())));
+		server.verify();
+
+		assertThat(cookies.get("foo").stream().map(ResponseCookie::getValue))
+				.isEqualTo(Collections.singletonList("bar"));
+		assertThat(cookies.get("baz").stream().map(ResponseCookie::getValue))
+				.isEqualTo(Collections.singletonList("bork"));
+		assertThat(cookies.get("qux").stream().map(ResponseCookie::getValue))
+				.isEqualTo(Arrays.asList("lorem-ipsum", "dolor-sit-amet"));
+	}
+
+	@Test
+	void responseBodyShouldBeReturned() {
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		server.expect(requestTo("/foo/bar/baz"))
+				.andRespond(withSuccess().body("hello, world!"));
+
+		String responseBody = assertSuccess(webClient.get().uri("/foo/bar/baz").retrieve().bodyToMono(String.class));
+		server.verify();
+
+		assertThat(responseBody).isEqualTo("hello, world!");
+	}
+
+	@ParameterizedTest(name = "expectErrorResponsesToThrowException for HTTP {0}")
+	@ValueSource(ints = {400, 401, 500, 501})
+	void expectErrorResponsesToThrowException(int code) {
+		HttpStatus responseStatus = HttpStatus.valueOf(code);
+
+		MockReactiveRestServiceServer server = MockReactiveRestServiceServer.createServer();
+		WebClient webClient = server.createWebClientBuilder().build();
+
+		HttpHeaders responseHeaders = new HttpHeaders();
+		responseHeaders.add("X-Foo", "bar");
+		responseHeaders.add("X-Baz", "bork");
+		responseHeaders.add("X-Duplicated", "first");
+		responseHeaders.add("X-Duplicated", "second");
+
+		server.expect(anything())
+				.andRespond(withStatus(responseStatus)
+						.headers(responseHeaders)
+						.body("something messed up"));
+
+		StepVerifier.create(webClient.get().retrieve().toEntity(String.class))
+				.expectErrorSatisfies(ex -> {
+					assertThat(ex).isInstanceOf(WebClientResponseException.class);
+					WebClientResponseException resEx = (WebClientResponseException) ex;
+
+					assertThat(resEx.getStatusCode()).isEqualTo(responseStatus);
+					assertThat(resEx.getRawStatusCode()).isEqualTo(code);
+					assertThat(resEx.getStatusText()).isEqualTo(responseStatus.getReasonPhrase());
+					assertThat(resEx.getHeaders()).isEqualTo(responseHeaders);
+					assertThat(resEx.getResponseBodyAsString()).isEqualTo("something messed up");
+				})
+				.verify();
+
+		server.verify();
+	}
+
+	private static void assertAssertionError(Publisher<?> publisher) {
+		StepVerifier
+				.create(publisher)
+				.expectError(AssertionError.class)
+				.verify();
+	}
+
+	private static <T> T assertSuccess(Publisher<T> publisher) {
+		AtomicReference<T> ref = new AtomicReference<>();
+
+		StepVerifier
+				.create(publisher)
+				.assertNext(ref::set)
+				.expectComplete()
+				.verify();
+
+		return ref.get();
+	}
+
+	private static class SimpleResponseMessage {
+		private String message;
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+	}
+}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientUtils.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientUtils.java
@@ -38,10 +38,12 @@ abstract class WebClientUtils {
 	private static final String VALUE_NONE = "\n\t\t\n\t\t\n\uE000\uE001\uE002\n\t\t\t\t\n";
 
 	/**
-	 * Predicate that returns true if an exception should be wrapped.
+	 * Predicate that returns true if an exception should be wrapped. This will not catch WebClientException instances,
+	 * nor will it catch CodecExceptions. Error types will not be caught either, as "no reasonable application" should
+	 * attempt to catch these by design, according to the JDK documentation.
 	 */
 	public final static Predicate<? super Throwable> WRAP_EXCEPTION_PREDICATE =
-			t -> !(t instanceof WebClientException) && !(t instanceof CodecException);
+			t -> !(t instanceof WebClientException || t instanceof CodecException || t instanceof Error);
 
 
 	/**


### PR DESCRIPTION
I noticed that Spring does not currently provide the same tools for
testing WebClient-based reactive remote calls that the non-reactive
RestTemplate API has, which from experience recently has lead to
a little bit of frustration due to having to use more 
heavyweight/complicated non-Spring APIs to mock WebClient calls.

Since this felt relatively simple to implement, I went ahead and
attempted to draft a reactive counterpart to the existing non-reactive
MockRestServiceServer API.

This implementation is a shim that internally converts all requests
and responses to the non-reactive counterparts. This enables the
reactive API to use all the existing non-reactive request and
response verification components without having to duplicate the
entire API.

WebClientUtils in WebFlux has had to be updated to exclude Error
types from the filter, otherwise AssertionErrors always end up
being filtered out by the ExchangeFunctions conduit. I don't believe
this should be an issue though, as the JavaDoc for Error types
states that "no reasonable application should try to catch these
types", which means that the ExchangeFunctions probably shouldn't
have been allowing this through in the first place. Applied de-Morgans
law to reduce the complexity of the expression a little.

The API itself attempts to be as similar to MockRestServiceServer as
possible. For example:

```kotlin
val server = MockReactiveRestServiceServer.createServer()
val client = server.createWebClient()
val responseHeaders = HttpHeaders()

responseHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

server
    .expect(requestTo("/actuator/health"))
    .andExpect(method(HttpMethod.GET))
    .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
    .andRespond(withSuccess()
        .headers(responseHeaders)
        .body("""{"status": "UP"}"""))

StepVerifier
    .create(client.get().uri("/actuator/health").retrieve().bodyToMono(String.class))
    .assertNext { assertThat(it).isEqualTo("""{"status": "UP"}""") }
    .verify()
```

Hope that contributions such as this are not considered out of place,
or anything. If this is in the wrong place, please let me know!

Likewise if there are any other suggestions or feedback, I'd be happy
to take those into account!