### PR TITLE
Fix memory leak with CglibAopProxy$ProxyCallbackFilter

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -512,6 +512,20 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 	}
 
 	/**
+	 * Build a configuration-only of AdvisedSupport.
+	 */
+	static AdvisedSupport createConfigurationOnly(ProxyConfig config, TargetSource targetSource,
+			AdvisorChainFactory advisorChainFactory, List<Class<?>> interfaces, Advisor[] advisors) {
+		AdvisedSupport advised = new AdvisedSupport();
+		advised.copyFrom(config);
+		advised.targetSource = targetSource;
+		advised.advisorChainFactory = advisorChainFactory;
+		advised.interfaces = interfaces;
+		advised.advisors = Arrays.asList(advisors);
+		return advised;
+	}
+
+	/**
 	 * Build a configuration-only copy of this AdvisedSupport,
 	 * replacing the TargetSource.
 	 */


### PR DESCRIPTION
## Bug report
Bug report and reason is explained very well here #26266.

In the cglib side, this issue [#80](https://github.com/cglib/cglib/issues/80#issue-160623315) is the consequence of trying to solve `CallbackFilter` leak.
As vlsi said
> "weakly reachable CallbackFilters" and "classloader reuse" do not play together well.

## Solution
* This solution is to try to reduce the leak by make `advisors` and `advisorChainFactory` WeakReference , so that there should have no chance to leak 'big object'. Think about class created by cglib is also 'leaked', I think that should be acceptable.

* Another quick solution is to make `AbstractAutoProxyCreator` implements `DisposableBean`, clear `CallbackFilter` field in generated class.
