### PR TITLE
Avoid rollback after a commit failure in `TransactionalOperator`

### DIFF
--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
@@ -264,7 +264,7 @@ class R2dbcTransactionManagerUnitTests {
 				.doOnNext(connection -> connection.createStatement("foo")).then()
 				.as(operator::transactional)
 				.as(StepVerifier::create)
-				.verifyError(IllegalTransactionStateException.class);
+				.verifyError(BadSqlGrammarException.class);
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));
@@ -317,7 +317,7 @@ class R2dbcTransactionManagerUnitTests {
 			return ConnectionFactoryUtils.getConnection(connectionFactoryMock)
 					.doOnNext(connection -> connection.createStatement("foo")).then();
 		}).as(StepVerifier::create)
-				.verifyError(IllegalTransactionStateException.class);
+				.verifyError(BadSqlGrammarException.class);
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
@@ -264,9 +264,7 @@ class R2dbcTransactionManagerUnitTests {
 				.doOnNext(connection -> connection.createStatement("foo")).then()
 				.as(operator::transactional)
 				.as(StepVerifier::create)
-				.verifyErrorSatisfies(ex -> assertThat(ex)
-						.isExactlyInstanceOf(RuntimeException.class)
-						.hasCauseInstanceOf(BadSqlGrammarException.class));
+				.verifyError(BadSqlGrammarException.class);
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));
@@ -319,9 +317,7 @@ class R2dbcTransactionManagerUnitTests {
 			return ConnectionFactoryUtils.getConnection(connectionFactoryMock)
 					.doOnNext(connection -> connection.createStatement("foo")).then();
 		}).as(StepVerifier::create)
-				.verifyErrorSatisfies(ex -> assertThat(ex)
-						.isExactlyInstanceOf(RuntimeException.class)
-						.hasCauseInstanceOf(BadSqlGrammarException.class));
+				.verifyError(BadSqlGrammarException.class);
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
@@ -264,7 +264,9 @@ class R2dbcTransactionManagerUnitTests {
 				.doOnNext(connection -> connection.createStatement("foo")).then()
 				.as(operator::transactional)
 				.as(StepVerifier::create)
-				.verifyError(BadSqlGrammarException.class);
+				.verifyErrorSatisfies(ex -> assertThat(ex)
+						.isExactlyInstanceOf(RuntimeException.class)
+						.hasCauseInstanceOf(BadSqlGrammarException.class));
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));
@@ -317,7 +319,9 @@ class R2dbcTransactionManagerUnitTests {
 			return ConnectionFactoryUtils.getConnection(connectionFactoryMock)
 					.doOnNext(connection -> connection.createStatement("foo")).then();
 		}).as(StepVerifier::create)
-				.verifyError(BadSqlGrammarException.class);
+				.verifyErrorSatisfies(ex -> assertThat(ex)
+						.isExactlyInstanceOf(RuntimeException.class)
+						.hasCauseInstanceOf(BadSqlGrammarException.class));
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
@@ -84,6 +84,7 @@ import org.springframework.util.StringUtils;
  * @author Sam Brannen
  * @author Mark Paluch
  * @author Sebastien Deleuze
+ * @author Enric Sala
  * @since 1.1
  * @see PlatformTransactionManager
  * @see ReactiveTransactionManager
