### PR TITLE
Remove Log4J initialization from package-info.java in spring-web

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/package-info.java
+++ b/spring-web/src/main/java/org/springframework/web/util/package-info.java
@@ -1,6 +1,6 @@
 /**
  * Miscellaneous web utility classes, such as HTML escaping,
- * Log4j initialization, and cookie handling.
+ * and cookie handling.
  */
 @NonNullApi
 @NonNullFields


### PR DESCRIPTION
Remove Log4J initialization from package-info.java as Log4jConfigListener and Log4jWebConfigurer have been removed from since 5.0.x