### PR TITLE
Open GraalVM internals to the ConstantFieldFeature

### DIFF
--- a/spring-core/src/main/resources/META-INF/native-image/org.springframework/spring-core/native-image.properties
+++ b/spring-core/src/main/resources/META-INF/native-image/org.springframework/spring-core/native-image.properties
@@ -2,4 +2,8 @@ Args = --initialize-at-build-time=org.springframework.aot.graalvm.ThrowawayClass
 org.springframework.util.ClassUtils,\
 org.springframework.util.ConcurrentReferenceHashMap,\
 org.springframework.util.MimeType,\
-org.springframework.util.MimeTypeUtils
+org.springframework.util.MimeTypeUtils \
+--add-opens org.graalvm.nativeimage.builder/com.oracle.svm.hosted=ALL-UNNAMED \
+--add-opens jdk.internal.vm.compiler/org.graalvm.compiler.debug=ALL-UNNAMED \
+--add-opens jdk.internal.vm.ci/jdk.vm.ci.meta=ALL-UNNAMED \
+--add-opens org.graalvm.nativeimage.builder/com.oracle.svm.core.meta=ALL-UNNAMED


### PR DESCRIPTION
This is needed as GraalVM 22.2 enabled the module system when building
native-images and all plugins have to participate in it.

Fixes this exception:

```
Fatal error: java.lang.IllegalAccessError: class org.springframework.aot.graalvm.ConstantFieldFeature (in unnamed module @0x60f2e150) cannot access class com.oracle.svm.hosted.FeatureImpl$DuringSetupAccessImpl (in module org.graalvm.nativeimage.builder) because module org.graalvm.nativeimage.builder does not export com.oracle.svm.hosted to unnamed module @0x60f2e150
        at org.springframework.aot.graalvm.ConstantFieldFeature.duringSetup(ConstantFieldFeature.java:37)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$setupNativeImage$16(NativeImageGenerator.java:899)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:78)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.setupNativeImage(NativeImageGenerator.java:899)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:561)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:521)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:407)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:585)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:128)
```