### PR TITLE
Remove unnecessary check in isBridgedCandidateFor()

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
@@ -98,7 +98,7 @@ public final class BridgeMethodResolver {
 	 * checks and can be used quickly filter for a set of possible matches.
 	 */
 	private static boolean isBridgedCandidateFor(Method candidateMethod, Method bridgeMethod) {
-		return (!candidateMethod.isBridge() && !candidateMethod.equals(bridgeMethod) &&
+		return (!candidateMethod.isBridge() &&
 				candidateMethod.getName().equals(bridgeMethod.getName()) &&
 				candidateMethod.getParameterCount() == bridgeMethod.getParameterCount());
 	}


### PR DESCRIPTION
In BridgeMethodResolver#isBridgedCandidateFor, candidateMethod is never not bridged, so it seems unnecessary to judge whether candidateMethod and bridgeMethod are the same.

