### PR TITLE
Clear cache when clearing argument resolvers

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/HandlerMethodArgumentResolverComposite.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/HandlerMethodArgumentResolverComposite.java
@@ -88,6 +88,7 @@ public class HandlerMethodArgumentResolverComposite implements HandlerMethodArgu
 	 */
 	public void clear() {
 		this.argumentResolvers.clear();
+		this.argumentResolverCache.clear();
 	}
 
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/reactive/HandlerMethodArgumentResolverComposite.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/invocation/reactive/HandlerMethodArgumentResolverComposite.java
@@ -90,6 +90,7 @@ public class HandlerMethodArgumentResolverComposite implements HandlerMethodArgu
 	 */
 	public void clear() {
 		this.argumentResolvers.clear();
+		this.argumentResolverCache.clear();
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/web/method/support/HandlerMethodArgumentResolverComposite.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/HandlerMethodArgumentResolverComposite.java
@@ -90,6 +90,7 @@ public class HandlerMethodArgumentResolverComposite implements HandlerMethodArgu
 	 */
 	public void clear() {
 		this.argumentResolvers.clear();
+		this.argumentResolverCache.clear();
 	}
 
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/HandlerMethodArgumentResolverComposite.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/HandlerMethodArgumentResolverComposite.java
@@ -87,6 +87,7 @@ class HandlerMethodArgumentResolverComposite implements HandlerMethodArgumentRes
 	 */
 	public void clear() {
 		this.argumentResolvers.clear();
+		this.argumentResolverCache.clear();
 	}
 
 


### PR DESCRIPTION
Getting a resolver for a parameter does not work correctly after clearing because the cache is not cleared.