### PR TITLE
Update Javadoc since for BeanDefinitionValueResolver

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/BeanDefinitionValueResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/BeanDefinitionValueResolver.java
@@ -57,7 +57,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Juergen Hoeller
  * @author Sam Brannen
- * @since 1.2
+ * @since 6.0
  * @see AbstractAutowireCapableBeanFactory
  */
 public class BeanDefinitionValueResolver {


### PR DESCRIPTION
This PR updates the Javadoc `@since` tag for the `BeanDefinitionValueResolver`.

See gh-28029