### PR TITLE
Remove clear() call to release method of WeakEntryReference and SoftEntryReference

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
+++ b/spring-core/src/main/java/org/springframework/util/ConcurrentReferenceHashMap.java
@@ -1046,7 +1046,6 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 		@Override
 		public void release() {
 			enqueue();
-			clear();
 		}
 	}
 
@@ -1083,7 +1082,6 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V> implemen
 		@Override
 		public void release() {
 			enqueue();
-			clear();
 		}
 	}
 


### PR DESCRIPTION
Remove `clear()` call to release method of `WeakEntryReference` and `SoftEntryReference`.

The code of the same behavior as the `clear` method is included inside the `enqueue` method.

java.lang.ref.Reference

```java
    /**
     * Clears this reference object.  Invoking this method will not cause this
     * object to be enqueued.
     *
     * <p> This method is invoked only by Java code; when the garbage collector
     * clears references it does so directly, without invoking this method.
     */
    public void clear() {
        this.referent = null;
    }

    /**
     * Clears this reference object and adds it to the queue with which
     * it is registered, if any.
     *
     * <p> This method is invoked only by Java code; when the garbage collector
     * enqueues references it does so directly, without invoking this method.
     *
     * @return   <code>true</code> if this reference object was successfully
     *           enqueued; <code>false</code> if it was already enqueued or if
     *           it was not registered with a queue when it was created
     */
    public boolean enqueue() {
        this.referent = null;
        return this.queue.enqueue(this);
    }
```
