### PR TITLE
Fix duplicated "the" occurrences in Javadoc and XSD

### DIFF
--- a/spring-core/src/main/java/org/springframework/asm/RecordComponentWriter.java
+++ b/spring-core/src/main/java/org/springframework/asm/RecordComponentWriter.java
@@ -37,7 +37,7 @@ final class RecordComponentWriter extends RecordComponentVisitor {
   /** The name_index field of the Record attribute. */
   private final int nameIndex;
 
-  /** The descriptor_index field of the the Record attribute. */
+  /** The descriptor_index field of the Record attribute. */
   private final int descriptorIndex;
 
   /**

--- a/spring-core/src/main/java/org/springframework/cglib/core/KeyFactory.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/KeyFactory.java
@@ -28,7 +28,7 @@ import org.springframework.cglib.core.internal.CustomizerRegistry;
 
 /**
  * Generates classes to handle multi-valued keys, for use in things such as Maps and Sets.
- * Code for <code>equals</code> and <code>hashCode</code> methods follow the
+ * Code for <code>equals</code> and <code>hashCode</code> methods follow
  * the rules laid out in <i>Effective Java</i> by Joshua Bloch.
  * <p>
  * To generate a <code>KeyFactory</code>, you need to supply an interface which

--- a/spring-core/src/main/java/org/springframework/util/ConcurrentLruCache.java
+++ b/spring-core/src/main/java/org/springframework/util/ConcurrentLruCache.java
@@ -174,7 +174,7 @@ public class ConcurrentLruCache<K, V> {
 	}
 
 	/**
-	 * Return the the maximum number of entries in the cache
+	 * Return the maximum number of entries in the cache
 	 * (0 indicates no caching, always generating a new value).
 	 * @see #size()
 	 */

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/config/AbstractMessageBrokerConfiguration.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/config/AbstractMessageBrokerConfiguration.java
@@ -82,7 +82,7 @@ import org.springframework.validation.Validator;
  * <li>{@link #userDestinationMessageHandler}</li>
  * </ul>
  *
- * <p>{@link #brokerChannel} delivers messages from within the application to the
+ * <p>{@link #brokerChannel} delivers messages from within the application to
  * the respective message handlers. {@link #brokerMessagingTemplate} can be injected
  * into any application component to send messages.
  *

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractDatabaseClientIntegrationTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractDatabaseClientIntegrationTests.java
@@ -59,7 +59,7 @@ public abstract class AbstractDatabaseClientIntegrationTests {
 	protected abstract ConnectionFactory createConnectionFactory();
 
 	/**
-	 * Return the the CREATE TABLE statement for table {@code legoset} with the following
+	 * Return the CREATE TABLE statement for table {@code legoset} with the following
 	 * three columns:
 	 * <ul>
 	 * <li>id integer (primary key), not null</li>

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractTransactionalDatabaseClientIntegrationTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractTransactionalDatabaseClientIntegrationTests.java
@@ -89,7 +89,7 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests  {
 	protected abstract ConnectionFactory createConnectionFactory();
 
 	/**
-	 * Return the the CREATE TABLE statement for table {@code legoset} with the following three columns:
+	 * Return the CREATE TABLE statement for table {@code legoset} with the following three columns:
 	 * <ul>
 	 * <li>id integer (primary key), not null</li>
 	 * <li>name varchar(255), nullable</li>

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/HandshakeInfo.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/HandshakeInfo.java
@@ -77,7 +77,7 @@ public class HandshakeInfo {
 	}
 
 	/**
-	 * Constructor targeting server-side use with extra information such as the
+	 * Constructor targeting server-side use with extra information such as
 	 * the remote address, attributes, and a log prefix.
 	 * @param uri the endpoint URL
 	 * @param headers server request headers

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java
@@ -87,7 +87,7 @@ public class PatternsRequestCondition extends AbstractRequestCondition<PatternsR
 	 * Variant of {@link #PatternsRequestCondition(String...)} with a
 	 * {@link UrlPathHelper} and a {@link PathMatcher}, and whether to match
 	 * trailing slashes.
-	 * <p>As of 5.3 the the path is obtained through the static method
+	 * <p>As of 5.3 the path is obtained through the static method
 	 * {@link UrlPathHelper#getResolvedLookupPath} and a {@code UrlPathHelper}
 	 * does not need to be passed in.
 	 * @since 5.2.4
@@ -105,7 +105,7 @@ public class PatternsRequestCondition extends AbstractRequestCondition<PatternsR
 	 * Variant of {@link #PatternsRequestCondition(String...)} with a
 	 * {@link UrlPathHelper} and a {@link PathMatcher}, and flags for matching
 	 * with suffixes and trailing slashes.
-	 * <p>As of 5.3 the the path is obtained through the static method
+	 * <p>As of 5.3 the path is obtained through the static method
 	 * {@link UrlPathHelper#getResolvedLookupPath} and a {@code UrlPathHelper}
 	 * does not need to be passed in.
 	 * @deprecated as of 5.2.4. See class-level note in
@@ -123,7 +123,7 @@ public class PatternsRequestCondition extends AbstractRequestCondition<PatternsR
 	 * Variant of {@link #PatternsRequestCondition(String...)} with a
 	 * {@link UrlPathHelper} and a {@link PathMatcher}, and flags for matching
 	 * with suffixes and trailing slashes, along with specific extensions.
-	 * <p>As of 5.3 the the path is obtained through the static method
+	 * <p>As of 5.3 the path is obtained through the static method
 	 * {@link UrlPathHelper#getResolvedLookupPath} and a {@code UrlPathHelper}
 	 * does not need to be passed in.
 	 * @deprecated as of 5.2.4. See class-level note in

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfo.java
@@ -47,7 +47,7 @@ import org.springframework.web.util.pattern.PathPattern;
 import org.springframework.web.util.pattern.PathPatternParser;
 
 /**
- * Request mapping information. A composite for the the following conditions:
+ * Request mapping information. A composite for the following conditions:
  * <ol>
  * <li>{@link PathPatternsRequestCondition} with parsed {@code PathPatterns} or
  * {@link PatternsRequestCondition} with String patterns via {@code PathMatcher}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletInvocableHandlerMethod.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletInvocableHandlerMethod.java
@@ -194,7 +194,7 @@ public class ServletInvocableHandlerMethod extends InvocableHandlerMethod {
 	}
 
 	/**
-	 * Create a nested ServletInvocableHandlerMethod subclass that returns the
+	 * Create a nested ServletInvocableHandlerMethod subclass that returns
 	 * the given value (or raises an Exception if the value is one) rather than
 	 * actually invoking the controller method. This is useful when processing
 	 * async return values (e.g. Callable, DeferredResult, ListenableFuture).

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
@@ -106,7 +106,7 @@ public class SockJsServiceRegistration {
 	 * also be set to point to a URL served by the application.
 	 * <p>Note that it's possible to specify a relative URL in which case the URL
 	 * must be relative to the iframe URL. For example assuming a SockJS endpoint
-	 * mapped to "/sockjs", and resulting iframe URL "/sockjs/iframe.html", then the
+	 * mapped to "/sockjs", and resulting iframe URL "/sockjs/iframe.html",
 	 * the relative URL must start with "../../" to traverse up to the location
 	 * above the SockJS mapping. In case of a prefix-based Servlet mapping one more
 	 * traversal may be needed.

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
@@ -153,7 +153,7 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 	 * However, it can also be set to point to a URL served by the application.
 	 * <p>Note that it's possible to specify a relative URL in which case the URL
 	 * must be relative to the iframe URL. For example assuming a SockJS endpoint
-	 * mapped to "/sockjs", and resulting iframe URL "/sockjs/iframe.html", then the
+	 * mapped to "/sockjs", and resulting iframe URL "/sockjs/iframe.html", then
 	 * the relative URL must start with "../../" to traverse up to the location
 	 * above the SockJS mapping. In case of a prefix-based Servlet mapping one more
 	 * traversal may be needed.

--- a/spring-websocket/src/main/resources/org/springframework/web/socket/config/spring-websocket.xsd
+++ b/spring-websocket/src/main/resources/org/springframework/web/socket/config/spring-websocket.xsd
@@ -141,8 +141,8 @@
 
 	Note that it's possible to specify a relative URL in which case the URL
 	must be relative to the iframe URL. For example assuming a SockJS endpoint
-	mapped to "/sockjs", and resulting iframe URL "/sockjs/iframe.html", then the
-	The relative URL must start with "../../" to traverse up to the location
+	mapped to "/sockjs", and resulting iframe URL "/sockjs/iframe.html", then
+	the relative URL must start with "../../" to traverse up to the location
 	above the SockJS mapping. In case of a prefix-based Servlet mapping one more
 	traversal may be needed.
                 ]]></xsd:documentation>


### PR DESCRIPTION
This PR fixes typos of "the the" to "the".