### PR TITLE
Modified SockJS close frame to prevent infinite loop for xhr-polling transport

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/frame/SockJsFrame.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/frame/SockJsFrame.java
@@ -170,7 +170,7 @@ public class SockJsFrame {
 	}
 
 	public static SockJsFrame closeFrame(int code, @Nullable String reason) {
-		return new SockJsFrame("c[" + code + ",\"" + (reason != null ? reason : "") + "\"]");
+		return new SockJsFrame("c[" + code + ",\"" + (reason != null ? reason : "") + "\"]\n");
 	}
 
 }


### PR DESCRIPTION
This pull request is regarding the issue of infinite loop in SockJS library for xhr-polling transport.

When Spring sends close frame like **c[1000, "Go Away!"]** then SockJS library is unable to parse it correctly and to recognise it as native close frame. Instead of that SockJS treats it as just plain text.

xhr.js file has next method to parse inbound text message:

```
XhrReceiver.prototype._chunkHandler = function(status, text) {
  debug('_chunkHandler', status);
  if (status !== 200 || !text) {
    return;
  }

  for (var idx = -1; ; this.bufferPosition += idx + 1) {
    var buf = text.slice(this.bufferPosition);
    idx = buf.indexOf('\n');
    if (idx === -1) {
      break;
    }
    var msg = buf.slice(0, idx);
    if (msg) {
      debug('message', msg);
      this.emit('message', msg);
    }
  }
};
```
That method expects **\n** at the end of the SockJS text frame to parse it correctly.

But Spring Framework sends frame without that ending **\n** which causes infinite loop of opened xhr requests as response on plain text frame **c[1000, "Go Away!"]**.

After this fix all works as expected and **c[1000, "Go Away!"]** successfully routes to the **'c'** section of next switch
```
SockJS.prototype._transportMessage = function(msg) {
  ...
  switch (type) {
    case 'a':
      if (Array.isArray(payload)) {
        payload.forEach(function(p) {
          debug('message', self.transport, p);
          self.dispatchEvent(new TransportMessageEvent(p));
        });
      }
      break;
    case 'm':
      debug('message', this.transport, payload);
      this.dispatchEvent(new TransportMessageEvent(payload));
      break;
    case 'c':
      if (Array.isArray(payload) && payload.length === 2) {
        this._close(payload[0], payload[1], true);
      }
      break;
  }
};
```