### PR TITLE
Support TreeSet collection type in CollectionFactory.createCollection() without using reflection

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/CollectionFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/CollectionFactory.java
@@ -190,7 +190,7 @@ public final class CollectionFactory {
 		else if (LinkedList.class == collectionType) {
 			return new LinkedList<>();
 		}
-		else if (SortedSet.class == collectionType || NavigableSet.class == collectionType) {
+		else if (TreeSet.class == collectionType || SortedSet.class == collectionType || NavigableSet.class == collectionType) {
 			return new TreeSet<>();
 		}
 		else if (EnumSet.class.isAssignableFrom(collectionType)) {


### PR DESCRIPTION
It seems to have been missed in #28718.