### PR TITLE
Update to Bouncycastle 1.71

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,7 +197,7 @@ configure(allprojects) { project ->
 			}
 			dependency "org.skyscreamer:jsonassert:1.5.0"
 			dependency "com.jayway.jsonpath:json-path:2.6.0"
-			dependency "org.bouncycastle:bcpkix-jdk15on:1.66"
+			dependency "org.bouncycastle:bcpkix-jdk18on:1.71"
 
 			dependency "javax.cache:cache-api:1.1.1"
 			dependency "javax.money:money-api:1.1"

--- a/spring-web/spring-web.gradle
+++ b/spring-web/spring-web.gradle
@@ -77,7 +77,7 @@ dependencies {
 	testFixturesApi("org.junit.jupiter:junit-jupiter-params")
 	testFixturesImplementation("io.projectreactor:reactor-test")
 	testFixturesImplementation("org.assertj:assertj-core")
-	testFixturesImplementation("org.bouncycastle:bcpkix-jdk15on") {
+	testFixturesImplementation("org.bouncycastle:bcpkix-jdk18on") {
 		because("needed by Netty's SelfSignedCertificate on JDK 15+")
 	}
 	testFixturesImplementation("org.eclipse.jetty.websocket:websocket-jetty-server")


### PR DESCRIPTION
BouncyCastle changed its artifact name suffix from `jdk15on` to `jdk18on` in the latest releases, as it now requires at least Java 1.8