### PR TITLE
Fix BindingResult error when ModelAttribute has custom name in WebFlux

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ErrorsMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ErrorsMethodArgumentResolver.java
@@ -86,7 +86,7 @@ public class ErrorsMethodArgumentResolver extends HandlerMethodArgumentResolverS
 				"Either declare the @ModelAttribute without an async wrapper type or " +
 				"handle a WebExchangeBindException error signal through the async type.");
 
-		ModelAttribute ann = parameter.getParameterAnnotation(ModelAttribute.class);
+		ModelAttribute ann = attributeParam.getParameterAnnotation(ModelAttribute.class);
 		String name = (ann != null && StringUtils.hasText(ann.value()) ?
 				ann.value() : Conventions.getVariableNameForParameter(attributeParam));
 		Object errors = context.getModel().asMap().get(BindingResult.MODEL_KEY_PREFIX + name);

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ErrorsMethodArgumentResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ErrorsMethodArgumentResolverTests.java
@@ -81,6 +81,21 @@ class ErrorsMethodArgumentResolverTests {
 		assertThat(actual).isSameAs(bindingResult);
 	}
 
+	@Test
+	void resolveOnBindingResultAndModelAttributeWithCustomValue() {
+		BindingResult bindingResult = createBindingResult(new Foo(), "custom");
+		this.bindingContext.getModel().asMap().put(BindingResult.MODEL_KEY_PREFIX + "custom", bindingResult);
+
+		ResolvableMethod testMethod = ResolvableMethod.on(getClass())
+				.named("handleWithModelAttributeValue").build();
+
+		MethodParameter parameter = testMethod.arg(Errors.class);
+		Object actual = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
+				.block(Duration.ofMillis(5000));
+
+		assertThat(actual).isSameAs(bindingResult);
+	}
+
 	private BindingResult createBindingResult(Foo target, String name) {
 		DataBinder binder = this.bindingContext.createDataBinder(this.exchange, target, name);
 		return binder.getBindingResult();
@@ -92,6 +107,21 @@ class ErrorsMethodArgumentResolverTests {
 		this.bindingContext.getModel().asMap().put(BindingResult.MODEL_KEY_PREFIX + "foo", Mono.just(bindingResult));
 
 		MethodParameter parameter = this.testMethod.arg(Errors.class);
+		Object actual = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
+				.block(Duration.ofMillis(5000));
+
+		assertThat(actual).isSameAs(bindingResult);
+	}
+
+	@Test
+	void resolveWithMonoOnBindingResultAndModelAttributeWithCustomValue() {
+		BindingResult bindingResult = createBindingResult(new Foo(), "custom");
+		this.bindingContext.getModel().asMap().put(BindingResult.MODEL_KEY_PREFIX + "custom", Mono.just(bindingResult));
+
+		ResolvableMethod testMethod = ResolvableMethod.on(getClass())
+				.named("handleWithModelAttributeValue").build();
+
+		MethodParameter parameter = testMethod.arg(Errors.class);
 		Object actual = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
 				.block(Duration.ofMillis(5000));
 
@@ -150,4 +180,13 @@ class ErrorsMethodArgumentResolverTests {
 			String string) {
 	}
 
+	@SuppressWarnings("unused")
+	void handleWithModelAttributeValue(
+			@ModelAttribute("custom") Foo foo,
+			Errors errors,
+			@ModelAttribute Mono<Foo> fooMono,
+			BindingResult bindingResult,
+			Mono<Errors> errorsMono,
+			String string) {
+	}
 }


### PR DESCRIPTION
I guess this part of the code is trying to get the `ModelAttribute` annotation from the `BindingResult` parameter itself instead of the previous one as it should be. This is causing `ann` variable to be always `null` and therefore ignoring the value of the `@ModelAttribute` annotation.