### PR TITLE
Fix assertion failure messages in DefaultDataBuffer.checkIndex()

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DefaultDataBuffer.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DefaultDataBuffer.java
@@ -453,9 +453,9 @@ public class DefaultDataBuffer implements DataBuffer {
 
 	private void checkIndex(int index, int length) {
 		assertIndex(index >= 0, "index %d must be >= 0", index);
-		assertIndex(length >= 0, "length %d must be >= 0", index);
+		assertIndex(length >= 0, "length %d must be >= 0", length);
 		assertIndex(index <= this.capacity, "index %d must be <= %d", index, this.capacity);
-		assertIndex(length <= this.capacity, "length %d must be <= %d", index, this.capacity);
+		assertIndex(length <= this.capacity, "length %d must be <= %d", length, this.capacity);
 	}
 
 	private void assertIndex(boolean expression, String format, Object... args) {


### PR DESCRIPTION
Fixed assertion logs in checkIndex to correctly use the length parameter