### PR TITLE
Remove references to JCacheConfigurerSupport and CachingConfigurerSupport

### DIFF
--- a/spring-aspects/src/test/java/org/springframework/cache/aspectj/AspectJEnableCachingIsolatedTests.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/aspectj/AspectJEnableCachingIsolatedTests.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.cache.interceptor.CacheResolver;
@@ -143,7 +143,7 @@ public class AspectJEnableCachingIsolatedTests {
 
 	@Configuration
 	@EnableCaching(mode = AdviceMode.ASPECTJ)
-	static class EnableCachingConfig extends CachingConfigurerSupport {
+	static class EnableCachingConfig implements CachingConfigurer {
 
 		@Override
 		@Bean
@@ -220,7 +220,7 @@ public class AspectJEnableCachingIsolatedTests {
 
 	@Configuration
 	@EnableCaching(mode = AdviceMode.ASPECTJ)
-	static class MultiCacheManagerConfigurer extends CachingConfigurerSupport {
+	static class MultiCacheManagerConfigurer implements CachingConfigurer {
 
 		@Bean
 		public CacheManager cm1() {
@@ -246,7 +246,7 @@ public class AspectJEnableCachingIsolatedTests {
 
 	@Configuration
 	@EnableCaching(mode = AdviceMode.ASPECTJ)
-	static class EmptyConfigSupportConfig extends CachingConfigurerSupport {
+	static class EmptyConfigSupportConfig implements CachingConfigurer {
 
 		@Bean
 		public CacheManager cm() {
@@ -258,7 +258,7 @@ public class AspectJEnableCachingIsolatedTests {
 
 	@Configuration
 	@EnableCaching(mode = AdviceMode.ASPECTJ)
-	static class FullCachingConfig extends CachingConfigurerSupport {
+	static class FullCachingConfig implements CachingConfigurer {
 
 		@Override
 		@Bean

--- a/spring-aspects/src/test/java/org/springframework/cache/aspectj/AspectJEnableCachingTests.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/aspectj/AspectJEnableCachingTests.java
@@ -17,7 +17,7 @@
 package org.springframework.cache.aspectj;
 
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.config.AnnotatedClassCacheableService;
 import org.springframework.cache.config.CacheableService;
@@ -47,7 +47,7 @@ public class AspectJEnableCachingTests extends AbstractCacheAnnotationTests {
 
 	@Configuration
 	@EnableCaching(mode = AdviceMode.ASPECTJ)
-	static class EnableCachingConfig extends CachingConfigurerSupport {
+	static class EnableCachingConfig implements CachingConfigurer {
 
 		@Override
 		@Bean

--- a/spring-context-support/src/main/java/org/springframework/cache/jcache/config/JCacheConfigurer.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/jcache/config/JCacheConfigurer.java
@@ -46,7 +46,7 @@ public interface JCacheConfigurer extends CachingConfigurer {
 	 * <pre class="code">
 	 * &#064;Configuration
 	 * &#064;EnableCaching
-	 * public class AppConfig extends JCacheConfigurerSupport {
+	 * public class AppConfig implements JCacheConfigurer {
 	 *     &#064;Bean // important!
 	 *     &#064;Override
 	 *     public CacheResolver exceptionCacheResolver() {

--- a/spring-context/src/main/java/org/springframework/cache/annotation/CachingConfigurer.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/CachingConfigurer.java
@@ -50,7 +50,7 @@ public interface CachingConfigurer {
 	 * <pre class="code">
 	 * &#064;Configuration
 	 * &#064;EnableCaching
-	 * public class AppConfig extends CachingConfigurerSupport {
+	 * public class AppConfig implements CachingConfigurer {
 	 *     &#064;Bean // important!
 	 *     &#064;Override
 	 *     public CacheManager cacheManager() {
@@ -77,7 +77,7 @@ public interface CachingConfigurer {
 	 * <pre class="code">
 	 * &#064;Configuration
 	 * &#064;EnableCaching
-	 * public class AppConfig extends CachingConfigurerSupport {
+	 * public class AppConfig implements CachingConfigurer {
 	 *     &#064;Bean // important!
 	 *     &#064;Override
 	 *     public CacheResolver cacheResolver() {
@@ -100,7 +100,7 @@ public interface CachingConfigurer {
 	 * <pre class="code">
 	 * &#064;Configuration
 	 * &#064;EnableCaching
-	 * public class AppConfig extends CachingConfigurerSupport {
+	 * public class AppConfig implements CachingConfigurer {
 	 *     &#064;Bean // important!
 	 *     &#064;Override
 	 *     public KeyGenerator keyGenerator() {
@@ -125,7 +125,7 @@ public interface CachingConfigurer {
 	 * <pre class="code">
 	 * &#064;Configuration
 	 * &#064;EnableCaching
-	 * public class AppConfig extends CachingConfigurerSupport {
+	 * public class AppConfig implements CachingConfigurer {
 	 *     &#064;Bean // important!
 	 *     &#064;Override
 	 *     public CacheErrorHandler errorHandler() {

--- a/spring-context/src/main/java/org/springframework/cache/annotation/EnableCaching.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/EnableCaching.java
@@ -103,7 +103,7 @@ import org.springframework.core.Ordered;
  * <pre class="code">
  * &#064;Configuration
  * &#064;EnableCaching
- * public class AppConfig extends CachingConfigurerSupport {
+ * public class AppConfig implements CachingConfigurer {
  *
  *     &#064;Bean
  *     public MyService myService() {


### PR DESCRIPTION
This PR removes references to deprecated `JCacheConfigurerSupport` and `CachingConfigurerSupport` in Javadoc and tests.

See gh-27811