### PR TITLE
Fix the issue#27683

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactory.java
@@ -232,7 +232,7 @@ public interface BeanFactory {
 	 * specific type, specify the actual bean type as an argument here and subsequently
 	 * use {@link ObjectProvider#orderedStream()} or its lazy streaming/iteration options.
 	 * <p>Also, generics matching is strict here, as per the Java assignment rules.
-	 * For lenient fallback matching with unchecked semantics (similar to the ´unchecked´
+	 * For lenient fallback matching with unchecked semantics (similar to the `unchecked`
 	 * Java compiler warning), consider calling {@link #getBeanProvider(Class)} with the
 	 * raw type as a second step if no full generic match is
 	 * {@link ObjectProvider#getIfAvailable() available} with this variant.

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -16,16 +16,12 @@
 
 package org.springframework.util;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import org.springframework.lang.Nullable;
+
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.springframework.lang.Nullable;
 
 /**
  * {@link PathMatcher} implementation for Ant-style path patterns.
@@ -423,7 +419,8 @@ public class AntPathMatcher implements PathMatcher {
 	 * @return the tokenized path parts
 	 */
 	protected String[] tokenizePath(String path) {
-		return StringUtils.tokenizeToStringArray(path, this.pathSeparator, this.trimTokens, true);
+		return Arrays.stream(StringUtils.delimitedListToStringArray(path, this.pathSeparator))
+				.map(t->trimTokens?t.trim():t).filter(StringUtils::hasLength).toArray(String[]::new);
 	}
 
 	/**
@@ -488,8 +485,8 @@ public class AntPathMatcher implements PathMatcher {
 	 */
 	@Override
 	public String extractPathWithinPattern(String pattern, String path) {
-		String[] patternParts = StringUtils.tokenizeToStringArray(pattern, this.pathSeparator, this.trimTokens, true);
-		String[] pathParts = StringUtils.tokenizeToStringArray(path, this.pathSeparator, this.trimTokens, true);
+		String[] patternParts = tokenizePattern(pattern);
+		String[] pathParts = tokenizePath(path);
 		StringBuilder builder = new StringBuilder();
 		boolean pathStarted = false;
 

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -18,7 +18,12 @@ package org.springframework.util;
 
 import org.springframework.lang.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -16,7 +16,6 @@
 
 package org.springframework.util;
 
-import org.springframework.lang.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -26,6 +25,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.springframework.lang.Nullable;
 
 /**
  * {@link PathMatcher} implementation for Ant-style path patterns.

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -17,7 +17,6 @@
 package org.springframework.util;
 
 import org.springframework.lang.Nullable;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -425,7 +424,7 @@ public class AntPathMatcher implements PathMatcher {
 	 */
 	protected String[] tokenizePath(String path) {
 		return Arrays.stream(StringUtils.delimitedListToStringArray(path, this.pathSeparator))
-				.map(t->trimTokens?t.trim():t).filter(StringUtils::hasLength).toArray(String[]::new);
+				.map(t->this.trimTokens?t.trim():t).filter(StringUtils::hasLength).toArray(String[]::new);
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -134,6 +134,16 @@ class AntPathMatcherTests {
 	}
 
 	@Test
+	void complexSeparatorMatch(){
+		AntPathMatcher antPathMatcher = new AntPathMatcher("\\t");
+		assertThat(antPathMatcher.match("consentreg","consentreg")).isTrue();
+		assertThat(antPathMatcher.match("consent\\treg","consent\\treg")).isTrue();
+		assertThat(antPathMatcher.match("consent\\t\\treg","consent\\t\\treg")).isTrue();
+		assertThat(antPathMatcher.match("consent\\t\\treg","consent\\treg")).isTrue();
+		assertThat(antPathMatcher.match("consent\\treg","consent\\treg")).isTrue();
+	}
+
+	@Test
 	void matchWithNullPath() {
 		assertThat(pathMatcher.match("/test", null)).isFalse();
 		assertThat(pathMatcher.match("/", null)).isFalse();


### PR DESCRIPTION
fix #27683 .
`pathSeparator` should be a complete separator, But in `StringUtils#tokenizeToStringArray`,each of the characters is individually considered as a delimiter. So I try to replace `StringUtils#tokenizeToStringArray` with `StringUtils#delimitedListToStringArray`.