### PR TITLE
Optimize initialization of HttpMessageConverter's

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -672,7 +672,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	 * @since 4.3
 	 */
 	protected RequestMappingHandlerAdapter createRequestMappingHandlerAdapter() {
-		return new RequestMappingHandlerAdapter();
+		return new RequestMappingHandlerAdapter(null);
 	}
 
 	/**
@@ -1057,7 +1057,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	 * @since 4.3
 	 */
 	protected ExceptionHandlerExceptionResolver createExceptionHandlerExceptionResolver() {
-		return new ExceptionHandlerExceptionResolver();
+		return new ExceptionHandlerExceptionResolver(null);
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
@@ -128,6 +128,9 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 		this.messageConverters.add(new AllEncompassingFormHttpMessageConverter());
 	}
 
+	public ExceptionHandlerExceptionResolver(List<HttpMessageConverter<?>> messageConverters) {
+		this.messageConverters = messageConverters;
+	}
 
 	/**
 	 * Provide resolvers for custom argument types. Custom resolvers are ordered

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -214,6 +214,9 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 		this.messageConverters.add(new AllEncompassingFormHttpMessageConverter());
 	}
 
+	public RequestMappingHandlerAdapter(List<HttpMessageConverter<?>> messageConverters) {
+		this.messageConverters = messageConverters;
+	}
 
 	/**
 	 * Provide resolvers for custom argument types. Custom resolvers are ordered


### PR DESCRIPTION
In WebMvcConfigurationSupport will setMessageConverters after
ExceptionHandlerExceptionResolver and RequestMappingHandlerAdapter creation
so there no need init messageConverters in its constructor.