### PR TITLE
Expose headers from native client request after request is committed

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
@@ -74,14 +74,13 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 		this.cookies = new LinkedMultiValueMap<>();
 	}
 
-
 	@Override
 	public HttpHeaders getHeaders() {
 		if (this.readOnlyHeaders != null) {
 			return this.readOnlyHeaders;
 		}
 		else if (State.COMMITTED.equals(this.state.get())) {
-			this.readOnlyHeaders = HttpHeaders.readOnlyHttpHeaders(this.headers);
+			this.readOnlyHeaders = initReadOnlyHeaders();
 			return this.readOnlyHeaders;
 		}
 		else {
@@ -142,6 +141,14 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 				.map(Supplier::get).collect(Collectors.toList());
 
 		return Flux.concat(actions).then();
+	}
+
+	/**
+	 * Initialize read-only headers with underlying request headers.
+	 * @return read-only headers
+	 */
+	protected HttpHeaders initReadOnlyHeaders() {
+		return HttpHeaders.readOnlyHttpHeaders(this.headers);
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
@@ -116,6 +116,11 @@ class HttpComponentsClientHttpRequest extends AbstractClientHttpRequest {
 	}
 
 	@Override
+	protected HttpHeaders initReadOnlyHeaders() {
+		return HttpHeaders.readOnlyHttpHeaders(new HttpComponentsHeadersAdapter(this.httpRequest));
+	}
+
+	@Override
 	protected void applyHeaders() {
 		HttpHeaders headers = getHeaders();
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsHeadersAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsHeadersAdapter.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpMessage;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
@@ -44,23 +44,23 @@ import org.springframework.util.MultiValueMap;
  */
 class HttpComponentsHeadersAdapter implements MultiValueMap<String, String> {
 
-	private final HttpResponse response;
+	private final HttpMessage message;
 
 
-	HttpComponentsHeadersAdapter(HttpResponse response) {
-		this.response = response;
+	HttpComponentsHeadersAdapter(HttpMessage message) {
+		this.message = message;
 	}
 
 
 	@Override
 	public String getFirst(String key) {
-		Header header = this.response.getFirstHeader(key);
+		Header header = this.message.getFirstHeader(key);
 		return (header != null ? header.getValue() : null);
 	}
 
 	@Override
 	public void add(String key, @Nullable String value) {
-		this.response.addHeader(key, value);
+		this.message.addHeader(key, value);
 	}
 
 	@Override
@@ -75,7 +75,7 @@ class HttpComponentsHeadersAdapter implements MultiValueMap<String, String> {
 
 	@Override
 	public void set(String key, @Nullable String value) {
-		this.response.setHeader(key, value);
+		this.message.setHeader(key, value);
 	}
 
 	@Override
@@ -86,29 +86,29 @@ class HttpComponentsHeadersAdapter implements MultiValueMap<String, String> {
 	@Override
 	public Map<String, String> toSingleValueMap() {
 		Map<String, String> map = CollectionUtils.newLinkedHashMap(size());
-		this.response.headerIterator().forEachRemaining(h -> map.putIfAbsent(h.getName(), h.getValue()));
+		this.message.headerIterator().forEachRemaining(h -> map.putIfAbsent(h.getName(), h.getValue()));
 		return map;
 	}
 
 	@Override
 	public int size() {
-		return this.response.getHeaders().length;
+		return this.message.getHeaders().length;
 	}
 
 	@Override
 	public boolean isEmpty() {
-		return (this.response.getHeaders().length == 0);
+		return (this.message.getHeaders().length == 0);
 	}
 
 	@Override
 	public boolean containsKey(Object key) {
-		return (key instanceof String headerName && this.response.containsHeader(headerName));
+		return (key instanceof String headerName && this.message.containsHeader(headerName));
 	}
 
 	@Override
 	public boolean containsValue(Object value) {
 		return (value instanceof String &&
-				Arrays.stream(this.response.getHeaders()).anyMatch(h -> h.getValue().equals(value)));
+				Arrays.stream(this.message.getHeaders()).anyMatch(h -> h.getValue().equals(value)));
 	}
 
 	@Nullable
@@ -116,7 +116,7 @@ class HttpComponentsHeadersAdapter implements MultiValueMap<String, String> {
 	public List<String> get(Object key) {
 		List<String> values = null;
 		if (containsKey(key)) {
-			Header[] headers = this.response.getHeaders((String) key);
+			Header[] headers = this.message.getHeaders((String) key);
 			values = new ArrayList<>(headers.length);
 			for (Header header : headers) {
 				values.add(header.getValue());
@@ -138,7 +138,7 @@ class HttpComponentsHeadersAdapter implements MultiValueMap<String, String> {
 	public List<String> remove(Object key) {
 		if (key instanceof String headerName) {
 			List<String> oldValues = get(key);
-			this.response.removeHeaders(headerName);
+			this.message.removeHeaders(headerName);
 			return oldValues;
 		}
 		return null;
@@ -151,13 +151,13 @@ class HttpComponentsHeadersAdapter implements MultiValueMap<String, String> {
 
 	@Override
 	public void clear() {
-		this.response.setHeaders();
+		this.message.setHeaders();
 	}
 
 	@Override
 	public Set<String> keySet() {
 		Set<String> keys = new LinkedHashSet<>(size());
-		for (Header header : this.response.getHeaders()) {
+		for (Header header : this.message.getHeaders()) {
 			keys.add(header.getName());
 		}
 		return keys;
@@ -166,7 +166,7 @@ class HttpComponentsHeadersAdapter implements MultiValueMap<String, String> {
 	@Override
 	public Collection<List<String>> values() {
 		Collection<List<String>> values = new ArrayList<>(size());
-		for (Header header : this.response.getHeaders()) {
+		for (Header header : this.message.getHeaders()) {
 			values.add(get(header.getName()));
 		}
 		return values;
@@ -196,7 +196,7 @@ class HttpComponentsHeadersAdapter implements MultiValueMap<String, String> {
 
 	private class EntryIterator implements Iterator<Entry<String, List<String>>> {
 
-		private final Iterator<Header> iterator = response.headerIterator();
+		private final Iterator<Header> iterator = message.headerIterator();
 
 		@Override
 		public boolean hasNext() {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpRequest.java
@@ -125,6 +125,10 @@ class JettyClientHttpRequest extends AbstractClientHttpRequest {
 		});
 	}
 
+	@Override
+	protected HttpHeaders initReadOnlyHeaders() {
+		return HttpHeaders.readOnlyHttpHeaders(new JettyHeadersAdapter(this.jettyRequest.getHeaders()));
+	}
 
 	@Override
 	protected void applyCookies() {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
@@ -31,6 +31,7 @@ import reactor.netty.http.client.HttpClientRequest;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ZeroCopyHttpOutputMessage;
 
@@ -119,6 +120,11 @@ class ReactorClientHttpRequest extends AbstractClientHttpRequest implements Zero
 	@Override
 	public Mono<Void> setComplete() {
 		return doCommit(this.outbound::then);
+	}
+
+	@Override
+	protected HttpHeaders initReadOnlyHeaders() {
+		return HttpHeaders.readOnlyHttpHeaders(new NettyHeadersAdapter(this.request.requestHeaders()));
 	}
 
 	@Override


### PR DESCRIPTION
Fixes issues like [that](https://github.com/zalando/logbook/pull/1150#issuecomment-986223607), when public API does not expose headers that have been set by connector implementation.