### PR TITLE
Use MediaType.APPLICATION_FORM_URLENCODED_VALUE constant

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/ServletServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/ServletServerHttpRequest.java
@@ -56,7 +56,7 @@ import org.springframework.util.StringUtils;
  */
 public class ServletServerHttpRequest implements ServerHttpRequest {
 
-	protected static final String FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
+	protected static final String FORM_CONTENT_TYPE = MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 	protected static final Charset FORM_CHARSET = StandardCharsets.UTF_8;
 

--- a/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
@@ -33,6 +33,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
 
 /**
@@ -53,9 +54,6 @@ import org.springframework.lang.Nullable;
  * @see ContentCachingResponseWrapper
  */
 public class ContentCachingRequestWrapper extends HttpServletRequestWrapper {
-
-	private static final String FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
-
 
 	private final ByteArrayOutputStream cachedContent;
 
@@ -151,7 +149,7 @@ public class ContentCachingRequestWrapper extends HttpServletRequestWrapper {
 
 	private boolean isFormPost() {
 		String contentType = getContentType();
-		return (contentType != null && contentType.contains(FORM_CONTENT_TYPE) &&
+		return (contentType != null && contentType.contains(MediaType.APPLICATION_FORM_URLENCODED_VALUE) &&
 				HttpMethod.POST.matches(getMethod()));
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -49,6 +49,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
 import org.springframework.core.log.LogFormatUtils;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.server.RequestPath;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.lang.Nullable;
@@ -986,7 +987,7 @@ public class DispatcherServlet extends FrameworkServlet {
 			}
 			else {
 				// Avoid request body parsing for form data
-				params = (StringUtils.startsWithIgnoreCase(contentType, "application/x-www-form-urlencoded") ||
+				params = (StringUtils.startsWithIgnoreCase(contentType, MediaType.APPLICATION_FORM_URLENCODED_VALUE) ||
 						!request.getParameterMap().isEmpty() ? "masked" : "");
 			}
 


### PR DESCRIPTION
This PR changes to use `MediaType.APPLICATION_FORM_URLENCODED_VALUE` where possible.