### PR TITLE
Use Arrays.hashCode() in ByteArrayResource.hashCode()

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/ByteArrayResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/ByteArrayResource.java
@@ -126,7 +126,7 @@ public class ByteArrayResource extends AbstractResource {
 	 */
 	@Override
 	public int hashCode() {
-		return (byte[].class.hashCode() * 29 * this.byteArray.length);
+		return Arrays.hashCode(byteArray);
 	}
 
 }


### PR DESCRIPTION
Current implementation produces equal hash codes for all instances of `ByteArrayResource` with the same length of underlying array disregarding their contents. This seems to be wrong as hash code should be calculated on the basis of the content of `byte[]`.