### PR TITLE
Add Javadoc `@since` tag for `CannotGetJdbcConnectionException(String, IllegalStateException)`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/CannotGetJdbcConnectionException.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/CannotGetJdbcConnectionException.java
@@ -52,6 +52,7 @@ public class CannotGetJdbcConnectionException extends DataAccessResourceFailureE
 	 * Constructor for CannotGetJdbcConnectionException.
 	 * @param msg the detail message
 	 * @param ex the root cause IllegalStateException
+	 * @since 5.3.22
 	 */
 	public CannotGetJdbcConnectionException(String msg, IllegalStateException ex) {
 		super(msg, ex);


### PR DESCRIPTION
This PR adds Javadoc `@since` tag for `CannotGetJdbcConnectionException(String, IllegalStateException)`.

See gh-28669