### PR TITLE
Support multiple segments in encoded Content-Disposition

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -371,9 +371,15 @@ public final class ContentDisposition {
 					if (value.startsWith("=?") ) {
 						Matcher matcher = BASE64_ENCODED_PATTERN.matcher(value);
 						if (matcher.find()) {
-							String match1 = matcher.group(1);
+							Charset match1 = Charset.forName(matcher.group(1));
 							String match2 = matcher.group(2);
-							filename = new String(Base64.getDecoder().decode(match2), Charset.forName(match1));
+							StringBuilder sb = new StringBuilder(new String(Base64.getDecoder().decode(match2), match1));
+							while (matcher.find()){
+								match1 = Charset.forName(matcher.group(1));
+								match2 = matcher.group(2);
+								sb.append(new String(Base64.getDecoder().decode(match2), match1));
+							}
+							filename = sb.toString();
 						}
 						else {
 							filename = value;

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -86,6 +86,14 @@ class ContentDispositionTests {
 		assertThat(parse(input).getFilename()).isEqualTo("日本語.csv");
 	}
 
+	@Test
+	void parseBase64EncodedFilenameHasMoreSegments() {
+		/* https://datatracker.ietf.org/doc/html/rfc2047#section-2
+		* An 'encoded-word' may not be more than 75 characters long */
+		String input = "attachment; filename=\"=?utf-8?B?U3ByaW5n5qGG5p625Li65Z+65LqOSmF2YeeahOeOsOS7o+S8geS4muW6lA==?= =?utf-8?B?55So56iL5bqP5o+Q5L6b5LqG5YWo6Z2i55qE57yW56iL5ZKM6YWN572u5qih?= =?utf-8?B?5Z6LLnR4dA==?=\"";
+		assertThat(parse(input).getFilename()).isEqualTo("Spring框架为基于Java的现代企业应用程序提供了全面的编程和配置模型.txt");
+	}
+
 	@Test // gh-26463
 	void parseBase64EncodedShiftJISFilename() {
 		String input = "attachment; filename=\"=?SHIFT_JIS?B?k/qWe4zqLmNzdg==?=\"";


### PR DESCRIPTION
According to  [Rfc6266](https://datatracker.ietf.org/doc/html/rfc6266) / [Appendix C.1 RFC 2047](https://datatracker.ietf.org/doc/html/rfc2047)  (MIME Part Three: Message Header Extensions for Non-ASCII Text), [Section 2. Syntax of encoded-words ( page 3 )](https://datatracker.ietf.org/doc/html/rfc2047#section-2) :

> An 'encoded-word' may not be more than 75 characters long, including
>    'charset', 'encoding', 'encoded-text', and delimiters.  If it is
>    desirable to encode more text than will fit in an 'encoded-word' of
>    75 characters, multiple 'encoded-word's (separated by CRLF SPACE) may
>    be used.
>

Original pull request : https://github.com/spring-projects/spring-framework/pull/26463 , try to decode base64 encoded filename, but he forget there is more segments case.

And thanks @guangtuan find it.