### PR TITLE
Fix a performance problem in CachedIntrospectionResults

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/CachedIntrospectionResults.java
+++ b/spring-beans/src/main/java/org/springframework/beans/CachedIntrospectionResults.java
@@ -179,7 +179,6 @@ public final class CachedIntrospectionResults {
 			return results;
 		}
 
-		results = new CachedIntrospectionResults(beanClass);
 		ConcurrentMap<Class<?>, CachedIntrospectionResults> classCacheToUse;
 
 		if (ClassUtils.isCacheSafe(beanClass, CachedIntrospectionResults.class.getClassLoader()) ||
@@ -193,8 +192,7 @@ public final class CachedIntrospectionResults {
 			classCacheToUse = softClassCache;
 		}
 
-		CachedIntrospectionResults existing = classCacheToUse.putIfAbsent(beanClass, results);
-		return (existing != null ? existing : results);
+		return classCacheToUse.computeIfAbsent(beanClass, CachedIntrospectionResults::new);
 	}
 
 	/**

--- a/spring-beans/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/spring-beans/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline 


### PR DESCRIPTION
# Description
This commit fixes a performance problem in CachedIntrospectionResults. If multiple threads call `CachedIntrospectionResults::forClass` at the same time, more than one CachedIntrospectionResults will be created redundantly and consume a lot of CPU time.

# Reproduce
I have a server with only one CPU. Assume that 100 requests come simultaneously and each request will call `BeanUtils::getPropertyDescriptor` directly and `CachedIntrospectionResults::forClass` indirectly. When loading the same keys by different threads, keys are not locked.
In my test, each `CachedIntrospectionResults::forClass` call consumes more than 100ms CPU time, so 100 requests consume 10000ms CPU time in total.

