### PR TITLE
Reintroduce Javadoc links to Apache HttpClient 5.1 APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -340,8 +340,7 @@ configure([rootProject] + javaProjects) { project ->
 			"https://fasterxml.github.io/jackson-core/javadoc/2.10/",
 			"https://fasterxml.github.io/jackson-databind/javadoc/2.10/",
 			"https://fasterxml.github.io/jackson-dataformat-xml/javadoc/2.10/",
-			// TODO Uncomment once httpclient5 API docs are again online.
-			// "https://hc.apache.org/httpcomponents-client-5.1.x/current/httpclient5/apidocs/",
+			"https://hc.apache.org/httpcomponents-client-5.1.x/current/httpclient5/apidocs/",
 			"https://projectreactor.io/docs/test/release/api/",
 			"https://junit.org/junit4/javadoc/4.13.2/",
 			// TODO Uncomment link to JUnit 5 docs once we have sorted out


### PR DESCRIPTION
Reintroduce commented out Javadoc links to Apache website which are now working

Closes #28811