### PR TITLE
mark function resolveType as private

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -830,7 +830,7 @@ public class ResolvableType implements Serializable {
 	 * <p>Note: The returned {@link ResolvableType} should only be used as an intermediary
 	 * as it cannot be serialized.
 	 */
-	ResolvableType resolveType() {
+	private ResolvableType resolveType() {
 		if (this.type instanceof ParameterizedType) {
 			return forType(((ParameterizedType) this.type).getRawType(), this.variableResolver);
 		}


### PR DESCRIPTION
function resolveType() is a internal function usually act as a callee, it is called by other function in ResolveType.java under conditional precondition. it is not a general function for users, we should mark this function as private explicitly, to prevent users from making mistakes