@@ -919,60 +920,41 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 					!COROUTINES_FLOW_CLASS_NAME.equals(new MethodParameter(method, -1).getParameterType().getName()))) {
 
 				return TransactionContextManager.currentContext().flatMap(context ->
-						createTransactionIfNecessary(rtm, txAttr, joinpointIdentification).flatMap(it -> {
-							try {
-								// Need re-wrapping until we get hold of the exception through usingWhen.
-								return Mono.<Object, ReactiveTransactionInfo>usingWhen(
-										Mono.just(it),
-										txInfo -> {
-											try {
-												return (Mono<?>) invocation.proceedWithInvocation();
-											}
-											catch (Throwable ex) {
-												return Mono.error(ex);
-											}
-										},
-										this::commitTransactionAfterReturning,
-										(txInfo, err) -> Mono.empty(),
-										this::rollbackTransactionOnCancel)
-										.onErrorResume(ex ->
-												completeTransactionAfterThrowing(it, ex).then(Mono.error(ex)));
-							}
-							catch (Throwable ex) {
-								// target invocation exception
-								return completeTransactionAfterThrowing(it, ex).then(Mono.error(ex));
-							}
-						})).contextWrite(TransactionContextManager.getOrCreateContext())
+							Mono.<Object, ReactiveTransactionInfo>usingWhen(
+								createTransactionIfNecessary(rtm, txAttr, joinpointIdentification),
+								tx -> {
+									try {
+										return (Mono<?>) invocation.proceedWithInvocation();
+									}
+									catch (Throwable ex) {
+										return Mono.error(ex);
+									}
+								},
+								this::commitTransactionAfterReturning,
+								this::completeTransactionAfterThrowing,
+								this::rollbackTransactionOnCancel)
+							.onErrorMap(this::unwrapIfResourceCleanupFailure))
+						.contextWrite(TransactionContextManager.getOrCreateContext())
 						.contextWrite(TransactionContextManager.getOrCreateContextHolder());
 			}
 
 			// Any other reactive type, typically a Flux
 			return this.adapter.fromPublisher(TransactionContextManager.currentContext().flatMapMany(context ->
-					createTransactionIfNecessary(rtm, txAttr, joinpointIdentification).flatMapMany(it -> {
-						try {
-							// Need re-wrapping until we get hold of the exception through usingWhen.
-							return Flux
-									.usingWhen(
-											Mono.just(it),
-											txInfo -> {
-												try {
-													return this.adapter.toPublisher(invocation.proceedWithInvocation());
-												}
-												catch (Throwable ex) {
-													return Mono.error(ex);
-												}
-											},
-											this::commitTransactionAfterReturning,
-											(txInfo, ex) -> Mono.empty(),
-											this::rollbackTransactionOnCancel)
-									.onErrorResume(ex ->
-											completeTransactionAfterThrowing(it, ex).then(Mono.error(ex)));
-						}
-						catch (Throwable ex) {
-							// target invocation exception
-							return completeTransactionAfterThrowing(it, ex).then(Mono.error(ex));
-						}
-					})).contextWrite(TransactionContextManager.getOrCreateContext())
+						Flux.usingWhen(
+							createTransactionIfNecessary(rtm, txAttr, joinpointIdentification),
+							tx -> {
+								try {
+									return this.adapter.toPublisher(invocation.proceedWithInvocation());
+								}
+								catch (Throwable ex) {
+									return Mono.error(ex);
+								}
+							},
+							this::commitTransactionAfterReturning,
+							this::completeTransactionAfterThrowing,
+							this::rollbackTransactionOnCancel)
+						.onErrorMap(this::unwrapIfResourceCleanupFailure))
+					.contextWrite(TransactionContextManager.getOrCreateContext())
 					.contextWrite(TransactionContextManager.getOrCreateContextHolder()));
 		}
 
@@ -1053,6 +1035,9 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 								if (ex2 instanceof TransactionSystemException systemException) {
 									systemException.initApplicationException(ex);
 								}
+								else {
+									ex2.addSuppressed(ex);
+								}
 								return ex2;
 							}
 					);
@@ -1065,12 +1050,29 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 								if (ex2 instanceof TransactionSystemException systemException) {
 									systemException.initApplicationException(ex);
 								}
+								else {
+									ex2.addSuppressed(ex);
+								}
 								return ex2;
 							}
 					);
 				}
 			}
 			return Mono.empty();
+		}
+
+		/**
+		 * Unwrap the cause of a throwable, if produced by a failure
+		 * during the async resource cleanup in {@link Flux#usingWhen}.
+		 * @param ex the throwable to try to unwrap
+		 */
+		private Throwable unwrapIfResourceCleanupFailure(Throwable ex) {
+			if (ex instanceof RuntimeException &&
+					ex.getCause() != null &&
+					ex.getMessage().startsWith("Async resource cleanup failed")) {
+				return ex.getCause();
+			}
+			return ex;
 		}
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
@@ -932,8 +932,7 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 								},
 								this::commitTransactionAfterReturning,
 								this::completeTransactionAfterThrowing,
-								this::rollbackTransactionOnCancel)
-							.onErrorMap(this::unwrapIfResourceCleanupFailure))
+								this::rollbackTransactionOnCancel))
 						.contextWrite(TransactionContextManager.getOrCreateContext())
 						.contextWrite(TransactionContextManager.getOrCreateContextHolder());
 			}
