### PR TITLE
Improve tests and Javadoc on binding to a property of type javax.servlet.Part

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMultipartHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMultipartHttpServletRequestBuilder.java
@@ -19,6 +19,7 @@ package org.springframework.test.web.servlet.request;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -154,7 +155,7 @@ public class MockMultipartHttpServletRequestBuilder extends MockHttpServletReque
 				String filename = part.getSubmittedFileName();
 				InputStream is = part.getInputStream();
 				if (filename != null) {
-					request.addFile(new MockMultipartFile(name, filename, part.getContentType(), is));
+					request.addFile(new MockStandardMultipartFile(part, filename));
 				}
 				else {
 					InputStreamReader reader = new InputStreamReader(is, getCharsetOrDefault(part, defaultCharset));
@@ -178,5 +179,52 @@ public class MockMultipartHttpServletRequestBuilder extends MockHttpServletReque
 			}
 		}
 		return defaultCharset;
+	}
+
+	/**
+	 * Spring MultipartFile adapter, wrapping a Servlet Part object.
+	 */
+	@SuppressWarnings("serial")
+	private static class MockStandardMultipartFile extends MockMultipartFile implements Part, Serializable {
+
+		private final Part part;
+
+		private final String filename;
+
+		public MockStandardMultipartFile(Part part, String filename) throws IOException {
+			super(part.getName(), part.getInputStream());
+			this.part = part;
+			this.filename = filename;
+		}
+
+		@Override
+		public String getSubmittedFileName() {
+			return this.part.getSubmittedFileName();
+		}
+
+		@Override
+		public void write(String fileName) throws IOException {
+			this.part.write(fileName);
+		}
+
+		@Override
+		public void delete() throws IOException {
+			this.part.delete();
+		}
+
+		@Override
+		public String getHeader(String name) {
+			return this.part.getHeader(name);
+		}
+
+		@Override
+		public Collection<String> getHeaders(String name) {
+			return this.part.getHeaders(name);
+		}
+
+		@Override
+		public Collection<String> getHeaderNames() {
+			return this.part.getHeaderNames();
+		}
 	}
 }

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMultipartHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMultipartHttpServletRequestBuilder.java
@@ -19,7 +19,6 @@ package org.springframework.test.web.servlet.request;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -155,7 +154,7 @@ public class MockMultipartHttpServletRequestBuilder extends MockHttpServletReque
 				String filename = part.getSubmittedFileName();
 				InputStream is = part.getInputStream();
 				if (filename != null) {
-					request.addFile(new MockStandardMultipartFile(part, filename));
+					request.addFile(new MockMultipartFile(name, filename, part.getContentType(), is));
 				}
 				else {
 					InputStreamReader reader = new InputStreamReader(is, getCharsetOrDefault(part, defaultCharset));
@@ -179,52 +178,5 @@ public class MockMultipartHttpServletRequestBuilder extends MockHttpServletReque
 			}
 		}
 		return defaultCharset;
-	}
-
-	/**
-	 * Spring MultipartFile adapter, wrapping a Servlet Part object.
-	 */
-	@SuppressWarnings("serial")
-	private static class MockStandardMultipartFile extends MockMultipartFile implements Part, Serializable {
-
-		private final Part part;
-
-		private final String filename;
-
-		public MockStandardMultipartFile(Part part, String filename) throws IOException {
-			super(part.getName(), part.getInputStream());
-			this.part = part;
-			this.filename = filename;
-		}
-
-		@Override
-		public String getSubmittedFileName() {
-			return this.part.getSubmittedFileName();
-		}
-
-		@Override
-		public void write(String fileName) throws IOException {
-			this.part.write(fileName);
-		}
-
-		@Override
-		public void delete() throws IOException {
-			this.part.delete();
-		}
-
-		@Override
-		public String getHeader(String name) {
-			return this.part.getHeader(name);
-		}
-
-		@Override
-		public Collection<String> getHeaders(String name) {
-			return this.part.getHeaders(name);
-		}
-
-		@Override
-		public Collection<String> getHeaderNames() {
-			return this.part.getHeaderNames();
-		}
 	}
 }

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/MultipartControllerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/MultipartControllerTests.java
@@ -38,6 +38,9 @@ import org.springframework.mock.web.MockPart;
 import org.springframework.stereotype.Controller;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.ui.Model;
