### PR TITLE
Use InputStream's new methods instead of StreamUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
@@ -112,7 +112,7 @@ public abstract class FileCopyUtils {
 			int count = (int) in.transferTo(out);
 			out.flush();
 			return count;
-        }
+		}
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
@@ -108,13 +108,11 @@ public abstract class FileCopyUtils {
 		Assert.notNull(in, "No InputStream specified");
 		Assert.notNull(out, "No OutputStream specified");
 
-		try {
-			return StreamUtils.copy(in, out);
-		}
-		finally {
-			close(in);
-			close(out);
-		}
+		try (in; out) {
+			int count = (int) in.transferTo(out);
+			out.flush();
+			return count;
+        }
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -140,6 +140,29 @@ public abstract class StreamUtils {
 	}
 
 	/**
+	 * Copy the contents of the given InputStream to the given OutputStream.
+	 * <p>Leaves both streams open when done.
+	 * @param in the InputStream to copy from
+	 * @param out the OutputStream to copy to
+	 * @return the number of bytes copied
+	 * @throws IOException in case of I/O errors
+	 */
+	public static int copy(InputStream in, OutputStream out) throws IOException {
+		Assert.notNull(in, "No InputStream specified");
+		Assert.notNull(out, "No OutputStream specified");
+
+		int byteCount = 0;
+		byte[] buffer = new byte[BUFFER_SIZE];
+		int bytesRead;
+		while ((bytesRead = in.read(buffer)) != -1) {
+			out.write(buffer, 0, bytesRead);
+			byteCount += bytesRead;
+		}
+		out.flush();
+		return byteCount;
+	}
+
+	/**
 	 * Copy a range of content of the given InputStream to the given OutputStream.
 	 * <p>If the specified range exceeds the length of the InputStream, this copies
 	 * up to the end of the stream and returns the actual number of copied bytes.

--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -65,9 +65,7 @@ public abstract class StreamUtils {
 			return new byte[0];
 		}
 
-		ByteArrayOutputStream out = new ByteArrayOutputStream(BUFFER_SIZE);
-		copy(in, out);
-		return out.toByteArray();
+		return in.readAllBytes();
 	}
 
 	/**
@@ -139,29 +137,6 @@ public abstract class StreamUtils {
 		Writer writer = new OutputStreamWriter(out, charset);
 		writer.write(in);
 		writer.flush();
-	}
-
-	/**
-	 * Copy the contents of the given InputStream to the given OutputStream.
-	 * <p>Leaves both streams open when done.
-	 * @param in the InputStream to copy from
-	 * @param out the OutputStream to copy to
-	 * @return the number of bytes copied
-	 * @throws IOException in case of I/O errors
-	 */
-	public static int copy(InputStream in, OutputStream out) throws IOException {
-		Assert.notNull(in, "No InputStream specified");
-		Assert.notNull(out, "No OutputStream specified");
-
-		int byteCount = 0;
-		byte[] buffer = new byte[BUFFER_SIZE];
-		int bytesRead;
-		while ((bytesRead = in.read(buffer)) != -1) {
-			out.write(buffer, 0, bytesRead);
-			byteCount += bytesRead;
-		}
-		out.flush();
-		return byteCount;
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/util/StreamUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StreamUtilsTests.java
@@ -84,13 +84,6 @@ class StreamUtilsTests {
 	}
 
 	@Test
-	void copyStream() throws Exception {
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		StreamUtils.copy(new ByteArrayInputStream(bytes), out);
-		assertThat(out.toByteArray()).isEqualTo(bytes);
-	}
-
-	@Test
 	void copyRange() throws Exception {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		StreamUtils.copyRange(new ByteArrayInputStream(bytes), out, 0, 100);

--- a/spring-core/src/test/java/org/springframework/util/StreamUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StreamUtilsTests.java
@@ -84,6 +84,13 @@ class StreamUtilsTests {
 	}
 
 	@Test
+	void copyStream() throws Exception {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		StreamUtils.copy(new ByteArrayInputStream(bytes), out);
+		assertThat(out.toByteArray()).isEqualTo(bytes);
+	}
+
+	@Test
 	void copyRange() throws Exception {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		StreamUtils.copyRange(new ByteArrayInputStream(bytes), out, 0, 100);

--- a/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
@@ -53,11 +53,7 @@ public class ByteArrayHttpMessageConverter extends AbstractHttpMessageConverter<
 
 	@Override
 	public byte[] readInternal(Class<? extends byte[]> clazz, HttpInputMessage inputMessage) throws IOException {
-		long contentLength = inputMessage.getHeaders().getContentLength();
-		ByteArrayOutputStream bos =
-				new ByteArrayOutputStream(contentLength >= 0 ? (int) contentLength : StreamUtils.BUFFER_SIZE);
-		StreamUtils.copy(inputMessage.getBody(), bos);
-		return bos.toByteArray();
+		return inputMessage.getBody().readAllBytes();
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
@@ -16,7 +16,6 @@
 
 package org.springframework.http.converter;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import org.springframework.http.HttpInputMessage;

--- a/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
@@ -19,6 +19,7 @@ package org.springframework.http.converter;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.InputStreamResource;
@@ -131,22 +132,13 @@ public class ResourceHttpMessageConverter extends AbstractHttpMessageConverter<R
 
 	protected void writeContent(Resource resource, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException {
-		try {
-			InputStream in = resource.getInputStream();
-			try {
-				StreamUtils.copy(in, outputMessage.getBody());
-			}
-			catch (NullPointerException ex) {
-				// ignore, see SPR-13620
-			}
-			finally {
-				try {
-					in.close();
-				}
-				catch (Throwable ex) {
-					// ignore, see SPR-12999
-				}
-			}
+		try (InputStream in = resource.getInputStream()){
+			OutputStream out = outputMessage.getBody();
+			in.transferTo(out);
+			out.flush();
+		}
+		catch (NullPointerException ex) {
+			// ignore, see SPR-13620
 		}
 		catch (FileNotFoundException ex) {
 			// ignore, see SPR-12999


### PR DESCRIPTION
As Spring Framework 6 uses JDK17 for its baseline, we can make use of the methods `transferTo(OutputStream out)` and `readAllBytes()` supported by `InputStream` in JDK9 instead of `StreamUtils`.