### PR TITLE
SockJsServiceRegistration#setSupressCors has a typo and should be deprecated

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
@@ -251,8 +251,21 @@ public class SockJsServiceRegistration {
 	 * SockJS requests.
 	 * <p>The default value is "false".
 	 * @since 4.1.2
+	 * @deprecated as of 5.3.23, in favor of {@link #setSuppressCors(boolean)},
+	 * to be removed in Spring Framework 6.0
 	 */
+	@Deprecated
 	public SockJsServiceRegistration setSupressCors(boolean suppressCors) {
+		return this.setSuppressCors(suppressCors);
+	}
+
+	/**
+	 * This option can be used to disable automatic addition of CORS headers for
+	 * SockJS requests.
+	 * <p>The default value is "false".
+	 * @since 4.1.2 (was named {@code setSupressCors} prior to 5.3.23)
+	 */
+	public SockJsServiceRegistration setSuppressCors(boolean suppressCors) {
 		this.suppressCors = suppressCors;
 		return this;
 	}

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistrationTests.java
@@ -166,7 +166,7 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 		WebMvcStompWebSocketEndpointRegistration registration =
 				new WebMvcStompWebSocketEndpointRegistration(new String[] {"/foo"}, this.handler, this.scheduler);
 
-		registration.withSockJS().setSupressCors(true);
+		registration.withSockJS().setSuppressCors(true);
 
 		MultiValueMap<HttpRequestHandler, String> mappings = registration.getMappings();
 		assertThat(mappings.size()).isEqualTo(1);


### PR DESCRIPTION
SockJsServiceRegistration#setSupressCors name contains a typo.
It is now deprecated in favor of a correctly spelled method, setSuppressCors.

Closes gh-28806