### PR TITLE
extra balnk space removed from 3 java file

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/CloseStatus.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/CloseStatus.java
@@ -17,7 +17,6 @@
 package org.springframework.web.socket;
 
 import java.io.Serializable;
-
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/AbstractWebSocketClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/AbstractWebSocketClient.java
@@ -22,10 +22,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;

--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/ConnectionManagerSupport.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/ConnectionManagerSupport.java
@@ -17,10 +17,8 @@
 package org.springframework.web.socket.client;
 
 import java.net.URI;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.context.SmartLifecycle;
 import org.springframework.web.util.UriComponentsBuilder;
 


### PR DESCRIPTION
I have removed 5 extra line breaks from 3 java files. 

I have seen there are some extra line breaks in some java files between the import statement.
I removed those and I think that will increase the code readability.

 - 1st file ->
 
![Screenshot_1](https://user-images.githubusercontent.com/97525250/165027798-f36869c6-5038-4a57-8357-bb992eeaef19.png)

- 2nd file ->

![Screenshot_2](https://user-images.githubusercontent.com/97525250/165027828-5d86f061-a51e-41f5-9b9e-aa56568c81e4.png)

- 3rd file ->

![Screenshot_3](https://user-images.githubusercontent.com/97525250/165027868-7c6b48aa-fcba-49f5-8536-68abca3007cb.png)

**Please let me know If I Should modify or change something!**
