### PR TITLE
Make inner classes static when feasible

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
@@ -654,7 +654,7 @@ public class AutowiredAnnotationBeanPostProcessor implements SmartInstantiationA
 	/**
 	 * Base class representing injection information.
 	 */
-	private abstract class AutowiredElement extends InjectionMetadata.InjectedElement {
+	private abstract static class AutowiredElement extends InjectionMetadata.InjectedElement {
 
 		protected final boolean required;
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/aot/BeanDefinitionPropertyValueCodeGenerator.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/aot/BeanDefinitionPropertyValueCodeGenerator.java
@@ -119,7 +119,7 @@ class BeanDefinitionPropertyValueCodeGenerator {
 	/**
 	 * {@link Delegate} for {@code primitive} types.
 	 */
-	private class PrimitiveDelegate implements Delegate {
+	private static class PrimitiveDelegate implements Delegate {
 
 		private static final Map<Character, String> CHAR_ESCAPES;
 
@@ -177,7 +177,7 @@ class BeanDefinitionPropertyValueCodeGenerator {
 	/**
 	 * {@link Delegate} for {@link String} types.
 	 */
-	private class StringDelegate implements Delegate {
+	private static class StringDelegate implements Delegate {
 
 		@Override
 		@Nullable
@@ -194,7 +194,7 @@ class BeanDefinitionPropertyValueCodeGenerator {
 	/**
 	 * {@link Delegate} for {@link Enum} types.
 	 */
-	private class EnumDelegate implements Delegate {
+	private static class EnumDelegate implements Delegate {
 
 		@Override
 		@Nullable
@@ -212,7 +212,7 @@ class BeanDefinitionPropertyValueCodeGenerator {
 	/**
 	 * {@link Delegate} for {@link Class} types.
 	 */
-	private class ClassDelegate implements Delegate {
+	private static class ClassDelegate implements Delegate {
 
 		@Override
 		@Nullable
@@ -229,7 +229,7 @@ class BeanDefinitionPropertyValueCodeGenerator {
 	/**
 	 * {@link Delegate} for {@link ResolvableType} types.
 	 */
-	private class ResolvableTypeDelegate implements Delegate {
+	private static class ResolvableTypeDelegate implements Delegate {
 
 		@Override
 		@Nullable
@@ -512,7 +512,7 @@ class BeanDefinitionPropertyValueCodeGenerator {
 	/**
 	 * {@link Delegate} for {@link BeanReference} types.
 	 */
-	private class BeanReferenceDelegate implements Delegate {
+	private static class BeanReferenceDelegate implements Delegate {
 
 		@Override
 		@Nullable

--- a/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/factory/generator/InnerComponentConfiguration.java
+++ b/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/factory/generator/InnerComponentConfiguration.java
@@ -20,14 +20,14 @@ import org.springframework.core.env.Environment;
 
 public class InnerComponentConfiguration {
 
-	public class NoDependencyComponent {
+	public static class NoDependencyComponent {
 
 		public NoDependencyComponent() {
 
 		}
 	}
 
-	public class EnvironmentAwareComponent {
+	public static class EnvironmentAwareComponent {
 
 		public EnvironmentAwareComponent(Environment environment) {
 

--- a/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/factory/generator/InnerComponentConfiguration.java
+++ b/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/factory/generator/InnerComponentConfiguration.java
@@ -20,14 +20,14 @@ import org.springframework.core.env.Environment;
 
 public class InnerComponentConfiguration {
 
-	public static class NoDependencyComponent {
+	public class NoDependencyComponent {
 
 		public NoDependencyComponent() {
 
 		}
 	}
 
-	public static class EnvironmentAwareComponent {
+	public class EnvironmentAwareComponent {
 
 		public EnvironmentAwareComponent(Environment environment) {
 

--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
@@ -509,7 +509,7 @@ public class ConfigurationClassPostProcessor implements BeanDefinitionRegistryPo
 	}
 
 
-	private class AotContribution implements BeanFactoryInitializationAotContribution {
+	private static class AotContribution implements BeanFactoryInitializationAotContribution {
 
 		private static final String BEAN_FACTORY_VARIABLE = BeanFactoryInitializationCode.BEAN_FACTORY_VARIABLE;
 

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowHttpHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowHttpHandlerAdapter.java
@@ -88,7 +88,7 @@ public class UndertowHttpHandlerAdapter implements io.undertow.server.HttpHandle
 	}
 
 
-	private class HandlerResultSubscriber implements Subscriber<Void> {
+	private static class HandlerResultSubscriber implements Subscriber<Void> {
 
 		private final HttpServerExchange exchange;
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/VersionResourceResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/VersionResourceResolver.java
@@ -236,7 +236,7 @@ public class VersionResourceResolver extends AbstractResourceResolver {
 	}
 
 
-	private class FileNameVersionedResource extends AbstractResource implements HttpResource {
+	private static class FileNameVersionedResource extends AbstractResource implements HttpResource {
 
 		private final Resource original;
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/upgrade/UndertowRequestUpgradeStrategy.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/upgrade/UndertowRequestUpgradeStrategy.java
@@ -82,7 +82,7 @@ public class UndertowRequestUpgradeStrategy implements RequestUpgradeStrategy {
 	}
 
 
-	private class DefaultCallback implements WebSocketConnectionCallback {
+	private static class DefaultCallback implements WebSocketConnectionCallback {
 
 		private final HandshakeInfo handshakeInfo;
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/VersionResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/VersionResourceResolver.java
@@ -232,7 +232,7 @@ public class VersionResourceResolver extends AbstractResourceResolver {
 	}
 
 
-	private class FileNameVersionedResource extends AbstractResource implements HttpResource {
+	private static class FileNameVersionedResource extends AbstractResource implements HttpResource {
 
 		private final Resource original;
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/XhrStreamingTransportHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/XhrStreamingTransportHandler.java
@@ -75,7 +75,7 @@ public class XhrStreamingTransportHandler extends AbstractHttpSendingTransportHa
 	}
 
 
-	private class XhrStreamingSockJsSession extends StreamingSockJsSession {
+	private static class XhrStreamingSockJsSession extends StreamingSockJsSession {
 
 		public XhrStreamingSockJsSession(String sessionId, SockJsServiceConfig config,
 				WebSocketHandler wsHandler, Map<String, Object> attributes) {


### PR DESCRIPTION
A static nested class does not keep an implicit reference to its enclosing instance.

This prevents a common cause of memory leaks and uses less memory per instance of the class.