### PR TITLE
Fix UrlPathHelper#shouldRemoveSemicolonContent()

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -147,7 +147,6 @@ public class UrlPathHelper {
 	 * Whether configured to remove ";" (semicolon) content from the request URI.
 	 */
 	public boolean shouldRemoveSemicolonContent() {
-		checkReadOnly();
 		return this.removeSemicolonContent;
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Unit tests for {@link UrlPathHelper}.
@@ -163,6 +164,11 @@ public class UrlPathHelperTests {
 		request.setRequestURI("/petclinic;a=b/welcome.html;c=d");
 
 		assertThat(helper.getLookupPathForRequest(request)).isEqualTo("/welcome.html;c=d");
+	}
+
+	@Test // gh-27303
+	public void shouldRemoveSemicolonContentWithReadOnlyInstance() {
+		assertThatCode(UrlPathHelper.defaultInstance::shouldRemoveSemicolonContent).doesNotThrowAnyException();
 	}
 
 


### PR DESCRIPTION
Fixes #27256

This PR fixes a bug that renders read-only `UrlPathHelper`s unusable, because `shouldRemoveSemicolonContent()` throws an exception. For example, when using `UrlPathHelper#rawPathInstance`, which is read-only.

The `checkReadOnly()` method should only be called from methods that modify properties to prevent modification of read-only instances.