### PR TITLE
Support parse placeholder in beanName

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -953,7 +953,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 
 		Assert.hasText(beanName, "Bean name must not be empty");
 		Assert.notNull(beanDefinition, "BeanDefinition must not be null");
-
+		beanName = resolveEmbeddedValue(beanName);
 		if (beanDefinition instanceof AbstractBeanDefinition abd) {
 			try {
 				abd.validate();

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -953,7 +953,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 
 		Assert.hasText(beanName, "Bean name must not be empty");
 		Assert.notNull(beanDefinition, "BeanDefinition must not be null");
-		beanName = resolveEmbeddedValue(beanName);
+
 		if (beanDefinition instanceof AbstractBeanDefinition abd) {
 			try {
 				abd.validate();

--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/BeanDefinitionParserDelegate.java
@@ -413,7 +413,7 @@ public class BeanDefinitionParserDelegate {
 	@Nullable
 	public BeanDefinitionHolder parseBeanDefinitionElement(Element ele, @Nullable BeanDefinition containingBean) {
 		String id = ele.getAttribute(ID_ATTRIBUTE);
-		String nameAttr = ele.getAttribute(NAME_ATTRIBUTE);
+		String nameAttr = getReaderContext().getEnvironment().resolvePlaceholders(ele.getAttribute(NAME_ATTRIBUTE));
 
 		List<String> aliases = new ArrayList<>();
 		if (StringUtils.hasLength(nameAttr)) {
@@ -778,7 +778,7 @@ public class BeanDefinitionParserDelegate {
 	public void parseConstructorArgElement(Element ele, BeanDefinition bd) {
 		String indexAttr = ele.getAttribute(INDEX_ATTRIBUTE);
 		String typeAttr = ele.getAttribute(TYPE_ATTRIBUTE);
-		String nameAttr = ele.getAttribute(NAME_ATTRIBUTE);
+		String nameAttr = getReaderContext().getEnvironment().resolvePlaceholders(ele.getAttribute(NAME_ATTRIBUTE));
 		if (StringUtils.hasLength(indexAttr)) {
 			try {
 				int index = Integer.parseInt(indexAttr);

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReaderTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReaderTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.beans.factory.xml;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -108,14 +109,17 @@ public class XmlBeanDefinitionReaderTests {
 	}
 
 	private void testBeanDefinitions(BeanDefinitionRegistry registry) {
-		assertThat(registry.getBeanDefinitionCount()).isEqualTo(24);
-		assertThat(registry.getBeanDefinitionNames().length).isEqualTo(24);
+		assertThat(registry.getBeanDefinitionCount()).isEqualTo(25);
+		assertThat(registry.getBeanDefinitionNames().length).isEqualTo(25);
 		assertThat(Arrays.asList(registry.getBeanDefinitionNames()).contains("rod")).isTrue();
 		assertThat(Arrays.asList(registry.getBeanDefinitionNames()).contains("aliased")).isTrue();
+		assertThat(Arrays.asList(registry.getBeanDefinitionNames()).contains("testList")).isTrue();
 		assertThat(registry.containsBeanDefinition("rod")).isTrue();
 		assertThat(registry.containsBeanDefinition("aliased")).isTrue();
+		assertThat(registry.containsBeanDefinition("testList")).isTrue();
 		assertThat(registry.getBeanDefinition("rod").getBeanClassName()).isEqualTo(TestBean.class.getName());
 		assertThat(registry.getBeanDefinition("aliased").getBeanClassName()).isEqualTo(TestBean.class.getName());
+		assertThat(registry.getBeanDefinition("testList").getBeanClassName()).isEqualTo(ArrayList.class.getName());
 		assertThat(registry.isAlias("youralias")).isTrue();
 		String[] aliases = registry.getAliases("aliased");
 		assertThat(aliases.length).isEqualTo(2);

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/XmlListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/XmlListableBeanFactoryTests.java
@@ -101,7 +101,7 @@ public class XmlListableBeanFactoryTests extends AbstractListableBeanFactoryTest
 	@Test
 	@Override
 	public void count() {
-		assertCount(24);
+		assertCount(25);
 	}
 
 	@Test

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/test.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/test.xml
@@ -16,6 +16,8 @@
 		<property name="name"><value>aliased</value></property>
 	</bean>
 
+	<bean class="java.util.ArrayList" name="${listName:testList}"/>
+
 	<alias name="aliased" alias="youralias"/>
 
 	<alias name="multiAliased" alias="alias3"/>


### PR DESCRIPTION
I'm not sure if there is a more elegant way to deal with it. If this proposal can be adopted, I hope you can give me more advice
I can confirm that the following problems exist
`     <bean name="${bean.name:product}" class="icu.funkye.entity.Product"></bean>`
bean name=${bean.name:product} Instead of product or bean.name=xxxx

I would like to be able to support placeholder resolution beanname

fixes #27224 