### PR TITLE
Fix library name for JavaPoet in src/docs/dist/license.txt

### DIFF
--- a/src/docs/dist/license.txt
+++ b/src/docs/dist/license.txt
@@ -257,16 +257,16 @@ is included above.
 
 >>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
 
-Per the LICENSE file in the CGLIB JAR distribution downloaded from
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
 https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
 JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
 which is included above.
 
 
->>> Objenesis 3.1 (org.objenesis:objenesis:3.1):
+>>> Objenesis 3.2 (org.objenesis:objenesis:3.2):
 
 Per the LICENSE file in the Objenesis ZIP distribution downloaded from
-http://objenesis.org/download.html, Objenesis 3.1 is licensed under the
+http://objenesis.org/download.html, Objenesis 3.2 is licensed under the
 Apache License, version 2.0, the text of which is included above.
 
 Per the NOTICE file in the Objenesis ZIP distribution downloaded from


### PR DESCRIPTION
This PR fixes library name for JavaPoet in `src/docs/dist/license.txt`.

This PR also updates Objenesis version in the file to align with [the version that Spring Framework is using](https://github.com/spring-projects/spring-framework/blob/main/spring-core/spring-core.gradle#L13).