### PR TITLE
Improve resource handling for empty files contained in jars

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/AbstractFileResolvingResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/AbstractFileResolvingResource.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -27,6 +28,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.StandardOpenOption;
+import java.util.jar.JarEntry;
 
 import org.springframework.util.ResourceUtils;
 
@@ -112,6 +114,16 @@ public abstract class AbstractFileResolvingResource extends AbstractResource {
 					if (code != HttpURLConnection.HTTP_OK) {
 						httpCon.disconnect();
 						return false;
+					}
+				}
+				else if (con instanceof JarURLConnection) {
+					JarURLConnection jarCon = (JarURLConnection) con;
+					JarEntry jarEntry = jarCon.getJarEntry();
+					if (jarEntry == null) {
+						return false;
+					}
+					else {
+						return !jarEntry.isDirectory();
 					}
 				}
 				long contentLength = con.getContentLengthLong();

--- a/spring-core/src/test/java/org/springframework/core/io/ClassPathResourceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/ClassPathResourceTests.java
@@ -16,11 +16,19 @@
 
 package org.springframework.core.io;
 
+import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -117,6 +125,34 @@ class ClassPathResourceTests {
 		Resource jarDir = new ClassPathResource("reactor/core");
 		assertThat(jarDir.exists()).isTrue();
 		assertThat(jarDir.isReadable()).isFalse();
+	}
+
+	@Test
+	void emptyFileReadable(@TempDir File tempDir) throws IOException {
+		File file = new File(tempDir, "empty.txt");
+		assertThat(file.createNewFile()).isTrue();
+		assertThat(file.isFile());
+
+		ClassLoader fileClassLoader = new URLClassLoader(new URL[]{tempDir.toURI().toURL()});
+
+		Resource emptyFile = new ClassPathResource("empty.txt", fileClassLoader);
+		assertThat(emptyFile.exists()).isTrue();
+		assertThat(emptyFile.isReadable()).isTrue();
+		assertThat(emptyFile.contentLength()).isEqualTo(0);
+
+		File jarFile = new File(tempDir, "test.jar");
+		try (ZipOutputStream zipOut = new ZipOutputStream(new FileOutputStream(jarFile))) {
+			zipOut.putNextEntry(new ZipEntry("empty2.txt"));
+			zipOut.closeEntry();
+		}
+		assertThat(jarFile.isFile());
+
+		ClassLoader jarClassLoader = new URLClassLoader(new URL[]{jarFile.toURI().toURL()});
+
+		Resource emptyJarEntry = new ClassPathResource("empty2.txt", jarClassLoader);
+		assertThat(emptyJarEntry.exists()).isTrue();
+		assertThat(emptyJarEntry.isReadable()).isTrue();
+		assertThat(emptyJarEntry.contentLength()).isEqualTo(0);
 	}
 
 


### PR DESCRIPTION
We noticed a strange behavior in WebMVC when working with empty files:

We had some empty files in a classpath location configured in `org.springframework.web.servlet.config.annotation.WebMvcConfigurer#addResourceHandlers`

When running the application locally using the IDE, the files could be _"successfully"_ accessed by the browser (it got a HTTP 200 response with content-length 0)

After packaging the application, the browser suddenly got 404 responses for the empty files.

The difference seems to be in `org.springframework.core.io.AbstractFileResolvingResource#checkReadable`.
As long as the empty files are actual files on the file system (`ResourceUtils.isFileURL(url) == true`), the corresponding ClasspathResource is considered both existent and readable.
After packaging into a jar file, the ClasspathResource is still existent, but no longer considered readable.

I know that serving empty files as static resources is not a typical use case, but I think it should still be (a) possible and (b) consistent, regardless of whether the ClasspathResource in question is an actual File or a JarFileEntry