### PR TITLE
Fix Kotlin example for filtering handler functions

### DIFF
--- a/src/docs/asciidoc/web/webmvc-functional.adoc
+++ b/src/docs/asciidoc/web/webmvc-functional.adoc
@@ -799,10 +799,10 @@ For instance, consider the following example:
 				ServerRequest.from(it)
 						.header("X-RequestHeader", "Value").build()
 			}
-			POST("/person", handler::createPerson)
-			after { _, response -> // <2>
-				logResponse(response)
-			}
+		}
+		POST("/person", handler::createPerson)
+		after { _, response -> // <2>
+			logResponse(response)
 		}
 	}
 ----


### PR DESCRIPTION
The Kotlin code example at _Filtering Handler Functions_ seems to be not equivalent to Java.

Suppose

> The `before` filter that adds a custom request header is only applied to the two GET routes.
The `after` filter that logs the response is applied to all routes, including the nested ones.

is correct, `POST("/person", handler::createPerson)` and `after()` should not be inside `nest`, if my understanding to RouterFunction is correct.