### PR TITLE
Caching HttpStatus/Series instances by int key

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -17,7 +17,7 @@
 package org.springframework.http;
 
 import java.io.Serializable;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -86,9 +86,9 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 	 */
 	public static final HttpMethod TRACE = new HttpMethod("TRACE");
 
-	private static final HttpMethod[] values = new HttpMethod[] { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE };
+	private static final List<HttpMethod> values = List.of(GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE);
 
-	private static final Map<String, HttpMethod> mappings = Arrays.stream(values)
+	private static final Map<String, HttpMethod> mappings = values.stream()
 			.collect(Collectors.toUnmodifiableMap(HttpMethod::name, Function.identity()));
 
 
@@ -109,9 +109,7 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 	 * in WebDav.
 	 */
 	public static HttpMethod[] values() {
-		HttpMethod[] copy = new HttpMethod[values.length];
-		System.arraycopy(values, 0, copy, 0, values.length);
-		return copy;
+		return values.toArray(HttpMethod[]::new);
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatus.java
@@ -16,6 +16,11 @@
 
 package org.springframework.http;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.springframework.lang.Nullable;
 
 /**
@@ -415,13 +420,8 @@ public enum HttpStatus implements HttpStatusCode {
 	 */
 	NETWORK_AUTHENTICATION_REQUIRED(511, Series.SERVER_ERROR, "Network Authentication Required");
 
-
-	private static final HttpStatus[] VALUES;
-
-	static {
-		VALUES = values();
-	}
-
+	private static final Map<Integer, HttpStatus> HTTP_STATUSES = Arrays.stream(HttpStatus.values())
+		.collect(Collectors.toUnmodifiableMap(HttpStatus::value, Function.identity()));
 
 	private final int value;
 
@@ -517,15 +517,8 @@ public enum HttpStatus implements HttpStatusCode {
 	 */
 	@Nullable
 	public static HttpStatus resolve(int statusCode) {
-		// Use cached VALUES instead of values() to prevent array allocation.
-		for (HttpStatus status : VALUES) {
-			if (status.value == statusCode) {
-				return status;
-			}
-		}
-		return null;
+		return HTTP_STATUSES.get(statusCode);
 	}
-
 
 	/**
 	 * Enumeration of HTTP status series.
@@ -538,6 +531,9 @@ public enum HttpStatus implements HttpStatusCode {
 		REDIRECTION(3),
 		CLIENT_ERROR(4),
 		SERVER_ERROR(5);
+
+		private static final Map<Integer, Series> SERIES = Arrays.stream(Series.values())
+			.collect(Collectors.toUnmodifiableMap(Series::value, Function.identity()));
 
 		private final int value;
 
@@ -586,12 +582,7 @@ public enum HttpStatus implements HttpStatusCode {
 		@Nullable
 		public static Series resolve(int statusCode) {
 			int seriesCode = statusCode / 100;
-			for (Series series : values()) {
-				if (series.value == seriesCode) {
-					return series;
-				}
-			}
-			return null;
+			return SERIES.get(seriesCode);
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatus.java
@@ -138,7 +138,7 @@ public enum HttpStatus implements HttpStatusCode {
 	 * @deprecated in favor of {@link #FOUND} which will be returned from {@code HttpStatus.valueOf(302)}
 	 */
 	@Deprecated
-	MOVED_TEMPORARILY(302, Series.REDIRECTION, "Moved Temporarily"),
+	MOVED_TEMPORARILY(302, Series.REDIRECTION, "Moved Temporarily", true),
 	/**
 	 * {@code 303 See Other}.
 	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.4">HTTP/1.1: Semantics and Content, section 6.4.4</a>
@@ -251,7 +251,7 @@ public enum HttpStatus implements HttpStatusCode {
 	 * returned from {@code HttpStatus.valueOf(413)}
 	 */
 	@Deprecated
-	REQUEST_ENTITY_TOO_LARGE(413, Series.CLIENT_ERROR, "Request Entity Too Large"),
+	REQUEST_ENTITY_TOO_LARGE(413, Series.CLIENT_ERROR, "Request Entity Too Large", true),
 	/**
 	 * {@code 414 URI Too Long}.
 	 * @since 4.1
@@ -265,7 +265,7 @@ public enum HttpStatus implements HttpStatusCode {
 	 * @deprecated in favor of {@link #URI_TOO_LONG} which will be returned from {@code HttpStatus.valueOf(414)}
 	 */
 	@Deprecated
-	REQUEST_URI_TOO_LONG(414, Series.CLIENT_ERROR, "Request-URI Too Long"),
+	REQUEST_URI_TOO_LONG(414, Series.CLIENT_ERROR, "Request-URI Too Long", true),
 	/**
 	 * {@code 415 Unsupported Media Type}.
 	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.13">
@@ -420,7 +420,9 @@ public enum HttpStatus implements HttpStatusCode {
 	 */
 	NETWORK_AUTHENTICATION_REQUIRED(511, Series.SERVER_ERROR, "Network Authentication Required");
 
-	private static final Map<Integer, HttpStatus> HTTP_STATUSES = Arrays.stream(HttpStatus.values())
+	private static final Map<Integer, HttpStatus> HTTP_STATUSES = Arrays
+		.stream(HttpStatus.values())
+		.filter(value -> !value.duplicated)
 		.collect(Collectors.toUnmodifiableMap(HttpStatus::value, Function.identity()));
 
 	private final int value;
@@ -429,12 +431,18 @@ public enum HttpStatus implements HttpStatusCode {
 
 	private final String reasonPhrase;
 
+	private final boolean duplicated;
+
 	HttpStatus(int value, Series series, String reasonPhrase) {
+		this(value, series, reasonPhrase, false);
+	}
+
+	HttpStatus(int value, Series series, String reasonPhrase, boolean duplicated) {
 		this.value = value;
 		this.series = series;
 		this.reasonPhrase = reasonPhrase;
+		this.duplicated = duplicated;
 	}
-
 
 	@Override
 	public int value() {


### PR DESCRIPTION
Reusing same solution of org.springframework.web.socket.sockjs.transport.TransportType to avoid a loop and allocations of Enum.values().