### PR TITLE
Add missing @Nullable annotations on ResponseCookieBuilder

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseCookie.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseCookie.java
@@ -238,13 +238,13 @@ public final class ResponseCookie extends HttpCookie {
 			}
 
 			@Override
-			public ResponseCookieBuilder domain(String domain) {
+			public ResponseCookieBuilder domain(@Nullable String domain) {
 				this.domain = initDomain(domain);
 				return this;
 			}
 
 			@Nullable
-			private String initDomain(String domain) {
+			private String initDomain(@Nullable String domain) {
 				if (lenient && StringUtils.hasLength(domain)) {
 					String str = domain.trim();
 					if (str.startsWith("\"") && str.endsWith("\"")) {
@@ -257,7 +257,7 @@ public final class ResponseCookie extends HttpCookie {
 			}
 
 			@Override
-			public ResponseCookieBuilder path(String path) {
+			public ResponseCookieBuilder path(@Nullable String path) {
 				this.path = path;
 				return this;
 			}
@@ -312,12 +312,12 @@ public final class ResponseCookie extends HttpCookie {
 		/**
 		 * Set the cookie "Path" attribute.
 		 */
-		ResponseCookieBuilder path(String path);
+		ResponseCookieBuilder path(@Nullable String path);
 
 		/**
 		 * Set the cookie "Domain" attribute.
 		 */
-		ResponseCookieBuilder domain(String domain);
+		ResponseCookieBuilder domain(@Nullable String domain);
 
 		/**
 		 * Add the "Secure" attribute to the cookie.


### PR DESCRIPTION
The ResponseCookie class already has @Nullable annotations for domain and path properties;
but the builder was not synchronised with these declarations.