### PR TITLE
Upgrade client support to R2DBC 0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -346,7 +346,7 @@ configure([rootProject] + javaProjects) { project ->
 			// "https://junit.org/junit5/docs/5.8.2/api/",
 			"https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
 			"https://javadoc.io/static/io.rsocket/rsocket-core/1.1.1/",
-			"https://r2dbc.io/spec/0.8.5.RELEASE/api/",
+			"https://r2dbc.io/spec/0.9.1.RELEASE/api/",
 			// The external Javadoc link for JSR 305 must come last to ensure that types from
 			// JSR 250 (such as @PostConstruct) are still supported. This is due to the fact
 			// that JSR 250 and JSR 305 both define types in javax.annotation, which results

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/BindParameterSource.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/BindParameterSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.r2dbc.core;
 
-import org.springframework.lang.Nullable;
+import io.r2dbc.spi.Parameter;
 
 /**
  * Interface that defines common functionality for objects
@@ -44,24 +44,13 @@ interface BindParameterSource {
 	boolean hasValue(String paramName);
 
 	/**
-	 * Return the parameter value for the requested named parameter.
+	 * Return the parameter for the requested named parameter.
 	 * @param paramName the name of the parameter
-	 * @return the value of the specified parameter (can be {@code null})
+	 * @return the specified parameter
 	 * @throws IllegalArgumentException if there is no value
 	 * for the requested parameter
 	 */
-	@Nullable
-	Object getValue(String paramName) throws IllegalArgumentException;
-
-	/**
-	 * Determine the type for the specified named parameter.
-	 * @param paramName the name of the parameter
-	 * @return the type of the specified parameter, or
-	 * {@link Object#getClass()} if not known.
-	 */
-	default Class<?> getType(String paramName) {
-		return Object.class;
-	}
+	Parameter getValue(String paramName) throws IllegalArgumentException;
 
 	/**
 	 * Return the parameter names of the underlying parameter source.

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/ColumnMapRowMapper.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/ColumnMapRowMapper.java
@@ -16,7 +16,7 @@
 
 package org.springframework.r2dbc.core;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -55,12 +55,12 @@ public class ColumnMapRowMapper implements BiFunction<Row, RowMetadata, Map<Stri
 	@SuppressWarnings("deprecation")  // getColumnNames() is deprecated as of R2DBC 0.9
 	@Override
 	public Map<String, Object> apply(Row row, RowMetadata rowMetadata) {
-		Collection<String> columns = rowMetadata.getColumnNames();
+		List<? extends ColumnMetadata> columns = rowMetadata.getColumnMetadatas();
 		int columnCount = columns.size();
 		Map<String, Object> mapOfColValues = createColumnMap(columnCount);
 		int index = 0;
-		for (String column : columns) {
-			String key = getColumnKey(column);
+		for (ColumnMetadata column : columns) {
+			String key = getColumnKey(column.getName());
 			Object obj = getColumnValue(row, index++);
 			mapOfColValues.put(key, obj);
 		}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,17 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Readable;
+import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
 import io.r2dbc.spi.Statement;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.r2dbc.core.binding.BindMarkersFactory;
@@ -157,9 +162,9 @@ public interface DatabaseClient extends ConnectionAccessor {
 
 		/**
 		 * Bind a non-{@code null} value to a parameter identified by its
-		 * {@code index}. {@code value} can be either a scalar value or {@link Parameter}.
+		 * {@code index}. {@code value} can be either a scalar value or {@link io.r2dbc.spi.Parameter}.
 		 * @param index zero based index to bind the parameter to
-		 * @param value either a scalar value or {@link Parameter}
+		 * @param value either a scalar value or {@link io.r2dbc.spi.Parameter}
 		 */
 		GenericExecuteSpec bind(int index, Object value);
 
@@ -213,14 +218,12 @@ public interface DatabaseClient extends ConnectionAccessor {
 
 		/**
 		 * Configure a result mapping {@link Function function} and enter the execution stage.
-		 * @param mappingFunction a function that maps from {@link Row} to the result type
+		 * @param mappingFunction a function that maps from {@link Readable} to the result type
 		 * @param <R> the result type
 		 * @return a {@link FetchSpec} for configuration what to fetch
+		 * @since 6.0
 		 */
-		default <R> RowsFetchSpec<R> map(Function<Row, R> mappingFunction) {
-			Assert.notNull(mappingFunction, "Mapping function must not be null");
-			return map((row, rowMetadata) -> mappingFunction.apply(row));
-		}
+		<R> RowsFetchSpec<R> map(Function<? super Readable, R> mappingFunction);
 
 		/**
 		 * Configure a result mapping {@link BiFunction function} and enter the execution stage.
@@ -230,6 +233,17 @@ public interface DatabaseClient extends ConnectionAccessor {
 		 * @return a {@link FetchSpec} for configuration what to fetch
 		 */
 		<R> RowsFetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
+
+		/**
+		 * Perform the SQL call and apply {@link BiFunction function} to the {@link  Result}.
+		 * @param mappingFunction a function that maps from {@link Result} into a result publisher
+		 * @param <R> the result type
+		 * @return a {@link Flux} emitting mapped elements
+		 * @since 6.0
+		 * @see Result#filter(Predicate)
+		 * @see Result#flatMap(Function)
+		 */
+		<R> Flux<R> flatMap(Function<Result, Publisher<R>> mappingFunction);
 
 		/**
 		 * Perform the SQL call and retrieve the result by entering the execution stage.

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,10 @@ import java.util.stream.Collectors;
 
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Parameter;
+import io.r2dbc.spi.Parameters;
 import io.r2dbc.spi.R2dbcException;
+import io.r2dbc.spi.Readable;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
@@ -188,11 +191,12 @@ class DefaultDatabaseClient implements DatabaseClient {
 				new CloseSuppressingInvocationHandler(con));
 	}
 
-	private static Mono<Integer> sumRowsUpdated(
+	private static Mono<Long> sumRowsUpdated(
 			Function<Connection, Flux<Result>> resultFunction, Connection it) {
 		return resultFunction.apply(it)
 				.flatMap(Result::getRowsUpdated)
-				.collect(Collectors.summingInt(Integer::intValue));
+				.cast(Number.class)
+				.collect(Collectors.summingLong(Number::longValue));
 	}
 
 	/**
@@ -243,17 +247,21 @@ class DefaultDatabaseClient implements DatabaseClient {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public DefaultGenericExecuteSpec bind(int index, Object value) {
 			assertNotPreparedOperation();
 			Assert.notNull(value, () -> String.format(
 					"Value at index %d must not be null. Use bindNull(…) instead.", index));
 
 			Map<Integer, Parameter> byIndex = new LinkedHashMap<>(this.byIndex);
-			if (value instanceof Parameter) {
-				byIndex.put(index, (Parameter) value);
+			if (value instanceof Parameter p) {
+				byIndex.put(index, p);
+			}
+			else if (value instanceof org.springframework.r2dbc.core.Parameter p) {
+				byIndex.put(index, p.hasValue() ? Parameters.in(p.getValue()) : Parameters.in(p.getType()));
 			}
 			else {
-				byIndex.put(index, Parameter.fromOrEmpty(value, value.getClass()));
+				byIndex.put(index, Parameters.in(value));
 			}
 
 			return new DefaultGenericExecuteSpec(byIndex, this.byName, this.sqlSupplier, this.filterFunction);
@@ -264,12 +272,13 @@ class DefaultDatabaseClient implements DatabaseClient {
 			assertNotPreparedOperation();
 
 			Map<Integer, Parameter> byIndex = new LinkedHashMap<>(this.byIndex);
-			byIndex.put(index, Parameter.empty(type));
+			byIndex.put(index, Parameters.in(type));
 
 			return new DefaultGenericExecuteSpec(byIndex, this.byName, this.sqlSupplier, this.filterFunction);
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public DefaultGenericExecuteSpec bind(String name, Object value) {
 			assertNotPreparedOperation();
 
@@ -278,11 +287,14 @@ class DefaultDatabaseClient implements DatabaseClient {
 					"Value for parameter %s must not be null. Use bindNull(…) instead.", name));
 
 			Map<String, Parameter> byName = new LinkedHashMap<>(this.byName);
-			if (value instanceof Parameter) {
-				byName.put(name, (Parameter) value);
+			if (value instanceof Parameter p) {
+				byName.put(name, p);
+			}
+			else if (value instanceof org.springframework.r2dbc.core.Parameter p) {
+				byName.put(name, p.hasValue() ? Parameters.in(p.getValue()) : Parameters.in(p.getType()));
 			}
 			else {
-				byName.put(name, Parameter.fromOrEmpty(value, value.getClass()));
+				byName.put(name, Parameters.in(value));
 			}
 
 			return new DefaultGenericExecuteSpec(this.byIndex, byName, this.sqlSupplier, this.filterFunction);
@@ -294,7 +306,7 @@ class DefaultDatabaseClient implements DatabaseClient {
 			Assert.hasText(name, "Parameter name must not be null or empty!");
 
 			Map<String, Parameter> byName = new LinkedHashMap<>(this.byName);
-			byName.put(name, Parameter.empty(type));
+			byName.put(name, Parameters.in(type));
 
 			return new DefaultGenericExecuteSpec(this.byIndex, byName, this.sqlSupplier, this.filterFunction);
 		}
@@ -307,14 +319,26 @@ class DefaultDatabaseClient implements DatabaseClient {
 		}
 
 		@Override
+		public <R> FetchSpec<R> map(Function<? super Readable, R> mappingFunction) {
+			Assert.notNull(mappingFunction, "Mapping function must not be null");
+			return execute(this.sqlSupplier, result -> result.map(mappingFunction));
+		}
+
+		@Override
 		public <R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction) {
 			Assert.notNull(mappingFunction, "Mapping function must not be null");
-			return execute(this.sqlSupplier, mappingFunction);
+			return execute(this.sqlSupplier, result -> result.map(mappingFunction));
+		}
+
+		@Override
+		public <R> Flux<R> flatMap(Function<Result, Publisher<R>> mappingFunction) {
+			Assert.notNull(mappingFunction, "Mapping function must not be null");
+			return flatMap(this.sqlSupplier, mappingFunction);
 		}
 
 		@Override
 		public FetchSpec<Map<String, Object>> fetch() {
-			return execute(this.sqlSupplier, ColumnMapRowMapper.INSTANCE);
+			return execute(this.sqlSupplier, result -> result.map(ColumnMapRowMapper.INSTANCE));
 		}
 
 		@Override
@@ -322,7 +346,7 @@ class DefaultDatabaseClient implements DatabaseClient {
 			return fetch().rowsUpdated().then();
 		}
 
-		private <T> FetchSpec<T> execute(Supplier<String> sqlSupplier, BiFunction<Row, RowMetadata, T> mappingFunction) {
+		private ResultFunction getResultFunction(Supplier<String> sqlSupplier) {
 			String sql = getRequiredSql(sqlSupplier);
 			Function<Connection, Statement> statementFunction = connection -> {
 				if (logger.isDebugEnabled()) {
@@ -376,11 +400,25 @@ class DefaultDatabaseClient implements DatabaseClient {
 				.cast(Result.class).checkpoint("SQL \"" + sql + "\" [DatabaseClient]");
 			};
 
+			return new ResultFunction(resultFunction, sql);
+		}
+
+		private <T> FetchSpec<T> execute(Supplier<String> sqlSupplier, Function<Result, Publisher<T>> resultAdapter) {
+			ResultFunction resultHandler = getResultFunction(sqlSupplier);
+
 			return new DefaultFetchSpec<>(
-					DefaultDatabaseClient.this, sql,
-					new ConnectionFunction<>(sql, resultFunction),
-					new ConnectionFunction<>(sql, connection -> sumRowsUpdated(resultFunction, connection)),
-					mappingFunction);
+					DefaultDatabaseClient.this, resultHandler.sql(),
+					new ConnectionFunction<>(resultHandler.sql(), resultHandler.function()),
+					new ConnectionFunction<>(resultHandler.sql(), connection -> sumRowsUpdated(resultHandler.function(), connection)),
+					resultAdapter);
+		}
+
+		private <T> Flux<T> flatMap(Supplier<String> sqlSupplier, Function<Result, Publisher<T>> mappingFunction) {
+			ResultFunction resultHandler = getResultFunction(sqlSupplier);
+			ConnectionFunction<Flux<T>> connectionFunction = new ConnectionFunction<>(resultHandler.sql(), cx -> resultHandler.function()
+					.apply(cx)
+					.flatMap(mappingFunction));
+			return inConnectionMany(connectionFunction);
 		}
 
 		private MapBindParameterSource retrieveParameters(String sql, List<String> parameterNames,
@@ -424,27 +462,11 @@ class DefaultDatabaseClient implements DatabaseClient {
 		}
 
 		private void bindByName(Statement statement, Map<String, Parameter> byName) {
-			byName.forEach((name, parameter) -> {
-				Object value = parameter.getValue();
-				if (value != null) {
-					statement.bind(name, value);
-				}
-				else {
-					statement.bindNull(name, parameter.getType());
-				}
-			});
+			byName.forEach(statement::bind);
 		}
 
 		private void bindByIndex(Statement statement, Map<Integer, Parameter> byIndex) {
-			byIndex.forEach((i, parameter) -> {
-				Object value = parameter.getValue();
-				if (value != null) {
-					statement.bind(i, value);
-				}
-				else {
-					statement.bindNull(i, parameter.getType());
-				}
-			});
+			byIndex.forEach(statement::bind);
 		}
 
 		private String getRequiredSql(Supplier<String> sqlSupplier) {
@@ -452,6 +474,9 @@ class DefaultDatabaseClient implements DatabaseClient {
 			Assert.state(StringUtils.hasText(sql), "SQL returned by SQL supplier must not be empty!");
 			return sql;
 		}
+
+		record ResultFunction(Function<Connection, Flux<Result>> function, String sql){}
+
 	}
 
 

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/MapBindParameterSource.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/MapBindParameterSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.r2dbc.core;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import io.r2dbc.spi.Parameter;
+import io.r2dbc.spi.Parameters;
 
 import org.springframework.util.Assert;
 
@@ -61,7 +64,7 @@ class MapBindParameterSource implements BindParameterSource {
 	MapBindParameterSource addValue(String paramName, Object value) {
 		Assert.notNull(paramName, "Parameter name must not be null");
 		Assert.notNull(value, "Value must not be null");
-		this.values.put(paramName, Parameter.fromOrEmpty(value, value.getClass()));
+		this.values.put(paramName, Parameters.in(value));
 		return this;
 	}
 
@@ -72,21 +75,11 @@ class MapBindParameterSource implements BindParameterSource {
 	}
 
 	@Override
-	public Class<?> getType(String paramName) {
-		Assert.notNull(paramName, "Parameter name must not be null");
-		Parameter parameter = this.values.get(paramName);
-		if (parameter != null) {
-			return parameter.getType();
-		}
-		return Object.class;
-	}
-
-	@Override
-	public Object getValue(String paramName) throws IllegalArgumentException {
+	public Parameter getValue(String paramName) throws IllegalArgumentException {
 		if (!hasValue(paramName)) {
 			throw new IllegalArgumentException("No value registered for key '" + paramName + "'");
 		}
-		return this.values.get(paramName).getValue();
+		return this.values.get(paramName);
 	}
 
 	@Override

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/Parameter.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ import org.springframework.util.ObjectUtils;
  * @author Mark Paluch
  * @author Juergen Hoeller
  * @since 5.3
+ * @deprecated since 6.0, use {@code io.r2dbc.spi.Parameter} instead.
  */
+@Deprecated(since = "6.0")
 public final class Parameter {
 
 	@Nullable

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/UpdatedRowsFetchSpec.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/UpdatedRowsFetchSpec.java
@@ -30,6 +30,6 @@ public interface UpdatedRowsFetchSpec {
 	 * Get the number of updated rows.
 	 * @return a Mono emitting the number of updated rows
 	 */
-	Mono<Integer> rowsUpdated();
+	Mono<Long> rowsUpdated();
 
 }

--- a/spring-r2dbc/src/main/kotlin/org/springframework/r2dbc/core/DatabaseClientExtensions.kt
+++ b/spring-r2dbc/src/main/kotlin/org/springframework/r2dbc/core/DatabaseClientExtensions.kt
@@ -16,6 +16,7 @@
 
 package org.springframework.r2dbc.core
 
+import io.r2dbc.spi.Parameters
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 
 /**
@@ -35,7 +36,7 @@ suspend fun DatabaseClient.GenericExecuteSpec.await() {
  * @author Ibanga Enoobong Ime
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-inline fun <reified T : Any> DatabaseClient.GenericExecuteSpec.bind(index: Int, value: T?) = bind(index, Parameter.fromOrEmpty(value, T::class.java))
+inline fun <reified T : Any> DatabaseClient.GenericExecuteSpec.bind(index: Int, value: T?) = bind(index, if (value != null) Parameters.`in`(value) else Parameters.`in`(T::class.java))
 
 /**
  * Extension for [DatabaseClient.GenericExecuteSpec.bind] providing a variant leveraging reified type parameters
@@ -44,4 +45,4 @@ inline fun <reified T : Any> DatabaseClient.GenericExecuteSpec.bind(index: Int, 
  * @author Ibanga Enoobong Ime
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-inline fun <reified T : Any> DatabaseClient.GenericExecuteSpec.bind(name: String, value: T?) = bind(name, Parameter.fromOrEmpty(value, T::class.java))
+inline fun <reified T : Any> DatabaseClient.GenericExecuteSpec.bind(name: String, value: T?) = bind(name, if (value != null) Parameters.`in`(value) else Parameters.`in`(T::class.java))

--- a/spring-r2dbc/src/main/kotlin/org/springframework/r2dbc/core/UpdatedRowsFetchSpecExtensions.kt
+++ b/spring-r2dbc/src/main/kotlin/org/springframework/r2dbc/core/UpdatedRowsFetchSpecExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,5 +23,5 @@ import kotlinx.coroutines.reactive.awaitSingle
  *
  * @author Fred Montariol
  */
-suspend fun UpdatedRowsFetchSpec.awaitRowsUpdated(): Int =
+suspend fun UpdatedRowsFetchSpec.awaitRowsUpdated(): Long =
 		rowsUpdated().awaitSingle()

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/TransactionAwareConnectionFactoryProxyUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/TransactionAwareConnectionFactoryProxyUnitTests.java
@@ -23,6 +23,7 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Wrapped;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -130,7 +131,7 @@ class TransactionAwareConnectionFactoryProxyUnitTests {
 
 	@Test
 	void shouldEmitBoundConnection() {
-		when(connectionMock1.beginTransaction()).thenReturn(Mono.empty());
+		when(connectionMock1.beginTransaction(ArgumentMatchers.any())).thenReturn(Mono.empty());
 		when(connectionMock1.commitTransaction()).thenReturn(Mono.empty());
 		when(connectionMock1.close()).thenReturn(Mono.empty());
 

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractDatabaseClientIntegrationTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractDatabaseClientIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public abstract class AbstractDatabaseClientIntegrationTests {
 				.bindNull("manual", Integer.class)
 				.fetch().rowsUpdated()
 				.as(StepVerifier::create)
-				.expectNext(1)
+				.expectNext(1L)
 				.verifyComplete();
 
 		databaseClient.sql("SELECT id FROM legoset")
@@ -123,7 +123,7 @@ public abstract class AbstractDatabaseClientIntegrationTests {
 				.bindNull("manual", Integer.class)
 				.fetch().rowsUpdated()
 				.as(StepVerifier::create)
-				.expectNext(1)
+				.expectNext(1L)
 				.verifyComplete();
 
 		databaseClient.sql("SELECT id FROM legoset")

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractTransactionalDatabaseClientIntegrationTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/AbstractTransactionalDatabaseClientIntegrationTests.java
@@ -109,15 +109,15 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests  {
 
 	@Test
 	public void executeInsertInTransaction() {
-		Flux<Integer> integerFlux = databaseClient
+		Flux<Long> longFlux = databaseClient
 				.sql(getInsertIntoLegosetStatement())
 				.bind(0, 42055)
 				.bind(1, "SCHAUFELRADBAGGER")
 				.bindNull(2, Integer.class)
 				.fetch().rowsUpdated().flux().as(rxtx::transactional);
 
-		integerFlux.as(StepVerifier::create)
-				.expectNext(1)
+		longFlux.as(StepVerifier::create)
+				.expectNext(1L)
 				.verifyComplete();
 
 		databaseClient

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientUnitTests.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Parameters;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.test.MockColumnMetadata;
@@ -137,12 +138,12 @@ class DefaultDatabaseClientUnitTests {
 		databaseClient.sql("SELECT * FROM table WHERE key = $1").bindNull(0,
 				String.class).then().as(StepVerifier::create).verifyComplete();
 
-		verify(statement).bindNull(0, String.class);
+		verify(statement).bind(0, Parameters.in(String.class));
 
 		databaseClient.sql("SELECT * FROM table WHERE key = $1").bindNull("$1",
 				String.class).then().as(StepVerifier::create).verifyComplete();
 
-		verify(statement).bindNull("$1", String.class);
+		verify(statement).bind("$1", Parameters.in(String.class));
 	}
 
 	@Test
@@ -155,13 +156,13 @@ class DefaultDatabaseClientUnitTests {
 				Parameter.empty(String.class)).then().as(
 						StepVerifier::create).verifyComplete();
 
-		verify(statement).bindNull(0, String.class);
+		verify(statement).bind(0, Parameters.in(String.class));
 
 		databaseClient.sql("SELECT * FROM table WHERE key = $1").bind("$1",
 				Parameter.empty(String.class)).then().as(
 						StepVerifier::create).verifyComplete();
 
-		verify(statement).bindNull("$1", String.class);
+		verify(statement).bind("$1", Parameters.in(String.class));
 	}
 
 	@Test
@@ -173,7 +174,7 @@ class DefaultDatabaseClientUnitTests {
 		databaseClient.sql("SELECT * FROM table WHERE key = :key").bindNull("key",
 				String.class).then().as(StepVerifier::create).verifyComplete();
 
-		verify(statement).bindNull(0, String.class);
+		verify(statement).bind(0, Parameters.in(String.class));
 	}
 
 	@Test
@@ -204,12 +205,12 @@ class DefaultDatabaseClientUnitTests {
 		databaseClient.sql("SELECT * FROM table WHERE key = $1").bind(0,
 				Parameter.from("foo")).then().as(StepVerifier::create).verifyComplete();
 
-		verify(statement).bind(0, "foo");
+		verify(statement).bind(0, Parameters.in("foo"));
 
 		databaseClient.sql("SELECT * FROM table WHERE key = $1").bind("$1",
 				"foo").then().as(StepVerifier::create).verifyComplete();
 
-		verify(statement).bind("$1", "foo");
+		verify(statement).bind("$1", Parameters.in("foo"));
 	}
 
 	@Test
@@ -221,7 +222,7 @@ class DefaultDatabaseClientUnitTests {
 		databaseClient.sql("SELECT * FROM table WHERE key = :key").bind("key",
 				"foo").then().as(StepVerifier::create).verifyComplete();
 
-		verify(statement).bind(0, "foo");
+		verify(statement).bind(0, Parameters.in("foo"));
 	}
 
 	@Test

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/NamedParameterUtilsUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/NamedParameterUtilsUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import io.r2dbc.spi.Parameters;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.r2dbc.core.binding.BindMarkersFactory;
@@ -294,7 +295,7 @@ public class NamedParameterUtilsUnitTests {
 
 		PreparedOperation<String> operation = NamedParameterUtils.substituteNamedParameters(
 				sql, factory, new MapBindParameterSource(
-						Collections.singletonMap("id", Parameter.from("foo"))));
+						Collections.singletonMap("id", Parameters.in("foo"))));
 
 		assertThat(operation.toQuery()).isEqualTo(
 				"SELECT * FROM person where name = $0 or lastname = $0");
@@ -307,7 +308,7 @@ public class NamedParameterUtilsUnitTests {
 			@Override
 			public void bind(int index, Object value) {
 				assertThat(index).isEqualTo(0);
-				assertThat(value).isEqualTo("foo");
+				assertThat(value).isEqualTo(Parameters.in("foo"));
 			}
 			@Override
 			public void bindNull(String identifier, Class<?> type) {
@@ -330,7 +331,7 @@ public class NamedParameterUtilsUnitTests {
 
 		PreparedOperation<String> operation = NamedParameterUtils.substituteNamedParameters(
 				sql, factory, new MapBindParameterSource(Collections.singletonMap("ids",
-						Parameter.from(Arrays.asList("foo", "bar", "baz")))));
+						Parameters.in(Arrays.asList("foo", "bar", "baz")))));
 
 		assertThat(operation.toQuery()).isEqualTo(
 				"SELECT * FROM person where name IN ($0, $1, $2) or lastname IN ($0, $1, $2)");
@@ -369,7 +370,7 @@ public class NamedParameterUtilsUnitTests {
 
 		PreparedOperation<String> operation = NamedParameterUtils.substituteNamedParameters(
 				sql, factory, new MapBindParameterSource(
-						Collections.singletonMap("id", Parameter.from("foo"))));
+						Collections.singletonMap("id", Parameters.in("foo"))));
 
 		assertThat(operation.toQuery()).isEqualTo(
 				"SELECT * FROM person where name = ? or lastname = ?");
@@ -395,7 +396,7 @@ public class NamedParameterUtilsUnitTests {
 			}
 		});
 
-		assertThat(bindValues).hasSize(2).containsEntry(0, "foo").containsEntry(1, "foo");
+		assertThat(bindValues).hasSize(2).containsEntry(0, Parameters.in("foo")).containsEntry(1, Parameters.in("foo"));
 	}
 
 	@Test
@@ -406,7 +407,7 @@ public class NamedParameterUtilsUnitTests {
 
 		PreparedOperation<String> operation = NamedParameterUtils.substituteNamedParameters(
 				sql, factory, new MapBindParameterSource(
-						Collections.singletonMap("id", Parameter.empty(String.class))));
+						Collections.singletonMap("id", Parameters.in(String.class))));
 
 		assertThat(operation.toQuery()).isEqualTo(
 				"SELECT * FROM person where name = $0 or lastname = $0");
@@ -418,7 +419,8 @@ public class NamedParameterUtilsUnitTests {
 			}
 			@Override
 			public void bind(int index, Object value) {
-				throw new UnsupportedOperationException();
+				assertThat(index).isEqualTo(0);
+				assertThat(value).isEqualTo(Parameters.in(String.class));
 			}
 			@Override
 			public void bindNull(String identifier, Class<?> type) {
@@ -426,8 +428,7 @@ public class NamedParameterUtilsUnitTests {
 			}
 			@Override
 			public void bindNull(int index, Class<?> type) {
-				assertThat(index).isEqualTo(0);
-				assertThat(type).isEqualTo(String.class);
+				throw new UnsupportedOperationException();
 			}
 		});
 	}

