### PR TITLE
Expose config field in RequestMappingHandlerMapping to subclasses

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
@@ -89,7 +89,7 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 	@Nullable
 	private StringValueResolver embeddedValueResolver;
 
-	private RequestMappingInfo.BuilderConfiguration config = new RequestMappingInfo.BuilderConfiguration();
+	protected RequestMappingInfo.BuilderConfiguration config = new RequestMappingInfo.BuilderConfiguration();
 
 
 	/**


### PR DESCRIPTION
in my project , I hava a PlatformRequestMappingHandlerMapping。

```java

public class PlatformRequestMappingHandlerMapping extends RequestMappingHandlerMapping {

    @Override
    protected RequestMappingInfo getMappingForMethod(Method method, Class<?> handlerType) {
        RequestMappingInfo requestMappingInfo = super.getMappingForMethod(method, handlerType);
        if (requestMappingInfo != null)
            return requestMappingInfo;
        return createCustomRequestMappingInfo(method);
    }

    private RequestMappingInfo createCustomRequestMappingInfo(AnnotatedElement element) {
        PlatformRestMapping mapping = AnnotatedElementUtils.findMergedAnnotation(element, PlatformRestMapping.class);
        // ....
        return RequestMappingInfo.paths(URI_PREFIX_OF_API + mapping.value())
                .methods(methods)
                .options(getConfig()) // need use super.config
                .build();
    }

    // bad impl
    private RequestMappingInfo.BuilderConfiguration getConfig() {
        try {
            Object config = FieldUtils.readField(this, "config", true);
            return (RequestMappingInfo.BuilderConfiguration) config;
        } catch (IllegalAccessException e) {
            throw new RuntimeException("config");
        }

    }
}


```