### PR TITLE
Passing attributes from WebClient to underlying HTTP library

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/http/client/reactive/MockClientHttpRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/client/reactive/MockClientHttpRequest.java
@@ -119,6 +119,10 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest {
 		getCookies().values().stream().flatMap(Collection::stream)
 				.forEach(cookie -> getHeaders().add(HttpHeaders.COOKIE, cookie.toString()));
 	}
+	
+	@Override
+	protected void applyAttributes() {
+	}
 
 	@Override
 	public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
@@ -17,7 +17,9 @@
 package org.springframework.http.client.reactive;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -55,6 +57,8 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 	private final HttpHeaders headers;
 
 	private final MultiValueMap<String, HttpCookie> cookies;
+	
+	private final Map<String, Object> attributes;
 
 	private final AtomicReference<State> state = new AtomicReference<>(State.NEW);
 
@@ -72,6 +76,7 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 		Assert.notNull(headers, "HttpHeaders must not be null");
 		this.headers = headers;
 		this.cookies = new LinkedMultiValueMap<>();
+		this.attributes = new LinkedHashMap<>();
 	}
 
 
@@ -95,6 +100,11 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 			return CollectionUtils.unmodifiableMultiValueMap(this.cookies);
 		}
 		return this.cookies;
+	}
+	
+	@Override
+	public Map<String, Object> getAttributes() {
+		return this.attributes;
 	}
 
 	@Override
@@ -131,6 +141,7 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 				Mono.fromRunnable(() -> {
 					applyHeaders();
 					applyCookies();
+					applyAttributes();
 					this.state.set(State.COMMITTED);
 				}));
 
@@ -156,5 +167,11 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 	 * This method is called once only.
 	 */
 	protected abstract void applyCookies();
+	
+	/**
+	 * Add attributes from {@link #getAttributes()} to the underlying request.
+	 * This method is called once only.
+	 */
+	protected abstract void applyAttributes();
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpRequest.java
@@ -17,6 +17,7 @@
 package org.springframework.http.client.reactive;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpMethod;
@@ -53,5 +54,8 @@ public interface ClientHttpRequest extends ReactiveHttpOutputMessage {
 	 * @since 5.3
 	 */
 	<T> T getNativeRequest();
+	
+	
+	Map<String, Object> getAttributes();
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpRequestDecorator.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpRequestDecorator.java
@@ -17,6 +17,7 @@
 package org.springframework.http.client.reactive;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
@@ -73,6 +74,11 @@ public class ClientHttpRequestDecorator implements ClientHttpRequest {
 	@Override
 	public MultiValueMap<String, HttpCookie> getCookies() {
 		return this.delegate.getCookies();
+	}
+	
+	@Override
+	public Map<String, Object> getAttributes() {
+		return this.delegate.getAttributes();
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
@@ -150,6 +150,14 @@ class HttpComponentsClientHttpRequest extends AbstractClientHttpRequest {
 					cookieStore.addCookie(clientCookie);
 				});
 	}
+	
+	@Override
+	protected void applyAttributes() {
+		getAttributes().forEach((key, value) -> {
+			if(this.context.getAttribute(key) == null) {
+				this.context.setAttribute(key, value);
+			}});
+	}
 
 	public AsyncRequestProducer toRequestProducer() {
 		ReactiveEntityProducer reactiveEntityProducer = null;

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpRequest.java
@@ -142,6 +142,12 @@ class JettyClientHttpRequest extends AbstractClientHttpRequest {
 			this.jettyRequest.header(HttpHeaders.ACCEPT, "*/*");
 		}
 	}
+	
+	@Override
+	protected void applyAttributes() {
+		getAttributes().forEach((key, value) -> this.jettyRequest.attribute(key, value));
+	}
+	
 
 	public ReactiveRequest toReactiveRequest() {
 		return this.builder.build();

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
@@ -132,5 +132,9 @@ class ReactorClientHttpRequest extends AbstractClientHttpRequest implements Zero
 				.map(cookie -> new DefaultCookie(cookie.getName(), cookie.getValue()))
 				.forEach(this.request::addCookie);
 	}
+	
+	@Override
+	protected void applyAttributes() {
+	}
 
 }

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/reactive/MockClientHttpRequest.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/reactive/MockClientHttpRequest.java
@@ -125,6 +125,10 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest implements 
 		getCookies().values().stream().flatMap(Collection::stream)
 				.forEach(cookie -> getHeaders().add(HttpHeaders.COOKIE, cookie.toString()));
 	}
+	
+	@Override
+	protected void applyAttributes() {
+	}
 
 	@Override
 	public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilder.java
@@ -271,6 +271,13 @@ final class DefaultClientRequestBuilder implements ClientRequest.Builder {
 			if (this.httpRequestConsumer != null) {
 				this.httpRequestConsumer.accept(request);
 			}
+			
+			Map<String, Object> requestAttributes = request.getAttributes();
+			if (!this.attributes.isEmpty()) {
+				this.attributes.forEach((name, value) -> {
+					requestAttributes.put(name, value);
+				});
+			}
 
 			return this.body.insert(request, new BodyInserter.Context() {
 				@Override


### PR DESCRIPTION
To be able to enable a more customizable logging of requests we need to be able to pass some attributes from the WebClient to the underlying library.

This functionality was discussed and agreed in the issue #26208

* Expose attributes map on ClientHttpRequest and get them populated from the request
* Add applyAttributes abstract method in AbstractClientHttpRequest that each HTTP Library can implement
* Jetty and Apache HttpComponents implementation of applyAttributes