### PR TITLE
Support custom HTTP status in client-side REST testing support

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/http/client/MockClientHttpResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/client/MockClientHttpResponse.java
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
  */
 public class MockClientHttpResponse extends MockHttpInputMessage implements ClientHttpResponse {
 
-	private final HttpStatus status;
+	private final Object status;
 
 
 	/**
@@ -45,6 +45,14 @@ public class MockClientHttpResponse extends MockHttpInputMessage implements Clie
 	}
 
 	/**
+	 * Constructor with response body as a byte array.
+	 */
+	public MockClientHttpResponse(byte[] body, int statusCode) {
+		super(body);
+		this.status = statusCode;
+	}
+
+	/**
 	 * Constructor with response body as InputStream.
 	 */
 	public MockClientHttpResponse(InputStream body, HttpStatus statusCode) {
@@ -53,20 +61,43 @@ public class MockClientHttpResponse extends MockHttpInputMessage implements Clie
 		this.status = statusCode;
 	}
 
+	/**
+	 * Constructor with response body as InputStream.
+	 */
+	public MockClientHttpResponse(InputStream body, int statusCode) {
+		super(body);
+		this.status = statusCode;
+	}
+
 
 	@Override
 	public HttpStatus getStatusCode() throws IOException {
-		return this.status;
+		if (this.status instanceof HttpStatus) {
+			return (HttpStatus) this.status;
+		}
+		else {
+			return HttpStatus.valueOf((Integer) this.status);
+		}
 	}
 
 	@Override
 	public int getRawStatusCode() throws IOException {
-		return this.status.value();
+		if (this.status instanceof HttpStatus) {
+			return ((HttpStatus) this.status).value();
+		}
+		else {
+			return (Integer) this.status;
+		}
 	}
 
 	@Override
 	public String getStatusText() throws IOException {
-		return this.status.getReasonPhrase();
+		if (this.status instanceof HttpStatus) {
+			return ((HttpStatus) this.status).getReasonPhrase();
+		}
+		else {
+			return "Custom http status";
+		}
 	}
 
 	@Override

--- a/spring-test/src/main/java/org/springframework/test/web/client/response/DefaultResponseCreator.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/response/DefaultResponseCreator.java
@@ -40,7 +40,7 @@ import org.springframework.util.Assert;
  */
 public class DefaultResponseCreator implements ResponseCreator {
 
-	private final HttpStatus statusCode;
+	private final Object statusCode;
 
 	private byte[] content = new byte[0];
 
@@ -56,6 +56,14 @@ public class DefaultResponseCreator implements ResponseCreator {
 	 */
 	protected DefaultResponseCreator(HttpStatus statusCode) {
 		Assert.notNull(statusCode, "HttpStatus must not be null");
+		this.statusCode = statusCode;
+	}
+
+	/**
+	 * Protected constructor.
+	 * Use static factory methods in {@link MockRestResponseCreators}.
+	 */
+	protected DefaultResponseCreator(int statusCode) {
 		this.statusCode = statusCode;
 	}
 
@@ -114,10 +122,20 @@ public class DefaultResponseCreator implements ResponseCreator {
 		MockClientHttpResponse response;
 		if (this.contentResource != null) {
 			InputStream stream = this.contentResource.getInputStream();
-			response = new MockClientHttpResponse(stream, this.statusCode);
+			if (this.statusCode instanceof HttpStatus) {
+				response = new MockClientHttpResponse(stream, (HttpStatus) this.statusCode);
+			}
+			else {
+				response = new MockClientHttpResponse(stream, (Integer) this.statusCode);
+			}
 		}
 		else {
-			response = new MockClientHttpResponse(this.content, this.statusCode);
+			if (this.statusCode instanceof HttpStatus) {
+				response = new MockClientHttpResponse(this.content, (HttpStatus) this.statusCode);
+			}
+			else {
+				response = new MockClientHttpResponse(this.content, (Integer) this.statusCode);
+			}
 		}
 		response.getHeaders().putAll(this.headers);
 		return response;

--- a/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
@@ -118,6 +118,14 @@ public abstract class MockRestResponseCreators {
 	}
 
 	/**
+	 * {@code ResponseCreator} with a specific HTTP status.
+	 * @param status the response status
+	 */
+	public static DefaultResponseCreator withStatus(int status) {
+		return new DefaultResponseCreator(status);
+	}
+
+	/**
 	 * {@code ResponseCreator} with an internal application {@code IOException}.
 	 * <p>For example, one could use this to simulate a {@code SocketTimeoutException}.
 	 * @param ex the {@code Exception} to be thrown at HTTP call time

--- a/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/response/ResponseCreatorsTests.java
@@ -129,6 +129,15 @@ class ResponseCreatorsTests {
 	}
 
 	@Test
+	void withCustomStatus() throws Exception {
+		DefaultResponseCreator responseCreator = MockRestResponseCreators.withStatus(454);
+		MockClientHttpResponse response = (MockClientHttpResponse) responseCreator.createResponse(null);
+
+		assertThat(response.getRawStatusCode()).isEqualTo(454);
+		assertThat(response.getStatusText()).isEqualTo("Custom http status");
+	}
+
+	@Test
 	void withException() {
 		ResponseCreator responseCreator = MockRestResponseCreators.withException(new SocketTimeoutException());
 		assertThatExceptionOfType(SocketTimeoutException.class)


### PR DESCRIPTION
## TL; DR;
Add supporting for custom http statuses in mocked responses
I copied logic from `org.springframework.http.ResponseEntity`

## Foreword
In my company we use "custom not found status" in our REST API's to prevent mixing network error (404 "not found" for unknown routes) with rest responses (when entity with given id not found).
There are good example for rest controller tests.
Suppose we have a rest endpoint for car entity: `GET /car/{id}`. 
Let's try to write test for case when entity with given id not found. Something like that:
```java
mockMvc.perform(get("/car/{id}/", nonExistsId.toString()))
        .andExpect(status().is(404));
```
And if our code in rest controller have bug, then test will fail with something like "500 internal server error"
But if we also make mistake in test in request's path, like that:
```java
mockMvc.perform(get("/carS/{id}/", nonExistsId.toString()))
        .andExpect(status().is(404));
```
then test will pass and we don't catch bugs in cases when entity with given id is non-exists.
So, for this reason we used "454" as http status for "not found" case.

## Problem
In our clients code we also write tests and want to cover this case with custom http status, but we cant because MockRestResponseCreators and MockClientHttpResponse not support custom http codes:
```java
  mockRestServiceServer.expect(requestTo(serverURI)
          .andExpect(method(HttpMethod.GET))
          .andRespond(withStatus(454)); // <-- will not work cause support only HttpStatus 
```