### PR TITLE
Add assertions to the test case of nullReturningBeanPostProcessor

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/AnnotationConfigApplicationContextTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/AnnotationConfigApplicationContextTests.java
@@ -154,19 +154,9 @@ class AnnotationConfigApplicationContextTests {
 				return (bean instanceof TestBean ? null : bean);
 			}
 		});
-		context.getBeanFactory().addBeanPostProcessor(new BeanPostProcessor() {
-			@Override
-			public Object postProcessBeforeInitialization(Object bean, String beanName) {
-				bean.getClass().getName();
-				return bean;
-			}
-			@Override
-			public Object postProcessAfterInitialization(Object bean, String beanName) {
-				bean.getClass().getName();
-				return bean;
-			}
-		});
 		context.refresh();
+
+		assertThat(context.getBean(TestBean.class)).isNotNull();
 	}
 
 	@Test


### PR DESCRIPTION
Hey Guys,

I would like to update the test code of nullReturningBeanPostProcessor.
1. Remove the second bean BeanPostProcessor since it does not help to understand the test case.
2. Add an assertion to tell, if a BeanPostProcessor returns null, the existing bean will be returned.
