### PR TITLE
Make ResourcePatternHints.Builder.build public

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/hint/ResourcePatternHints.java
+++ b/spring-core/src/main/java/org/springframework/aot/hint/ResourcePatternHints.java
@@ -120,7 +120,7 @@ public final class ResourcePatternHints {
 		 * builder.
 		 * @return a resource pattern hint
 		 */
-		ResourcePatternHints build() {
+		public ResourcePatternHints build() {
 			return new ResourcePatternHints(this);
 		}
 


### PR DESCRIPTION
Makes the `ResourcePatternHints.Builder.build()` method public. I assume it's an oversight that it's not public, as the class and all other methods are.