### PR TITLE
Fix typo in reference docs regarding RequestMappingHandlerAdapter

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -218,7 +218,7 @@ on the server side (for example, in Spring MVC REST controllers).
 
 Concrete implementations for the main media (MIME) types are provided in the framework
 and are, by default, registered with the `RestTemplate` on the client side and with
-`RequestMethodHandlerAdapter` on the server side (see
+`RequestMappingHandlerAdapter` on the server side (see
 <<web.adoc#mvc-config-message-converters, Configuring Message Converters>>).
 
 The implementations of `HttpMessageConverter` are described in the following sections.


### PR DESCRIPTION
This PR fix a typo in referece docs.

A list of `HttpMessageConverter`'s are registered as `this.messageConverters` in the constructor of `RequestMappingHandlerAdapter` (not `RequestMethodHandlerAdapter`).
https://github.com/spring-projects/spring-framework/blob/be7fa3aaa879cfb44fc976be7331caf5479a943f/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java#L203-L216

