### PR TITLE
Avoid Commons Logging API for using LoggingCacheErrorHandler with a custom logger

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/LoggingCacheErrorHandler.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/LoggingCacheErrorHandler.java
@@ -77,6 +77,19 @@ public class LoggingCacheErrorHandler implements CacheErrorHandler {
 		this.logStackTraces = logStackTraces;
 	}
 
+	/**
+	 * Create a {@code LoggingCacheErrorHandler} that uses the supplied
+	 * {@code loggerName} and {@code logStackTraces} flag.
+	 * @param loggerName the logger name to use
+	 * @param logStackTraces whether to log stack traces
+	 * @since 5.3.24
+	 */
+	public LoggingCacheErrorHandler(String loggerName, boolean logStackTraces) {
+		Assert.notNull(loggerName, "'loggerName' must not be null");
+		this.logger = LogFactory.getLog(loggerName);
+		this.logStackTraces = logStackTraces;
+	}
+
 
 	@Override
 	public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {

--- a/spring-context/src/test/java/org/springframework/cache/interceptor/LoggingCacheErrorHandlerTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/interceptor/LoggingCacheErrorHandlerTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.cache.Cache;
 import org.springframework.cache.support.NoOpCache;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -82,6 +83,12 @@ class LoggingCacheErrorHandlerTests {
 		RuntimeException exception = new RuntimeException();
 		this.handler.handleCacheGetError(exception, CACHE, KEY);
 		verify(this.logger).warn("Cache 'NOOP' failed to get entry with key 'enigma'", exception);
+	}
+
+	@Test
+	void constructorWithLoggerName() {
+		assertThatCode(() -> new LoggingCacheErrorHandler("org.apache.commons.logging.Log", true))
+				.doesNotThrowAnyException();
 	}
 
 }


### PR DESCRIPTION
At present, creating `LoggingCacheErrorHandler` with custom logger requires use of Commons Logging API, as the appropriate constructor expects `org.apache.commons.logging.Log` instance. As Commons Logging is rarely the logging framework of choice in applications these days, interaction with its API might not be desirable.

This commit adds `LoggingCacheErrorHandler` constructor that accepts logger name and thus avoids leaking out any details about the underlying logging framework, while also deprecating the existing constructor that accepts `org.apache.commons.logging.Log`.

---

I'm opening this PR to discuss one aspect of #28648 that was overlooked as that PR was superseded:

> The first commit could maybe be update to deprecate the existing constructor that takes `org.apache.commons.logging.Log` and replace it with the one that takes `String` representing logger name as that way Commons Logging dependency wouldn't leak out at all. But I'd leave that decision to whoever reviews this PR.

These days, it's almost inevitable to have several logging frameworks on the classpath, with only one of those being the intended application-wide logging API. To avoid unintended use of other logging APIs, something like Checkstyle can be used to prohibit imports of undesirable classes. However, `LoggingCacheErrorHandler` makes this a bit difficult at the moment hence this proposal.

If you agree this proposal and also with the deprecation of constructor that uses `org.apache.commons.logging.Log`, I'll rework the tests to avoid use of deprecated constructor.