### PR TITLE
Improve toString representation of complex parameters in SimpleKey

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * A simple key as returned from the {@link SimpleKeyGenerator}.

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/SimpleKey.java
@@ -74,7 +74,7 @@ public class SimpleKey implements Serializable {
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + " [" + StringUtils.arrayToCommaDelimitedString(this.params) + "]";
+		return getClass().getSimpleName() + " " + Arrays.deepToString(this.params);
 	}
 
 	private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {


### PR DESCRIPTION
Arrays.deep* is being used in all the other functions, use it in toString as well - this avoids debugging output that just looks like [Ljava.lang.Object;@123456