### PR TITLE
Fix typos in Javadoc of class AbstractEncoder

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/codec/AbstractEncoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/AbstractEncoder.java
@@ -27,7 +27,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.MimeType;
 
 /**
- * Abstract base class for {@link Decoder} implementations.
+ * Abstract base class for {@link Encoder} implementations.
  *
  * @author Sebastien Deleuze
  * @author Arjen Poutsma


### PR DESCRIPTION
AbstractEncoder is a Encoder implementations.