### PR TITLE
selfCoders → Split the RequestBodyAdvice.supports method into Request…

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/JsonViewRequestBodyAdvice.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/JsonViewRequestBodyAdvice.java
@@ -49,8 +49,16 @@ import org.springframework.util.Assert;
 public class JsonViewRequestBodyAdvice extends RequestBodyAdviceAdapter {
 
 	@Override
-	public boolean supports(MethodParameter methodParameter, Type targetType,
-			Class<? extends HttpMessageConverter<?>> converterType) {
+	public boolean beforeBodySupport(MethodParameter methodParameter, Type targetType,
+					Class<? extends HttpMessageConverter<?>> converterType) {
+
+		return (AbstractJackson2HttpMessageConverter.class.isAssignableFrom(converterType) &&
+				methodParameter.getParameterAnnotation(JsonView.class) != null);
+	}
+
+	@Override
+	public boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+					Class<? extends HttpMessageConverter<?>> converterType) {
 
 		return (AbstractJackson2HttpMessageConverter.class.isAssignableFrom(converterType) &&
 				methodParameter.getParameterAnnotation(JsonView.class) != null);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdvice.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdvice.java
@@ -41,14 +41,28 @@ public interface RequestBodyAdvice {
 
 	/**
 	 * Invoked first to determine if this interceptor applies.
+	 *
 	 * @param methodParameter the method parameter
-	 * @param targetType the target type, not necessarily the same as the method
-	 * parameter type, e.g. for {@code HttpEntity<String>}.
-	 * @param converterType the selected converter type
+	 * @param targetType      the target type, not necessarily the same as the method
+	 *                        parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param converterType   the selected converter type
 	 * @return whether this interceptor should be invoked or not
 	 */
-	boolean supports(MethodParameter methodParameter, Type targetType,
-			Class<? extends HttpMessageConverter<?>> converterType);
+	boolean beforeBodySupport(MethodParameter methodParameter, Type targetType,
+							  Class<? extends HttpMessageConverter<?>> converterType);
+
+	/**
+	 * Invoked third to determine if this interceptor applies.
+	 *
+	 * @param methodParameter the method parameter
+	 *
+	 * @param targetType      the target type, not necessarily the same as the method
+	 *                        parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param converterType   the selected converter type
+	 * @return whether this interceptor should be invoked or not
+	 */
+	boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+							 Class<? extends HttpMessageConverter<?>> converterType);
 
 	/**
 	 * Invoked second before the request body is read and converted.
@@ -63,7 +77,7 @@ public interface RequestBodyAdvice {
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) throws IOException;
 
 	/**
-	 * Invoked third (and last) after the request body is converted to an Object.
+	 * Invoked fourth (and last) after the request body is converted to an Object.
 	 * @param body set to the converter Object before the first advice is called
 	 * @param inputMessage the request
 	 * @param parameter the target method parameter

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdviceAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdviceAdapter.java
@@ -29,7 +29,7 @@ import org.springframework.lang.Nullable;
  * {@link org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice
  * RequestBodyAdvice} with default method implementations.
  *
- * <p>Subclasses are required to implement {@link #supports} to return true
+ * <p>Subclasses are required to implement {@link #beforeBodySupport} and {@link #afterBodySupport} to return true
  * depending on when the advice applies.
  *
  * @author Rossen Stoyanchev

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChain.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChain.java
@@ -74,12 +74,17 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 
 
 	@Override
-	public boolean supports(MethodParameter param, Type type, Class<? extends HttpMessageConverter<?>> converterType) {
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
 		throw new UnsupportedOperationException("Not implemented");
 	}
 
 	@Override
-	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+	public boolean beforeBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public boolean afterBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 		throw new UnsupportedOperationException("Not implemented");
 	}
 
@@ -88,7 +93,7 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) throws IOException {
 
 		for (RequestBodyAdvice advice : getMatchingAdvice(parameter, RequestBodyAdvice.class)) {
-			if (advice.supports(parameter, targetType, converterType)) {
+			if (advice.beforeBodySupport(parameter, targetType, converterType)) {
 				request = advice.beforeBodyRead(request, parameter, targetType, converterType);
 			}
 		}
@@ -100,7 +105,7 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
 		for (RequestBodyAdvice advice : getMatchingAdvice(parameter, RequestBodyAdvice.class)) {
-			if (advice.supports(parameter, targetType, converterType)) {
+			if (advice.afterBodySupport(parameter, targetType, converterType)) {
 				body = advice.afterBodyRead(body, inputMessage, parameter, targetType, converterType);
 			}
 		}
@@ -122,7 +127,8 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
 		for (RequestBodyAdvice advice : getMatchingAdvice(parameter, RequestBodyAdvice.class)) {
-			if (advice.supports(parameter, targetType, converterType)) {
+			if (advice.beforeBodySupport(parameter, targetType, converterType)
+					&& advice.afterBodySupport(parameter, targetType, converterType)) {
 				body = advice.handleEmptyBody(body, inputMessage, parameter, targetType, converterType);
 			}
 		}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapterTests.java
@@ -385,8 +385,13 @@ public class RequestMappingHandlerAdapterTests {
 		}
 
 		@Override
-		public boolean supports(MethodParameter methodParameter, Type targetType,
-				Class<? extends HttpMessageConverter<?>> converterType) {
+		public boolean beforeBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+
+			return StringHttpMessageConverter.class.equals(converterType);
+		}
+
+		@Override
+		public boolean afterBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
 			return StringHttpMessageConverter.class.equals(converterType);
 		}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
@@ -1083,8 +1083,15 @@ public class RequestResponseBodyMethodProcessorTests {
 	private static class EmptyRequestBodyAdvice implements RequestBodyAdvice {
 
 		@Override
-		public boolean supports(MethodParameter methodParameter, Type targetType,
-				Class<? extends HttpMessageConverter<?>> converterType) {
+		public boolean beforeBodySupport(MethodParameter methodParameter, Type targetType,
+						Class<? extends HttpMessageConverter<?>> converterType) {
+
+			return StringHttpMessageConverter.class.equals(converterType);
+		}
+
+		@Override
+		public boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+						Class<? extends HttpMessageConverter<?>> converterType) {
 
 			return StringHttpMessageConverter.class.equals(converterType);
 		}


### PR DESCRIPTION
…BodyAdvice.beforeBodySupport and RequestBodyAdvice.afterBodySupport, judge whether the RequestBodyAdvice.beforeBodyRead and RequestBodyAdvice.afterBodyRead methods are applicable respectively , Corresponding changes have also been made to the related parts