### PR TITLE
Avoid duplicate JCacheOperationSource bean registration in <cache:annotation-driven />

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/config/AnnotationDrivenCacheBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/cache/config/AnnotationDrivenCacheBeanDefinitionParser.java
@@ -245,16 +245,20 @@ class AnnotationDrivenCacheBeanDefinitionParser implements BeanDefinitionParser 
 		private static void registerCacheAspect(Element element, ParserContext parserContext) {
 			if (!parserContext.getRegistry().containsBeanDefinition(CacheManagementConfigUtils.JCACHE_ASPECT_BEAN_NAME)) {
 				Object eleSource = parserContext.extractSource(element);
+
+				BeanDefinition sourceDef = createJCacheOperationSourceBeanDefinition(element, eleSource);
+				String sourceName = parserContext.getReaderContext().registerWithGeneratedName(sourceDef);
+
 				RootBeanDefinition def = new RootBeanDefinition();
 				def.setBeanClassName(JCACHE_ASPECT_CLASS_NAME);
 				def.setFactoryMethodName("aspectOf");
-				BeanDefinition sourceDef = createJCacheOperationSourceBeanDefinition(element, eleSource);
-				String sourceName =
-						parserContext.getReaderContext().registerWithGeneratedName(sourceDef);
 				def.getPropertyValues().add("cacheOperationSource", new RuntimeBeanReference(sourceName));
+				parserContext.getRegistry().registerBeanDefinition(CacheManagementConfigUtils.JCACHE_ASPECT_BEAN_NAME, def);
 
-				parserContext.registerBeanComponent(new BeanComponentDefinition(sourceDef, sourceName));
-				parserContext.registerBeanComponent(new BeanComponentDefinition(def, CacheManagementConfigUtils.JCACHE_ASPECT_BEAN_NAME));
+				CompositeComponentDefinition compositeDef = new CompositeComponentDefinition(element.getTagName(), eleSource);
+				compositeDef.addNestedComponent(new BeanComponentDefinition(sourceDef, sourceName));
+				compositeDef.addNestedComponent(new BeanComponentDefinition(def, CacheManagementConfigUtils.JCACHE_ASPECT_BEAN_NAME));
+				parserContext.registerComponent(compositeDef);
 			}
 		}
 


### PR DESCRIPTION
Hello.

In our application we use XML context and `<cache:annotation-driven mode="aspectj"/>` declaration in combination with JCache API.  Also we disable bean definition overrides by setting `GenericApplicationContext.setAllowBeanDefinitionOverriding(false)` in an `ApplicationContextInitializer`.

Such combination leads to `BeanDefinitionOverrideException` because the bean "org.springframework.cache.jcache.interceptor.DefaultJCacheOperationSource" is registered twice: 

```java
String sourceName = parserContext.getReaderContext().registerWithGeneratedName(sourceDef);
parserContext.registerBeanComponent(new BeanComponentDefinition(sourceDef, sourceName));
```
