### PR TITLE
Add formatting for SockJS close GoAway frame to prevent infinite loop for xhr-polling and xhr-streaming transport

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/AbstractHttpSendingTransportHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/AbstractHttpSendingTransportHandler.java
@@ -79,9 +79,11 @@ public abstract class AbstractHttpSendingTransportHandler extends AbstractTransp
 			if (logger.isDebugEnabled()) {
 				logger.debug("Connection already closed (but not removed yet) for " + sockJsSession);
 			}
+			SockJsFrameFormat frameFormat = this.getFrameFormat(request);
 			SockJsFrame frame = SockJsFrame.closeFrameGoAway();
+			String formattedFrame = frameFormat.format(frame);
 			try {
-				response.getBody().write(frame.getContentBytes());
+				response.getBody().write(formattedFrame.getBytes(SockJsFrame.CHARSET));
 			}
 			catch (IOException ex) {
 				throw new SockJsException("Failed to send " + frame, sockJsSession.getId(), ex);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/AbstractHttpSockJsSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/session/AbstractHttpSockJsSession.java
@@ -257,7 +257,8 @@ public abstract class AbstractHttpSockJsSession extends AbstractSockJsSession {
 		synchronized (this.responseLock) {
 			try {
 				if (isClosed()) {
-					response.getBody().write(SockJsFrame.closeFrameGoAway().getContentBytes());
+					String formattedFrame = frameFormat.format(SockJsFrame.closeFrameGoAway());
+					response.getBody().write(formattedFrame.getBytes(SockJsFrame.CHARSET));
 					return;
 				}
 				this.response = response;


### PR DESCRIPTION
This pull request is regarding the issue of infinite loop in SockJS library for xhr-polling and xhr-streaming transport.

When Spring sends unformatted frame **SockJsFrame.closeFrameGoAway()** without ending **\n**  like **c[1000, "Go Away!"]** then SockJS library is unable to parse it correctly and to recognise it as native close frame. Instead of that SockJS treats it as just plain text.

**xhr.js** file has next method to parse inbound text message:

```JavaScript
XhrReceiver.prototype._chunkHandler = function(status, text) {
  debug('_chunkHandler', status);
  if (status !== 200 || !text) {
    return;
  }

  for (var idx = -1; ; this.bufferPosition += idx + 1) {
    var buf = text.slice(this.bufferPosition);
    idx = buf.indexOf('\n');
    if (idx === -1) {
      break;
    }
    var msg = buf.slice(0, idx);
    if (msg) {
      debug('message', msg);
      this.emit('message', msg);
    }
  }
};

```

That method expects **\n** at the end of the SockJS text frame.

But in case of **"Connection already closed (but not removed yet) for sessionId"** Spring Framework sends unformatted SockJsFrame.closeFrameGoAway() without ending **\n**. That leads to infinite loop at SockJS library because it is unable to parse that frame.

This fix is about to add formatting for **SockJsFrame.closeFrameGoAway()** before sending to the client.

Some reported issues:
[https://github.com/sockjs/sockjs-client/issues/418](https://github.com/sockjs/sockjs-client/issues/418)
[https://github.com/sockjs/sockjs-client/issues/308](https://github.com/sockjs/sockjs-client/issues/308)
[https://stackoverflow.com/questions/37030416/sockjs-infinite-xhr-streaming-calls-after-reconnect/70957300#70957300](https://stackoverflow.com/questions/37030416/sockjs-infinite-xhr-streaming-calls-after-reconnect/70957300#70957300)