### PR TITLE
Make `BeanThatListens`, `TestApplicationListener`, `ResourceUrlProvider` threadsafe

### DIFF
--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/beans/BeanThatListens.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/beans/BeanThatListens.java
@@ -17,6 +17,7 @@
 package org.springframework.context.testfixture.beans;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
@@ -31,7 +32,7 @@ public class BeanThatListens implements ApplicationListener<ApplicationEvent> {
 
 	private BeanThatBroadcasts beanThatBroadcasts;
 
-	private int eventCount;
+	private final AtomicInteger eventCount = new AtomicInteger(0);
 
 
 	public BeanThatListens() {
@@ -48,18 +49,18 @@ public class BeanThatListens implements ApplicationListener<ApplicationEvent> {
 
 	@Override
 	public void onApplicationEvent(ApplicationEvent event) {
-		eventCount++;
+		eventCount.getAndIncrement();
 		if (beanThatBroadcasts != null) {
 			beanThatBroadcasts.receivedCount++;
 		}
 	}
 
 	public int getEventCount() {
-		return eventCount;
+		return eventCount.get();
 	}
 
 	public void zero() {
-		eventCount = 0;
+		eventCount.set(0);
 	}
 
 }

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/beans/BeanThatListens.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/beans/BeanThatListens.java
@@ -27,6 +27,7 @@ import org.springframework.context.ApplicationListener;
  *
  * @author Thomas Risberg
  * @author Juergen Hoeller
+ * @author Genkui Du
  */
 public class BeanThatListens implements ApplicationListener<ApplicationEvent> {
 

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/beans/TestApplicationListener.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/beans/TestApplicationListener.java
@@ -19,27 +19,30 @@ package org.springframework.context.testfixture.beans;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Listener that maintains a global count of events.
  *
  * @author Rod Johnson
+ * @author GenKui Du
  * @since January 21, 2001
  */
 public class TestApplicationListener implements ApplicationListener<ApplicationEvent> {
 
-	private int eventCount;
+	private final AtomicInteger eventCount = new AtomicInteger(0);
 
 	public int getEventCount() {
-		return eventCount;
+		return eventCount.get();
 	}
 
 	public void zeroCounter() {
-		eventCount = 0;
+		eventCount.set(0);
 	}
 
 	@Override
 	public void onApplicationEvent(ApplicationEvent e) {
-		++eventCount;
+		eventCount.getAndIncrement();
 	}
 
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceUrlProvider.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceUrlProvider.java
@@ -52,7 +52,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  *
  * @author Rossen Stoyanchev
  * @author Brian Clozel
- * @author
+ * @author Genkui Du
  * @since 5.0
  */
 public class ResourceUrlProvider implements ApplicationListener<ContextRefreshedEvent>, ApplicationContextAware {


### PR DESCRIPTION
The listener could be invoked concurrently by multiple thread, we should make them threadsafe.

https://github.com/spring-projects/spring-framework/blob/f40a391916ed6c1f9e1130638a0bf19479e514dd/spring-context/src/main/java/org/springframework/context/event/SimpleApplicationEventMulticaster.java#L40
>By default, all listeners are invoked in the calling thread.