### PR TITLE
Update reference docs to use PropertySourcesPlaceholderConfigurer

### DIFF
--- a/src/docs/asciidoc/web/webflux.adoc
+++ b/src/docs/asciidoc/web/webflux.adoc
@@ -1563,7 +1563,7 @@ extracts the name, version, and file extension:
 ----
 
 URI path patterns can also have embedded `${...}` placeholders that are resolved on startup
-through `PropertyPlaceHolderConfigurer` against local, system, environment, and other property
+through `PropertySourcesPlaceholderConfigurer` against local, system, environment, and other property
 sources. You ca use this to, for example, parameterize a base URL based on some external
 configuration.
 

--- a/src/docs/asciidoc/web/webmvc.adoc
+++ b/src/docs/asciidoc/web/webmvc.adoc
@@ -1718,7 +1718,7 @@ extracts the name, version, and file extension:
 ----
 
 URI path patterns can also have embedded `${...}` placeholders that are resolved on startup
-by using `PropertyPlaceHolderConfigurer` against local, system, environment, and other property
+by using `PropertySourcesPlaceholderConfigurer` against local, system, environment, and other property
 sources. You can use this, for example, to parameterize a base URL based on some external
 configuration.
 


### PR DESCRIPTION
`PropertyPlaceholderConfigurer` has been deprecated as of Spring 5.2, in favor of `PropertySourcesPlaceholderConfigurer`, according to the doc comments following:

https://github.com/spring-projects/spring-framework/blob/305055d6b1a42c7795891b7b389936ed80270505/spring-beans/src/main/java/org/springframework/beans/factory/config/PropertyPlaceholderConfigurer.java#L52-L54
