### PR TITLE
StringUtils.collectionToDelimitedString(…) fails with NullPointerException when the collection contains null

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -1301,7 +1301,7 @@ public abstract class StringUtils {
 
 		int totalLength = coll.size() * (prefix.length() + suffix.length()) + (coll.size() - 1) * delim.length();
 		for (Object element : coll) {
-			totalLength += element.toString().length();
+			totalLength += String.valueOf(element).length();
 		}
 
 		StringBuilder sb = new StringBuilder(totalLength);


### PR DESCRIPTION

Using `String.valueOf` toString this  `element`, cover the `null` case.

fix #27411 