### PR TITLE
Support `TimeUnit` in the `@Scheduled` annotation

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -16,13 +16,13 @@
 
 package org.springframework.scheduling.annotation;
 
-import java.util.concurrent.TimeUnit;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
@@ -120,12 +120,6 @@ public @interface Scheduled {
 	String fixedDelayString() default "";
 
 	/**
-	 * Specify the {@link TimeUnit} to use for the fixedDelay and the fixedDelayString values.
-	 * @return the {@link TimeUnit}, by default milliseconds will be used.
-	 */
-	TimeUnit fixedDelayTimeUnit() default TimeUnit.MILLISECONDS;
-
-	/**
 	 * Execute the annotated method with a fixed period between
 	 * invocations.
 	 * Using milliseconds by default with fixedRateTimeUnit().
@@ -142,12 +136,6 @@ public @interface Scheduled {
 	 * @since 3.2.2
 	 */
 	String fixedRateString() default "";
-
-	/**
-	 * Specify the {@link TimeUnit} to use for the fixedRate and the fixedRateString values.
-	 * @return the {@link TimeUnit}, by default milliseconds will be used.
-	 */
-	TimeUnit fixedRateTimeUnit() default TimeUnit.MILLISECONDS;
 
 	/**
 	 * Number to delay before the first execution of a
@@ -169,9 +157,9 @@ public @interface Scheduled {
 	String initialDelayString() default "";
 
 	/**
-	 * Specify the {@link TimeUnit} to use for the initialDelay and the initialDelayString values.
+	 * Specify the {@link TimeUnit} to use for initialDelay, fixedRate and fixedDelay values.
 	 * @return the {@link TimeUnit}, by default milliseconds will be used.
 	 */
-	TimeUnit initialDelayTimeUnit() default TimeUnit.MILLISECONDS;
+	TimeUnit timeUnit() default TimeUnit.MILLISECONDS;
 
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -104,7 +104,7 @@ public @interface Scheduled {
 	/**
 	 * Execute the annotated method with a fixed period between the
 	 * end of the last invocation and the start of the next.
-	 * Using milliseconds by default with fixedDelayTimeUnit().
+	 * Using milliseconds by default with timeUnit().
 	 * @return the delay
 	 */
 	long fixedDelay() default -1;
@@ -122,7 +122,7 @@ public @interface Scheduled {
 	/**
 	 * Execute the annotated method with a fixed period between
 	 * invocations.
-	 * Using milliseconds by default with fixedRateTimeUnit().
+	 * Using milliseconds by default with timeUnit().
 	 * @return the period
 	 */
 	long fixedRate() default -1;
@@ -140,7 +140,7 @@ public @interface Scheduled {
 	/**
 	 * Number to delay before the first execution of a
 	 * {@link #fixedRate} or {@link #fixedDelay} task.
-	 * Using milliseconds by default with initialDelayTimeUnit().
+	 * Using milliseconds by default with timeUnit().
 	 * @return the initial
 	 * @since 3.2
 	 */

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -16,14 +16,10 @@
 
 package org.springframework.scheduling.annotation;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+import java.lang.annotation.*;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Annotation that marks a method to be scheduled. Exactly one of the
@@ -101,52 +97,76 @@ public @interface Scheduled {
 	String zone() default "";
 
 	/**
-	 * Execute the annotated method with a fixed period in milliseconds between the
+	 * Execute the annotated method with a fixed period between the
 	 * end of the last invocation and the start of the next.
-	 * @return the delay in milliseconds
+	 * Using milliseconds by default with fixedDelayTimeUnit().
+	 * @return the delay
 	 */
 	long fixedDelay() default -1;
 
 	/**
-	 * Execute the annotated method with a fixed period in milliseconds between the
+	 * Execute the annotated method with a fixed period between the
 	 * end of the last invocation and the start of the next.
-	 * @return the delay in milliseconds as a String value, e.g. a placeholder
+	 * Using milliseconds by default with fixedDelayTimeUnit().
+	 * @return the delay as a String value, e.g. a placeholder
 	 * or a {@link java.time.Duration#parse java.time.Duration} compliant value
 	 * @since 3.2.2
 	 */
 	String fixedDelayString() default "";
 
 	/**
-	 * Execute the annotated method with a fixed period in milliseconds between
+	 * Specify the {@link TimeUnit} to use for the fixedDelay and the fixedDelayString values.
+	 * @return the {@link TimeUnit}, by default milliseconds will be used.
+	 */
+	TimeUnit fixedDelayTimeUnit() default TimeUnit.MILLISECONDS;
+
+	/**
+	 * Execute the annotated method with a fixed period between
 	 * invocations.
-	 * @return the period in milliseconds
+	 * Using milliseconds by default with fixedRateTimeUnit().
+	 * @return the period
 	 */
 	long fixedRate() default -1;
 
 	/**
-	 * Execute the annotated method with a fixed period in milliseconds between
+	 * Execute the annotated method with a fixed period between
 	 * invocations.
-	 * @return the period in milliseconds as a String value, e.g. a placeholder
+	 * Using milliseconds by default with fixedRateTimeUnit().
+	 * @return the period as a String value, e.g. a placeholder
 	 * or a {@link java.time.Duration#parse java.time.Duration} compliant value
 	 * @since 3.2.2
 	 */
 	String fixedRateString() default "";
 
 	/**
-	 * Number of milliseconds to delay before the first execution of a
+	 * Specify the {@link TimeUnit} to use for the fixedRate and the fixedRateString values.
+	 * @return the {@link TimeUnit}, by default milliseconds will be used.
+	 */
+	TimeUnit fixedRateTimeUnit() default TimeUnit.MILLISECONDS;
+
+	/**
+	 * Number to delay before the first execution of a
 	 * {@link #fixedRate} or {@link #fixedDelay} task.
-	 * @return the initial delay in milliseconds
+	 * Using milliseconds by default with initialDelayTimeUnit().
+	 * @return the initial
 	 * @since 3.2
 	 */
 	long initialDelay() default -1;
 
 	/**
-	 * Number of milliseconds to delay before the first execution of a
+	 * Number to delay before the first execution of a
 	 * {@link #fixedRate} or {@link #fixedDelay} task.
+	 * Using milliseconds by default with initialDelayTimeUnit().
 	 * @return the initial delay in milliseconds as a String value, e.g. a placeholder
 	 * or a {@link java.time.Duration#parse java.time.Duration} compliant value
 	 * @since 3.2.2
 	 */
 	String initialDelayString() default "";
+
+	/**
+	 * Specify the {@link TimeUnit} to use for the initialDelay and the initialDelayString values.
+	 * @return the {@link TimeUnit}, by default milliseconds will be used.
+	 */
+	TimeUnit initialDelayTimeUnit() default TimeUnit.MILLISECONDS;
 
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -22,7 +22,9 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
 
+import org.joda.time.DateTimeUtils;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
 /**
@@ -101,52 +103,76 @@ public @interface Scheduled {
 	String zone() default "";
 
 	/**
-	 * Execute the annotated method with a fixed period in milliseconds between the
+	 * Execute the annotated method with a fixed period between the
 	 * end of the last invocation and the start of the next.
-	 * @return the delay in milliseconds
+	 * Using milliseconds by default with fixedDelayTimeUnit().
+	 * @return the delay
 	 */
 	long fixedDelay() default -1;
 
 	/**
-	 * Execute the annotated method with a fixed period in milliseconds between the
+	 * Execute the annotated method with a fixed period between the
 	 * end of the last invocation and the start of the next.
-	 * @return the delay in milliseconds as a String value, e.g. a placeholder
+	 * Using milliseconds by default with fixedDelayTimeUnit().
+	 * @return the delay as a String value, e.g. a placeholder
 	 * or a {@link java.time.Duration#parse java.time.Duration} compliant value
 	 * @since 3.2.2
 	 */
 	String fixedDelayString() default "";
 
 	/**
-	 * Execute the annotated method with a fixed period in milliseconds between
+	 * Specify the {@link TimeUnit} to use for the fixedDelay and the fixedDelayString values.
+	 * @return the {@link TimeUnit}, by default milliseconds will be used.
+	 */
+	TimeUnit fixedDelayTimeUnit() default TimeUnit.MILLISECONDS;
+
+	/**
+	 * Execute the annotated method with a fixed period between
 	 * invocations.
-	 * @return the period in milliseconds
+	 * Using milliseconds by default with fixedRateTimeUnit().
+	 * @return the period
 	 */
 	long fixedRate() default -1;
 
 	/**
-	 * Execute the annotated method with a fixed period in milliseconds between
+	 * Execute the annotated method with a fixed period between
 	 * invocations.
-	 * @return the period in milliseconds as a String value, e.g. a placeholder
+	 * Using milliseconds by default with fixedRateTimeUnit().
+	 * @return the period as a String value, e.g. a placeholder
 	 * or a {@link java.time.Duration#parse java.time.Duration} compliant value
 	 * @since 3.2.2
 	 */
 	String fixedRateString() default "";
 
 	/**
-	 * Number of milliseconds to delay before the first execution of a
+	 * Specify the {@link TimeUnit} to use for the fixedRate and the fixedRateString values.
+	 * @return the {@link TimeUnit}, by default milliseconds will be used.
+	 */
+	TimeUnit fixedRateTimeUnit() default TimeUnit.MILLISECONDS;
+
+	/**
+	 * Number to delay before the first execution of a
 	 * {@link #fixedRate} or {@link #fixedDelay} task.
-	 * @return the initial delay in milliseconds
+	 * Using milliseconds by default with initialDelayTimeUnit().
+	 * @return the initial
 	 * @since 3.2
 	 */
 	long initialDelay() default -1;
 
 	/**
-	 * Number of milliseconds to delay before the first execution of a
+	 * Number to delay before the first execution of a
 	 * {@link #fixedRate} or {@link #fixedDelay} task.
+	 * Using milliseconds by default with initialDelayTimeUnit().
 	 * @return the initial delay in milliseconds as a String value, e.g. a placeholder
 	 * or a {@link java.time.Duration#parse java.time.Duration} compliant value
 	 * @since 3.2.2
 	 */
 	String initialDelayString() default "";
+
+	/**
+	 * Specify the {@link TimeUnit} to use for the initialDelay and the initialDelayString values.
+	 * @return the {@link TimeUnit}, by default milliseconds will be used.
+	 */
+	TimeUnit initialDelayTimeUnit() default TimeUnit.MILLISECONDS;
 
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -76,6 +76,7 @@ import org.springframework.scheduling.support.ScheduledMethodRunnable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
+
 /**
  * Bean post-processor that registers methods annotated with @{@link Scheduled}
  * to be invoked by a {@link org.springframework.scheduling.TaskScheduler} according
@@ -398,7 +399,7 @@ public class ScheduledAnnotationBeanPostProcessor
 			Set<ScheduledTask> tasks = new LinkedHashSet<>(4);
 
 			// Determine initial delay
-			long initialDelay = TimeUnit.MILLISECONDS.convert(scheduled.initialDelay(), scheduled.initialDelayTimeUnit());
+			long initialDelay = TimeUnit.MILLISECONDS.convert(scheduled.initialDelay(), scheduled.timeUnit());
 			String initialDelayString = scheduled.initialDelayString();
 			if (StringUtils.hasText(initialDelayString)) {
 				Assert.isTrue(initialDelay < 0, "Specify 'initialDelay' or 'initialDelayString', not both");
@@ -407,7 +408,7 @@ public class ScheduledAnnotationBeanPostProcessor
 				}
 				if (StringUtils.hasLength(initialDelayString)) {
 					try {
-						initialDelay = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(initialDelayString), scheduled.initialDelayTimeUnit());
+						initialDelay = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(initialDelayString), scheduled.timeUnit());
 					}
 					catch (RuntimeException ex) {
 						throw new IllegalArgumentException(
@@ -446,7 +447,7 @@ public class ScheduledAnnotationBeanPostProcessor
 			}
 
 			// Check fixed delay
-			long fixedDelay = TimeUnit.MILLISECONDS.convert(scheduled.fixedDelay(), scheduled.fixedDelayTimeUnit());
+			long fixedDelay = TimeUnit.MILLISECONDS.convert(scheduled.fixedDelay(), scheduled.timeUnit());
 			if (fixedDelay >= 0) {
 				Assert.isTrue(!processedSchedule, errorMessage);
 				processedSchedule = true;
@@ -462,7 +463,7 @@ public class ScheduledAnnotationBeanPostProcessor
 					Assert.isTrue(!processedSchedule, errorMessage);
 					processedSchedule = true;
 					try {
-						fixedDelay = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(fixedDelayString), scheduled.fixedDelayTimeUnit());
+						fixedDelay = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(fixedDelayString), scheduled.timeUnit());
 					}
 					catch (RuntimeException ex) {
 						throw new IllegalArgumentException(
@@ -473,7 +474,7 @@ public class ScheduledAnnotationBeanPostProcessor
 			}
 
 			// Check fixed rate
-			long fixedRate = TimeUnit.MILLISECONDS.convert(scheduled.fixedRate(), scheduled.fixedRateTimeUnit());
+			long fixedRate = TimeUnit.MILLISECONDS.convert(scheduled.fixedRate(), scheduled.timeUnit());
 			if (fixedRate >= 0) {
 				Assert.isTrue(!processedSchedule, errorMessage);
 				processedSchedule = true;
@@ -488,7 +489,7 @@ public class ScheduledAnnotationBeanPostProcessor
 					Assert.isTrue(!processedSchedule, errorMessage);
 					processedSchedule = true;
 					try {
-						fixedRate = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(fixedRateString), scheduled.fixedRateTimeUnit());
+						fixedRate = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(fixedRateString), scheduled.timeUnit());
 					}
 					catch (RuntimeException ex) {
 						throw new IllegalArgumentException(

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -397,7 +398,7 @@ public class ScheduledAnnotationBeanPostProcessor
 			Set<ScheduledTask> tasks = new LinkedHashSet<>(4);
 
 			// Determine initial delay
-			long initialDelay = scheduled.initialDelayTimeUnit().toMillis(1) * scheduled.initialDelay();
+			long initialDelay = TimeUnit.MILLISECONDS.convert(scheduled.initialDelay(), scheduled.initialDelayTimeUnit());
 			String initialDelayString = scheduled.initialDelayString();
 			if (StringUtils.hasText(initialDelayString)) {
 				Assert.isTrue(initialDelay < 0, "Specify 'initialDelay' or 'initialDelayString', not both");
@@ -406,7 +407,7 @@ public class ScheduledAnnotationBeanPostProcessor
 				}
 				if (StringUtils.hasLength(initialDelayString)) {
 					try {
-						initialDelay = scheduled.initialDelayTimeUnit().toMillis(1) * parseDelayAsLong(initialDelayString);
+						initialDelay = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(initialDelayString), scheduled.initialDelayTimeUnit());
 					}
 					catch (RuntimeException ex) {
 						throw new IllegalArgumentException(
@@ -445,7 +446,7 @@ public class ScheduledAnnotationBeanPostProcessor
 			}
 
 			// Check fixed delay
-			long fixedDelay = scheduled.fixedDelayTimeUnit().toMillis(1) * scheduled.fixedDelay();
+			long fixedDelay = TimeUnit.MILLISECONDS.convert(scheduled.fixedDelay(), scheduled.fixedDelayTimeUnit());
 			if (fixedDelay >= 0) {
 				Assert.isTrue(!processedSchedule, errorMessage);
 				processedSchedule = true;
@@ -461,7 +462,7 @@ public class ScheduledAnnotationBeanPostProcessor
 					Assert.isTrue(!processedSchedule, errorMessage);
 					processedSchedule = true;
 					try {
-						fixedDelay = scheduled.fixedDelayTimeUnit().toMillis(1) * parseDelayAsLong(fixedDelayString);
+						fixedDelay = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(fixedDelayString), scheduled.fixedDelayTimeUnit());
 					}
 					catch (RuntimeException ex) {
 						throw new IllegalArgumentException(
@@ -472,7 +473,7 @@ public class ScheduledAnnotationBeanPostProcessor
 			}
 
 			// Check fixed rate
-			long fixedRate = scheduled.fixedRateTimeUnit().toMillis(1) * scheduled.fixedRate();
+			long fixedRate = TimeUnit.MILLISECONDS.convert(scheduled.fixedRate(), scheduled.fixedRateTimeUnit());
 			if (fixedRate >= 0) {
 				Assert.isTrue(!processedSchedule, errorMessage);
 				processedSchedule = true;
@@ -487,7 +488,7 @@ public class ScheduledAnnotationBeanPostProcessor
 					Assert.isTrue(!processedSchedule, errorMessage);
 					processedSchedule = true;
 					try {
-						fixedRate = scheduled.fixedRateTimeUnit().toMillis(1) * parseDelayAsLong(fixedRateString);
+						fixedRate = TimeUnit.MILLISECONDS.convert(parseDelayAsLong(fixedRateString), scheduled.fixedRateTimeUnit());
 					}
 					catch (RuntimeException ex) {
 						throw new IllegalArgumentException(

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -108,6 +109,62 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 	}
 
 	@Test
+	public void fixedDelayWithSecondsTimeUnitTask() {
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(FixedDelayWithSecondsTimeUnitTestBean.class);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+
+		ScheduledTaskHolder postProcessor = context.getBean("postProcessor", ScheduledTaskHolder.class);
+		assertThat(postProcessor.getScheduledTasks().size()).isEqualTo(1);
+
+		Object target = context.getBean("target");
+		ScheduledTaskRegistrar registrar = (ScheduledTaskRegistrar)
+				new DirectFieldAccessor(postProcessor).getPropertyValue("registrar");
+		@SuppressWarnings("unchecked")
+		List<IntervalTask> fixedDelayTasks = (List<IntervalTask>)
+				new DirectFieldAccessor(registrar).getPropertyValue("fixedDelayTasks");
+		assertThat(fixedDelayTasks.size()).isEqualTo(1);
+		IntervalTask task = fixedDelayTasks.get(0);
+		ScheduledMethodRunnable runnable = (ScheduledMethodRunnable) task.getRunnable();
+		Object targetObject = runnable.getTarget();
+		Method targetMethod = runnable.getMethod();
+		assertThat(targetObject).isEqualTo(target);
+		assertThat(targetMethod.getName()).isEqualTo("fixedDelay");
+		assertThat(task.getInitialDelay()).isEqualTo(0L);
+		assertThat(task.getInterval()).isEqualTo(5000L);
+	}
+
+	@Test
+	public void fixedDelayWithMinutesTimeUnitTask() {
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(FixedDelayWithMinutesTimeUnitTestBean.class);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+
+		ScheduledTaskHolder postProcessor = context.getBean("postProcessor", ScheduledTaskHolder.class);
+		assertThat(postProcessor.getScheduledTasks().size()).isEqualTo(1);
+
+		Object target = context.getBean("target");
+		ScheduledTaskRegistrar registrar = (ScheduledTaskRegistrar)
+				new DirectFieldAccessor(postProcessor).getPropertyValue("registrar");
+		@SuppressWarnings("unchecked")
+		List<IntervalTask> fixedDelayTasks = (List<IntervalTask>)
+				new DirectFieldAccessor(registrar).getPropertyValue("fixedDelayTasks");
+		assertThat(fixedDelayTasks.size()).isEqualTo(1);
+		IntervalTask task = fixedDelayTasks.get(0);
+		ScheduledMethodRunnable runnable = (ScheduledMethodRunnable) task.getRunnable();
+		Object targetObject = runnable.getTarget();
+		Method targetMethod = runnable.getMethod();
+		assertThat(targetObject).isEqualTo(target);
+		assertThat(targetMethod.getName()).isEqualTo("fixedDelay");
+		assertThat(task.getInitialDelay()).isEqualTo(0L);
+		assertThat(task.getInterval()).isEqualTo(180000L);
+	}
+
+	@Test
 	public void fixedRateTask() {
 		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
 		BeanDefinition targetDefinition = new RootBeanDefinition(FixedRateTestBean.class);
@@ -136,6 +193,62 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 	}
 
 	@Test
+	public void fixedRateWithSecondsTimeUnitTask() {
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(FixedRateWithSecondsTimeUnitTestBean.class);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+
+		ScheduledTaskHolder postProcessor = context.getBean("postProcessor", ScheduledTaskHolder.class);
+		assertThat(postProcessor.getScheduledTasks().size()).isEqualTo(1);
+
+		Object target = context.getBean("target");
+		ScheduledTaskRegistrar registrar = (ScheduledTaskRegistrar)
+				new DirectFieldAccessor(postProcessor).getPropertyValue("registrar");
+		@SuppressWarnings("unchecked")
+		List<IntervalTask> fixedRateTasks = (List<IntervalTask>)
+				new DirectFieldAccessor(registrar).getPropertyValue("fixedRateTasks");
+		assertThat(fixedRateTasks.size()).isEqualTo(1);
+		IntervalTask task = fixedRateTasks.get(0);
+		ScheduledMethodRunnable runnable = (ScheduledMethodRunnable) task.getRunnable();
+		Object targetObject = runnable.getTarget();
+		Method targetMethod = runnable.getMethod();
+		assertThat(targetObject).isEqualTo(target);
+		assertThat(targetMethod.getName()).isEqualTo("fixedRate");
+		assertThat(task.getInitialDelay()).isEqualTo(0L);
+		assertThat(task.getInterval()).isEqualTo(5000L);
+	}
+
+	@Test
+	public void fixedRateWithMinutesTimeUnitTask() {
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(FixedRateWithMinutesTimeUnitTestBean.class);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+
+		ScheduledTaskHolder postProcessor = context.getBean("postProcessor", ScheduledTaskHolder.class);
+		assertThat(postProcessor.getScheduledTasks().size()).isEqualTo(1);
+
+		Object target = context.getBean("target");
+		ScheduledTaskRegistrar registrar = (ScheduledTaskRegistrar)
+				new DirectFieldAccessor(postProcessor).getPropertyValue("registrar");
+		@SuppressWarnings("unchecked")
+		List<IntervalTask> fixedRateTasks = (List<IntervalTask>)
+				new DirectFieldAccessor(registrar).getPropertyValue("fixedRateTasks");
+		assertThat(fixedRateTasks.size()).isEqualTo(1);
+		IntervalTask task = fixedRateTasks.get(0);
+		ScheduledMethodRunnable runnable = (ScheduledMethodRunnable) task.getRunnable();
+		Object targetObject = runnable.getTarget();
+		Method targetMethod = runnable.getMethod();
+		assertThat(targetObject).isEqualTo(target);
+		assertThat(targetMethod.getName()).isEqualTo("fixedRate");
+		assertThat(task.getInitialDelay()).isEqualTo(0L);
+		assertThat(task.getInterval()).isEqualTo(180000L);
+	}
+
+	@Test
 	public void fixedRateTaskWithInitialDelay() {
 		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
 		BeanDefinition targetDefinition = new RootBeanDefinition(FixedRateWithInitialDelayTestBean.class);
@@ -161,6 +274,62 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 		assertThat(targetMethod.getName()).isEqualTo("fixedRate");
 		assertThat(task.getInitialDelay()).isEqualTo(1000L);
 		assertThat(task.getInterval()).isEqualTo(3000L);
+	}
+
+	@Test
+	public void fixedRateTaskWithSecondsTimeUnitWithInitialDelay() {
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(FixedRateWithSecondsTimeUnitInitialDelayTestBean.class);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+
+		ScheduledTaskHolder postProcessor = context.getBean("postProcessor", ScheduledTaskHolder.class);
+		assertThat(postProcessor.getScheduledTasks().size()).isEqualTo(1);
+
+		Object target = context.getBean("target");
+		ScheduledTaskRegistrar registrar = (ScheduledTaskRegistrar)
+				new DirectFieldAccessor(postProcessor).getPropertyValue("registrar");
+		@SuppressWarnings("unchecked")
+		List<IntervalTask> fixedRateTasks = (List<IntervalTask>)
+				new DirectFieldAccessor(registrar).getPropertyValue("fixedRateTasks");
+		assertThat(fixedRateTasks.size()).isEqualTo(1);
+		IntervalTask task = fixedRateTasks.get(0);
+		ScheduledMethodRunnable runnable = (ScheduledMethodRunnable) task.getRunnable();
+		Object targetObject = runnable.getTarget();
+		Method targetMethod = runnable.getMethod();
+		assertThat(targetObject).isEqualTo(target);
+		assertThat(targetMethod.getName()).isEqualTo("fixedRate");
+		assertThat(task.getInitialDelay()).isEqualTo(5000L);
+		assertThat(task.getInterval()).isEqualTo(3000L);
+	}
+
+	@Test
+	public void fixedRateTaskWithMinutesTimeUnitWithInitialDelay() {
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(FixedRateWithMinutesTimeUnitInitialDelayTestBean.class);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+
+		ScheduledTaskHolder postProcessor = context.getBean("postProcessor", ScheduledTaskHolder.class);
+		assertThat(postProcessor.getScheduledTasks().size()).isEqualTo(1);
+
+		Object target = context.getBean("target");
+		ScheduledTaskRegistrar registrar = (ScheduledTaskRegistrar)
+				new DirectFieldAccessor(postProcessor).getPropertyValue("registrar");
+		@SuppressWarnings("unchecked")
+		List<IntervalTask> fixedRateTasks = (List<IntervalTask>)
+				new DirectFieldAccessor(registrar).getPropertyValue("fixedRateTasks");
+		assertThat(fixedRateTasks.size()).isEqualTo(1);
+		IntervalTask task = fixedRateTasks.get(0);
+		ScheduledMethodRunnable runnable = (ScheduledMethodRunnable) task.getRunnable();
+		Object targetObject = runnable.getTarget();
+		Method targetMethod = runnable.getMethod();
+		assertThat(targetObject).isEqualTo(target);
+		assertThat(targetMethod.getName()).isEqualTo("fixedRate");
+		assertThat(task.getInitialDelay()).isEqualTo(60000L);
+		assertThat(task.getInterval()).isEqualTo(180000L);
 	}
 
 	@Test
@@ -702,10 +871,40 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 		}
 	}
 
+	static class FixedDelayWithSecondsTimeUnitTestBean {
+
+		@Scheduled(fixedDelay = 5, timeUnit = TimeUnit.SECONDS)
+		public void fixedDelay() {
+		}
+
+	}
+
+	static class FixedDelayWithMinutesTimeUnitTestBean {
+
+		@Scheduled(fixedDelay = 3, timeUnit = TimeUnit.MINUTES)
+		public void fixedDelay() {
+		}
+
+	}
+
 
 	static class FixedRateTestBean {
 
 		@Scheduled(fixedRate = 3000)
+		public void fixedRate() {
+		}
+	}
+	static class FixedRateWithSecondsTimeUnitTestBean {
+
+		@Scheduled(fixedRate = 5, timeUnit = TimeUnit.SECONDS)
+		public void fixedRate() {
+		}
+	}
+
+
+	static class FixedRateWithMinutesTimeUnitTestBean {
+
+		@Scheduled(fixedRate = 3, timeUnit = TimeUnit.MINUTES)
 		public void fixedRate() {
 		}
 	}
@@ -714,6 +913,20 @@ public class ScheduledAnnotationBeanPostProcessorTests {
 	static class FixedRateWithInitialDelayTestBean {
 
 		@Scheduled(fixedRate = 3000, initialDelay = 1000)
+		public void fixedRate() {
+		}
+	}
+
+	static class FixedRateWithSecondsTimeUnitInitialDelayTestBean {
+
+		@Scheduled(fixedRate = 3, initialDelay = 5, timeUnit = TimeUnit.SECONDS)
+		public void fixedRate() {
+		}
+	}
+
+	static class FixedRateWithMinutesTimeUnitInitialDelayTestBean {
+
+		@Scheduled(fixedRate = 3, initialDelay = 1, timeUnit = TimeUnit.MINUTES)
 		public void fixedRate() {
 		}
 	}


### PR DESCRIPTION
Added an option to use `java.util.concurrent.TimeUnit` with `fixedDelay`, `fixedRate` and `initialDelay` in the `@Scheduled` annotation. Using by default milliseconds as before.