### PR TITLE
Configure optional configuration to consume its dependencies' API

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
@@ -44,18 +44,14 @@ public class OptionalDependenciesPlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
 		Configuration optional = project.getConfigurations().create("optional");
-		optional.attributes((attributes) -> attributes.attribute(Usage.USAGE_ATTRIBUTE,
-				project.getObjects().named(Usage.class, Usage.JAVA_API)));
 		optional.setCanBeConsumed(false);
-		optional.setCanBeResolved(true);
+		optional.setCanBeResolved(false);
 		project.getPlugins().withType(JavaPlugin.class, (javaPlugin) -> {
-			SourceSetContainer sourceSets = project.getConvention()
-					.getPlugin(JavaPluginConvention.class).getSourceSets();
+			SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class)
+					.getSourceSets();
 			sourceSets.all((sourceSet) -> {
-				sourceSet.setCompileClasspath(
-						sourceSet.getCompileClasspath().plus(optional));
-				sourceSet.setRuntimeClasspath(
-						sourceSet.getRuntimeClasspath().plus(optional));
+				project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName()).extendsFrom(optional);
+				project.getConfigurations().getByName(sourceSet.getRuntimeClasspathConfigurationName()).extendsFrom(optional);
 			});
 		});
 		project.getPlugins().withType(EclipsePlugin.class, (eclipePlugin) -> {

--- a/buildSrc/src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
@@ -19,6 +19,7 @@ package org.springframework.build.optional;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -43,6 +44,10 @@ public class OptionalDependenciesPlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
 		Configuration optional = project.getConfigurations().create("optional");
+		optional.attributes((attributes) -> attributes.attribute(Usage.USAGE_ATTRIBUTE,
+				project.getObjects().named(Usage.class, Usage.JAVA_API)));
+		optional.setCanBeConsumed(false);
+		optional.setCanBeResolved(true);
 		project.getPlugins().withType(JavaPlugin.class, (javaPlugin) -> {
 			SourceSetContainer sourceSets = project.getConvention()
 					.getPlugin(JavaPluginConvention.class).getSourceSets();


### PR DESCRIPTION
This PR refines the attributes of the `optional` configuration to ensure that it consumes its dependencies' Java API and not just their runtime. It should fix the problem described in https://github.com/junit-team/junit5/issues/2705#issuecomment-912669965.