### PR TITLE
fix :  the same method was cached twice in the "attributeCache", changed to once

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/AbstractFallbackCacheOperationSource.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/AbstractFallbackCacheOperationSource.java
@@ -89,7 +89,7 @@ public abstract class AbstractFallbackCacheOperationSource implements CacheOpera
 			return null;
 		}
 
-		Object cacheKey = getCacheKey(method, targetClass);
+		Object cacheKey = getCacheKey(AopUtils.getMostSpecificMethod(method,targetClass), targetClass);
 		Collection<CacheOperation> cached = this.attributeCache.get(cacheKey);
 
 		if (cached != null) {

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/AbstractFallbackTransactionAttributeSource.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/AbstractFallbackTransactionAttributeSource.java
@@ -107,7 +107,7 @@ public abstract class AbstractFallbackTransactionAttributeSource
 		}
 
 		// First, see if we have a cached value.
-		Object cacheKey = getCacheKey(method, targetClass);
+		Object cacheKey = getCacheKey(AopUtils.getMostSpecificMethod(method,targetClass), targetClass);
 		TransactionAttribute cached = this.attributeCache.get(cacheKey);
 		if (cached != null) {
 			// Value will either be canonical value indicating there is no transaction attribute,


### PR DESCRIPTION
 **in  AbstractFallbackTransactionAttributeSource**
```
public TransactionAttribute getTransactionAttribute(Method method, @Nullable Class<?> targetClass) {
	// ...
	Object cacheKey = getCacheKey(method, targetClass);
	TransactionAttribute cached = this.attributeCache.get(cacheKey);
	if (cached != null) {
		//...
	}
	else {
		// We need to work it out.
		TransactionAttribute txAttr = computeTransactionAttribute(method, targetClass);
		//...
	}
}

```
**When using JDK dynamic proxy：**
```
@Configuration
@EnableTransactionManagement(mode = AdviceMode.PROXY )
public class EnableTransactionManagementBean {
   //...
}
```
**For example：**
```
public interface YqleeService {
    void  testMethod();
}
```

```
@Service
public class YqleeServiceImpl implements YqleeService {

    @Transactional
    @Override
    public void testMethod() {
        //TODO do something
    }
}
```

when calling before generating the JDK dynamic proxy, the parameter "method" belongs to the implementation class(YqleeServiceImpl )：

![before](https://user-images.githubusercontent.com/13343630/142340627-2ba44b3a-3339-4ff3-ab26-7cb2f4285064.png)

but, when calling after generating the JDK dynamic proxy, the parameter "method" belongs to the interface(YqleeService)：

![after](https://user-images.githubusercontent.com/13343630/142340759-614084b2-10d0-4f0c-8c28-3e81b5081302.png)

**The method "getTransactionAttribute"  is called twice, but the "attributeCache" does not work very well because the "cacheKey" is different.because the parameter "method" belongs to a different class.**

```
// First, see if we have a cached value.
Object cacheKey = getCacheKey(method, targetClass);
```
It might be better to change to this：

`Object cacheKey = getCacheKey(AopUtils.getMostSpecificMethod(method,targetClass), targetClass);`

**as same as AbstractFallbackCacheOperationSource**