### PR TITLE
invoke BeanFactoryPostProcessors with explicit order

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -522,9 +522,8 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 	 * Return the list of BeanFactoryPostProcessors that will get applied
 	 * to the internal BeanFactory.
 	 */
-	public List<BeanFactoryPostProcessor> getBeanFactoryPostProcessors() {
-	    // respecting explicit order 
-	    AnnotationAwareOrderComparator.sort(this.beanFactoryPostProcessors);
+	public List<BeanFactoryPostProcessor> getBeanFactoryPostProcessors() { 
+		AnnotationAwareOrderComparator.sort(this.beanFactoryPostProcessors);
 		return this.beanFactoryPostProcessors;
 	}
 

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -522,6 +522,8 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 	 * to the internal BeanFactory.
 	 */
 	public List<BeanFactoryPostProcessor> getBeanFactoryPostProcessors() {
+	    // respecting explicit order 
+	    AnnotationAwareOrderComparator.sort(this.beanFactoryPostProcessors);
 		return this.beanFactoryPostProcessors;
 	}
 

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -522,7 +522,7 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 	 * Return the list of BeanFactoryPostProcessors that will get applied
 	 * to the internal BeanFactory.
 	 */
-	public List<BeanFactoryPostProcessor> getBeanFactoryPostProcessors() { 
+	public List<BeanFactoryPostProcessor> getBeanFactoryPostProcessors() {
 		AnnotationAwareOrderComparator.sort(this.beanFactoryPostProcessors);
 		return this.beanFactoryPostProcessors;
 	}

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -87,6 +87,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 /**
  * Abstract implementation of the {@link org.springframework.context.ApplicationContext}

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -70,6 +70,7 @@ import org.springframework.context.weaving.LoadTimeWeaverAwareProcessor;
 import org.springframework.core.NativeDetector;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.SpringProperties;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -87,7 +88,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
-import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 /**
  * Abstract implementation of the {@link org.springframework.context.ApplicationContext}


### PR DESCRIPTION
`BeanFactoryPostProcessor` may implement interface `Ordered` or not ,  for example: `CachingMetadataReaderFactoryPostProcessor`, `ConfigurationWarningsPostProcessor`. 

If we want to invoke them by order, we need sorting, otherwise the order is depends on the order of their owner `ApplicationContextInitializer`:

the caller:

```java
	protected void invokeBeanFactoryPostProcessors(ConfigurableListableBeanFactory beanFactory) {
		PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(beanFactory, getBeanFactoryPostProcessors());
                // some code
	}
```

```java
class SharedMetadataReaderFactoryContextInitializer
		implements ApplicationContextInitializer<ConfigurableApplicationContext>, Ordered {
	@Override
	public void initialize(ConfigurableApplicationContext applicationContext) {
		BeanFactoryPostProcessor postProcessor = new CachingMetadataReaderFactoryPostProcessor(applicationContext);
		applicationContext.addBeanFactoryPostProcessor(postProcessor);
	}

	@Override
	public int getOrder() {
		return 0;
	}

	static class CachingMetadataReaderFactoryPostProcessor
			implements BeanDefinitionRegistryPostProcessor, PriorityOrdered {
		@Override
		public int getOrder() {
			// Must happen before the ConfigurationClassPostProcessor is created
			return Ordered.HIGHEST_PRECEDENCE;
		}
        }
}
```

```java
public class ConfigurationWarningsApplicationContextInitializer
		implements ApplicationContextInitializer<ConfigurableApplicationContext> {
	@Override
	public void initialize(ConfigurableApplicationContext context) {
		context.addBeanFactoryPostProcessor(new ConfigurationWarningsPostProcessor(getChecks()));
	}

	protected static final class ConfigurationWarningsPostProcessor
			implements PriorityOrdered, BeanDefinitionRegistryPostProcessor {
             
		@Override
		public int getOrder() {
			return Ordered.LOWEST_PRECEDENCE - 1;
		}
}
```