### PR TITLE
 Simplify default locale/timezone resolution in cookie/session locale resolvers

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/LocaleContextResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/LocaleContextResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.context.i18n.LocaleContext;
+import org.springframework.context.i18n.SimpleLocaleContext;
 import org.springframework.lang.Nullable;
 
 /**
  * Extension of {@link LocaleResolver}, adding support for a rich locale context
  * (potentially including locale and time zone information).
+ *
+ * <p>Also provides pre-implemented versions of {@link #resolveLocale} and {@link #setLocale},
+ * delegating to {@link #resolveLocaleContext} and {@link #setLocaleContext}.
  *
  * @author Juergen Hoeller
  * @since 4.0
@@ -72,5 +76,16 @@ public interface LocaleContextResolver extends LocaleResolver {
 	 */
 	void setLocaleContext(HttpServletRequest request, @Nullable HttpServletResponse response,
 			@Nullable LocaleContext localeContext);
+
+	@Override
+	default Locale resolveLocale(HttpServletRequest request) {
+		Locale locale = resolveLocaleContext(request).getLocale();
+		return (locale != null ? locale : request.getLocale());
+	}
+
+	@Override
+	default void setLocale(HttpServletRequest request, @Nullable HttpServletResponse response, @Nullable Locale locale) {
+		setLocaleContext(request, response, (locale != null ? new SimpleLocaleContext(locale) : null));
+	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleContextResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleContextResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,14 @@
 
 package org.springframework.web.servlet.i18n;
 
-import java.util.Locale;
 import java.util.TimeZone;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import org.springframework.context.i18n.SimpleLocaleContext;
 import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.LocaleContextResolver;
 
 /**
  * Abstract base class for {@link LocaleContextResolver} implementations.
  * Provides support for a default locale and a default time zone.
- *
- * <p>Also provides pre-implemented versions of {@link #resolveLocale} and {@link #setLocale},
- * delegating to {@link #resolveLocaleContext} and {@link #setLocaleContext}.
  *
  * @author Juergen Hoeller
  * @since 4.0
@@ -57,18 +49,6 @@ public abstract class AbstractLocaleContextResolver extends AbstractLocaleResolv
 	@Nullable
 	public TimeZone getDefaultTimeZone() {
 		return this.defaultTimeZone;
-	}
-
-
-	@Override
-	public Locale resolveLocale(HttpServletRequest request) {
-		Locale locale = resolveLocaleContext(request).getLocale();
-		return (locale != null ? locale : request.getLocale());
-	}
-
-	@Override
-	public void setLocale(HttpServletRequest request, @Nullable HttpServletResponse response, @Nullable Locale locale) {
-		setLocaleContext(request, response, (locale != null ? new SimpleLocaleContext(locale) : null));
 	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.springframework.web.servlet.LocaleResolver;
  * specified in the "accept-language" header of the HTTP request (that is,
  * the locale sent by the client browser, normally that of the client's OS).
  *
- * <p>Note: Does not support {@code setLocale}, since the accept header
+ * <p>Note: Does not support {@code setLocale}, since the "accept-header"
  * can only be changed through changing the client's locale settings.
  *
  * @author Juergen Hoeller
@@ -41,12 +41,9 @@ import org.springframework.web.servlet.LocaleResolver;
  * @since 27.02.2003
  * @see jakarta.servlet.http.HttpServletRequest#getLocale()
  */
-public class AcceptHeaderLocaleResolver implements LocaleResolver {
+public class AcceptHeaderLocaleResolver extends AbstractLocaleResolver {
 
 	private final List<Locale> supportedLocales = new ArrayList<>(4);
-
-	@Nullable
-	private Locale defaultLocale;
 
 
 	/**
@@ -67,29 +64,6 @@ public class AcceptHeaderLocaleResolver implements LocaleResolver {
 	 */
 	public List<Locale> getSupportedLocales() {
 		return this.supportedLocales;
-	}
-
-	/**
-	 * Configure a fixed default locale to fall back on if the request does not
-	 * have an "Accept-Language" header.
-	 * <p>By default this is not set in which case when there is no "Accept-Language"
-	 * header, the default locale for the server is used as defined in
-	 * {@link HttpServletRequest#getLocale()}.
-	 * @param defaultLocale the default locale to use
-	 * @since 4.3
-	 */
-	public void setDefaultLocale(@Nullable Locale defaultLocale) {
-		this.defaultLocale = defaultLocale;
-	}
-
-	/**
-	 * The configured default locale, if any.
-	 * <p>This method may be overridden in subclasses.
-	 * @since 4.3
-	 */
-	@Nullable
-	public Locale getDefaultLocale() {
-		return this.defaultLocale;
 	}
 
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieLocaleResolver.java
@@ -18,6 +18,7 @@ package org.springframework.web.servlet.i18n;
 
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Function;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -50,6 +51,7 @@ import org.springframework.web.util.WebUtils;
  *
  * @author Juergen Hoeller
  * @author Jean-Pierre Pawlak
+ * @author Vedran Pavic
  * @since 27.02.2003
  * @see #setDefaultLocale
  * @see #setDefaultTimeZone
@@ -94,6 +96,15 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 	@Nullable
 	private TimeZone defaultTimeZone;
 
+	private Function<HttpServletRequest, Locale> defaultLocaleFunction = request -> {
+		Locale defaultLocale = getDefaultLocale();
+		if (defaultLocale == null) {
+			defaultLocale = request.getLocale();
+		}
+		return defaultLocale;
+	};
+
+	private Function<HttpServletRequest, TimeZone> defaultTimeZoneFunction = request -> getDefaultTimeZone();
 
 	/**
 	 * Create a new instance of the {@link CookieLocaleResolver} class
@@ -137,8 +148,8 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 	 * @since 5.1.7
 	 * @see #setDefaultLocale
 	 * @see #setDefaultTimeZone
-	 * @see #determineDefaultLocale
-	 * @see #determineDefaultTimeZone
+	 * @see #setDefaultLocaleFunction(Function)
+	 * @see #setDefaultTimeZoneFunction(Function)
 	 */
 	public void setRejectInvalidCookies(boolean rejectInvalidCookies) {
 		this.rejectInvalidCookies = rejectInvalidCookies;
@@ -184,6 +195,35 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 	@Nullable
 	protected TimeZone getDefaultTimeZone() {
 		return this.defaultTimeZone;
+	}
+
+	/**
+	 * Set the function used to determine the default locale for the given request,
+	 * called if no {@link Locale} session attribute has been found.
+	 * <p>The default implementation returns the specified default locale,
+	 * if any, else falls back to the request's accept-header locale.
+	 * @param defaultLocaleFunction the function used to determine the default locale
+	 * @since 6.0
+	 * @see #setDefaultLocale
+	 * @see jakarta.servlet.http.HttpServletRequest#getLocale()
+	 */
+	public void setDefaultLocaleFunction(Function<HttpServletRequest, Locale> defaultLocaleFunction) {
+		Assert.notNull(defaultLocaleFunction, "defaultLocaleFunction must not be null");
+		this.defaultLocaleFunction = defaultLocaleFunction;
+	}
+
+	/**
+	 * Set the function used to determine the default time zone for the given request,
+	 * called if no {@link TimeZone} session attribute has been found.
+	 * <p>The default implementation returns the specified default time zone,
+	 * if any, or {@code null} otherwise.
+	 * @param defaultTimeZoneFunction the function used to determine the default time zone
+	 * @since 6.0
+	 * @see #setDefaultTimeZone
+	 */
+	public void setDefaultTimeZoneFunction(Function<HttpServletRequest, TimeZone> defaultTimeZoneFunction) {
+		Assert.notNull(defaultTimeZoneFunction, "defaultTimeZoneFunction must not be null");
+		this.defaultTimeZoneFunction = defaultTimeZoneFunction;
 	}
 
 
@@ -260,9 +300,9 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 			}
 
 			request.setAttribute(LOCALE_REQUEST_ATTRIBUTE_NAME,
-					(locale != null ? locale : determineDefaultLocale(request)));
+					(locale != null ? locale : this.defaultLocaleFunction.apply(request)));
 			request.setAttribute(TIME_ZONE_REQUEST_ATTRIBUTE_NAME,
-					(timeZone != null ? timeZone : determineDefaultTimeZone(request)));
+					(timeZone != null ? timeZone : this.defaultTimeZoneFunction.apply(request)));
 		}
 	}
 
