### PR TITLE
Fix property binding issue for spring beans when default value is null

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -16,8 +16,25 @@
 
 package org.springframework.beans;
 
+import java.beans.PropertyChangeEvent;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.security.PrivilegedActionException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionException;
@@ -27,11 +44,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-
-import java.beans.PropertyChangeEvent;
-import java.lang.reflect.*;
-import java.security.PrivilegedActionException;
-import java.util.*;
 
 /**
  * A basic {@link ConfigurablePropertyAccessor} that provides the necessary

--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -16,25 +16,8 @@
 
 package org.springframework.beans;
 
-import java.beans.PropertyChangeEvent;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.security.PrivilegedActionException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionException;
@@ -44,6 +27,11 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+
+import java.beans.PropertyChangeEvent;
+import java.lang.reflect.*;
+import java.security.PrivilegedActionException;
+import java.util.*;
 
 /**
  * A basic {@link ConfigurablePropertyAccessor} that provides the necessary
@@ -768,7 +756,9 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 			}
 			setPropertyValue(name, newArray);
 			Object defaultValue = getPropertyValue(name);
-			Assert.state(defaultValue != null, "Default value must not be null");
+			if (defaultValue == null) {
+				throw new NoDefaultValuePropertyException(getRootClass(), this.nestedPath + name);
+			}
 			return defaultValue;
 		}
 		else {
@@ -874,7 +864,9 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 		PropertyValue pv = createDefaultPropertyValue(tokens);
 		setPropertyValue(tokens, pv);
 		Object defaultValue = getPropertyValue(tokens);
-		Assert.state(defaultValue != null, "Default value must not be null");
+		if (defaultValue == null) {
+			throw new NoDefaultValuePropertyException(getRootClass(), this.nestedPath + tokens.canonicalName);
+		}
 		return defaultValue;
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/AbstractPropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractPropertyAccessor.java
@@ -85,6 +85,11 @@ public abstract class AbstractPropertyAccessor extends TypeConverterSupport impl
 	}
 
 	@Override
+	public void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown, boolean ignoreInvalid) throws BeansException {
+		setPropertyValues(pvs, ignoreUnknown, ignoreInvalid, false);
+	}
+
+	@Override
 	public void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown, boolean ignoreInvalid, boolean ignoreNoDefaultValue)
 			throws BeansException {
 

--- a/spring-beans/src/main/java/org/springframework/beans/AbstractPropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractPropertyAccessor.java
@@ -76,16 +76,16 @@ public abstract class AbstractPropertyAccessor extends TypeConverterSupport impl
 
 	@Override
 	public void setPropertyValues(PropertyValues pvs) throws BeansException {
-		setPropertyValues(pvs, false, false);
+		setPropertyValues(pvs, false, false, false);
 	}
 
 	@Override
 	public void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown) throws BeansException {
-		setPropertyValues(pvs, ignoreUnknown, false);
+		setPropertyValues(pvs, ignoreUnknown, false, false);
 	}
 
 	@Override
-	public void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown, boolean ignoreInvalid)
+	public void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown, boolean ignoreInvalid, boolean ignoreNoDefaultValue)
 			throws BeansException {
 
 		List<PropertyAccessException> propertyAccessExceptions = null;
@@ -105,6 +105,12 @@ public abstract class AbstractPropertyAccessor extends TypeConverterSupport impl
 				}
 				catch (NotWritablePropertyException ex) {
 					if (!ignoreUnknown) {
+						throw ex;
+					}
+					// Otherwise, just ignore it and continue...
+				}
+				catch (NoDefaultValuePropertyException ex) {
+					if (!ignoreNoDefaultValue) {
 						throw ex;
 					}
 					// Otherwise, just ignore it and continue...

--- a/spring-beans/src/main/java/org/springframework/beans/NoDefaultValuePropertyException.java
+++ b/spring-beans/src/main/java/org/springframework/beans/NoDefaultValuePropertyException.java
@@ -5,6 +5,7 @@ package org.springframework.beans;
  *
  * @author dillonm79
  */
+@SuppressWarnings("serial")
 public class NoDefaultValuePropertyException extends InvalidPropertyException {
 
 

--- a/spring-beans/src/main/java/org/springframework/beans/NoDefaultValuePropertyException.java
+++ b/spring-beans/src/main/java/org/springframework/beans/NoDefaultValuePropertyException.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.beans;
 
 /**
- * Exception is thrown on attempted to bind a default value of null to a target parameter
+ * Exception is thrown on attempted to bind a default value of null to a target parameter.
  *
- * @author dillonm79
+ * @author Dillon McMahon
  */
 @SuppressWarnings("serial")
 public class NoDefaultValuePropertyException extends InvalidPropertyException {

--- a/spring-beans/src/main/java/org/springframework/beans/NoDefaultValuePropertyException.java
+++ b/spring-beans/src/main/java/org/springframework/beans/NoDefaultValuePropertyException.java
@@ -1,0 +1,21 @@
+package org.springframework.beans;
+
+/**
+ * Exception is thrown on attempted to bind a default value of null to a target parameter
+ *
+ * @author dillonm79
+ */
+public class NoDefaultValuePropertyException extends InvalidPropertyException {
+
+
+	/**
+	 * Create a new NoDefaultValuePropertyException.
+	 *
+	 * @param beanClass    the offending bean class
+	 * @param propertyName the offending property name
+	 */
+	public NoDefaultValuePropertyException(Class<?> beanClass, String propertyName) {
+		super(beanClass, propertyName,
+				"Bean property '" + propertyName + "' does not have a default value. Default value must not be null");
+	}
+}

--- a/spring-beans/src/main/java/org/springframework/beans/PropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyAccessor.java
@@ -228,8 +228,10 @@ public interface PropertyAccessor {
 	 * occurred for specific properties during the batch update. This exception bundles
 	 * all individual PropertyAccessExceptions. All other properties will have been
 	 * successfully updated.
+	 * @throws NoDefaultValuePropertyException if a default value of null is attempted to
+	 * be bound to a target parameter.
 	 */
-	void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown, boolean ignoreInvalid)
+	void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown, boolean ignoreInvalid, boolean ignoreNoDefaultValue)
 			throws BeansException;
 
 }

