### PR TITLE
Fix CaffeineCacheManager configuration in the documentation

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -6545,7 +6545,7 @@ are made available by the manager. The following example shows how to do so:
 [source,xml,indent=0,subs="verbatim,quotes"]
 ----
 	<bean id="cacheManager" class="org.springframework.cache.caffeine.CaffeineCacheManager">
-		<property name="caches">
+		<property name="cacheNames">
 			<set>
 				<value>default</value>
 				<value>books</value>


### PR DESCRIPTION
With Spring Framework 6.0.0-M2, the `caches` property is not valid and may be replaced by `cacheNames`