### PR TITLE
Deprecate CookieGenerator

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/CookieGenerator.java
+++ b/spring-web/src/main/java/org/springframework/web/util/CookieGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,9 @@ import org.springframework.util.Assert;
  * @see #removeCookie
  * @see org.springframework.web.servlet.i18n.CookieLocaleResolver
  * @see org.springframework.web.servlet.theme.CookieThemeResolver
+ * @deprecated since 6.0 in favor of {@link org.springframework.http.ResponseCookie}
  */
+@Deprecated
 public class CookieGenerator {
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieLocaleResolver.java
@@ -57,6 +57,7 @@ import org.springframework.web.util.WebUtils;
  * @see #setDefaultLocale
  * @see #setDefaultTimeZone
  */
+@SuppressWarnings("deprecation")
 public class CookieLocaleResolver extends CookieGenerator implements LocaleContextResolver {
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/CookieThemeResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/CookieThemeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.springframework.web.util.WebUtils;
  * @since 17.06.2003
  * @see #setThemeName
  */
+@SuppressWarnings("deprecation")
 public class CookieThemeResolver extends CookieGenerator implements ThemeResolver {
 
 	/**


### PR DESCRIPTION
This commit deprecates `CookieGenerator` in favor of a more modern alternative in `ResponseCookie`.

---

Ideally, all Framework generated cookies should be consistent is sense they use the same infrastructure for creating response cookies. `CookieGenerator` has only two usages that either have PRs to replace them with `ResponseCookie` (`CookieLocaleResolver`) or are about to be deprecated (`CookieThemeResolver`).

Related:

- https://github.com/spring-projects/spring-framework/pull/28779
- https://github.com/spring-projects/spring-framework/issues/28868