### PR TITLE
fix ColumnMapRowMapper.java #apply Method Result KeyValue Not corresponding

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/ColumnMapRowMapper.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/ColumnMapRowMapper.java
@@ -43,7 +43,7 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
  * HashMap, which will still preserve column order but requires the application
  * to specify the column names in the same casing as exposed by the driver.
  *
- * @author Mark Paluch
+ * @author Mark Paluch 16K
  * @since 5.3
  */
 public class ColumnMapRowMapper implements BiFunction<Row, RowMetadata, Map<String, Object>> {
@@ -57,10 +57,11 @@ public class ColumnMapRowMapper implements BiFunction<Row, RowMetadata, Map<Stri
 		Collection<String> columns = rowMetadata.getColumnNames();
 		int columnCount = columns.size();
 		Map<String, Object> mapOfColValues = createColumnMap(columnCount);
-		int index = 0;
+		//int index = 0;
 		for (String column : columns) {
 			String key = getColumnKey(column);
-			Object obj = getColumnValue(row, index++);
+			//Object obj = getColumnValue(row, index++);
+			Object obj = getColumnValue(row,column);
 			mapOfColValues.put(key, obj);
 		}
 		return mapOfColValues;
@@ -97,6 +98,18 @@ public class ColumnMapRowMapper implements BiFunction<Row, RowMetadata, Map<Stri
 	@Nullable
 	protected Object getColumnValue(Row row, int index) {
 		return row.get(index);
+	}
+	
+	/**
+	 * Retrieve a R2DBC object value for the specified columnName.
+	 * <p>The default implementation uses the {@link Row#get(String)} method.
+	 * @param row is the {@link Row} holding the data
+	 * @param columnName the column name as returned by the {@link Row}
+	 * @return the Object returned
+	 */
+	@Nullable
+	protected Object getColumnValue(Row row, String columnName) {
+		return row.get(columnName);
 	}
 
 }

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/ColumnMapRowMapper.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/ColumnMapRowMapper.java
@@ -99,7 +99,7 @@ public class ColumnMapRowMapper implements BiFunction<Row, RowMetadata, Map<Stri
 	protected Object getColumnValue(Row row, int index) {
 		return row.get(index);
 	}
-	
+
 	/**
 	 * Retrieve a R2DBC object value for the specified columnName.
 	 * <p>The default implementation uses the {@link Row#get(String)} method.

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientUnitTests.java
@@ -310,7 +310,7 @@ class DefaultDatabaseClientUnitTests {
 
 		Statement statement = mockStatement();
 		MockResult result = mockSingleColumnResult(
-				MockRow.builder().identified(0, Object.class, "Walter"));
+				MockRow.builder().identified("name", Object.class, "Walter"));
 
 		DatabaseClient databaseClient = databaseClientBuilder.executeFunction(
 				stmnt -> Mono.just(result)).build();
@@ -325,7 +325,7 @@ class DefaultDatabaseClientUnitTests {
 	void shouldApplyPreparedOperation() {
 
 		MockResult result = mockSingleColumnResult(
-				MockRow.builder().identified(0, Object.class, "Walter"));
+				MockRow.builder().identified("name", Object.class, "Walter"));
 		Statement statement = mockStatementFor("SELECT * FROM person", result);
 
 		DatabaseClient databaseClient = databaseClientBuilder.build();


### PR DESCRIPTION
add getColumnValue(Row row, String columnName)  Method
change apply(Row row, RowMetadata rowMetadata) code # 60 # 63 # 64 

Reason for submission:
# code 57 (Collection<String> columns = rowMetadata.getColumnNames();)
# method apply(Row row, RowMetadata rowMetadata) 

The order of the key is not the same as the order of the value, causing the result to be an error.
I sent you an email if you can see it. From admin@maxmc.cn