### PR TITLE
Improve mapping function in ExtendedEntityManagerCreator.createProxy()

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/ExtendedEntityManagerCreator.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/ExtendedEntityManagerCreator.java
@@ -228,10 +228,10 @@ public abstract class ExtendedEntityManagerCreator {
 
 		if (emIfc != null) {
 			interfaces = cachedEntityManagerInterfaces.computeIfAbsent(emIfc, key -> {
-				Set<Class<?>> ifcs = new LinkedHashSet<>(4);
-				ifcs.add(key);
-				ifcs.add(EntityManagerProxy.class);
-				return ClassUtils.toClassArray(ifcs);
+				if (EntityManagerProxy.class.equals(key)) {
+					return new Class<?>[]{key};
+				}
+				return new Class<?>[]{key, EntityManagerProxy.class};
 			});
 		}
 		else {


### PR DESCRIPTION
As soon as there are up to two items in the resulting array we can populate it explicitly which is faster and memory-saving.