### PR TITLE
Support coroutines suspending in @HttpExchange interface

### DIFF
--- a/spring-web/spring-web.gradle
+++ b/spring-web/spring-web.gradle
@@ -47,6 +47,8 @@ dependencies {
 	optional("com.googlecode.protobuf-java-format:protobuf-java-format")
 	optional("com.rometools:rome")
 	optional("org.apache.groovy:groovy")
+	optional("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+	optional("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 	optional("org.jetbrains.kotlin:kotlin-reflect")
 	optional("org.jetbrains.kotlin:kotlin-stdlib")
 	optional("org.jetbrains.kotlinx:kotlinx-serialization-json")

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/CoroutinesSuspendArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/CoroutinesSuspendArgumentResolver.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.service.invoker;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+
+/**
+ * {@link HttpServiceArgumentResolver} for suspend method.
+ *
+ * @author Wonwoo Lee
+ * @since 6.0
+ */
+public class CoroutinesSuspendArgumentResolver implements HttpServiceArgumentResolver {
+
+	@Override
+	public boolean resolve(@Nullable Object argument, MethodParameter parameter, HttpRequestValues.Builder requestValues) {
+
+		if ("kotlin.coroutines.Continuation".equals(parameter.getParameterType().getName()) && argument != null) {
+			requestValues.setContinuation(argument);
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValues.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValues.java
@@ -79,12 +79,15 @@ public final class HttpRequestValues {
 	@Nullable
 	private final ParameterizedTypeReference<?> bodyElementType;
 
+	@Nullable
+	private final Object continuation;
 
 	private HttpRequestValues(HttpMethod httpMethod,
 			@Nullable URI uri, @Nullable String uriTemplate, Map<String, String> uriVariables,
 			HttpHeaders headers, MultiValueMap<String, String> cookies,
 			@Nullable Object bodyValue,
-			@Nullable Publisher<?> body, @Nullable ParameterizedTypeReference<?> bodyElementType) {
+			@Nullable Publisher<?> body, @Nullable ParameterizedTypeReference<?> bodyElementType,
+			@Nullable Object continuation) {
 
 		Assert.isTrue(uri != null || uriTemplate != null, "Neither URI nor URI template");
 
@@ -97,6 +100,7 @@ public final class HttpRequestValues {
 		this.bodyValue = bodyValue;
 		this.body = body;
 		this.bodyElementType = bodyElementType;
+		this.continuation = continuation;
 	}
 
 
@@ -176,6 +180,13 @@ public final class HttpRequestValues {
 		return this.bodyElementType;
 	}
 
+	/**
+	 * 	Return the Continuation parameter.
+	 */
+	@Nullable
+	public Object getContinuation() {
+		return this.continuation;
+	}
 
 	public static Builder builder(HttpMethod httpMethod) {
 		return new Builder(httpMethod);
@@ -217,6 +228,9 @@ public final class HttpRequestValues {
 
 		@Nullable
 		private ParameterizedTypeReference<?> bodyElementType;
+
+		@Nullable
+		private Object continuation;
 
 		private Builder(HttpMethod httpMethod) {
 			Assert.notNull(httpMethod, "HttpMethod is required");
@@ -348,6 +362,15 @@ public final class HttpRequestValues {
 		}
 
 		/**
+		 * Set the Continuation parameter.
+		 */
+		public Builder setContinuation(Object continuation) {
+			Assert.notNull(continuation, "HttpMethod is required");
+			this.continuation = continuation;
+			return this;
+		}
+
+		/**
 		 * Builder the {@link HttpRequestValues} instance.
 		 */
 		public HttpRequestValues build() {
@@ -390,7 +413,7 @@ public final class HttpRequestValues {
 
 			return new HttpRequestValues(
 					this.httpMethod, uri, uriTemplate, uriVars, headers, cookies, bodyValue,
-					this.body, this.bodyElementType);
+					this.body, this.bodyElementType, this.continuation);
 		}
 
 		private String appendQueryParams(

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValues.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValues.java
@@ -365,7 +365,6 @@ public final class HttpRequestValues {
 		 * Set the Continuation parameter.
 		 */
 		public Builder setContinuation(Object continuation) {
-			Assert.notNull(continuation, "HttpMethod is required");
 			this.continuation = continuation;
 			return this;
 		}

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceProxyFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceProxyFactory.java
@@ -28,6 +28,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.core.KotlinDetector;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -193,6 +194,9 @@ public final class HttpServiceProxyFactory {
 			resolvers.add(new CookieValueArgumentResolver(conversionService));
 			resolvers.add(new UrlArgumentResolver());
 			resolvers.add(new HttpMethodArgumentResolver());
+			if (KotlinDetector.isKotlinPresent()) {
+				resolvers.add(new CoroutinesSuspendArgumentResolver());
+			}
 			return resolvers;
 		}
 

--- a/spring-web/src/test/kotlin/org/springframework/web/service/invoker/CoroutinesSuspendArgumentResolverKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/service/invoker/CoroutinesSuspendArgumentResolverKotlinTests.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.web.service.invoker
 
 import kotlinx.coroutines.runBlocking

--- a/spring-web/src/test/kotlin/org/springframework/web/service/invoker/CoroutinesSuspendArgumentResolverKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/service/invoker/CoroutinesSuspendArgumentResolverKotlinTests.kt
@@ -1,0 +1,28 @@
+package org.springframework.web.service.invoker
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.web.service.annotation.GetExchange
+
+class CoroutinesSuspendArgumentResolverKotlinTests {
+
+	private val client = TestHttpClientAdapter()
+
+	private val service = HttpServiceProxyFactory.builder(client).build().createClient(Service::class.java)
+
+	@Test
+	fun continuation() {
+		runBlocking {
+			service.execute()
+			assertThat(client.requestValues.continuation).isNotNull
+		}
+	}
+
+	private interface Service {
+
+		@GetExchange
+		suspend fun execute()
+	}
+
+}

--- a/spring-web/src/test/kotlin/org/springframework/web/service/invoker/HttpServiceMethodKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/service/invoker/HttpServiceMethodKotlinTests.kt
@@ -15,6 +15,8 @@
  */
 package org.springframework.web.service.invoker
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
@@ -48,6 +50,13 @@ class HttpServiceMethodKotlinTests {
 
 			val entity = service.entity()
 			assertThat(entity.body).isEqualTo("requestToEntity")
+
+			val flowEntity = service.flowEntity()
+			assertThat(flowEntity.body?.toList()).containsExactly("request", "To", "Entity", "Flux");
+
+			val flow = service.flow()
+			assertThat(flow.toList()).containsExactly("request", "To", "Body", "Flux");
+
 		}
 	}
 
@@ -68,6 +77,12 @@ class HttpServiceMethodKotlinTests {
 
 		@GetExchange
 		suspend fun entity(): ResponseEntity<String>
+
+		@GetExchange
+		suspend fun flowEntity(): ResponseEntity<Flow<String>>
+
+		@GetExchange
+		fun flow() : Flow<String>
 
 	}
 

--- a/spring-web/src/test/kotlin/org/springframework/web/service/invoker/HttpServiceMethodKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/service/invoker/HttpServiceMethodKotlinTests.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.web.service.invoker
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseEntity
+import org.springframework.web.service.annotation.GetExchange
+
+import org.assertj.core.api.Assertions.assertThat
+
+class HttpServiceMethodKotlinTests {
+
+	private val clientAdapter = TestHttpClientAdapter()
+
+	private val proxyFactory = HttpServiceProxyFactory.builder(clientAdapter).build()
+
+	@Test
+	fun suspendService() {
+		val service = proxyFactory.createClient(SuspendService::class.java)
+
+		runBlocking {
+
+			service.execute()
+
+			val headers = service.headers()
+			assertThat(headers).isNotNull
+
+			val body  = service.body()
+			assertThat(body).isEqualTo("requestToBody")
+
+			val voidEntity = service.voidEntity()
+			assertThat(voidEntity.body).isNull()
+
+			val entity = service.entity()
+			assertThat(entity.body).isEqualTo("requestToEntity")
+		}
+	}
+
+
+	private interface SuspendService {
+
+		@GetExchange
+		suspend fun execute()
+
+		@GetExchange
+		suspend fun headers(): HttpHeaders
+
+		@GetExchange
+		suspend fun body(): String?
+
+		@GetExchange
+		suspend fun voidEntity(): ResponseEntity<Void>
+
+		@GetExchange
+		suspend fun entity(): ResponseEntity<String>
+
+	}
+
+}


### PR DESCRIPTION

Usage example:

```kotlin
interface SuspendService {

	@GetExchange
	suspend fun execute()

}
```

