### PR TITLE
Ensure utility classes cannot be instantiated.

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotatedElementUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotatedElementUtils.java
@@ -90,7 +90,11 @@ import org.springframework.util.MultiValueMap;
  * @see AnnotationUtils
  * @see BridgeMethodResolver
  */
-public abstract class AnnotatedElementUtils {
+public class AnnotatedElementUtils {
+
+	private AnnotatedElementUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Build an adapted {@link AnnotatedElement} for the given annotations,

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
@@ -102,7 +102,7 @@ import org.springframework.util.StringUtils;
  * @see java.lang.reflect.AnnotatedElement#getAnnotation(Class)
  * @see java.lang.reflect.AnnotatedElement#getDeclaredAnnotations()
  */
-public abstract class AnnotationUtils {
+public class AnnotationUtils {
 
 	/**
 	 * The attribute name for annotations with a single element.
@@ -115,6 +115,10 @@ public abstract class AnnotationUtils {
 	private static final Map<Class<? extends Annotation>, Map<String, DefaultValueHolder>> defaultValuesCache =
 			new ConcurrentReferenceHashMap<>();
 
+
+	private AnnotationUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Determine whether the given class is a candidate for carrying one of the specified

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationsScanner.java
@@ -42,7 +42,7 @@ import org.springframework.util.ReflectionUtils;
  * @since 5.2
  * @see AnnotationsProcessor
  */
-abstract class AnnotationsScanner {
+class AnnotationsScanner {
 
 	private static final Annotation[] NO_ANNOTATIONS = {};
 
@@ -57,6 +57,7 @@ abstract class AnnotationsScanner {
 
 
 	private AnnotationsScanner() {
+		throw new AssertionError();
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotationCollectors.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotationCollectors.java
@@ -38,7 +38,7 @@ import org.springframework.util.MultiValueMap;
  * @author Sam Brannen
  * @since 5.2
  */
-public abstract class MergedAnnotationCollectors {
+public class MergedAnnotationCollectors {
 
 	private static final Characteristics[] NO_CHARACTERISTICS = {};
 
@@ -46,6 +46,7 @@ public abstract class MergedAnnotationCollectors {
 
 
 	private MergedAnnotationCollectors() {
+		throw new AssertionError();
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotationPredicates.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotationPredicates.java
@@ -34,9 +34,10 @@ import org.springframework.util.ObjectUtils;
  * @author Phillip Webb
  * @since 5.2
  */
-public abstract class MergedAnnotationPredicates {
+public class MergedAnnotationPredicates {
 
 	private MergedAnnotationPredicates() {
+		throw new AssertionError();
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotationSelectors.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotationSelectors.java
@@ -28,7 +28,7 @@ import java.util.function.Predicate;
  * @see MergedAnnotations#get(Class, Predicate, MergedAnnotationSelector)
  * @see MergedAnnotations#get(String, Predicate, MergedAnnotationSelector)
  */
-public abstract class MergedAnnotationSelectors {
+public class MergedAnnotationSelectors {
 
 	private static final MergedAnnotationSelector<?> NEAREST = new Nearest();
 
@@ -36,6 +36,7 @@ public abstract class MergedAnnotationSelectors {
 
 
 	private MergedAnnotationSelectors() {
+		throw new AssertionError();
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/annotation/OrderUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/OrderUtils.java
@@ -33,7 +33,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  * @see Order
  * @see jakarta.annotation.Priority
  */
-public abstract class OrderUtils {
+public class OrderUtils {
 
 	/** Cache marker for a non-annotated Class. */
 	private static final Object NOT_ANNOTATED = new Object();
@@ -43,6 +43,9 @@ public abstract class OrderUtils {
 	/** Cache for @Order value (or NOT_ANNOTATED marker) per Class. */
 	private static final Map<AnnotatedElement, Object> orderCache = new ConcurrentReferenceHashMap<>(64);
 
+	private OrderUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Return the order on the specified {@code type}, or the specified

--- a/spring-core/src/main/java/org/springframework/util/Assert.java
+++ b/spring-core/src/main/java/org/springframework/util/Assert.java
@@ -59,7 +59,11 @@ import org.springframework.lang.Nullable;
  * @author Rob Harrop
  * @since 1.1.2
  */
-public abstract class Assert {
+public class Assert {
+
+	private Assert() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Assert a boolean expression, throwing an {@code IllegalStateException}

--- a/spring-core/src/main/java/org/springframework/util/Base64Utils.java
+++ b/spring-core/src/main/java/org/springframework/util/Base64Utils.java
@@ -30,10 +30,13 @@ import java.util.Base64;
  * @since 4.1
  * @see java.util.Base64
  */
-public abstract class Base64Utils {
+public class Base64Utils {
 
 	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
+	private Base64Utils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Base64-encode the given byte array.

--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -54,7 +54,7 @@ import org.springframework.lang.Nullable;
  * @see TypeUtils
  * @see ReflectionUtils
  */
-public abstract class ClassUtils {
+public class ClassUtils {
 
 	/** Suffix for array class names: {@code "[]"}. */
 	public static final String ARRAY_SUFFIX = "[]";
@@ -83,6 +83,9 @@ public abstract class ClassUtils {
 	/** The ".class" file suffix. */
 	public static final String CLASS_FILE_SUFFIX = ".class";
 
+	private ClassUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Map with primitive wrapper type as key and corresponding primitive

--- a/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
@@ -41,7 +41,7 @@ import org.springframework.lang.Nullable;
  * @author Arjen Poutsma
  * @since 1.1.3
  */
-public abstract class CollectionUtils {
+public class CollectionUtils {
 
 	/**
 	 * Default load factor for {@link HashMap}/{@link LinkedHashMap} variants.
@@ -49,6 +49,10 @@ public abstract class CollectionUtils {
 	 * @see #newLinkedHashMap(int)
 	 */
 	static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+	private CollectionUtils() {
+		throw new AssertionError();
+	}
 
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/DigestUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/DigestUtils.java
@@ -33,13 +33,16 @@ import java.security.NoSuchAlgorithmException;
  * @author Craig Andrews
  * @since 3.0
  */
-public abstract class DigestUtils {
+public class DigestUtils {
 
 	private static final String MD5_ALGORITHM_NAME = "MD5";
 
 	private static final char[] HEX_CHARS =
 			{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
+	private DigestUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Calculate the MD5 digest of the given bytes.

--- a/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
@@ -43,13 +43,16 @@ import org.springframework.lang.Nullable;
  * @see StreamUtils
  * @see FileSystemUtils
  */
-public abstract class FileCopyUtils {
+public class FileCopyUtils {
 
 	/**
 	 * The default buffer size used when copying bytes.
 	 */
 	public static final int BUFFER_SIZE = StreamUtils.BUFFER_SIZE;
 
+	private FileCopyUtils() {
+		throw new AssertionError();
+	}
 
 	//---------------------------------------------------------------------
 	// Copy methods for java.io.File

--- a/spring-core/src/main/java/org/springframework/util/FileSystemUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileSystemUtils.java
@@ -40,7 +40,11 @@ import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
  * @see java.nio.file.Path
  * @see java.nio.file.Files
  */
-public abstract class FileSystemUtils {
+public class FileSystemUtils {
+
+	private FileSystemUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Delete the supplied {@link File} - for directories,

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -43,13 +43,17 @@ import org.springframework.lang.Nullable;
  * @author Sam Brannen
  * @since 4.0
  */
-public abstract class MimeTypeUtils {
+public class MimeTypeUtils {
 
 	private static final byte[] BOUNDARY_CHARS =
 			new byte[] {'-', '_', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 'b', 'c', 'd', 'e', 'f', 'g',
 					'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A',
 					'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',
 					'V', 'W', 'X', 'Y', 'Z'};
+
+	private MimeTypeUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Comparator formally used by {@link #sortBySpecificity(List)}.

--- a/spring-core/src/main/java/org/springframework/util/NumberUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/NumberUtils.java
@@ -36,7 +36,7 @@ import org.springframework.lang.Nullable;
  * @author Rob Harrop
  * @since 1.1.2
  */
-public abstract class NumberUtils {
+public class NumberUtils {
 
 	private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
 
@@ -59,6 +59,10 @@ public abstract class NumberUtils {
 		numberTypes.add(Double.class);
 		numberTypes.add(BigDecimal.class);
 		STANDARD_NUMBER_TYPES = Collections.unmodifiableSet(numberTypes);
+	}
+
+	private NumberUtils() {
+		throw new AssertionError();
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -43,7 +43,7 @@ import org.springframework.lang.Nullable;
  * @see CollectionUtils
  * @see StringUtils
  */
-public abstract class ObjectUtils {
+public class ObjectUtils {
 
 	private static final int INITIAL_HASH = 7;
 	private static final int MULTIPLIER = 31;
@@ -56,6 +56,9 @@ public abstract class ObjectUtils {
 	private static final String ARRAY_ELEMENT_SEPARATOR = ", ";
 	private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
+	private ObjectUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Return whether the given throwable is a checked exception:

--- a/spring-core/src/main/java/org/springframework/util/PatternMatchUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/PatternMatchUtils.java
@@ -25,7 +25,11 @@ import org.springframework.lang.Nullable;
  * @author Juergen Hoeller
  * @since 2.0
  */
-public abstract class PatternMatchUtils {
+public class PatternMatchUtils {
+
+	private PatternMatchUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Match a String against the given pattern, supporting the following simple

--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -43,7 +43,7 @@ import org.springframework.lang.Nullable;
  * @author Chris Beams
  * @since 1.2.2
  */
-public abstract class ReflectionUtils {
+public class ReflectionUtils {
 
 	/**
 	 * Pre-built MethodFilter that matches all non-bridge non-synthetic methods
@@ -86,6 +86,9 @@ public abstract class ReflectionUtils {
 	 */
 	private static final Map<Class<?>, Field[]> declaredFieldsCache = new ConcurrentReferenceHashMap<>(256);
 
+	private ReflectionUtils() {
+		throw new AssertionError();
+	}
 
 	// Exception handling
 

--- a/spring-core/src/main/java/org/springframework/util/ResourceUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ResourceUtils.java
@@ -45,7 +45,7 @@ import org.springframework.lang.Nullable;
  * @see org.springframework.core.io.UrlResource
  * @see org.springframework.core.io.ResourceLoader
  */
-public abstract class ResourceUtils {
+public class ResourceUtils {
 
 	/** Pseudo URL prefix for loading from the class path: "classpath:". */
 	public static final String CLASSPATH_URL_PREFIX = "classpath:";
@@ -92,6 +92,9 @@ public abstract class ResourceUtils {
 	/** Special separator between WAR URL and jar part on Tomcat. */
 	public static final String WAR_URL_SEPARATOR = "*/";
 
+	private ResourceUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Return whether the given resource location is a URL:

--- a/spring-core/src/main/java/org/springframework/util/SerializationUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/SerializationUtils.java
@@ -30,7 +30,11 @@ import org.springframework.lang.Nullable;
  * @author Dave Syer
  * @since 3.0.5
  */
-public abstract class SerializationUtils {
+public class SerializationUtils {
+
+	private SerializationUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Serialize the given object to a byte array.

--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -43,7 +43,7 @@ import org.springframework.lang.Nullable;
  * @since 3.2.2
  * @see FileCopyUtils
  */
-public abstract class StreamUtils {
+public class StreamUtils {
 
 	/**
 	 * The default buffer size used when copying bytes.
@@ -52,6 +52,9 @@ public abstract class StreamUtils {
 
 	private static final byte[] EMPTY_CONTENT = new byte[0];
 
+	private StreamUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Copy the contents of the given InputStream into a new byte array.

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -59,7 +59,7 @@ import org.springframework.lang.Nullable;
  * @author Brian Clozel
  * @since 16 April 2001
  */
-public abstract class StringUtils {
+public class StringUtils {
 
 	private static final String[] EMPTY_STRING_ARRAY = {};
 
@@ -73,6 +73,9 @@ public abstract class StringUtils {
 
 	private static final char EXTENSION_SEPARATOR = '.';
 
+	private StringUtils() {
+		throw new AssertionError();
+	}
 
 	//---------------------------------------------------------------------
 	// General convenience methods for working with Strings

--- a/spring-core/src/main/java/org/springframework/util/SystemPropertyUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/SystemPropertyUtils.java
@@ -33,7 +33,11 @@ import org.springframework.lang.Nullable;
  * @see #PLACEHOLDER_SUFFIX
  * @see System#getProperty(String)
  */
-public abstract class SystemPropertyUtils {
+public class SystemPropertyUtils {
+
+	private SystemPropertyUtils() {
+		throw new AssertionError();
+	}
 
 	/** Prefix for system property placeholders: "${". */
 	public static final String PLACEHOLDER_PREFIX = "${";

--- a/spring-core/src/main/java/org/springframework/util/TypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/TypeUtils.java
@@ -33,7 +33,11 @@ import org.springframework.lang.Nullable;
  * @author Sam Brannen
  * @since 2.0.7
  */
-public abstract class TypeUtils {
+public class TypeUtils {
+
+	private TypeUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Check if the right-hand side type may be assigned to the left-hand side

--- a/spring-core/src/main/java/org/springframework/util/comparator/Comparators.java
+++ b/spring-core/src/main/java/org/springframework/util/comparator/Comparators.java
@@ -25,7 +25,11 @@ import java.util.Comparator;
  * @author Juergen Hoeller
  * @since 5.0
  */
-public abstract class Comparators {
+public class Comparators {
+
+	private Comparators() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Return a {@link Comparable} adapter.

--- a/spring-core/src/main/java/org/springframework/util/function/SupplierUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/function/SupplierUtils.java
@@ -27,7 +27,11 @@ import org.springframework.lang.Nullable;
  * @since 5.1
  * @see SingletonSupplier
  */
-public abstract class SupplierUtils {
+public class SupplierUtils {
+
+	private SupplierUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Resolve the given {@code Supplier}, getting its result or immediately

--- a/spring-core/src/main/java/org/springframework/util/xml/DomUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/DomUtils.java
@@ -45,7 +45,11 @@ import org.springframework.util.Assert;
  * @see org.w3c.dom.Node
  * @see org.w3c.dom.Element
  */
-public abstract class DomUtils {
+public class DomUtils {
+
+	private DomUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Retrieves all child elements of the given DOM element that match any of the given element names.

--- a/spring-core/src/main/java/org/springframework/util/xml/StaxUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/StaxUtils.java
@@ -51,7 +51,11 @@ import org.springframework.util.StreamUtils;
  * @author Juergen Hoeller
  * @since 3.0
  */
-public abstract class StaxUtils {
+public class StaxUtils {
+
+	private StaxUtils() {
+		throw new AssertionError();
+	}
 
 	private static final XMLResolver NO_OP_XML_RESOLVER =
 			(publicID, systemID, base, ns) -> StreamUtils.emptyInput();

--- a/spring-core/src/main/java/org/springframework/util/xml/TransformerUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/TransformerUtils.java
@@ -29,7 +29,7 @@ import org.springframework.util.Assert;
  * @author Juergen Hoeller
  * @since 2.5.5
  */
-public abstract class TransformerUtils {
+public class TransformerUtils {
 
 	/**
 	 * The indent amount of characters if {@link #enableIndenting indenting is enabled}.
@@ -37,6 +37,9 @@ public abstract class TransformerUtils {
 	 */
 	public static final int DEFAULT_INDENT_AMOUNT = 2;
 
+	private TransformerUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Enable indenting for the supplied {@link javax.xml.transform.Transformer}.

--- a/spring-web/src/main/java/org/springframework/web/util/HtmlUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlUtils.java
@@ -38,7 +38,7 @@ import org.springframework.util.Assert;
  * @author Craig Andrews
  * @since 01.03.2003
  */
-public abstract class HtmlUtils {
+public class HtmlUtils {
 
 	/**
 	 * Shared instance of pre-parsed HTML character entity references.
@@ -46,6 +46,9 @@ public abstract class HtmlUtils {
 	private static final HtmlCharacterEntityReferences characterEntityReferences =
 			new HtmlCharacterEntityReferences();
 
+	private HtmlUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Turn special characters into HTML character references.

--- a/spring-web/src/main/java/org/springframework/web/util/JavaScriptUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/JavaScriptUtils.java
@@ -29,7 +29,11 @@ package org.springframework.web.util;
  * @author Rossen Stoyanchev
  * @since 1.1.1
  */
-public abstract class JavaScriptUtils {
+public class JavaScriptUtils {
+
+	private JavaScriptUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Turn JavaScript special characters into escaped characters.

--- a/spring-web/src/main/java/org/springframework/web/util/ServletContextPropertyUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ServletContextPropertyUtils.java
@@ -35,7 +35,7 @@ import org.springframework.util.SystemPropertyUtils;
  * @see SystemPropertyUtils
  * @see ServletContext#getInitParameter(String)
  */
-public abstract class ServletContextPropertyUtils {
+public class ServletContextPropertyUtils {
 
 	private static final PropertyPlaceholderHelper strictHelper =
 			new PropertyPlaceholderHelper(SystemPropertyUtils.PLACEHOLDER_PREFIX,
@@ -45,6 +45,9 @@ public abstract class ServletContextPropertyUtils {
 			new PropertyPlaceholderHelper(SystemPropertyUtils.PLACEHOLDER_PREFIX,
 					SystemPropertyUtils.PLACEHOLDER_SUFFIX, SystemPropertyUtils.VALUE_SEPARATOR, true);
 
+	private ServletContextPropertyUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Resolve ${...} placeholders in the given text, replacing them with corresponding

--- a/spring-web/src/main/java/org/springframework/web/util/ServletRequestPathUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ServletRequestPathUtils.java
@@ -43,11 +43,14 @@ import org.springframework.util.StringUtils;
  * @author Rossen Stoyanchev
  * @since 5.3
  */
-public abstract class ServletRequestPathUtils {
+public class ServletRequestPathUtils {
 
 	/** Name of Servlet request attribute that holds the parsed {@link RequestPath}. */
 	public static final String PATH_ATTRIBUTE = ServletRequestPathUtils.class.getName() + ".PATH";
 
+	private ServletRequestPathUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Parse the {@link HttpServletRequest#getRequestURI() requestURI} to a

--- a/spring-web/src/main/java/org/springframework/web/util/TagUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/TagUtils.java
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
  * @author Juergen Hoeller
  * @author Rick Evans
  */
-public abstract class TagUtils {
+public class TagUtils {
 
 	/** Constant identifying the page scope. */
 	public static final String SCOPE_PAGE = "page";
@@ -56,6 +56,9 @@ public abstract class TagUtils {
 	/** Constant identifying the application scope. */
 	public static final String SCOPE_APPLICATION = "application";
 
+	private TagUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Determines the scope for a given input {@code String}.

--- a/spring-web/src/main/java/org/springframework/web/util/UriUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriUtils.java
@@ -51,7 +51,11 @@ import org.springframework.util.StringUtils;
  * @since 3.0
  * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>
  */
-public abstract class UriUtils {
+public class UriUtils {
+
+	private UriUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Encode the given URI scheme with the given encoding.

--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -55,7 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Sebastien Deleuze
  * @author Sam Brannen
  */
-public abstract class WebUtils {
+public class WebUtils {
 
 	/**
 	 * Standard Servlet 2.3+ spec request attribute for include request URI.
@@ -221,6 +221,9 @@ public abstract class WebUtils {
 	/** Key for the mutex session attribute. */
 	public static final String SESSION_MUTEX_ATTRIBUTE = WebUtils.class.getName() + ".MUTEX";
 
+	private WebUtils() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Set a system property to the web application root directory.


### PR DESCRIPTION
According to pull request #1848, utility classes are noninstantiable, but abstract is not enough for preventing create objects by subclasses.
This change modified almost all utility classes, but I do think it is necessary, and the effects should small and limited.
