### PR TITLE
Add support for bytes literal of spring expression

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
@@ -255,8 +255,13 @@ public enum SpelMessage {
 
 	/** @since 4.3.17 */
 	FLAWED_PATTERN(Kind.ERROR, 1073,
-			"Failed to efficiently evaluate pattern ''{0}'': consider redesigning it");
+			"Failed to efficiently evaluate pattern ''{0}'': consider redesigning it"),
 
+	NON_TERMINATING_DOUBLE_QUOTED_BYTES(Kind.ERROR, 1074,
+			"Cannot find terminating \" for bytes"),
+
+	NON_TERMINATING_QUOTED_BYTES(Kind.ERROR, 1075,
+			"Cannot find terminating '' for bytes");
 
 	private final Kind kind;
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/BytesLiteral.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/BytesLiteral.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.expression.spel.ast;
+
+import org.springframework.asm.MethodVisitor;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.CodeFlow;
+
+/**
+ * Expression language AST node that represents a bytes literal.
+ *
+ * @author ABKing
+ */
+public class BytesLiteral extends Literal{
+
+	private final TypedValue value;
+
+	public BytesLiteral(String payload, int startPos, int endPos, String value) {
+		super(payload, startPos, endPos);
+		this.value = new TypedValue(payload);
+		this.exitTypeDescriptor = "LB";
+	}
+
+	@Override
+	public TypedValue getLiteralValue() {
+		return this.value;
+	}
+	@Override
+	public String toString() {
+		return "'" + getLiteralValue().getValue() + "'";
+	}
+
+	@Override
+	public boolean isCompilable() {
+		return true;
+	}
+
+	@Override
+	public void generateCode(MethodVisitor mv, CodeFlow cf) {
+		mv.visitLdcInsn(this.value.getValue());
+		cf.pushDescriptor(this.exitTypeDescriptor);
+	}
+}

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
@@ -73,6 +73,7 @@ import org.springframework.expression.spel.ast.StringLiteral;
 import org.springframework.expression.spel.ast.Ternary;
 import org.springframework.expression.spel.ast.TypeReference;
 import org.springframework.expression.spel.ast.VariableReference;