--- a/spring-r2dbc/src/test/kotlin/org/springframework/r2dbc/core/DatabaseClientExtensionsTests.kt
+++ b/spring-r2dbc/src/test/kotlin/org/springframework/r2dbc/core/DatabaseClientExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.r2dbc.core
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.r2dbc.spi.Parameters
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
@@ -42,7 +43,7 @@ class DatabaseClientExtensionsTests {
 		}
 
 		verify {
-			spec.bind(0, Parameter.fromOrEmpty("foo", String::class.java))
+			spec.bind(0, Parameters.`in`("foo"))
 		}
 	}
 
@@ -56,7 +57,7 @@ class DatabaseClientExtensionsTests {
 		}
 
 		verify {
-			spec.bind(0, Parameter.empty(String::class.java))
+			spec.bind(0, Parameters.`in`(String::class.java))
 		}
 	}
 
@@ -70,7 +71,7 @@ class DatabaseClientExtensionsTests {
 		}
 
 		verify {
-			spec.bind("field", Parameter.fromOrEmpty("foo", String::class.java))
+			spec.bind("field", Parameters.`in`("foo"))
 		}
 	}
 
@@ -84,7 +85,7 @@ class DatabaseClientExtensionsTests {
 		}
 
 		verify {
-			spec.bind("field", Parameter.empty(String::class.java))
+			spec.bind("field", Parameters.`in`(String::class.java))
 		}
 	}
 


### PR DESCRIPTION
* `DatabaseClient.map(…)` now a mapping `Function` for `Readable` to consume tabular and stored procedure results (via `OutParameters`). Also, `DatabaseClient.flatMap(…)` allows consuming individual segments from a response (update counts, database messages, rows, out parameters).
* `R2dbcTransactionManager` now supports extensible transaction definitions to provide all transaction attributes upon transaction start
* We use consistently R2DBC's `Parameters` instead of our own `Parameter` type. Our own `Parameter` is deprecated now.
* Switch to `Long` for update operations in preparation for R2DBC 1.0