### PR TITLE
Adds observation support for R2DBC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ configure(allprojects) { project ->
 			mavenBom "org.junit:junit-bom:5.8.2"
 
 			// observability
-			mavenBom "io.micrometer:micrometer-bom:2.0.0-SNAPSHOT"
-			mavenBom "io.micrometer:micrometer-tracing-bom:1.0.0-SNAPSHOT"
+			mavenBom "io.micrometer:micrometer-bom:2.0.0-M2"
+			mavenBom "io.micrometer:micrometer-tracing-bom:1.0.0-M1"
 		}
 		dependencies {
 			dependencySet(group: 'org.apache.logging.log4j', version: '2.17.1') {
@@ -253,7 +253,8 @@ configure(allprojects) { project ->
 		repositories {
 			mavenCentral()
 			maven { url "https://repo.spring.io/libs-spring-framework-build" }
-			maven { url "https://repo.spring.io/snapshot" } // reactor, observability
+			maven { url "https://repo.spring.io/milestone" } // observability
+			maven { url "https://repo.spring.io/snapshot" } // reactor
 		}
 	}
 	configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ configure(allprojects) { project ->
 
 			// observability
 			mavenBom "io.micrometer:micrometer-bom:2.0.0-M2"
-			mavenBom "io.micrometer:micrometer-tracing-bom:1.0.0-M1"
+			mavenBom "io.micrometer:micrometer-tracing-bom:1.0.0-M2"
 		}
 		dependencies {
 			dependencySet(group: 'org.apache.logging.log4j', version: '2.17.1') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ configure(allprojects) { project ->
 			mavenBom "org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.0"
 			mavenBom "org.jetbrains.kotlinx:kotlinx-serialization-bom:1.3.2"
 			mavenBom "org.junit:junit-bom:5.8.2"
+
+			// observability
+			mavenBom "io.micrometer:micrometer-bom:2.0.0-SNAPSHOT"
+			mavenBom "io.micrometer:micrometer-tracing-bom:1.0.0-SNAPSHOT"
 		}
 		dependencies {
 			dependencySet(group: 'org.apache.logging.log4j', version: '2.17.1') {
@@ -249,7 +253,7 @@ configure(allprojects) { project ->
 		repositories {
 			mavenCentral()
 			maven { url "https://repo.spring.io/libs-spring-framework-build" }
-			maven { url "https://repo.spring.io/snapshot" } // reactor
+			maven { url "https://repo.spring.io/snapshot" } // reactor, observability
 		}
 	}
 	configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ configure(allprojects) { project ->
 			mavenBom "org.junit:junit-bom:5.8.2"
 
 			// observability
-			mavenBom "io.micrometer:micrometer-bom:2.0.0-M2"
-			mavenBom "io.micrometer:micrometer-tracing-bom:1.0.0-M2"
+			mavenBom "io.micrometer:micrometer-bom:2.0.0-SNAPSHOT"
+			mavenBom "io.micrometer:micrometer-tracing-bom:1.0.0-SNAPSHOT"
 		}
 		dependencies {
 			dependencySet(group: 'org.apache.logging.log4j', version: '2.17.1') {

--- a/spring-r2dbc/spring-r2dbc.gradle
+++ b/spring-r2dbc/spring-r2dbc.gradle
@@ -12,6 +12,9 @@ dependencies {
 	optional("org.jetbrains.kotlin:kotlin-stdlib")
 	optional("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 	optional("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+	optional("io.r2dbc:r2dbc-proxy")
+	optional("io.micrometer:micrometer-api")
+	optional("io.micrometer:micrometer-tracing")
 	testImplementation(testFixtures(project(":spring-beans")))
 	testImplementation(testFixtures(project(":spring-core")))
 	testImplementation(testFixtures(project(":spring-context")))
@@ -20,4 +23,7 @@ dependencies {
 	testImplementation("io.r2dbc:r2dbc-spi-test:0.9.1.RELEASE") {
 		exclude group: "org.springframework", module: "spring-jdbc"
 	}
+	testImplementation("io.micrometer:micrometer-test")
+	testImplementation("io.micrometer:micrometer-tracing-test")
+	testImplementation("io.micrometer:micrometer-tracing-integration-test")
 }

--- a/spring-r2dbc/spring-r2dbc.gradle
+++ b/spring-r2dbc/spring-r2dbc.gradle
@@ -27,3 +27,31 @@ dependencies {
 	testImplementation("io.micrometer:micrometer-tracing-test")
 	testImplementation("io.micrometer:micrometer-tracing-integration-test")
 }
+
+ext {
+	micrometerDocsVersion = "1.0.0-M1"
+}
+
+configurations {
+	adoc
+}
+
+dependencies {
+	adoc "io.micrometer:micrometer-docs-generator-spans:$micrometerDocsVersion"
+	adoc "io.micrometer:micrometer-docs-generator-metrics:$micrometerDocsVersion"
+}
+
+task generateObservabilityDocs(dependsOn: ["generateObservabilityMetricsDocs", "generateObservabilitySpansDocs"]) {
+}
+
+task generateObservabilityMetricsDocs(type: JavaExec) {
+	mainClass = "io.micrometer.docs.metrics.DocsFromSources"
+	classpath configurations.adoc
+	args project.projectDir.getAbsolutePath(), ".*", project.buildDir.getAbsolutePath()
+}
+
+task generateObservabilitySpansDocs(type: JavaExec) {
+	mainClass = "io.micrometer.docs.spans.DocsFromSources"
+	classpath configurations.adoc
+	args project.projectDir.getAbsolutePath(), ".*", project.buildDir.getAbsolutePath()
+}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/DefaultR2dbcTagsProvider.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/DefaultR2dbcTagsProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import io.micrometer.api.instrument.Tags;
+
+/**
+ * Default {@link R2dbcTagsProvider}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 6.0.0
+ */
+public class DefaultR2dbcTagsProvider implements R2dbcTagsProvider {
+	@Override
+	public Tags getLowCardinalityTags(R2dbcContext context) {
+		return Tags.of(R2dbcObservation.LowCardinalityTags.BEAN_NAME.of(context.getConnectionFactoryName()),
+				R2dbcObservation.LowCardinalityTags.CONNECTION.of(context.getConnectionName()),
+				R2dbcObservation.LowCardinalityTags.THREAD.of(context.getThreadName()));
+	}
+}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListener.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListener.java
@@ -40,23 +40,6 @@ public class ObservationProxyExecutionListener implements ProxyExecutionListener
 
 	private final String connectionFactoryName;
 
-	private final Observation.TagsProvider<Observation.Context> tagsProvider;
-
-	/**
-	 * Creates an instance of {@link ObservationProxyExecutionListener}.
-	 *
-	 * @param observationRegistry observation registry
-	 * @param connectionFactory connection factory
-	 * @param connectionFactoryName connection factory name
-	 * @param tagsProvider tags provider
-	 */
-	public ObservationProxyExecutionListener(ObservationRegistry observationRegistry, ConnectionFactory connectionFactory, String connectionFactoryName, Observation.TagsProvider<Observation.Context> tagsProvider) {
-		this.observationRegistry = observationRegistry;
-		this.connectionFactory = connectionFactory;
-		this.connectionFactoryName = connectionFactoryName;
-		this.tagsProvider = tagsProvider;
-	}
-
 	/**
 	 * Creates an instance of {@link ObservationProxyExecutionListener}.
 	 *
@@ -68,7 +51,6 @@ public class ObservationProxyExecutionListener implements ProxyExecutionListener
 		this.observationRegistry = observationRegistry;
 		this.connectionFactory = connectionFactory;
 		this.connectionFactoryName = connectionFactoryName;
-		this.tagsProvider = Observation.TagsProvider.EMPTY;
 	}
 
 	@Override
@@ -100,7 +82,6 @@ public class ObservationProxyExecutionListener implements ProxyExecutionListener
 	private Observation childObservation(QueryExecutionInfo executionInfo, String name) {
 		return Observation.createNotStarted(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getName(), this.observationRegistry)
 				.contextualName(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getContextualName())
-				.tagsProvider(this.tagsProvider)
 				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.BEAN_NAME.of(this.connectionFactoryName))
 				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.CONNECTION.of(name))
 				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.THREAD.of(executionInfo.getThreadName()))

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListener.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListener.java
@@ -40,6 +40,8 @@ public class ObservationProxyExecutionListener implements ProxyExecutionListener
 
 	private final String connectionFactoryName;
 
+	private R2dbcTagsProvider r2dbcTagsProvider = new DefaultR2dbcTagsProvider();
+
 	/**
 	 * Creates an instance of {@link ObservationProxyExecutionListener}.
 	 *
@@ -80,12 +82,15 @@ public class ObservationProxyExecutionListener implements ProxyExecutionListener
 	}
 
 	private Observation childObservation(QueryExecutionInfo executionInfo, String name) {
-		return Observation.createNotStarted(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getName(), this.observationRegistry)
+		R2dbcContext context = new R2dbcContext(name, this.connectionFactoryName, executionInfo.getThreadName());
+		return Observation.createNotStarted(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getName(), context, this.observationRegistry)
 				.contextualName(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getContextualName())
-				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.BEAN_NAME.of(this.connectionFactoryName))
-				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.CONNECTION.of(name))
-				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.THREAD.of(executionInfo.getThreadName()))
+				.tagsProvider(this.r2dbcTagsProvider)
 				.start();
+	}
+
+	public void setTagsProvider(R2dbcTagsProvider r2dbcTagsProvider) {
+		this.r2dbcTagsProvider = r2dbcTagsProvider;
 	}
 
 	private void tagQueries(QueryExecutionInfo executionInfo, Observation observation) {

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListener.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListener.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.api.instrument.observation.ObservationRegistry;
+import io.r2dbc.proxy.core.QueryExecutionInfo;
+import io.r2dbc.proxy.core.QueryInfo;
+import io.r2dbc.proxy.listener.ProxyExecutionListener;
+import io.r2dbc.spi.ConnectionFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Observation of a {@link ProxyExecutionListener}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 6.0.0
+ */
+public class ObservationProxyExecutionListener implements ProxyExecutionListener {
+	private static final Log logger = LogFactory.getLog(ObservationProxyExecutionListener.class);
+
+	private final ObservationRegistry observationRegistry;
+
+	private final ConnectionFactory connectionFactory;
+
+	private final String connectionFactoryName;
+
+	private final Observation.TagsProvider<Observation.Context> tagsProvider;
+
+	/**
+	 * Creates an instance of {@link ObservationProxyExecutionListener}.
+	 *
+	 * @param observationRegistry observation registry
+	 * @param connectionFactory connection factory
+	 * @param connectionFactoryName connection factory name
+	 * @param tagsProvider tags provider
+	 */
+	public ObservationProxyExecutionListener(ObservationRegistry observationRegistry, ConnectionFactory connectionFactory, String connectionFactoryName, Observation.TagsProvider<Observation.Context> tagsProvider) {
+		this.observationRegistry = observationRegistry;
+		this.connectionFactory = connectionFactory;
+		this.connectionFactoryName = connectionFactoryName;
+		this.tagsProvider = tagsProvider;
+	}
+
+	/**
+	 * Creates an instance of {@link ObservationProxyExecutionListener}.
+	 *
+	 * @param observationRegistry observation registry
+	 * @param connectionFactory connection factory
+	 * @param connectionFactoryName connection factory name
+	 */
+	public ObservationProxyExecutionListener(ObservationRegistry observationRegistry, ConnectionFactory connectionFactory, String connectionFactoryName) {
+		this.observationRegistry = observationRegistry;
+		this.connectionFactory = connectionFactory;
+		this.connectionFactoryName = connectionFactoryName;
+		this.tagsProvider = Observation.TagsProvider.EMPTY;
+	}
+
+	@Override
+	public void beforeQuery(QueryExecutionInfo executionInfo) {
+		// TODO: How can we ensure that all of those methods are executed ONLY when context is ready?
+		// we used to have issues with this getting executed extremely early
+
+		// Ideas: ObservationRegistry available as parent context? - that implies tracing too
+
+		//		if (isContextUnusable()) {
+		//			if (log.isDebugEnabled()) {
+		//				log.debug("Context is not ready - won't do anything");
+		//			}
+		//			return;
+		//		}
+
+		if (this.observationRegistry.getCurrentObservation() == null) {
+			return;
+		}
+		String name = this.connectionFactory.getMetadata().getName();
+		Observation observation = childObservation(executionInfo, name);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Created a new child observation before query [" + observation + "]");
+		}
+		tagQueries(executionInfo, observation);
+		executionInfo.getValueStore().put(Observation.Scope.class, observation.openScope());
+	}
+
+	private Observation childObservation(QueryExecutionInfo executionInfo, String name) {
+		return Observation.createNotStarted(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getName(), this.observationRegistry)
+				.contextualName(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getContextualName())
+				.tagsProvider(this.tagsProvider)
+				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.BEAN_NAME.of(this.connectionFactoryName))
+				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.CONNECTION.of(name))
+				.lowCardinalityTag(R2dbcObservation.LowCardinalityTags.THREAD.of(executionInfo.getThreadName()))
+				.start();
+	}
+
+	private void tagQueries(QueryExecutionInfo executionInfo, Observation observation) {
+		int i = 0;
+		for (QueryInfo queryInfo : executionInfo.getQueries()) {
+			observation.highCardinalityTag(String.format(R2dbcObservation.HighCardinalityTags.QUERY.getKey(), i), queryInfo.getQuery());
+			i = i + 1;
+		}
+	}
+
+	@Override
+	public void afterQuery(QueryExecutionInfo executionInfo) {
+		// TODO: How can we ensure that all of those methods are executed ONLY when context is ready?
+		// we used to have issues with this getting executed extremely early
+
+		// Ideas: ObservationRegistry available as parent context? - that implies tracing too
+
+		//		if (isContextUnusable()) {
+		//			if (log.isDebugEnabled()) {
+		//				log.debug("Context is not ready - won't do anything");
+		//			}
+		//			return;
+		//		}
+		Observation.Scope scope = executionInfo.getValueStore().get(Observation.Scope.class, Observation.Scope.class);
+		if (scope == null) {
+			return;
+		}
+		try (scope) {
+			Observation observation = scope.getCurrentObservation();
+			if (logger.isDebugEnabled()) {
+				logger.debug("Continued the child observation in after query [" + observation + "]");
+			}
+			final Throwable throwable = executionInfo.getThrowable();
+			if (throwable != null) {
+				observation.error(throwable);
+			}
+			observation.stop();
+		}
+	}
+
+}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcContext.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import io.micrometer.api.instrument.observation.Observation;
+
+/**
+ * R2DBC {@link Observation.Context}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 6.0.0
+ */
+public final class R2dbcContext extends Observation.Context {
+	private final String connectionName;
+
+	private final String connectionFactoryName;
+
+	private final String threadName;
+
+	public R2dbcContext(String connectionName, String connectionFactoryName, String threadName) {
+		this.connectionName = connectionName;
+		this.connectionFactoryName = connectionFactoryName;
+		this.threadName = threadName;
+	}
+
+	public String getConnectionName() {
+		return this.connectionName;
+	}
+
+	public String getConnectionFactoryName() {
+		return this.connectionFactoryName;
+	}
+
+	public String getThreadName() {
+		return this.threadName;
+	}
+}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcObservation.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcObservation.java
@@ -47,7 +47,7 @@ enum R2dbcObservation implements DocumentedObservation {
 
 		@Override
 		public String getPrefix() {
-			return "r2dbc.";
+			return "r2dbc";
 		}
 	};
 

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcObservation.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcObservation.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import io.micrometer.api.instrument.docs.DocumentedObservation;
+import io.micrometer.api.instrument.docs.TagKey;
+
+enum R2dbcObservation implements DocumentedObservation {
+
+	/**
+	 * Observation created for a R2DBC query.
+	 */
+	R2DBC_QUERY_OBSERVATION {
+		@Override
+		public String getName() {
+			return "r2dbc.query";
+		}
+
+		@Override
+		public String getContextualName() {
+			return "query";
+		}
+
+		@Override
+		public TagKey[] getLowCardinalityTagKeys() {
+			return LowCardinalityTags.values();
+		}
+
+		@Override
+		public TagKey[] getHighCardinalityTagKeys() {
+			return HighCardinalityTags.values();
+		}
+
+		@Override
+		public String getPrefix() {
+			return "r2dbc.";
+		}
+	};
+
+	enum LowCardinalityTags implements TagKey {
+
+		/**
+		 * Name of the R2DBC connection.
+		 */
+		CONNECTION {
+			@Override
+			public String getKey() {
+				return "r2dbc.connection";
+			}
+		},
+
+		/**
+		 * R2DBC url.
+		 */
+		URL {
+			@Override
+			public String getKey() {
+				return "r2dbc.url";
+			}
+		},
+
+		/**
+		 * Bean name of a ConnectionFactory.
+		 */
+		BEAN_NAME {
+			@Override
+			public String getKey() {
+				return "r2dbc.connection.bean-name";
+			}
+		},
+
+		/**
+		 * Name of the R2DBC thread.
+		 */
+		THREAD {
+			@Override
+			public String getKey() {
+				return "r2dbc.thread";
+			}
+		}
+	}
+
+	enum HighCardinalityTags implements TagKey {
+		/**
+		 * Name of the R2DBC query.
+		 */
+		QUERY {
+			@Override
+			public String getKey() {
+				return "r2dbc.query[%s]";
+			}
+		},
+
+	}
+
+}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcObservationTracingHandler.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcObservationTracingHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import java.net.URI;
+
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.TracingObservationHandler;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * A {@link TracingObservationHandler} for R2DBC.
+ *
+ * @author Marcin Grzejszczak
+ * @since 6.0.0
+ */
+public class R2dbcObservationTracingHandler implements TracingObservationHandler<Observation.Context> {
+
+	private static final Log log = LogFactory.getLog(R2dbcObservationTracingHandler.class);
+
+	private final Tracer tracer;
+
+	/**
+	 * Creates an instance of {@link R2dbcObservationTracingHandler}.
+	 *
+	 * @param tracer tracer
+	 */
+	public R2dbcObservationTracingHandler(Tracer tracer) {
+		this.tracer = tracer;
+	}
+
+	@Override
+	public void onStart(Observation.Context context) {
+		Span.Builder builder = tracer.spanBuilder()
+				.name(context.getContextualName())
+				.kind(Span.Kind.CLIENT);
+		getTracingContext(context).setSpan(builder.start());
+	}
+
+	@Override
+	public void onStop(Observation.Context context) {
+		Span span = getRequiredSpan(context);
+		tagSpan(context, span);
+		String connectionName = "r2dbc";
+		String url = null;
+		for (Tag tag : context.getLowCardinalityTags()) {
+			if (tag.getKey().equals(R2dbcObservation.LowCardinalityTags.CONNECTION.getKey())) {
+				connectionName = tag.getValue();
+			}
+			else if (tag.getKey().equals(R2dbcObservation.LowCardinalityTags.URL.getKey())) {
+				url = tag.getValue();
+			}
+		}
+		span.remoteServiceName(connectionName);
+		if (url != null) {
+			try {
+				URI uri = URI.create(url);
+				span.remoteIpAndPort(uri.getHost(), uri.getPort());
+			}
+			catch (Exception e) {
+				if (log.isDebugEnabled()) {
+					log.debug("Failed to parse the url [" + url + "]. Won't set this value on the span");
+				}
+			}
+		}
+		span.end();
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context context) {
+		return R2dbcObservation.R2DBC_QUERY_OBSERVATION.getName().equals(context.getName());
+	}
+
+	@Override
+	public Tracer getTracer() {
+		return this.tracer;
+	}
+}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcObservationTracingHandler.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcObservationTracingHandler.java
@@ -49,7 +49,7 @@ public class R2dbcObservationTracingHandler implements TracingObservationHandler
 
 	@Override
 	public void onStart(Observation.Context context) {
-		Span.Builder builder = tracer.spanBuilder()
+		Span.Builder builder = this.tracer.spanBuilder()
 				.name(context.getContextualName())
 				.kind(Span.Kind.CLIENT);
 		getTracingContext(context).setSpan(builder.start());
@@ -75,7 +75,7 @@ public class R2dbcObservationTracingHandler implements TracingObservationHandler
 				URI uri = URI.create(url);
 				span.remoteIpAndPort(uri.getHost(), uri.getPort());
 			}
-			catch (Exception e) {
+			catch (Exception ex) {
 				if (log.isDebugEnabled()) {
 					log.debug("Failed to parse the url [" + url + "]. Won't set this value on the span");
 				}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcTagsProvider.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/observability/R2dbcTagsProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import io.micrometer.api.instrument.observation.Observation;
+
+/**
+ * {@link Observation.TagsProvider} for {@link R2dbcContext}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 6.0.0
+ */
+public interface R2dbcTagsProvider extends Observation.TagsProvider<R2dbcContext> {
+	@Override
+	default boolean supportsContext(Observation.Context context) {
+		return context instanceof R2dbcContext;
+	}
+}

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerIntegrationTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerIntegrationTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import java.util.function.BiConsumer;
+
+import io.micrometer.api.instrument.MeterRegistry;
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.Tags;
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.test.SampleTestRunner;
+import io.r2dbc.h2.H2ConnectionFactory;
+import io.r2dbc.proxy.ProxyConnectionFactory;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Result;
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.r2dbc.core.DatabaseClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+
+@Disabled("run this manually to visually test spans in Zipkin & Wavefront")
+class ObservationProxyExecutionListenerIntegrationTests extends SampleTestRunner {
+
+	public static String CREATE_TABLE_LEGOSET = "CREATE TABLE legoset (\n" //
+			+ "    id          serial CONSTRAINT id PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
+			+ "    name        varchar(255) NOT NULL,\n" //
+			+ "    manual      integer NULL\n" //
+			+ ");";
+
+	ObservationProxyExecutionListenerIntegrationTests() {
+		super(SampleRunnerConfig.builder()
+				.wavefrontApplicationName("spring-r2dbc-demo")
+				.wavefrontServiceName("spring-r2dbc-test")
+				// TODO: Add these to test against Wavefront. Remember not to commit it!
+				.wavefrontToken("")
+				.wavefrontUrl("")
+				.build());
+	}
+
+	private ConnectionFactory connectionFactory;
+
+	@BeforeEach
+	public void before() {
+		connectionFactory = createConnectionFactory();
+
+		Mono.from(connectionFactory.create())
+				.flatMapMany(connection -> Flux.from(connection.createStatement("DROP TABLE legoset").execute())
+						.flatMap(Result::getRowsUpdated)
+						.onErrorResume(e -> Mono.empty())
+						.thenMany(connection.createStatement(getCreateTableStatement()).execute())
+						.flatMap(Result::getRowsUpdated).thenMany(connection.close())).as(StepVerifier::create)
+				.verifyComplete();
+	}
+
+
+	private ConnectionFactory createConnectionFactory() {
+		ConnectionFactory connectionFactory = H2ConnectionFactory.inMemory("r2dbc-observability-test");
+		ProxyConnectionFactory.Builder builder = ProxyConnectionFactory.builder(connectionFactory);
+		builder.listener(new ObservationProxyExecutionListener(getMeterRegistry(), connectionFactory, "my-name", new Observation.TagsProvider<>() {
+			@Override
+			public boolean supportsContext(Observation.Context context) {
+				return context.getName().equals(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getName());
+			}
+
+			@Override
+			public Tags getLowCardinalityTags(Observation.Context context) {
+				return Tags.of(R2dbcObservation.LowCardinalityTags.URL.of("http://localhost:6543"));
+			}
+
+			@Override
+			public Tags getHighCardinalityTags(Observation.Context context) {
+				return Tags.of(Tag.of("my-high-cardinality-tag", "foo"));
+			}
+		}));
+		return builder.build();
+	}
+
+	private String getCreateTableStatement() {
+		return CREATE_TABLE_LEGOSET;
+	}
+
+	@Override
+	public BiConsumer<Tracer, MeterRegistry> yourCode() throws Exception {
+		return (tracer, meterRegistry) -> {
+			Span rootSpan = tracer.currentSpan();
+			executeInsert(tracer, rootSpan);
+		};
+	}
+
+	private void executeInsert(Tracer tracer, Span rootSpan) {
+		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
+
+		databaseClient.sql("INSERT INTO legoset (id, name, manual) VALUES(:id, :name, :manual)")
+				.bind("id", 42055)
+				.bind("name", "SCHAUFELRADBAGGER")
+				.bindNull("manual", Integer.class)
+				.fetch().rowsUpdated()
+				.as(StepVerifier::create)
+				.expectNext(1)
+				.verifyComplete();
+
+		Span span = tracer.currentSpan();
+		then(span.context().spanId()).isEqualTo(rootSpan.context().spanId());
+
+		databaseClient.sql("SELECT id FROM legoset")
+				.map(row -> row.get("id"))
+				.first()
+				.as(StepVerifier::create)
+				.assertNext(actual -> {
+					assertThat(actual).isInstanceOf(Number.class);
+					assertThat(((Number) actual).intValue()).isEqualTo(42055);
+				}).verifyComplete();
+
+		span = tracer.currentSpan();
+		then(span.context().spanId()).isEqualTo(rootSpan.context().spanId());
+	}
+}

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerMetricsUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerMetricsUnitTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import io.micrometer.api.instrument.MeterRegistry;
+import io.micrometer.api.instrument.Tag;
+import io.micrometer.api.instrument.Tags;
+import io.micrometer.api.instrument.observation.Observation;
+import io.micrometer.api.instrument.simple.SimpleMeterRegistry;
+import io.r2dbc.proxy.core.QueryExecutionInfo;
+import io.r2dbc.proxy.core.QueryInfo;
+import io.r2dbc.proxy.test.MockQueryExecutionInfo;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.r2dbc.connection.SingleConnectionFactory;
+
+import static io.micrometer.core.tck.MeterRegistryAssert.then;
+
+class ObservationProxyExecutionListenerMetricsUnitTests {
+
+	@Test
+	void shouldNotCreateObservationsForR2dbcWhenThereIsNoObservation() {
+		MeterRegistry registry = registry();
+		SingleConnectionFactory factory = singleConnectionFactory();
+		ObservationProxyExecutionListener listener = new ObservationProxyExecutionListener(registry, factory, "hello");
+
+		listener.beforeQuery(MockQueryExecutionInfo.builder().build());
+		listener.afterQuery(MockQueryExecutionInfo.builder().build());
+
+		thenNothingHappened(registry);
+	}
+
+	void thenNothingHappened(MeterRegistry registry) {
+		then(registry).hasNoMetrics();
+	}
+
+	@Test
+	void shouldCreateObservationsForR2dbc() {
+		MeterRegistry registry = registry();
+		SingleConnectionFactory factory = singleConnectionFactory();
+		QueryExecutionInfo queryExecutionInfo = queryExecutionInfo().build();
+		ObservationProxyExecutionListener listener = listener(registry, factory);
+
+		runBeforeAndAfterQuery(registry, listener, queryExecutionInfo);
+
+		thenObservabilityGotApplied(registry);
+	}
+
+	void thenObservabilityGotApplied(MeterRegistry registry) {
+		then(registry).hasTimerWithNameAndTags(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getName(), Tags.of(
+				Tag.of("additional.tag", "bar"),
+				R2dbcObservation.LowCardinalityTags.BEAN_NAME.of("hello"),
+				R2dbcObservation.LowCardinalityTags.CONNECTION.of("H2"),
+				R2dbcObservation.LowCardinalityTags.THREAD.of("test-thread"),
+				R2dbcObservation.LowCardinalityTags.URL.of("http://localhost:6543"),
+				Tag.of("error", "none")
+		));
+	}
+
+	@Test
+	void shouldCreateObservationsForR2dbcWithError() {
+		MeterRegistry registry = registry();
+		SingleConnectionFactory factory = singleConnectionFactory();
+		QueryExecutionInfo queryExecutionInfo = queryExecutionInfo().throwable(new RuntimeException("Boom!")).build();
+		ObservationProxyExecutionListener listener = listener(registry, factory);
+
+		runBeforeAndAfterQuery(registry, listener, queryExecutionInfo);
+
+		thenObservabilityGotAppliedWithException(registry);
+	}
+
+	void thenObservabilityGotAppliedWithException(MeterRegistry registry) {
+		then(registry).hasTimerWithNameAndTags(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getName(), Tags.of(
+				Tag.of("additional.tag", "bar"),
+				R2dbcObservation.LowCardinalityTags.BEAN_NAME.of("hello"),
+				R2dbcObservation.LowCardinalityTags.CONNECTION.of("H2"),
+				R2dbcObservation.LowCardinalityTags.THREAD.of("test-thread"),
+				R2dbcObservation.LowCardinalityTags.URL.of("http://localhost:6543"),
+				Tag.of("error", "Boom!")
+		));
+	}
+
+	private SingleConnectionFactory singleConnectionFactory() {
+		return new SingleConnectionFactory("r2dbc:h2:mem:///foo", false);
+	}
+
+	private void runBeforeAndAfterQuery(MeterRegistry registry, ObservationProxyExecutionListener listener, QueryExecutionInfo queryExecutionInfo) {
+		Observation.createNotStarted("test", registry).scoped(() -> {
+			listener.beforeQuery(queryExecutionInfo);
+			assertStateAfterBeforeQuery();
+			listener.afterQuery(queryExecutionInfo);
+			assertStateAfterAfterQuery();
+		});
+	}
+
+	void assertStateAfterBeforeQuery() {
+
+	}
+
+	void assertStateAfterAfterQuery() {
+
+	}
+
+	private MockQueryExecutionInfo.Builder queryExecutionInfo() {
+		return MockQueryExecutionInfo.builder()
+				.threadName("test-thread")
+				.queryInfo(new QueryInfo("foo"));
+	}
+
+	private ObservationProxyExecutionListener listener(MeterRegistry registry, SingleConnectionFactory factory) {
+		return new ObservationProxyExecutionListener(registry, factory, "hello",
+				new Observation.TagsProvider<>() {
+					@Override
+					public boolean supportsContext(Observation.Context context) {
+						return true;
+					}
+
+					@Override
+					public Tags getLowCardinalityTags(Observation.Context context) {
+						return Tags.of(Tag.of("additional.tag", "bar"), R2dbcObservation.LowCardinalityTags.URL.of("http://localhost:6543"));
+					}
+				});
+	}
+
+	MeterRegistry registry() {
+		return new SimpleMeterRegistry().withTimerObservationHandler();
+	}
+}

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerMetricsUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerMetricsUnitTests.java
@@ -122,21 +122,22 @@ class ObservationProxyExecutionListenerMetricsUnitTests {
 	}
 
 	private ObservationProxyExecutionListener listener(MeterRegistry registry, SingleConnectionFactory factory) {
-		return new ObservationProxyExecutionListener(registry, factory, "hello",
-				new Observation.TagsProvider<>() {
-					@Override
-					public boolean supportsContext(Observation.Context context) {
-						return true;
-					}
-
-					@Override
-					public Tags getLowCardinalityTags(Observation.Context context) {
-						return Tags.of(Tag.of("additional.tag", "bar"), R2dbcObservation.LowCardinalityTags.URL.of("http://localhost:6543"));
-					}
-				});
+		return new ObservationProxyExecutionListener(registry, factory, "hello");
 	}
 
 	MeterRegistry registry() {
-		return new SimpleMeterRegistry().withTimerObservationHandler();
+		MeterRegistry meterRegistry = new SimpleMeterRegistry().withTimerObservationHandler();
+		meterRegistry.observationConfig().tagsProvider(new Observation.TagsProvider<>() {
+			@Override
+			public boolean supportsContext(Observation.Context context) {
+				return true;
+			}
+
+			@Override
+			public Tags getLowCardinalityTags(Observation.Context context) {
+				return Tags.of(Tag.of("additional.tag", "bar"), R2dbcObservation.LowCardinalityTags.URL.of("http://localhost:6543"));
+			}
+		});
+		return meterRegistry;
 	}
 }

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerMetricsUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerMetricsUnitTests.java
@@ -122,7 +122,14 @@ class ObservationProxyExecutionListenerMetricsUnitTests {
 	}
 
 	private ObservationProxyExecutionListener listener(MeterRegistry registry, SingleConnectionFactory factory) {
-		return new ObservationProxyExecutionListener(registry, factory, "hello");
+		ObservationProxyExecutionListener listener =  new ObservationProxyExecutionListener(registry, factory, "hello");
+		listener.setTagsProvider(new DefaultR2dbcTagsProvider() {
+			@Override
+			public Tags getLowCardinalityTags(R2dbcContext context) {
+				return super.getLowCardinalityTags(context).and(R2dbcObservation.LowCardinalityTags.URL.of("http://localhost:6543"));
+			}
+		});
+		return listener;
 	}
 
 	MeterRegistry registry() {
@@ -135,7 +142,7 @@ class ObservationProxyExecutionListenerMetricsUnitTests {
 
 			@Override
 			public Tags getLowCardinalityTags(Observation.Context context) {
-				return Tags.of(Tag.of("additional.tag", "bar"), R2dbcObservation.LowCardinalityTags.URL.of("http://localhost:6543"));
+				return Tags.of(Tag.of("additional.tag", "bar"));
 			}
 		});
 		return meterRegistry;

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerTracingUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/observability/ObservationProxyExecutionListenerTracingUnitTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.r2dbc.connection.observability;
+
+import io.micrometer.api.instrument.MeterRegistry;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import io.micrometer.tracing.test.simple.SpanAssert;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class ObservationProxyExecutionListenerTracingUnitTests extends ObservationProxyExecutionListenerMetricsUnitTests {
+
+	SimpleTracer tracer = new SimpleTracer();
+
+	@Override
+	void thenNothingHappened(MeterRegistry registry) {
+		then(tracer.getSpans()).isEmpty();
+	}
+
+	@Override
+	void thenObservabilityGotApplied(MeterRegistry registry) {
+		thenASingleSpanSet();
+	}
+
+	@Override
+	void assertStateAfterBeforeQuery() {
+		then(tracer.currentSpan()).isNotNull();
+	}
+	@Override
+	void assertStateAfterAfterQuery() {
+		then(tracer.currentSpan()).isNull();
+	}
+
+	private SpanAssert thenASingleSpanSet() {
+		return SpanAssert.then(tracer.onlySpan())
+				.hasRemoteServiceNameEqualTo("H2")
+				.hasNameEqualTo(R2dbcObservation.R2DBC_QUERY_OBSERVATION.getContextualName())
+				.hasTag("additional.tag", "bar")
+				.hasTag(R2dbcObservation.LowCardinalityTags.CONNECTION.getKey(), "H2")
+				.hasTag(R2dbcObservation.LowCardinalityTags.THREAD.getKey(), "test-thread")
+				.hasTag(R2dbcObservation.LowCardinalityTags.URL.getKey(), "http://localhost:6543")
+				.hasTag(R2dbcObservation.LowCardinalityTags.BEAN_NAME.getKey(), "hello")
+				.hasTag(String.format(R2dbcObservation.HighCardinalityTags.QUERY.getKey(), "0"), "foo")
+				.hasIpEqualTo("localhost")
+				.hasPortThatIsSet()
+				.hasKindEqualTo(Span.Kind.CLIENT);
+	}
+
+	@Override
+	void thenObservabilityGotAppliedWithException(MeterRegistry registry) {
+		thenASingleSpanSet()
+				.thenThrowable()
+				.isInstanceOf(RuntimeException.class)
+				.hasMessage("Boom!");
+	}
+
+	@Override
+	MeterRegistry registry() {
+		MeterRegistry meterRegistry = super.registry();
+		meterRegistry.observationConfig().observationHandler(new R2dbcObservationTracingHandler(this.tracer));
+		return meterRegistry;
+	}
+}


### PR DESCRIPTION
# What is it about?

Adds observation support for R2DBC.

- adds micrometer BOM
- adds micrometer tracing BOM
- adds micrometer & micrometer tracing optional deps to R2DBC module
- adds tracing support for R2DBC (metrics come out of the box)

# To discuss

- I have left a commented out section in the listener where in Sleuth we needed to check if the context is ready. The listener might be called early in the lifecycle of Spring and certain beans might not have been initialized (micrometer or tracing related ones)
- I would like to add the automated asciidoctor documentation generation from sources (check [this project out](https://github.com/micrometer-metrics/micrometer-docs))
- I've a test annotated as `@Disabled` that is typically used for manual assertion of spans in Zipkin or Wavefront. Do we want to leave it there in the code or are there some dedicated samples that we can reuse for that?

cc @mp911de 