@@ -291,9 +331,9 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 			removeCookie(response);
 		}
 		request.setAttribute(LOCALE_REQUEST_ATTRIBUTE_NAME,
-				(locale != null ? locale : determineDefaultLocale(request)));
+				(locale != null ? locale : this.defaultLocaleFunction.apply(request)));
 		request.setAttribute(TIME_ZONE_REQUEST_ATTRIBUTE_NAME,
-				(timeZone != null ? timeZone : determineDefaultTimeZone(request)));
+				(timeZone != null ? timeZone : this.defaultTimeZoneFunction.apply(request)));
 	}
 
 
@@ -334,13 +374,11 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 	 * @return the default locale (never {@code null})
 	 * @see #setDefaultLocale
 	 * @see jakarta.servlet.http.HttpServletRequest#getLocale()
+	 * @deprecated as of 6.0, in favor of {@link #setDefaultLocaleFunction(Function)}
 	 */
+	@Deprecated
 	protected Locale determineDefaultLocale(HttpServletRequest request) {
-		Locale defaultLocale = getDefaultLocale();
-		if (defaultLocale == null) {
-			defaultLocale = request.getLocale();
-		}
-		return defaultLocale;
+		return this.defaultLocaleFunction.apply(request);
 	}
 
 	/**
@@ -351,10 +389,12 @@ public class CookieLocaleResolver extends CookieGenerator implements LocaleConte
 	 * @param request the request to resolve the time zone for
 	 * @return the default time zone (or {@code null} if none defined)
 	 * @see #setDefaultTimeZone
+	 * @deprecated as of 6.0, in favor of {@link #setDefaultTimeZoneFunction(Function)}
 	 */
+	@Deprecated
 	@Nullable
 	protected TimeZone determineDefaultTimeZone(HttpServletRequest request) {
-		return getDefaultTimeZone();
+		return this.defaultTimeZoneFunction.apply(request);
 	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/SessionLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/SessionLocaleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.web.servlet.i18n;
 
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Function;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,6 +26,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.i18n.LocaleContext;
 import org.springframework.context.i18n.TimeZoneAwareLocaleContext;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 import org.springframework.web.util.WebUtils;
 
 /**
@@ -54,6 +56,7 @@ import org.springframework.web.util.WebUtils;
  * against the current {@code HttpServletRequest}.
  *
  * @author Juergen Hoeller
+ * @author Vedran Pavic
  * @since 27.02.2003
  * @see #setDefaultLocale
  * @see #setDefaultTimeZone
@@ -85,6 +88,15 @@ public class SessionLocaleResolver extends AbstractLocaleContextResolver {
 
 	private String timeZoneAttributeName = TIME_ZONE_SESSION_ATTRIBUTE_NAME;
 
+	private Function<HttpServletRequest, Locale> defaultLocaleFunction = request -> {
+		Locale defaultLocale = getDefaultLocale();
+		if (defaultLocale == null) {
+			defaultLocale = request.getLocale();
+		}
+		return defaultLocale;
+	};
+
+	private Function<HttpServletRequest, TimeZone> defaultTimeZoneFunction = request -> getDefaultTimeZone();
 
 	/**
 	 * Specify the name of the corresponding attribute in the {@code HttpSession},
@@ -106,12 +118,40 @@ public class SessionLocaleResolver extends AbstractLocaleContextResolver {
 		this.timeZoneAttributeName = timeZoneAttributeName;
 	}
 
+	/**
+	 * Set the function used to determine the default locale for the given request,
+	 * called if no {@link Locale} session attribute has been found.
+	 * <p>The default implementation returns the specified default locale,
+	 * if any, else falls back to the request's accept-header locale.
+	 * @param defaultLocaleFunction the function used to determine the default locale
+	 * @since 6.0
+	 * @see #setDefaultLocale
+	 * @see jakarta.servlet.http.HttpServletRequest#getLocale()
+	 */
+	public void setDefaultLocaleFunction(Function<HttpServletRequest, Locale> defaultLocaleFunction) {
+		Assert.notNull(defaultLocaleFunction, "defaultLocaleFunction must not be null");
+		this.defaultLocaleFunction = defaultLocaleFunction;
+	}
+
+	/**
+	 * Set the function used to determine the default time zone for the given request,
+	 * called if no {@link TimeZone} session attribute has been found.
+	 * <p>The default implementation returns the specified default time zone,
+	 * if any, or {@code null} otherwise.
+	 * @param defaultTimeZoneFunction the function used to determine the default time zone
+	 * @since 6.0
+	 * @see #setDefaultTimeZone
+	 */
+	public void setDefaultTimeZoneFunction(Function<HttpServletRequest, TimeZone> defaultTimeZoneFunction) {
+		Assert.notNull(defaultTimeZoneFunction, "defaultTimeZoneFunction must not be null");
+		this.defaultTimeZoneFunction = defaultTimeZoneFunction;
+	}
 
 	@Override
 	public Locale resolveLocale(HttpServletRequest request) {
 		Locale locale = (Locale) WebUtils.getSessionAttribute(request, this.localeAttributeName);
 		if (locale == null) {
-			locale = determineDefaultLocale(request);
+			locale = this.defaultLocaleFunction.apply(request);
 		}
 		return locale;
 	}
@@ -123,7 +163,7 @@ public class SessionLocaleResolver extends AbstractLocaleContextResolver {
 			public Locale getLocale() {
 				Locale locale = (Locale) WebUtils.getSessionAttribute(request, localeAttributeName);
 				if (locale == null) {
-					locale = determineDefaultLocale(request);
+					locale = SessionLocaleResolver.this.defaultLocaleFunction.apply(request);
 				}
 				return locale;
 			}
@@ -132,7 +172,7 @@ public class SessionLocaleResolver extends AbstractLocaleContextResolver {
 			public TimeZone getTimeZone() {
 				TimeZone timeZone = (TimeZone) WebUtils.getSessionAttribute(request, timeZoneAttributeName);
 				if (timeZone == null) {
-					timeZone = determineDefaultTimeZone(request);
+					timeZone = SessionLocaleResolver.this.defaultTimeZoneFunction.apply(request);
 				}
 				return timeZone;
 			}
@@ -165,13 +205,11 @@ public class SessionLocaleResolver extends AbstractLocaleContextResolver {
 	 * @return the default locale (never {@code null})
 	 * @see #setDefaultLocale
 	 * @see jakarta.servlet.http.HttpServletRequest#getLocale()
+	 * @deprecated as of 6.0, in favor of {@link #setDefaultLocaleFunction(Function)}
 	 */
+	@Deprecated
 	protected Locale determineDefaultLocale(HttpServletRequest request) {
-		Locale defaultLocale = getDefaultLocale();
-		if (defaultLocale == null) {
-			defaultLocale = request.getLocale();
-		}
-		return defaultLocale;
+		return this.defaultLocaleFunction.apply(request);
 	}
 
 	/**
@@ -182,10 +220,12 @@ public class SessionLocaleResolver extends AbstractLocaleContextResolver {
 	 * @param request the request to resolve the time zone for
 	 * @return the default time zone (or {@code null} if none defined)
 	 * @see #setDefaultTimeZone
+	 * @deprecated as of 6.0, in favor of {@link #setDefaultTimeZoneFunction(Function)}
 	 */
+	@Deprecated
 	@Nullable
 	protected TimeZone determineDefaultTimeZone(HttpServletRequest request) {
-		return getDefaultTimeZone();
+		return this.defaultTimeZoneFunction.apply(request);
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/CookieLocaleResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/CookieLocaleResolverTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Juergen Hoeller
  * @author Rick Evans
  * @author Sam Brannen
+ * @author Vedran Pavic
  */
 class CookieLocaleResolverTests {
 
@@ -408,6 +409,26 @@ class CookieLocaleResolverTests {
 		Cookie localeCookie = cookies[0];
 		assertThat(localeCookie.getName()).isEqualTo(CookieLocaleResolver.DEFAULT_COOKIE_NAME);
 		assertThat(localeCookie.getValue()).isEqualTo("");
+	}
+
+	@Test
+	void testCustomDefaultLocaleFunction() {
+		request.addPreferredLocale(Locale.TAIWAN);
+
+		resolver.setDefaultLocaleFunction(request -> Locale.GERMAN);
+
+		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.GERMAN);
+	}
+
+	@Test
+	void testCustomDefaultTimeZoneFunction() {
+		request.addPreferredLocale(Locale.TAIWAN);
+
+		resolver.setDefaultTimeZoneFunction(request -> TimeZone.getTimeZone("GMT+1"));
+
+		TimeZoneAwareLocaleContext context = (TimeZoneAwareLocaleContext) resolver.resolveLocaleContext(request);
+		assertThat(context.getLocale()).isEqualTo(Locale.TAIWAN);
+		assertThat(context.getTimeZone()).isEqualTo(TimeZone.getTimeZone("GMT+1"));
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/SessionLocaleResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/SessionLocaleResolverTests.java
@@ -17,10 +17,12 @@
 package org.springframework.web.servlet.i18n;
 
 import java.util.Locale;
+import java.util.TimeZone;
 
 import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.context.i18n.TimeZoneAwareLocaleContext;
 import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 import org.springframework.web.testfixture.servlet.MockHttpServletResponse;
 
@@ -31,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Juergen Hoeller
  * @author Sam Brannen
+ * @author Vedran Pavic
  */
 class SessionLocaleResolverTests {
 
@@ -92,6 +95,27 @@ class SessionLocaleResolverTests {
 		request.setSession(session);
 		resolver = new SessionLocaleResolver();
 		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.TAIWAN);
+	}
+
+	@Test
+	void testCustomDefaultLocaleFunction() {
+		request.addPreferredLocale(Locale.TAIWAN);
+
+		SessionLocaleResolver resolver = new SessionLocaleResolver();
+		resolver.setDefaultLocaleFunction(request -> Locale.GERMAN);
+
+		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.GERMAN);
+	}
+
+	@Test
+	void testCustomDefaultTimeZoneFunction() {
+		request.addPreferredLocale(Locale.TAIWAN);
+
+		resolver.setDefaultTimeZoneFunction(request -> TimeZone.getTimeZone("GMT+1"));
+
+		TimeZoneAwareLocaleContext context = (TimeZoneAwareLocaleContext) resolver.resolveLocaleContext(request);
+		assertThat(context.getLocale()).isEqualTo(Locale.TAIWAN);
+		assertThat(context.getTimeZone()).isEqualTo(TimeZone.getTimeZone("GMT+1"));
 	}
 
 }


### PR DESCRIPTION
At present, the customization of the default locale and timezone resolution in `CookieLocaleResolver` and `SessionLocaleResolver` requires subclassing them and overriding `determineDefaultLocale` and/or `determineDefaultTimeZone` methods.

This PR simplifies resolution of the default locale and timezone resolution by introducing dedicated functions for these purposes, thus allowing the customization without needing to resort to subclassing the locale resolvers.

Additionally, there are also 2 small commits that improve some aspects of the `LocaleResolver` hierarchy:
-  Update `AcceptHeaderLocaleResolver` to extend `AbstractLocaleResolver`:
This commit updates AcceptHeaderLocaleResolver to extend AbstractLocaleResolver, which allows the removal of defaultLocale managing code in AcceptHeaderLocaleResolver.

- Update `LocaleContextResolver` to implement `LocaleResolver`:
This commit updates `LocaleContextResolver` to implement `LocaleResolver` using default methods, which simplifies `AbstractLocaleContextResolver` and aligns it more closely with `AbstractLocaleResolver`.