+import org.springframework.util.StreamUtils;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -55,6 +58,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 /**
  * @author Rossen Stoyanchev
  * @author Juergen Hoeller
+ * @author Jaebin Joo
  */
 public class MultipartControllerTests {
 
@@ -224,7 +228,7 @@ public class MultipartControllerTests {
 	}
 
 	@Test
-	public void multipartRequestWithServletParts() throws Exception {
+	public void multipartRequestWithParts_resolvesMultipartFileArguments() throws Exception {
 		byte[] fileContent = "bar".getBytes(StandardCharsets.UTF_8);
 		MockPart filePart = new MockPart("file", "orig", fileContent);
 
@@ -237,6 +241,50 @@ public class MultipartControllerTests {
 				.andExpect(status().isFound())
 				.andExpect(model().attribute("fileContent", fileContent))
 				.andExpect(model().attribute("jsonContent", Collections.singletonMap("name", "yeeeah")));
+	}
+
+	@Test
+	public void multipartRequestWithParts_resolvesPartArguments() throws Exception {
+		byte[] fileContent = "bar".getBytes(StandardCharsets.UTF_8);
+		MockPart filePart = new MockPart("file", "orig", fileContent);
+
+		byte[] json = "{\"name\":\"yeeeah\"}".getBytes(StandardCharsets.UTF_8);
+		MockPart jsonPart = new MockPart("json", json);
+		jsonPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+		standaloneSetup(new MultipartController()).build()
+				.perform(multipart("/part").part(filePart).part(jsonPart))
+				.andExpect(status().isFound())
+				.andExpect(model().attribute("fileContent", fileContent))
+				.andExpect(model().attribute("jsonContent", Collections.singletonMap("name", "yeeeah")));
+	}
+
+	@Test
+	public void multipartRequestWithParts_resolvesMultipartFileProperties() throws Exception {
+		byte[] fileContent = "bar".getBytes(StandardCharsets.UTF_8);
+		MockPart filePart = new MockPart("file", "orig", fileContent);
+
+		standaloneSetup(new MultipartController()).build()
+				.perform(multipart("/multipartfileproperty").part(filePart))
+				.andExpect(status().isFound())
+				.andExpect(model().attribute("fileContent", fileContent));
+	}
+
+	@Test
+	public void multipartRequestWithParts_cannotResolvePartProperties() throws Exception {
+		byte[] fileContent = "bar".getBytes(StandardCharsets.UTF_8);
+		MockPart filePart = new MockPart("file", "orig", fileContent);
+
+		Exception exception = standaloneSetup(new MultipartController()).build()
+				.perform(multipart("/partproperty").part(filePart))
+				.andExpect(status().is4xxClientError())
+				.andReturn()
+				.getResolvedException();
+
+		assertThat(exception).isNotNull();
+		assertThat(exception).isInstanceOf(BindException.class);
+		assertThat(((BindException) exception).getFieldError("file"))
+				.as("MultipartRequest would not bind Part properties.").isNotNull();
 	}
 
 	@Test  // SPR-13317
@@ -342,10 +390,13 @@ public class MultipartControllerTests {
 		}
 
 		@RequestMapping(value = "/part", method = RequestMethod.POST)
-		public String processPart(@RequestParam Part part,
+		public String processPart(@RequestPart Part file,
 				@RequestPart Map<String, String> json, Model model) throws IOException {
 
-			model.addAttribute("fileContent", part.getInputStream());
+			if (file != null) {
+				byte[] content = StreamUtils.copyToByteArray(file.getInputStream());
+				model.addAttribute("fileContent", content);
+			}
 			model.addAttribute("jsonContent", json);
 
 			return "redirect:/index";
@@ -356,8 +407,60 @@ public class MultipartControllerTests {
 			model.addAttribute("json", json);
 			return "redirect:/index";
 		}
+
+		@RequestMapping(value = "/multipartfileproperty", method = RequestMethod.POST)
+		public String processMultipartFileBean(MultipartFileBean multipartFileBean, Model model, BindingResult bindingResult)
+				throws IOException {
+
+			if (!bindingResult.hasErrors()) {
+				MultipartFile file = multipartFileBean.getFile();
+				if (file != null) {
+					model.addAttribute("fileContent", file.getBytes());
+				}
+			}
+			return "redirect:/index";
+		}
+
+		@RequestMapping(value = "/partproperty", method = RequestMethod.POST)
+		public String processPartBean(PartBean partBean, Model model, BindingResult bindingResult)
+				throws IOException {
+
+			if (!bindingResult.hasErrors()) {
+				Part file = partBean.getFile();
+				if (file != null) {
+					byte[] content = StreamUtils.copyToByteArray(file.getInputStream());
+					model.addAttribute("fileContent", content);
+				}
+			}
+			return "redirect:/index";
+		}
 	}
 
+	private static class MultipartFileBean {
+
+		private MultipartFile file;
+
+		public MultipartFile getFile() {
+			return file;
+		}
+
+		public void setFile(MultipartFile file) {
+			this.file = file;
+		}
+	}
+
+	private static class PartBean {
+
+		private Part file;
+
+		public Part getFile() {
+			return file;
+		}
+
+		public void setFile(Part file) {
+			this.file = file;
+		}
+	}
 
 	private static class RequestWrappingFilter extends OncePerRequestFilter {
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/MultipartControllerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/MultipartControllerTests.java
@@ -38,7 +38,6 @@ import org.springframework.mock.web.MockPart;
 import org.springframework.stereotype.Controller;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.ui.Model;
-import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -240,38 +239,6 @@ public class MultipartControllerTests {
 				.andExpect(model().attribute("jsonContent", Collections.singletonMap("name", "yeeeah")));
 	}
 
-	@Test
-	public void multipartRequestWithServletPartsForPartAttribute() throws Exception {
-		byte[] fileContent = "bar".getBytes(StandardCharsets.UTF_8);
-		MockPart filePart = new MockPart("file", "orig", fileContent);
-
-		byte[] json = "{\"name\":\"yeeeah\"}".getBytes(StandardCharsets.UTF_8);
-		MockPart jsonPart = new MockPart("json", json);
-		jsonPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
-
-		standaloneSetup(new MultipartController()).build()
-				.perform(multipart("/partattr").part(filePart).part(jsonPart))
-				.andExpect(status().isFound())
-				.andExpect(model().attribute("fileContent", fileContent))
-				.andExpect(model().attribute("jsonContent", Collections.singletonMap("name", "yeeeah")));
-	}
-
-	@Test
-	public void multipartRequestWithServletPartsForMultipartFileAttribute() throws Exception {
-		byte[] fileContent = "foo".getBytes(StandardCharsets.UTF_8);
-		MockPart filePart = new MockPart("file", "orig", fileContent);
-
-		byte[] json = "{\"name\":\"yeeeah\"}".getBytes(StandardCharsets.UTF_8);
-		MockPart jsonPart = new MockPart("json", json);
-		jsonPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
-
-		standaloneSetup(new MultipartController()).build()
-				.perform(multipart("/multipartfileattr").part(filePart).part(jsonPart))
-				.andExpect(status().isFound())
-				.andExpect(model().attribute("fileContent", fileContent))
-				.andExpect(model().attribute("jsonContent", Collections.singletonMap("name", "yeeeah")));
-	}
-
 	@Test  // SPR-13317
 	public void multipartRequestWrapped() throws Exception {
 		byte[] json = "{\"name\":\"yeeeah\"}".getBytes(StandardCharsets.UTF_8);
@@ -374,79 +341,29 @@ public class MultipartControllerTests {
 			return "redirect:/index";
 		}
 
+		@RequestMapping(value = "/part", method = RequestMethod.POST)
+		public String processPart(@RequestParam Part part,
+				@RequestPart Map<String, String> json, Model model) throws IOException {
+
+			model.addAttribute("fileContent", part.getInputStream());
+			model.addAttribute("jsonContent", json);
+
+			return "redirect:/index";
+		}
+
 		@RequestMapping(value = "/json", method = RequestMethod.POST)
 		public String processMultipart(@RequestPart Map<String, String> json, Model model) {
 			model.addAttribute("json", json);
 			return "redirect:/index";
 		}
-
-		@RequestMapping(value = "/partattr")
-		public String processPartAttribute(PartForm form,
-				@RequestPart(required = false) Map<String, String> json, Model model) throws IOException {
-
-			if (form != null) {
-				Part part = form.getFile();
-				if (0 != part.getSize()) {
-					byte[] fileContent = StreamUtils.copyToByteArray(part.getInputStream());
-					model.addAttribute("fileContent", fileContent);
-				}
-			}
-			if (json != null) {
-				model.addAttribute("jsonContent", json);
-			}
-
-			return "redirect:/index";
-		}
-
-		@RequestMapping(value = "/multipartfileattr")
-		public String processMultipartFileAttribute(MultipartFileForm form,
-													@RequestPart(required = false) Map<String, String> json, Model model) throws IOException {
-
-			if (form != null) {
-				MultipartFile file = form.getFile();
-				if (!file.isEmpty()) {
-					model.addAttribute("fileContent", file.getBytes());
-				}
-			}
-			if (json != null) {
-				model.addAttribute("jsonContent", json);
-			}
-
-			return "redirect:/index";
-		}
 	}
 
-	private static class PartForm {
-
-		private Part file;
-
-		public PartForm(Part file) {
-			this.file = file;
-		}
-
-		public Part getFile() {
-			return file;
-		}
-	}
-
-	private static class MultipartFileForm {
-
-		private MultipartFile file;
-
-		public MultipartFileForm(MultipartFile file) {
-			this.file = file;
-		}
-
-		public MultipartFile getFile() {
-			return file;
-		}
-	}
 
 	private static class RequestWrappingFilter extends OncePerRequestFilter {
 
 		@Override
 		protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-										FilterChain filterChain) throws IOException, ServletException {
+				FilterChain filterChain) throws IOException, ServletException {
 
 			request = new HttpServletRequestWrapper(request);
 			filterChain.doFilter(request, response);

--- a/spring-web/src/main/java/org/springframework/web/bind/ServletRequestDataBinder.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/ServletRequestDataBinder.java
@@ -95,11 +95,14 @@ public class ServletRequestDataBinder extends WebDataBinder {
 	 * HTTP parameters: i.e. "uploadedFile" to an "uploadedFile" bean property,
 	 * invoking a "setUploadedFile" setter method.
 	 * <p>The type of the target property for a multipart file can be MultipartFile,
-	 * byte[], or String. The latter two receive the contents of the uploaded file;
+	 * Part, byte[], or String. The Part binding is only supported when the request
+	 * is not a MultipartRequest. The latter two receive the contents of the uploaded file;
 	 * all metadata like original file name, content type, etc are lost in those cases.
 	 * @param request the request with parameters to bind (can be multipart)
 	 * @see org.springframework.web.multipart.MultipartHttpServletRequest
+	 * @see org.springframework.web.multipart.MultipartRequest
 	 * @see org.springframework.web.multipart.MultipartFile
+	 * @see jakarta.servlet.http.Part
 	 * @see #bind(org.springframework.beans.PropertyValues)
 	 */
 	public void bind(ServletRequest request) {

--- a/spring-web/src/main/java/org/springframework/web/bind/support/WebRequestDataBinder.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/support/WebRequestDataBinder.java
@@ -99,7 +99,8 @@ public class WebRequestDataBinder extends WebDataBinder {
 	 * HTTP parameters: i.e. "uploadedFile" to an "uploadedFile" bean property,
 	 * invoking a "setUploadedFile" setter method.
 	 * <p>The type of the target property for a multipart file can be Part, MultipartFile,
-	 * byte[], or String. The latter two receive the contents of the uploaded file;
+	 * byte[], or String. The Part binding is only supported when the request
+	 * is not a MultipartRequest. The latter two receive the contents of the uploaded file;
 	 * all metadata like original file name, content type, etc are lost in those cases.
 	 * @param request the request with parameters to bind (can be multipart)
 	 * @see org.springframework.web.multipart.MultipartRequest


### PR DESCRIPTION
When a controller obtains files from multipart requests,
there is an inconsistency when `jakarta.servlet.http.Part` type is an attribute of an object or an argument of a handler method.

If a method has an object argument, and expects files to be saved to attributes of that argument, the attribute type should not be `Part`, but it would rather be `MultipartFile`.

This is because `StandardMultipartHttpServletRequest` wraps its `Part`s, whose filename exists, with `StandardMultipartFile`.
`StandardMultipartFile` is an private class that implements `MultipartFile` class. So `Part` type attributes generate conversion errors.

In contrast, if the method has an argument type of `Part`, it can normally receive multipart files from the framework.

My idea is simply modifying `StandardMultipartFile` class to implement both `MultipartFile` and `Part`, so preventing conversion issues. Likewise I added new `MockStandardMultipartFile` class that replaces `MockMultipartFile` class. 

**Issues:** https://github.com/spring-projects/spring-framework/issues/27819 
