### PR TITLE
DefaultResponseErrorHandler update javadoc comment

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
@@ -123,9 +123,9 @@ public class DefaultResponseErrorHandler implements ResponseErrorHandler {
 	}
 
 	/**
-	 * Return error message with details from the response body, possibly truncated:
+	 * Return error message with details from the response body:
 	 * <pre>
-	 * 404 Not Found: [{'id': 123, 'message': 'my very long... (500 bytes)]
+	 * 404 Not Found: [{'id': 123, 'message': 'my message'}]
 	 * </pre>
 	 */
 	private String getErrorMessage(


### PR DESCRIPTION
Error message truncation was removed as part of https://github.com/spring-projects/spring-framework/issues/27552, updating the javadoc comment of the method to reflect that.