### PR TITLE
Upgrade to Reactor 2022.0.0-M2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,7 +250,7 @@ configure(allprojects) { project ->
 		repositories {
 			mavenCentral()
 			maven { url "https://repo.spring.io/libs-spring-framework-build" }
-			maven { url "https://repo.spring.io/libs-milestone-local"}
+			maven { url "https://repo.spring.io/milestone"}
 		}
 	}
 	configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ configure(allprojects) { project ->
 		imports {
 			mavenBom "com.fasterxml.jackson:jackson-bom:2.13.1"
 			mavenBom "io.netty:netty-bom:4.1.75.Final"
-			mavenBom "io.projectreactor:reactor-bom:2020.0.18"
+			mavenBom "io.projectreactor:reactor-bom:2022.0.0-M2"
 			mavenBom "io.r2dbc:r2dbc-bom:Borca-SR1"
 			mavenBom "io.rsocket:rsocket-bom:1.1.2"
 			mavenBom "org.eclipse.jetty:jetty-bom:11.0.9"
@@ -250,6 +250,7 @@ configure(allprojects) { project ->
 		repositories {
 			mavenCentral()
 			maven { url "https://repo.spring.io/libs-spring-framework-build" }
+			maven { url "https://repo.spring.io/libs-milestone-local"}
 		}
 	}
 	configurations.all {


### PR DESCRIPTION
This PR ensures that Spring Framework uses newly released M2 milestone
of Reactor `2022.0.0`:
 - Reactor-Core `3.5.0-M2`
 - Reactor-Netty `1.1.0-M2`

This should be the version that the upcoming 6.0.0-M4 release should depend on.