### PR TITLE
Use SpringProperties in native image detection

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/NativeDetector.java
+++ b/spring-core/src/main/java/org/springframework/core/NativeDetector.java
@@ -27,13 +27,11 @@ package org.springframework.core;
  */
 public abstract class NativeDetector {
 
-	// See https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/ImageInfo.java
-	private static final boolean imageCode = (System.getProperty("org.graalvm.nativeimage.imagecode") != null);
-
 	/**
 	 * Returns {@code true} if invoked in the context of image building or during image runtime, else {@code false}.
 	 */
 	public static boolean inNativeImage() {
-		return imageCode;
+		// See https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/ImageInfo.java
+		return SpringProperties.getProperty("org.graalvm.nativeimage.imagecode") != null;
 	}
 }

--- a/spring-core/src/test/java/org/springframework/core/NativeDetectorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/NativeDetectorTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link NativeDetector}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+class NativeDetectorTests {
+
+	@Test
+	void inNativeImage() {
+		assertThat(NativeDetector.inNativeImage()).isFalse();
+		try {
+			SpringProperties.setProperty("org.graalvm.nativeimage.imagecode", "some-value");
+			assertThat(NativeDetector.inNativeImage()).isTrue();
+		}
+		finally {
+			SpringProperties.setProperty("org.graalvm.nativeimage.imagecode", null);
+		}
+	}
+
+}


### PR DESCRIPTION
While writing tests for `@EnabledOnNative` and `@DisabledOnNative` in Spring Native (https://github.com/spring-projects-experimental/spring-native/pull/1460), I encountered it is very difficult to mock the native detection result - `NativeDetector.inNativeImage()`.  

This is because it performs a system property check at the class initialization and keeps the result in a static final variable.

In this PR, I changed the detection logic to lookup `SpringProperties`, similar to `AotModeDetector` does in Spring Native.

This way, tests that need to modify the native-detection-result can interact with `SpringProperties` to dynamically change the value.
