### PR TITLE
Improve AssertJ usage in cache config tests

### DIFF
--- a/spring-context/src/test/java/org/springframework/cache/config/CacheAdviceParserTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/CacheAdviceParserTests.java
@@ -17,23 +17,22 @@
 package org.springframework.cache.config;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.context.support.GenericXmlApplicationContext;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * AOP advice specific parsing tests.
  *
  * @author Stephane Nicoll
  */
-public class CacheAdviceParserTests {
+class CacheAdviceParserTests {
 
 	@Test
-	public void keyAndKeyGeneratorCannotBeSetTogether() {
-		assertThatExceptionOfType(BeanDefinitionStoreException.class).isThrownBy(() ->
-				new GenericXmlApplicationContext("/org/springframework/cache/config/cache-advice-invalid.xml"));
+	void keyAndKeyGeneratorCannotBeSetTogether() {
+		assertThatThrownBy(() -> new GenericXmlApplicationContext("/org/springframework/cache/config/cache-advice-invalid.xml"))
+				.isInstanceOf(BeanDefinitionStoreException.class);
 		// TODO better exception handling
 	}
 

--- a/spring-context/src/test/java/org/springframework/cache/config/CustomInterceptorTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/CustomInterceptorTests.java
@@ -16,13 +16,9 @@
 
 package org.springframework.cache.config;
 
-import java.io.IOException;
-import java.util.Map;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.CacheInterceptor;
@@ -36,13 +32,16 @@ import org.springframework.context.testfixture.cache.CacheTestUtils;
 import org.springframework.context.testfixture.cache.beans.CacheableService;
 import org.springframework.context.testfixture.cache.beans.DefaultCacheableService;
 
+import java.io.IOException;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Stephane Nicoll
  */
-public class CustomInterceptorTests {
+class CustomInterceptorTests {
 
 	protected ConfigurableApplicationContext ctx;
 
@@ -60,25 +59,25 @@ public class CustomInterceptorTests {
 	}
 
 	@Test
-	public void onlyOneInterceptorIsAvailable() {
+	void onlyOneInterceptorIsAvailable() {
 		Map<String, CacheInterceptor> interceptors = this.ctx.getBeansOfType(CacheInterceptor.class);
-		assertThat(interceptors.size()).as("Only one interceptor should be defined").isEqualTo(1);
+		assertThat(interceptors).as("Only one interceptor should be defined").hasSize(1);
 		CacheInterceptor interceptor = interceptors.values().iterator().next();
-		assertThat(interceptor.getClass()).as("Custom interceptor not defined").isEqualTo(TestCacheInterceptor.class);
+		assertThat(interceptor).as("Custom interceptor not defined").isInstanceOf(TestCacheInterceptor.class);
 	}
 
 	@Test
-	public void customInterceptorAppliesWithRuntimeException() {
+	void customInterceptorAppliesWithRuntimeException() {
 		Object o = this.cs.throwUnchecked(0L);
 		// See TestCacheInterceptor
 		assertThat(o).isEqualTo(55L);
 	}
 
 	@Test
-	public void customInterceptorAppliesWithCheckedException() {
-		assertThatRuntimeException()
-			.isThrownBy(() -> this.cs.throwChecked(0L))
-			.withCauseExactlyInstanceOf(IOException.class);
+	void customInterceptorAppliesWithCheckedException() {
+		assertThatThrownBy(() -> this.cs.throwChecked(0L))
+				.isInstanceOf(RuntimeException.class)
+				.hasCauseExactlyInstanceOf(IOException.class);
 	}
 
 
@@ -116,8 +115,7 @@ public class CustomInterceptorTests {
 		protected Object invokeOperation(CacheOperationInvoker invoker) {
 			try {
 				return super.invokeOperation(invoker);
-			}
-			catch (CacheOperationInvoker.ThrowableWrapper e) {
+			} catch (CacheOperationInvoker.ThrowableWrapper e) {
 				Throwable original = e.getOriginal();
 				if (original.getClass() == UnsupportedOperationException.class) {
 					return 55L;

--- a/spring-context/src/test/java/org/springframework/cache/config/EnableCachingIntegrationTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/EnableCachingIntegrationTests.java
@@ -16,11 +16,8 @@
 
 package org.springframework.cache.config;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -37,6 +34,8 @@ import org.springframework.context.testfixture.cache.CacheTestUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.context.testfixture.cache.CacheTestUtils.assertCacheHit;
 import static org.springframework.context.testfixture.cache.CacheTestUtils.assertCacheMiss;
@@ -46,7 +45,7 @@ import static org.springframework.context.testfixture.cache.CacheTestUtils.asser
  *
  * @author Stephane Nicoll
  */
-public class EnableCachingIntegrationTests {
+class EnableCachingIntegrationTests {
 
 	private ConfigurableApplicationContext context;
 
@@ -60,14 +59,14 @@ public class EnableCachingIntegrationTests {
 
 
 	@Test
-	public void fooServiceWithInterface() {
+	void fooServiceWithInterface() {
 		this.context = new AnnotationConfigApplicationContext(FooConfig.class);
 		FooService service = this.context.getBean(FooService.class);
 		fooGetSimple(service);
 	}
 
 	@Test
-	public void fooServiceWithInterfaceCglib() {
+	void fooServiceWithInterfaceCglib() {
 		this.context = new AnnotationConfigApplicationContext(FooConfigCglib.class);
 		FooService service = this.context.getBean(FooService.class);
 		fooGetSimple(service);
@@ -84,7 +83,7 @@ public class EnableCachingIntegrationTests {
 	}
 
 	@Test
-	public void barServiceWithCacheableInterfaceCglib() {
+	void barServiceWithCacheableInterfaceCglib() {
 		this.context = new AnnotationConfigApplicationContext(BarConfigCglib.class);
 		BarService service = this.context.getBean(BarService.class);
 		Cache cache = getCache();
@@ -97,7 +96,7 @@ public class EnableCachingIntegrationTests {
 	}
 
 	@Test
-	public void beanConditionOff() {
+	void beanConditionOff() {
 		this.context = new AnnotationConfigApplicationContext(BeanConditionConfig.class);
 		FooService service = this.context.getBean(FooService.class);
 		Cache cache = getCache();
@@ -112,7 +111,7 @@ public class EnableCachingIntegrationTests {
 	}
 
 	@Test
-	public void beanConditionOn() {
+	void beanConditionOn() {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
 		ctx.setEnvironment(new MockEnvironment().withProperty("bar.enabled", "true"));
 		ctx.register(BeanConditionConfig.class);

--- a/spring-context/src/test/java/org/springframework/cache/config/EnableCachingTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/EnableCachingTests.java
@@ -17,7 +17,6 @@
 package org.springframework.cache.config;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.cache.CacheManager;
@@ -44,6 +43,8 @@ import org.springframework.context.testfixture.cache.beans.CacheableService;
 import org.springframework.context.testfixture.cache.beans.DefaultCacheableService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Integration tests for {@code @EnableCaching} and its related
@@ -54,7 +55,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class EnableCachingTests extends AbstractCacheAnnotationTests {
 
-	/** hook into superclass suite of tests */
+	/**
+	 * hook into superclass suite of tests
+	 */
 	@Override
 	protected ConfigurableApplicationContext getApplicationContext() {
 		return new AnnotationConfigApplicationContext(EnableCachingConfig.class);
@@ -76,7 +79,7 @@ class EnableCachingTests extends AbstractCacheAnnotationTests {
 	void singleCacheManagerBean() {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
 		ctx.register(SingleCacheManagerConfig.class);
-		ctx.refresh();
+		assertThatCode(ctx::refresh).doesNotThrowAnyException();
 		ctx.close();
 	}
 
@@ -85,20 +88,17 @@ class EnableCachingTests extends AbstractCacheAnnotationTests {
 		@SuppressWarnings("resource")
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
 		ctx.register(MultiCacheManagerConfig.class);
-		try {
-			ctx.refresh();
-		}
-		catch (IllegalStateException ex) {
-			assertThat(ex.getMessage().contains("no unique bean of type CacheManager")).isTrue();
-			assertThat(ex).hasCauseInstanceOf(NoUniqueBeanDefinitionException.class);
-		}
+		assertThatThrownBy(ctx::refresh)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("no unique bean of type CacheManager")
+				.hasCauseInstanceOf(NoUniqueBeanDefinitionException.class);
 	}
 
 	@Test
 	void multipleCacheManagerBeans_implementsCachingConfigurer() {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
 		ctx.register(MultiCacheManagerConfigurer.class);
-		ctx.refresh();  // does not throw an exception
+		assertThatCode(ctx::refresh).doesNotThrowAnyException();
 		ctx.close();
 	}
 
@@ -107,12 +107,8 @@ class EnableCachingTests extends AbstractCacheAnnotationTests {
 		@SuppressWarnings("resource")
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
 		ctx.register(MultiCacheManagerConfigurer.class, EnableCachingConfig.class);
-		try {
-			ctx.refresh();
-		}
-		catch (IllegalStateException ex) {
-			assertThat(ex.getMessage().contains("implementations of CachingConfigurer")).isTrue();
-		}
+		assertThatThrownBy(ctx::refresh)
+				.hasMessageContaining("implementations of CachingConfigurer");
 	}
 
 	@Test
@@ -120,22 +116,19 @@ class EnableCachingTests extends AbstractCacheAnnotationTests {
 		@SuppressWarnings("resource")
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
 		ctx.register(EmptyConfig.class);
-		try {
-			ctx.refresh();
-		}
-		catch (IllegalStateException ex) {
-			assertThat(ex.getMessage().contains("no bean of type CacheManager")).isTrue();
-			assertThat(ex).hasCauseInstanceOf(NoSuchBeanDefinitionException.class);
-		}
+		assertThatThrownBy(ctx::refresh)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("no bean of type CacheManager")
+				.hasCauseInstanceOf(NoSuchBeanDefinitionException.class);
 	}
 
 	@Test
 	void emptyConfigSupport() {
 		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(EmptyConfigSupportConfig.class);
 		CacheInterceptor ci = context.getBean(CacheInterceptor.class);
-		assertThat(ci.getCacheResolver()).isNotNull();
-		assertThat(ci.getCacheResolver().getClass()).isEqualTo(SimpleCacheResolver.class);
-		assertThat(((SimpleCacheResolver) ci.getCacheResolver()).getCacheManager()).isSameAs(context.getBean(CacheManager.class));
+		assertThat(ci.getCacheResolver()).isInstanceOfSatisfying(SimpleCacheResolver.class, cacheResolver -> {
+			assertThat(cacheResolver.getCacheManager()).isSameAs(context.getBean(CacheManager.class));
+		});
 		context.close();
 	}
 


### PR DESCRIPTION
Just some code improvements I've found while studying code in that area. It boils down to using more AssertJ features instead of hand-written code and removes `public` at some places (unnecessary with JUnit 5).