### PR TITLE
Return empty LinkedHashMap instead of `Collections.emptyMap()` in PathVariableMapMethodArgumentResolver

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/PathVariableMapMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/PathVariableMapMethodArgumentResolver.java
@@ -16,7 +16,7 @@
 
 package org.springframework.web.reactive.result.method.annotation;
 
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.core.MethodParameter;
@@ -62,7 +62,7 @@ public class PathVariableMapMethodArgumentResolver extends HandlerMethodArgument
 			MethodParameter methodParameter, BindingContext context, ServerWebExchange exchange) {
 
 		String name = HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE;
-		return exchange.getAttributeOrDefault(name, Collections.emptyMap());
+		return exchange.getAttributeOrDefault(name, new LinkedHashMap<>());
 	}
 
 }

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/PathVariableMapMethodArgumentResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/PathVariableMapMethodArgumentResolverTests.java
@@ -19,6 +19,7 @@ package org.springframework.web.reactive.result.method.annotation;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +95,8 @@ public class PathVariableMapMethodArgumentResolverTests {
 		Mono<Object> mono = this.resolver.resolveArgument(this.paramMap, new BindingContext(), this.exchange);
 		Object result = mono.block();
 
-		assertThat(result).isEqualTo(Collections.emptyMap());
+		assertThat(result).isOfAnyClassIn(LinkedHashMap.class);
+		assertThat(result).isEqualTo(new LinkedHashMap<>());
 	}
 
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
@@ -16,7 +16,6 @@
 
 package org.springframework.web.servlet.mvc.method.annotation;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -66,7 +65,7 @@ public class PathVariableMapMethodArgumentResolver implements HandlerMethodArgum
 			return new LinkedHashMap<>(uriTemplateVars);
 		}
 		else {
-			return Collections.emptyMap();
+			return new LinkedHashMap<>();
 		}
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolverTests.java
@@ -19,6 +19,7 @@ package org.springframework.web.servlet.mvc.method.annotation;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -92,7 +93,8 @@ public class PathVariableMapMethodArgumentResolverTests {
 	public void resolveArgumentNoUriVars() throws Exception {
 		Map<String, String> map = (Map<String, String>) resolver.resolveArgument(paramMap, mavContainer, webRequest, null);
 
-		assertThat(map).isEqualTo(Collections.emptyMap());
+		assertThat(map).isOfAnyClassIn(LinkedHashMap.class);
+		assertThat(map).isEqualTo(new LinkedHashMap<>());
 	}
 
 


### PR DESCRIPTION
I think it would be better that return empty `LinkedHashMap` instead of `Collections.emptyMap()` in `PathVariableMapMethodArgumentResolver`, because they do't have same support for `put` operation.  And I think that the supported operatioin of `Map` annotated with `@PathVariable` should not be changed according the value(empty or not).