### PR TITLE
Batch update return generated keys

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcOperations.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcOperations.java
@@ -993,17 +993,23 @@ public interface JdbcOperations {
 	/**
 	 * Issue multiple update statements on a single PreparedStatement,
 	 * using batch updates and a BatchPreparedStatementSetter to set values.
+	 * Generated keys will be put into the given KeyHolder.
+	 * <p>Note that the given PreparedStatementCreator has to create a statement
+	 * with activated extraction of generated keys (a JDBC 3.0 feature). This can
+	 * either be done directly or through using a PreparedStatementCreatorFactory.
 	 * <p>Will fall back to separate updates on a single PreparedStatement
 	 * if the JDBC driver does not support batch updates.
 	 * @param psc a callback that creates a PreparedStatement given a Connection
 	 * @param pss object to set parameters on the PreparedStatement
 	 * created by this method
+	 * @param generatedKeyHolder a KeyHolder that will hold the generated keys
 	 * @return an array of the number of rows affected by each statement
 	 * (may also contain special JDBC-defined negative values for affected rows such as
 	 * {@link java.sql.Statement#SUCCESS_NO_INFO}/{@link java.sql.Statement#EXECUTE_FAILED})
 	 * @throws DataAccessException if there is any problem issuing the update
+	 * @see org.springframework.jdbc.support.GeneratedKeyHolder
 	 */
-	int[] batchUpdate(PreparedStatementCreator psc, BatchPreparedStatementSetter pss) throws DataAccessException;
+	int[] batchUpdate(PreparedStatementCreator psc, BatchPreparedStatementSetter pss, KeyHolder generatedKeyHolder) throws DataAccessException;
 
 	/**
 	 * Execute a batch using the supplied SQL statement with the batch of supplied arguments.

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcOperations.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcOperations.java
@@ -991,6 +991,21 @@ public interface JdbcOperations {
 	int[] batchUpdate(String sql, BatchPreparedStatementSetter pss) throws DataAccessException;
 
 	/**
+	 * Issue multiple update statements on a single PreparedStatement,
+	 * using batch updates and a BatchPreparedStatementSetter to set values.
+	 * <p>Will fall back to separate updates on a single PreparedStatement
+	 * if the JDBC driver does not support batch updates.
+	 * @param psc a callback that creates a PreparedStatement given a Connection
+	 * @param pss object to set parameters on the PreparedStatement
+	 * created by this method
+	 * @return an array of the number of rows affected by each statement
+	 * (may also contain special JDBC-defined negative values for affected rows such as
+	 * {@link java.sql.Statement#SUCCESS_NO_INFO}/{@link java.sql.Statement#EXECUTE_FAILED})
+	 * @throws DataAccessException if there is any problem issuing the update
+	 */
+	int[] batchUpdate(PreparedStatementCreator psc, BatchPreparedStatementSetter pss) throws DataAccessException;
+
+	/**
 	 * Execute a batch using the supplied SQL statement with the batch of supplied arguments.
 	 * @param sql the SQL statement to execute
 	 * @param batchArgs the List of Object arrays containing the batch of arguments for the query

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1563,7 +1563,8 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 					int[] results = ps.executeBatch();
 					afterUpdateCallback.doInPreparedStatement(ps);
 					return results;
-				} else {
+				}
+				else {
 					List<Integer> rowsAffected = new ArrayList<>();
 					for (int i = 0; i < batchSize; i++) {
 						pss.setValues(ps, i);
@@ -1579,7 +1580,8 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 					}
 					return rowsAffectedArray;
 				}
-			} finally {
+			}
+			finally {
 				if (pss instanceof ParameterDisposer) {
 					((ParameterDisposer) pss).cleanupParameters();
 				}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1026,49 +1026,20 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 	}
 
 	@Override
+	public int[] batchUpdate(PreparedStatementCreator psc, final BatchPreparedStatementSetter pss) throws DataAccessException {
+		int[] result = execute(psc, getPreparedStatementCallback(pss));
+
+		Assert.state(result != null, "No result array");
+		return result;
+	}
+
+	@Override
 	public int[] batchUpdate(String sql, final BatchPreparedStatementSetter pss) throws DataAccessException {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Executing SQL batch update [" + sql + "]");
 		}
 
-		int[] result = execute(sql, (PreparedStatementCallback<int[]>) ps -> {
-			try {
-				int batchSize = pss.getBatchSize();
-				InterruptibleBatchPreparedStatementSetter ipss =
-						(pss instanceof InterruptibleBatchPreparedStatementSetter ?
-						(InterruptibleBatchPreparedStatementSetter) pss : null);
-				if (JdbcUtils.supportsBatchUpdates(ps.getConnection())) {
-					for (int i = 0; i < batchSize; i++) {
-						pss.setValues(ps, i);
-						if (ipss != null && ipss.isBatchExhausted(i)) {
-							break;
-						}
-						ps.addBatch();
-					}
-					return ps.executeBatch();
-				}
-				else {
-					List<Integer> rowsAffected = new ArrayList<>();
-					for (int i = 0; i < batchSize; i++) {
-						pss.setValues(ps, i);
-						if (ipss != null && ipss.isBatchExhausted(i)) {
-							break;
-						}
-						rowsAffected.add(ps.executeUpdate());
-					}
-					int[] rowsAffectedArray = new int[rowsAffected.size()];
-					for (int i = 0; i < rowsAffectedArray.length; i++) {
-						rowsAffectedArray[i] = rowsAffected.get(i);
-					}
-					return rowsAffectedArray;
-				}
-			}
-			finally {
-				if (pss instanceof ParameterDisposer) {
-					((ParameterDisposer) pss).cleanupParameters();
-				}
-			}
-		});
+		int[] result = execute(sql, getPreparedStatementCallback(pss));
 
 		Assert.state(result != null, "No result array");
 		return result;
@@ -1565,6 +1536,45 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 	private static int updateCount(@Nullable Integer result) {
 		Assert.state(result != null, "No update count");
 		return result;
+	}
+
+	private PreparedStatementCallback<int[]> getPreparedStatementCallback(BatchPreparedStatementSetter pss) {
+		return ps -> {
+			try {
+				int batchSize = pss.getBatchSize();
+				InterruptibleBatchPreparedStatementSetter ipss =
+						(pss instanceof InterruptibleBatchPreparedStatementSetter ?
+								(InterruptibleBatchPreparedStatementSetter) pss : null);
+				if (JdbcUtils.supportsBatchUpdates(ps.getConnection())) {
+					for (int i = 0; i < batchSize; i++) {
+						pss.setValues(ps, i);
+						if (ipss != null && ipss.isBatchExhausted(i)) {
+							break;
+						}
+						ps.addBatch();
+					}
+					return ps.executeBatch();
+				} else {
+					List<Integer> rowsAffected = new ArrayList<>();
+					for (int i = 0; i < batchSize; i++) {
+						pss.setValues(ps, i);
+						if (ipss != null && ipss.isBatchExhausted(i)) {
+							break;
+						}
+						rowsAffected.add(ps.executeUpdate());
+					}
+					int[] rowsAffectedArray = new int[rowsAffected.size()];
+					for (int i = 0; i < rowsAffectedArray.length; i++) {
+						rowsAffectedArray[i] = rowsAffected.get(i);
+					}
+					return rowsAffectedArray;
+				}
+			} finally {
+				if (pss instanceof ParameterDisposer) {
+					((ParameterDisposer) pss).cleanupParameters();
+				}
+			}
+		};
 	}
 
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1026,7 +1026,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 	}
 
 	@Override
-	public int[] batchUpdate(PreparedStatementCreator psc, final BatchPreparedStatementSetter pss) throws DataAccessException {
+	public int[] batchUpdate(final PreparedStatementCreator psc, final BatchPreparedStatementSetter pss, final KeyHolder generatedKeyHolder) throws DataAccessException {
 		int[] result = execute(psc, getPreparedStatementCallback(pss));
 
 		Assert.state(result != null, "No result array");

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -991,7 +991,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 		return updateCount(execute(psc, ps -> {
 			int rows = ps.executeUpdate();
 			generatedKeyHolder.getKeyList().clear();
-			storeGeneratedKeys(generatedKeyHolder, ps);
+			storeGeneratedKeys(generatedKeyHolder, ps, 1);
 			if (logger.isTraceEnabled()) {
 				logger.trace("SQL update affected " + rows + " rows and returned " + generatedKeyHolder.getKeyList().size() + " keys");
 			}
@@ -1527,13 +1527,13 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 		return result;
 	}
 
-	private void storeGeneratedKeys(KeyHolder generatedKeyHolder, PreparedStatement ps) throws SQLException {
+	private void storeGeneratedKeys(KeyHolder generatedKeyHolder, PreparedStatement ps, int rowsExpected) throws SQLException {
 		List<Map<String, Object>> generatedKeys = generatedKeyHolder.getKeyList();
 		ResultSet keys = ps.getGeneratedKeys();
 		if (keys != null) {
 			try {
 				RowMapperResultSetExtractor<Map<String, Object>> rse =
-						new RowMapperResultSetExtractor<>(getColumnMapRowMapper(), 1);
+						new RowMapperResultSetExtractor<>(getColumnMapRowMapper(), rowsExpected);
 				generatedKeys.addAll(result(rse.extractData(keys)));
 			}
 			finally {
@@ -1562,7 +1562,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 					}
 					int[] results = ps.executeBatch();
 					if (generatedKeyHolder != null) {
-						storeGeneratedKeys(generatedKeyHolder, ps);
+						storeGeneratedKeys(generatedKeyHolder, ps, batchSize);
 					}
 					return results;
 				}
@@ -1575,7 +1575,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 						}
 						rowsAffected.add(ps.executeUpdate());
 						if (generatedKeyHolder != null) {
-							storeGeneratedKeys(generatedKeyHolder, ps);
+							storeGeneratedKeys(generatedKeyHolder, ps, 1);
 						}
 					}
 					int[] rowsAffectedArray = new int[rowsAffected.size()];

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1573,6 +1573,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 						rowsAffected.add(ps.executeUpdate());
 					}
 					int[] rowsAffectedArray = new int[rowsAffected.size()];
+					afterUpdateCallback.doInPreparedStatement(ps);
 					for (int i = 0; i < rowsAffectedArray.length; i++) {
 						rowsAffectedArray[i] = rowsAffected.get(i);
 					}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcOperations.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcOperations.java
@@ -549,4 +549,18 @@ public interface NamedParameterJdbcOperations {
 	 */
 	int[] batchUpdate(String sql, SqlParameterSource[] batchArgs);
 
+	/**
+	 * Execute a batch using the supplied SQL statement with the batch of supplied arguments,
+	 * returning generated keys.
+	 * @param sql the SQL statement to execute
+	 * @param batchArgs the array of {@link SqlParameterSource} containing the batch of
+	 * arguments for the query
+	 * @param generatedKeyHolder a {@link KeyHolder} that will hold the generated keys
+	 * @return an array containing the numbers of rows affected by each update in the batch
+	 * (may also contain special JDBC-defined negative values for affected rows such as
+	 * {@link java.sql.Statement#SUCCESS_NO_INFO}/{@link java.sql.Statement#EXECUTE_FAILED})
+	 * @throws DataAccessException if there is any problem issuing the update
+	 * @see org.springframework.jdbc.support.GeneratedKeyHolder
+	 */
+	int[] batchUpdate(String sql, SqlParameterSource[] batchArgs, KeyHolder generatedKeyHolder);
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcOperations.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcOperations.java
@@ -563,4 +563,20 @@ public interface NamedParameterJdbcOperations {
 	 * @see org.springframework.jdbc.support.GeneratedKeyHolder
 	 */
 	int[] batchUpdate(String sql, SqlParameterSource[] batchArgs, KeyHolder generatedKeyHolder);
+
+	/**
+	 * Execute a batch using the supplied SQL statement with the batch of supplied arguments,
+	 * returning generated keys.
+	 * @param sql the SQL statement to execute
+	 * @param batchArgs the array of {@link SqlParameterSource} containing the batch of
+	 * arguments for the query
+	 * @param generatedKeyHolder a {@link KeyHolder} that will hold the generated keys
+	 * @param keyColumnNames names of the columns that will have keys generated for them
+	 * @return an array containing the numbers of rows affected by each update in the batch
+	 * (may also contain special JDBC-defined negative values for affected rows such as
+	 * {@link java.sql.Statement#SUCCESS_NO_INFO}/{@link java.sql.Statement#EXECUTE_FAILED})
+	 * @throws DataAccessException if there is any problem issuing the update
+	 * @see org.springframework.jdbc.support.GeneratedKeyHolder
+	 */
+	int[] batchUpdate(String sql, SqlParameterSource[] batchArgs, KeyHolder generatedKeyHolder, String[] keyColumnNames);
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
@@ -401,7 +401,8 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 		PreparedStatementCreatorFactory pscf = getPreparedStatementCreatorFactory(parsedSql, paramSource);
 		if (keyColumnNames != null) {
 			pscf.setGeneratedKeysColumnNames(keyColumnNames);
-		} else {
+		}
+		else {
 			pscf.setReturnGeneratedKeys(true);
 		}
 		Object[] params = NamedParameterUtils.buildValueArray(parsedSql, paramSource, null);

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
@@ -409,7 +409,8 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 					public int getBatchSize() {
 						return batchArgs.length;
 					}
-				});
+				},
+				keyHolder);
 	}
 
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
@@ -386,7 +386,12 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 	}
 
 	@Override
