### PR TITLE
Fix Javadoc typo in PathMatchConfigurer#setUseSuffixPatternMatch

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/PathMatchConfigurer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/PathMatchConfigurer.java
@@ -120,7 +120,7 @@ public class PathMatchConfigurer {
 	/**
 	 * Whether to use suffix pattern match (".*") when matching patterns to
 	 * requests. If enabled a method mapped to "/users" also matches to "/users.*".
-	 * <p>By default this is set to {@code true}.
+	 * <p>By default this is set to {@code false}.
 	 * <p><strong>Note:</strong> This property is mutually exclusive with and
 	 * ignored when {@link #setPatternParser(PathPatternParser)} is set.
 	 * @deprecated as of 5.2.4. See class-level note in


### PR DESCRIPTION
fix the java doc because in 5.3.x the default is set to false  see this issue 
https://github.com/spring-projects/spring-framework/issues/27269