+import org.springframework.expression.spel.ast.BytesLiteral;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -863,6 +864,9 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		}
 		else if (t.kind == TokenKind.LITERAL_STRING) {
 			push(new StringLiteral(t.stringValue(), t.startPos, t.endPos, t.stringValue()));
+		}
+		else if (t.kind == TokenKind.LITERAL_BYTES) {
+			push(new BytesLiteral(t.stringValue(), t.startPos, t.endPos, t.stringValue()));
 		}
 		else {
 			return false;

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/TokenKind.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/TokenKind.java
@@ -40,6 +40,8 @@ enum TokenKind {
 
 	LITERAL_REAL_FLOAT,
 
+	LITERAL_BYTES,
+
 	LPAREN("("),
 
 	RPAREN(")"),

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.springframework.expression.spel.InternalParseException;
 import org.springframework.expression.spel.SpelMessage;
 import org.springframework.expression.spel.SpelParseException;
+import org.springframework.util.Assert;
 
 /**
  * Lex some input data into a stream of tokens that can then be parsed.
@@ -88,6 +89,17 @@ class Tokenizer {
 		while (this.pos < this.max) {
 			char ch = this.charsToProcess[this.pos];
 			if (isAlphabetic(ch)) {
+				if (ch == 'b') {
+					Assert.isTrue(this.pos + 1 < this.max, "Is not bytes literal");
+					if (this.charsToProcess[this.pos + 1] == '\'') {
+						lexQuotedBytesLiteral();
+						break;
+					}
+					else if (this.charsToProcess[this.pos + 1] == '\"') {
+						lexDoubleQuotedBytesLiteral();
+						break;
+					}
+				}
 				lexIdentifier();
 			}
 			else {
@@ -320,7 +332,111 @@ class Tokenizer {
 		this.pos++;
 		this.tokens.add(new Token(TokenKind.LITERAL_STRING, subarray(start, this.pos), start, this.pos));
 	}
+	// Bytes_LITERAL: 'b\'\x12\x34\x56\''!;
+	private void lexQuotedBytesLiteral() {
+		List<Character> bytesList = new ArrayList<>();
+		int start = this.pos++;
+		boolean terminated = false;
+		while (!terminated) {
+			this.pos++;
+			char ch = this.charsToProcess[this.pos];
+			if (ch == '\'') {
+				// may not be the end if the char after is also a '
+				if (this.charsToProcess[this.pos + 1] == '\'') {
+					this.pos++;  // skip over that too, and continue
+				}
+				else {
+					terminated = true;
+				}
+			} else if (ch == '\\') {
+				char c = this.charsToProcess[++this.pos];
+				switch (c) {
+					case 'x', 'X' -> {
+						int v = 0;
+						for (int i = 0; i < 2; i++) {
+							this.pos++;
+							int x = 0;
+							if (this.charsToProcess[this.pos] >= '0' && this.charsToProcess[this.pos] <= '9') {
+								x = this.charsToProcess[this.pos] - '0';
+							}
+							else if (this.charsToProcess[this.pos] >= 'a' && this.charsToProcess[this.pos] <= 'f') {
+								x = this.charsToProcess[this.pos] - 'a' + 10;
+							}
+							else if (this.charsToProcess[this.pos] >= 'A' && this.charsToProcess[this.pos] <= 'F') {
+								x = this.charsToProcess[this.pos] - 'A' + 10;
+							}
+							v = v << 4 | x;
+						}
+						bytesList.add((char) v);
+					}
+				}
 
+			} else {
+				bytesList.add(ch);
+			}
+			if (isExhausted()) {
+				raiseParseException(start, SpelMessage.NON_TERMINATING_QUOTED_BYTES);
+			}
+		}
+		char[] result = new char[bytesList.size()];
+		for (int i = 0; i < bytesList.size(); i++) {
+			result[i] = bytesList.get(i);
+		}
+		this.tokens.add(new Token(TokenKind.LITERAL_BYTES, result, 0, result.length - 1));
+	}
+
+	// Bytes_LITERAL: 'b"\x12\x34\x56"'!;
+	private void lexDoubleQuotedBytesLiteral() {
+		List<Character> bytesList = new ArrayList<>();
+		int start = this.pos++;
+		boolean terminated = false;
+		while (!terminated) {
+			this.pos++;
+			char ch = this.charsToProcess[this.pos];
+			if (ch == '"') {
+				// may not be the end if the char after is also a '
+				if (this.charsToProcess[this.pos + 1] == '"') {
+					this.pos++;  // skip over that too, and continue
+				}
+				else {
+					terminated = true;
+				}
+			}
+			else if (ch == '\\') {
+				char c = this.charsToProcess[++this.pos];
+				switch (c) {
+					case 'x', 'X' -> {
+						int v = 0;
+						for (int i = 0; i < 2; i++) {
+							this.pos++;
+							int x = 0;
+							if (this.charsToProcess[this.pos] >= '0' && this.charsToProcess[this.pos] <= '9') {
+								x = this.charsToProcess[this.pos] - '0';
+							}
+							else if (this.charsToProcess[this.pos] >= 'a' && this.charsToProcess[this.pos] <= 'f') {
+								x = this.charsToProcess[this.pos] - 'a' + 10;
+							}
+							else if (this.charsToProcess[this.pos] >= 'A' && this.charsToProcess[this.pos] <= 'F') {
+								x = this.charsToProcess[this.pos] - 'A' + 10;
+							}
+							v = v << 4 | x;
+						}
+						bytesList.add((char) v);
+					}
+				}
+			} else {
+				bytesList.add(ch);
+			}
+			if (isExhausted()) {
+				raiseParseException(start, SpelMessage.NON_TERMINATING_DOUBLE_QUOTED_BYTES);
+			}
+		}
+		char[] result = new char[bytesList.size()];
+		for (int i = 0; i < bytesList.size(); i++) {
+			result[i] = bytesList.get(i);
+		}
+		this.tokens.add(new Token(TokenKind.LITERAL_BYTES, result, 0, result.length - 1));
+	}
 	// REAL_LITERAL :
 	// ('.' (DECIMAL_DIGIT)+ (EXPONENT_PART)? (REAL_TYPE_SUFFIX)?) |
 	// ((DECIMAL_DIGIT)+ '.' (DECIMAL_DIGIT)+ (EXPONENT_PART)? (REAL_TYPE_SUFFIX)?) |

--- a/spring-expression/src/test/java/org/springframework/expression/spel/LiteralTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/LiteralTests.java
@@ -82,6 +82,46 @@ public class LiteralTests extends AbstractExpressionTests {
 	}
 
 	@Test
+	public void testLiteralBytes01() {
+		evaluate("b'\\x61\\x62\\x63'", "abc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes02() {
+		evaluate("b'\\x61\\x62\\x63abc'", "abcabc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes03() {
+		evaluate("b\"\\x61a\\x62b\\x63c\"", "aabbcc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes04() {
+		evaluate("b\"\\x61\\x62\\x63\"", "abc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes05() {
+		evaluate("b\"\\x61\\x62\\x63abc\"", "abcabc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes06() {
+		evaluate("b\"\\x61a\\x62b\\x63c\"", "aabbcc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes07() {
+		evaluate("b\"abc\"", new String(new byte[] {97, 98, 99}), String.class);
+	}
+
+	@Test
+	public void testLiteralBytes08() {
+		evaluate("b\"\\x61\\x62\\x63\"", new String(new byte[] {97, 98, 99}), String.class);
+	}
+
+	@Test
 	public void testHexIntLiteral01() {
 		evaluate("0x7FFFF", "524287", Integer.class);
 		evaluate("0x7FFFFL", 524287L, Long.class);


### PR DESCRIPTION
Google's common expression language supports **bytes literal**, which I think is a good function. I hope spring expression can also expand this capability

`b"\\x61\\x62\\x63"` will be resolved to `abc`
`b"abc\\x61\\x62\\x63"` will be resolved to `abcabc`

prefix:`b'` or `b"`
suffix: `'` or `"`

Reference: https://github.com/google/cel-spec/blob/master/doc/langdef.md