### PR TITLE
Support custom resolution of empty strings in ResourceWebHandler

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -454,7 +454,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 		PathContainer pathWithinHandler = exchange.getRequiredAttribute(name);
 
 		String path = processPath(pathWithinHandler.value());
-		if (!StringUtils.hasText(path) || isInvalidPath(path)) {
+		if (path != null || isInvalidPath(path)) {
 			return Mono.empty();
 		}
 		if (isInvalidEncodedPath(path)) {


### PR DESCRIPTION
The empty string can be resolved as `index.html` in a custom `ResourceResolver`. It is useful when deploying front-end services.  

Here is an example:

```java
String fallBack = "/index.html";
new ResourceResolver() {
    @Override @NonNull
    public Mono<Resource> resolveResource(ServerWebExchange exchange, @NonNull String requestPath, @NonNull List<? extends Resource> locations, @NonNull ResourceResolverChain chain) {
        return chain
                .resolveResource(exchange, requestPath, locations)
                .switchIfEmpty(Mono.defer(()->chain.resolveResource(exchange, fallBack, locations)));
    }

    @Override @NonNull
    public Mono<String> resolveUrlPath(@NonNull String resourcePath,@NonNull List<? extends Resource> locations,@NonNull ResourceResolverChain chain) {
        return chain
                .resolveUrlPath(resourcePath, locations)
                .switchIfEmpty(Mono.defer(()->chain.resolveUrlPath(fallBack, locations)));
    }
}
```

Its function is similar to that in nginx:

```javascript
location / {
  try_files $uri $uri/ @router;
}
location @router {
  rewrite ^.*$ /index.html last;
}
```