### PR TITLE
Fix WebClientAdapter.createHttpServiceProxyFactory() example in ref docs

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -390,7 +390,7 @@ Two, create a proxy that will perform the declared HTTP exchanges:
 [source,java,indent=0,subs="verbatim,quotes"]
 ----
 	WebClient client = WebClient.builder().baseUrl("https://api.github.com/").build();
-	HttpServiceProxyFactory factory = WebClientAdapter.createHttpServiceProxyFactory(client)).build();
+	HttpServiceProxyFactory factory = WebClientAdapter.createHttpServiceProxyFactory(client);
 
 	RepositoryService service = factory.createClient(RepositoryService.class);
 ----

--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -391,6 +391,7 @@ Two, create a proxy that will perform the declared HTTP exchanges:
 ----
 	WebClient client = WebClient.builder().baseUrl("https://api.github.com/").build();
 	HttpServiceProxyFactory factory = WebClientAdapter.createHttpServiceProxyFactory(client);
+	factory.afterPropertiesSet();
 
 	RepositoryService service = factory.createClient(RepositoryService.class);
 ----


### PR DESCRIPTION
Following the changes applied to `HttpServiceProxyFactory` and `WebClientAdapter` in 48c1746 and b72ee5f, this PR applies fixes into HTTP Interface snippet in order to correctly initialize the client.