### PR TITLE
Use `{@code}` instead of HTML entities in Javadoc

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJWeaverMessageHandler.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJWeaverMessageHandler.java
@@ -35,7 +35,7 @@ import org.aspectj.bridge.IMessageHandler;
  * <p>to the weaver; for example, specifying the following in a
  * "{@code META-INF/aop.xml} file:
  *
- * <p><code class="code">&lt;weaver options="..."/&gt;</code>
+ * <p>{@code <weaver options="..."/>}
  *
  * @author Adrian Colyer
  * @author Juergen Hoeller

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AnnotationAwareAspectJAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AnnotationAwareAspectJAutoProxyCreator.java
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  * advice applied if Spring AOP's proxy-based model is capable of applying it.
  * This covers method execution joinpoints.
  *
- * <p>If the &lt;aop:include&gt; element is used, only @AspectJ beans with names matched by
+ * <p>If the {@code <aop:include>} element is used, only @AspectJ beans with names matched by
  * an include pattern will be considered as defining aspects to use for Spring auto-proxying.
  *
  * <p>Processing of Spring Advisors follows the rules established in

--- a/spring-aop/src/test/java/org/springframework/aop/config/TopLevelAopTagTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/config/TopLevelAopTagTests.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.core.testfixture.io.ResourceTestUtils.qualifiedResource;
 
 /**
- * Tests that the &lt;aop:config/&gt; element can be used as a top level element.
+ * Tests that the {@code <aop:config/>} element can be used as a top level element.
  *
  * @author Rob Harrop
  * @author Chris Beams

--- a/spring-beans/src/test/java/org/springframework/beans/factory/xml/DuplicateBeanIdTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/xml/DuplicateBeanIdTests.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatException;
 /**
  * With Spring 3.1, bean id attributes (and all other id attributes across the
  * core schemas) are no longer typed as xsd:id, but as xsd:string.  This allows
- * for using the same bean id within nested &lt;beans&gt; elements.
+ * for using the same bean id within nested {@code <beans>} elements.
  *
  * Duplicate ids *within the same level of nesting* will still be treated as an
  * error through the ProblemReporter, as this could never be an intended/valid

--- a/spring-context/src/main/java/org/springframework/context/annotation/AnnotationConfigBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/AnnotationConfigBeanDefinitionParser.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.lang.Nullable;
 
 /**
- * Parser for the &lt;context:annotation-config/&gt; element.
+ * Parser for the {@code <context:annotation-config/>} element.
  *
  * @author Mark Fisher
  * @author Juergen Hoeller

--- a/spring-context/src/main/java/org/springframework/context/config/AbstractPropertyLoadingBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/AbstractPropertyLoadingBeanDefinitionParser.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.StringUtils;
 
 /**
- * Abstract parser for &lt;context:property-.../&gt; elements.
+ * Abstract parser for {@code <context:property-.../>} elements.
  *
  * @author Juergen Hoeller
  * @author Arjen Poutsma

--- a/spring-context/src/main/java/org/springframework/context/config/LoadTimeWeaverBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/LoadTimeWeaverBeanDefinitionParser.java
@@ -31,7 +31,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.ClassUtils;
 
 /**
- * Parser for the &lt;context:load-time-weaver/&gt; element.
+ * Parser for the {@code <context:load-time-weaver/>} element.
  *
  * @author Juergen Hoeller
  * @since 2.5

--- a/spring-context/src/main/java/org/springframework/context/config/MBeanExportBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/MBeanExportBeanDefinitionParser.java
@@ -28,7 +28,7 @@ import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.util.StringUtils;
 
 /**
- * Parser for the &lt;context:mbean-export/&gt; element.
+ * Parser for the {@code <context:mbean-export/>} element.
  *
  * <p>Registers an instance of
  * {@link org.springframework.jmx.export.annotation.AnnotationMBeanExporter}

--- a/spring-context/src/main/java/org/springframework/context/config/MBeanServerBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/MBeanServerBeanDefinitionParser.java
@@ -27,7 +27,7 @@ import org.springframework.jmx.support.MBeanServerFactoryBean;
 import org.springframework.util.StringUtils;
 
 /**
- * Parser for the &lt;context:mbean-server/&gt; element.
+ * Parser for the {@code <context:mbean-server/>} element.
  *
  * <p>Registers an instance of
  * {@link org.springframework.jmx.export.annotation.AnnotationMBeanExporter}

--- a/spring-context/src/main/java/org/springframework/context/config/PropertyOverrideBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/PropertyOverrideBeanDefinitionParser.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 
 /**
- * Parser for the &lt;context:property-override/&gt; element.
+ * Parser for the {@code <context:property-override/>} element.
  *
  * @author Juergen Hoeller
  * @author Dave Syer

--- a/spring-context/src/main/java/org/springframework/format/support/FormattingConversionServiceFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/format/support/FormattingConversionServiceFactoryBean.java
@@ -110,7 +110,7 @@ public class FormattingConversionServiceFactoryBean
 	 * formatting. All types related needed to support the formatting
 	 * category can be registered from one place.
 	 * <p>FormatterRegistrars can also be used to register Formatters
-	 * indexed under a specific field type different from its own &lt;T&gt;,
+	 * indexed under a specific field type different from its own {@code <T>},
 	 * or when registering a Formatter from a Printer/Parser pair.
 	 * @see FormatterRegistry#addFormatterForFieldType(Class, Formatter)
 	 * @see FormatterRegistry#addFormatterForFieldType(Class, Printer, Parser)

--- a/spring-context/src/test/java/org/springframework/scheduling/config/LazyScheduledTasksBeanDefinitionParserTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/config/LazyScheduledTasksBeanDefinitionParserTests.java
@@ -23,9 +23,9 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericXmlApplicationContext;
 
 /**
- * Tests ensuring that tasks scheduled using the &lt;task:scheduled&gt; element
- * are never marked lazy, even if the enclosing &lt;beans&gt; element declares
- * default-lazy-init="true". See  SPR-8498
+ * Tests ensuring that tasks scheduled using the {@code <task:scheduled>} element
+ * are never marked lazy, even if the enclosing {@code <beans>} element declares
+ * {@code default-lazy-init="true"}. See SPR-8498.
  *
  * @author Mike Youngstrom
  * @author Chris Beams

--- a/spring-tx/src/main/java/org/springframework/transaction/config/JtaTransactionManagerBeanDefinitionParser.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/config/JtaTransactionManagerBeanDefinitionParser.java
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.transaction.jta.JtaTransactionManager;
 
 /**
- * Parser for the &lt;tx:jta-transaction-manager/&gt; XML configuration element.
+ * Parser for the {@code <tx:jta-transaction-manager/>} XML configuration element.
  *
  * @author Juergen Hoeller
  * @author Christian Dupuis

--- a/spring-tx/src/main/java/org/springframework/transaction/config/JtaTransactionManagerFactoryBean.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/config/JtaTransactionManagerFactoryBean.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.TransactionSystemException;
 import org.springframework.transaction.jta.JtaTransactionManager;
 
 /**
- * A {@link FactoryBean} equivalent to the &lt;tx:jta-transaction-manager/&gt; XML element.
+ * A {@link FactoryBean} equivalent to the {@code <tx:jta-transaction-manager/>} XML element.
  *
  * @author Juergen Hoeller
  * @since 4.1.1

--- a/spring-web/src/main/java/org/springframework/web/context/request/async/StandardServletAsyncWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/StandardServletAsyncWebRequest.java
@@ -36,7 +36,7 @@ import org.springframework.web.context.request.ServletWebRequest;
  *
  * <p>The servlet and all filters involved in an async request must have async
  * support enabled using the Servlet API or by adding an
- * <code>&lt;async-supported&gt;true&lt;/async-supported&gt;</code> element to servlet and filter
+ * {@code <async-supported>true</async-supported>} element to servlet and filter
  * declarations in {@code web.xml}.
  *
  * @author Rossen Stoyanchev

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/client/UndertowWebSocketClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/client/UndertowWebSocketClient.java
@@ -137,7 +137,7 @@ public class UndertowWebSocketClient implements WebSocketClient {
 	}
 
 	/**
-	 * Return the configured <code>Consumer&lt;ConnectionBuilder&gt;</code>.
+	 * Return the configured {@code Consumer<ConnectionBuilder>}.
 	 */
 	public Consumer<ConnectionBuilder> getConnectionBuilderConsumer() {
 		return this.builderConsumer;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/FreeMarkerConfigurerBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/FreeMarkerConfigurerBeanDefinitionParser.java
@@ -29,7 +29,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
 /**
- * Parse the <code>&lt;mvc:freemarker-configurer&gt;</code> MVC namespace element and
+ * Parse the {@code <mvc:freemarker-configurer>} MVC namespace element and
  * register {@code FreeMarkerConfigurer} bean.
  *
  * @author Rossen Stoyanchev

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/GroovyMarkupConfigurerBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/GroovyMarkupConfigurerBeanDefinitionParser.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.xml.AbstractSimpleBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 
 /**
- * Parse the <code>&lt;mvc:groovy-configurer&gt;</code> MVC namespace element and register a
+ * Parse the {@code <mvc:groovy-configurer>} MVC namespace element and register a
  * {@code GroovyConfigurer} bean.
  *
  * @author Sebastien Deleuze

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/ScriptTemplateConfigurerBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/ScriptTemplateConfigurerBeanDefinitionParser.java
@@ -30,7 +30,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
 /**
- * Parse the <code>&lt;mvc:script-template-configurer&gt;</code> MVC namespace element and
+ * Parse the {@code <mvc:script-template-configurer>} MVC namespace element and
  * register a {@code ScriptTemplateConfigurer} bean.
  *
  * @author Sebastien Deleuze

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/SockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/SockJsService.java
@@ -28,7 +28,7 @@ import org.springframework.web.socket.handler.ExceptionWebSocketHandlerDecorator
  * <p>In a Servlet 3+ container, {@link org.springframework.web.socket.sockjs.support.SockJsHttpRequestHandler}
  * can be used to invoke this service. The processing servlet, as well as all filters involved,
  * must have asynchronous support enabled through the ServletContext API or by adding an
- * <code>&lt;async-support&gt;true&lt;/async-support&gt;</code> element to servlet and filter declarations
+ * {@code <async-support>true</async-support>} element to servlet and filter declarations
  * in web.xml.
  *
  * @author Rossen Stoyanchev


### PR DESCRIPTION
Special characters, like < or >, don't need to be escaped in `{@code}` Javadoc tag (https://reflectoring.io/howto-format-code-snippets-in-javadoc/). Using `{@code}` improves readability of the Javadoc in code.