### PR TITLE
Use UTF-8 for application/json in MockHttpServletResponse

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -24,6 +24,7 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -314,6 +315,11 @@ public class MockHttpServletResponse implements HttpServletResponse {
 				MediaType mediaType = MediaType.parseMediaType(contentType);
 				if (mediaType.getCharset() != null) {
 					setExplicitCharacterEncoding(mediaType.getCharset().name());
+				}
+				else {
+					if (contentType.equals(MediaType.APPLICATION_JSON_VALUE)) {
+						this.characterEncoding = StandardCharsets.UTF_8.name();
+					}
 				}
 			}
 			catch (Exception ex) {

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.util.WebUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -358,6 +359,14 @@ class MockHttpServletResponseTests {
 	void servletWriterAutoFlushedForString() throws IOException {
 		response.getWriter().write("X");
 		assertThat(response.getContentAsString()).isEqualTo("X");
+	}
+
+	@Test
+	void getContentAsStringWhenContentTypeIsApplicationJsonShouldUseUtf8() throws IOException {
+		String content = "{\"value\": \"테스트\"}";
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.getWriter().write(content);
+		assertThat(response.getContentAsString()).isEqualTo(content);
 	}
 
 	@Test

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletResponse.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletResponse.java
@@ -24,6 +24,7 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -314,6 +315,11 @@ public class MockHttpServletResponse implements HttpServletResponse {
 				MediaType mediaType = MediaType.parseMediaType(contentType);
 				if (mediaType.getCharset() != null) {
 					setExplicitCharacterEncoding(mediaType.getCharset().name());
+				}
+				else {
+					if (contentType.equals(MediaType.APPLICATION_JSON_VALUE)) {
+						this.characterEncoding = StandardCharsets.UTF_8.name();
+					}
 				}
 			}
 			catch (Exception ex) {


### PR DESCRIPTION
This PR changes to use UTF-8 for `application/json` in `MockHttpServletResponse`.