### PR TITLE
Refactor some test code to use lambda expressions and method references

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/annotation/MissingMergedAnnotationTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/MissingMergedAnnotationTests.java
@@ -257,7 +257,7 @@ class MissingMergedAnnotationTests {
 
 	@Test
 	void synthesizeThrowsNoSuchElementException() {
-		assertThatNoSuchElementException().isThrownBy(() -> this.missing.synthesize());
+		assertThatNoSuchElementException().isThrownBy(this.missing::synthesize);
 	}
 
 	@Test

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -190,12 +190,7 @@ class GenericConversionServiceTests {
 
 	@Test
 	void convertSuperSourceType() {
-		conversionService.addConverter(new Converter<CharSequence, Integer>() {
-			@Override
-			public Integer convert(CharSequence source) {
-				return Integer.valueOf(source.toString());
-			}
-		});
+		conversionService.addConverter(CharSequence.class, Integer.class, source -> Integer.valueOf(source.toString()));
 		Integer result = conversionService.convert("3", Integer.class);
 		assertThat((int) result).isEqualTo((int) Integer.valueOf(3));
 	}

--- a/spring-core/src/test/java/org/springframework/core/convert/support/StreamConverterTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/StreamConverterTests.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.core.convert.TypeDescriptor;
-import org.springframework.core.convert.converter.Converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -134,12 +133,7 @@ class StreamConverterTests {
 	@SuppressWarnings("resource")
 	void convertFromArrayToStream() throws NoSuchFieldException {
 		Integer[] stream = new Integer[] {1, 0, 1};
-		this.conversionService.addConverter(new Converter<Integer, Boolean>() {
-			@Override
-			public Boolean convert(Integer source) {
-				return source == 1;
-			}
-		});
+		this.conversionService.addConverter(Integer.class, Boolean.class, source -> source == 1);
 		TypeDescriptor streamOfBoolean = new TypeDescriptor(Types.class.getField("streamOfBooleans"));
 		Object result = this.conversionService.convert(stream, streamOfBoolean);
 

--- a/spring-core/src/test/java/org/springframework/core/env/ProfilesTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/ProfilesTests.java
@@ -47,8 +47,7 @@ class ProfilesTests {
 
 	@Test
 	void ofWhenEmptyThrowsException() {
-		assertThatIllegalArgumentException().isThrownBy(() ->
-				Profiles.of())
+		assertThatIllegalArgumentException().isThrownBy(Profiles::of)
 			.withMessageContaining("Must specify at least one profile");
 	}
 

--- a/spring-core/src/test/java/org/springframework/core/env/StandardEnvironmentTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/StandardEnvironmentTests.java
@@ -212,7 +212,7 @@ public class StandardEnvironmentTests {
 	void defaultProfileWithCircularPlaceholder() {
 		try {
 			System.setProperty(DEFAULT_PROFILES_PROPERTY_NAME, "${spring.profiles.default}");
-			assertThatIllegalArgumentException().isThrownBy(() -> environment.getDefaultProfiles());
+			assertThatIllegalArgumentException().isThrownBy(environment::getDefaultProfiles);
 		}
 		finally {
 			System.clearProperty(DEFAULT_PROFILES_PROPERTY_NAME);

--- a/spring-core/src/test/java/org/springframework/core/io/buffer/DataBufferUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/buffer/DataBufferUtilsTests.java
@@ -78,7 +78,7 @@ class DataBufferUtilsTests extends AbstractDataBufferAllocatingTests {
 		super.bufferFactory = bufferFactory;
 
 		Flux<DataBuffer> flux = DataBufferUtils.readInputStream(
-				() -> this.resource.getInputStream(), super.bufferFactory, 3);
+				this.resource::getInputStream, super.bufferFactory, 3);
 
 		verifyReadData(flux);
 	}

--- a/spring-core/src/test/java/org/springframework/core/task/SimpleAsyncTaskExecutorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/task/SimpleAsyncTaskExecutorTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.core.task;
 
-import java.util.concurrent.ThreadFactory;
-
 import org.junit.jupiter.api.Test;
 
 import org.springframework.util.ConcurrencyThrottleSupport;
@@ -61,12 +59,7 @@ class SimpleAsyncTaskExecutorTests {
 	@Test
 	void threadFactoryOverridesDefaults() throws Exception {
 		final Object monitor = new Object();
-		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor(new ThreadFactory() {
-			@Override
-			public Thread newThread(Runnable r) {
-				return new Thread(r, "test");
-			}
-		});
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor(runnable -> new Thread(runnable, "test"));
 		ThreadNameHarvester task = new ThreadNameHarvester(monitor);
 		executeAndWait(executor, task, monitor);
 		assertThat(task.getThreadName()).isEqualTo("test");

--- a/spring-core/src/test/java/org/springframework/util/concurrent/SettableListenableFutureTests.java
+++ b/spring-core/src/test/java/org/springframework/util/concurrent/SettableListenableFutureTests.java
@@ -332,8 +332,7 @@ class SettableListenableFutureTests {
 	void cancelStateThrowsExceptionWhenCallingGet() throws ExecutionException, InterruptedException {
 		settableListenableFuture.cancel(true);
 
-		assertThatExceptionOfType(CancellationException.class).isThrownBy(() ->
-				settableListenableFuture.get());
+		assertThatExceptionOfType(CancellationException.class).isThrownBy(settableListenableFuture::get);
 
 		assertThat(settableListenableFuture.isCancelled()).isTrue();
 		assertThat(settableListenableFuture.isDone()).isTrue();

--- a/spring-core/src/test/java/org/springframework/util/xml/AbstractStaxXMLReaderTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/AbstractStaxXMLReaderTests.java
@@ -179,12 +179,9 @@ abstract class AbstractStaxXMLReaderTests {
 		ContentHandler contentHandler = mock(ContentHandler.class);
 		willAnswer(new CopyCharsAnswer()).given(contentHandler).characters(any(char[].class), anyInt(), anyInt());
 		willAnswer(new CopyCharsAnswer()).given(contentHandler).ignorableWhitespace(any(char[].class), anyInt(), anyInt());
-		willAnswer(new Answer<Object>() {
-			@Override
-			public Object answer(InvocationOnMock invocation) throws Throwable {
-				invocation.getArguments()[3] = new AttributesImpl((Attributes) invocation.getArguments()[3]);
-				return null;
-			}
+		willAnswer(invocation -> {
+			invocation.getArguments()[3] = new AttributesImpl((Attributes) invocation.getArguments()[3]);
+			return null;
 		}).given(contentHandler).startElement(anyString(), anyString(), anyString(), any(Attributes.class));
 		return contentHandler;
 	}


### PR DESCRIPTION
Hi,

I refactored some test codes to use lambda expression and method reference for the sake of conciseness.

Due to an issue of java language itself described in #22509, tests that includes `addConverter` was refactored with input/output type informations.

I checked that build done successfully using `./gradlew check`

Thanks.