### PR TITLE
Support dollar sign quoting and parentheses in `ScriptUtils`

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/init/ScriptUtils.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/init/ScriptUtils.java
@@ -488,18 +488,19 @@ public abstract class ScriptUtils {
 			else if (!inSingleQuote && (c == '"')) {
 				inDoubleQuote = !inDoubleQuote;
 			}
-			else if ((c == '$') && (nc != null) && (nc == '$')) {
+			else if (matchOnDollarQuote(c, nc)) {
 				inDollarQuote = !inDollarQuote;
 			}
 			else if (c == '(') {
-				brackets.push(i);
+				brackets.push(i); // open bracket
 			}
 			else if (c == ')') {
-				brackets.pop();
+				brackets.pop(); // close bracket
 			}
 
 			if (!inSingleQuote && !inDoubleQuote) {
-				if (script.startsWith(separator, i) && !inDollarQuote && brackets.isEmpty()) {
+				var notInBrackets = brackets.isEmpty();
+				if (script.startsWith(separator, i) && !inDollarQuote && notInBrackets) {
 					// We've reached the end of the current statement
 					if (sb.length() > 0) {
 						statements.add(sb.toString());
@@ -563,7 +564,12 @@ public abstract class ScriptUtils {
 
 	@Nullable
 	private static Character nextCharAt(String script, int i) {
-		return script.length() != (i + 1) ? script.charAt(i + 1) : null;
+		var nextIdx = i + 1;
+		return script.length() > nextIdx ? script.charAt(nextIdx) : null;
+	}
+
+	private static boolean matchOnDollarQuote(char current, @Nullable Character next) {
+		return current == '$' && next != null && next == '$';
 	}
 
 	private static Publisher<? extends Void> runStatement(String statement, Connection connection,

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/init/ScriptUtilsUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/init/ScriptUtilsUnitTests.java
@@ -179,6 +179,28 @@ public class ScriptUtilsUnitTests {
 		assertThat(statements).containsExactly(statement1, statement2);
 	}
 
+	@Test
+	public void readAndSplitScriptWithDollarQuoting() throws Exception {
+		String script = readScript("test-data-with-dollar-quoting.sql");
+		List<String> statements = splitSqlScript(script, ";");
+
+		String statement1 = "create function insert_emp_view() returns trigger as $$ insert into emp_audit values('D', user, old.*); $$ LANGUAGE plpgsql";
+		String statement2 = "create function update_emp_view() returns trigger as $$ update emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname; $$ LANGUAGE plpgsql";
+
+		assertThat(statements).containsExactly(statement1, statement2);
+	}
+
+	@Test
+	public void readAndSplitScriptWithRoundBrackets() throws Exception {
+		String script = readScript("test-data-with-round-brackets.sql");
+		List<String> statements = splitSqlScript(script, ";");
+
+		String statement1 = "create rule insert_emp_view as on insert to emp_view do instead ( insert into emp values(new.empname, new.salary); insert into emp_audit values('I', now(), user, new.*) )";
+		String statement2 = "create rule update_emp_view as on insert to emp_view do instead ( UPDATE emp set salary = new.salary where empname = old.empname; UPDATE emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname )";
+
+		assertThat(statements).containsExactly(statement1, statement2);
+	}
+
 	@ParameterizedTest
 	@CsvSource(delimiter = '|', quoteCharacter = '~', textBlock = """
 		# semicolon

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/init/ScriptUtilsUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/init/ScriptUtilsUnitTests.java
@@ -184,7 +184,7 @@ public class ScriptUtilsUnitTests {
 		String script = readScript("test-data-with-dollar-quoting.sql");
 		List<String> statements = splitSqlScript(script, ";");
 
-		String statement1 = "create function insert_emp_view() returns trigger as $$ insert into emp_audit values('D', user, old.*); $$ LANGUAGE plpgsql";
+		String statement1 = "create function insert_emp_view() returns trigger as $$ insert into emp_audit values('I', user, new.*); $$ LANGUAGE plpgsql";
 		String statement2 = "create function update_emp_view() returns trigger as $$ update emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname; $$ LANGUAGE plpgsql";
 
 		assertThat(statements).containsExactly(statement1, statement2);
@@ -196,7 +196,7 @@ public class ScriptUtilsUnitTests {
 		List<String> statements = splitSqlScript(script, ";");
 
 		String statement1 = "create rule insert_emp_view as on insert to emp_view do instead ( insert into emp values(new.empname, new.salary); insert into emp_audit values('I', now(), user, new.*) )";
-		String statement2 = "create rule update_emp_view as on insert to emp_view do instead ( UPDATE emp set salary = new.salary where empname = old.empname; UPDATE emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname )";
+		String statement2 = "create rule update_emp_view as on update to emp_view do instead ( update emp set salary = new.salary where empname = old.empname; update emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname )";
 
 		assertThat(statements).containsExactly(statement1, statement2);
 	}

--- a/spring-r2dbc/src/test/resources/org/springframework/r2dbc/connection/init/test-data-with-dollar-quoting.sql
+++ b/spring-r2dbc/src/test/resources/org/springframework/r2dbc/connection/init/test-data-with-dollar-quoting.sql
@@ -1,0 +1,7 @@
+create function insert_emp_view() returns trigger as $$
+    insert into emp_audit values('D', user, old.*);
+$$ LANGUAGE plpgsql;
+
+create function update_emp_view() returns trigger as $$
+    update emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname;
+$$ LANGUAGE plpgsql;

--- a/spring-r2dbc/src/test/resources/org/springframework/r2dbc/connection/init/test-data-with-dollar-quoting.sql
+++ b/spring-r2dbc/src/test/resources/org/springframework/r2dbc/connection/init/test-data-with-dollar-quoting.sql
@@ -1,5 +1,5 @@
 create function insert_emp_view() returns trigger as $$
-    insert into emp_audit values('D', user, old.*);
+    insert into emp_audit values('I', user, new.*);
 $$ LANGUAGE plpgsql;
 
 create function update_emp_view() returns trigger as $$

--- a/spring-r2dbc/src/test/resources/org/springframework/r2dbc/connection/init/test-data-with-round-brackets.sql
+++ b/spring-r2dbc/src/test/resources/org/springframework/r2dbc/connection/init/test-data-with-round-brackets.sql
@@ -1,0 +1,9 @@
+create rule insert_emp_view as on insert to emp_view do instead (
+    insert into emp values(new.empname, new.salary);
+    insert into emp_audit values('I', now(), user, new.*)
+);
+
+create rule update_emp_view as on insert to emp_view do instead (
+    UPDATE emp set salary = new.salary where empname = old.empname;
+    UPDATE emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname
+);

--- a/spring-r2dbc/src/test/resources/org/springframework/r2dbc/connection/init/test-data-with-round-brackets.sql
+++ b/spring-r2dbc/src/test/resources/org/springframework/r2dbc/connection/init/test-data-with-round-brackets.sql
@@ -3,7 +3,7 @@ create rule insert_emp_view as on insert to emp_view do instead (
     insert into emp_audit values('I', now(), user, new.*)
 );
 
-create rule update_emp_view as on insert to emp_view do instead (
-    UPDATE emp set salary = new.salary where empname = old.empname;
-    UPDATE emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname
+create rule update_emp_view as on update to emp_view do instead (
+    update emp set salary = new.salary where empname = old.empname;
+    update emp_audit set operation = 'U', stamp = now(), salary = new.salary where empname = old.empname
 );


### PR DESCRIPTION
- spring-r2dbc `ScriptUtils.splitSqlScript`: Change not to use ; character between $$ ... $$ or ( ... ) as statement separator
- [Existing Issue](https://github.com/spring-projects/spring-framework/issues/28090)
- Reopen PR with branch issue. sorry. [Existing PR](https://github.com/spring-projects/spring-framework/pull/28091)