### PR TITLE
Correct not compiling example code in Data Access docs

### DIFF
--- a/src/docs/asciidoc/data-access.adoc
+++ b/src/docs/asciidoc/data-access.adoc
@@ -2444,9 +2444,9 @@ the `TransactionOperator` resembles the next example:
 		}
 
 		public Mono<Object> someServiceMethod() {
-			
+
 			// the code in this method runs in a transactional context
-			
+
             Mono<Object> update = updateOperation1();
 
 			return update.then(resultOfUpdateOperation2).as(transactionalOperator::transactional);
@@ -8212,10 +8212,16 @@ that uses the `@PersistenceUnit` annotation:
 		}
 
 		public Collection loadProductsByCategory(String category) {
-			try (EntityManager em = this.emf.createEntityManager()) {
+			EntityManager em = this.emf.createEntityManager();
+			try {
 				Query query = em.createQuery("from Product as p where p.category = ?1");
 				query.setParameter(1, category);
 				return query.getResultList();
+			}
+			finally {
+				if (em != null) {
+					em.close();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I've noticed, that there is a piece of sample code that does not compile with Spring 5.x, because the the EntityManager interface [does not implement AutoCloseable](https://github.com/eclipse-ee4j/jpa-api/blob/2.2-2.2.3/api/src/main/java/javax/persistence/EntityManager.java#L54) until JPA 3.x ([relevant commit in jpa-api](https://github.com/eclipse-ee4j/jpa-api/commit/1ae01ae3793d129bf921e9b1fe893bed744065d8))

The sample should be fine for Spring 6.x - so I'm not sure if targeting `main` is the correct workflow here?

* Partially reverts 189e1afc6ee6bd40b
* Releates to https://github.com/spring-projects/spring-framework/issues/22269

Thanks for looking at this!