### PR TITLE
Use `Integer.parseInt` without substring method

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReader.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/PropertiesBeanDefinitionReader.java
@@ -457,11 +457,11 @@ public class PropertiesBeanDefinitionReader extends AbstractBeanDefinitionReader
 				}
 				else if (property.startsWith(CONSTRUCTOR_ARG_PREFIX)) {
 					if (property.endsWith(REF_SUFFIX)) {
-						int index = Integer.parseInt(property.substring(1, property.length() - REF_SUFFIX.length()));
+						int index = Integer.parseInt(property, 1, property.length() - REF_SUFFIX.length(), 10);
 						cas.addIndexedArgumentValue(index, new RuntimeBeanReference(entry.getValue().toString()));
 					}
 					else {
-						int index = Integer.parseInt(property.substring(1));
+						int index = Integer.parseInt(property, 1, property.length(), 10);
 						cas.addIndexedArgumentValue(index, readValue(entry));
 					}
 				}

--- a/spring-context/src/main/java/org/springframework/scheduling/config/TaskExecutorFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/config/TaskExecutorFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,8 +106,8 @@ public class TaskExecutorFactoryBean implements
 				int maxPoolSize;
 				int separatorIndex = this.poolSize.indexOf('-');
 				if (separatorIndex != -1) {
-					corePoolSize = Integer.parseInt(this.poolSize.substring(0, separatorIndex));
-					maxPoolSize = Integer.parseInt(this.poolSize.substring(separatorIndex + 1));
+					corePoolSize = Integer.parseInt(this.poolSize, 0, separatorIndex, 10);
+					maxPoolSize = Integer.parseInt(this.poolSize, separatorIndex + 1, this.poolSize.length(), 10);
 					if (corePoolSize > maxPoolSize) {
 						throw new IllegalArgumentException(
 								"Lower bound of pool-size range must not exceed the upper bound");

--- a/spring-context/src/main/java/org/springframework/scheduling/support/BitsCronField.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/BitsCronField.java
@@ -161,8 +161,8 @@ final class BitsCronField extends CronField {
 				return ValueRange.of(result, result);
 			}
 			else {
-				int min = Integer.parseInt(value.substring(0, hyphenPos));
-				int max = Integer.parseInt(value.substring(hyphenPos + 1));
+				int min = Integer.parseInt(value, 0, hyphenPos, 10);
+				int max = Integer.parseInt(value, hyphenPos + 1, value.length(), 10);
 				min = type.checkValidValue(min);
 				max = type.checkValidValue(max);
 				if (type == Type.DAY_OF_WEEK && min == 7) {

--- a/spring-context/src/main/java/org/springframework/scheduling/support/QuartzCronField.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/QuartzCronField.java
@@ -86,7 +86,7 @@ final class QuartzCronField extends CronField {
 					adjuster = lastDayOfMonth();
 				}
 				else { // "L-[0-9]+"
-					int offset = Integer.parseInt(value.substring(idx + 1));
+					int offset = Integer.parseInt(value, idx + 1, value.length(), 10);
 					if (offset >= 0) {
 						throw new IllegalArgumentException("Offset '" + offset + " should be < 0 '" + value + "'");
 					}
@@ -104,7 +104,7 @@ final class QuartzCronField extends CronField {
 				throw new IllegalArgumentException("Unrecognized characters after 'W' in '" + value + "'");
 			}
 			else { // "[0-9]+W"
-				int dayOfMonth = Integer.parseInt(value.substring(0, idx));
+				int dayOfMonth = Integer.parseInt(value, 0, idx, 10);
 				dayOfMonth = Type.DAY_OF_MONTH.checkValidValue(dayOfMonth);
 				TemporalAdjuster adjuster = weekdayNearestTo(dayOfMonth);
 				return new QuartzCronField(Type.DAY_OF_MONTH, adjuster, value);
@@ -152,7 +152,7 @@ final class QuartzCronField extends CronField {
 			}
 			// "[0-7]#[0-9]+"
 			DayOfWeek dayOfWeek = parseDayOfWeek(value.substring(0, idx));
-			int ordinal = Integer.parseInt(value.substring(idx + 1));
+			int ordinal = Integer.parseInt(value, idx + 1, value.length(), 10);
 			if (ordinal <= 0) {
 				throw new IllegalArgumentException("Ordinal '" + ordinal + "' in '" + value +
 						"' must be positive number ");

--- a/spring-context/src/test/java/org/springframework/format/support/FormattingConversionServiceFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/format/support/FormattingConversionServiceFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,7 +204,7 @@ public class FormattingConversionServiceFactoryBeanTests {
 			return new Parser<Integer>() {
 				@Override
 				public Integer parse(String text, Locale locale) throws ParseException {
-					return Integer.parseInt(text.substring(1));
+					return Integer.parseInt(text, 1, text.length(), 10);
 				}
 			};
 		}

--- a/spring-jms/src/main/java/org/springframework/jms/listener/DefaultMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/DefaultMessageListenerContainer.java
@@ -309,8 +309,8 @@ public class DefaultMessageListenerContainer extends AbstractPollingMessageListe
 		try {
 			int separatorIndex = concurrency.indexOf('-');
 			if (separatorIndex != -1) {
-				setConcurrentConsumers(Integer.parseInt(concurrency.substring(0, separatorIndex)));
-				setMaxConcurrentConsumers(Integer.parseInt(concurrency.substring(separatorIndex + 1)));
+				setConcurrentConsumers(Integer.parseInt(concurrency, 0, separatorIndex, 10));
+				setMaxConcurrentConsumers(Integer.parseInt(concurrency, separatorIndex + 1, concurrency.length(), 10));
 			}
 			else {
 				setConcurrentConsumers(1);

--- a/spring-jms/src/main/java/org/springframework/jms/listener/SimpleMessageListenerContainer.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/SimpleMessageListenerContainer.java
@@ -126,7 +126,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		try {
 			int separatorIndex = concurrency.indexOf('-');
 			if (separatorIndex != -1) {
-				setConcurrentConsumers(Integer.parseInt(concurrency.substring(separatorIndex + 1)));
+				setConcurrentConsumers(Integer.parseInt(concurrency, separatorIndex + 1, concurrency.length(), 10));
 			}
 			else {
 				setConcurrentConsumers(Integer.parseInt(concurrency));

--- a/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/JmsActivationSpecConfig.java
+++ b/spring-jms/src/main/java/org/springframework/jms/listener/endpoint/JmsActivationSpecConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,7 +226,7 @@ public class JmsActivationSpecConfig {
 		try {
 			int separatorIndex = concurrency.indexOf('-');
 			if (separatorIndex != -1) {
-				setMaxConcurrency(Integer.parseInt(concurrency.substring(separatorIndex + 1)));
+				setMaxConcurrency(Integer.parseInt(concurrency, separatorIndex + 1, concurrency.length(), 10));
 			}
 			else {
 				setMaxConcurrency(Integer.parseInt(concurrency));

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -707,7 +707,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 				idx = host.indexOf(':');
 			}
 			if (idx != -1) {
-				return Integer.parseInt(host.substring(idx + 1));
+				return Integer.parseInt(host, idx + 1, host.length(), 10);
 			}
 		}
 

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
@@ -94,7 +94,7 @@ class ReactorServerHttpRequest extends AbstractServerHttpRequest {
 			if (portIndex != -1) {
 				try {
 					return new URI(scheme, null, header.substring(0, portIndex),
-							Integer.parseInt(header.substring(portIndex + 1)), null, null, null);
+							Integer.parseInt(header, portIndex + 1, header.length(), 10), null, null, null);
 				}
 				catch (NumberFormatException ex) {
 					throw new URISyntaxException(header, "Unable to parse port", portIndex);

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -364,7 +364,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 					}
 					host = value.substring(0, portSeparatorIdx);
 					try {
-						port = Integer.parseInt(value.substring(portSeparatorIdx + 1));
+						port = Integer.parseInt(value, portSeparatorIdx + 1, value.length(), 10);
 					}
 					catch (NumberFormatException ex) {
 						throw new IllegalArgumentException(
@@ -904,7 +904,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 				throw new IllegalArgumentException("Invalid IPv4 address: " + rawValue);
 			}
 			host(rawValue.substring(0, portSeparatorIdx));
-			port(Integer.parseInt(rawValue.substring(portSeparatorIdx + 1)));
+			port(Integer.parseInt(rawValue, portSeparatorIdx + 1, rawValue.length(), 10));
 		}
 		else {
 			host(rawValue);

--- a/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityReferencesTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityReferencesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@ public class HtmlCharacterEntityReferencesTests {
 		private int nextReferredCharacterId() throws IOException {
 			String reference = nextWordToken();
 			if (reference != null && reference.startsWith("&#") && reference.endsWith(";")) {
-				return Integer.parseInt(reference.substring(2, reference.length() - 1));
+				return Integer.parseInt(reference, 2, reference.length() - 1, 10);
 			}
 			return -1;
 		}

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletRequest.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletRequest.java
@@ -710,7 +710,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 				idx = host.indexOf(':');
 			}
 			if (idx != -1) {
-				return Integer.parseInt(host.substring(idx + 1));
+				return Integer.parseInt(host, idx + 1, host.length(), 10);
 			}
 		}
 


### PR DESCRIPTION
As Spring Framework 6 uses JDK17 for its baseline, `parseInt` method can be used without using `substring` method.
- use `parseInt(CharSequence s, int beginIndex, int endIndex, int radix)` - JDK 9

I think this modification can prevent to create unnecessary string object.