### PR TITLE
Improve example in Javadoc for HttpEntity

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpEntity.java
@@ -28,7 +28,7 @@ import org.springframework.util.ObjectUtils;
  * <pre class="code">
  * HttpHeaders headers = new HttpHeaders();
  * headers.setContentType(MediaType.TEXT_PLAIN);
- * HttpEntity&lt;String&gt; entity = new HttpEntity&lt;String&gt;(helloWorld, headers);
+ * HttpEntity&lt;String&gt; entity = new HttpEntity&lt;String&gt;("helloWorld", headers);
  * URI location = template.postForLocation("https://example.com", entity);
  * </pre>
  * or


### PR DESCRIPTION
There is a minor typo in java doc.
To be specific, provided code snippet in `HttpEntity` does not work because of lack of quotation marks.

```java
HttpHeaders headers = new HttpHeaders();
headers.setContentType(MediaType.TEXT_PLAIN);
HttpEntity<String> entity = new HttpEntity<String>(helloWorld, headers);
URI location = template.postForLocation("https://example.com", entity);
```



<!--
!!! For Security Vulnerabilities, please go to https://spring.io/security-policy !!!
-->
**Affects:** \<5.3.10>