### PR TITLE
Adding a hasAnyContributors() to CompositeUriComponentsContributor

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/support/CompositeUriComponentsContributor.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/CompositeUriComponentsContributor.java
@@ -93,6 +93,7 @@ public class CompositeUriComponentsContributor implements UriComponentsContribut
 	}
 
 	/**
+	 * Check if the list of contributors is empty or not.
 	 * @deprecated in favor of {@link #hasAnyContributors()} as the method name
 	 * is not compliant with its intention and returns 'true' when there are no contributors
 	 */

--- a/spring-web/src/main/java/org/springframework/web/method/support/CompositeUriComponentsContributor.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/CompositeUriComponentsContributor.java
@@ -36,6 +36,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  *
  * @author Rossen Stoyanchev
  * @author Juergen Hoeller
+ * @author Safeer Ansari
  * @since 4.0
  */
 public class CompositeUriComponentsContributor implements UriComponentsContributor {
@@ -91,9 +92,17 @@ public class CompositeUriComponentsContributor implements UriComponentsContribut
 		this.conversionService = (cs != null ? cs : new DefaultFormattingConversionService());
 	}
 
-
+	/**
+	 * @deprecated in favor of {@link #hasAnyContributors()} as the method name
+	 * is not compliant with its intention and returns 'true' when there are no contributors
+	 */
+	@Deprecated
 	public boolean hasContributors() {
 		return this.contributors.isEmpty();
+	}
+
+	public boolean hasAnyContributors() {
+		return !this.contributors.isEmpty();
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/web/method/support/CompositeUriComponentsContributorTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/support/CompositeUriComponentsContributorTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@link org.springframework.web.method.support.CompositeUriComponentsContributor}.
  *
  * @author Rossen Stoyanchev
+ * @author Safeer Ansari
  */
 public class CompositeUriComponentsContributorTests {
 
@@ -54,6 +55,8 @@ public class CompositeUriComponentsContributorTests {
 		assertThat(contributor.supportsParameter(new MethodParameter(method, 0))).isTrue();
 		assertThat(contributor.supportsParameter(new MethodParameter(method, 1))).isTrue();
 		assertThat(contributor.supportsParameter(new MethodParameter(method, 2))).isFalse();
+		assertThat(contributor.hasContributors()).isFalse();
+		assertThat(contributor.hasAnyContributors()).isTrue();
 	}
 
 


### PR DESCRIPTION
In this commit, a method `hasContributors` has been deprecated as its name isn't compliant with its intention. The method returns `true` when there are no contributors available. A new method has been added, named `hasAnyContributors` that returns the value expected of its name.

Closes #27275