@@ -952,8 +951,7 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 							},
 							this::commitTransactionAfterReturning,
 							this::completeTransactionAfterThrowing,
-							this::rollbackTransactionOnCancel)
-						.onErrorMap(this::unwrapIfResourceCleanupFailure))
+							this::rollbackTransactionOnCancel))
 					.contextWrite(TransactionContextManager.getOrCreateContext())
 					.contextWrite(TransactionContextManager.getOrCreateContextHolder()));
 		}
@@ -1035,9 +1033,6 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 								if (ex2 instanceof TransactionSystemException systemException) {
 									systemException.initApplicationException(ex);
 								}
-								else {
-									ex2.addSuppressed(ex);
-								}
 								return ex2;
 							}
 					);
@@ -1050,29 +1045,12 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 								if (ex2 instanceof TransactionSystemException systemException) {
 									systemException.initApplicationException(ex);
 								}
-								else {
-									ex2.addSuppressed(ex);
-								}
 								return ex2;
 							}
 					);
 				}
 			}
 			return Mono.empty();
-		}
-
-		/**
-		 * Unwrap the cause of a throwable, if produced by a failure
-		 * during the async resource cleanup in {@link Flux#usingWhen}.
-		 * @param ex the throwable to try to unwrap
-		 */
-		private Throwable unwrapIfResourceCleanupFailure(Throwable ex) {
-			if (ex instanceof RuntimeException &&
-					ex.getCause() != null &&
-					ex.getMessage().startsWith("Async resource cleanup failed")) {
-				return ex.getCause();
-			}
-			return ex;
 		}
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperator.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.transaction.TransactionException;
  *
  * @author Mark Paluch
  * @author Juergen Hoeller
+ * @author Enric Sala
  * @since 5.2
  * @see #execute
  * @see ReactiveTransactionManager
@@ -69,7 +70,9 @@ public interface TransactionalOperator {
 	 * @throws TransactionException in case of initialization, rollback, or system errors
 	 * @throws RuntimeException if thrown by the TransactionCallback
 	 */
-	<T> Mono<T> transactional(Mono<T> mono);
+	default <T> Mono<T> transactional(Mono<T> mono) {
+		return execute(it -> mono).singleOrEmpty();
+	}
 
 	/**
 	 * Execute the action specified by the given callback object within a transaction.

--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperatorImpl.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperatorImpl.java
@@ -79,8 +79,7 @@ final class TransactionalOperatorImpl implements TransactionalOperator {
 				action::doInTransaction,
 				this.transactionManager::commit,
 				this::rollbackOnException,
-				this.transactionManager::rollback)
-			.onErrorMap(this::unwrapIfResourceCleanupFailure))
+				this.transactionManager::rollback))
 		.contextWrite(TransactionContextManager.getOrCreateContext())
 		.contextWrite(TransactionContextManager.getOrCreateContextHolder());
 	}
@@ -98,26 +97,9 @@ final class TransactionalOperatorImpl implements TransactionalOperator {
 					if (ex2 instanceof TransactionSystemException tse) {
 						tse.initApplicationException(ex);
 					}
-					else {
-						ex2.addSuppressed(ex);
-					}
 					return ex2;
 				}
 		);
-	}
-
-	/**
-	 * Unwrap the cause of a throwable, if produced by a failure
-	 * during the async resource cleanup in {@link Flux#usingWhen}.
-	 * @param ex the throwable to try to unwrap
-	 */
-	private Throwable unwrapIfResourceCleanupFailure(Throwable ex) {
-		if (ex instanceof RuntimeException &&
-				ex.getCause() != null &&
-				ex.getMessage().startsWith("Async resource cleanup failed")) {
-			return ex.getCause();
-		}
-		return ex;
 	}
 
 

--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperatorImpl.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperatorImpl.java
@@ -79,7 +79,8 @@ final class TransactionalOperatorImpl implements TransactionalOperator {
 				action::doInTransaction,
 				this.transactionManager::commit,
 				this::rollbackOnException,
-				this.transactionManager::rollback))
+				this.transactionManager::rollback)
+			.onErrorMap(this::unwrapIfResourceCleanupFailure))
 		.contextWrite(TransactionContextManager.getOrCreateContext())
 		.contextWrite(TransactionContextManager.getOrCreateContextHolder());
 	}
