### PR TITLE
Fix duplicated "the" occurrences in Javadoc

### DIFF
--- a/spring-core/src/main/java/org/springframework/asm/RecordComponentWriter.java
+++ b/spring-core/src/main/java/org/springframework/asm/RecordComponentWriter.java
@@ -37,7 +37,7 @@ final class RecordComponentWriter extends RecordComponentVisitor {
   /** The name_index field of the Record attribute. */
   private final int nameIndex;
 
-  /** The descriptor_index field of the the Record attribute. */
+  /** The descriptor_index field of the Record attribute. */
   private final int descriptorIndex;
 
   /**


### PR DESCRIPTION
This PR fixes a typo of "the the" to "the".