### PR TITLE
Improve `LoggingCacheErrorHandler`

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/LoggingCacheErrorHandler.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/LoggingCacheErrorHandler.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  *
  * @author Adam Ostrožlík
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  * @since 5.3.16
  */
 public class LoggingCacheErrorHandler implements CacheErrorHandler {
@@ -50,10 +51,18 @@ public class LoggingCacheErrorHandler implements CacheErrorHandler {
 	}
 
 	/**
+	 * Create an instance.
+	 * @param logStacktrace whether to log stacktrace
+	 */
+	public LoggingCacheErrorHandler(boolean logStacktrace) {
+		this(LogFactory.getLog(LoggingCacheErrorHandler.class), logStacktrace);
+	}
+
+	/**
 	 * Create an instance that does not log stack traces.
 	 */
 	public LoggingCacheErrorHandler() {
-		this(LogFactory.getLog(LoggingCacheErrorHandler.class), false);
+		this(false);
 	}
 
 

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/LoggingCacheErrorHandler.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/LoggingCacheErrorHandler.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cache.interceptor;
 
+import java.util.function.Supplier;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -69,46 +71,46 @@ public class LoggingCacheErrorHandler implements CacheErrorHandler {
 	@Override
 	public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
 		logCacheError(logger,
-				createMessage(cache, "failed to get entry with key '" + key + "'"),
+				() -> String.format("Cache '%s' %s", cache.getName(), "failed to get entry with key '" + key + "'"),
 				exception);
 	}
 
 	@Override
 	public void handleCachePutError(RuntimeException exception, Cache cache, Object key, @Nullable Object value) {
 		logCacheError(logger,
-				createMessage(cache, "failed to put entry with key '" + key + "'"),
+				() -> String.format("Cache '%s' %s", cache.getName(), "failed to put entry with key '" + key + "'"),
 				exception);
 	}
 
 	@Override
 	public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
 		logCacheError(logger,
-				createMessage(cache, "failed to evict entry with key '" + key + "'"),
+				() -> String.format("Cache '%s' %s", cache.getName(), "failed to evict entry with key '" + key + "'"),
 				exception);
 	}
 
 	@Override
 	public void handleCacheClearError(RuntimeException exception, Cache cache) {
-		logCacheError(logger, createMessage(cache, "failed to clear entries"), exception);
+		logCacheError(logger,
+				() -> String.format("Cache '%s' %s", cache.getName(), "failed to clear entries"),
+				exception);
 	}
 
 	/**
 	 * Log the specified message.
 	 * @param logger the logger
-	 * @param message the message
+	 * @param messageSupplier the message supplier
 	 * @param ex the exception
 	 */
-	protected void logCacheError(Log logger, String message, RuntimeException ex) {
-		if (this.logStacktrace) {
-			logger.warn(message, ex);
+	protected void logCacheError(Log logger, Supplier<String> messageSupplier, RuntimeException ex) {
+		if (logger.isWarnEnabled()) {
+			if (this.logStacktrace) {
+				logger.warn(messageSupplier.get(), ex);
+			}
+			else {
+				logger.warn(messageSupplier.get());
+			}
 		}
-		else {
-			logger.warn(message);
-		}
-	}
-
-	private String createMessage(Cache cache, String reason) {
-		return String.format("Cache '%s' %s", cache.getName(), reason);
 	}
 
 }

--- a/spring-context/src/test/java/org/springframework/cache/interceptor/LoggingCacheErrorHandlerTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/interceptor/LoggingCacheErrorHandlerTests.java
@@ -17,11 +17,15 @@
 package org.springframework.cache.interceptor;
 
 import org.apache.commons.logging.Log;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.cache.support.NoOpCache;
 
-import static org.mockito.Mockito.mock;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -29,48 +33,53 @@ import static org.mockito.Mockito.verify;
  *
  * @author Adam Ostrožlík
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  */
-public class LoggingCacheErrorHandlerTests {
+@ExtendWith(MockitoExtension.class)
+class LoggingCacheErrorHandlerTests {
+
+	@Mock
+	private Log logger;
+
+	@BeforeEach
+	void setUp() {
+		given(this.logger.isWarnEnabled()).willReturn(true);
+	}
 
 	@Test
 	void handleGetCacheErrorLogsAppropriateMessage() {
-		Log logger = mock(Log.class);
-		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(logger, false);
+		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(this.logger, false);
 		handler.handleCacheGetError(new RuntimeException(), new NoOpCache("NOOP"), "key");
-		verify(logger).warn("Cache 'NOOP' failed to get entry with key 'key'");
+		verify(this.logger).warn("Cache 'NOOP' failed to get entry with key 'key'");
 	}
 
 	@Test
 	void handlePutCacheErrorLogsAppropriateMessage() {
-		Log logger = mock(Log.class);
-		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(logger, false);
+		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(this.logger, false);
 		handler.handleCachePutError(new RuntimeException(), new NoOpCache("NOOP"), "key", new Object());
-		verify(logger).warn("Cache 'NOOP' failed to put entry with key 'key'");
+		verify(this.logger).warn("Cache 'NOOP' failed to put entry with key 'key'");
 	}
 
 	@Test
 	void handleEvictCacheErrorLogsAppropriateMessage() {
-		Log logger = mock(Log.class);
-		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(logger, false);
+		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(this.logger, false);
 		handler.handleCacheEvictError(new RuntimeException(), new NoOpCache("NOOP"), "key");
-		verify(logger).warn("Cache 'NOOP' failed to evict entry with key 'key'");
+		verify(this.logger).warn("Cache 'NOOP' failed to evict entry with key 'key'");
 	}
 
 	@Test
 	void handleClearErrorLogsAppropriateMessage() {
-		Log logger = mock(Log.class);
-		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(logger, false);
+		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(this.logger, false);
 		handler.handleCacheClearError(new RuntimeException(), new NoOpCache("NOOP"));
-		verify(logger).warn("Cache 'NOOP' failed to clear entries");
+		verify(this.logger).warn("Cache 'NOOP' failed to clear entries");
 	}
 
 	@Test
 	void handleCacheErrorWithStacktrace() {
-		Log logger = mock(Log.class);
-		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(logger, true);
+		LoggingCacheErrorHandler handler = new LoggingCacheErrorHandler(this.logger, true);
 		RuntimeException exception = new RuntimeException();
 		handler.handleCacheGetError(exception, new NoOpCache("NOOP"), "key");
-		verify(logger).warn("Cache 'NOOP' failed to get entry with key 'key'", exception);
+		verify(this.logger).warn("Cache 'NOOP' failed to get entry with key 'key'", exception);
 	}
 
 }


### PR DESCRIPTION
This PR contains 2 commits with some improvements to `LoggingCacheErrorHandler`:

1. Simplify creation of `LoggingCacheErrorHandler` with logged stacktrace:
At present, creating `LoggingCacheErrorHandler` that logs stacktrace also requires supplying the logger to be used. This might be inconvenient for some users, as it requires usage of Commons Logging API. This commit simplifies creation of such as `LoggingCacheErrorHandler` instance by adding a constructor that only accepts a boolean flag indicating whether to log stacktrace.

2. Defer log message creation in `LoggingCacheErrorHandler`:
At present, `LoggingCacheErrorHandler` creates log message eagerly and does not verify whether warn level is enabled at all for the used logger. This commit ensures that log message creation is deferred until it is about to be logged.

The first commit could maybe be update to deprecate the existing constructor that takes `org.apache.commons.logging.Log` and replace it with the one that takes `String` representing logger name as that way Commons Logging dependency wouldn't leak out at all. But I'd leave that decision to whoever reviews this PR.