### PR TITLE
Working POST ajax requests sent by HtmlUnit

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/HtmlUnitRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/HtmlUnitRequestBuilder.java
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -242,6 +243,14 @@ final class HtmlUnitRequestBuilder implements RequestBuilder, Mergeable {
 		if (requestBody == null) {
 			return;
 		}
+
+		Arrays.asList(requestBody.split("&")).stream()
+			.filter(param -> param.contains("="))
+			.forEach( param -> {
+			String[] entry = param.split("=", 2);
+			request.addParameter(urlDecode(entry[0]), urlDecode(entry[1]));
+		});
+
 		request.setContent(requestBody.getBytes(charset));
 	}
 


### PR DESCRIPTION
As I understood when I analysed the behaviour of a POST request in a classic web application (by a form or an ajax request), the HttpServletRequest object must have both his **content** and **parameters** fields filled.

In HtmlUnitRequestBuilder.java, when converting the webRequest object into the MockHttpServletRequest the **content** field is filled only for an ajax request, and the **parameters** field are filled only for a form request. It seems there's a confusion about the meaning of the term _parameters_.

My correction is intended to have the **parameters** field filled for both the form and the ajax request when using an UI/UX unit test (as it is done when using a classic application).