### PR TITLE
Adding isNotEmpty methods for collections and maps

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
@@ -62,6 +62,17 @@ public abstract class CollectionUtils {
 	}
 
 	/**
+	 * Return {@code true} if the supplied Collection is neither {@code null} nor empty.
+	 * Otherwise, return {@code false}.
+	 *
+	 * @param collection the Collection to check
+	 * @return whether the given Collection is not empty
+	 */
+	public static boolean isNotEmpty(@Nullable Collection<?> collection) {
+		return !isEmpty(collection);
+	}
+
+	/**
 	 * Return {@code true} if the supplied Map is {@code null} or empty.
 	 * Otherwise, return {@code false}.
 	 * @param map the Map to check
@@ -69,6 +80,17 @@ public abstract class CollectionUtils {
 	 */
 	public static boolean isEmpty(@Nullable Map<?, ?> map) {
 		return (map == null || map.isEmpty());
+	}
+
+	/**
+	 * Return {@code true} if the supplied Map is neither {@code null} nor empty.
+	 * Otherwise, return {@code false}.
+	 *
+	 * @param map the Map to check
+	 * @return whether the given Map is not empty
+	 */
+	public static boolean isNotEmpty(@Nullable Map<?, ?> map) {
+		return !isEmpty(map);
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/util/CollectionUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/CollectionUtilsTests.java
@@ -55,6 +55,22 @@ class CollectionUtilsTests {
 	}
 
 	@Test
+	void isNotEmpty() {
+		assertThat(CollectionUtils.isNotEmpty((Set<Object>) null)).isFalse();
+		assertThat(CollectionUtils.isNotEmpty((Map<String, String>) null)).isFalse();
+		assertThat(CollectionUtils.isNotEmpty(new HashMap<String, String>())).isFalse();
+		assertThat(CollectionUtils.isNotEmpty(new HashSet<>())).isFalse();
+
+		List<Object> list = new ArrayList<>();
+		list.add(new Object());
+		assertThat(CollectionUtils.isNotEmpty(list)).isTrue();
+
+		Map<String, String> map = new HashMap<>();
+		map.put("foo", "bar");
+		assertThat(CollectionUtils.isNotEmpty(map)).isTrue();
+	}
+
+	@Test
 	void mergeArrayIntoCollection() {
 		Object[] arr = new Object[] {"value1", "value2"};
 		List<Comparable<?>> list = new ArrayList<>();


### PR DESCRIPTION
The motivation for this changes are

1. Majority of time the intention is to check that the collection is not empty instead of empty, as we cannot do much for null collections.
2. `CollectionUtils.isNotEmpty(collection)` is more readable than `!CollectionUtils.isEmpty(collection)` and there is no chance os missing the `!`.
3. `CollectionUtils::isNotEmpty` can be used as method reference.