### PR TITLE
Undeprecate PathMatchConfigurer::isUseTrailingSlashMatch

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/PathMatchConfigurer.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/PathMatchConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,7 +186,6 @@ public class PathMatchConfigurer {
 	}
 
 	@Nullable
-	@Deprecated
 	public Boolean isUseTrailingSlashMatch() {
 		return this.trailingSlashMatch;
 	}


### PR DESCRIPTION
This commit removes deprecation from `PathMatchConfigurer::isUseTrailingSlashMatch` that was accidentally introduced in 5225a574.