@@ -97,9 +98,26 @@ final class TransactionalOperatorImpl implements TransactionalOperator {
 					if (ex2 instanceof TransactionSystemException tse) {
 						tse.initApplicationException(ex);
 					}
+					else {
+						ex2.addSuppressed(ex);
+					}
 					return ex2;
 				}
 		);
+	}
+
+	/**
+	 * Unwrap the cause of a throwable, if produced by a failure
+	 * during the async resource cleanup in {@link Flux#usingWhen}.
+	 * @param ex the throwable to try to unwrap
+	 */
+	private Throwable unwrapIfResourceCleanupFailure(Throwable ex) {
+		if (ex instanceof RuntimeException &&
+				ex.getCause() != null &&
+				ex.getMessage().startsWith("Async resource cleanup failed")) {
+			return ex.getCause();
+		}
+		return ex;
 	}
 
 

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractReactiveTransactionAspectTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractReactiveTransactionAspectTests.java
@@ -335,11 +335,7 @@ public abstract class AbstractReactiveTransactionAspectTests {
 
 		Mono.from(itb.setName(name))
 				.as(StepVerifier::create)
-				.consumeErrorWith(throwable -> {
-					assertThat(throwable.getClass()).isEqualTo(RuntimeException.class);
-					assertThat(throwable.getCause()).isEqualTo(ex);
-				})
-				.verify();
+				.verifyErrorSatisfies(actual -> assertThat(actual).isEqualTo(ex));
 
 		// Should have invoked target and changed name
 

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractReactiveTransactionAspectTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractReactiveTransactionAspectTests.java
@@ -256,7 +256,9 @@ public abstract class AbstractReactiveTransactionAspectTests {
 				.as(StepVerifier::create)
 				.expectErrorSatisfies(actual -> {
 					if (rollbackException) {
-						assertThat(actual).isEqualTo(tex);
+						assertThat(actual)
+								.isExactlyInstanceOf(RuntimeException.class)
+								.hasCause(tex);
 					}
 					else {
 						assertThat(actual).isEqualTo(ex);
@@ -335,7 +337,9 @@ public abstract class AbstractReactiveTransactionAspectTests {
 
 		Mono.from(itb.setName(name))
 				.as(StepVerifier::create)
-				.verifyErrorSatisfies(actual -> assertThat(actual).isEqualTo(ex));
+				.verifyErrorSatisfies(actual -> assertThat(actual)
+						.isExactlyInstanceOf(RuntimeException.class)
+						.hasCause(ex));
 
 		// Should have invoked target and changed name
 

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractReactiveTransactionAspectTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/AbstractReactiveTransactionAspectTests.java
@@ -256,9 +256,7 @@ public abstract class AbstractReactiveTransactionAspectTests {
 				.as(StepVerifier::create)
 				.expectErrorSatisfies(actual -> {
 					if (rollbackException) {
-						assertThat(actual)
-								.isExactlyInstanceOf(RuntimeException.class)
-								.hasCause(tex);
+						assertThat(actual).isEqualTo(tex);
 					}
 					else {
 						assertThat(actual).isEqualTo(ex);
@@ -337,9 +335,7 @@ public abstract class AbstractReactiveTransactionAspectTests {
 
 		Mono.from(itb.setName(name))
 				.as(StepVerifier::create)
-				.verifyErrorSatisfies(actual -> assertThat(actual)
-						.isExactlyInstanceOf(RuntimeException.class)
-						.hasCause(ex));
+				.verifyErrorSatisfies(actual -> assertThat(actual).isEqualTo(ex));
 
 		// Should have invoked target and changed name
 

--- a/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,29 @@
 
 package org.springframework.transaction.reactive;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.PublisherProbe;
 
+import org.springframework.transaction.ReactiveTransaction;
+import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link TransactionalOperator}.
  *
  * @author Mark Paluch
+ * @author Enric Sala
  */
 public class TransactionalOperatorTests {
 
@@ -100,6 +108,43 @@ public class TransactionalOperatorTests {
 	}
 
 	@Test
+	public void commitFailureWithMono() {
+		ReactiveTransactionManager tm = mock(ReactiveTransactionManager.class);
+		given(tm.getReactiveTransaction(any())).willReturn(Mono.just(mock(ReactiveTransaction.class)));
+		PublisherProbe<Void> commit = PublisherProbe.of(Mono.error(IOException::new));
+		given(tm.commit(any())).willReturn(commit.mono());
+		PublisherProbe<Void> rollback = PublisherProbe.empty();
+		given(tm.rollback(any())).willReturn(rollback.mono());
+
+		TransactionalOperator operator = TransactionalOperator.create(tm, new DefaultTransactionDefinition());
+		Mono.just(true).as(operator::transactional)
+				.as(StepVerifier::create)
+				.verifyError(IOException.class);
+		assertThat(commit.subscribeCount()).isEqualTo(1);
+		rollback.assertWasNotSubscribed();
+	}
+
+	@Test
+	public void rollbackFailureWithMono() {
+		ReactiveTransactionManager tm = mock(ReactiveTransactionManager.class);
+		given(tm.getReactiveTransaction(any())).willReturn(Mono.just(mock(ReactiveTransaction.class)));
+		PublisherProbe<Void> commit = PublisherProbe.empty();
+		given(tm.commit(any())).willReturn(commit.mono());
+		PublisherProbe<Void> rollback = PublisherProbe.of(Mono.error(IOException::new));
+		given(tm.rollback(any())).willReturn(rollback.mono());
+
+		TransactionalOperator operator = TransactionalOperator.create(tm, new DefaultTransactionDefinition());
+		IllegalStateException actionFailure = new IllegalStateException();
+		Mono.error(actionFailure).as(operator::transactional)
+				.as(StepVerifier::create)
+				.verifyErrorSatisfies(ex -> assertThat(ex)
+						.isInstanceOf(IOException.class)
+						.hasSuppressedException(actionFailure));
+		commit.assertWasNotSubscribed();
+		assertThat(rollback.subscribeCount()).isEqualTo(1);
+	}
+
+	@Test
 	public void commitWithFlux() {
 		TransactionalOperator operator = TransactionalOperator.create(tm, new DefaultTransactionDefinition());
 		Flux.just(1, 2, 3, 4).as(operator::transactional)
@@ -118,6 +163,45 @@ public class TransactionalOperatorTests {
 				.verifyError(IllegalStateException.class);
 		assertThat(tm.commit).isFalse();
 		assertThat(tm.rollback).isTrue();
+	}
+
+	@Test
+	public void commitFailureWithFlux() {
+		ReactiveTransactionManager tm = mock(ReactiveTransactionManager.class);
+		given(tm.getReactiveTransaction(any())).willReturn(Mono.just(mock(ReactiveTransaction.class)));
+		PublisherProbe<Void> commit = PublisherProbe.of(Mono.error(IOException::new));
+		given(tm.commit(any())).willReturn(commit.mono());
+		PublisherProbe<Void> rollback = PublisherProbe.empty();
+		given(tm.rollback(any())).willReturn(rollback.mono());
+
+		TransactionalOperator operator = TransactionalOperator.create(tm, new DefaultTransactionDefinition());
+		Flux.just(1, 2, 3, 4).as(operator::transactional)
+				.as(StepVerifier::create)
+				.expectNextCount(4)
+				.verifyError(IOException.class);
+		assertThat(commit.subscribeCount()).isEqualTo(1);
+		rollback.assertWasNotSubscribed();
+	}
+
+	@Test
+	public void rollbackFailureWithFlux() {
+		ReactiveTransactionManager tm = mock(ReactiveTransactionManager.class);
+		given(tm.getReactiveTransaction(any())).willReturn(Mono.just(mock(ReactiveTransaction.class)));
+		PublisherProbe<Void> commit = PublisherProbe.empty();
+		given(tm.commit(any())).willReturn(commit.mono());
+		PublisherProbe<Void> rollback = PublisherProbe.of(Mono.error(IOException::new));
+		given(tm.rollback(any())).willReturn(rollback.mono());
+
+		TransactionalOperator operator = TransactionalOperator.create(tm, new DefaultTransactionDefinition());
+		IllegalStateException actionFailure = new IllegalStateException();
+		Flux.just(1, 2, 3).concatWith(Flux.error(actionFailure)).as(operator::transactional)
+				.as(StepVerifier::create)
+				.expectNextCount(3)
+				.verifyErrorSatisfies(ex -> assertThat(ex)
+						.isInstanceOf(IOException.class)
+						.hasSuppressedException(actionFailure));
+		commit.assertWasNotSubscribed();
+		assertThat(rollback.subscribeCount()).isEqualTo(1);
 	}
 
 }

--- a/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
@@ -119,7 +119,9 @@ public class TransactionalOperatorTests {
 		TransactionalOperator operator = TransactionalOperator.create(tm, new DefaultTransactionDefinition());
 		Mono.just(true).as(operator::transactional)
 				.as(StepVerifier::create)
-				.verifyError(IOException.class);
+				.verifyErrorSatisfies(ex ->	assertThat(ex)
+						.isExactlyInstanceOf(RuntimeException.class)
+						.hasCauseInstanceOf(IOException.class));
 		assertThat(commit.subscribeCount()).isEqualTo(1);
 		rollback.assertWasNotSubscribed();
 	}
@@ -138,7 +140,8 @@ public class TransactionalOperatorTests {
 		Mono.error(actionFailure).as(operator::transactional)
 				.as(StepVerifier::create)
 				.verifyErrorSatisfies(ex -> assertThat(ex)
-						.isInstanceOf(IOException.class)
+						.isExactlyInstanceOf(RuntimeException.class)
+						.hasCauseInstanceOf(IOException.class)
 						.hasSuppressedException(actionFailure));
 		commit.assertWasNotSubscribed();
 		assertThat(rollback.subscribeCount()).isEqualTo(1);
@@ -178,7 +181,9 @@ public class TransactionalOperatorTests {
 		Flux.just(1, 2, 3, 4).as(operator::transactional)
 				.as(StepVerifier::create)
 				.expectNextCount(4)
-				.verifyError(IOException.class);
+				.verifyErrorSatisfies(ex ->	assertThat(ex)
+						.isExactlyInstanceOf(RuntimeException.class)
+						.hasCauseInstanceOf(IOException.class));
 		assertThat(commit.subscribeCount()).isEqualTo(1);
 		rollback.assertWasNotSubscribed();
 	}
@@ -198,7 +203,8 @@ public class TransactionalOperatorTests {
 				.as(StepVerifier::create)
 				.expectNextCount(3)
 				.verifyErrorSatisfies(ex -> assertThat(ex)
-						.isInstanceOf(IOException.class)
+						.isExactlyInstanceOf(RuntimeException.class)
+						.hasCauseInstanceOf(IOException.class)
 						.hasSuppressedException(actionFailure));
 		commit.assertWasNotSubscribed();
 		assertThat(rollback.subscribeCount()).isEqualTo(1);

--- a/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
@@ -119,9 +119,7 @@ public class TransactionalOperatorTests {
 		TransactionalOperator operator = TransactionalOperator.create(tm, new DefaultTransactionDefinition());
 		Mono.just(true).as(operator::transactional)
 				.as(StepVerifier::create)
-				.verifyErrorSatisfies(ex ->	assertThat(ex)
-						.isExactlyInstanceOf(RuntimeException.class)
-						.hasCauseInstanceOf(IOException.class));
+				.verifyError(IOException.class);
 		assertThat(commit.subscribeCount()).isEqualTo(1);
 		rollback.assertWasNotSubscribed();
 	}
@@ -140,8 +138,7 @@ public class TransactionalOperatorTests {
 		Mono.error(actionFailure).as(operator::transactional)
 				.as(StepVerifier::create)
 				.verifyErrorSatisfies(ex -> assertThat(ex)
-						.isExactlyInstanceOf(RuntimeException.class)
-						.hasCauseInstanceOf(IOException.class)
+						.isInstanceOf(IOException.class)
 						.hasSuppressedException(actionFailure));
 		commit.assertWasNotSubscribed();
 		assertThat(rollback.subscribeCount()).isEqualTo(1);
@@ -181,9 +178,7 @@ public class TransactionalOperatorTests {
 		Flux.just(1, 2, 3, 4).as(operator::transactional)
 				.as(StepVerifier::create)
 				.expectNextCount(4)
-				.verifyErrorSatisfies(ex ->	assertThat(ex)
-						.isExactlyInstanceOf(RuntimeException.class)
-						.hasCauseInstanceOf(IOException.class));
+				.verifyError(IOException.class);
 		assertThat(commit.subscribeCount()).isEqualTo(1);
 		rollback.assertWasNotSubscribed();
 	}
@@ -203,8 +198,7 @@ public class TransactionalOperatorTests {
 				.as(StepVerifier::create)
 				.expectNextCount(3)
 				.verifyErrorSatisfies(ex -> assertThat(ex)
-						.isExactlyInstanceOf(RuntimeException.class)
-						.hasCauseInstanceOf(IOException.class)
+						.isInstanceOf(IOException.class)
 						.hasSuppressedException(actionFailure));
 		commit.assertWasNotSubscribed();
 		assertThat(rollback.subscribeCount()).isEqualTo(1);

--- a/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
+++ b/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
@@ -290,9 +290,8 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 			try {
 				itb.setName(name)
 			}
-			catch (ex: Exception) {
-				assertThat(ex).isInstanceOf(RuntimeException::class.java)
-				assertThat(ex.cause).hasMessage(ex.message).isInstanceOf(ex::class.java)
+			catch (actual: Exception) {
+				assertThat(actual).isEqualTo(ex)
 			}
 			// Should have invoked target and changed name
 			assertThat(itb.getName()).isEqualTo(name)

--- a/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
+++ b/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
@@ -291,7 +291,8 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 				itb.setName(name)
 			}
 			catch (actual: Exception) {
-				assertThat(actual).isEqualTo(ex)
+				assertThat(actual).isInstanceOf(ex.javaClass)
+				assertThat(actual).hasMessage(ex.message)
 			}
 			// Should have invoked target and changed name
 			assertThat(itb.getName()).isEqualTo(name)

--- a/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
+++ b/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
@@ -218,7 +218,11 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 			}
 			catch (actual: Exception) {
 				if (rollbackException) {
-					assertThat(actual).hasMessage(tex.message).isInstanceOf(tex::class.java)
+					assertThat(actual)
+						.isExactlyInstanceOf(RuntimeException::class.java)
+						.cause
+						.isExactlyInstanceOf(RuntimeException::class.java)
+						.hasCause(tex)
 				} else {
 					assertThat(actual).hasMessage(ex.message).isInstanceOf(ex::class.java)
 				}
@@ -291,7 +295,11 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 				itb.setName(name)
 			}
 			catch (actual: Exception) {
-				assertThat(actual).isEqualTo(ex)
+				assertThat(actual)
+					.isExactlyInstanceOf(RuntimeException::class.java)
+					.cause
+					.isExactlyInstanceOf(RuntimeException::class.java)
+					.hasCause(ex)
 			}
 			// Should have invoked target and changed name
 			assertThat(itb.getName()).isEqualTo(name)

--- a/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
+++ b/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
@@ -218,11 +218,7 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 			}
 			catch (actual: Exception) {
 				if (rollbackException) {
-					assertThat(actual)
-						.isExactlyInstanceOf(RuntimeException::class.java)
-						.cause
-						.isExactlyInstanceOf(RuntimeException::class.java)
-						.hasCause(tex)
+					assertThat(actual).hasMessage(tex.message).isInstanceOf(tex::class.java)
 				} else {
 					assertThat(actual).hasMessage(ex.message).isInstanceOf(ex::class.java)
 				}
@@ -295,11 +291,7 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 				itb.setName(name)
 			}
 			catch (actual: Exception) {
-				assertThat(actual)
-					.isExactlyInstanceOf(RuntimeException::class.java)
-					.cause
-					.isExactlyInstanceOf(RuntimeException::class.java)
-					.hasCause(ex)
+				assertThat(actual).isEqualTo(ex)
 			}
 			// Should have invoked target and changed name
 			assertThat(itb.getName()).isEqualTo(name)


### PR DESCRIPTION
A failure to commit a reactive transaction will complete the transaction and clean up resources. Executing a rollback at that point is invalid, which causes an `IllegalTransactionStateException` that masks the cause of the commit failure.

This change restructures `TransactionalOperatorImpl` and `ReactiveTransactionSupport` to avoid executing a rollback after a failed commit. While there, the `Mono` transaction handling in `TransactionalOperator` is simplified by moving it to a default method on the interface.

See gh-27523