### PR TITLE
Fix Javadoc since for AopProxyUtils.isLambda()

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AopProxyUtils.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AopProxyUtils.java
@@ -246,7 +246,7 @@ public abstract class AopProxyUtils {
 	 * checks that work on modern, main stream JVMs.
 	 * @param clazz the class to check
 	 * @return {@code true} if the class is a lambda implementation class
-	 * @since 5.2.16
+	 * @since 5.3.16
 	 */
 	static boolean isLambda(Class<?> clazz) {
 		return (clazz.isSynthetic() && (clazz.getSuperclass() == Object.class) &&


### PR DESCRIPTION
This PR fixes Javadoc `@since` tag for `AopProxyUtils.isLambda()`.

See gh-27971