### PR TITLE
Update spring-webmvc RequestBodyAdvice.supports method

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/JsonViewRequestBodyAdvice.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/JsonViewRequestBodyAdvice.java
@@ -57,7 +57,7 @@ public class JsonViewRequestBodyAdvice extends RequestBodyAdviceAdapter {
 	}
 
 	@Override
-	public boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+	public boolean afterBodySupport(HttpInputMessage inputMessage, MethodParameter methodParameter, Type targetType,
 					Class<? extends HttpMessageConverter<?>> converterType) {
 
 		return (AbstractJackson2HttpMessageConverter.class.isAssignableFrom(converterType) &&

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/JsonViewRequestBodyAdvice.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/JsonViewRequestBodyAdvice.java
@@ -49,8 +49,16 @@ import org.springframework.util.Assert;
 public class JsonViewRequestBodyAdvice extends RequestBodyAdviceAdapter {
 
 	@Override
-	public boolean supports(MethodParameter methodParameter, Type targetType,
-			Class<? extends HttpMessageConverter<?>> converterType) {
+	public boolean beforeBodySupport(MethodParameter methodParameter, Type targetType,
+					Class<? extends HttpMessageConverter<?>> converterType) {
+
+		return (AbstractJackson2HttpMessageConverter.class.isAssignableFrom(converterType) &&
+				methodParameter.getParameterAnnotation(JsonView.class) != null);
+	}
+
+	@Override
+	public boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+					Class<? extends HttpMessageConverter<?>> converterType) {
 
 		return (AbstractJackson2HttpMessageConverter.class.isAssignableFrom(converterType) &&
 				methodParameter.getParameterAnnotation(JsonView.class) != null);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdvice.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdvice.java
@@ -41,14 +41,28 @@ public interface RequestBodyAdvice {
 
 	/**
 	 * Invoked first to determine if this interceptor applies.
+	 *
 	 * @param methodParameter the method parameter
-	 * @param targetType the target type, not necessarily the same as the method
-	 * parameter type, e.g. for {@code HttpEntity<String>}.
-	 * @param converterType the selected converter type
+	 * @param targetType      the target type, not necessarily the same as the method
+	 *                        parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param converterType   the selected converter type
 	 * @return whether this interceptor should be invoked or not
 	 */
-	boolean supports(MethodParameter methodParameter, Type targetType,
-			Class<? extends HttpMessageConverter<?>> converterType);
+	boolean beforeBodySupport(MethodParameter methodParameter, Type targetType,
+							  Class<? extends HttpMessageConverter<?>> converterType);
+
+	/**
+	 * Invoked third to determine if this interceptor applies.
+	 *
+	 * @param methodParameter the method parameter
+	 *
+	 * @param targetType      the target type, not necessarily the same as the method
+	 *                        parameter type, e.g. for {@code HttpEntity<String>}.
+	 * @param converterType   the selected converter type
+	 * @return whether this interceptor should be invoked or not
+	 */
+	boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+							 Class<? extends HttpMessageConverter<?>> converterType);
 
 	/**
 	 * Invoked second before the request body is read and converted.
@@ -63,7 +77,7 @@ public interface RequestBodyAdvice {
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) throws IOException;
 
 	/**
-	 * Invoked third (and last) after the request body is converted to an Object.
+	 * Invoked fourth (and last) after the request body is converted to an Object.
 	 * @param body set to the converter Object before the first advice is called
 	 * @param inputMessage the request
 	 * @param parameter the target method parameter

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdvice.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdvice.java
@@ -52,13 +52,14 @@ public interface RequestBodyAdvice {
 
 	/**
 	 * Invoked third to determine if this interceptor applies.
+	 * @param inputMessage the request
 	 * @param methodParameter the method parameter
 	 * @param targetType      the target type, not necessarily the same as the method
 	 *                        parameter type, e.g. for {@code HttpEntity<String>}.
 	 * @param converterType   the selected converter type
 	 * @return whether this interceptor should be invoked or not
 	 */
-	boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+	boolean afterBodySupport(HttpInputMessage inputMessage, MethodParameter methodParameter, Type targetType,
 			Class<? extends HttpMessageConverter<?>> converterType);
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdvice.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdvice.java
@@ -41,7 +41,6 @@ public interface RequestBodyAdvice {
 
 	/**
 	 * Invoked first to determine if this interceptor applies.
-	 *
 	 * @param methodParameter the method parameter
 	 * @param targetType      the target type, not necessarily the same as the method
 	 *                        parameter type, e.g. for {@code HttpEntity<String>}.
@@ -49,20 +48,18 @@ public interface RequestBodyAdvice {
 	 * @return whether this interceptor should be invoked or not
 	 */
 	boolean beforeBodySupport(MethodParameter methodParameter, Type targetType,
-							  Class<? extends HttpMessageConverter<?>> converterType);
+			Class<? extends HttpMessageConverter<?>> converterType);
 
 	/**
 	 * Invoked third to determine if this interceptor applies.
-	 *
 	 * @param methodParameter the method parameter
-	 *
 	 * @param targetType      the target type, not necessarily the same as the method
 	 *                        parameter type, e.g. for {@code HttpEntity<String>}.
 	 * @param converterType   the selected converter type
 	 * @return whether this interceptor should be invoked or not
 	 */
 	boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
-							 Class<? extends HttpMessageConverter<?>> converterType);
+			Class<? extends HttpMessageConverter<?>> converterType);
 
 	/**
 	 * Invoked second before the request body is read and converted.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdviceAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestBodyAdviceAdapter.java
@@ -29,7 +29,7 @@ import org.springframework.lang.Nullable;
  * {@link org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice
  * RequestBodyAdvice} with default method implementations.
  *
- * <p>Subclasses are required to implement {@link #supports} to return true
+ * <p>Subclasses are required to implement {@link #beforeBodySupport} and {@link #afterBodySupport} to return true
  * depending on when the advice applies.
  *
  * @author Rossen Stoyanchev

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChain.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChain.java
@@ -84,7 +84,7 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 	}
 
 	@Override
-	public boolean afterBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+	public boolean afterBodySupport(HttpInputMessage inputMessage, MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 		throw new UnsupportedOperationException("Not implemented");
 	}
 
@@ -105,7 +105,7 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
 		for (RequestBodyAdvice advice : getMatchingAdvice(parameter, RequestBodyAdvice.class)) {
-			if (advice.afterBodySupport(parameter, targetType, converterType)) {
+			if (advice.afterBodySupport(inputMessage, parameter, targetType, converterType)) {
 				body = advice.afterBodyRead(body, inputMessage, parameter, targetType, converterType);
 			}
 		}
@@ -128,7 +128,7 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 
 		for (RequestBodyAdvice advice : getMatchingAdvice(parameter, RequestBodyAdvice.class)) {
 			if (advice.beforeBodySupport(parameter, targetType, converterType)
-					&& advice.afterBodySupport(parameter, targetType, converterType)) {
+					&& advice.afterBodySupport(inputMessage, parameter, targetType, converterType)) {
 				body = advice.handleEmptyBody(body, inputMessage, parameter, targetType, converterType);
 			}
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChain.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChain.java
@@ -74,12 +74,17 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 
 
 	@Override
-	public boolean supports(MethodParameter param, Type type, Class<? extends HttpMessageConverter<?>> converterType) {
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
 		throw new UnsupportedOperationException("Not implemented");
 	}
 
 	@Override
-	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+	public boolean beforeBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public boolean afterBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 		throw new UnsupportedOperationException("Not implemented");
 	}
 
@@ -88,7 +93,7 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) throws IOException {
 
 		for (RequestBodyAdvice advice : getMatchingAdvice(parameter, RequestBodyAdvice.class)) {
-			if (advice.supports(parameter, targetType, converterType)) {
+			if (advice.beforeBodySupport(parameter, targetType, converterType)) {
 				request = advice.beforeBodyRead(request, parameter, targetType, converterType);
 			}
 		}
@@ -100,7 +105,7 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
 		for (RequestBodyAdvice advice : getMatchingAdvice(parameter, RequestBodyAdvice.class)) {
-			if (advice.supports(parameter, targetType, converterType)) {
+			if (advice.afterBodySupport(parameter, targetType, converterType)) {
 				body = advice.afterBodyRead(body, inputMessage, parameter, targetType, converterType);
 			}
 		}
@@ -122,7 +127,8 @@ class RequestResponseBodyAdviceChain implements RequestBodyAdvice, ResponseBodyA
 			Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
 		for (RequestBodyAdvice advice : getMatchingAdvice(parameter, RequestBodyAdvice.class)) {
-			if (advice.supports(parameter, targetType, converterType)) {
+			if (advice.beforeBodySupport(parameter, targetType, converterType)
+					&& advice.afterBodySupport(parameter, targetType, converterType)) {
 				body = advice.handleEmptyBody(body, inputMessage, parameter, targetType, converterType);
 			}
 		}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapterTests.java
@@ -385,8 +385,13 @@ public class RequestMappingHandlerAdapterTests {
 		}
 
 		@Override
-		public boolean supports(MethodParameter methodParameter, Type targetType,
-				Class<? extends HttpMessageConverter<?>> converterType) {
+		public boolean beforeBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+
+			return StringHttpMessageConverter.class.equals(converterType);
+		}
+
+		@Override
+		public boolean afterBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
 			return StringHttpMessageConverter.class.equals(converterType);
 		}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapterTests.java
@@ -391,7 +391,7 @@ public class RequestMappingHandlerAdapterTests {
 		}
 
 		@Override
-		public boolean afterBodySupport(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+		public boolean afterBodySupport(HttpInputMessage inputMessage, MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
 			return StringHttpMessageConverter.class.equals(converterType);
 		}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChainTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChainTests.java
@@ -96,7 +96,7 @@ public class RequestResponseBodyAdviceChainTests {
 		assertThat(chain.beforeBodyRead(this.request, this.paramType, String.class, this.converterType)).isSameAs(wrapped);
 
 		String modified = "body++";
-		given(requestAdvice.afterBodySupport(this.paramType, String.class, this.converterType)).willReturn(true);
+		given(requestAdvice.afterBodySupport(this.request, this.paramType, String.class, this.converterType)).willReturn(true);
 		given(requestAdvice.afterBodyRead(eq(this.body), eq(this.request), eq(this.paramType),
 				eq(String.class), eq(this.converterType))).willReturn(modified);
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChainTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyAdviceChainTests.java
@@ -89,13 +89,14 @@ public class RequestResponseBodyAdviceChainTests {
 		RequestResponseBodyAdviceChain chain = new RequestResponseBodyAdviceChain(advice);
 
 		HttpInputMessage wrapped = new ServletServerHttpRequest(new MockHttpServletRequest());
-		given(requestAdvice.supports(this.paramType, String.class, this.converterType)).willReturn(true);
+		given(requestAdvice.beforeBodySupport(this.paramType, String.class, this.converterType)).willReturn(true);
 		given(requestAdvice.beforeBodyRead(eq(this.request), eq(this.paramType), eq(String.class),
 				eq(this.converterType))).willReturn(wrapped);
 
 		assertThat(chain.beforeBodyRead(this.request, this.paramType, String.class, this.converterType)).isSameAs(wrapped);
 
 		String modified = "body++";
+		given(requestAdvice.afterBodySupport(this.paramType, String.class, this.converterType)).willReturn(true);
 		given(requestAdvice.afterBodyRead(eq(this.body), eq(this.request), eq(this.paramType),
 				eq(String.class), eq(this.converterType))).willReturn(modified);
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
@@ -1090,7 +1090,7 @@ public class RequestResponseBodyMethodProcessorTests {
 		}
 
 		@Override
-		public boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+		public boolean afterBodySupport(HttpInputMessage inputMessage, MethodParameter methodParameter, Type targetType,
 						Class<? extends HttpMessageConverter<?>> converterType) {
 
 			return StringHttpMessageConverter.class.equals(converterType);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
@@ -1083,8 +1083,15 @@ public class RequestResponseBodyMethodProcessorTests {
 	private static class EmptyRequestBodyAdvice implements RequestBodyAdvice {
 
 		@Override
-		public boolean supports(MethodParameter methodParameter, Type targetType,
-				Class<? extends HttpMessageConverter<?>> converterType) {
+		public boolean beforeBodySupport(MethodParameter methodParameter, Type targetType,
+						Class<? extends HttpMessageConverter<?>> converterType) {
+
+			return StringHttpMessageConverter.class.equals(converterType);
+		}
+
+		@Override
+		public boolean afterBodySupport(MethodParameter methodParameter, Type targetType,
+						Class<? extends HttpMessageConverter<?>> converterType) {
 
 			return StringHttpMessageConverter.class.equals(converterType);
 		}


### PR DESCRIPTION
I found that when the RequestBodyAdvice is working, the supports method will be executed twice to determine whether it is applicable to the beforeBodyRead and afterBodyRead methods, but sometimes such a judgment is not necessary, so I think it should be split for different judgments, so I put RequestBodyAdvice The .supports method is divided into beforeBodySupport and afterBodySupport methods