### PR TITLE
Use Arrays.toString for initMethodNames and destroyMethodNames arrays in AbstractBeanDefinition#toString

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinition.java
@@ -1281,8 +1281,8 @@ public abstract class AbstractBeanDefinition extends BeanMetadataAttributeAccess
 		sb.append("; primary=").append(this.primary);
 		sb.append("; factoryBeanName=").append(this.factoryBeanName);
 		sb.append("; factoryMethodName=").append(this.factoryMethodName);
-		sb.append("; initMethodNames=").append(this.initMethodNames);
-		sb.append("; destroyMethodNames=").append(this.destroyMethodNames);
+		sb.append("; initMethodNames=").append(Arrays.toString(this.initMethodNames));
+		sb.append("; destroyMethodNames=").append(Arrays.toString(this.destroyMethodNames));
 		if (this.resource != null) {
 			sb.append("; defined in ").append(this.resource.getDescription());
 		}


### PR DESCRIPTION
Default array `toString` implementation will not produce a readable result, `Arrays.toString` should be used instead