### PR TITLE
Avoid eager instantiation of non-singleton FactoryBean in getBeanNamesForType

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -574,7 +574,8 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 							if (!matchFound) {
 								// In case of FactoryBean, try to match FactoryBean instance itself next.
 								beanName = FACTORY_BEAN_PREFIX + beanName;
-								matchFound = isTypeMatch(beanName, type, allowFactoryBeanInit);
+								matchFound = (includeNonSingletons || isSingleton(beanName, mbd, dbd)) && isTypeMatch(beanName, type, allowFactoryBeanInit);
+
 							}
 						}
 						if (matchFound) {


### PR DESCRIPTION
Fix for #28615