### PR TITLE
Support bytes literals in SpEL expressions

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
@@ -255,8 +255,13 @@ public enum SpelMessage {
 
 	/** @since 4.3.17 */
 	FLAWED_PATTERN(Kind.ERROR, 1073,
-			"Failed to efficiently evaluate pattern ''{0}'': consider redesigning it");
+			"Failed to efficiently evaluate pattern ''{0}'': consider redesigning it"),
 
+	NON_TERMINATING_DOUBLE_QUOTED_BYTES(Kind.ERROR, 1074,
+			"Cannot find terminating \" for bytes"),
+
+	NON_TERMINATING_QUOTED_BYTES(Kind.ERROR, 1075,
+			"Cannot find terminating '' for bytes");
 
 	private final Kind kind;
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/BytesLiteral.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/BytesLiteral.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.expression.spel.ast;
+
+import org.springframework.asm.MethodVisitor;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.CodeFlow;
+
+/**
+ * Expression language AST node that represents a bytes literal.
+ *
+ * @author Qiang Jin
+ */
+public class BytesLiteral extends Literal{
+
+	private final TypedValue value;
+
+	public BytesLiteral(String payload, int startPos, int endPos, String value) {
+		super(payload, startPos, endPos);
+		this.value = new TypedValue(payload);
+		this.exitTypeDescriptor = "LB";
+	}
+
+	@Override
+	public TypedValue getLiteralValue() {
+		return this.value;
+	}
+	@Override
+	public String toString() {
+		return "'" + getLiteralValue().getValue() + "'";
+	}
+
+	@Override
+	public boolean isCompilable() {
+		return true;
+	}
+
+	@Override
+	public void generateCode(MethodVisitor mv, CodeFlow cf) {
+		mv.visitLdcInsn(this.value.getValue());
+		cf.pushDescriptor(this.exitTypeDescriptor);
+	}
+}

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
@@ -33,6 +33,7 @@ import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.expression.spel.ast.Assign;
 import org.springframework.expression.spel.ast.BeanReference;
 import org.springframework.expression.spel.ast.BooleanLiteral;
+import org.springframework.expression.spel.ast.BytesLiteral;
 import org.springframework.expression.spel.ast.CompoundExpression;
 import org.springframework.expression.spel.ast.ConstructorReference;
 import org.springframework.expression.spel.ast.Elvis;
@@ -863,6 +864,9 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		}
 		else if (t.kind == TokenKind.LITERAL_STRING) {
 			push(new StringLiteral(t.stringValue(), t.startPos, t.endPos, t.stringValue()));
+		}
+		else if (t.kind == TokenKind.LITERAL_BYTES) {
+			push(new BytesLiteral(t.stringValue(), t.startPos, t.endPos, t.stringValue()));
 		}
 		else {
 			return false;

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/TokenKind.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/TokenKind.java
@@ -40,6 +40,8 @@ enum TokenKind {
 
 	LITERAL_REAL_FLOAT,
 
+	LITERAL_BYTES,
+
 	LPAREN("("),
 
 	RPAREN(")"),

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/Tokenizer.java
@@ -367,6 +367,8 @@ class Tokenizer {
 							v = v << 4 | x;
 						}
 						bytesList.add((char) v);
+					case '"', '\'':
+						bytesList.add(c);
 				}
 			}
 			else {

--- a/spring-expression/src/test/java/org/springframework/expression/spel/LiteralTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/LiteralTests.java
@@ -82,6 +82,51 @@ public class LiteralTests extends AbstractExpressionTests {
 	}
 
 	@Test
+	public void testLiteralBytes01() {
+		evaluate("b'\\x61\\x62\\x63'", "abc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes02() {
+		evaluate("b'\\x61\\x62\\x63abc'", "abcabc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes03() {
+		evaluate("b\"\\x61a\\x62b\\x63c\"", "aabbcc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes04() {
+		evaluate("b\"\\x61\\x62\\x63\"", "abc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes05() {
+		evaluate("b\"\\x61\\x62\\x63abc\"", "abcabc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes06() {
+		evaluate("b\"\\x61a\\x62b\\x63c\"", "aabbcc", String.class);
+	}
+
+	@Test
+	public void testLiteralBytes07() {
+		evaluate("b\"abc\"", new String(new byte[] {97, 98, 99}), String.class);
+	}
+
+	@Test
+	public void testLiteralBytes08() {
+		evaluate("b\"\\x61\\x62\\x63\"", new String(new byte[] {97, 98, 99}), String.class);
+	}
+
+	@Test
+	public void testLiteralBytes09() {
+		evaluate("b'\\x61\\x62\\x63' + b\"\\x64\\x65\\x66\"", "abcdef", String.class);
+	}
+
+	@Test
 	public void testHexIntLiteral01() {
 		evaluate("0x7FFFF", "524287", Integer.class);
 		evaluate("0x7FFFFL", 524287L, Long.class);


### PR DESCRIPTION
Google's common expression language supports **bytes literal**, which I think is a good function. I hope spring expression can also expand this capability

`b"\\x61\\x62\\x63"` will be resolved to `abc`
`b"abc\\x61\\x62\\x63"` will be resolved to `abcabc`
`b"\\x61\\x62\\x63" + b"\\x64\\x65\\x66"` will be resolved to `abcdef`
prefix:`b'` or `b"`
suffix: `'` or `"`

Reference: https://github.com/google/cel-spec/blob/master/doc/langdef.md#string-and-bytes-values