### PR TITLE
RFC: resttemplate builder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/builder/SpringRestTemplateClientBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/client/builder/SpringRestTemplateClientBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.builder;
+
+import java.lang.reflect.Proxy;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.builder.handler.SpringRestTemplateClientInvocationHandler;
+
+public final class SpringRestTemplateClientBuilder {
+	private SpringRestTemplateClientBuilder() {
+	}
+
+	public static <T> Builder<T> springRestTemplateClientBuilder(final Class<T> clazz) {
+		return new Builder<>(clazz);
+	}
+
+	public static <T> Builder<T> create(final Class<T> clazz) {
+		return springRestTemplateClientBuilder(clazz);
+	}
+
+	public static class Builder<T> {
+		private final Class<T> api;
+		private RestTemplate restTemplate = new RestTemplate();
+		private HttpHeaders headers = new HttpHeaders();
+		private String url;
+
+		public Builder(final Class<T> api) {
+			if (api == null) {
+				throw new IllegalArgumentException("api cannot be null");
+			}
+			this.api = api;
+		}
+
+		public Builder<T> setRestTemplate(final RestTemplate restTemplate) {
+			this.restTemplate = restTemplate;
+			return this;
+		}
+
+		public Builder<T> setUrl(final String url) {
+			this.url = url;
+			return this;
+		}
+
+		public Builder<T> setHeaders(final HttpHeaders headers) {
+			this.headers = headers;
+			return this;
+		}
+
+		public Builder<T> setHeader(final String headerName, final String headerValue) {
+			this.headers.add(headerName, headerValue);
+			return this;
+		}
+
+		@SuppressWarnings("unchecked")
+		public T build() {
+			if (this.url == null) {
+				throw new IllegalArgumentException("url cannot be null");
+			}
+			final SpringRestTemplateClientInvocationHandler<T> invocationHandler =
+					new SpringRestTemplateClientInvocationHandler<>(
+							this.url, this.restTemplate, this.headers);
+
+			return (T)
+					Proxy.newProxyInstance(
+							this.api.getClassLoader(), new Class<?>[]{this.api}, invocationHandler);
+		}
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/client/builder/handler/SpringRestTemplateClientInvocationHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/builder/handler/SpringRestTemplateClientInvocationHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.builder.handler;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.RequestEntity.BodyBuilder;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.builder.parse.InvocationParser;
+import org.springframework.web.client.builder.parse.model.InvocationDetails;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class SpringRestTemplateClientInvocationHandler<T> implements InvocationHandler {
+
+	private final String url;
+	private final RestTemplate restTemplate;
+
+	public SpringRestTemplateClientInvocationHandler(
+			final String url, final RestTemplate restTemplate, final HttpHeaders headers) {
+		this.url = url;
+		this.restTemplate = restTemplate;
+	}
+
+	@Override
+	public Object invoke(final Object proxy, final Method method, final Object[] args)
+			throws Throwable {
+		final InvocationDetails invocationDetails =
+				InvocationParser.getInvocationDetails(proxy, method, args);
+		return this.doRequest(invocationDetails);
+	}
+
+	private Object doRequest(final InvocationDetails invocationDetails) {
+		final URI uri =
+				UriComponentsBuilder.fromHttpUrl(this.url) //
+						.path(invocationDetails.getRequestDetails().getRequestPath())
+						.queryParams(invocationDetails.getQueryParams())
+						.build(invocationDetails.getPathVariables());
+
+		final BodyBuilder bodyBuilder =
+				RequestEntity.method(invocationDetails.getRequestDetails().getRequestMethod(), uri);
+
+		bodyBuilder.headers(invocationDetails.getHeaders());
+
+		if (invocationDetails.getRequestDetails().findConsumes().isPresent()) {
+			bodyBuilder.contentType(invocationDetails.getRequestDetails().findConsumes().get());
+		}
+
+		if (invocationDetails.getRequestDetails().findProduces().isPresent()) {
+			bodyBuilder.accept(invocationDetails.getRequestDetails().findProduces().get());
+		}
+
+		RequestEntity<?> requestEntity;
+		if (invocationDetails.findRequestBody().isPresent()) {
+			requestEntity = bodyBuilder.body(invocationDetails.findRequestBody().get());
+		}
+		else {
+			requestEntity = bodyBuilder.build();
+		}
+
+		if (invocationDetails.isMethodReurnTypeResponseEntity()) {
+			return this.restTemplate.exchange(requestEntity, invocationDetails.getResponseType());
+		}
+		else {
+			return this.restTemplate
+					.exchange(requestEntity, invocationDetails.getResponseType())
+					.getBody();
+		}
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/client/builder/parse/InvocationParser.java
+++ b/spring-web/src/main/java/org/springframework/web/client/builder/parse/InvocationParser.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.builder.parse;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.builder.parse.model.InvocationDetails;
+import org.springframework.web.client.builder.parse.model.RequestDetails;
+
+public final class InvocationParser {
+
+	private InvocationParser() {
+	}
+
+	public static RequestMethod getRequestMethod(final Method method) {
+		if (findAnnotation(method, GetMapping.class).isPresent()) {
+			return RequestMethod.GET;
+		}
+		else if (findAnnotation(method, PostMapping.class).isPresent()) {
+			return RequestMethod.POST;
+		}
+		else if (findAnnotation(method, PutMapping.class).isPresent()) {
+			return RequestMethod.PUT;
+		}
+		else if (findAnnotation(method, DeleteMapping.class).isPresent()) {
+			return RequestMethod.DELETE;
+		}
+		else if (findAnnotation(method, PatchMapping.class).isPresent()) {
+			return RequestMethod.PATCH;
+		}
+		else {
+			final Optional<RequestMapping> requestMapping = findAnnotation(method, RequestMapping.class);
+			if (requestMapping.isPresent()) {
+				return requestMapping.get().method()[0];
+			}
+		}
+		throw new RuntimeException("Cannot find request method of " + method.getName());
+	}
+
+	public static <T> Optional<T> findAnnotation(final Method method, final Class<T> findAnnotation) {
+		final Annotation[] methodAnnotations = method.getAnnotations();
+		return findAnnotation(methodAnnotations, findAnnotation);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> Optional<T> findAnnotation(
+			final Annotation[] methodAnnotations, final Class<T> annotations) {
+		for (final Annotation annotation : methodAnnotations) {
+			if (annotation.annotationType() == annotations) {
+				return Optional.of((T) annotation);
+			}
+		}
+		return Optional.empty();
+	}
+
+	public static <T> T getAnnotation(
+			final Method method, final Class<T> clazz, final String message) {
+		final Optional<T> requestMapping = InvocationParser.findAnnotation(method, clazz);
+		if (!requestMapping.isPresent()) {
+			throw new RuntimeException(message);
+		}
+		return requestMapping.get();
+	}
+
+	public static Map<String, String> getPathVariables(final Method method, final Object[] args) {
+		final Map<String, String> map = new HashMap<>();
+
+		for (int i = 0; i < method.getParameterCount(); i++) {
+			final Parameter p = method.getParameters()[i];
+
+			final PathVariable pv = p.getAnnotation(PathVariable.class);
+			if (pv != null) {
+				map.put(pv.value(), args[i].toString());
+			}
+		}
+		return map;
+	}
+
+	public static MultiValueMap<String, String> getRequestVariables(
+			final Method method, final Object[] args) {
+		final MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		for (int i = 0; i < method.getParameterCount(); i++) {
+			final Parameter p = method.getParameters()[i];
+
+			final RequestParam rp = p.getAnnotation(RequestParam.class);
+			if (rp != null) {
+				final Object arg = args[i];
+				if (arg instanceof List) {
+					@SuppressWarnings("unchecked") final List<Object> arr = (List<Object>) arg;
+					for (final Object element : arr) {
+						map.add(rp.value(), element.toString());
+					}
+				}
+				else if (arg.getClass().isArray()) {
+					final Object[] arr = (Object[]) arg;
+					for (final Object element : arr) {
+						map.add(rp.value(), element.toString());
+					}
+				}
+				else {
+					map.add(rp.value(), args[i].toString());
+				}
+			}
+		}
+		return map;
+	}
+
+	private static MultiValueMap<String, String> getHeaderVariables(
+			final Method method, final Object[] args) {
+		final MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		for (int i = 0; i < method.getParameterCount(); i++) {
+			final Parameter p = method.getParameters()[i];
+			final RequestHeader rh = p.getAnnotation(RequestHeader.class);
+			if (rh != null) {
+				map.add(rh.value(), args[i].toString());
+			}
+		}
+		return map;
+	}
+
+	public static Optional<Object> findReqestBody(final Method method, final Object[] args) {
+		for (int i = 0; i < method.getParameterCount(); i++) {
+			final Parameter p = method.getParameters()[i];
+			final RequestBody rb = p.getAnnotation(RequestBody.class);
+			if (rb != null) {
+				return Optional.of(args[i]);
+			}
+		}
+		return Optional.empty();
+	}
+
+	public static Type getGenericTypeOfMethod(final Object proxy, final Method method) {
+		final ResolvableType r = ResolvableType.forMethodReturnType(method);
+		return r.getGeneric(0).getType();
+	}
+
+	public static InvocationDetails getInvocationDetails(
+			final Object proxy, final Method method, final Object[] args) throws ClassNotFoundException {
+		final RequestDetails requestDetails = getRequestDetails(method);
+
+		final MultiValueMap<String, String> queryParams =
+				InvocationParser.getRequestVariables(method, args);
+
+		final Map<String, String> pathVariables = InvocationParser.getPathVariables(method, args);
+
+		final Optional<Object> requestBody = InvocationParser.findReqestBody(method, args);
+
+		final boolean methodReurnTypeIsResponseEntity =
+				method.getReturnType().isAssignableFrom(ResponseEntity.class);
+
+		ParameterizedTypeReference<?> responseType = null;
+		if (methodReurnTypeIsResponseEntity) {
+			responseType =
+					new ParameterizedTypeReference<Type>() {
+						@Override
+						public Type getType() {
+							return InvocationParser.getGenericTypeOfMethod(proxy, method);
+						}
+					};
+		}
+		else {
+			responseType =
+					new ParameterizedTypeReference<Type>() {
+						@Override
+						public Type getType() {
+							return method.getGenericReturnType();
+						}
+					};
+		}
+
+		final HttpHeaders headers = requestDetails.getHttpHeaders();
+		final MultiValueMap<String, String> headerParams =
+				InvocationParser.getHeaderVariables(method, args);
+		for (final Entry<String, List<String>> header : headerParams.entrySet()) {
+			for (final String value : header.getValue()) {
+				headers.add(header.getKey(), value);
+			}
+		}
+
+		return new InvocationDetails(
+				requestDetails,
+				queryParams,
+				pathVariables,
+				requestBody.orElse(null),
+				methodReurnTypeIsResponseEntity,
+				responseType,
+				headers);
+	}
+
+	private static RequestDetails getRequestDetails(final Method method) {
+		final Optional<RequestMapping> requestMapping =
+				InvocationParser.findAnnotation(method, RequestMapping.class);
+		if (requestMapping.isPresent()) {
+			return RequestMappingParser.getRequestDetails(requestMapping.get());
+		}
+		throw new RuntimeException("Only RequestMapping is, currently, implemented. PR:s are welcome.");
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/client/builder/parse/RequestMappingParser.java
+++ b/spring-web/src/main/java/org/springframework/web/client/builder/parse/RequestMappingParser.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.builder.parse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.client.builder.parse.model.RequestDetails;
+
+public final class RequestMappingParser {
+
+	private RequestMappingParser() {
+	}
+
+	public static RequestDetails getRequestDetails(final RequestMapping requestMapping) {
+		if (requestMapping.method().length != 1) {
+			throw new RuntimeException(
+					"Only one request method, currently, supported. PR:s are welcome.");
+		}
+		final HttpMethod requestMethod = HttpMethod.valueOf(requestMapping.method()[0].name());
+
+		if (requestMapping.value().length != 1) {
+			throw new RuntimeException("Only one request path, currently, supported. PR:s are welcome.");
+		}
+		final String requestPath = requestMapping.value()[0];
+
+		if (requestMapping.consumes().length > 1) {
+			throw new RuntimeException(
+					"Only one, or zero, consumes, currently, supported. PR:s are welcome.");
+		}
+		MediaType consumes = null;
+		if (requestMapping.consumes().length == 1) {
+			final String consumesString = requestMapping.consumes()[0];
+			consumes = MediaType.parseMediaType(consumesString);
+		}
+
+		if (requestMapping.produces().length > 1) {
+			throw new RuntimeException(
+					"Only one, or zero, produces, currently, supported. PR:s are welcome.");
+		}
+		MediaType produces = null;
+		if (requestMapping.produces().length == 1) {
+			final String producesString = requestMapping.produces()[0];
+			produces = MediaType.parseMediaType(producesString);
+		}
+
+		final HttpHeaders httpHeaders = new HttpHeaders();
+		for (final String header : requestMapping.headers()) {
+			final int equalityIndex = header.indexOf("=");
+			if (equalityIndex == -1) {
+				throw new RuntimeException("Cannot parse header '" + header + "'");
+			}
+			final String[] spitted = header.split("=");
+			httpHeaders.add(spitted[0], spitted[1]);
+		}
+
+		return new RequestDetails(requestMethod, requestPath, consumes, produces, httpHeaders);
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/client/builder/parse/model/InvocationDetails.java
+++ b/spring-web/src/main/java/org/springframework/web/client/builder/parse/model/InvocationDetails.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.builder.parse.model;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.MultiValueMap;
+
+public class InvocationDetails {
+
+	private final RequestDetails requestDetails;
+	private final MultiValueMap<String, String> queryParams;
+	private final Map<String, String> pathVariables;
+	private final Object requestBody;
+	private final boolean methodReurnTypeIsResponseEntity;
+	private final ParameterizedTypeReference<?> responseType;
+	private final HttpHeaders headers;
+
+	public InvocationDetails(
+			final RequestDetails requestDetails,
+			final MultiValueMap<String, String> queryParams,
+			final Map<String, String> pathVariables,
+			final Object requestBody,
+			final boolean methodReurnTypeIsResponseEntity,
+			final ParameterizedTypeReference<?> responseType,
+			final HttpHeaders headers) {
+		this.requestDetails = requestDetails;
+		this.queryParams = queryParams;
+		this.pathVariables = pathVariables;
+		this.requestBody = requestBody;
+		this.methodReurnTypeIsResponseEntity = methodReurnTypeIsResponseEntity;
+		this.responseType = responseType;
+		this.headers = headers;
+	}
+
+	public Map<String, String> getPathVariables() {
+		return this.pathVariables;
+	}
+
+	public MultiValueMap<String, String> getQueryParams() {
+		return this.queryParams;
+	}
+
+	public HttpHeaders getHeaders() {
+		return this.headers;
+	}
+
+	public Optional<Object> findRequestBody() {
+		return Optional.ofNullable(this.requestBody);
+	}
+
+	public RequestDetails getRequestDetails() {
+		return this.requestDetails;
+	}
+
+	public ParameterizedTypeReference<?> getResponseType() {
+		return this.responseType;
+	}
+
+	public boolean isMethodReurnTypeResponseEntity() {
+		return this.methodReurnTypeIsResponseEntity;
+	}
+
+	@Override
+	public String toString() {
+		return "InvocationDetails [requestDetails="
+				+ this.requestDetails
+				+ ", queryParams="
+				+ this.queryParams
+				+ ", pathVariables="
+				+ this.pathVariables
+				+ ", requestBody="
+				+ this.requestBody
+				+ ", methodReurnTypeIsResponseEntity="
+				+ this.methodReurnTypeIsResponseEntity
+				+ ", responseType="
+				+ this.responseType
+				+ ", headers="
+				+ this.headers
+				+ "]";
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/client/builder/parse/model/RequestDetails.java
+++ b/spring-web/src/main/java/org/springframework/web/client/builder/parse/model/RequestDetails.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.builder.parse.model;
+
+import java.util.Optional;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+public class RequestDetails {
+
+	private final HttpMethod requestMethod;
+	private final String requestPath;
+	private final MediaType consumes;
+	private final MediaType produces;
+	private final HttpHeaders httpHeaders;
+
+	public RequestDetails(
+			final HttpMethod requestMethod,
+			final String requestPath,
+			final MediaType consumes,
+			final MediaType produces,
+			final HttpHeaders httpHeaders) {
+		this.requestMethod = requestMethod;
+		this.requestPath = requestPath;
+		this.consumes = consumes;
+		this.produces = produces;
+		this.httpHeaders = httpHeaders;
+	}
+
+	public Optional<MediaType> findConsumes() {
+		return Optional.ofNullable(this.consumes);
+	}
+
+	public Optional<MediaType> findProduces() {
+		return Optional.ofNullable(this.produces);
+	}
+
+	public HttpMethod getRequestMethod() {
+		return this.requestMethod;
+	}
+
+	public String getRequestPath() {
+		return this.requestPath;
+	}
+
+	public HttpHeaders getHttpHeaders() {
+		return this.httpHeaders;
+	}
+
+	@Override
+	public String toString() {
+		return "RequestDetails [requestMethod="
+				+ this.requestMethod
+				+ ", requestPath="
+				+ this.requestPath
+				+ ", consumes="
+				+ this.consumes
+				+ ", produces="
+				+ this.produces
+				+ ", httpHeaders="
+				+ this.httpHeaders
+				+ "]";
+	}
+}


### PR DESCRIPTION
I created [a library](https://github.com/tomasbjerre/spring-resttemplate-client) and would like to ask if it can be merged into Spring? I only added the production code in this PR to show what would need to be changed. The test cases are still in [the library](https://github.com/tomasbjerre/spring-resttemplate-client).

Would you like me to continue work on this?

-----
Dynamically create Spring RestTemplate (proxy class) client from annotated interface.

Given `MyApiInterface` is a Spring-annotated Java interface.

```java
final MyApiInterface myClient = SpringRestTemplateClientBuilder
  .create(MyApiInterface.class)
  .setUrl(this.getMockUrl())
  .setRestTemplate(restTemplate)         // Optional
  .setHeader("header-name", "the value") // Optional
  .setHeaders(HttpHeaders)               // Optional
  .build();
```

Here `myClient` is a dynamically created [Java Proxy object](https://docs.oracle.com/javase/7/docs/api/java/lang/reflect/Proxy.html).

```java
final ResponseEntity<MyDTO> response = myClient.getMyDto();
```

The method invocation (`getMyDto()`) on that object (`myClient`) will be translated to a HTTP request using the annotations of that method in that interface. And `response` will be the result of that HTTP request.