### PR TITLE
Expose headers from STOMP RECEIPT frame to registered callbacks

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import org.apache.commons.logging.Log;
 
@@ -441,7 +442,7 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 					String receiptId = headers.getReceiptId();
 					ReceiptHandler handler = this.receiptHandlers.get(receiptId);
 					if (handler != null) {
-						handler.handleReceiptReceived();
+						handler.handleReceiptReceived(headers);
 					}
 					else if (logger.isDebugEnabled()) {
 						logger.debug("No matching receipt: " + accessor.getDetailedLogMessage(message.getPayload()));
@@ -546,15 +547,18 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 		@Nullable
 		private final String receiptId;
 
-		private final List<Runnable> receiptCallbacks = new ArrayList<>(2);
+		private final List<Consumer<StompHeaders>> receiptCallbacks = new ArrayList<>(2);
 
-		private final List<Runnable> receiptLostCallbacks = new ArrayList<>(2);
+		private final List<Consumer<StompHeaders>> receiptLostCallbacks = new ArrayList<>(2);
 
 		@Nullable
 		private ScheduledFuture<?> future;
 
 		@Nullable
 		private Boolean result;
+
+		@Nullable
+		private StompHeaders receiptHeaders;
 
 		public ReceiptHandler(@Nullable String receiptId) {
 			this.receiptId = receiptId;
@@ -578,15 +582,20 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 
 		@Override
 		public void addReceiptTask(Runnable task) {
+			addTask(h -> task.run(), true);
+		}
+
+		@Override
+		public void addReceiptTask(Consumer<StompHeaders> task) {
 			addTask(task, true);
 		}
 
 		@Override
 		public void addReceiptLostTask(Runnable task) {
-			addTask(task, false);
+			addTask(h -> task.run(), false);
 		}
 
-		private void addTask(Runnable task, boolean successTask) {
+		private void addTask(Consumer<StompHeaders> task, boolean successTask) {
 			Assert.notNull(this.receiptId,
 					"To track receipts, set autoReceiptEnabled=true or add 'receiptId' header");
 			synchronized (this) {
@@ -604,10 +613,10 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 			}
 		}
 
-		private void invoke(List<Runnable> callbacks) {
-			for (Runnable runnable : callbacks) {
+		private void invoke(List<Consumer<StompHeaders>> callbacks) {
+			for (Consumer<StompHeaders> consumer : callbacks) {
 				try {
-					runnable.run();
+					consumer.accept(this.receiptHeaders);
 				}
 				catch (Throwable ex) {
 					// ignore
@@ -615,20 +624,21 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 			}
 		}
 
-		public void handleReceiptReceived() {
-			handleInternal(true);
+		public void handleReceiptReceived(StompHeaders receiptHeaders) {
+			handleInternal(true, receiptHeaders);
 		}
 
 		public void handleReceiptNotReceived() {
-			handleInternal(false);
+			handleInternal(false, null);
 		}
 
-		private void handleInternal(boolean result) {
+		private void handleInternal(boolean result, @Nullable StompHeaders receiptHeaders) {
 			synchronized (this) {
 				if (this.result != null) {
 					return;
 				}
 				this.result = result;
+				this.receiptHeaders = receiptHeaders;
 				invoke(result ? this.receiptCallbacks : this.receiptLostCallbacks);
 				DefaultStompSession.this.receiptHandlers.remove(this.receiptId);
 				if (this.future != null) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.messaging.simp.stomp;
+
+import java.util.function.Consumer;
 
 import org.springframework.lang.Nullable;
 
@@ -142,6 +144,13 @@ public interface StompSession {
 		 * @throws java.lang.IllegalArgumentException if the receiptId is {@code null}
 		 */
 		void addReceiptTask(Runnable runnable);
+
+		/**
+		 * Consumer to invoke when a receipt is received. Accepts the headers of the received RECEIPT frame.
+		 * @throws java.lang.IllegalArgumentException if the receiptId is {@code null}
+		 * @since TBD
+		 */
+		void addReceiptTask(Consumer<StompHeaders> task);
 
 		/**
 		 * Task to invoke when a receipt is not received in the configured time.

--- a/src/docs/asciidoc/web/websocket.adoc
+++ b/src/docs/asciidoc/web/websocket.adoc
@@ -1347,7 +1347,7 @@ receipt if the server supports it (simple broker does not). For example, with th
 	headers.setDestination("/topic/...");
 	headers.setReceipt("r1");
 	FrameHandler handler = ...;
-	stompSession.subscribe(headers, handler).addReceiptTask(() -> {
+	stompSession.subscribe(headers, handler).addReceiptTask(receiptHeaders -> {
 		// Subscription ready...
 	});
 ----


### PR DESCRIPTION
My use case for wanting access to the headers in receipt callbacks is to communicate additional information about the result of processing of a message back to the client.


Relevant parts from the STOMP docs: https://stomp.github.io/stomp-specification-1.2.html#RECEIPT
```
RECEIPT
A RECEIPT frame is sent from the server to the client once a server has successfully
processed a client frame that requests a receipt. A RECEIPT frame MUST include
the header receipt-id, where the value is the value of the receipt header in the frame
which this is a receipt for.

RECEIPT
receipt-id:message-12345

^@
A RECEIPT frame is an acknowledgment that the corresponding client frame has
been processed by the server. Since STOMP is stream based, the receipt is also
a cumulative acknowledgment that all the previous frames have been received by
the server. However, these previous frames may not yet be fully processed. If the
client disconnects, previously received frames SHOULD continue to get
processed by the server.
```


Please let me know if I can improve anything or if you think this requires more discussion up front =)