### PR TITLE
Introduce class-level execution phases for `@Sql`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/TestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/TestContext.java
@@ -42,6 +42,7 @@ import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
  * override {@link #setMethodInvoker(MethodInvoker)} and {@link #getMethodInvoker()}.
  *
  * @author Sam Brannen
+ * @author Andreas Ahlenstorf
  * @since 2.5
  * @see TestContextManager
  * @see TestExecutionListener

--- a/spring-test/src/main/java/org/springframework/test/context/TestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/TestContext.java
@@ -111,6 +111,25 @@ public interface TestContext extends AttributeAccessor, Serializable {
 	Object getTestInstance();
 
 	/**
+	 * Tests whether a test method is part of this test context. Returns
+	 * {@code true} if this context has a current test method, {@code false}
+	 * otherwise.
+	 *
+	 * <p>The default implementation of this method always returns {@code false}.
+	 * Custom {@code TestContext} implementations are therefore highly encouraged
+	 * to override this method with a more meaningful implementation. Note that
+	 * the standard {@code TestContext} implementation in Spring overrides this
+	 * method appropriately.
+	 * @return {@code true} if the test execution has already entered a test
+	 * method
+	 * @since 6.1
+	 * @see #getTestMethod()
+	 */
+	default boolean hasTestMethod() {
+		return false;
+	}
+
+	/**
 	 * Get the current {@linkplain Method test method} for this test context.
 	 * <p>Note: this is a mutable property.
 	 * @return the current test method (never {@code null})

--- a/spring-test/src/main/java/org/springframework/test/context/jdbc/Sql.java
+++ b/spring-test/src/main/java/org/springframework/test/context/jdbc/Sql.java
@@ -33,6 +33,11 @@ import org.springframework.core.annotation.AliasFor;
  *
  * <p>Method-level declarations override class-level declarations by default,
  * but this behavior can be configured via {@link SqlMergeMode @SqlMergeMode}.
+ * However, this does not apply to class-level declarations that use
+ * {@link ExecutionPhase#BEFORE_TEST_CLASS} or
+ * {@link ExecutionPhase#AFTER_TEST_CLASS}. Such declarations are retained and
+ * scripts and statements are executed once per class in addition to any
+ * method-level annotations.
  *
  * <p>Script execution is performed by the {@link SqlScriptsTestExecutionListener},
  * which is enabled by default.
@@ -160,6 +165,18 @@ public @interface Sql {
 	 * Enumeration of <em>phases</em> that dictate when SQL scripts are executed.
 	 */
 	enum ExecutionPhase {
+
+		/**
+		 * The configured SQL scripts and statements will be executed
+		 * once <em>before</em> any test method is run.
+		 */
+		BEFORE_TEST_CLASS,
+
+		/**
+		 * The configured SQL scripts and statements will be executed
+		 * once <em>after</em> any test method is run.
+		 */
+		AFTER_TEST_CLASS,
 
 		/**
 		 * The configured SQL scripts and statements will be executed

--- a/spring-test/src/main/java/org/springframework/test/context/jdbc/Sql.java
+++ b/spring-test/src/main/java/org/springframework/test/context/jdbc/Sql.java
@@ -66,6 +66,7 @@ import org.springframework.core.annotation.AliasFor;
  * modules as well as their transitive dependencies to be present on the classpath.
  *
  * @author Sam Brannen
+ * @author Andreas Ahlenstorf
  * @since 4.1
  * @see SqlConfig
  * @see SqlMergeMode

--- a/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
@@ -285,6 +285,9 @@ public class SqlScriptsTestExecutionListener extends AbstractTestExecutionListen
 	private void executeSqlScripts(
 			Sql sql, ExecutionPhase executionPhase, TestContext testContext, boolean classLevel) {
 
+		Assert.isTrue(classLevel || isValidMethodLevelPhase(sql.executionPhase()),
+				() -> "%s cannot be used on methods".formatted(sql.executionPhase()));
+
 		if (executionPhase != sql.executionPhase()) {
 			return;
 		}
@@ -455,4 +458,9 @@ public class SqlScriptsTestExecutionListener extends AbstractTestExecutionListen
 				.forEach(runtimeHints.resources()::registerResource);
 	}
 
+	private static boolean isValidMethodLevelPhase(ExecutionPhase executionPhase) {
+		// Class-level phases cannot be used on methods.
+		return executionPhase != ExecutionPhase.BEFORE_TEST_CLASS &&
+				executionPhase != ExecutionPhase.AFTER_TEST_CLASS;
+	}
 }

--- a/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
@@ -105,6 +105,7 @@ import static org.springframework.util.ResourceUtils.CLASSPATH_URL_PREFIX;
  *
  * @author Sam Brannen
  * @author Dmitry Semukhin
+ * @author Andreas Ahlenstorf
  * @since 4.1
  * @see Sql
  * @see SqlConfig

--- a/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
@@ -414,9 +414,7 @@ public class SqlScriptsTestExecutionListener extends AbstractTestExecutionListen
 	 * {@link Sql#scripts}.
 	 */
 	private String detectDefaultScript(Class<?> testClass, @Nullable Method testMethod, boolean classLevel) {
-		if (!classLevel && testMethod == null) {
-			throw new AssertionError("Method-level @Sql requires a testMethod");
-		}
+		Assert.state(classLevel || testMethod != null, "Method-level @Sql requires a testMethod");
 
 		String elementType = (classLevel ? "class" : "method");
 		String elementName = (classLevel ? testClass.getName() : testMethod.toString());
@@ -460,7 +458,7 @@ public class SqlScriptsTestExecutionListener extends AbstractTestExecutionListen
 
 	private static boolean isValidMethodLevelPhase(ExecutionPhase executionPhase) {
 		// Class-level phases cannot be used on methods.
-		return executionPhase != ExecutionPhase.BEFORE_TEST_CLASS &&
-				executionPhase != ExecutionPhase.AFTER_TEST_CLASS;
+		return executionPhase == ExecutionPhase.BEFORE_TEST_METHOD ||
+				executionPhase == ExecutionPhase.AFTER_TEST_METHOD;
 	}
 }

--- a/spring-test/src/main/java/org/springframework/test/context/support/DefaultTestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DefaultTestContext.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  * @author Sam Brannen
  * @author Juergen Hoeller
  * @author Rob Harrop
+ * @author Andreas Ahlenstorf
  * @since 4.0
  */
 @SuppressWarnings("serial")

--- a/spring-test/src/main/java/org/springframework/test/context/support/DefaultTestContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DefaultTestContext.java
@@ -167,6 +167,11 @@ public class DefaultTestContext implements TestContext {
 	}
 
 	@Override
+	public boolean hasTestMethod() {
+		return this.testMethod != null;
+	}
+
+	@Override
 	public final Method getTestMethod() {
 		Method testMethod = this.testMethod;
 		Assert.state(testMethod != null, "No test method");

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TestContextTransactionUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TestContextTransactionUtils.java
@@ -227,7 +227,8 @@ public abstract class TestContextTransactionUtils {
 	/**
 	 * Create a delegating {@link TransactionAttribute} for the supplied target
 	 * {@link TransactionAttribute} and {@link TestContext}, using the names of
-	 * the test class and test method to build the name of the transaction.
+	 * the test class and test method (if available) to build the name of the
+	 * transaction.
 	 * @param testContext the {@code TestContext} upon which to base the name
 	 * @param targetAttribute the {@code TransactionAttribute} to delegate to
 	 * @return the delegating {@code TransactionAttribute}
@@ -248,7 +249,13 @@ public abstract class TestContextTransactionUtils {
 
 		public TestContextTransactionAttribute(TransactionAttribute targetAttribute, TestContext testContext) {
 			super(targetAttribute);
-			this.name = ClassUtils.getQualifiedMethodName(testContext.getTestMethod(), testContext.getTestClass());
+
+			if (testContext.hasTestMethod()) {
+				this.name = ClassUtils.getQualifiedMethodName(testContext.getTestMethod(), testContext.getTestClass());
+			}
+			else {
+				this.name = testContext.getTestClass().getName();
+			}
 		}
 
 		@Override

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TestContextTransactionUtils.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TestContextTransactionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Sam Brannen
  * @author Juergen Hoeller
+ * @author Andreas Ahlenstorf
  * @since 4.1
  */
 public abstract class TestContextTransactionUtils {

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/AfterTestClassSqlScriptsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/AfterTestClassSqlScriptsTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.jdbc;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.Ordered;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.context.transaction.TestContextTransactionUtils;
+
+@SpringJUnitConfig(PopulatedSchemaDatabaseConfig.class)
+@DirtiesContext
+@Sql(value = {"drop-schema.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_CLASS)
+@TestExecutionListeners(
+		value = AfterTestClassSqlScriptsTests.VerifyTestExecutionListener.class,
+		mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
+class AfterTestClassSqlScriptsTests extends AbstractTransactionalTests {
+
+	@Test
+	@Sql(scripts = "data-add-catbert.sql")
+	void databaseHasBeenInitialized() {
+		// Ensure that the database has been initialized and can be accessed.
+		assertUsers("Catbert");
+	}
+
+	static class VerifyTestExecutionListener implements TestExecutionListener, Ordered {
+
+		@Override
+		public void afterTestClass(TestContext testContext) throws Exception {
+			DataSource dataSource = TestContextTransactionUtils.retrieveDataSource(testContext, null);
+			try {
+				new JdbcTemplate(dataSource).queryForList("SELECT name FROM user", String.class);
+				throw new AssertionError("BadSqlGrammarException should have been thrown.");
+			}
+			catch (BadSqlGrammarException expected) {
+			}
+		}
+
+		@Override
+		public int getOrder() {
+			// Must run before DirtiesContextTestExecutionListener. Otherwise, the old data source will be removed and
+			// replaced with a new one.
+			return 3001;
+		}
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/AfterTestClassSqlScriptsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/AfterTestClassSqlScriptsTests.java
@@ -32,6 +32,8 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.transaction.TestContextTransactionUtils;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 /**
  * Verifies that {@link Sql @Sql} with {@link Sql.ExecutionPhase#AFTER_TEST_CLASS} is run after all tests in the class
  * have been run.
@@ -69,12 +71,10 @@ class AfterTestClassSqlScriptsTests extends AbstractTransactionalTests {
 		@Override
 		public void afterTestClass(TestContext testContext) throws Exception {
 			DataSource dataSource = TestContextTransactionUtils.retrieveDataSource(testContext, null);
-			try {
-				new JdbcTemplate(dataSource).queryForList("SELECT name FROM user", String.class);
-				throw new AssertionError("BadSqlGrammarException should have been thrown.");
-			}
-			catch (BadSqlGrammarException expected) {
-			}
+			JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+
+			assertThatExceptionOfType(BadSqlGrammarException.class)
+					.isThrownBy(() -> jdbcTemplate.queryForList("SELECT name FROM user", String.class));
 		}
 
 		@Override

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/BeforeTestClassSqlScriptsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/BeforeTestClassSqlScriptsTests.java
@@ -55,11 +55,4 @@ class BeforeTestClassSqlScriptsTests extends AbstractTransactionalTests {
 		assertUsers("Dogbert", "Catbert");
 	}
 
-	@Test
-	@Sql(scripts = {"data-add-catbert.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
-	void classLevelPhaseIsIgnoredOnMethod() {
-		// There is a unique constraint on the name. If the script had been run, there would have been a
-		// constraint violation.
-		assertUsers("Catbert");
-	}
 }

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/BeforeTestClassSqlScriptsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/BeforeTestClassSqlScriptsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,13 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.OVERRIDE;
 
+/**
+ * Verifies that {@link Sql @Sql} with {@link Sql.ExecutionPhase#BEFORE_TEST_CLASS} is run before all tests in the class
+ * have been run.
+ *
+ * @author Andreas Ahlenstorf
+ * @since 6.1
+ */
 @SpringJUnitConfig(classes = EmptyDatabaseConfig.class)
 @DirtiesContext
 @Sql(value = {"schema.sql", "data-add-catbert.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
@@ -51,9 +58,8 @@ class BeforeTestClassSqlScriptsTests extends AbstractTransactionalTests {
 	@Test
 	@Sql(scripts = {"data-add-catbert.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
 	void classLevelPhaseIsIgnoredOnMethod() {
-		// There's a unique constraint on the name. If the script succeeded, there would be a
+		// There is a unique constraint on the name. If the script had been run, there would have been a
 		// constraint violation.
 		assertUsers("Catbert");
 	}
 }
-

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/BeforeTestClassSqlScriptsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/BeforeTestClassSqlScriptsTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.OVERRIDE;
+
+@SpringJUnitConfig(classes = EmptyDatabaseConfig.class)
+@DirtiesContext
+@Sql(value = {"schema.sql", "data-add-catbert.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+class BeforeTestClassSqlScriptsTests extends AbstractTransactionalTests {
+
+	@Test
+	void classLevelScriptsHaveBeenRun() {
+		assertUsers("Catbert");
+	}
+
+	@Test
+	@Sql("data-add-dogbert.sql")
+	@SqlMergeMode(MERGE)
+	void mergeDoesNotAffectClassLevelPhase() {
+		assertUsers("Catbert", "Dogbert");
+	}
+
+	@Test
+	@Sql({"data-add-dogbert.sql"})
+	@SqlMergeMode(OVERRIDE)
+	void overrideDoesNotAffectClassLevelPhase() {
+		assertUsers("Dogbert", "Catbert");
+	}
+
+	@Test
+	@Sql(scripts = {"data-add-catbert.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+	void classLevelPhaseIsIgnoredOnMethod() {
+		// There's a unique constraint on the name. If the script succeeded, there would be a
+		// constraint violation.
+		assertUsers("Catbert");
+	}
+}
+

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListenerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListenerTests.java
@@ -56,6 +56,7 @@ class SqlScriptsTestExecutionListenerTests {
 	void missingValueAndScriptsAndStatementsAtMethodLevel() throws Exception {
 		Class<?> clazz = MissingValueAndScriptsAndStatementsAtMethodLevel.class;
 		BDDMockito.<Class<?>> given(testContext.getTestClass()).willReturn(clazz);
+		given(testContext.hasTestMethod()).willReturn(true);
 		given(testContext.getTestMethod()).willReturn(clazz.getDeclaredMethod("foo"));
 
 		assertExceptionContains(clazz.getSimpleName() + ".foo" + ".sql");

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListenerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListenerTests.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.TestContext;
 import org.springframework.test.context.jdbc.SqlConfig.TransactionMode;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.mock;
  * Unit tests for {@link SqlScriptsTestExecutionListener}.
  *
  * @author Sam Brannen
+ * @author Andreas Ahlenstorf
  * @since 4.1
  */
 class SqlScriptsTestExecutionListenerTests {
@@ -103,6 +105,30 @@ class SqlScriptsTestExecutionListenerTests {
 		assertExceptionContains("supply at least a DataSource or PlatformTransactionManager");
 	}
 
+	@Test
+	void beforeTestClassOnMethod() throws Exception {
+		Class<?> clazz = ClassLevelExecutionPhaseOnMethod.class;
+		BDDMockito.<Class<?>> given(testContext.getTestClass()).willReturn(clazz);
+		given(testContext.hasTestMethod()).willReturn(true);
+		given(testContext.getTestMethod()).willReturn(clazz.getDeclaredMethod("beforeTestClass"));
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> listener.beforeTestMethod(testContext))
+				.withMessage("BEFORE_TEST_CLASS cannot be used on methods");
+	}
+
+	@Test
+	void afterTestClassOnMethod() throws Exception {
+		Class<?> clazz = ClassLevelExecutionPhaseOnMethod.class;
+		BDDMockito.<Class<?>> given(testContext.getTestClass()).willReturn(clazz);
+		given(testContext.hasTestMethod()).willReturn(true);
+		given(testContext.getTestMethod()).willReturn(clazz.getDeclaredMethod("afterTestClass"));
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> listener.beforeTestMethod(testContext))
+				.withMessage("AFTER_TEST_CLASS cannot be used on methods");
+	}
+
 	private void assertExceptionContains(String msg) throws Exception {
 		assertThatIllegalStateException().isThrownBy(() ->
 				listener.beforeTestMethod(testContext))
@@ -147,4 +173,14 @@ class SqlScriptsTestExecutionListenerTests {
 		}
 	}
 
+	static class ClassLevelExecutionPhaseOnMethod {
+
+		@Sql(scripts = "foo.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+		public void beforeTestClass() {
+		}
+
+		@Sql(scripts = "foo.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_CLASS)
+		public void afterTestClass() {
+		}
+	}
 }


### PR DESCRIPTION
This PR is a proposal to address #18929.

So far, scripts or inline statements declared with `@Sql` run before or after every test method. It is not possible to declare a script or inline statement to be run once before any test method has been run or after all test methods have been run.

This PR makes it possible by adding two additional execution phases, `BEFORE_TEST_CLASS` and `AFTER_TEST_CLASS`. Scripts or inline statements with `BEFORE_TEST_CLASS` will be run once before any test method has been started. Anything marked with `AFTER_TEST_CLASS` will be run after all test methods have been completed.

#1835 added `MergeMode`. `MergeMode` allows method-level `@Sql` annotations to override or extend class-level `@Sql` annotations. In my proposal, `MergeMode` has no effect on `@Sql` annotations with an execution phase of `BEFORE_TEST_CLASS` or `AFTER_TEST_CLASS`. The reason is that any method-level processing would come too late to influence a script or inline statement that runs when the test context is being set up. Furthermore, it would pose the question how to resolve conflicting annotations. If one test method wished to override a class-level `BEFORE_TEST_CLASS` annotation while others would not, honoring that wish would effectively turn `BEFORE_TEST_CLASS` into `BEFORE_TEST_METHOD`. `AFTER_TEST_CLASS` has roughly the same problem, just backwards.
