### PR TITLE
Remove Log4J configurer from package-info.java in spring-core

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/package-info.java
+++ b/spring-core/src/main/java/org/springframework/util/package-info.java
@@ -1,6 +1,6 @@
 /**
  * Miscellaneous utility classes, such as String manipulation utilities,
- * a Log4J configurer, and a state holder for paged lists of objects.
+ * and a state holder for paged lists of objects.
  */
 @NonNullApi
 @NonNullFields


### PR DESCRIPTION
Remove Log4J configurer from package-info.java as Log4jConfigurer has been removed sicne spring5.0.x. 