### PR TITLE
Use getHost instead of getContainerIpAddress in Redis examples

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/DynamicPropertySource.java
+++ b/spring-test/src/main/java/org/springframework/test/context/DynamicPropertySource.java
@@ -76,7 +76,7 @@ import java.lang.annotation.Target;
  *
  *     &#064;DynamicPropertySource
  *     static void redisProperties(DynamicPropertyRegistry registry) {
- *         registry.add("redis.host", redis::getContainerIpAddress);
+ *         registry.add("redis.host", redis::getHost);
  *         registry.add("redis.port", redis::getMappedPort);
  *     }
  *

--- a/src/docs/asciidoc/testing.adoc
+++ b/src/docs/asciidoc/testing.adoc
@@ -4295,7 +4295,7 @@ properties.
 
 		@DynamicPropertySource
 		static void redisProperties(DynamicPropertyRegistry registry) {
-			registry.add("redis.host", redis::getContainerIpAddress);
+			registry.add("redis.host", redis::getHost);
 			registry.add("redis.port", redis::getMappedPort);
 		}
 
@@ -4319,7 +4319,7 @@ properties.
 			@DynamicPropertySource
 			@JvmStatic
 			fun redisProperties(registry: DynamicPropertyRegistry) {
-				registry.add("redis.host", redis::getContainerIpAddress)
+				registry.add("redis.host", redis::getHost)
 				registry.add("redis.port", redis::getMappedPort)
 			}
 		}


### PR DESCRIPTION
getContainerIpAddress is deprecated.
