### PR TITLE
Fix response body missing 1st byte inside UnknownContentTypeException

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/HttpMessageConverterExtractor.java
+++ b/spring-web/src/main/java/org/springframework/web/client/HttpMessageConverterExtractor.java
@@ -122,8 +122,8 @@ public class HttpMessageConverterExtractor<T> implements ResponseExtractor<T> {
 		}
 
 		throw new UnknownContentTypeException(this.responseType, contentType,
-				response.getRawStatusCode(), response.getStatusText(), response.getHeaders(),
-				getResponseBody(response));
+				responseWrapper.getRawStatusCode(), responseWrapper.getStatusText(), responseWrapper.getHeaders(),
+				getResponseBody(responseWrapper));
 	}
 
 	/**


### PR DESCRIPTION
This commit fixes the creation of `UnknownContentTypeException` when it is thrown from `HttpMessageConverterExtractor.extractData`.

This exception is usually thrown from `RestTemplate` when `HttpMessageConverterExtractor` can't extract response body.
In this case `HttpMessageConverterExtractor` throws `UnknownContentTypeException` with response body as byte array.

Before this change the returned exception contained incorrect `responseBody` when `InputStream` from `ClientHttpResponse` was not markable (`markSupported()` is false). This is the usual case for HTTP response's `InputStream` implementations.

The first byte of response body inside `UnknownContentTypeException` was missing because it was already read from `InputStream`.

The `responseBody` was read from original `InputStream`, while it should be read from the wrapper of original `InputStream`.

---

To a person who will merge: please improve the commit message if possible as I feel difficulties in attempt to correctly and briefly describe the change, that is essentially a bug fix (not a native English speaker).