### PR TITLE
Modify status code 103 to ("Early Hints")

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/StatusResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/StatusResultMatchers.java
@@ -145,9 +145,9 @@ public class StatusResultMatchers {
 	}
 
 	/**
-	 * Assert the response status code is {@code HttpStatus.CHECKPOINT} (103).
+	 * Assert the response status code is {@code HttpStatus.EARLY_HINTS} (103).
 	 */
-	public ResultMatcher isCheckpoint() {
+	public ResultMatcher isEarlyHints() {
 		return matcher(HttpStatus.valueOf(103));
 	}
 

--- a/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/StatusResultMatchersDsl.kt
+++ b/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/StatusResultMatchersDsl.kt
@@ -115,10 +115,10 @@ class StatusResultMatchersDsl internal constructor (private val actions: ResultA
 	}
 
 	/**
-	 * @see StatusResultMatchers.isCheckpoint
+	 * @see StatusResultMatchers.isEarlyHints
 	 */
-	fun isCheckpoint() {
-		actions.andExpect(matchers.isCheckpoint())
+	fun isEarlyHints() {
+		actions.andExpect(matchers.isEarlyHints())
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatus.java
@@ -51,11 +51,10 @@ public enum HttpStatus {
 	 */
 	PROCESSING(102, Series.INFORMATIONAL, "Processing"),
 	/**
-	 * {@code 103 Checkpoint}.
-	 * @see <a href="https://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal">A proposal for supporting
-	 * resumable POST/PUT HTTP requests in HTTP/1.0</a>
+	 * {@code 103 Early Hints}.
+	 * @see <a href="https://tools.ietf.org/html/rfc8297#section-2">An HTTP Status Code for Indicating Hints</a>
 	 */
-	CHECKPOINT(103, Series.INFORMATIONAL, "Checkpoint"),
+	EARLY_HINTS(103, Series.INFORMATIONAL, "Early Hints"),
 
 	// 2xx Success
 

--- a/spring-web/src/test/java/org/springframework/http/HttpStatusTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpStatusTests.java
@@ -37,7 +37,7 @@ class HttpStatusTests {
 		statusCodes.put(100, "CONTINUE");
 		statusCodes.put(101, "SWITCHING_PROTOCOLS");
 		statusCodes.put(102, "PROCESSING");
-		statusCodes.put(103, "CHECKPOINT");
+		statusCodes.put(103, "EARLY_HINTS");
 
 		statusCodes.put(200, "OK");
 		statusCodes.put(201, "CREATED");


### PR DESCRIPTION
According to rfc8297(https://tools.ietf.org/html/rfc8297), the reason
phase of status code 103 should be "Early Hints", not "Checkpoint".

This commit modifies the status code 103 reason phase from ("Checkpoint")
to ("Early Hints").