### PR TITLE
Add support for strict JSON comparison in WebTestClient

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -659,10 +659,10 @@ class DefaultWebTestClient implements WebTestClient {
 		}
 
 		@Override
-		public BodyContentSpec json(String json) {
+		public BodyContentSpec json(String json, boolean strict) {
 			this.result.assertWithDiagnostics(() -> {
 				try {
-					new JsonExpectationsHelper().assertJsonEqual(json, getBodyAsString());
+					new JsonExpectationsHelper().assertJsonEqual(json, getBodyAsString(), strict);
 				}
 				catch (Exception ex) {
 					throw new AssertionError("JSON parsing error", ex);

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -979,7 +979,24 @@ public interface WebTestClient {
 		 * on to be on the classpath.
 		 * @param expectedJson the expected JSON content.
 		 */
-		BodyContentSpec json(String expectedJson);
+		default BodyContentSpec json(String expectedJson) {
+			return json(expectedJson, false);
+		}
+
+		/**
+		 * Parse the expected and actual response content as JSON and perform a
+		 * comparison in two modes, depending on {@code strict} parameter value, verifying the same attribute-value pairs.
+		 * <ul>
+		 * <li>{@code true}: strict checking.
+		 * <li>{@code false}: lenient checking.
+		 * </ul>
+		 * <p>Use of this option requires the
+		 * <a href="https://jsonassert.skyscreamer.org/">JSONassert</a> library
+		 * on to be on the classpath.
+		 * @param expectedJson the expected JSON content.
+		 * @param strict enables strict checking
+		 */
+		BodyContentSpec json(String expectedJson, boolean strict);
 
 		/**
 		 * Parse expected and actual response content as XML and assert that

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 /**

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
@@ -49,11 +49,20 @@ public class JsonContentTests {
 
 	@Test
 	public void jsonContent() {
-		this.client.get().uri("/persons")
+		this.client.get().uri("/persons/extended")
 				.accept(MediaType.APPLICATION_JSON)
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().json("[{\"name\":\"Jane\"},{\"name\":\"Jason\"},{\"name\":\"John\"}]");
+	}
+
+	@Test
+	public void jsonContentStrict() {
+		this.client.get().uri("/persons/extended")
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody().json("[{\"name\":\"Jane\",\"surname\":\"Williams\"},{\"name\":\"Jason\",\"surname\":\"Johnson\"},{\"name\":\"John\",\"surname\":\"Smith\"}]", true);
 	}
 
 	@Test
@@ -98,6 +107,11 @@ public class JsonContentTests {
 			return Flux.just(new Person("Jane"), new Person("Jason"), new Person("John"));
 		}
 
+		@GetMapping("/extended")
+		Flux<ExtendedPerson> getExtendedPersons() {
+			return Flux.just(new ExtendedPerson("Jane", "Williams"), new ExtendedPerson("Jason", "Johnson"), new ExtendedPerson("John", "Smith"));
+		}
+
 		@GetMapping("/{name}")
 		Person getPerson(@PathVariable String name) {
 			return new Person(name);
@@ -106,6 +120,24 @@ public class JsonContentTests {
 		@PostMapping
 		ResponseEntity<String> savePerson(@RequestBody Person person) {
 			return ResponseEntity.created(URI.create("/persons/" + person.getName())).build();
+		}
+	}
+
+	static class ExtendedPerson {
+		private String name;
+		private String surname;
+
+		public ExtendedPerson(String name, String surname) {
+			this.name = name;
+			this.surname = surname;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getSurname() {
+			return surname;
 		}
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -58,13 +59,12 @@ public class JsonContentTests {
 
 	@Test
 	public void jsonContentStrictFail() {
-		assertThrows(AssertionError.class, () -> {
-			this.client.get().uri("/persons/extended")
-					.accept(MediaType.APPLICATION_JSON)
-					.exchange()
-					.expectStatus().isOk()
-					.expectBody().json("[{\"name\":\"Jane\"},{\"name\":\"Jason\"},{\"name\":\"John\"}]", true);
-		});
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> this.client.get().uri("/persons/extended")
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody().json("[{\"name\":\"Jane\"},{\"name\":\"Jason\"},{\"name\":\"John\"}]", true)
+		);
 	}
 
 	@Test

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/samples/JsonContentTests.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.hamcrest.Matchers.containsString;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 /**
@@ -54,6 +54,17 @@ public class JsonContentTests {
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().json("[{\"name\":\"Jane\"},{\"name\":\"Jason\"},{\"name\":\"John\"}]");
+	}
+
+	@Test
+	public void jsonContentStrictFail() {
+		assertThrows(AssertionError.class, () -> {
+			this.client.get().uri("/persons/extended")
+					.accept(MediaType.APPLICATION_JSON)
+					.exchange()
+					.expectStatus().isOk()
+					.expectBody().json("[{\"name\":\"Jane\"},{\"name\":\"Jason\"},{\"name\":\"John\"}]", true);
+		});
 	}
 
 	@Test


### PR DESCRIPTION
Support for `expectedBody().json(<expected strict json>, true);`

Part of the code base already has support - via `JsonExpectationsHelper` - but `WebTestClient` has no method to use the strict version. The existing method uses `lenient`, which is not always desired.

Example: 
Let's say `/persons/1/` returns the following response:

```json
{
  "name":"John",
  "surname":"Smith"
}
```

The following test works fine:

```java
webTestClient.get()
    .uri("/persons/1")
    .accept(MediaType.APPLICATION_JSON)
    .exchange()
    .expectStatus().isOk()
    .expectBody().json("{\"name\":\"John\"}");
```

I'm just adding a new method so that we can use strict comparison when appropriate.

Example:

This test fails because the response has more fields than expected and we're using strict mode: 

```java
webTestClient.get()
    .uri("/persons/1")
    .accept(MediaType.APPLICATION_JSON)
    .exchange()
    .expectStatus().isOk()
    .expectBody().json("{\"name\":\"John\"}", true);
```

But the following test passes because we're expecting all fields:

```java
webTestClient.get()
    .uri("/persons/1")
    .accept(MediaType.APPLICATION_JSON)
    .exchange()
    .expectStatus().isOk()
    .expectBody().json("{\"name\":\"John\",\"surname\":\"Smith\"}", true);
```