-	public int[] batchUpdate(String sql, SqlParameterSource[] batchArgs, KeyHolder keyHolder) {
+	public int[] batchUpdate(String sql, SqlParameterSource[] batchArgs, KeyHolder generatedKeyHolder) {
+		return batchUpdate(sql, batchArgs, generatedKeyHolder, null);
+	}
+
+	@Override
+	public int[] batchUpdate(String sql, SqlParameterSource[] batchArgs, KeyHolder generatedKeyHolder, String[] keyColumnNames) {
 		if (batchArgs.length == 0) {
 			return new int[0];
 		}
@@ -394,7 +399,11 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 		ParsedSql parsedSql = getParsedSql(sql);
 		SqlParameterSource paramSource = batchArgs[0];
 		PreparedStatementCreatorFactory pscf = getPreparedStatementCreatorFactory(parsedSql, paramSource);
-		pscf.setReturnGeneratedKeys(true);
+		if (keyColumnNames != null) {
+			pscf.setGeneratedKeysColumnNames(keyColumnNames);
+		} else {
+			pscf.setReturnGeneratedKeys(true);
+		}
 		Object[] params = NamedParameterUtils.buildValueArray(parsedSql, paramSource, null);
 		PreparedStatementCreator psc = pscf.newPreparedStatementCreator(params);
 		return getJdbcOperations().batchUpdate(
@@ -410,7 +419,7 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 						return batchArgs.length;
 					}
 				},
-				keyHolder);
+				generatedKeyHolder);
 	}
 
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
@@ -385,6 +385,33 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 				});
 	}
 
