### PR TITLE
Add Javadoc since tags for GraphQL constants

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -70,18 +70,20 @@ public abstract class MimeTypeUtils {
 
 	/**
 	 * Public constant mime type for {@code application/graphql+json}.
+	 * @since 5.3.19
 	 * @see <a href="https://github.com/graphql/graphql-over-http">GraphQL over HTTP spec</a>
-	 * */
+	 */
 	public static final MimeType APPLICATION_GRAPHQL;
 
 	/**
 	 * A String equivalent of {@link MimeTypeUtils#APPLICATION_GRAPHQL}.
+	 * @since 5.3.19
 	 */
 	public static final String APPLICATION_GRAPHQL_VALUE = "application/graphql+json";
 
 	/**
 	 * Public constant mime type for {@code application/json}.
-	 * */
+	 */
 	public static final MimeType APPLICATION_JSON;
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -97,12 +97,14 @@ public class MediaType extends MimeType implements Serializable {
 
 	/**
 	 * Public constant media type for {@code application/graphql+json}.
+	 * @since 5.3.19
 	 * @see <a href="https://github.com/graphql/graphql-over-http">GraphQL over HTTP spec</a>
 	 */
 	public static final MediaType APPLICATION_GRAPHQL;
 
 	/**
 	 * A String equivalent of {@link MediaType#APPLICATION_GRAPHQL}.
+	 * @since 5.3.19
 	 */
 	public static final String APPLICATION_GRAPHQL_VALUE = "application/graphql+json";
 


### PR DESCRIPTION
This PR adds Javadoc `@since` tag for GraphQL constants.

See gh-28271