### PR TITLE
EOFException in HttpMessageConverterExtractor while extracting data of a empty GZiped response

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/IntrospectingClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/web/client/IntrospectingClientHttpResponse.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.client;
 
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
@@ -96,14 +98,20 @@ class IntrospectingClientHttpResponse extends ClientHttpResponseDecorator {
 			}
 		}
 		else {
-			this.pushbackInputStream = new PushbackInputStream(body);
-			int b = this.pushbackInputStream.read();
-			if (b == -1) {
-				return true;
+			try {
+				this.pushbackInputStream = new PushbackInputStream(body);
+				int b = this.pushbackInputStream.read();
+				if (b == -1) {
+					return true;
+				}
+				else {
+					this.pushbackInputStream.unread(b);
+					return false;
+				}
 			}
-			else {
-				this.pushbackInputStream.unread(b);
-				return false;
+			catch (EOFException ex) {
+				this.pushbackInputStream = new PushbackInputStream(new ByteArrayInputStream(new byte[0]));
+				return true;
 			}
 		}
 	}

--- a/spring-web/src/test/java/org/springframework/web/client/HttpMessageConverterExtractorTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/HttpMessageConverterExtractorTests.java
@@ -18,9 +18,11 @@ package org.springframework.web.client;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
+import java.util.zip.GZIPInputStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -109,6 +111,22 @@ class HttpMessageConverterExtractorTests {
 		given(response.getStatusCode()).willReturn(HttpStatus.OK);
 		given(response.getHeaders()).willReturn(responseHeaders);
 		given(response.getBody()).willReturn(new ByteArrayInputStream("".getBytes()));
+
+		Object result = extractor.extractData(response);
+		assertThat(result).isNull();
+	}
+
+	@Test
+	void emptyLazyGzipMessageBody() throws IOException {
+		given(response.getStatusCode()).willReturn(HttpStatus.BAD_REQUEST);
+		given(response.getHeaders()).willReturn(responseHeaders);
+		given(response.getBody()).willReturn(new InputStream() {
+			@Override
+			public int read() throws IOException {
+				// Simulates lazy gzip stream reading
+				return new GZIPInputStream(new ByteArrayInputStream("".getBytes())).read();
+			}
+		});
 
 		Object result = extractor.extractData(response);
 		assertThat(result).isNull();


### PR DESCRIPTION
**Problem**: When calling RestTemplate#exchange with response type != Void.class, if

- The server responds with
  - an _empty body_ and
  - _Content-Encoding: gzip_

we get a EOFException in the RestTemplate client.

**Solution**: IntrospectingClientHttpResponse#hasEmptyMessageBody should not throw an exception when the response body is an empty lazy gzip stream.

After reading the first byte, if it receives an EOFException, it should understand it as a signal of the end of the stream, thus returning true to the question "Has an empty message body?", not EOFException to the RestTemplate client.

Related issue:
https://github.com/spring-projects/spring-framework/issues/12671