+	@Override
+	public int[] batchUpdate(String sql, SqlParameterSource[] batchArgs, KeyHolder keyHolder) {
+		if (batchArgs.length == 0) {
+			return new int[0];
+		}
+
+		ParsedSql parsedSql = getParsedSql(sql);
+		SqlParameterSource paramSource = batchArgs[0];
+		PreparedStatementCreatorFactory pscf = getPreparedStatementCreatorFactory(parsedSql, paramSource);
+		pscf.setReturnGeneratedKeys(true);
+		Object[] params = NamedParameterUtils.buildValueArray(parsedSql, paramSource, null);
+		PreparedStatementCreator psc = pscf.newPreparedStatementCreator(params);
+		return getJdbcOperations().batchUpdate(
+				psc,
+				new BatchPreparedStatementSetter() {
+					@Override
+					public void setValues(PreparedStatement ps, int i) throws SQLException {
+						Object[] values = NamedParameterUtils.buildValueArray(parsedSql, batchArgs[i], null);
+						pscf.newPreparedStatementSetter(values).setValues(ps);
+					}
+					@Override
+					public int getBatchSize() {
+						return batchArgs.length;
+					}
+				});
+	}
+
 
 	/**
 	 * Build a {@link PreparedStatementCreator} based on the given SQL and named parameters.

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
@@ -1131,14 +1131,18 @@ public class JdbcTemplateTests {
 		DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
 		given(databaseMetaData.supportsBatchUpdates()).willReturn(false);
 		given(this.connection.getMetaData()).willReturn(databaseMetaData);
-		ResultSet generatedKeysResultSet = mock(ResultSet.class);
 		ResultSetMetaData rsmd = mock(ResultSetMetaData.class);
 		given(rsmd.getColumnCount()).willReturn(1);
 		given(rsmd.getColumnLabel(1)).willReturn("someId");
-		given(generatedKeysResultSet.getMetaData()).willReturn(rsmd);
-		given(generatedKeysResultSet.getObject(1)).willReturn(123, 456);
-		given(generatedKeysResultSet.next()).willReturn(true, true, false);
-		given(this.preparedStatement.getGeneratedKeys()).willReturn(generatedKeysResultSet);
+		ResultSet generatedKeysResultSet1 = mock(ResultSet.class);
+		given(generatedKeysResultSet1.getMetaData()).willReturn(rsmd);
+		given(generatedKeysResultSet1.getObject(1)).willReturn(123);
+		given(generatedKeysResultSet1.next()).willReturn(true, false);
+		ResultSet generatedKeysResultSet2 = mock(ResultSet.class);
+		given(generatedKeysResultSet2.getMetaData()).willReturn(rsmd);
+		given(generatedKeysResultSet2.getObject(1)).willReturn(456);
+		given(generatedKeysResultSet2.next()).willReturn(true, false);
+		given(this.preparedStatement.getGeneratedKeys()).willReturn(generatedKeysResultSet1, generatedKeysResultSet2);
 
 		int[] values = new int[]{100, 200};
 		BatchPreparedStatementSetter bpss = new BatchPreparedStatementSetter() {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
@@ -47,6 +47,8 @@ import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.jdbc.core.support.AbstractInterruptibleBatchPreparedStatementSetter;
 import org.springframework.jdbc.datasource.ConnectionProxy;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 import org.springframework.jdbc.support.SQLStateSQLExceptionTranslator;
 import org.springframework.util.LinkedCaseInsensitiveMap;
@@ -1085,6 +1087,42 @@ public class JdbcTemplateTests {
 		assertThat(map.get("x")).isEqualTo("first value");
 	}
 
+	@Test
+	void testBatchUpdateReturnsGeneratedKeys() throws SQLException {
+		final int[] rowsAffected = new int[] {1, 2};
+		given(this.preparedStatement.executeBatch()).willReturn(rowsAffected);
+		DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+		given(databaseMetaData.supportsBatchUpdates()).willReturn(true);
+		given(this.connection.getMetaData()).willReturn(databaseMetaData);
+		ResultSet generatedKeysResultSet = mock(ResultSet.class);
+		ResultSetMetaData rsmd = mock(ResultSetMetaData.class);
+		given(rsmd.getColumnCount()).willReturn(1);
+		given(rsmd.getColumnLabel(1)).willReturn("someId");
+		given(generatedKeysResultSet.getMetaData()).willReturn(rsmd);
+		given(generatedKeysResultSet.getObject(1)).willReturn(123, 456);
+		given(generatedKeysResultSet.next()).willReturn(true, true, false);
+		given(this.preparedStatement.getGeneratedKeys()).willReturn(generatedKeysResultSet);
+
+		int[] values = new int[]{100, 200};
+		BatchPreparedStatementSetter bpss = new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				ps.setObject(i, values[i]);
+			}
+
+			@Override
+			public int getBatchSize() {
+				return 2;
+			}
+		};
+
+		KeyHolder keyHolder = new GeneratedKeyHolder();
+		this.template.batchUpdate(con -> con.prepareStatement(""), bpss, keyHolder);
+
+		assertThat(keyHolder.getKeyList()).containsExactly(
+				Collections.singletonMap("someId", 123),
+				Collections.singletonMap("someId", 456));
+	}
 
 	private void mockDatabaseMetaData(boolean supportsBatchUpdates) throws SQLException {
 		DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);


### PR DESCRIPTION
Add `NamedParameterJdbcTemplate#batchUpdate` methods taking `KeyHolder` and `String[] keyColumnNames` as counterparts to the `NamedParameterJdbcTemplate#update` methods of the same form.

This is in service of an enhancement to [`spring-data-jdbc`](https://github.com/spring-projects/spring-data-relational/pull/1191) to perform batch inserts to persist collections of entities referenced by an aggregate, when adequately supported by the database. The proposed changes to `spring-data-jdbc` currently include a [copy of the changes](https://github.com/spring-projects/spring-data-relational/pull/1191/files#diff-2526db37d52bc8ab9d5cb280c184ac07d28c0f1bfea856ea228653584374c04b) being proposed here, and could be refactored to use the respective `NamedParameterJdbcTemplate#batchUpdate` once accepted and merged.

Related to spring-projects/spring-framework#6530.