### PR TITLE
Replace use of the <tt> HTML tag in Javadoc

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/Cache.java
+++ b/spring-context/src/main/java/org/springframework/cache/Cache.java
@@ -24,7 +24,7 @@ import org.springframework.lang.Nullable;
  * Interface that defines common cache operations.
  *
  * <b>Note:</b> Due to the generic use of caching, it is recommended that
- * implementations allow storage of <tt>null</tt> values (for example to
+ * implementations allow storage of {@code null} values (for example to
  * cache methods that return {@code null}).
  *
  * @author Costin Leau

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
@@ -153,7 +153,7 @@ final class AnnotationTypeMappings {
 	 * @param index the index to return
 	 * @return the {@link AnnotationTypeMapping}
 	 * @throws IndexOutOfBoundsException if the index is out of range
-	 * (<tt>index &lt; 0 || index &gt;= size()</tt>)
+	 * ({@code index < 0 || index >= size()})
 	 */
 	AnnotationTypeMapping get(int index) {
 		return this.mappings.get(index);

--- a/spring-core/src/main/java/org/springframework/core/annotation/AttributeMethods.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AttributeMethods.java
@@ -168,7 +168,7 @@ final class AttributeMethods {
 	 * @param index the index of the attribute to return
 	 * @return the attribute method
 	 * @throws IndexOutOfBoundsException if the index is out of range
-	 * (<tt>index &lt; 0 || index &gt;= size()</tt>)
+	 * ({@code index < 0 || index >= size()})
 	 */
 	Method get(int index) {
 		return this.attributeMethods[index];

--- a/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
@@ -238,7 +238,7 @@ public class TypeDescriptor implements Serializable {
 	 * <p>As of Spring Framework 4.2, this method supports arbitrary levels
 	 * of meta-annotations.
 	 * @param annotationType the annotation type
-	 * @return <tt>true</tt> if the annotation is present
+	 * @return {@code true} if the annotation is present
 	 */
 	public boolean hasAnnotation(Class<? extends Annotation> annotationType) {
 		if (this.annotatedElement.isEmpty()) {
@@ -273,8 +273,8 @@ public class TypeDescriptor implements Serializable {
 	 * On the other hand, {@code valueOf(Number.class).isAssignableTo(valueOf(Integer.class))}
 	 * returns {@code false} because, while all Integers are Numbers, not all Numbers are Integers.
 	 * <p>For arrays, collections, and maps, element and key/value types are checked if declared.
-	 * For example, a List&lt;String&gt; field value is assignable to a Collection&lt;CharSequence&gt;
-	 * field, but List&lt;Number&gt; is not assignable to List&lt;Integer&gt;.
+	 * For example, a {@code List<String>} field value is assignable to a {@code Collection<CharSequence>}
+	 * field, but {@code List<Number>} is not assignable to {@code List<Integer>}.
 	 * @return {@code true} if this type is assignable to the type represented by the provided
 	 * type descriptor
 	 * @see #getObjectType()
@@ -575,7 +575,7 @@ public class TypeDescriptor implements Serializable {
 	/**
 	 * Create a new type descriptor from a {@link java.util.Map} type.
 	 * <p>Useful for converting to typed Maps.
-	 * <p>For example, a Map&lt;String, String&gt; could be converted to a Map&lt;Id, EmailAddress&gt;
+	 * <p>For example, a {@code Map<String, String>} could be converted to a {@code Map<Id, EmailAddress>}
 	 * by converting to a targetType built with this method:
 	 * The method call to construct such a TypeDescriptor would look something like:
 	 * <pre class="code">

--- a/spring-core/src/main/java/org/springframework/core/convert/converter/ConvertingComparator.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/converter/ConvertingComparator.java
@@ -104,7 +104,7 @@ public class ConvertingComparator<S, T> implements Comparator<S> {
 
 
 	/**
-	 * Adapts a {@link ConversionService} and <tt>targetType</tt> to a {@link Converter}.
+	 * Adapts a {@link ConversionService} and {@code targetType} to a {@link Converter}.
 	 */
 	private static class ConversionServiceConverter<S, T> implements Converter<S, T> {
 

--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DataBuffer.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DataBuffer.java
@@ -38,9 +38,9 @@ import org.springframework.util.Assert;
  * the following invariant holds for the read and write positions, and the capacity:
  *
  * <blockquote>
- *     <tt>0</tt> <tt>&lt;=</tt>
- *     <i>readPosition</i> <tt>&lt;=</tt>
- *     <i>writePosition</i> <tt>&lt;=</tt>
+ *     {@code 0} {@code <=}
+ *     <i>readPosition</i> {@code <=}
+ *     <i>writePosition</i> {@code <=}
  *     <i>capacity</i>
  * </blockquote>
  *

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -642,7 +642,7 @@ public class AntPathMatcher implements PathMatcher {
 	/**
 	 * Tests whether a string matches against a pattern via a {@link Pattern}.
 	 * <p>The pattern may contain special characters: '*' means zero or more characters; '?' means one and
-	 * only one character; '{' and '}' indicate a URI template pattern. For example <tt>/users/{user}</tt>.
+	 * only one character; '{' and '}' indicate a URI template pattern. For example {@code /users/{user}}.
 	 */
 	protected static class AntPathStringMatcher {
 

--- a/spring-core/src/main/java/org/springframework/util/FastByteArrayOutputStream.java
+++ b/spring-core/src/main/java/org/springframework/util/FastByteArrayOutputStream.java
@@ -150,7 +150,7 @@ public class FastByteArrayOutputStream extends OutputStream {
 
 	/**
 	 * Convert the buffer's contents into a string decoding bytes using the
-	 * platform's default character set. The length of the new <tt>String</tt>
+	 * platform's default character set. The length of the new {@code String}
 	 * is a function of the character set, and hence may not be equal to the
 	 * size of the buffer.
 	 * <p>This method always replaces malformed-input and unmappable-character

--- a/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WebUtils.java
@@ -629,17 +629,17 @@ public abstract class WebUtils {
 	 * following algorithm:
 	 * <ol>
 	 * <li>Try to get the parameter value using just the given <i>logical</i> name.
-	 * This handles parameters of the form <tt>logicalName = value</tt>. For normal
+	 * This handles parameters of the form {@code logicalName = value}. For normal
 	 * parameters, e.g. submitted using a hidden HTML form field, this will return
 	 * the requested value.</li>
 	 * <li>Try to obtain the parameter value from the parameter name, where the
-	 * parameter name in the request is of the form <tt>logicalName_value = xyz</tt>
+	 * parameter name in the request is of the form {@code logicalName_value = xyz}
 	 * with "_" being the configured delimiter. This deals with parameter values
 	 * submitted using an HTML form submit button.</li>
 	 * <li>If the value obtained in the previous step has a ".x" or ".y" suffix,
 	 * remove that. This handles cases where the value was submitted using an
 	 * HTML form image button. In this case the parameter in the request would
-	 * actually be of the form <tt>logicalName_value.x = 123</tt>. </li>
+	 * actually be of the form {@code logicalName_value.x = 123}.</li>
 	 * </ol>
 	 * @param parameters the available parameter map
 	 * @param name the <i>logical</i> name of the request parameter

--- a/spring-web/src/main/java/org/springframework/web/util/pattern/InternalPathPatternParser.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/InternalPathPatternParser.java
@@ -192,8 +192,8 @@ class InternalPathPatternParser {
 	 * Just hit a ':' and want to jump over the regex specification for this
 	 * variable. pos will be pointing at the ':', we want to skip until the }.
 	 * <p>
-	 * Nested {...} pairs don't have to be escaped: <tt>/abc/{var:x{1,2}}/def</tt>
-	 * <p>An escaped } will not be treated as the end of the regex: <tt>/abc/{var:x\\{y:}/def</tt>
+	 * Nested {...} pairs don't have to be escaped: <code>/abc/{var:x{1,2}}/def</code>
+	 * <p>An escaped } will not be treated as the end of the regex: <code>/abc/{var:x\\{y:}/def</code>
 	 * <p>A separator that should not indicate the end of the regex can be escaped:
 	 */
 	private void skipCaptureRegex() {

--- a/spring-web/src/main/java/org/springframework/web/util/pattern/RegexPathElement.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/RegexPathElement.java
@@ -26,7 +26,7 @@ import org.springframework.web.util.pattern.PathPattern.MatchingContext;
 
 /**
  * A regex path element. Used to represent any complicated element of the path.
- * For example in '<tt>/foo/&ast;_&ast;/&ast;_{foobar}</tt>' both <tt>*_*</tt> and <tt>*_{foobar}</tt>
+ * For example in '<code>/foo/&#42;_&#42;/&#42;_{foobar}</code>' both {@code *_*} and {@code *_{foobar}}
  * are {@link RegexPathElement} path elements. Derived from the general
  * {@link org.springframework.util.AntPathMatcher} approach.
  *

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
@@ -97,7 +97,7 @@ public class MappingJackson2JsonView extends AbstractJackson2View {
 	}
 
 	/**
-	 * Indicates whether the JSON output by this view should be prefixed with <tt>")]}', "</tt>.
+	 * Indicates whether the JSON output by this view should be prefixed with <code>")]}', "</code>.
 	 * Default is {@code false}.
 	 * <p>Prefixing the JSON string in this manner is used to help prevent JSON Hijacking.
 	 * The prefix renders the string syntactically invalid as a script so that it cannot be hijacked.


### PR DESCRIPTION
The `<tt>` HTML tag was used in HTML 4 to define teletype text. It is not supported in HTML5 and its use is discouraged (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt).