### PR TITLE
Add new header method #28309

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -232,6 +232,13 @@ class DefaultWebClient implements WebClient {
 		}
 
 		@Override
+		public DefaultRequestBodyUriSpec header(String headerValue) {
+			String[] header = headerValue.split(":");
+			getHeaders().add(header[0], header[1]);
+			return this;
+		}
+
+		@Override
 		public DefaultRequestBodyUriSpec header(String headerName, String... headerValues) {
 			for (String headerValue : headerValues) {
 				getHeaders().add(headerName, headerValue);

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -436,6 +436,13 @@ public interface WebClient {
 
 		/**
 		 * Add the given, single header value under the given name.
+		 * @param headerValue the header value
+		 * @return this builder
+		 */
+		S header(String headerValue);
+
+		/**
+		 * Add the given, single header value under the given name.
 		 * @param headerName  the header name
 		 * @param headerValues the header value(s)
 		 * @return this builder


### PR DESCRIPTION
```Java
@Override
public DefaultRequestBodyUriSpec header(String headerValue) {
	String[] header = headerValue.split(":");
	getHeaders().add(header[0], header[1]);
	return this;
}
```
Users can add headers using only one parameter.

If there are any mistakes, please comment. Thanks!