### PR TITLE
Use URL and HTTP method in DefaultResponseErrorHandler

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/ExtractingResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/ExtractingResponseErrorHandler.java
@@ -17,11 +17,13 @@
 package org.springframework.web.client;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpResponse;
@@ -148,8 +150,13 @@ public class ExtractingResponseErrorHandler extends DefaultResponseErrorHandler 
 		}
 	}
 
+	@Override
+	public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
+		handleError(response, response.getStatusCode());
+	}
+
 	private void extract(@Nullable Class<? extends RestClientException> exceptionClass,
-			ClientHttpResponse response) throws IOException {
+						ClientHttpResponse response) throws IOException {
 
 		if (exceptionClass == null) {
 			return;

--- a/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerTests.java
@@ -18,11 +18,13 @@ package org.springframework.web.client;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -74,6 +76,22 @@ public class DefaultResponseErrorHandlerTests {
 		assertThatExceptionOfType(HttpClientErrorException.class)
 				.isThrownBy(() -> handler.handleError(response))
 				.withMessage("404 Not Found: \"Hello World\"")
+				.satisfies(ex -> assertThat(ex.getResponseHeaders()).isSameAs(headers));
+	}
+
+	@Test
+	public void handleErrorWithUrlAndMethod() throws Exception {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.TEXT_PLAIN);
+
+		given(response.getStatusCode()).willReturn(HttpStatus.NOT_FOUND);
+		given(response.getStatusText()).willReturn("Not Found");
+		given(response.getHeaders()).willReturn(headers);
+		given(response.getBody()).willReturn(new ByteArrayInputStream("Hello World".getBytes(StandardCharsets.UTF_8)));
+
+		assertThatExceptionOfType(HttpClientErrorException.class)
+				.isThrownBy(() -> handler.handleError(URI.create("https://example.com"), HttpMethod.GET, response))
+				.withMessage("404 Not Found after GET https://example.com : \"Hello World\"")
 				.satisfies(ex -> assertThat(ex.getResponseHeaders()).isSameAs(headers));
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateIntegrationTests.java
@@ -242,6 +242,7 @@ class RestTemplateIntegrationTests extends AbstractMockWebServerTests {
 				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 				assertThat(ex.getStatusText()).isNotNull();
 				assertThat(ex.getResponseBodyAsString()).isNotNull();
+				assertThat(ex.getMessage()).isEqualTo("404 Client Error after GET http://localhost:" + port + "/status/notfound : [no body]");
 			});
 	}
 
@@ -253,7 +254,7 @@ class RestTemplateIntegrationTests extends AbstractMockWebServerTests {
 				template.execute(baseUrl + "/status/badrequest", HttpMethod.GET, null, null))
 			.satisfies(ex -> {
 				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-				assertThat(ex.getMessage()).isEqualTo("400 Client Error: [no body]");
+				assertThat(ex.getMessage()).isEqualTo("400 Client Error after GET http://localhost:" + port + "/status/badrequest : [no body]");
 			});
 	}
 
@@ -267,6 +268,7 @@ class RestTemplateIntegrationTests extends AbstractMockWebServerTests {
 				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 				assertThat(ex.getStatusText()).isNotNull();
 				assertThat(ex.getResponseBodyAsString()).isNotNull();
+				assertThat(ex.getMessage()).isEqualTo("500 Server Error after GET http://localhost:" + port + "/status/server : [no body]");
 			});
 	}
 


### PR DESCRIPTION
Good evening team,

This is a followup of a previous PR from January 2021: https://github.com/spring-projects/spring-framework/pull/26480 .
Previously it was closed with a conclusion that the change bypasses a protected method:

> Given the change of protected methods I'd rather avoid this change at this stage of the 5.3.x branch. 

Now that Spring 6 is coming, do you think there's a chance to add this change?

Below is the original description of the PR:

======

The REST Client exception contains a preview of the body, which is great, and it helps a lot to quickly diagnose errors.

Now, the stacktrace looks like this:
```
Caused by: org.springframework.web.client.HttpServerErrorException$InternalServerError: 500 Server Error: [no body]
	at org.springframework.web.client.HttpServerErrorException.create(HttpServerErrorException.java:101)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:238)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:147)
```

I'd like to add the HTTP method and URL to the error, so that the stacktrace looks like this:
```
Caused by: org.springframework.web.client.HttpServerErrorException$InternalServerError: 500 Server Error after GET http://localhost:49709/status/server : [no body]
	at org.springframework.web.client.HttpServerErrorException.create(HttpServerErrorException.java:101)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:238)
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:147)
```

======

Thank you! 