### PR TITLE
Fix transitive dependency on  Java EE 8 JAX-B API in spring-webmvc test compile classpath

### DIFF
--- a/spring-webmvc/spring-webmvc.gradle
+++ b/spring-webmvc/spring-webmvc.gradle
@@ -45,7 +45,9 @@ dependencies {
 	testImplementation("org.apache.httpcomponents:httpclient")
 	testImplementation("commons-io:commons-io")
 	testImplementation("org.mozilla:rhino")
-	testImplementation("org.dom4j:dom4j")
+	testImplementation("org.dom4j:dom4j") {
+		exclude group: 'javax.xml.bind', module: "jaxb-api"
+	}
 	testImplementation("jaxen:jaxen")
 	testImplementation("org.xmlunit:xmlunit-assertj")
 	testImplementation("org.xmlunit:xmlunit-matchers")


### PR DESCRIPTION
spring-webmvc has the Java EE 8 JAX-B API on its test compile classpath (through dom4j) 
see https://github.com/spring-projects/spring-framework/issues/27685