### PR TITLE
Remove unnecessary brace in WebSocket documentation

### DIFF
--- a/src/docs/asciidoc/web/websocket.adoc
+++ b/src/docs/asciidoc/web/websocket.adoc
@@ -1177,7 +1177,7 @@ We can trace the flow through a simple example. Consider the following example, 
 	@Controller
 	public class GreetingController {
 
-		@MessageMapping("/greeting") {
+		@MessageMapping("/greeting")
 		public String handle(String greeting) {
 			return "[" + getTimestamp() + ": " + greeting;
 		}


### PR DESCRIPTION
There is an unnecessary brace in one of the examples in the WebSocket documentation.