### PR TITLE
Deprecate SerializationUtils#deserialize

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/jcache/interceptor/CacheResultInterceptor.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/jcache/interceptor/CacheResultInterceptor.java
@@ -150,7 +150,7 @@ class CacheResultInterceptor extends AbstractKeyCacheInterceptor<CacheResultOper
 	@Nullable
 	private static <T extends Throwable> T cloneException(T exception) {
 		try {
-			return (T) SerializationUtils.deserialize(SerializationUtils.serialize(exception));
+			return SerializationUtils.clone(exception);
 		}
 		catch (Exception ex) {
 			return null;  // exception parameter cannot be cloned

--- a/spring-core/src/main/java/org/springframework/util/SerializationUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/SerializationUtils.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 
 import org.springframework.lang.Nullable;
 
@@ -57,8 +58,13 @@ public abstract class SerializationUtils {
 	 * Deserialize the byte array into an object.
 	 * @param bytes a serialized object
 	 * @return the result of deserializing the bytes
+	 * @deprecated This utility uses Java's reflection, which allows arbitrary code to be
+	 * run and is known for being the source of many Remote Code Execution vulnerabilities.
+	 * <p>Prefer the use of an external tool (that serializes to JSON, XML or any other format)
+	 * which is regularly checked and updated for not allowing RCE.
 	 */
 	@Nullable
+	@Deprecated
 	public static Object deserialize(@Nullable byte[] bytes) {
 		if (bytes == null) {
 			return null;
@@ -74,4 +80,15 @@ public abstract class SerializationUtils {
 		}
 	}
 
+	/**
+	 * Clone the given object using Java's serialization.
+	 * @param object the object to clone
+	 * @param <T> the type of the object to clone
+	 * @return a clone (deep-copy) of the given object
+	 * @since 6.0.0
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends Serializable> T clone(T object) {
+		return (T) SerializationUtils.deserialize(SerializationUtils.serialize(object));
+	}
 }

--- a/spring-core/src/test/java/org/springframework/util/SerializationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/SerializationUtilsTests.java
@@ -67,4 +67,9 @@ class SerializationUtilsTests {
 		assertThat(SerializationUtils.deserialize(null)).isNull();
 	}
 
+	@Test
+	void cloneException() {
+		IllegalArgumentException ex = new IllegalArgumentException("foo");
+		assertThat(SerializationUtils.clone(ex)).hasMessage("foo").isNotSameAs(ex);
+	}
 }


### PR DESCRIPTION
As based on Java's serialization mechanism, it can be the source of Remote Code Execution vulnerabilities.

Today this utility is part of the `public` API and can be naively used to _convert_ from object to text and vice versa.
However a naive use can lead to RCE vulnerability if user-input data (like files, cookies, etc.) is transfered using this utility.

I think it should be nice to at least warn the user about the use of this tool (with `@Deprecated`) and later on remove it totally from the public API as this sole use in Spring code is to clone exceptions in `org.springframework.cache.jcache.interceptor.CacheResultInterceptor`.

I am not sure on how it can (or should) be handled.
Let me know if you need me to adapt the code of this PR.