### PR TITLE
Support `@Value` for record injection

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -1352,6 +1352,10 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 	 */
 	@SuppressWarnings("deprecation")  // for postProcessPropertyValues
 	protected void populateBean(String beanName, RootBeanDefinition mbd, @Nullable BeanWrapper bw) {
+		// record has not set methods
+		if (mbd.getBeanClass().isRecord()) {
+			return;
+		}
 		if (bw == null) {
 			if (mbd.hasPropertyValues()) {
 				throw new BeanCreationException(

--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/AutowiredConfigurationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/AutowiredConfigurationTests.java
@@ -43,6 +43,7 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.testfixture.stereotype.Component;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -231,6 +232,15 @@ class AutowiredConfigurationTests {
 		assertThat(testBean.getName()).isEqualTo("localhost");
 		assertThat(testBean.getAge()).isEqualTo(contentLength());
 		context.close();
+	}
+
+	@Test
+	void testValueInjectionWithRecord() {
+		System.setProperty("recordBeanName", "recordBean");
+		GenericApplicationContext context = new AnnotationConfigApplicationContext(RecordBean.class);
+		context.refresh();
+		RecordBean recordBean = context.getBean(RecordBean.class);
+		assertThat(recordBean.name()).isEqualTo("recordBean");
 	}
 
 	private int contentLength() throws IOException {
@@ -506,4 +516,8 @@ class AutowiredConfigurationTests {
 		}
 	}
 
+
+	@Component
+	static record RecordBean(@Value("recordBeanName") String name) {
+	}
 }


### PR DESCRIPTION
Add `@Value` support for record injection by disabling `populateBean()` for records, since records are immutable.

Addresses #28770 