### PR TITLE
Make isConnected() in WebSocketConnectionManager public

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/WebSocketConnectionManager.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/WebSocketConnectionManager.java
@@ -161,7 +161,7 @@ public class WebSocketConnectionManager extends ConnectionManagerSupport {
 	}
 
 	@Override
-	protected boolean isConnected() {
+	public boolean isConnected() {
 		return (this.webSocketSession != null && this.webSocketSession.isOpen());
 	}
 


### PR DESCRIPTION
In my case, I was creating a ReconnectTask to connect to my WebSocket server.
Here I noticed that the method start() or startInternal() in the abstract class ConnectionManagerSupport always sets the boolean running to true. And it does this even if the connection could not be established.
This means that it is not possible to add a retry-handling if the method start() or startInternal() can successfully establish the connection to the server.

But to be able to check yourself if the connection was successfully established you need access to the method isConnected().

But if there is another way to enable retry-handling for the connection to the server, an answer would help me.