### PR TITLE
Use Jakarta EE XML namespaces instead of Java EE

### DIFF
--- a/spring-web/src/main/resources/META-INF/web-fragment.xml
+++ b/spring-web/src/main/resources/META-INF/web-fragment.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<web-fragment xmlns="http://java.sun.com/xml/ns/javaee"
+<?xml version="1.0" encoding="UTF-8"?>
+<web-fragment xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd"
-	version="3.0" metadata-complete="true">
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-fragment_5_0.xsd"
+	version="5.0" metadata-complete="true">
 
 	<name>spring_web</name>
 	<distributable/>

--- a/src/docs/asciidoc/web/websocket.adoc
+++ b/src/docs/asciidoc/web/websocket.adoc
@@ -215,12 +215,12 @@ through the use of the `<absolute-ordering />` element in `web.xml`, as the foll
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="
-			http://java.sun.com/xml/ns/javaee
-			https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-		version="3.0">
+			https://jakarta.ee/xml/ns/jakartaee
+			https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+		version="5.0">
 
 		<absolute-ordering/>
 
@@ -233,12 +233,12 @@ Java initialization API. The following example shows how to do so:
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="
-			http://java.sun.com/xml/ns/javaee
-			https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-		version="3.0">
+			https://jakarta.ee/xml/ns/jakartaee
+			https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+		version="5.0">
 
 		<absolute-ordering>
 			<name>spring_web</name>


### PR DESCRIPTION
I used Jakarta EE 9 namespaces here, which should be the new baseline.