### PR TITLE
Propagate `CoroutineContext` in reactive transaction

### DIFF
--- a/spring-tx/src/main/kotlin/org/springframework/transaction/reactive/TransactionalOperatorExtensions.kt
+++ b/spring-tx/src/main/kotlin/org/springframework/transaction/reactive/TransactionalOperatorExtensions.kt
@@ -1,13 +1,33 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.transaction.reactive
 
-import java.util.Optional
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitLast
 import kotlinx.coroutines.reactor.asFlux
 import kotlinx.coroutines.reactor.mono
 import org.springframework.transaction.ReactiveTransaction
+import java.util.Optional
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.coroutineContext
 
 /**
  * Coroutines variant of [TransactionalOperator.transactional] as a [Flow] extension.
@@ -15,17 +35,22 @@ import org.springframework.transaction.ReactiveTransaction
  * @author Sebastien Deleuze
  * @since 5.2
  */
-fun <T : Any> Flow<T>.transactional(operator: TransactionalOperator): Flow<T> =
-		operator.transactional(asFlux()).asFlow()
+fun <T : Any> Flow<T>.transactional(
+	operator: TransactionalOperator,
+	context: CoroutineContext = EmptyCoroutineContext
+): Flow<T> =
+	operator.transactional(asFlux(context)).asFlow()
 
 /**
-* Coroutines variant of [TransactionalOperator.execute] with a suspending lambda
-* parameter.
-*
-* @author Sebastien Deleuze
-* @author Mark Paluch
-* @since 5.2
-*/
-suspend fun <T : Any> TransactionalOperator.executeAndAwait(f: suspend (ReactiveTransaction) -> T?): T? =
-		execute { status -> mono(Dispatchers.Unconfined) { f(status) } }.map { value -> Optional.of(value) }
-				.defaultIfEmpty(Optional.empty()).awaitLast().orElse(null)
+ * Coroutines variant of [TransactionalOperator.execute] with a suspending lambda
+ * parameter.
+ *
+ * @author Sebastien Deleuze
+ * @author Mark Paluch
+ * @since 5.2
+ */
+suspend fun <T> TransactionalOperator.executeAndAwait(f: suspend (ReactiveTransaction) -> T): T {
+	val ctx = Dispatchers.Unconfined + coroutineContext.minusKey(Job)
+	return execute { status -> mono(ctx) { f(status) } }.map { value -> Optional.of(value!!) }
+		.defaultIfEmpty(Optional.empty()).awaitLast().orElse(null)
+}

--- a/spring-tx/src/test/kotlin/org/springframework/transaction/reactive/TransactionalOperatorExtensionsTests.kt
+++ b/spring-tx/src/test/kotlin/org/springframework/transaction/reactive/TransactionalOperatorExtensionsTests.kt
@@ -16,6 +16,7 @@
 
 package org.springframework.transaction.reactive
 
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
@@ -24,6 +25,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.springframework.transaction.support.DefaultTransactionDefinition
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
 
 class TransactionalOperatorExtensionsTests {
 
@@ -107,4 +110,49 @@ class TransactionalOperatorExtensionsTests {
 			}
 		}
 	}
+
+	@Test
+	fun coroutineContextWithSuspendingFunction() {
+		val operator = TransactionalOperator.create(tm, DefaultTransactionDefinition())
+		runBlocking(User(role = "admin")) {
+			try {
+				operator.executeAndAwait {
+					delay(1)
+					val currentUser = currentCoroutineContext()[User]
+					assertThat(currentUser).isNotNull()
+					assertThat(currentUser!!.role).isEqualTo("admin")
+					throw IllegalStateException()
+				}
+			} catch (e: IllegalStateException) {
+				assertThat(tm.commit).isFalse()
+				assertThat(tm.rollback).isTrue()
+				return@runBlocking
+			}
+		}
+	}
+
+	@Test
+	fun coroutineContextWithFlow() {
+		val operator = TransactionalOperator.create(tm, DefaultTransactionDefinition())
+		val flow = flow<Int> {
+			delay(1)
+			val currentUser = currentCoroutineContext()[User]
+			assertThat(currentUser).isNotNull()
+			assertThat(currentUser!!.role).isEqualTo("admin")
+			throw IllegalStateException()
+		}
+		runBlocking(User(role = "admin")) {
+			try {
+				flow.transactional(operator, coroutineContext).toList()
+			} catch (e: IllegalStateException) {
+				assertThat(tm.commit).isFalse()
+				assertThat(tm.rollback).isTrue()
+				return@runBlocking
+			}
+		}
+	}
+}
+
+private data class User(val role: String) : AbstractCoroutineContextElement(User) {
+	companion object Key : CoroutineContext.Key<User>
 }


### PR DESCRIPTION
#### Motivation:
* Fixes #27307 

#### Modifications:
* Propagate caller's `CoroutineContext` when converting coroutines into `Mono`.
  - In `CoroutinesUtils#invokeSuspendingFunction`
  - In `TransactionalOperatorExtensions`
    + `Flow<T>.transactional(...)`
    + `TransactionalOperator.executeAndAwait(...)`
* Change `TransactionalOperator.executeAndAwait(...)`'s type parameter upper bound from `Any` to `Any?`
  - For better usability.