### PR TITLE
Fix Javadoc for DatabaseClient

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
@@ -50,8 +50,8 @@ import org.springframework.util.Assert;
  *
  * DatabaseClient client = DatabaseClient.create(factory);
  * Mono&lt;Actor&gt; actor = client.sql("select first_name, last_name from t_actor")
- *     .map(row -&gt; new Actor(row.get("first_name, String.class"),
- *          row.get("last_name, String.class")))
+ *     .map(row -&gt; new Actor(row.get("first_name", String.class),
+ *          row.get("last_name", String.class)))
  *     .first();
  * </pre>
  *


### PR DESCRIPTION
Fixed a misplaced double quote in the
documentation for `DatabaseClient` in the
example on how to map a `select` statement to a `Row`.