### PR TITLE
Fix method reference in Kotlin documentation 

### DIFF
--- a/spring-beans/src/main/kotlin/org/springframework/beans/factory/ListableBeanFactoryExtensions.kt
+++ b/spring-beans/src/main/kotlin/org/springframework/beans/factory/ListableBeanFactoryExtensions.kt
@@ -39,7 +39,7 @@ inline fun <reified T : Any> ListableBeanFactory.getBeansOfType(includeNonSingle
 
 /**
  * Extension for [ListableBeanFactory.getBeanNamesForAnnotation] providing a
- * `getBeansOfType<Foo>()` variant.
+ * `getBeanNamesForAnnotation<Foo>()` variant.
  *
  * @author Sebastien Deleuze
  * @since 5.0


### PR DESCRIPTION
Documentation was probably copied from the `getBeansOfType` method, but not correctly altered.