### PR TITLE
Avoid unescape when CONNECT and CONNECTED frames

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
@@ -143,7 +143,7 @@ public class StompDecoder {
 				StompCommand stompCommand = StompCommand.valueOf(command);
 				headerAccessor = StompHeaderAccessor.create(stompCommand);
 				initHeaders(headerAccessor);
-				readHeaders(byteBuffer, headerAccessor);
+				readHeaders(stompCommand, byteBuffer, headerAccessor);
 				payload = readPayload(byteBuffer, headerAccessor);
 			}
 			if (payload != null) {
@@ -215,7 +215,9 @@ public class StompDecoder {
 		return StreamUtils.copyToString(command, StandardCharsets.UTF_8);
 	}
 
-	private void readHeaders(ByteBuffer byteBuffer, StompHeaderAccessor headerAccessor) {
+	private void readHeaders(StompCommand stompCommand, ByteBuffer byteBuffer, StompHeaderAccessor headerAccessor) {
+		boolean shouldUnescape = (stompCommand != StompCommand.CONNECT && stompCommand != StompCommand.STOMP
+				&& stompCommand != StompCommand.CONNECTED);
 		while (true) {
 			ByteArrayOutputStream headerStream = new ByteArrayOutputStream(256);
 			boolean headerComplete = false;
@@ -236,8 +238,8 @@ public class StompDecoder {
 					}
 				}
 				else {
-					String headerName = unescape(header.substring(0, colonIndex));
-					String headerValue = unescape(header.substring(colonIndex + 1));
+					String headerName = shouldUnescape ? unescape(header.substring(0, colonIndex)) : header.substring(0, colonIndex);
+					String headerValue = shouldUnescape ? unescape(header.substring(colonIndex + 1)) : header.substring(colonIndex + 1);
 					try {
 						headerAccessor.addNativeHeader(headerName, headerValue);
 					}

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompDecoderTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/StompDecoderTests.java
@@ -160,6 +160,23 @@ public class StompDecoderTests {
 	}
 
 	@Test
+	public void decodeFrameWithHeaderWithBackslashValue() {
+		String accept = "accept-version:1.1\n";
+		String keyAndValueWithBackslash = "key:\\value\n";
+
+		Message<byte[]> frame = decode("CONNECT\n" + accept + keyAndValueWithBackslash + "\n\0");
+		StompHeaderAccessor headers = StompHeaderAccessor.wrap(frame);
+
+		assertThat(headers.getCommand()).isEqualTo(StompCommand.CONNECT);
+
+		assertThat(headers.toNativeHeaderMap().size()).isEqualTo(2);
+		assertThat(headers.getFirstNativeHeader("accept-version")).isEqualTo("1.1");
+		assertThat(headers.getFirstNativeHeader("key")).isEqualTo("\\value");
+
+		assertThat(frame.getPayload().length).isEqualTo(0);
+	}
+
+	@Test
 	public void decodeFrameBodyNotAllowed() {
 		assertThatExceptionOfType(StompConversionException.class).isThrownBy(() ->
 				decode("CONNECT\naccept-version:1.2\n\nThe body of the message\0"));


### PR DESCRIPTION
I faced an error that stomp websocket client can not send a header with backslash.
Then I found reason.

[StopmEncoder](https://github.com/spring-projects/spring-framework/blob/d84ca2ba90d27a7c63d7b35a6259b5b9cf341118/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompEncoder.java#L129) dose not escape headers when CONNECT and CONNECTED frames, to follow the spec below:
https://stomp.github.io/stomp-specification-1.2.html#Value_Encoding
However, StompDecoder try to unescape when CONNECT and CONNECTED frames.

StopmDecoder should not unescape when CONNECT and CONNECTED frames, because the frames are not escaped.