### PR TITLE
Increase StreamUtils.BUFFER_SIZE to 8192

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -33,7 +33,7 @@ import org.springframework.lang.Nullable;
 /**
  * Simple utility methods for dealing with streams. The copy methods of this class are
  * similar to those defined in {@link FileCopyUtils} except that all affected streams are
- * left open when done. All copy methods use a block size of 4096 bytes.
+ * left open when done. All copy methods use a block size of 8192 bytes.
  *
  * <p>Mainly for use within the framework, but also useful for application code.
  *
@@ -48,7 +48,7 @@ public abstract class StreamUtils {
 	/**
 	 * The default buffer size used when copying bytes.
 	 */
-	public static final int BUFFER_SIZE = 4096;
+	public static final int BUFFER_SIZE = 8192;
 
 	private static final byte[] EMPTY_CONTENT = new byte[0];
 
@@ -83,7 +83,7 @@ public abstract class StreamUtils {
 			return "";
 		}
 
-		StringBuilder out = new StringBuilder(BUFFER_SIZE);
+		StringBuilder out = new StringBuilder();
 		InputStreamReader reader = new InputStreamReader(in, charset);
 		char[] buffer = new char[BUFFER_SIZE];
 		int charsRead;


### PR DESCRIPTION
This aligns the buffer size used in StreamUtils with the buffer sized
used throughout the JDK (see InputStream, BufferedInputStream, Files).