### PR TITLE
Use 'toString(Charset)' instead of 'toString(String)' for encodings

### DIFF
--- a/spring-context-indexer/src/main/java/org/springframework/context/index/processor/SortedProperties.java
+++ b/spring-context-indexer/src/main/java/org/springframework/context/index/processor/SortedProperties.java
@@ -88,7 +88,7 @@ class SortedProperties extends Properties {
 	public void store(OutputStream out, String comments) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		super.store(baos, (this.omitComments ? null : comments));
-		String contents = baos.toString(StandardCharsets.ISO_8859_1.name());
+		String contents = baos.toString(StandardCharsets.ISO_8859_1);
 		for (String line : contents.split(EOL)) {
 			if (!(this.omitComments && line.startsWith("#"))) {
 				out.write((line + EOL).getBytes(StandardCharsets.ISO_8859_1));

--- a/spring-core/src/main/java/org/springframework/core/SortedProperties.java
+++ b/spring-core/src/main/java/org/springframework/core/SortedProperties.java
@@ -90,7 +90,7 @@ class SortedProperties extends Properties {
 	public void store(OutputStream out, @Nullable String comments) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		super.store(baos, (this.omitComments ? null : comments));
-		String contents = baos.toString(StandardCharsets.ISO_8859_1.name());
+		String contents = baos.toString(StandardCharsets.ISO_8859_1);
 		for (String line : contents.split(EOL)) {
 			if (!(this.omitComments && line.startsWith("#"))) {
 				out.write((line + EOL).getBytes(StandardCharsets.ISO_8859_1));

--- a/spring-core/src/main/java/org/springframework/core/convert/support/PropertiesToStringConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/PropertiesToStringConverter.java
@@ -18,6 +18,7 @@ package org.springframework.core.convert.support;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.springframework.core.convert.converter.Converter;
@@ -36,7 +37,7 @@ final class PropertiesToStringConverter implements Converter<Properties, String>
 		try {
 			ByteArrayOutputStream os = new ByteArrayOutputStream(256);
 			source.store(os, null);
-			return os.toString("ISO-8859-1");
+			return os.toString(StandardCharsets.ISO_8859_1);
 		}
 		catch (IOException ex) {
 			// Should never happen.

--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 

--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -105,14 +105,8 @@ public abstract class StreamUtils {
 	public static String copyToString(ByteArrayOutputStream baos, Charset charset) {
 		Assert.notNull(baos, "No ByteArrayOutputStream specified");
 		Assert.notNull(charset, "No Charset specified");
-		try {
-			// Can be replaced with toString(Charset) call in Java 10+
-			return baos.toString(charset.name());
-		}
-		catch (UnsupportedEncodingException ex) {
-			// Should never happen
-			throw new IllegalArgumentException("Invalid charset name: " + charset, ex);
-		}
+
+		return baos.toString(charset);
 	}
 
 	/**

--- a/spring-messaging/src/main/java/org/springframework/messaging/converter/ProtobufMessageConverter.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/converter/ProtobufMessageConverter.java
@@ -183,7 +183,7 @@ public class ProtobufMessageConverter extends AbstractMessageConverter {
 			else if (this.protobufFormatSupport != null) {
 				ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 				this.protobufFormatSupport.print(message, outputStream, contentType, charset);
-				payload = outputStream.toString(charset.name());
+				payload = outputStream.toString(charset);
 			}
 		}
 		catch (IOException ex) {

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -279,8 +279,11 @@ public class MockHttpServletResponse implements HttpServletResponse {
 	 * @see #setContentType(String)
 	 */
 	public String getContentAsString(Charset fallbackCharset) throws UnsupportedEncodingException {
-		String charsetName = (this.characterEncodingSet ? getCharacterEncoding() : fallbackCharset.name());
-		return this.content.toString(charsetName);
+		if (this.characterEncodingSet) {
+			return this.content.toString(getCharacterEncoding());
+		}
+
+		return this.content.toString(fallbackCharset);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
@@ -16,7 +16,6 @@
 
 package org.springframework.http.codec;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
@@ -158,21 +158,16 @@ public class FormHttpMessageReader extends LoggingCodecSupport
 	private MultiValueMap<String, String> parseFormData(Charset charset, String body) {
 		String[] pairs = StringUtils.tokenizeToStringArray(body, "&");
 		MultiValueMap<String, String> result = new LinkedMultiValueMap<>(pairs.length);
-		try {
-			for (String pair : pairs) {
-				int idx = pair.indexOf('=');
-				if (idx == -1) {
-					result.add(URLDecoder.decode(pair, charset.name()), null);
-				}
-				else {
-					String name = URLDecoder.decode(pair.substring(0, idx),  charset.name());
-					String value = URLDecoder.decode(pair.substring(idx + 1), charset.name());
-					result.add(name, value);
-				}
+		for (String pair : pairs) {
+			int idx = pair.indexOf('=');
+			if (idx == -1) {
+				result.add(URLDecoder.decode(pair, charset), null);
 			}
-		}
-		catch (UnsupportedEncodingException ex) {
-			throw new IllegalStateException(ex);
+			else {
+				String name = URLDecoder.decode(pair.substring(0, idx),  charset);
+				String value = URLDecoder.decode(pair.substring(idx + 1), charset);
+				result.add(name, value);
+			}
 		}
 		return result;
 	}

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
@@ -162,18 +162,13 @@ public class FormHttpMessageWriter extends LoggingCodecSupport
 		StringBuilder builder = new StringBuilder();
 		formData.forEach((name, values) ->
 				values.forEach(value -> {
-					try {
-						if (builder.length() != 0) {
-							builder.append('&');
-						}
-						builder.append(URLEncoder.encode(name, charset.name()));
-						if (value != null) {
-							builder.append('=');
-							builder.append(URLEncoder.encode(value, charset.name()));
-						}
+					if (builder.length() != 0) {
+						builder.append('&');
 					}
-					catch (UnsupportedEncodingException ex) {
-						throw new IllegalStateException(ex);
+					builder.append(URLEncoder.encode(name, charset));
+					if (value != null) {
+						builder.append('=');
+						builder.append(URLEncoder.encode(value, charset));
 					}
 				}));
 		return builder.toString();

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
@@ -16,7 +16,6 @@
 
 package org.springframework.http.codec;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;

--- a/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
@@ -348,11 +348,11 @@ public class FormHttpMessageConverter implements HttpMessageConverter<MultiValue
 		for (String pair : pairs) {
 			int idx = pair.indexOf('=');
 			if (idx == -1) {
-				result.add(URLDecoder.decode(pair, charset.name()), null);
+				result.add(URLDecoder.decode(pair, charset), null);
 			}
 			else {
-				String name = URLDecoder.decode(pair.substring(0, idx), charset.name());
-				String value = URLDecoder.decode(pair.substring(idx + 1), charset.name());
+				String name = URLDecoder.decode(pair.substring(0, idx), charset);
+				String value = URLDecoder.decode(pair.substring(idx + 1), charset);
 				result.add(name, value);
 			}
 		}
@@ -438,18 +438,13 @@ public class FormHttpMessageConverter implements HttpMessageConverter<MultiValue
 					return;
 				}
 				values.forEach(value -> {
-					try {
-						if (builder.length() != 0) {
-							builder.append('&');
-						}
-						builder.append(URLEncoder.encode(name, charset.name()));
-						if (value != null) {
-							builder.append('=');
-							builder.append(URLEncoder.encode(String.valueOf(value), charset.name()));
-						}
+					if (builder.length() != 0) {
+						builder.append('&');
 					}
-					catch (UnsupportedEncodingException ex) {
-						throw new IllegalStateException(ex);
+					builder.append(URLEncoder.encode(name, charset));
+					if (value != null) {
+						builder.append('=');
+						builder.append(URLEncoder.encode(String.valueOf(value), charset));
 					}
 				});
 		});

--- a/spring-web/src/main/java/org/springframework/http/server/ServletServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/ServletServerHttpRequest.java
@@ -249,10 +249,10 @@ public class ServletServerHttpRequest implements ServerHttpRequest {
 			List<String> values = Arrays.asList(entry.getValue());
 			for (Iterator<String> valueIterator = values.iterator(); valueIterator.hasNext();) {
 				String value = valueIterator.next();
-				writer.write(URLEncoder.encode(name, FORM_CHARSET.name()));
+				writer.write(URLEncoder.encode(name, FORM_CHARSET));
 				if (value != null) {
 					writer.write('=');
-					writer.write(URLEncoder.encode(value, FORM_CHARSET.name()));
+					writer.write(URLEncoder.encode(value, FORM_CHARSET));
 					if (valueIterator.hasNext()) {
 						writer.write('&');
 					}

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletResponse.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletResponse.java
@@ -279,8 +279,11 @@ public class MockHttpServletResponse implements HttpServletResponse {
 	 * @see #setContentType(String)
 	 */
 	public String getContentAsString(Charset fallbackCharset) throws UnsupportedEncodingException {
-		String charsetName = (this.characterEncodingSet ? getCharacterEncoding() : fallbackCharset.name());
-		return this.content.toString(charsetName);
+		if (this.characterEncodingSet) {
+			return this.content.toString(getCharacterEncoding());
+		}
+
+		return this.content.toString(fallbackCharset);
 	}
 
 	@Override

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransport.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransport.java
@@ -252,8 +252,8 @@ public class RestTemplateXhrTransport extends AbstractXhrTransport {
 			return null;
 		}
 
-		private void handleFrame(ByteArrayOutputStream os) throws IOException {
-			String content = os.toString(SockJsFrame.CHARSET.name());
+		private void handleFrame(ByteArrayOutputStream os) {
+			String content = os.toString(SockJsFrame.CHARSET);
 			os.reset();
 			if (logger.isTraceEnabled()) {
 				logger.trace("XHR receive content: " + content);


### PR DESCRIPTION
As Spring Framework 6 uses JDK17 for its baseline, 
we can make use of 'toString(Charset)' which was introduced in JDK 10.