### PR TITLE
Remove AsyncConfigurerSupport reference in EnableAsync Javadoc

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableAsync.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableAsync.java
@@ -104,8 +104,7 @@ import org.springframework.core.Ordered;
  * }</pre>
  *
  * <p>If only one item needs to be customized, {@code null} can be returned to
- * keep the default settings. Consider also extending from {@link AsyncConfigurerSupport}
- * when possible.
+ * keep the default settings.
  *
  * <p>Note: In the above example the {@code ThreadPoolTaskExecutor} is not a fully managed
  * Spring bean. Add the {@code @Bean} annotation to the {@code getAsyncExecutor()} method


### PR DESCRIPTION
This PR removes a deprecated `AsyncConfigurerSupport` reference in `EnableAsync` Javadoc.

See gh-27812