### PR TITLE
Support "*" catch-all mappings for MockMvc Filter registrations

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/setup/PatternMappingFilterProxy.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/setup/PatternMappingFilterProxy.java
@@ -41,9 +41,11 @@ import org.springframework.web.util.UrlPathHelper;
  */
 final class PatternMappingFilterProxy implements Filter {
 
-	private static final String EXTENSION_MAPPING_PATTERN = "*.";
+	private static final String ALL_MAPPING_PATTERN = "*";
 
-	private static final String PATH_MAPPING_PATTERN = "/*";
+	private static final String EXTENSION_MAPPING_PATTERN = ALL_MAPPING_PATTERN + ".";
+
+	private static final String PATH_MAPPING_PATTERN = "/" + ALL_MAPPING_PATTERN;
 
 	private final Filter delegate;
 
@@ -73,7 +75,7 @@ final class PatternMappingFilterProxy implements Filter {
 		if (urlPattern.startsWith(EXTENSION_MAPPING_PATTERN)) {
 			this.endsWithMatches.add(urlPattern.substring(1));
 		}
-		else if (urlPattern.equals(PATH_MAPPING_PATTERN)) {
+		else if (urlPattern.equals(PATH_MAPPING_PATTERN) || urlPattern.equals(ALL_MAPPING_PATTERN)) {
 			this.startsWithMatches.add("");
 		}
 		else if (urlPattern.endsWith(PATH_MAPPING_PATTERN)) {

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/setup/ConditionalDelegatingFilterProxyTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/setup/ConditionalDelegatingFilterProxyTests.java
@@ -93,7 +93,7 @@ public class ConditionalDelegatingFilterProxyTests {
 
 	@Test
 	public void matchPathMappingAll() throws Exception {
-		assertFilterInvoked("/test", "/*");
+		assertFilterInvoked("/test", "*");
 	}
 
 	@Test


### PR DESCRIPTION
I believe most business developers think * is equivalent to /*

fixes #28017 