### PR TITLE
Introduce andPerformRequest() method in ResponseActions

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/ResponseActions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/ResponseActions.java
@@ -37,4 +37,9 @@ public interface ResponseActions {
 	 */
 	void andRespond(ResponseCreator responseCreator);
 
+	/**
+	 * Keep default httpClient implementation.
+	 */
+	void andPerformRequest();
+
 }

--- a/spring-test/src/test/java/org/springframework/test/web/client/MockRestServiceServerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/MockRestServiceServerTests.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.test.web.client.MockRestServiceServer.MockRestServiceServerBuilder;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -42,6 +43,19 @@ public class MockRestServiceServerTests {
 
 	private final RestTemplate restTemplate = new RestTemplate();
 
+	/**
+	 * Test to demonstrate andPerformRequest() that simulates real client-side Rest Call <br>
+	 *
+	 * @author Edmond Daher
+	 */
+	@Test
+	public void callRealEndpoint() {
+		MockRestServiceServer server = MockRestServiceServer.createServer(this.restTemplate);
+		server.expect(requestTo("http://localhost:8080/foo")).andPerformRequest();
+
+		assertThatExceptionOfType(ResourceAccessException.class)
+				.isThrownBy(() -> restTemplate.getForObject("http://localhost:8080/foo", String.class));
+	}
 
 	@Test
 	public void buildMultipleTimes() {


### PR DESCRIPTION
Prior to this commit it wasn't possible to achieve real
client-side Rest using a restTemplate that was bound by MockRestServiceServer

This commit introduces andPerformRequest() method in
which it supplies responseCreator with a real Rest call provided by copying the clientHttpRequest and performing a http call using the default ClientHttpRequest used by restTemplate: SimpleClientHttpRequestFactory