### PR TITLE
Use equals() instead of contains() in RollbackRuleAttribute

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/RollbackRuleAttribute.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/RollbackRuleAttribute.java
@@ -112,7 +112,7 @@ public class RollbackRuleAttribute implements Serializable{
 
 
 	private int getDepth(Class<?> exceptionClass, int depth) {
-		if (exceptionClass.getName().contains(this.exceptionName)) {
+		if (exceptionClass.getName().equals(this.exceptionName)) {
 			// Found it!
 			return depth;
 		}

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/MyRuntimeExceptionX.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/MyRuntimeExceptionX.java
@@ -1,0 +1,8 @@
+package org.springframework.transaction.interceptor;
+
+/**
+ * An example for use in testing issue #28098.
+ * @author Zijian Liao
+ */
+public class MyRuntimeExceptionX extends RuntimeException {
+}

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/RollbackRuleTests.java
@@ -91,6 +91,12 @@ class RollbackRuleTests {
 		assertThat(rr.getDepth(new EnclosingException.EnclosedException())).isEqualTo(0);
 	}
 
+	@Test
+	public void useEqualsCompareExceptionName(){
+		RollbackRuleAttribute rr = new RollbackRuleAttribute(MyRuntimeException.class);
+		assertThat(rr.getDepth(new MyRuntimeExceptionX())).isEqualTo(-1);
+	}
+
 	@SuppressWarnings("serial")
 	static class EnclosingException extends RuntimeException {
 


### PR DESCRIPTION
Closes gh-28098