### PR TITLE
SimpleCacheResolver resolves templated SpEL expressions

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/annotation/ProxyCachingConfiguration.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/ProxyCachingConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.cache.config.CacheManagementConfigUtils;
 import org.springframework.cache.interceptor.BeanFactoryCacheOperationSourceAdvisor;
 import org.springframework.cache.interceptor.CacheInterceptor;
+import org.springframework.cache.interceptor.CacheOperationExpressionEvaluator;
 import org.springframework.cache.interceptor.CacheOperationSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,6 +32,7 @@ import org.springframework.context.annotation.Role;
  *
  * @author Chris Beams
  * @author Juergen Hoeller
+ * @author Sam Kruglov
  * @since 3.1
  * @see EnableCaching
  * @see CachingConfigurationSelector
@@ -61,8 +63,17 @@ public class ProxyCachingConfiguration extends AbstractCachingConfiguration {
 
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-	public CacheInterceptor cacheInterceptor(CacheOperationSource cacheOperationSource) {
-		CacheInterceptor interceptor = new CacheInterceptor();
+	public CacheOperationExpressionEvaluator cacheOperationExpressionEvaluator() {
+		return new CacheOperationExpressionEvaluator();
+	}
+
+	@Bean
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+	public CacheInterceptor cacheInterceptor(
+			CacheOperationSource cacheOperationSource,
+			CacheOperationExpressionEvaluator cacheOperationExpressionEvaluator
+	) {
+		CacheInterceptor interceptor = new CacheInterceptor(cacheOperationExpressionEvaluator);
 		interceptor.configure(this.errorHandler, this.keyGenerator, this.cacheResolver, this.cacheManager);
 		interceptor.setCacheOperationSource(cacheOperationSource);
 		return interceptor;

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheEvaluationContext.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheEvaluationContext.java
@@ -40,14 +40,15 @@ import org.springframework.lang.Nullable;
  * @author Costin Leau
  * @author Stephane Nicoll
  * @author Juergen Hoeller
+ * @author Sam Kruglov
  * @since 3.1
  */
-class CacheEvaluationContext extends MethodBasedEvaluationContext {
+public class CacheEvaluationContext extends MethodBasedEvaluationContext {
 
 	private final Set<String> unavailableVariables = new HashSet<>(1);
 
 
-	CacheEvaluationContext(Object rootObject, Method method, Object[] arguments,
+	public CacheEvaluationContext(Object rootObject, Method method, Object[] arguments,
 			ParameterNameDiscoverer parameterNameDiscoverer) {
 
 		super(rootObject, method, arguments, parameterNameDiscoverer);

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheExpressionRootObjectWithCaches.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheExpressionRootObjectWithCaches.java
@@ -17,6 +17,9 @@
 package org.springframework.cache.interceptor;
 
 import java.lang.reflect.Method;
+import java.util.Collection;
+
+import org.springframework.cache.Cache;
 
 /**
  * Class describing the root object used during the expression evaluation.
@@ -24,47 +27,19 @@ import java.lang.reflect.Method;
  * @author Costin Leau
  * @author Sam Brannen
  * @author Sam Kruglov
- * @since 6.0
+ * @since 3.1
  */
-public class CacheExpressionRootObject {
+public class CacheExpressionRootObjectWithCaches extends CacheExpressionRootObject {
 
-	private final Method method;
+	private final Collection<? extends Cache> caches;
 
-	private final Object[] args;
-
-	private final Object target;
-
-	private final Class<?> targetClass;
-
-
-	public CacheExpressionRootObject(
-			Method method, Object[] args, Object target, Class<?> targetClass) {
-
-		this.method = method;
-		this.target = target;
-		this.targetClass = targetClass;
-		this.args = args;
+	public CacheExpressionRootObjectWithCaches(
+			Collection<? extends Cache> caches, Method method, Object[] args, Object target, Class<?> targetClass) {
+		super(method, args, target, targetClass);
+		this.caches = caches;
 	}
 
-
-	public Method getMethod() {
-		return this.method;
+	public Collection<? extends Cache> getCaches() {
+		return this.caches;
 	}
-
-	public String getMethodName() {
-		return this.method.getName();
-	}
-
-	public Object[] getArgs() {
-		return this.args;
-	}
-
-	public Object getTarget() {
-		return this.target;
-	}
-
-	public Class<?> getTargetClass() {
-		return this.targetClass;
-	}
-
 }

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheInterceptor.java
@@ -39,10 +39,19 @@ import org.springframework.util.Assert;
  *
  * @author Costin Leau
  * @author Juergen Hoeller
+ * @author Sam Kruglov
  * @since 3.1
  */
 @SuppressWarnings("serial")
 public class CacheInterceptor extends CacheAspectSupport implements MethodInterceptor, Serializable {
+
+	public CacheInterceptor() {
+		super();
+	}
+
+	public CacheInterceptor(CacheOperationExpressionEvaluator evaluator) {
+		super(evaluator);
+	}
 
 	@Override
 	@Nullable

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleCacheResolver.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleCacheResolver.java
@@ -16,29 +16,52 @@
 
 package org.springframework.cache.interceptor;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Collection;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.context.expression.AnnotatedElementKey;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * A simple {@link CacheResolver} that resolves the {@link Cache} instance(s)
- * based on a configurable {@link CacheManager} and the name of the
- * cache(s) as provided by {@link BasicOperation#getCacheNames() getCacheNames()}.
+ * based on a configurable {@link CacheManager} and the name of the cache(s)
+ * (which can be templated SpEL expressions)
+ * as provided by {@link BasicOperation#getCacheNames() getCacheNames()}.
  *
  * @author Stephane Nicoll
  * @author Juergen Hoeller
+ * @author Sam Kruglov
  * @since 4.1
  * @see BasicOperation#getCacheNames()
  */
 public class SimpleCacheResolver extends AbstractCacheResolver {
+
+	private static final Log logger = LogFactory.getLog(SimpleCacheResolver.class);
+
+	private final CacheOperationExpressionEvaluator cacheOperationExpressionEvaluator;
+	private final TemplateParserContext templateParserContext = new TemplateParserContext();
+	@Nullable
+	private final BeanFactory beanFactory;
 
 	/**
 	 * Construct a new {@code SimpleCacheResolver}.
 	 * @see #setCacheManager
 	 */
 	public SimpleCacheResolver() {
+		cacheOperationExpressionEvaluator = new CacheOperationExpressionEvaluator();
+		beanFactory = null;
 	}
 
 	/**
@@ -47,12 +70,75 @@ public class SimpleCacheResolver extends AbstractCacheResolver {
 	 */
 	public SimpleCacheResolver(CacheManager cacheManager) {
 		super(cacheManager);
+		cacheOperationExpressionEvaluator = new CacheOperationExpressionEvaluator();
+		beanFactory = null;
+	}
+
+	public SimpleCacheResolver(
+			CacheManager cacheManager,
+			BeanFactory beanFactory
+	) {
+		super(cacheManager);
+		this.cacheOperationExpressionEvaluator = new CacheOperationExpressionEvaluator();
+		this.beanFactory = beanFactory;
+	}
+
+	public SimpleCacheResolver(
+			CacheManager cacheManager,
+			CacheOperationExpressionEvaluator cacheOperationExpressionEvaluator
+	) {
+		super(cacheManager);
+		this.cacheOperationExpressionEvaluator = cacheOperationExpressionEvaluator;
+		beanFactory = null;
+	}
+
+	public SimpleCacheResolver(
+			CacheManager cacheManager,
+			@Nullable CacheOperationExpressionEvaluator cacheOperationExpressionEvaluator,
+			@Nullable BeanFactory beanFactory
+	) {
+		super(cacheManager);
+		this.cacheOperationExpressionEvaluator = cacheOperationExpressionEvaluator != null
+				? cacheOperationExpressionEvaluator
+				: new CacheOperationExpressionEvaluator();
+		this.beanFactory = beanFactory;
 	}
 
 
 	@Override
 	protected Collection<String> getCacheNames(CacheOperationInvocationContext<?> context) {
-		return context.getOperation().getCacheNames();
+		return context.getOperation().getCacheNames()
+				.stream()
+				.map(name -> parseExpression(context, name))
+				.toList();
+	}
+
+	private String parseExpression(CacheOperationInvocationContext<?> context, String expression) {
+		if (!expression.contains(templateParserContext.getExpressionPrefix())) return expression;
+		Class<?> targetClass = AopProxyUtils.ultimateTargetClass(context.getTarget());
+		Method method = context.getMethod();
+		EvaluationContext evaluationContext = cacheOperationExpressionEvaluator.createEvaluationContext(
+				null,
+				method,
+				context.getArgs(),
+				context.getTarget(),
+				targetClass,
+				(!Proxy.isProxyClass(targetClass) ? AopUtils.getMostSpecificMethod(method, targetClass) : method),
+				null,
+				beanFactory
+		);
+		String cacheName = cacheOperationExpressionEvaluator.cacheName(
+				expression, new AnnotatedElementKey(method, targetClass),
+				evaluationContext, templateParserContext
+		);
+		Assert.state(cacheName != null,
+				"Null cache name returned for cache operation (maybe you are " +
+						"using named params on classes without debug info?) " + context.getOperation()
+		);
+		if (logger.isTraceEnabled()) {
+			logger.trace("Computed cache name '" + cacheName + "' for operation " + context.getOperation());
+		}
+		return cacheName;
 	}
 
 
@@ -65,6 +151,20 @@ public class SimpleCacheResolver extends AbstractCacheResolver {
 	@Nullable
 	static SimpleCacheResolver of(@Nullable CacheManager cacheManager) {
 		return (cacheManager != null ? new SimpleCacheResolver(cacheManager) : null);
+	}
+
+	/**
+	 * Return a {@code SimpleCacheResolver} for the given {@link CacheManager}.
+	 * @return the SimpleCacheResolver ({@code null} if the CacheManager was {@code null})
+	 * @since 5.1
+	 */
+	@Nullable
+	static SimpleCacheResolver of(
+			@Nullable CacheManager cacheManager,
+			@Nullable CacheOperationExpressionEvaluator evaluator,
+			@Nullable BeanFactory beanFactory
+	) {
+		return (cacheManager != null ? new SimpleCacheResolver(cacheManager, evaluator, beanFactory) : null);
 	}
 
 }

--- a/spring-context/src/test/java/org/springframework/cache/CacheReproTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/CacheReproTests.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.verify;
  * @author Phillip Webb
  * @author Juergen Hoeller
  * @author Stephane Nicoll
+ * @author Sam Kruglov
  */
 public class CacheReproTests {
 
@@ -131,7 +132,7 @@ public class CacheReproTests {
 	}
 
 	@Test
-	public void spr14230AdaptsToOptional() {
+	public void spr14230AdaptsToOptionalAndResolvesCacheWithExpression() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Spr14230Config.class);
 		Spr14230Service bean = context.getBean(Spr14230Service.class);
 		Cache cache = context.getBean(CacheManager.class).getCache("itemCache");
@@ -354,7 +355,7 @@ public class CacheReproTests {
 
 	public static class Spr14230Service {
 
-		@Cacheable("itemCache")
+		@Cacheable("item#{'Cache'}")
 		public Optional<TestBean> findById(String id) {
 			return Optional.of(new TestBean(id));
 		}

--- a/spring-context/src/test/resources/log4j2-test.xml
+++ b/spring-context/src/test/resources/log4j2-test.xml
@@ -10,6 +10,7 @@
 		<Logger name="org.springframework.beans" level="warn" />
 		<Logger name="org.springframework.context" level="warn" />
 		<Logger name="org.springframework.core" level="warn" />
+		<Logger name="org.springframework.cache" level="trace"/>
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>


### PR DESCRIPTION
Currently, it's expected from the user to provide their own `CacheResolver` if they wish to use SpEL inside `@Cache*(cacheNames="...")`. I think it wouldn't hurt if it was implemented out of the box as templated expressions:
```
"myCache-#{#arg}-#{@bean.something()}" etc.
```
Especially given the fact that `CacheOperationExpressionEvaluator` is already implemented for `key`, `unless`, and `condition` attributes of `@Cache*` annotations.

And it will behave exactly the same as it does now but also can evaluate a templated expression if there is one:
```java
if (!expression.contains(templateParserContext.getExpressionPrefix())) return expression;
```
I decided to put that stuff right into `SimpleCacheResolver` making its factory methods backward-compatible. I don't see a point in creating a second resolver class because it still does the same thing if there's no nested expression in the name, and there's effectively no penalty in simply checking `String#contains` every time.

Example usecase:
```java
@Cacheable(cacheNames = "schemas-#{#vendorId}", key = "#entityId")
public Schema getSchema(String vendorId, String entityId){...}

@CacheEvict(cacheNames = "schemas-#{#vendorId}", allEntries = true)
public void updateVendor(String vendorId, VendorDto newData){...}
```
Here, if I don't have SpEL inside cache names, I can only define a cache named "schemas", but whenever I want to update one vendor, I only want its cache to be evicted, not everyone's. An alternative is to manage the cache programmatically or implement my own cache resolver.