### PR TITLE
Improve the fluency of the ResponseCreator API

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
@@ -82,6 +83,13 @@ public abstract class MockRestResponseCreators {
 	}
 
 	/**
+	 * {@code ResponseCreator} for a 202 response (ACCEPTED).
+	 */
+	public static DefaultResponseCreator withAccepted() {
+		return new DefaultResponseCreator(HttpStatus.ACCEPTED);
+	}
+
+	/**
 	 * {@code ResponseCreator} for a 204 response (NO_CONTENT).
 	 */
 	public static DefaultResponseCreator withNoContent() {
@@ -103,10 +111,68 @@ public abstract class MockRestResponseCreators {
 	}
 
 	/**
+	 * {@code ResponseCreator} for a 403 response (FORBIDDEN).
+	 */
+	public static DefaultResponseCreator withForbiddenRequest() {
+		return new DefaultResponseCreator(HttpStatus.FORBIDDEN);
+	}
+
+	/**
+	 * {@code ResponseCreator} for a 404 response (NOT_FOUND).
+	 */
+	public static DefaultResponseCreator withResourceNotFound() {
+		return new DefaultResponseCreator(HttpStatus.NOT_FOUND);
+	}
+
+	/**
+	 * {@code ResponseCreator} for a 409 response (CONFLICT).
+	 */
+	public static DefaultResponseCreator withRequestConflict() {
+		return new DefaultResponseCreator(HttpStatus.CONFLICT);
+	}
+
+	/**
+	 * {@code ResponseCreator} for a 429 ratelimited response (TOO_MANY_REQUESTS).
+	 */
+	public static DefaultResponseCreator withTooManyRequests() {
+		return new DefaultResponseCreator(HttpStatus.TOO_MANY_REQUESTS);
+	}
+
+	/**
+	 * {@code ResponseCreator} for a 429 ratelimited response (TOO_MANY_REQUESTS) with a {@code Retry-After} header
+	 * in seconds.
+	 */
+	public static DefaultResponseCreator withTooManyRequests(int retryAfter) {
+		return new DefaultResponseCreator(HttpStatus.TOO_MANY_REQUESTS)
+				.header(HttpHeaders.RETRY_AFTER, Integer.toString(retryAfter));
+	}
+
+	/**
 	 * {@code ResponseCreator} for a 500 response (SERVER_ERROR).
 	 */
 	public static DefaultResponseCreator withServerError() {
 		return new DefaultResponseCreator(HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	/**
+	 * {@code ResponseCreator} for a 502 response (BAD_GATEWAY).
+	 */
+	public static DefaultResponseCreator withBadGateway() {
+		return new DefaultResponseCreator(HttpStatus.BAD_GATEWAY);
+	}
+
+	/**
+	 * {@code ResponseCreator} for a 503 response (SERVICE_UNAVAILABLE).
+	 */
+	public static DefaultResponseCreator withServiceUnavailable() {
+		return new DefaultResponseCreator(HttpStatus.SERVICE_UNAVAILABLE);
+	}
+
+	/**
+	 * {@code ResponseCreator} for a 504 response (GATEWAY_TIMEOUT).
+	 */
+	public static DefaultResponseCreator withGatewayTimeout() {
+		return new DefaultResponseCreator(HttpStatus.GATEWAY_TIMEOUT);
 	}
 
 	/**

--- a/spring-test/src/test/java/org/springframework/test/web/client/response/DefaultResponseCreatorTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/response/DefaultResponseCreatorTests.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.web.client.response;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the {@link DefaultResponseCreator} factory methods.
+ *
+ * @author Ashley Scopes
+ */
+class DefaultResponseCreatorTests {
+	@ParameterizedTest(name = "expect status to be set [{0}]")
+	@ValueSource(ints = {200, 401, 429})
+	void expectStatus(int statusValue) throws IOException {
+		HttpStatus status = HttpStatus.valueOf(statusValue);
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(status));
+		assertThat(response.getStatusCode()).isEqualTo(status);
+	}
+
+	@Test
+	void setBodyFromString() throws IOException {
+		// Use unicode codepoint for "thinking" emoji to help verify correct encoding is used internally.
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK)
+				.body("hello, world! \uD83E\uDD14"));
+
+		assertThat(IOUtils.toByteArray(response.getBody()))
+				.isEqualTo("hello, world! \uD83E\uDD14".getBytes(StandardCharsets.UTF_8));
+	}
+
+	@ParameterizedTest(name = "setBodyFromStringWithCharset [{0}]")
+	@ValueSource(strings = {"Cp1047", "UTF-8", "UTF-16", "US-ASCII", "ISO-8859-1"})
+	void setBodyFromStringWithCharset(String charset) throws IOException {
+
+		assumeThat(Charset.isSupported(charset))
+				.overridingErrorMessage("charset %s is not supported by this JVM", charset)
+				.isTrue();
+
+		Charset charsetObj = Charset.forName(charset);
+
+		String content = "hello! €½$~@><·─";
+
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK)
+				.body(content, charsetObj));
+
+		ByteBuffer expectBuff = charsetObj.encode(content);
+		byte[] expect = new byte[expectBuff.remaining()];
+		expectBuff.get(expect);
+
+		assertThat(IOUtils.toByteArray(response.getBody())).isEqualTo(expect);
+	}
+
+	@Test
+	void setBodyFromByteArray() throws IOException {
+		byte[] body = { 0, 9, 18, 27, 36, 45, 54, 63, 72, 81, 90 };
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK).body(body));
+		assertThat(IOUtils.toByteArray(response.getBody())).isEqualTo(body);
+	}
+
+	@Test
+	void setBodyFromResource() throws IOException {
+		byte[] resourceContent = {7, 14, 21, 28, 35};
+
+		Resource resource = mock(Resource.class);
+		given(resource.getInputStream()).willReturn(new ByteArrayInputStream(resourceContent));
+
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK).body(resource));
+
+		then(resource).should().getInputStream();
+
+		assertThat(IOUtils.toByteArray(response.getBody())).isEqualTo(resourceContent);
+	}
+
+	@Test
+	void setContentType() throws IOException {
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK)
+				.contentType(MediaType.APPLICATION_JSON));
+
+		assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+	}
+
+	@Test
+	void setLocation() throws IOException {
+		URI uri = UriComponentsBuilder
+				.fromUriString("https://docs.spring.io/spring-framework/docs/current/reference/html/testing.html")
+				.build()
+				.toUri();
+
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK).location(uri));
+		assertThat(response.getHeaders().getLocation()).isEqualTo(uri);
+	}
+
+	@Test
+	void setHeader() throws IOException {
+
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK)
+				.header("foo", "bar")
+				.header("baz", "bork")
+				.headers("lorem", "ipsum", "dolor", "sit", "amet"));
+
+		HttpHeaders headers = response.getHeaders();
+		assertThat(headers.get("foo")).isNotNull().isEqualTo(Collections.singletonList("bar"));
+		assertThat(headers.get("baz")).isNotNull().isEqualTo(Collections.singletonList("bork"));
+		assertThat(headers.get("lorem")).isNotNull().isEqualTo(Arrays.asList("ipsum", "dolor", "sit", "amet"));
+	}
+
+	@Test
+	void setHeaders() throws IOException {
+
+		HttpHeaders firstHeaders = new HttpHeaders();
+		firstHeaders.setContentType(MediaType.APPLICATION_JSON);
+		firstHeaders.setOrigin("https://github.com");
+
+		HttpHeaders secondHeaders = new HttpHeaders();
+		secondHeaders.setAllow(Collections.singleton(HttpMethod.PUT));
+
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK)
+				.headers(firstHeaders)
+				.headers(secondHeaders));
+
+		HttpHeaders responseHeaders = response.getHeaders();
+
+		assertThat(responseHeaders.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+		assertThat(responseHeaders.getOrigin()).isEqualTo("https://github.com");
+		assertThat(responseHeaders.getAllow()).isEqualTo(Collections.singleton(HttpMethod.PUT));
+	}
+
+	@Test
+	void setCookie() throws IOException {
+		ResponseCookie firstCookie = ResponseCookie.from("user-id", "1234").build();
+		ResponseCookie secondCookie = ResponseCookie.from("group-id", "5432").build();
+		ResponseCookie thirdCookie = ResponseCookie.from("cookie-cookie", "cookies").build();
+		ResponseCookie fourthCookie = ResponseCookie.from("foobar", "bazbork").build();
+
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK)
+				.cookie(firstCookie)
+				.cookie(secondCookie)
+				.cookies(thirdCookie, fourthCookie));
+
+		HttpHeaders responseHeaders = response.getHeaders();
+
+		assertThat(responseHeaders.get(HttpHeaders.SET_COOKIE))
+				.isNotNull()
+				.containsExactly(
+						firstCookie.toString(),
+						secondCookie.toString(),
+						thirdCookie.toString(),
+						fourthCookie.toString()
+				);
+	}
+
+	@Test
+	void setCookies() throws IOException {
+		ResponseCookie firstCookie = ResponseCookie.from("user-id", "1234").build();
+		ResponseCookie secondCookie = ResponseCookie.from("group-id", "5432").build();
+		MultiValueMap<String, ResponseCookie> firstCookies = new LinkedMultiValueMap<>();
+		firstCookies.add(firstCookie.getName(), firstCookie);
+		firstCookies.add(secondCookie.getName(), secondCookie);
+
+		ResponseCookie thirdCookie = ResponseCookie.from("cookie-cookie", "cookies").build();
+		ResponseCookie fourthCookie = ResponseCookie.from("foobar", "bazbork").build();
+		MultiValueMap<String, ResponseCookie> secondCookies = new LinkedMultiValueMap<>();
+		firstCookies.add(thirdCookie.getName(), thirdCookie);
+		firstCookies.add(fourthCookie.getName(), fourthCookie);
+
+		ClientHttpResponse response = createResponse(new DefaultResponseCreator(HttpStatus.OK)
+				.cookies(firstCookies)
+				.cookies(secondCookies));
+
+		HttpHeaders responseHeaders = response.getHeaders();
+
+		assertThat(responseHeaders.get(HttpHeaders.SET_COOKIE))
+				.isNotNull()
+				.containsExactly(
+						firstCookie.toString(),
+						secondCookie.toString(),
+						thirdCookie.toString(),
+						fourthCookie.toString()
+				);
+	}
+
+	private static ClientHttpResponse createResponse(DefaultResponseCreator creator) throws IOException {
+		URI uri = UriComponentsBuilder.fromUriString("/foo/bar").build().toUri();
+		return creator.createResponse(new MockClientHttpRequest(HttpMethod.POST, uri));
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
@@ -21,6 +21,7 @@ import java.net.URI;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.http.client.MockClientHttpResponse;
@@ -79,6 +80,15 @@ class ResponseCreatorsTests {
 	}
 
 	@Test
+	void accepted() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withAccepted();
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
 	void noContent() throws Exception {
 		DefaultResponseCreator responseCreator = MockRestResponseCreators.withNoContent();
 		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
@@ -109,12 +119,86 @@ class ResponseCreatorsTests {
 	}
 
 	@Test
+	void forbiddenRequest() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withForbiddenRequest();
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
+	void resourceNotFound() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withResourceNotFound();
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
+	void requestConflict() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withRequestConflict();
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
+	void tooManyRequests() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withTooManyRequests();
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+		assertThat(response.getHeaders()).doesNotContainKey(HttpHeaders.RETRY_AFTER);
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
+	void tooManyRequestsWithRetryAfter() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withTooManyRequests(512);
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+		assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isEqualTo("512");
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
 	void serverError() throws Exception {
 		DefaultResponseCreator responseCreator = MockRestResponseCreators.withServerError();
 		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
 
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 		assertThat(response.getHeaders().isEmpty()).isTrue();
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
+	void badGateway() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withBadGateway();
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
+	void serviceUnavailable() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withServiceUnavailable();
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
+	}
+
+	@Test
+	void gatewayTimeout() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withGatewayTimeout();
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
 		assertThat(StreamUtils.copyToByteArray(response.getBody()).length).isEqualTo(0);
 	}
 


### PR DESCRIPTION
* Added utility methods to DefaultResponseCreator
  
  This enables the ability to fluently add single headers like you can
  already with the mock request specification APIs by chaining
  `.header(name, value)` repeatedly. This reduces code clutter within
  test cases.
    
  Added the ability to add cookies as this simplifies tests that work
  with sessions.
    
  Added the ability to override the character encoding used for setting
  a string body on a response, as this is useful when working in
  environments that do not automatically assume UTF-8, such as
  integrating with legacy applications from a new Spring one.
  
* Added unit tests for DefaultResponseCreator
    
  These were already *partially* tested by the MockRestResponseCreator, but some
  existing calls prior to this PR were missing, and this was also an opportunity
  for me to directly test the changes I added.
  
* Added common response statuses to MockRestResponseCreators
    
  It appears that a couple of the more commonly used HTTP status codes
  were missed out from the default methods in MockRestResponseCreators.
  The methods included are common enough that most test packs will probably
  have at least one case that uses one of these calls, so it enables
  keeping the fluent API tidy.
    
  I added a couple of additional edge cases for common response
  statuses that will occur when working in cloud environments, such as
  AWS, CloudFlare, or using gateways such as Kong, where resillient
  applications should be able to respond to ratelimits, gateway errors,
  and gateway timeouts (which may occur if a remote service is down).
    
  Added test cases for any changes made.


These changes allow for cases to be written like so:

```java
server
    .expect(requestTo("/api/v1/users"))
    .andExpect(method(POST))
    .andExpect(header("Content-Type", APPLICATION_JSON_VALUE))
    .andExpect(header("Accept", APPLICATION_JSON_VALUE))
    .andExpect(jsonPath("$.name").value("Ashley"))
    .andExpect(jsonPath("$.username").value("ascopes"))
    .andExpect(jsonPath("$.password").value("12345"))
    .andRespond(withRequestConflict()
        .header("X-Request-ID", "12345")
        .header(HttpHeaders.PRAGMA, "no-cache")
        .cookie(ResponseCookie.from("anon-session-id", "12345").build())
        .body("Entity already exists", StandardCharsets.US_ASCII));
```
which should be more fluent and easy to read than what would be needed on the existing API:

```java
HttpHeaders responseHeaders = new HttpHeaders();
responseHeaders.add("X-Request-ID", "12345");
responseHeaders.add(HttpHeaders.PRAGMA, "no-cache");
responseHeaders.add(HttpHeaders.SET_COOKIE, ResponseCookie.from("anon-session-id", "12345").build().toString());


server
    .expect(requestTo("/api/v1/users"))
    .andExpect(method(POST))
    .andExpect(header("Content-Type", APPLICATION_JSON_VALUE))
    .andExpect(header("Accept", APPLICATION_JSON_VALUE))
    .andExpect(jsonPath("$.name").value("Ashley"))
    .andExpect(jsonPath("$.username").value("ascopes"))
    .andExpect(jsonPath("$.password").value("12345"))
    .andRespond(withStatus(HttpStatus.CONFLICT)
        .headers(responseHeaders)
        .body("Entity already exists".getBytes(StandardCharsets.US_ASCII)));
```        
