### PR TITLE
use Arrays.deepToString for toString in SimpleKey

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
@@ -74,7 +74,7 @@ public class SimpleKey implements Serializable {
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + " [" + StringUtils.arrayToCommaDelimitedString(this.params) + "]";
+		return getClass().getSimpleName() + " " + Arrays.deepToString(this.params);
 	}
 
 	private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {


### PR DESCRIPTION
Arrays.deep* is being used in all the other functions, use it in toString as well - this avoid debugging output that just looks like [Ljava.lang.Object;@123456