### PR TITLE
Add ParameterNamesModule to "well known" jackson modules

### DIFF
--- a/spring-web/spring-web.gradle
+++ b/spring-web/spring-web.gradle
@@ -59,6 +59,7 @@ dependencies {
 	testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
 	testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 	testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+	testImplementation("com.fasterxml.jackson.module:jackson-module-parameter-names")
 	testImplementation("org.apache.tomcat:tomcat-util")
 	testImplementation("org.apache.tomcat.embed:tomcat-embed-core")
 	testImplementation("org.eclipse.jetty:jetty-server")

--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
@@ -825,6 +825,16 @@ public class Jackson2ObjectMapperBuilder {
 		}
 
 		try {
+			Class<? extends Module> parameterNamesModuleClass = (Class<? extends Module>)
+					ClassUtils.forName("com.fasterxml.jackson.module.paramnames.ParameterNamesModule", this.moduleClassLoader);
+			Module parameterNamesModule = BeanUtils.instantiateClass(parameterNamesModuleClass);
+			modulesToRegister.set(parameterNamesModule.getTypeId(), parameterNamesModule);
+		}
+		catch (ClassNotFoundException ex) {
+			// jackson-module-parameter-names not available
+		}
+
+		try {
 			Class<? extends Module> javaTimeModuleClass = (Class<? extends Module>)
 					ClassUtils.forName("com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", this.moduleClassLoader);
 			Module javaTimeModule = BeanUtils.instantiateClass(javaTimeModuleClass);

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
@@ -85,6 +85,7 @@ import org.springframework.beans.FatalBeanException;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -257,6 +258,25 @@ class Jackson2ObjectMapperBuilderTests {
 		assertThat(serializers.findSerializer(null, SimpleType.construct(Integer.class), null).getClass()).isSameAs(CustomIntegerSerializer.class);
 	}
 
+	static class ParameterModuleDto {
+
+		int x;
+		int y;
+
+		ParameterModuleDto(int x, int y) {
+			this.x = x;
+			this.y = y;
+		}
+
+		int getX() {
+			return x;
+		}
+
+		int getY() {
+			return y;
+		}
+	}
+
 	@Test
 	void wellKnownModules() throws JsonProcessingException, UnsupportedEncodingException {
 		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
@@ -266,6 +286,9 @@ class Jackson2ObjectMapperBuilderTests {
 
 		Optional<String> optional = Optional.of("test");
 		assertThat(new String(objectMapper.writeValueAsBytes(optional), "UTF-8")).isEqualTo("\"test\"");
+
+
+		assertThatCode(() -> objectMapper.readValue("{\"x\":1,\"y\":2}", ParameterModuleDto.class)).doesNotThrowAnyException();
 
 		// Kotlin module
 		IntRange range = new IntRange(1, 3);


### PR DESCRIPTION
Also, I'm surprised to see that `org.springframework.http.converter.json.Jackson2ObjectMapperBuilder#findModulesViaServiceLoader` is not `true` by default. Why not always just let it scan the classpath, seems like `findWellKnownModules` does the same but manually.