### PR TITLE
Remove "The" in "The BeanFactory" title in Core AsciiDoc documentation

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -11155,7 +11155,7 @@ by other application modules on the same machine.
 
 
 [[beans-beanfactory]]
-== The `BeanFactory`
+== `BeanFactory`
 
 The `BeanFactory` API provides the underlying basis for Spring's IoC functionality.
 Its specific contracts are mostly used in integration with other parts of Spring and


### PR DESCRIPTION
This title is cross-referenced in "1.1. Introduction to the Spring IoC Container and Beans". In this chapter, it would look cleaner if "The BeanFactory" was called "BeanFactory". Also, this title is the only one with the article "The" in the Core Technologies documentation.