### PR TITLE
Fix javadoc reference to ThrowsAdvice

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/adapter/ThrowsAdviceAdapter.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/adapter/ThrowsAdviceAdapter.java
@@ -25,7 +25,7 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.ThrowsAdvice;
 
 /**
- * Adapter to enable {@link org.springframework.aop.MethodBeforeAdvice}
+ * Adapter to enable {@link org.springframework.aop.ThrowsAdvice}
  * to be used in the Spring AOP framework.
  *
  * @author Rod Johnson


### PR DESCRIPTION
In the process of learning, I found a little flaw in Javadoc

Maybe we can change {@link org.springframework.aop.MethodBeforeAdvice} to {@link org.springframework.aop.ThrowsAdvice}