### PR TITLE
Use Collection factory methods

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -29,7 +29,6 @@ import java.time.temporal.Temporal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -79,20 +78,15 @@ public abstract class BeanUtils {
 	private static final Set<Class<?>> unknownEditorTypes =
 			Collections.newSetFromMap(new ConcurrentReferenceHashMap<>(64));
 
-	private static final Map<Class<?>, Object> DEFAULT_TYPE_VALUES;
-
-	static {
-		Map<Class<?>, Object> values = new HashMap<>();
-		values.put(boolean.class, false);
-		values.put(byte.class, (byte) 0);
-		values.put(short.class, (short) 0);
-		values.put(int.class, 0);
-		values.put(long.class, 0L);
-		values.put(float.class, 0F);
-		values.put(double.class, 0D);
-		values.put(char.class, '\0');
-		DEFAULT_TYPE_VALUES = Collections.unmodifiableMap(values);
-	}
+	private static final Map<Class<?>, Object> DEFAULT_TYPE_VALUES = Map.of(
+			boolean.class, false,
+			byte.class, (byte) 0,
+			short.class, (short) 0,
+			int.class, 0,
+			long.class, 0L,
+			float.class, 0F,
+			double.class, 0D,
+			char.class, '\0');
 
 
 	/**

--- a/spring-context/src/main/java/org/springframework/format/datetime/DateTimeFormatAnnotationFormatterFactory.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/DateTimeFormatAnnotationFormatterFactory.java
@@ -18,9 +18,7 @@ package org.springframework.format.datetime;
 
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -42,16 +40,7 @@ import org.springframework.util.StringUtils;
 public class DateTimeFormatAnnotationFormatterFactory  extends EmbeddedValueResolutionSupport
 		implements AnnotationFormatterFactory<DateTimeFormat> {
 
-	private static final Set<Class<?>> FIELD_TYPES;
-
-	static {
-		Set<Class<?>> fieldTypes = new HashSet<>(4);
-		fieldTypes.add(Date.class);
-		fieldTypes.add(Calendar.class);
-		fieldTypes.add(Long.class);
-		FIELD_TYPES = Collections.unmodifiableSet(fieldTypes);
-	}
-
+	private static final Set<Class<?>> FIELD_TYPES = Set.of(Date.class, Calendar.class, Long.class);
 
 	@Override
 	public Set<Class<?>> getFieldTypes() {

--- a/spring-context/src/main/java/org/springframework/format/datetime/standard/Jsr310DateTimeFormatAnnotationFormatterFactory.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/standard/Jsr310DateTimeFormatAnnotationFormatterFactory.java
@@ -28,8 +28,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -53,22 +51,17 @@ import org.springframework.util.StringUtils;
 public class Jsr310DateTimeFormatAnnotationFormatterFactory extends EmbeddedValueResolutionSupport
 		implements AnnotationFormatterFactory<DateTimeFormat> {
 
-	private static final Set<Class<?>> FIELD_TYPES;
-
-	static {
-		// Create the set of field types that may be annotated with @DateTimeFormat.
-		Set<Class<?>> fieldTypes = new HashSet<>(8);
-		fieldTypes.add(Instant.class);
-		fieldTypes.add(LocalDate.class);
-		fieldTypes.add(LocalTime.class);
-		fieldTypes.add(LocalDateTime.class);
-		fieldTypes.add(ZonedDateTime.class);
-		fieldTypes.add(OffsetDateTime.class);
-		fieldTypes.add(OffsetTime.class);
-		fieldTypes.add(YearMonth.class);
-		fieldTypes.add(MonthDay.class);
-		FIELD_TYPES = Collections.unmodifiableSet(fieldTypes);
-	}
+	// Create the set of field types that may be annotated with @DateTimeFormat.
+	private static final Set<Class<?>> FIELD_TYPES = Set.of(
+				Instant.class,
+				LocalDate.class,
+				LocalTime.class,
+				LocalDateTime.class,
+				ZonedDateTime.class,
+				OffsetDateTime.class,
+				OffsetTime.class,
+				YearMonth.class,
+				MonthDay.class);
 
 	@Override
 	public final Set<Class<?>> getFieldTypes() {

--- a/spring-core/src/main/java/org/springframework/core/annotation/TypeMappedAnnotation.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/TypeMappedAnnotation.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,20 +69,16 @@ import org.springframework.util.ReflectionUtils;
  */
 final class TypeMappedAnnotation<A extends Annotation> extends AbstractMergedAnnotation<A> {
 
-	private static final Map<Class<?>, Object> EMPTY_ARRAYS;
-	static {
-		Map<Class<?>, Object> emptyArrays = new HashMap<>();
-		emptyArrays.put(boolean.class, new boolean[0]);
-		emptyArrays.put(byte.class, new byte[0]);
-		emptyArrays.put(char.class, new char[0]);
-		emptyArrays.put(double.class, new double[0]);
-		emptyArrays.put(float.class, new float[0]);
-		emptyArrays.put(int.class, new int[0]);
-		emptyArrays.put(long.class, new long[0]);
-		emptyArrays.put(short.class, new short[0]);
-		emptyArrays.put(String.class, new String[0]);
-		EMPTY_ARRAYS = Collections.unmodifiableMap(emptyArrays);
-	}
+	private static final Map<Class<?>, Object> EMPTY_ARRAYS = Map.of(
+		boolean.class, new boolean[0],
+		byte.class, new byte[0],
+		char.class, new char[0],
+		double.class, new double[0],
+		float.class, new float[0],
+		int.class, new int[0],
+		long.class, new long[0],
+		short.class, new short[0],
+		String.class, new String[0]);
 
 
 	private final AnnotationTypeMapping mapping;

--- a/spring-core/src/main/java/org/springframework/core/convert/support/ByteBufferConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/ByteBufferConverter.java
@@ -17,8 +17,6 @@
 package org.springframework.core.convert.support;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.springframework.core.convert.ConversionService;
@@ -40,17 +38,11 @@ final class ByteBufferConverter implements ConditionalGenericConverter {
 
 	private static final TypeDescriptor BYTE_ARRAY_TYPE = TypeDescriptor.valueOf(byte[].class);
 
-	private static final Set<ConvertiblePair> CONVERTIBLE_PAIRS;
-
-	static {
-		Set<ConvertiblePair> convertiblePairs = new HashSet<>(4);
-		convertiblePairs.add(new ConvertiblePair(ByteBuffer.class, byte[].class));
-		convertiblePairs.add(new ConvertiblePair(byte[].class, ByteBuffer.class));
-		convertiblePairs.add(new ConvertiblePair(ByteBuffer.class, Object.class));
-		convertiblePairs.add(new ConvertiblePair(Object.class, ByteBuffer.class));
-		CONVERTIBLE_PAIRS = Collections.unmodifiableSet(convertiblePairs);
-	}
-
+	private static final Set<ConvertiblePair> CONVERTIBLE_PAIRS = Set.of(
+				new ConvertiblePair(ByteBuffer.class, byte[].class),
+				new ConvertiblePair(byte[].class, ByteBuffer.class),
+				new ConvertiblePair(ByteBuffer.class, Object.class),
+				new ConvertiblePair(Object.class, ByteBuffer.class));
 
 	private final ConversionService conversionService;
 

--- a/spring-core/src/main/java/org/springframework/util/NumberUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/NumberUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.springframework.lang.Nullable;
@@ -46,21 +44,15 @@ public abstract class NumberUtils {
 	 * Standard number types (all immutable):
 	 * Byte, Short, Integer, Long, BigInteger, Float, Double, BigDecimal.
 	 */
-	public static final Set<Class<?>> STANDARD_NUMBER_TYPES;
-
-	static {
-		Set<Class<?>> numberTypes = new HashSet<>(8);
-		numberTypes.add(Byte.class);
-		numberTypes.add(Short.class);
-		numberTypes.add(Integer.class);
-		numberTypes.add(Long.class);
-		numberTypes.add(BigInteger.class);
-		numberTypes.add(Float.class);
-		numberTypes.add(Double.class);
-		numberTypes.add(BigDecimal.class);
-		STANDARD_NUMBER_TYPES = Collections.unmodifiableSet(numberTypes);
-	}
-
+	public static final Set<Class<?>> STANDARD_NUMBER_TYPES = Set.of(
+			Byte.class,
+			Short.class,
+			Integer.class,
+			Long.class,
+			BigInteger.class,
+			Float.class,
+			Double.class,
+			BigDecimal.class);
 
 	/**
 	 * Convert the given number into an instance of the given target class.

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectivePropertyAccessor.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectivePropertyAccessor.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -65,15 +64,7 @@ public class ReflectivePropertyAccessor implements PropertyAccessor {
 
 	private static final Set<Class<?>> ANY_TYPES = Collections.emptySet();
 
-	private static final Set<Class<?>> BOOLEAN_TYPES;
-
-	static {
-		Set<Class<?>> booleanTypes = new HashSet<>(4);
-		booleanTypes.add(Boolean.class);
-		booleanTypes.add(Boolean.TYPE);
-		BOOLEAN_TYPES = Collections.unmodifiableSet(booleanTypes);
-	}
-
+	private static final Set<Class<?>> BOOLEAN_TYPES = Set.of(Boolean.class, Boolean.TYPE);
 
 	private final boolean allowWrite;
 

--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2CodecSupport.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2CodecSupport.java
@@ -19,7 +19,6 @@ package org.springframework.http.codec.json;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -75,11 +74,10 @@ public abstract class Jackson2CodecSupport {
 	private static final String JSON_VIEW_HINT_ERROR =
 			"@JsonView only supported for write hints with exactly 1 class argument: ";
 
-	private static final List<MimeType> DEFAULT_MIME_TYPES = Collections.unmodifiableList(
-			Arrays.asList(
-					MediaType.APPLICATION_JSON,
-					new MediaType("application", "*+json"),
-					MediaType.APPLICATION_NDJSON));
+	private static final List<MimeType> DEFAULT_MIME_TYPES = List.of(
+			MediaType.APPLICATION_JSON,
+			new MediaType("application", "*+json"),
+			MediaType.APPLICATION_NDJSON);
 
 
 	protected final Log logger = HttpLogging.forLogName(getClass());
@@ -99,7 +97,7 @@ public abstract class Jackson2CodecSupport {
 		Assert.notNull(objectMapper, "ObjectMapper must not be null");
 		this.defaultObjectMapper = objectMapper;
 		this.mimeTypes = !ObjectUtils.isEmpty(mimeTypes) ?
-				Collections.unmodifiableList(Arrays.asList(mimeTypes)) : DEFAULT_MIME_TYPES;
+				List.of(mimeTypes) : DEFAULT_MIME_TYPES;
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
 package org.springframework.http.codec.multipart;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -56,12 +54,12 @@ public class MultipartHttpMessageReader extends LoggingCodecSupport
 	private static final ResolvableType MULTIPART_VALUE_TYPE = ResolvableType.forClassWithGenerics(
 			MultiValueMap.class, String.class, Part.class);
 
-	static final List<MediaType> MIME_TYPES = Collections.unmodifiableList(Arrays.asList(
-			MediaType.MULTIPART_FORM_DATA, MediaType.MULTIPART_MIXED, MediaType.MULTIPART_RELATED));
-
+	static final List<MediaType> MIME_TYPES = List.of(
+			MediaType.MULTIPART_FORM_DATA,
+			MediaType.MULTIPART_MIXED,
+			MediaType.MULTIPART_RELATED);
 
 	private final HttpMessageReader<Part> partReader;
-
 
 	public MultipartHttpMessageReader(HttpMessageReader<Part> partReader) {
 		Assert.notNull(partReader, "'partReader' is required");

--- a/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufCodecSupport.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufCodecSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.springframework.http.codec.protobuf;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.lang.Nullable;
@@ -31,11 +29,10 @@ import org.springframework.util.MimeType;
  */
 public abstract class ProtobufCodecSupport {
 
-	static final List<MimeType> MIME_TYPES = Collections.unmodifiableList(
-			Arrays.asList(
+	static final List<MimeType> MIME_TYPES = List.of(
 					new MimeType("application", "x-protobuf"),
 					new MimeType("application", "octet-stream"),
-					new MimeType("application", "vnd.google.protobuf")));
+					new MimeType("application", "vnd.google.protobuf"));
 
 	static final String DELIMITED_KEY = "delimited";
 

--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.web.cors;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -65,11 +64,10 @@ public class CorsConfiguration {
 
 	private static final List<String> DEFAULT_PERMIT_ALL = Collections.singletonList(ALL);
 
-	private static final List<HttpMethod> DEFAULT_METHODS = Collections.unmodifiableList(
-			Arrays.asList(HttpMethod.GET, HttpMethod.HEAD));
+	private static final List<HttpMethod> DEFAULT_METHODS = List.of(HttpMethod.GET, HttpMethod.HEAD);
 
-	private static final List<String> DEFAULT_PERMIT_METHODS = Collections.unmodifiableList(
-			Arrays.asList(HttpMethod.GET.name(), HttpMethod.HEAD.name(), HttpMethod.POST.name()));
+	private static final List<String> DEFAULT_PERMIT_METHODS = List.of(HttpMethod.GET.name(),
+			HttpMethod.HEAD.name(), HttpMethod.POST.name());
 
 
 	@Nullable

--- a/spring-web/src/main/java/org/springframework/web/filter/HiddenHttpMethodFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/HiddenHttpMethodFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
 package org.springframework.web.filter;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -57,8 +55,7 @@ import org.springframework.web.util.WebUtils;
 public class HiddenHttpMethodFilter extends OncePerRequestFilter {
 
 	private static final List<String> ALLOWED_METHODS =
-			Collections.unmodifiableList(Arrays.asList(HttpMethod.PUT.name(),
-					HttpMethod.DELETE.name(), HttpMethod.PATCH.name()));
+			List.of(HttpMethod.PUT.name(), HttpMethod.DELETE.name(), HttpMethod.PATCH.name());
 
 	/** Default method parameter: {@code _method}. */
 	public static final String DEFAULT_METHOD_PARAM = "_method";

--- a/spring-web/src/main/java/org/springframework/web/filter/reactive/HiddenHttpMethodFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/reactive/HiddenHttpMethodFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.springframework.web.filter.reactive;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -49,8 +47,7 @@ import org.springframework.web.server.WebFilterChain;
 public class HiddenHttpMethodFilter implements WebFilter {
 
 	private static final List<HttpMethod> ALLOWED_METHODS =
-			Collections.unmodifiableList(Arrays.asList(HttpMethod.PUT,
-					HttpMethod.DELETE, HttpMethod.PATCH));
+			List.of(HttpMethod.PUT, HttpMethod.DELETE, HttpMethod.PATCH);
 
 	/** Default name of the form parameter with the HTTP method to use. */
 	public static final String DEFAULT_METHOD_PARAMETER_NAME = "_method";

--- a/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
@@ -898,7 +897,7 @@ final class HierarchicalUriComponents extends UriComponents {
 		@Override
 		public List<String> getPathSegments() {
 			String[] segments = StringUtils.tokenizeToStringArray(getPath(), PATH_DELIMITER_STRING);
-			return Collections.unmodifiableList(Arrays.asList(segments));
+			return List.of(segments);
 		}
 
 		@Override


### PR DESCRIPTION
Use the collection factory methods when applicable
and available. Replaces the use of
Collections.unmodifiableList/Set/Map with the `of`
factory method.