### PR TITLE
Add Javadoc since tag for RootBeanDefinition(ResolvableType) constructor

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/RootBeanDefinition.java
@@ -153,6 +153,7 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 	/**
 	 * Create a new RootBeanDefinition for a singleton.
 	 * @param beanType the type of bean to instantiate
+	 * @since 6.0
 	 * @see #setTargetType(ResolvableType)
 	 */
 	public RootBeanDefinition(@Nullable ResolvableType beanType) {
@@ -169,7 +170,6 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 	 * @see #setInstanceSupplier
 	 */
 	public <T> RootBeanDefinition(@Nullable Class<T> beanClass, @Nullable Supplier<T> instanceSupplier) {
-		super();
 		setBeanClass(beanClass);
 		setInstanceSupplier(instanceSupplier);
 	}
@@ -185,7 +185,6 @@ public class RootBeanDefinition extends AbstractBeanDefinition {
 	 * @see #setInstanceSupplier
 	 */
 	public <T> RootBeanDefinition(@Nullable Class<T> beanClass, String scope, @Nullable Supplier<T> instanceSupplier) {
-		super();
 		setBeanClass(beanClass);
 		setScope(scope);
 		setInstanceSupplier(instanceSupplier);


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `RootBeanDefinition(ResolvableType)` constructor.

This PR also removes redundant `super()` invocations.

See gh-28418