### PR TITLE
Simplify creation of LoggingCacheErrorHandler with logged stacktrace

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/LoggingCacheErrorHandler.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/LoggingCacheErrorHandler.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  *
  * @author Adam Ostrožlík
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  * @since 5.3.16
  */
 public class LoggingCacheErrorHandler implements CacheErrorHandler {
@@ -50,10 +51,18 @@ public class LoggingCacheErrorHandler implements CacheErrorHandler {
 	}
 
 	/**
+	 * Create an instance.
+	 * @param logStacktrace whether to log stacktrace
+	 */
+	public LoggingCacheErrorHandler(boolean logStacktrace) {
+		this(LogFactory.getLog(LoggingCacheErrorHandler.class), logStacktrace);
+	}
+
+	/**
 	 * Create an instance that does not log stack traces.
 	 */
 	public LoggingCacheErrorHandler() {
-		this(LogFactory.getLog(LoggingCacheErrorHandler.class), false);
+		this(false);
 	}
 
 


### PR DESCRIPTION
At present, creating `LoggingCacheErrorHandler` that logs stacktrace also requires supplying the logger to be used. This might be inconvenient for some users, as it requires usage of Commons Logging API.

This commit simplifies creation of such as `LoggingCacheErrorHandler` instance by adding a constructor that only accepts a boolean flag indicating whether to log stacktrace.

---

This was originally a part of:

- #28648

For consideration:

> The first commit could maybe be update to deprecate the existing constructor that takes `org.apache.commons.logging.Log` and replace it with the one that takes `String` representing logger name as that way Commons Logging dependency wouldn't leak out at all. But I'd leave that decision to whoever reviews this PR.