### PR TITLE
Enhance conditional bean creation when using method overloading

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClass.java
@@ -16,7 +16,7 @@
 
 package org.springframework.context.annotation;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -65,8 +65,7 @@ final class ConfigurationClass {
 	private final Map<ImportBeanDefinitionRegistrar, AnnotationMetadata> importBeanDefinitionRegistrars =
 			new LinkedHashMap<>();
 
-	final Set<String> skippedBeanMethods = new HashSet<>();
-
+	final Map<String, MethodMetadataWrapper> skippedBeanMethods = new HashMap<>();
 
 	/**
 	 * Create a new {@link ConfigurationClass} with the given name.

--- a/spring-context/src/main/java/org/springframework/context/annotation/MethodMetadataWrapper.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/MethodMetadataWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation;
+
+import java.util.Optional;
+
+import org.springframework.core.type.MethodMetadata;
+
+public class MethodMetadataWrapper {
+
+	private final MethodMetadata methodMetadata;
+
+	public MethodMetadataWrapper(MethodMetadata methodMetadata) {
+		this.methodMetadata = methodMetadata;
+	}
+
+	public String getBeanName() {
+		return this.methodMetadata.getMethodName();
+	}
+
+	public Optional<Class<?>> getClassForDeclaredBean() {
+		try {
+			Class<?> clazz = Class.forName(this.methodMetadata.getDeclaringClassName());
+			return Optional.of(clazz);
+		}
+		catch (ClassNotFoundException ex) {
+			return Optional.empty();
+		}
+	}
+
+	public Optional<? extends Class<?>> getSuperClassForDeclaredBean() {
+		return getClassForDeclaredBean()
+				.map(Class::getSuperclass)
+				.filter(superClass -> !"java.lang.Object".equals(superClass.getName()));
+	}
+
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassWithConditionTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassWithConditionTests.java
@@ -136,9 +136,15 @@ public class ConfigurationClassWithConditionTests {
 	}
 
 	@Test
-	public void conditionOnOverriddenMethodHonored() {
+	public void conditionOnOverriddenMethodHonoredWhenHavingInheritance() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ConfigWithBeanSkipped.class);
 		assertThat(context.getBeansOfType(ExampleBean.class).size()).isEqualTo(0);
+	}
+
+	@Test
+	public void conditionOnOverriddenMethodHonoredWhenHavingMethodOverloading() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ConfigWithBeanNotSkippedWithMethodOverloading.class);
+		assertThat(context.getBeansOfType(ExampleBean.class).size()).isEqualTo(1);
 	}
 
 	@Test
@@ -356,6 +362,27 @@ public class ConfigurationClassWithConditionTests {
 		public ExampleBean baz() {
 			return new ExampleBean();
 		}
+	}
+
+	static class ConfigWithBeanNotSkippedWithMethodOverloading {
+
+		@Bean
+		@Conditional(NeverCondition.class)
+		public ExampleBean baz() {
+			return new ExampleBean();
+		}
+
+		@Bean
+		@Conditional(AlwaysCondition.class)
+		public ExampleBean baz(Object foo) {
+			return new ExampleBean();
+		}
+
+		@Bean
+		public Object foo() {
+			return new Object();
+		}
+
 	}
 
 	static class ConfigWithBeanReactivated extends ConfigWithBeanSkipped {


### PR DESCRIPTION
This pull request closes the issue mentioned here: https://github.com/spring-projects/spring-framework/issues/22609

Short summary:
A bean won't be created when it is being skipped by a condition for example when using `@ConditionalOnProperty` or `@ConditionalOnExpression` because the condition is evaluated to false. However a second bean with exactly the same name with different parameters may evaluate to true because the condition has met, so this bean should be created but that does not happen.

An example code snippet:
```java
class Config {

    @Bean
    @ConditionalOnExpression("${some-property-enabled} == true and ${some-different-property} == false")
    public ExampleBean baz() {
        return new ExampleBean();
    }

    @Bean
    @ConditionalOnExpression("${some-property-enabled} == false and ${some-different-property} == true")
    public ExampleBean baz(Object foo) {
        return new ExampleBean();
    }

}
```

When `some-property-enabled` is false and some-different-property is true the second method should be called and the bean should be created, however this does not happen. The bean name is already in the to be skipped beans list.

The pull request contains the changes to reconsider a skipped bean when it encounters a new bean definition having a different condition. If it should not be skipped it will be created. The PR also takes into inheritance into consideration (for backwards compatibility, see https://github.com/spring-projects/spring-framework/blob/c263cbfbe486d7712b9e46b80ed151c1eda98c74/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassWithConditionTests.java#L139)

In that specific use case the parent class defines a bean which should be created, however it is getting overridden by a subclass which defines a condition on the bean, so it will be created conditionally and may not even be created when it evaluates to false.

This PR uses a wrapper for the MethodMetadata as a helper class for resolving the inheritance with the condition on a subclass when it still needs to be skipped.

### My use case
In my use case I wanted to refactor my code base. I have the bean configuration below:

[github/mutual-tls-ssl/SSLConfig.java](https://github.com/Hakky54/mutual-tls-ssl/blob/ca34a84fc4d6cd62fc675ec148e52d1fedd800ff/client/src/main/java/nl/altindag/client/SSLConfig.java#L24)

```java
@Component
public class SSLConfig {

    @Bean
    @Scope("prototype")
    public SSLFactory sslFactory(
            @Value("${client.ssl.one-way-authentication-enabled:false}") boolean oneWayAuthenticationEnabled,
            @Value("${client.ssl.two-way-authentication-enabled:false}") boolean twoWayAuthenticationEnabled,
            @Value("${client.ssl.key-store:}") String keyStorePath,
            @Value("${client.ssl.key-store-password:}") char[] keyStorePassword,
            @Value("${client.ssl.trust-store:}") String trustStorePath,
            @Value("${client.ssl.trust-store-password:}") char[] trustStorePassword) {
        SSLFactory sslFactory = null;

        if (oneWayAuthenticationEnabled) {
            sslFactory = SSLFactory.builder()
                    .withTrustMaterial(trustStorePath, trustStorePassword)
                    .withProtocols("TLSv1.3")
                    .build();
        }

        if (twoWayAuthenticationEnabled) {
            sslFactory = SSLFactory.builder()
                    .withIdentityMaterial(keyStorePath, keyStorePassword)
                    .withTrustMaterial(trustStorePath, trustStorePassword)
                    .withProtocols("TLSv1.3")
                    .build();
        }

        return sslFactory;
    }

}
```

And I wanted to refactor it to the following snippet:
```java
@Component
public class SSLConfig {

    @Bean
    @Scope("prototype")
    @ConditionalOnExpression("${client.ssl.one-way-authentication-enabled} == true and ${client.ssl.two-way-authentication-enabled} == false")
    public SSLFactory sslFactory(@Value("${client.ssl.trust-store:}") String trustStorePath,
                                 @Value("${client.ssl.trust-store-password:}") char[] trustStorePassword) {

        return SSLFactory.builder()
                .withTrustMaterial(trustStorePath, trustStorePassword)
                .withProtocols("TLSv1.3")
                .build();
    }


    @Bean
    @Scope("prototype")
    @ConditionalOnExpression("${client.ssl.two-way-authentication-enabled} == true and ${client.ssl.one-way-authentication-enabled} == false")
    public SSLFactory sslFactory(@Value("${client.ssl.key-store:}") String keyStorePath,
                                 @Value("${client.ssl.key-store-password:}") char[] keyStorePassword,
                                 @Value("${client.ssl.trust-store:}") String trustStorePath,
                                 @Value("${client.ssl.trust-store-password:}") char[] trustStorePassword) {

        return SSLFactory.builder()
                .withIdentityMaterial(keyStorePath, keyStorePassword)
                .withTrustMaterial(trustStorePath, trustStorePassword)
                .withProtocols("TLSv1.3")
                .build();
    }

}
```

However it fails. But with the code changes of the Pull request it will create one of the beans when the conditions is true.