### PR TITLE
Add Javadoc @since tag to new PayloadApplicationEvent constructor

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/PayloadApplicationEvent.java
+++ b/spring-context/src/main/java/org/springframework/context/PayloadApplicationEvent.java
@@ -46,6 +46,7 @@ public class PayloadApplicationEvent<T> extends ApplicationEvent implements Reso
 	 * @param source the object on which the event initially occurred (never {@code null})
 	 * @param payload the payload object (never {@code null})
 	 * @param payloadType the type object of payload object (can be {@code null})
+	 * @since 6.0.0
 	 */
 	public PayloadApplicationEvent(Object source, T payload, @Nullable ResolvableType payloadType) {
 		super(source);


### PR DESCRIPTION
This PR adds Javadoc `@since` tag to the new `PayloadApplicationEvent` constructor.

See gh-24599