### PR TITLE
Use toUnmodifiableSet and toList instead of collectingAndThen

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
@@ -146,7 +146,7 @@ public abstract class YamlProcessor {
 		else {
 			Assert.noNullElements(supportedTypes, "'supportedTypes' must not contain null elements");
 			this.supportedTypes = Arrays.stream(supportedTypes).map(Class::getName)
-					.collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
+					.collect(Collectors.toUnmodifiableSet());
 		}
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/io/support/SpringFactoriesLoader.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/SpringFactoriesLoader.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/spring-core/src/main/java/org/springframework/core/io/support/SpringFactoriesLoader.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/SpringFactoriesLoader.java
@@ -157,8 +157,7 @@ public final class SpringFactoriesLoader {
 			}
 
 			// Replace all lists with unmodifiable lists containing unique elements
-			result.replaceAll((factoryType, implementations) -> implementations.stream().distinct()
-					.collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList)));
+			result.replaceAll((factoryType, implementations) -> implementations.stream().distinct().toList());
 			cache.put(classLoader, result);
 		}
 		catch (IOException ex) {


### PR DESCRIPTION
As Spring Framework 6 uses JDK17 for its baseline, we can make use of
toList() and toUnmodifiableSet() which introduced in JDK 16 and JDK 10
respectively.