### PR TITLE
Bean definition contribution includes attributes that are not used at…

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/aot/BeanDefinitionPropertiesCodeGenerator.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/aot/BeanDefinitionPropertiesCodeGenerator.java
@@ -88,19 +88,16 @@ class BeanDefinitionPropertiesCodeGenerator {
 
 	private final RuntimeHints hints;
 
-	private final Predicate<String> attributeFilter;
-
 	private final BiFunction<String, Object, CodeBlock> customValueCodeGenerator;
 
 	private final BeanDefinitionPropertyValueCodeGenerator valueCodeGenerator;
 
 
 	BeanDefinitionPropertiesCodeGenerator(RuntimeHints hints,
-			Predicate<String> attributeFilter, MethodGenerator methodGenerator,
+			MethodGenerator methodGenerator,
 			BiFunction<String, Object, CodeBlock> customValueCodeGenerator) {
 
 		this.hints = hints;
-		this.attributeFilter = attributeFilter;
 		this.customValueCodeGenerator = customValueCodeGenerator;
 		this.valueCodeGenerator = new BeanDefinitionPropertyValueCodeGenerator(
 				methodGenerator);
@@ -133,7 +130,6 @@ class BeanDefinitionPropertiesCodeGenerator {
 		}
 		addConstructorArgumentValues(builder, beanDefinition);
 		addPropertyValues(builder, beanDefinition);
-		addAttributes(builder, beanDefinition);
 		return builder.build();
 	}
 
@@ -241,21 +237,6 @@ class BeanDefinitionPropertiesCodeGenerator {
 				.filter(pd -> propertyName.equals(pd.getName()))
 				.map(java.beans.PropertyDescriptor::getWriteMethod)
 				.filter(Objects::nonNull).findFirst().orElse(null);
-	}
-
-
-	private void addAttributes(CodeBlock.Builder builder, BeanDefinition beanDefinition) {
-		String[] attributeNames = beanDefinition.attributeNames();
-		if (!ObjectUtils.isEmpty(attributeNames)) {
-			for (String attributeName : attributeNames) {
-				if (this.attributeFilter.test(attributeName)) {
-					CodeBlock value = this.valueCodeGenerator
-							.generateCode(beanDefinition.getAttribute(attributeName));
-					builder.addStatement("$L.setAttribute($S, $L)",
-							BEAN_DEFINITION_VARIABLE, attributeName, value);
-				}
-			}
-		}
 	}
 
 	private boolean hasScope(String defaultValue, String actualValue) {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/aot/DefaultBeanRegistrationCodeFragments.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/aot/DefaultBeanRegistrationCodeFragments.java
@@ -104,7 +104,7 @@ class DefaultBeanRegistrationCodeFragments extends BeanRegistrationCodeFragments
 			Predicate<String> attributeFilter) {
 
 		return new BeanDefinitionPropertiesCodeGenerator(
-				generationContext.getRuntimeHints(), attributeFilter,
+				generationContext.getRuntimeHints(),
 				beanRegistrationCode.getMethodGenerator(),
 				(name, value) -> generateValueCode(generationContext, name, value))
 						.generateCode(beanDefinition);

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionMethodGeneratorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionMethodGeneratorTests.java
@@ -167,39 +167,20 @@ class BeanDefinitionMethodGeneratorTests {
 	}
 
 	@Test
-	void generateBeanDefinitionMethodWhenHasAttributeFilterGeneratesMethod() {
+	void generateBeanDefinitionMethodWhenHasAttributes() {
 		RootBeanDefinition beanDefinition = new RootBeanDefinition(TestBean.class);
 		beanDefinition.setAttribute("a", "A");
 		beanDefinition.setAttribute("b", "B");
 		RegisteredBean registeredBean = registerBean(beanDefinition);
-		List<BeanRegistrationCodeFragmentsCustomizer> fragmentCustomizers = Collections
-				.singletonList(this::customizeWithAttributeFilter);
 		BeanDefinitionMethodGenerator generator = new BeanDefinitionMethodGenerator(
 				this.methodGeneratorFactory, registeredBean, null,
-				Collections.emptyList(), fragmentCustomizers);
+				Collections.emptyList(), Collections.emptyList());
 		MethodReference method = generator.generateBeanDefinitionMethod(
 				this.generationContext, this.beanRegistrationsCode);
 		testCompiledResult(method, (actual, compiled) -> {
-			assertThat(actual.getAttribute("a")).isEqualTo("A");
+			assertThat(actual.getAttribute("a")).isNull();
 			assertThat(actual.getAttribute("b")).isNull();
 		});
-	}
-
-	private BeanRegistrationCodeFragments customizeWithAttributeFilter(
-			RegisteredBean registeredBean, BeanRegistrationCodeFragments codeFragments) {
-		return new BeanRegistrationCodeFragments(codeFragments) {
-
-			@Override
-			public CodeBlock generateSetBeanDefinitionPropertiesCode(
-					GenerationContext generationContext,
-					BeanRegistrationCode beanRegistrationCode,
-					RootBeanDefinition beanDefinition,
-					Predicate<String> attributeFilter) {
-				return super.generateSetBeanDefinitionPropertiesCode(generationContext,
-						beanRegistrationCode, beanDefinition, name -> "a".equals(name));
-			}
-
-		};
 	}
 
 	@Test

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionPropertiesCodeGeneratorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionPropertiesCodeGeneratorTests.java
@@ -65,7 +65,7 @@ class BeanDefinitionPropertiesCodeGeneratorTests {
 	private final RuntimeHints hints = new RuntimeHints();
 
 	private BeanDefinitionPropertiesCodeGenerator generator = new BeanDefinitionPropertiesCodeGenerator(
-			this.hints, attribute -> true, this.generatedMethods, (name, value) -> null);
+			this.hints, this.generatedMethods, (name, value) -> null);
 
 
 	@Test
@@ -350,33 +350,6 @@ class BeanDefinitionPropertiesCodeGeneratorTests {
 			Object value = actual.getPropertyValues().get("value");
 			assertThat(value).isInstanceOf(ManagedMap.class);
 			assertThat(((Map<?, ?>) value).get("test")).isInstanceOf(BeanReference.class);
-		});
-	}
-
-	@Test
-	void attributesWhenAllFiltered() {
-		this.beanDefinition.setAttribute("a", "A");
-		this.beanDefinition.setAttribute("b", "B");
-		Predicate<String> attributeFilter = attribute -> false;
-		this.generator = new BeanDefinitionPropertiesCodeGenerator(this.hints,
-				attributeFilter, this.generatedMethods, (name, value) -> null);
-		testCompiledResult((actual, compiled) -> {
-			assertThat(compiled.getSourceFile()).doesNotContain("setAttribute");
-			assertThat(actual.getAttribute("a")).isNull();
-			assertThat(actual.getAttribute("b")).isNull();
-		});
-	}
-
-	@Test
-	void attributesWhenSomeFiltered() {
-		this.beanDefinition.setAttribute("a", "A");
-		this.beanDefinition.setAttribute("b", "B");
-		Predicate<String> attributeFilter = attribute -> "a".equals(attribute);
-		this.generator = new BeanDefinitionPropertiesCodeGenerator(this.hints,
-				attributeFilter, this.generatedMethods, (name, value) -> null);
-		testCompiledResult(this.beanDefinition, (actual, compiled) -> {
-			assertThat(actual.getAttribute("a")).isEqualTo("A");
-			assertThat(actual.getAttribute("b")).isNull();
 		});
 	}
 


### PR DESCRIPTION
Hello! This commit fixes issue #28516 by removing mechanism for adding attributes to dynamically compiled beans. I think that attributes in compiled beans are not relevant, so this solution may do the thing. Other solution may be implementing filter to automatically filter attributes with "PostProcessor" string in it as they are used internally and don't really contribute in runtime. What do you think?