### PR TITLE
Support SQUARE brackets [] around NAMED parameter

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/NamedParameterUtils.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/NamedParameterUtils.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Thomas Risberg
  * @author Juergen Hoeller
  * @author Mark Paluch
+ * @author Anton Naydenov
  * @since 5.3
  */
 abstract class NamedParameterUtils {
@@ -66,7 +67,7 @@ abstract class NamedParameterUtils {
 	 * Set of characters that qualify as parameter separators,
 	 * indicating that a parameter name in an SQL String has ended.
 	 */
-	private static final String PARAMETER_SEPARATORS = "\"':&,;()|=+-*%/\\<>^";
+	private static final String PARAMETER_SEPARATORS = "\"':&,;()|=+-*%/\\<>^[]";
 
 	/**
 	 * An index with separator flags per character code.

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/NamedParameterUtilsUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/NamedParameterUtilsUnitTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.verify;
  *
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Anton Naydenov
  */
 public class NamedParameterUtilsUnitTests {
 
@@ -272,6 +273,18 @@ public class NamedParameterUtilsUnitTests {
 
 		assertThat(psql2.getTotalParameterCount()).isEqualTo(1);
 		assertThat(psql2.getParameterNames()).containsExactly("xxx");
+	}
+
+	@Test public void parseSqlStatementWithSquareBracket() {
+		// given
+		String sql = "SELECT ARRAY[:ext]";
+
+		// when
+		ParsedSql psql = NamedParameterUtils.parseSqlStatement(sql);
+
+		//then
+		assertThat(psql.getNamedParameterCount()).isEqualTo(1);
+		assertThat(psql.getParameterNames()).containsExactly("ext");
 	}
 
 	@Test


### PR DESCRIPTION
At the moment, if sql statement has a variable in square brackets, then the name of the variable will be incorrect.
For example:
`SELECT ARRAY[:ext];`
We'll get "**ext]**" instead of "**ext**".

But:
`SELECT ARRAY[:ext   ]; --with white space`
We'll get "**ext**".