### PR TITLE
Clarify docs on JNDI properties in Servlet environment

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/support/StandardServletEnvironment.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/StandardServletEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,8 @@ public class StandardServletEnvironment extends StandardEnvironment implements C
 	 * {@link StubPropertySource stubs} at this stage, and will be
 	 * {@linkplain #initPropertySources(ServletContext, ServletConfig) fully initialized}
 	 * once the actual {@link ServletContext} object becomes available.
+	 * <p>Addition of {@value #JNDI_PROPERTY_SOURCE_NAME} can be disabled with
+	 * {@link JndiLocatorDelegate#IGNORE_JNDI_PROPERTY_NAME}.
 	 * @see StandardEnvironment#customizePropertySources
 	 * @see org.springframework.core.env.AbstractEnvironment#customizePropertySources
 	 * @see ServletConfigPropertySource

--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -9981,9 +9981,8 @@ is configured with two PropertySource objects -- one representing the set of JVM
 
 NOTE: These default property sources are present for `StandardEnvironment`, for use in standalone
 applications. {api-spring-framework}/web/context/support/StandardServletEnvironment.html[`StandardServletEnvironment`]
-is populated with additional default property sources including servlet config and servlet
-context parameters. It can optionally enable a {api-spring-framework}/jndi/JndiPropertySource.html[`JndiPropertySource`].
-See the javadoc for details.
+is populated with additional default property sources: Servlet config, servlet context parameters and a 
+{api-spring-framework}/jndi/JndiPropertySource.html[`JndiPropertySource`].
 
 Concretely, when you use the `StandardEnvironment`, the call to `env.containsProperty("my-property")`
 returns true if a `my-property` system property or `my-property` environment variable is present at


### PR DESCRIPTION
- Clarified that JndiPropertySource is always enabled. Previous statement "can optionally enable" might have been before #13189
- Mentioned global off switch JndiLocatorDelegate.IGNORE_JNDI_PROPERTY_NAME in StandardServletEnvironment