### PR TITLE
Adding JCStress support for ConcurrentLruCache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
 	id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
 	id 'de.undercouch.download' version '5.1.0'
 	id 'me.champeau.jmh' version '0.6.6' apply false
+	id 'io.github.reyerizo.gradle.jcstress' version '0.8.13' apply false
 }
 
 ext {

--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -4,9 +4,11 @@ import org.springframework.build.shadow.ShadowSource
 description = "Spring Core"
 
 apply plugin: "kotlin"
+apply plugin: "io.github.reyerizo.gradle.jcstress"
 
 def javapoetVersion = "1.13.0"
 def objenesisVersion = "3.2"
+def jcstressVersion = "0.15"
 
 configurations {
 	javapoet
@@ -146,3 +148,9 @@ eclipse {
 }
 
 tasks['eclipse'].dependsOn(javapoetRepackJar, javapoetSourceJar, objenesisRepackJar, objenesisSourceJar)
+
+jcstress {
+	jcstressDependency "org.openjdk.jcstress:jcstress-core:${jcstressVersion}"
+	verbose = true
+	timeMillis = "200"
+}

--- a/spring-core/src/jcstress/java/org/springframework/util/ConcurrentLruCacheJCStressTests.java
+++ b/spring-core/src/jcstress/java/org/springframework/util/ConcurrentLruCacheJCStressTests.java
@@ -1,0 +1,163 @@
+package org.springframework.util;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Description;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+import org.openjdk.jcstress.infra.results.ZZI_Result;
+import org.openjdk.jcstress.infra.results.Z_Result;
+
+import java.util.function.Function;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+public class ConcurrentLruCacheJCStressTests {
+
+	@JCStressTest
+	@Description("Testing size feature")
+	@Outcome(id = {"0", "1", "2"}, expect = ACCEPTABLE, desc = "Valid sizes")
+	@Outcome(id = "3", expect = FORBIDDEN, desc = "Invalid Size")
+	@State
+	public static class Case1 {
+
+		int sizeLimit = 2;
+		Function<String, String> generator = (key) -> key + "-value";
+		private final ConcurrentLruCache<String, String> cache = new ConcurrentLruCache<>(sizeLimit, generator);
+
+		@Actor
+		public void actor1(I_Result r) {
+			r.r1 = cache.size();
+		}
+
+		@Actor
+		public void actor2(I_Result r) {
+			this.cache.get("k1");
+			r.r1 = cache.size();
+		}
+
+		@Actor
+		public void actor3(I_Result r) {
+			this.cache.get("k2");
+			r.r1 = cache.size();
+		}
+
+		@Actor
+		public void actor4(I_Result r) {
+			this.cache.get("k3");
+			r.r1 = cache.size();
+		}
+	}
+
+	@JCStressTest
+	@Description("Testing the internal movement of a LRU Cache")
+	@Outcome(id = "true, false, 1", expect = ACCEPTABLE, desc = "Valid existence")
+	@Outcome(id = "false, true, 1", expect = ACCEPTABLE, desc = "Valid existence")
+	@Outcome(id = "true, true, 2", expect = FORBIDDEN, desc = "Invalid existence")
+	@State
+	public static class Case2 {
+
+		int sizeLimit = 1;
+		Function<Integer, Integer> generator = (key) -> key;
+		private final ConcurrentLruCache<Integer, Integer> cache = new ConcurrentLruCache<>(sizeLimit, generator);
+
+		@Actor
+		public void actor1() {
+			this.cache.get(1);
+		}
+
+		@Actor
+		public void actor2() {
+			this.cache.get(2);
+		}
+
+		@Arbiter
+		public void arbiter(ZZI_Result r) {
+			r.r1 = cache.contains(1);
+			r.r2 = cache.contains(2);
+			r.r3 = cache.size();
+		}
+	}
+
+	@JCStressTest
+	@Description("Testing value feature")
+	@Outcome(id = "true", expect = ACCEPTABLE, desc = "Valid values")
+	@Outcome(id = "false", expect = ACCEPTABLE, desc = "Valid values")
+	@State
+	public static class Case3 {
+
+		int sizeLimit = 1;
+		Function<Integer, Integer> generator = (key) -> key;
+		private final ConcurrentLruCache<Integer, Integer> cache = new ConcurrentLruCache<>(sizeLimit, generator);
+
+		@Actor
+		public void actor1(Z_Result r) {
+			r.r1 = (this.cache.get(1) == 1);
+		}
+
+		@Actor
+		public void actor2(Z_Result r) {
+			r.r1 = this.cache.contains(1);
+		}
+	}
+
+	@JCStressTest
+	@Description("Testing remove feature")
+	@Outcome(id = {"0", "1"}, expect = ACCEPTABLE, desc = "Valid values")
+	@State
+	public static class Case4 {
+
+		int sizeLimit = 2;
+		Function<Integer, Integer> generator = (key) -> key;
+		private final ConcurrentLruCache<Integer, Integer> cache = new ConcurrentLruCache<>(sizeLimit, generator);
+
+		@Actor
+		public void actor1() {
+			this.cache.get(1);
+		}
+
+		@Actor
+		public void actor2() {
+			this.cache.remove(1);
+		}
+
+		@Arbiter
+		public void arbiter(I_Result r) {
+			r.r1 = cache.size();
+		}
+	}
+
+	@JCStressTest
+	@Description("Testing clear feature")
+	@Outcome(id = {"0", "1", "2"}, expect = ACCEPTABLE, desc = "Valid results")
+	@State
+	public static class Case5 {
+
+		int sizeLimit = 2;
+		Function<Integer, Integer> generator = (key) -> key;
+		private final ConcurrentLruCache<Integer, Integer> cache = new ConcurrentLruCache<>(sizeLimit, generator);
+
+		@Actor
+		public void actor1() {
+			this.cache.get(1);
+		}
+
+		@Actor
+		public void actor2() {
+			this.cache.get(2);
+		}
+
+		@Actor
+		public void actor3() {
+			this.cache.clear();
+		}
+
+		@Arbiter
+		public void arbiter(I_Result r) {
+			r.r1 = cache.size();
+		}
+	}
+}


### PR DESCRIPTION
The PR improve current testing support for the class:
- https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/main/java/org/springframework/util/ConcurrentLruCache.java
- https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/test/java/org/springframework/util/ConcurrentLruCacheTests.java

Adding JCStress support for the class `ConcurrentLruCache`:
https://github.com/openjdk/jcstress

How to test it:
```
./gradlew clean jcstress --tests "ConcurrentLruCacheJCStressTests" -Pmodule=spring-core
```