### PR TITLE
ServerHttpResponseDecorator does not delegate methods for raw status code

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpResponseDecorator.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpResponseDecorator.java
@@ -66,6 +66,16 @@ public class ServerHttpResponseDecorator implements ServerHttpResponse {
 	}
 
 	@Override
+	public boolean setRawStatusCode(@Nullable Integer value) {
+		return getDelegate().setRawStatusCode(value);
+	}
+
+	@Override
+	public Integer getRawStatusCode() {
+		return getDelegate().getRawStatusCode();
+	}
+
+	@Override
 	public HttpHeaders getHeaders() {
 		return getDelegate().getHeaders();
 	}


### PR DESCRIPTION
Non-standard HTTP status code has been fixed in #24400. But `ServerHttpResponseDecorator` still not fully implements the raw status code of `ServerHttpResponse`.