### PR TITLE
Avoid IllegalArgumentException when setting WebSocket error status

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/adapter/AbstractListenerWebSocketSession.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/adapter/AbstractListenerWebSocketSession.java
@@ -33,6 +33,7 @@ import org.springframework.http.server.reactive.AbstractListenerReadPublisher;
 import org.springframework.http.server.reactive.AbstractListenerWriteProcessor;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.socket.CloseStatus;
 import org.springframework.web.reactive.socket.HandshakeInfo;
 import org.springframework.web.reactive.socket.WebSocketHandler;
@@ -221,7 +222,12 @@ public abstract class AbstractListenerWebSocketSession<T> extends AbstractWebSoc
 			// Ignore result: can't overflow, ok if not first or no one listens
 			this.handlerCompletionSink.tryEmitError(ex);
 		}
-		close(CloseStatus.SERVER_ERROR.withReason(ex.getMessage()));
+		if(!StringUtils.hasText(ex.getMessage())) {
+			close(CloseStatus.SERVER_ERROR);
+		}
+		else {
+			close(CloseStatus.SERVER_ERROR.withReason(ex.getMessage()));
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixing internal error, when the message of an exception doesn't contain any text.

In my application, this probably caused a memory leak. (Which I will retest with a fork, but it will take some time because the issue happened very infrequently)

This is how it looks in the log:
```
java.lang.IllegalArgumentException: Reason must not be empty
	at org.springframework.util.Assert.hasText(Assert.java:289) ~[spring-core-5.3.21.jar!/:5.3.21]
	at org.springframework.web.reactive.socket.CloseStatus.withReason(CloseStatus.java:184) ~[spring-webflux-5.3.21.jar!/:5.3.21]
	at org.springframework.web.reactive.socket.adapter.AbstractListenerWebSocketSession.onError(AbstractListenerWebSocketSession.java:250) ~[spring-webflux-5.3.21.jar!/:5.3.21]
	at reactor.core.publisher.StrictSubscriber.onError(StrictSubscriber.java:106) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onError(FluxOnAssembly.java:544) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onError(FluxDoFinally.java:119) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.secondError(MonoFlatMap.java:192) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.MonoFlatMap$FlatMapInner.onError(MonoFlatMap.java:259) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.MonoIgnoreElements$IgnoreElementsSubscriber.onError(MonoIgnoreElements.java:84) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.checkTerminated(FluxFlatMap.java:842) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.drainLoop(FluxFlatMap.java:608) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.drain(FluxFlatMap.java:588) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxFlatMap$FlatMapMain.innerError(FluxFlatMap.java:863) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxFlatMap$FlatMapInner.onError(FluxFlatMap.java:990) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onError(MonoPeekTerminal.java:258) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxPeekFuseable$PeekConditionalSubscriber.onError(FluxPeekFuseable.java:903) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.onError(MonoSubscribeOn.java:152) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.SinkEmptyMulticast$VoidInner.error(SinkEmptyMulticast.java:247) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.SinkEmptyMulticast.tryEmitError(SinkEmptyMulticast.java:88) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.SinkEmptySerialized.tryEmitError(SinkEmptySerialized.java:65) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at org.springframework.web.reactive.socket.adapter.AbstractListenerWebSocketSession.onError(AbstractListenerWebSocketSession.java:245) ~[spring-webflux-5.3.21.jar!/:5.3.21]
	at reactor.core.publisher.StrictSubscriber.onError(StrictSubscriber.java:106) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onError(FluxOnAssembly.java:544) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onError(MonoPeekTerminal.java:258) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.MonoNext$NextSubscriber.onError(MonoNext.java:93) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at reactor.core.publisher.MonoNext$NextSubscriber.onError(MonoNext.java:93) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at org.springframework.http.server.reactive.WriteResultPublisher$State.publishError(WriteResultPublisher.java:277) ~[spring-web-5.3.21.jar!/:5.3.21]
	at org.springframework.http.server.reactive.WriteResultPublisher.publishError(WriteResultPublisher.java:99) ~[spring-web-5.3.21.jar!/:5.3.21]
	at org.springframework.http.server.reactive.AbstractListenerWriteProcessor$State.onError(AbstractListenerWriteProcessor.java:479) ~[spring-web-5.3.21.jar!/:5.3.21]
	at org.springframework.http.server.reactive.AbstractListenerWriteProcessor.onError(AbstractListenerWriteProcessor.java:132) ~[spring-web-5.3.21.jar!/:5.3.21]
	at reactor.core.publisher.StrictSubscriber.onError(StrictSubscriber.java:106) ~[reactor-core-3.4.19.jar!/:3.4.19]
	at org.springframework.http.server.reactive.AbstractListenerReadPublisher$State.onError(AbstractListenerReadPublisher.java:497) ~[spring-web-5.3.21.jar!/:5.3.21]
	at org.springframework.http.server.reactive.AbstractListenerReadPublisher.onError(AbstractListenerReadPublisher.java:145) ~[spring-web-5.3.21.jar!/:5.3.21]
	at org.springframework.web.reactive.socket.adapter.AbstractListenerWebSocketSession.handleError(AbstractListenerWebSocketSession.java:208) ~[spring-webflux-5.3.21.jar!/:5.3.21]
	at org.springframework.web.reactive.socket.adapter.StandardWebSocketHandlerAdapter.onError(StandardWebSocketHandlerAdapter.java:120) ~[spring-webflux-5.3.21.jar!/:5.3.21]
	at org.apache.tomcat.websocket.server.WsHttpUpgradeHandler.onError(WsHttpUpgradeHandler.java:234) ~[tomcat-embed-websocket-9.0.64.jar!/:na]
	at org.apache.tomcat.websocket.server.WsHttpUpgradeHandler.upgradeDispatch(WsHttpUpgradeHandler.java:161) ~[tomcat-embed-websocket-9.0.64.jar!/:na]
	at org.apache.coyote.http11.upgrade.UpgradeProcessorInternal.dispatch(UpgradeProcessorInternal.java:60) ~[tomcat-embed-core-9.0.64.jar!/:na]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:59) ~[tomcat-embed-core-9.0.64.jar!/:na]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:890) ~[tomcat-embed-core-9.0.64.jar!/:na]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1787) ~[tomcat-embed-core-9.0.64.jar!/:na]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.64.jar!/:na]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat-embed-core-9.0.64.jar!/:na]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-9.0.64.jar!/:na]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.64.jar!/:na]
	at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]
```