### PR TITLE
Add Node.js file extensions to javascript

### DIFF
--- a/spring-web/src/main/resources/org/springframework/http/mime.types
+++ b/spring-web/src/main/resources/org/springframework/http/mime.types
@@ -146,7 +146,7 @@ application/ipfix				ipfix
 application/java-archive			jar
 application/java-serialized-object		ser
 application/java-vm				class
-application/javascript				js
+application/javascript				js mjs cjs
 # application/jose
 # application/jose+json
 # application/jrd+json


### PR DESCRIPTION
Node.js recognizes .mjs as an ES6 module and .cjs as a CommonJS module. Other web servers e.g. in other languages recognize them as well. This change makes the resource handlers in Spring Web work the same with *.mjs as *.js.

Example with Python:

```
$ curl -v localhost:8000/hello.mjs > /dev/null
...
< Content-type: application/javascript
< Content-Length: 825
< Last-Modified: Tue, 15 Mar 2022 11:00:54 GMT
< 
```
