### PR TITLE
Add getter for RequestMappingInfo builder config

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
@@ -246,6 +246,17 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 		return this.config.getFileExtensions();
 	}
 
+	/**
+	 * Get the configuration to build {@link RequestMappingInfo}
+	 * instances. This is useful for programmatic registration of
+	 * additional mappings following the same configuration as {@link
+	 * #createRequestMappingInfo(RequestMapping, RequestCondition)}.
+	 *
+	 * @return builder configuration to be supplied into {@link RequestMappingInfo.Builder#options}.
+	 */
+	public RequestMappingInfo.BuilderConfiguration getRequestMappingInfoBuilderConfiguration() {
+		return this.config;
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMappingTests.java
@@ -79,6 +79,17 @@ public class RequestMappingHandlerMappingTests {
 		return Stream.of(Arguments.of(mapping1, wac1), Arguments.of(mapping2, wac2));
 	}
 
+	@Test
+	void getRequestMappingInfoBuilderConfiguration() {
+		RequestMappingHandlerMapping handlerMapping = new RequestMappingHandlerMapping();
+		handlerMapping.setApplicationContext(new StaticWebApplicationContext());
+
+		RequestMappingInfo.BuilderConfiguration beforeAfterPropertiesSet = handlerMapping.getRequestMappingInfoBuilderConfiguration();
+		assertThat(beforeAfterPropertiesSet).isNotNull();
+		handlerMapping.afterPropertiesSet();
+		RequestMappingInfo.BuilderConfiguration afterPropertiesSet = handlerMapping.getRequestMappingInfoBuilderConfiguration();
+		assertThat(afterPropertiesSet).isNotNull().isNotSameAs(beforeAfterPropertiesSet);
+	}
 
 	@Test
 	@SuppressWarnings("deprecation")


### PR DESCRIPTION
This improves support for programmatic mapping registration following the same config as other mappings managed in RequestMappingHandlerMapping.

See also issue #27715.