### PR TITLE
Improve SimpleJdbcCall for Oracle database

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Risberg
  * @author Juergen Hoeller
  * @author Kiril Nugmanov
+ * @author Loïc Lefèvre
  * @since 2.5
  */
 public class CallMetaDataContext {
@@ -249,9 +250,10 @@ public class CallMetaDataContext {
 	/**
 	 * Initialize this class with meta-data from the database.
 	 * @param dataSource the DataSource used to retrieve meta-data
+	 * @param parameters the list of parameters to use as a base
 	 */
-	public void initializeMetaData(DataSource dataSource) {
-		this.metaDataProvider = CallMetaDataProviderFactory.createMetaDataProvider(dataSource, this);
+	public void initializeMetaData(DataSource dataSource, List<SqlParameter> parameters) {
+		this.metaDataProvider = CallMetaDataProviderFactory.createMetaDataProvider(dataSource, this, parameters);
 	}
 
 	private CallMetaDataProvider obtainMetaDataProvider() {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.lang.Nullable;
  * {@link org.springframework.jdbc.core.simple.SimpleJdbcCall}.
  *
  * @author Thomas Risberg
+ * @author Loïc Lefèvre
  * @since 2.5
  */
 public interface CallMetaDataProvider {
@@ -46,14 +47,13 @@ public interface CallMetaDataProvider {
 	 * This is only called for databases that are supported. This initialization
 	 * can be turned off by specifying that column meta-data should not be used.
 	 * @param databaseMetaData used to retrieve database specific information
-	 * @param catalogName name of catalog to use (or {@code null} if none)
-	 * @param schemaName name of schema name to use (or {@code null} if none)
-	 * @param procedureName name of the stored procedure
+	 * @param context the class that holds configuration and meta-data
+	 * @param parameters the list of parameters to use as a base
 	 * @throws SQLException in case of initialization failure
 	 * @see	org.springframework.jdbc.core.simple.SimpleJdbcCall#withoutProcedureColumnMetaDataAccess()
 	 */
-	void initializeWithProcedureColumnMetaData(DatabaseMetaData databaseMetaData, @Nullable String catalogName,
-			@Nullable String schemaName, @Nullable String procedureName) throws SQLException;
+	void initializeWithProcedureColumnMetaData(DatabaseMetaData databaseMetaData,
+								CallMetaDataContext context, List<SqlParameter> parameters) throws SQLException;
 
 	/**
 	 * Provide any modification of the procedure name passed in to match the meta-data currently used.

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProviderFactory.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProviderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.jdbc.core.SqlParameter;
 import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.jdbc.support.MetaDataAccessException;
 
@@ -34,6 +35,7 @@ import org.springframework.jdbc.support.MetaDataAccessException;
  *
  * @author Thomas Risberg
  * @author Juergen Hoeller
+ * @author Loïc Lefèvre
  * @since 2.5
  */
 public final class CallMetaDataProviderFactory {
@@ -71,9 +73,11 @@ public final class CallMetaDataProviderFactory {
 	 * Create a {@link CallMetaDataProvider} based on the database meta-data.
 	 * @param dataSource the JDBC DataSource to use for retrieving meta-data
 	 * @param context the class that holds configuration and meta-data
+	 * @param parameters the list of parameters to use as a base
 	 * @return instance of the CallMetaDataProvider implementation to be used
 	 */
-	public static CallMetaDataProvider createMetaDataProvider(DataSource dataSource, final CallMetaDataContext context) {
+	public static CallMetaDataProvider createMetaDataProvider(DataSource dataSource, CallMetaDataContext context,
+																List<SqlParameter> parameters) {
 		try {
 			return JdbcUtils.extractDatabaseMetaData(dataSource, databaseMetaData -> {
 				String databaseProductName = JdbcUtils.commonDatabaseName(databaseMetaData.getDatabaseProductName());
@@ -134,8 +138,7 @@ public final class CallMetaDataProviderFactory {
 				}
 				provider.initializeWithMetaData(databaseMetaData);
 				if (accessProcedureColumnMetaData) {
-					provider.initializeWithProcedureColumnMetaData(databaseMetaData,
-							context.getCatalogName(), context.getSchemaName(), context.getProcedureName());
+					provider.initializeWithProcedureColumnMetaData(databaseMetaData, context, parameters);
 				}
 				return provider;
 			});

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallParameterMetaData.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallParameterMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,25 +25,25 @@ import org.springframework.lang.Nullable;
  *
  * @author Thomas Risberg
  * @author Juergen Hoeller
+ * @author Loïc Lefèvre
  * @since 2.5
  * @see GenericCallMetaDataProvider
  */
 public class CallParameterMetaData {
 
-	private final boolean function;
+	protected final boolean function;
 
 	@Nullable
-	private final String parameterName;
+	protected final String parameterName;
 
-	private final int parameterType;
+	protected final int parameterType;
 
-	private final int sqlType;
+	protected final int sqlType;
 
 	@Nullable
-	private final String typeName;
+	protected final String typeName;
 
-	private final boolean nullable;
-
+	protected final boolean nullable;
 
 	/**
 	 * Constructor taking all the properties including the function marker.

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/OracleCallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/OracleCallMetaDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,19 +17,25 @@
 package org.springframework.jdbc.core.metadata;
 
 import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.jdbc.core.ColumnMapRowMapper;
 import org.springframework.jdbc.core.SqlOutParameter;
 import org.springframework.jdbc.core.SqlParameter;
 import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
 
 /**
  * Oracle-specific implementation for the {@link CallMetaDataProvider} interface.
  * This class is intended for internal use by the Simple JDBC classes.
  *
  * @author Thomas Risberg
+ * @author Loïc Lefèvre
  * @since 2.5
  */
 public class OracleCallMetaDataProvider extends GenericCallMetaDataProvider {
@@ -81,4 +87,201 @@ public class OracleCallMetaDataProvider extends GenericCallMetaDataProvider {
 		}
 	}
 
+	@Override
+	protected void processProcedureColumns(DatabaseMetaData databaseMetaData, final CallMetaDataContext context,
+											final List<SqlParameter> parameters) {
+
+		String metaDataCatalogName = metaDataCatalogNameToUse(context.getCatalogName());
+		String metaDataSchemaName = metaDataSchemaNameToUse(context.getSchemaName());
+		String metaDataProcedureName = procedureNameToUse(context.getProcedureName());
+		if (logger.isDebugEnabled()) {
+			logger.debug("Retrieving column meta-data for " + (context.isFunction() ? "function" : "procedure") + ' ' +
+					metaDataCatalogName + '/' + metaDataSchemaName + '/' + metaDataProcedureName);
+		}
+
+		try {
+			int objectsFound = 0;
+
+			if (context.isFunction()) {
+				try (ResultSet functions = databaseMetaData.getFunctions(
+						metaDataCatalogName, metaDataSchemaName, metaDataProcedureName)) {
+					while (functions.next()) {
+						objectsFound++;
+					}
+				}
+			}
+			else {
+				try (ResultSet procedures = databaseMetaData.getProcedures(
+						metaDataCatalogName, metaDataSchemaName, metaDataProcedureName)) {
+					while (procedures.next()) {
+						objectsFound++;
+					}
+				}
+			}
+
+			if (objectsFound == 0) {
+				if (metaDataProcedureName != null && metaDataProcedureName.contains(".") &&
+						!StringUtils.hasText(metaDataCatalogName)) {
+					String packageName = metaDataProcedureName.substring(0, metaDataProcedureName.indexOf('.'));
+					throw new InvalidDataAccessApiUsageException(
+							"Unable to determine the correct call signature for '" + metaDataProcedureName +
+									"' - package name should be specified separately using '.withCatalogName(\"" +
+									packageName + "\")'");
+				}
+				else if (metaDataSchemaName != null && !"SYS".equalsIgnoreCase(metaDataSchemaName) &&
+						metaDataCatalogName != null && metaDataCatalogName.toLowerCase().startsWith("dbms_")) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Chances are that the package name '" + metaDataCatalogName +
+								"' is owned by internal Oracle 'SYS' user - try using '.withSchemaName(\"SYS\")'");
+					}
+				}
+				else {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Oracle JDBC driver did not return procedure/function/signature for '" +
+								metaDataProcedureName + "' - assuming a non-exposed synonym");
+					}
+				}
+			}
+
+			try (ResultSet columns = context.isFunction() ?
+					databaseMetaData.getFunctionColumns(metaDataCatalogName, metaDataSchemaName, metaDataProcedureName,
+							null) :
+					databaseMetaData.getProcedureColumns(metaDataCatalogName, metaDataSchemaName, metaDataProcedureName,
+							null)) {
+
+				boolean overloadColumnPresent = false;
+				for (int i = 1; i <= columns.getMetaData().getColumnCount(); i++) {
+					if ("OVERLOAD".equals(columns.getMetaData().getColumnName(i))) {
+						overloadColumnPresent = true;
+						break;
+					}
+				}
+
+				if (objectsFound > 1 && !overloadColumnPresent) {
+					throw new InvalidDataAccessApiUsageException(
+							"Unable to determine the correct call signature - multiple signatures for '" +
+									metaDataProcedureName + "': found " + objectsFound + " " + (context.isFunction() ?
+									"functions" : "procedures"));
+				}
+
+				while (columns.next()) {
+					String columnName = columns.getString("COLUMN_NAME");
+					int columnType = columns.getInt("COLUMN_TYPE");
+					if (columnName == null && isInOrOutColumn(columnType, context.isFunction())) {
+						if (logger.isDebugEnabled()) {
+							logger.debug("Skipping meta-data for: " + columnType + " " +
+									columns.getInt("DATA_TYPE") + " " +
+									columns.getString("TYPE_NAME") + " " +
+									columns.getInt("NULLABLE") + " (probably a member of a collection)");
+						}
+					}
+					else {
+						int nullable = (context.isFunction() ? DatabaseMetaData.functionNullable :
+								DatabaseMetaData.procedureNullable);
+						CallParameterMetaData meta = overloadColumnPresent ? new OracleCallParameterMetaData(
+								context.isFunction(), columnName, columnType,
+								columns.getInt("DATA_TYPE"), columns.getString("TYPE_NAME"),
+								columns.getInt("NULLABLE") == nullable,
+								columns.getInt("OVERLOAD")) :
+								new CallParameterMetaData(context.isFunction(), columnName, columnType,
+										columns.getInt("DATA_TYPE"),
+										columns.getString("TYPE_NAME"),
+										columns.getInt("NULLABLE") == nullable);
+						this.callParameterMetaData.add(meta);
+						if (logger.isDebugEnabled()) {
+							logger.debug("Retrieved meta-data: " + meta.getParameterName() + " " +
+									meta.getParameterType() + " " + meta.getSqlType() + " " +
+									meta.getTypeName() + " " + meta.isNullable());
+						}
+					}
+				}
+
+				if (objectsFound > 1) {
+					if (parameters.isEmpty()) {
+						throw new InvalidDataAccessApiUsageException(
+								"Unable to determine the correct call signature - multiple signatures for '" +
+										metaDataProcedureName + "': found " + objectsFound + " " +
+										(context.isFunction() ? "functions" : "procedures"));
+					}
+
+					// now work on the different overloads and keep only the one matching the requested parameters
+					// this ensures that no issue happens at runtime (in production)
+					// although this check can bring a performance penalty if used intensively
+					int currentOverload;
+					int overloadStartIndex = 0;
+					List<CallParameterMetaData> newCallParameterMetaData = new ArrayList<>();
+					boolean signatureFound = false;
+					for (int i = 0; i < this.callParameterMetaData.size(); i++) {
+						OracleCallParameterMetaData meta = (OracleCallParameterMetaData) callParameterMetaData.get(i);
+						currentOverload = meta.overload;
+
+						boolean allMatched = true;
+						for (SqlParameter sqlParameter : parameters) {
+							if (sqlParameter.getSqlType() == meta.getSqlType() && (meta.getParameterName() == null ||
+									meta.getParameterName().equalsIgnoreCase(sqlParameter.getName()))) {
+								if (i < this.callParameterMetaData.size() - 1) {
+									i++;
+									meta = (OracleCallParameterMetaData) callParameterMetaData.get(i);
+								}
+								else {
+									break;
+								}
+							}
+							else {
+								allMatched = false;
+								break;
+							}
+						}
+
+						if (allMatched) {
+							// Matching overload starts at index overloadStartIndex
+							for (int j = 0; j < parameters.size(); j++) {
+								newCallParameterMetaData.add(this.callParameterMetaData.get(j + overloadStartIndex));
+							}
+							signatureFound = true;
+							break;
+						}
+						else {
+							// get to the next overload
+							while (i < this.callParameterMetaData.size()) {
+								i++;
+								meta = (OracleCallParameterMetaData) callParameterMetaData.get(i);
+								if (currentOverload < meta.overload) {
+									overloadStartIndex = i;
+									i--;
+									break;
+								}
+							}
+						}
+					}
+
+					if (signatureFound) {
+						// replace all the parameters meta-data with the right overload ones
+						this.callParameterMetaData.clear();
+						this.callParameterMetaData.addAll(newCallParameterMetaData);
+					}
+					else {
+						throw new InvalidDataAccessApiUsageException(
+								"Unable to determine the correct call signature - multiple signatures for '" +
+								metaDataProcedureName + "': found " + objectsFound + " " +
+								(context.isFunction() ? "functions" : "procedures"));
+					}
+				}
+			}
+		}
+		catch (SQLException ex) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("Error while retrieving meta-data for " +
+						(context.isFunction() ? "function" : "procedure") + " columns. " +
+						"Consider declaring explicit parameters -- for example, " +
+						"via SimpleJdbcCall#addDeclaredParameter().",
+						ex);
+			}
+			// Although we could invoke `this.callParameterMetaData.clear()` so that
+			// we don't retain a partial list of column names (like we do in
+			// GenericTableMetaDataProvider.processTableColumns(...)), we choose
+			// not to do that here, since invocation of the stored procedure will
+			// likely fail anyway with an incorrect argument list.
+		}
+	}
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/OracleCallParameterMetaData.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/OracleCallParameterMetaData.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.core.metadata;
+
+import java.sql.DatabaseMetaData;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Holder of Orcle meta-data for a specific parameter that is used for call processing.
+ *
+ * @author Loïc Lefèvre
+ * @since 5.3.16
+ * @see GenericCallMetaDataProvider
+ */
+public class OracleCallParameterMetaData extends CallParameterMetaData {
+	// denotes the procedure or function overload number this parameter belongs to
+	protected final int overload;
+
+	/**
+	 * Constructor taking all the properties including the function marker and the overload number.
+	 * @since 5.3.16
+	 */
+	public OracleCallParameterMetaData(boolean function, @Nullable String columnName, int columnType,
+								int sqlType, @Nullable String typeName, boolean nullable, int overload) {
+		super(function, columnName, columnType, sqlType, typeName, nullable);
+		this.overload = overload;
+	}
+
+	/**
+	 * Determine whether the declared parameter qualifies as a 'return' parameter
+	 * for our purposes: type {@link DatabaseMetaData#procedureColumnReturn} or
+	 * {@link DatabaseMetaData#procedureColumnResult}, or in case of a function,
+	 * {@link DatabaseMetaData#functionReturn}.
+	 * @since 5.3.16
+	 */
+	@Override
+	public boolean isReturnParameter() {
+		return (this.function ? (this.parameterType == DatabaseMetaData.functionReturn ||
+				this.parameterType == DatabaseMetaData.functionColumnResult) :
+				(this.parameterType == DatabaseMetaData.procedureColumnReturn ||
+						this.parameterType == DatabaseMetaData.procedureColumnResult));
+	}
+}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Thomas Risberg
  * @author Juergen Hoeller
+ * @author Loïc Lefèvre
  * @since 2.5
  */
 public abstract class AbstractJdbcCall {
@@ -312,10 +313,11 @@ public abstract class AbstractJdbcCall {
 	protected void compileInternal() {
 		DataSource dataSource = getJdbcTemplate().getDataSource();
 		Assert.state(dataSource != null, "No DataSource set");
-		this.callMetaDataContext.initializeMetaData(dataSource);
+		this.callMetaDataContext.initializeMetaData(dataSource, this.declaredParameters);
 
 		// Iterate over the declared RowMappers and register the corresponding SqlParameter
-		this.declaredRowMappers.forEach((key, value) -> this.declaredParameters.add(this.callMetaDataContext.createReturnResultSetParameter(key, value)));
+		this.declaredRowMappers.forEach((key, value) -> this.declaredParameters.add(
+				this.callMetaDataContext.createReturnResultSetParameter(key, value)));
 		this.callMetaDataContext.processParameters(this.declaredParameters);
 
 		this.callString = this.callMetaDataContext.createCallString();

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/CallMetaDataContextTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/CallMetaDataContextTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.verify;
  * Mock object based tests for CallMetaDataContext.
  *
  * @author Thomas Risberg
+ * @author Loïc Lefèvre
  */
 public class CallMetaDataContextTests {
 
@@ -90,7 +91,7 @@ public class CallMetaDataContextTests {
 		parameterSource.addValue("customer_no", "12345XYZ");
 
 		context.setProcedureName(TABLE);
-		context.initializeMetaData(dataSource);
+		context.initializeMetaData(dataSource,parameters);
 		context.processParameters(parameters);
 
 		Map<String, Object> inParameters = context.matchInParameterValuesWithCallParameters(parameterSource);


### PR DESCRIPTION
Improves SimpleJdbcCall when targeting the Oracle database:

- Improve support of Oracle PL/SQL packages for Spring JDBC: Oracle
database stored procedures or functions can be overloaded. Hence,
the possibility to find several matching signatures by just using
the schema name, catalog name and procedure/function name is real.
This PR adds columns data type checking to properly find the desired
stored procedure or function.

- Ease debugging for DBMS_ packages if SYS not specified: explicitly
checks the catalog name being used and if starting with DBMS_% and no
matching signature was found then report in the log it could be
useful to use SYS as the schema name