### PR TITLE
added missing @Nullable annotations to methods that may return null and are overridden by methods already using @Nullable

### DIFF
--- a/spring-core/src/main/java/org/springframework/asm/AnnotationVisitor.java
+++ b/spring-core/src/main/java/org/springframework/asm/AnnotationVisitor.java
@@ -27,6 +27,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 package org.springframework.asm;
 
+import org.springframework.lang.Nullable;
+
 /**
  * A visitor to visit a Java annotation. The methods of this class must be called in the following
  * order: ( {@code visit} | {@code visitEnum} | {@code visitAnnotation} | {@code visitArray} )*
@@ -121,6 +123,7 @@ public abstract class AnnotationVisitor {
    *     visitor is not interested in visiting this nested annotation. <i>The nested annotation
    *     value must be fully visited before calling other methods on this annotation visitor</i>.
    */
+  @Nullable
   public AnnotationVisitor visitAnnotation(final String name, final String descriptor) {
     if (av != null) {
       return av.visitAnnotation(name, descriptor);

--- a/spring-core/src/main/java/org/springframework/asm/ClassVisitor.java
+++ b/spring-core/src/main/java/org/springframework/asm/ClassVisitor.java
@@ -27,6 +27,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 package org.springframework.asm;
 
+import org.springframework.lang.Nullable;
+
 /**
  * A visitor to visit a Java class. The methods of this class must be called in the following order:
  * {@code visit} [ {@code visitSource} ] [ {@code visitModule} ][ {@code visitNestHost} ][ {@code
@@ -190,6 +192,7 @@ public abstract class ClassVisitor {
    * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
    *     interested in visiting this annotation.
    */
+  @Nullable
   public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
     if (cv != null) {
       return cv.visitAnnotation(descriptor, visible);
@@ -353,6 +356,7 @@ public abstract class ClassVisitor {
    * @return an object to visit the byte code of the method, or {@literal null} if this class
    *     visitor is not interested in visiting the code of this method.
    */
+  @Nullable
   public MethodVisitor visitMethod(
       final int access,
       final String name,

--- a/spring-core/src/main/java/org/springframework/asm/MethodVisitor.java
+++ b/spring-core/src/main/java/org/springframework/asm/MethodVisitor.java
@@ -27,6 +27,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 package org.springframework.asm;
 
+import org.springframework.lang.Nullable;
+
 /**
  * A visitor to visit a Java method. The methods of this class must be called in the following
  * order: ( {@code visitParameter} )* [ {@code visitAnnotationDefault} ] ( {@code visitAnnotation} |
@@ -137,6 +139,7 @@ public abstract class MethodVisitor {
    * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
    *     interested in visiting this annotation.
    */
+  @Nullable
   public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
     if (mv != null) {
       return mv.visitAnnotation(descriptor, visible);


### PR DESCRIPTION
**1/4 Added `@Nullable` to return type of 
`org.springframework.asm.AnnotationVisitor::visitAnnotation`**

_Reasons:_ 
1. On inspection, the method may return null
2. The method is overridden by methods with nullable annotation (violating LSP indicating that return types should not be generalised in overridden methods, assuming that most static null checkers will use the nonull-by-default assumption):

- org.springframework.core.type.classreading.MergedAnnotationReadingVisitor::visitAnnotation
- org.springframework.core.type.classreading.MergedAnnotationReadingVisitor$ArrayVisitor::visitAnnotation


**2/4 Added `@Nullable` to return type of 
`org.springframework.asm.ClassVisitor::visitMethod`**

_Reasons:_ 
1. On inspection, the method may return null
2. The method is overridden by methods with nullable annotation (violating LSP indicating that return types should not be generalised in overridden methods, assuming that most static null checkers will use the nonull-by-default assumption):

- org.springframework.core.type.classreading.SimpleAnnotationMetadataReadingVisitor::visitMethod
- org.springframework.core.LocalVariableTableParameterNameDiscoverer$ParameterNameDiscoveringVisitor::visitMethod

**3/4 Added `@Nullable` to return type of 
`org.springframework.asm.ClassVisitor::visitAnnotation`**

_Reasons:_ 
1. On inspection, the method may return null
2. The method is overridden by methods with nullable annotation (violating LSP indicating that return types should not be generalised in overridden methods, assuming that most static null checkers will use the nonull-by-default assumption):

- org.springframework.core.type.classreading.SimpleAnnotationMetadataReadingVisitor::visitAnnotation

**4/4 Added `@Nullable` to return type of 
`org.springframework.asm.MethodVisitor::visitAnnotation`**

_Reasons:_ 
1. On inspection, the method may return null
2. The method is overridden by methods with nullable annotation (violating LSP indicating that return types should not be generalised in overridden methods, assuming that most static null checkers will use the nonull-by-default assumption):

- org.springframework.core.type.classreading.SimpleMethodMetadataReadingVisitor::visitAnnotation


Note that there are similar methods in those classes that could also be annotated as `@Nullable` based on code inspection. This PR is conservative as it only adds `@Nullable` to methods where there are multiple reasons. If this gets accepted, I can create a separate PR for those.