--- a/spring-beans/src/main/java/org/springframework/beans/PropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyAccessor.java
@@ -228,8 +228,29 @@ public interface PropertyAccessor {
 	 * occurred for specific properties during the batch update. This exception bundles
 	 * all individual PropertyAccessExceptions. All other properties will have been
 	 * successfully updated.
-	 * @throws NoDefaultValuePropertyException if a default value of null is attempted to
-	 * be bound to a target parameter.
+	 */
+	void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown, boolean ignoreInvalid)
+			throws BeansException;
+
+	/**
+	 * Perform a batch update with full control over behavior.
+	 * <p>Note that performing a batch update differs from performing a single update,
+	 * in that an implementation of this class will continue to update properties
+	 * if a <b>recoverable</b> error (such as a type mismatch, but <b>not</b> an
+	 * invalid field name or the like) is encountered, throwing a
+	 * {@link PropertyBatchUpdateException} containing all the individual errors.
+	 * This exception can be examined later to see all binding errors.
+	 * Properties that were successfully updated remain changed.
+	 * @param pvs a PropertyValues to set on the target object
+	 * @param ignoreUnknown should we ignore unknown properties (not found in the bean)
+	 * @param ignoreInvalid should we ignore invalid properties (found but not accessible)
+	 * @param ignoreNoDefaultValue should we ignore null default value binding
+	 * @throws InvalidPropertyException if there is no such property or
+	 * if the property isn't writable
+	 * @throws PropertyBatchUpdateException if one or more PropertyAccessExceptions
+	 * occurred for specific properties during the batch update. This exception bundles
+	 * all individual PropertyAccessExceptions. All other properties will have been
+	 * successfully updated.
 	 */
 	void setPropertyValues(PropertyValues pvs, boolean ignoreUnknown, boolean ignoreInvalid, boolean ignoreNoDefaultValue)
 			throws BeansException;

--- a/spring-context/src/main/java/org/springframework/validation/DataBinder.java
+++ b/spring-context/src/main/java/org/springframework/validation/DataBinder.java
@@ -138,6 +138,8 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 
 	private boolean ignoreInvalidFields = false;
 
+	private boolean ignoreNoDefaultValue = false;
+
 	private boolean autoGrowNestedPaths = true;
 
 	private int autoGrowCollectionLimit = DEFAULT_AUTO_GROW_COLLECTION_LIMIT;
@@ -415,6 +417,26 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 */
 	public boolean isIgnoreInvalidFields() {
 		return this.ignoreInvalidFields;
+	}
+
+	/**
+	 * Set whether to ignore binding a null default value to fields.
+	 * <p>Default is "false". Turn this on to not ignore attempts
+	 * to bind a default value of a parameter to the target object.
+	 * <p>Note that this setting only applies to <i>binding</i> operations
+	 * on this DataBinder, not to <i>retrieving</i> values via its
+	 * {@link #getBindingResult() BindingResult}.
+	 * @see #bind
+	 */
+	public void setIgnoreNoDefaultValue(boolean ignoreNoDefaultValue) {
+		this.ignoreNoDefaultValue = ignoreNoDefaultValue;
+	}
+
+	/**
+	 * Return whether to ignore property bindings when attempting to bind a null default value to a property.
+	 */
+	public boolean isIgnoreNoDefaultValue() {
+		return this.ignoreNoDefaultValue;
 	}
 
 	/**
@@ -853,7 +875,7 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	protected void applyPropertyValues(MutablePropertyValues mpvs) {
 		try {
 			// Bind request parameters onto target object.
-			getPropertyAccessor().setPropertyValues(mpvs, isIgnoreUnknownFields(), isIgnoreInvalidFields());
+			getPropertyAccessor().setPropertyValues(mpvs, isIgnoreUnknownFields(), isIgnoreInvalidFields(), isIgnoreNoDefaultValue());
 		}
 		catch (PropertyBatchUpdateException ex) {
 			// Use bind error processor to create FieldErrors.


### PR DESCRIPTION
This PR introduced a bug an does not allow us to upgrade passed 5.3.0: https://github.com/spring-projects/spring-framework/issues/25986 . Before, `AbstractNestablePropertyAccessor#processLocalProperty` threw `createNotWritablePropertyException`  when our class being deserialized did not have a setter on a property. This was then swallowed by `AbstractPropertyAccessor#setPropertyValues(org.springframework.beans.PropertyValues, boolean, boolean, boolean)` and binding of the next property was attempted. This is the wanted outcome. Now if this exception is not thrown (caught by the guard clause), we don't have default values on these fields so AbstractNestablePropertyAccessor#setDefaultValue throws an assertion which is not swallowed. Setting `ignoreInvalid` to false does cause `createNotWritablePropertyException` to be thrown, but it does not swallow the exception as before. This PR keeps the exact same functionality as now, but allows not having a default value for a property to be swallowed, in the same way it is in the other cases if desired. It also is a better way to handle the error and then throwing an assertion.