### PR TITLE
Add `MockMvcRequestBuilders.multipart(HttpMethod, String, Object...)`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMultipartHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMultipartHttpServletRequestBuilder.java
@@ -64,7 +64,11 @@ public class MockMultipartHttpServletRequestBuilder extends MockHttpServletReque
 	 * @param uriVariables zero or more URI variables
 	 */
 	MockMultipartHttpServletRequestBuilder(String urlTemplate, Object... uriVariables) {
-		super(HttpMethod.POST, urlTemplate, uriVariables);
+		this(HttpMethod.POST, urlTemplate, uriVariables);
+	}
+
+	MockMultipartHttpServletRequestBuilder(HttpMethod httpMethod, String urlTemplate, Object... uriVariables) {
+		super(httpMethod, urlTemplate, uriVariables);
 		super.contentType(MediaType.MULTIPART_FORM_DATA);
 	}
 
@@ -74,8 +78,7 @@ public class MockMultipartHttpServletRequestBuilder extends MockHttpServletReque
 	 * @since 4.0.3
 	 */
 	MockMultipartHttpServletRequestBuilder(URI uri) {
-		super(HttpMethod.POST, uri);
-		super.contentType(MediaType.MULTIPART_FORM_DATA);
+		this(HttpMethod.POST, uri);
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
@@ -215,6 +215,17 @@ public abstract class MockMvcRequestBuilders {
 	}
 
 	/**
+	 * Create a {@link MockMultipartHttpServletRequestBuilder} for a multipart request.
+	 * @param httpMethod the HTTP method to use
+	 * @param urlTemplate a URL template; the resulting URL will be encoded
+	 * @param uriVars zero or more URI variables
+	 * @since 5.3.22
+	 */
+	public static MockMultipartHttpServletRequestBuilder multipart(HttpMethod httpMethod, String urlTemplate, Object... uriVars) {
+		return new MockMultipartHttpServletRequestBuilder(httpMethod, urlTemplate, uriVars);
+	}
+
+	/**
 	 * Variant of {@link #multipart(String, Object...)} with a {@link URI}.
 	 * @param uri the URL
 	 * @since 5.0


### PR DESCRIPTION
This PR adds `MockMvcRequestBuilders.multipart(HttpMethod, String, Object...)` that is similar to `MockMvcRequestBuilders.multipart(HttpMethod, URI)` that has been added in #28545.