### PR TITLE
Fix nesting of headings in RestTemplate section of integration.adoc

### DIFF
--- a/src/docs/asciidoc/integration.adoc
+++ b/src/docs/asciidoc/integration.adoc
@@ -325,7 +325,7 @@ to serialize only a subset of the object properties, as the following example sh
 ----
 
 [[rest-template-multipart]]
-===== Multipart
+==== Multipart
 
 To send multipart data, you need to provide a `MultiValueMap<String, Object>` whose values
 may be an `Object` for part content, a `Resource` for a file part, or an `HttpEntity` for


### PR DESCRIPTION
Stop nesting the multipart section within the jsonview section