### PR TITLE
Expose ThreadPoolTaskExecutor queue size and capacity for metrics

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.java
@@ -315,6 +315,20 @@ public class ThreadPoolTaskExecutor extends ExecutorConfigurationSupport
 		}
 		return this.threadPoolExecutor.getPoolSize();
 	}
+	
+	/**
+	 * Return the current number of threads waiting in the queue
+	 */
+	public int getCurrentQueueSize() {
+		return this.getThreadPoolExecutor().getQueue().size();
+	}
+
+	/**
+	* Return the maximum capacity of the queue
+	*/
+	public int getQueueCapacity() {
+		return this.queueCapacity;
+	}
 
 	/**
 	 * Return the number of currently active threads.


### PR DESCRIPTION
We're using grafana to monitor our app through java jmx exporter. We planned to configure some alerts based on those metrics, and we think it could be interesting to have at least the currentQueueCapacity for this purpose  since the queue size directly affects the app memory load.
(Having the queueCapacity seems also interesting to set up triggers whose trigger value are calculated based on the maximum capacity of the queue.)