### PR TITLE
Property name consistent with the one in the code

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -1281,7 +1281,7 @@ part of a Spring XML configuration file specifies some bean definitions as follo
 
 		<!-- setter injection using the neater ref attribute -->
 		<property name="beanTwo" ref="yetAnotherBean"/>
-		<property name="integerProperty" value="1"/>
+		<property name="i" value="1"/>
 	</bean>
 
 	<bean id="anotherExampleBean" class="examples.AnotherBean"/>


### PR DESCRIPTION
In XML file, the property name is 'integerProperty' while the field in the code is 'i'.