### PR TITLE
Stop implementing SynthesizedAnnotation in annotation proxies

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/BeanFactoryAnnotationsRuntimeHints.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/BeanFactoryAnnotationsRuntimeHints.java
@@ -30,6 +30,7 @@ import org.springframework.lang.Nullable;
 class BeanFactoryAnnotationsRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 		RuntimeHintsUtils.registerSynthesizedAnnotation(hints, Qualifier.class);
 	}

--- a/spring-core/src/main/java/org/springframework/aot/hint/support/RuntimeHintsUtils.java
+++ b/spring-core/src/main/java/org/springframework/aot/hint/support/RuntimeHintsUtils.java
@@ -71,7 +71,9 @@ public abstract class RuntimeHintsUtils {
 	 * @param hints the {@link RuntimeHints} instance to use
 	 * @param annotationType the annotation type
 	 * @see SynthesizedAnnotation
+	 * @deprecated For removal in Spring Framework 6.0
 	 */
+	@Deprecated
 	public static void registerSynthesizedAnnotation(RuntimeHints hints, Class<?> annotationType) {
 		hints.proxies().registerJdkProxy(annotationType, SynthesizedAnnotation.class);
 	}

--- a/spring-core/src/main/java/org/springframework/core/annotation/AliasFor.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AliasFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,7 +173,6 @@ import java.lang.annotation.Target;
  * @author Sam Brannen
  * @since 4.2
  * @see MergedAnnotations
- * @see SynthesizedAnnotation
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationConfigurationException.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.springframework.core.NestedRuntimeException;
  * @author Sam Brannen
  * @since 4.2
  * @see AnnotationUtils
- * @see SynthesizedAnnotation
  */
 @SuppressWarnings("serial")
 public class AnnotationConfigurationException extends NestedRuntimeException {

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationUtils.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -1185,7 +1186,7 @@ public abstract class AnnotationUtils {
 	public static <A extends Annotation> A synthesizeAnnotation(
 			A annotation, @Nullable AnnotatedElement annotatedElement) {
 
-		if (annotation instanceof SynthesizedAnnotation || AnnotationFilter.PLAIN.matches(annotation)) {
+		if (isSynthesizedAnnotation(annotation) || AnnotationFilter.PLAIN.matches(annotation)) {
 			return annotation;
 		}
 		return MergedAnnotation.from(annotatedElement, annotation).synthesize();
@@ -1277,6 +1278,19 @@ public abstract class AnnotationUtils {
 			synthesized[i] = synthesizeAnnotation(annotations[i], annotatedElement);
 		}
 		return synthesized;
+	}
+
+	/**
+	 * Determine if the supplied {@link Annotation} has been <em>synthesized</em>
+	 * by Spring (i.e. wrapped in a dynamic proxy) with additional functionality
+	 * such as attribute alias handling.
+	 * @param annotation the annotation to check
+	 * @return {@code true} if the supplied annotation is a synthesized annotation
+	 * @since 6.0
+	 */
+	public static boolean isSynthesizedAnnotation(@Nullable Annotation annotation) {
+		return ((annotation != null) && Proxy.isProxyClass(annotation.getClass()) &&
+				(Proxy.getInvocationHandler(annotation) instanceof SynthesizedMergedAnnotationInvocationHandler));
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/core/annotation/SynthesizedAnnotation.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/SynthesizedAnnotation.java
@@ -23,6 +23,8 @@ package org.springframework.core.annotation;
  *
  * @author Sam Brannen
  * @since 4.2
+ * @deprecated For removal in Spring Framework 6.0
  */
+@Deprecated
 public interface SynthesizedAnnotation {
 }

--- a/spring-core/src/main/java/org/springframework/core/annotation/SynthesizedMergedAnnotationInvocationHandler.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/SynthesizedMergedAnnotationInvocationHandler.java
@@ -300,27 +300,13 @@ final class SynthesizedMergedAnnotationInvocationHandler<A extends Annotation> i
 	static <A extends Annotation> A createProxy(MergedAnnotation<A> annotation, Class<A> type) {
 		ClassLoader classLoader = type.getClassLoader();
 		InvocationHandler handler = new SynthesizedMergedAnnotationInvocationHandler<>(annotation, type);
-		Class<?>[] interfaces = isVisible(classLoader, SynthesizedAnnotation.class) ?
-				new Class<?>[] {type, SynthesizedAnnotation.class} : new Class<?>[] {type};
+		Class<?>[] interfaces = new Class<?>[] {type};
 		return (A) Proxy.newProxyInstance(classLoader, interfaces, handler);
 	}
 
 	private static String getName(Class<?> clazz) {
 		String canonicalName = clazz.getCanonicalName();
 		return (canonicalName != null ? canonicalName : clazz.getName());
-	}
-
-
-	private static boolean isVisible(ClassLoader classLoader, Class<?> interfaceClass) {
-		if (classLoader == interfaceClass.getClassLoader()) {
-			return true;
-		}
-		try {
-			return Class.forName(interfaceClass.getName(), false, classLoader) == interfaceClass;
-		}
-		catch (ClassNotFoundException ex) {
-			return false;
-		}
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/annotation/TypeMappedAnnotation.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/TypeMappedAnnotation.java
@@ -363,7 +363,7 @@ final class TypeMappedAnnotation<A extends Annotation> extends AbstractMergedAnn
 	 * @since 5.3.22
 	 */
 	private boolean isSynthesizable(Annotation annotation) {
-		if (annotation instanceof SynthesizedAnnotation) {
+		if (AnnotationUtils.isSynthesizedAnnotation(annotation)) {
 			return false;
 		}
 		return isSynthesizable();

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationBackCompatibilityTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationBackCompatibilityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ class AnnotationBackCompatibilityTests {
 
 	@Test
 	void multiplRoutesToMetaAnnotation() {
-		Class<WithMetaMetaTestAnnotation1AndMetaTestAnnotation2> source = WithMetaMetaTestAnnotation1AndMetaTestAnnotation2.class;
+		Class<?> source = WithMetaMetaTestAnnotation1AndMetaTestAnnotation2.class;
 		// Merged annotation chooses lowest depth
 		MergedAnnotation<TestAnnotation> mergedAnnotation = MergedAnnotations.from(source).get(TestAnnotation.class);
 		assertThat(mergedAnnotation.getString("value")).isEqualTo("testAndMetaTest");
@@ -45,7 +45,7 @@ class AnnotationBackCompatibilityTests {
 	@Test
 	void defaultValue() {
 		DefaultValueAnnotation synthesized = MergedAnnotations.from(WithDefaultValue.class).get(DefaultValueAnnotation.class).synthesize();
-		assertThat(synthesized).isInstanceOf(SynthesizedAnnotation.class);
+		assertThat(AnnotationUtils.isSynthesizedAnnotation(synthesized)).as("synthesized annotation").isTrue();
 		Object defaultValue = AnnotationUtils.getDefaultValue(synthesized, "enumValue");
 		assertThat(defaultValue).isEqualTo(TestEnum.ONE);
 	}
@@ -60,14 +60,12 @@ class AnnotationBackCompatibilityTests {
 	@Retention(RetentionPolicy.RUNTIME)
 	@TestAnnotation("metaTest")
 	@interface MetaTestAnnotation {
-
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@TestAnnotation("testAndMetaTest")
 	@MetaTestAnnotation
 	@interface TestAndMetaTestAnnotation {
-
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)
@@ -78,7 +76,6 @@ class AnnotationBackCompatibilityTests {
 	@MetaMetaTestAnnotation
 	@TestAndMetaTestAnnotation
 	static class WithMetaMetaTestAnnotation1AndMetaTestAnnotation2 {
-
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)
@@ -94,7 +91,6 @@ class AnnotationBackCompatibilityTests {
 
 	@DefaultValueAnnotation
 	static class WithDefaultValue {
-
 	}
 
 	enum TestEnum {

--- a/spring-core/src/test/java/org/springframework/core/annotation/MergedAnnotationCollectorsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/MergedAnnotationCollectorsTests.java
@@ -45,7 +45,7 @@ class MergedAnnotationCollectorsTests {
 				MergedAnnotationCollectors.toAnnotationSet());
 		assertThat(set).isInstanceOf(LinkedHashSet.class).flatExtracting(
 				TestAnnotation::value).containsExactly("a", "b", "c");
-		assertThat(set).allMatch(SynthesizedAnnotation.class::isInstance);
+		assertThat(set).allMatch(AnnotationUtils::isSynthesizedAnnotation);
 	}
 
 	@Test
@@ -55,7 +55,7 @@ class MergedAnnotationCollectorsTests {
 		assertThat(Arrays.stream(array).map(
 				annotation -> ((TestAnnotation) annotation).value())).containsExactly("a",
 						"b", "c");
-		assertThat(array).allMatch(SynthesizedAnnotation.class::isInstance);
+		assertThat(array).allMatch(AnnotationUtils::isSynthesizedAnnotation);
 	}
 
 	@Test
@@ -64,7 +64,7 @@ class MergedAnnotationCollectorsTests {
 				MergedAnnotationCollectors.toAnnotationArray(TestAnnotation[]::new));
 		assertThat(Arrays.stream(array).map(TestAnnotation::value)).containsExactly("a",
 				"b", "c");
-		assertThat(array).allMatch(SynthesizedAnnotation.class::isInstance);
+		assertThat(array).allMatch(AnnotationUtils::isSynthesizedAnnotation);
 	}
 
 	@Test

--- a/spring-core/src/test/java/org/springframework/core/annotation/MergedAnnotationsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/MergedAnnotationsTests.java
@@ -1511,6 +1511,26 @@ class MergedAnnotationsTests {
 		assertThat(MergedAnnotation.from(component).isSynthesizable()).isFalse();
 	}
 
+	/**
+	 * @since 6.0
+	 */
+	@Test
+	void synthesizedAnnotationShouldReuseJdkProxyClass() throws Exception {
+		Method method = WebController.class.getMethod("handleMappedWithValueAttribute");
+
+		RequestMapping jdkRequestMapping = method.getAnnotation(RequestMapping.class);
+		assertThat(jdkRequestMapping).isNotNull();
+		assertThat(jdkRequestMapping.value()).containsExactly("/test");
+		assertThat(jdkRequestMapping.path()).containsExactly("");
+
+		RequestMapping synthesizedRequestMapping = MergedAnnotation.from(jdkRequestMapping).synthesize();
+		assertSynthesized(synthesizedRequestMapping);
+		assertThat(synthesizedRequestMapping.value()).containsExactly("/test");
+		assertThat(synthesizedRequestMapping.path()).containsExactly("/test");
+
+		assertThat(jdkRequestMapping.getClass()).isEqualTo(synthesizedRequestMapping.getClass());
+	}
+
 	@Test
 	void synthesizeAlreadySynthesized() throws Exception {
 		Method method = WebController.class.getMethod("handleMappedWithValueAttribute");
@@ -1520,9 +1540,10 @@ class MergedAnnotationsTests {
 		RequestMapping synthesizedWebMapping = MergedAnnotation.from(webMapping).synthesize();
 		RequestMapping synthesizedAgainWebMapping = MergedAnnotation.from(synthesizedWebMapping).synthesize();
 
-		assertThat(synthesizedWebMapping).isInstanceOf(SynthesizedAnnotation.class);
-		assertThat(synthesizedAgainWebMapping).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesizedWebMapping);
+		assertSynthesized(synthesizedAgainWebMapping);
 		assertThat(synthesizedWebMapping).isEqualTo(synthesizedAgainWebMapping);
+		assertThat(synthesizedWebMapping).isSameAs(synthesizedAgainWebMapping);
 		assertThat(synthesizedWebMapping.name()).isEqualTo("foo");
 		assertThat(synthesizedWebMapping.path()).containsExactly("/test");
 		assertThat(synthesizedWebMapping.value()).containsExactly("/test");
@@ -1537,7 +1558,7 @@ class MergedAnnotationsTests {
 		Id synthesizedId = MergedAnnotation.from(id).synthesize();
 		assertThat(id).isEqualTo(synthesizedId);
 		// It doesn't make sense to synthesize @Id since it declares zero attributes.
-		assertThat(synthesizedId).isNotInstanceOf(SynthesizedAnnotation.class);
+		assertNotSynthesized(synthesizedId);
 		assertThat(id).isSameAs(synthesizedId);
 
 		GeneratedValue generatedValue = method.getAnnotation(GeneratedValue.class);
@@ -1545,7 +1566,7 @@ class MergedAnnotationsTests {
 		GeneratedValue synthesizedGeneratedValue = MergedAnnotation.from(generatedValue).synthesize();
 		assertThat(generatedValue).isEqualTo(synthesizedGeneratedValue);
 		// It doesn't make sense to synthesize @GeneratedValue since it declares zero attributes with aliases.
-		assertThat(synthesizedGeneratedValue).isNotInstanceOf(SynthesizedAnnotation.class);
+		assertNotSynthesized(synthesizedGeneratedValue);
 		assertThat(generatedValue).isSameAs(synthesizedGeneratedValue);
 	}
 
@@ -1555,19 +1576,19 @@ class MergedAnnotationsTests {
 		MergedAnnotations mergedAnnotations = MergedAnnotations.from(directlyAnnotatedField);
 		RootAnnotation rootAnnotation = mergedAnnotations.get(RootAnnotation.class).synthesize();
 		assertThat(rootAnnotation.flag()).isFalse();
-		assertThat(rootAnnotation).isNotInstanceOf(SynthesizedAnnotation.class);
+		assertNotSynthesized(rootAnnotation);
 
 		Field metaAnnotatedField = ReflectionUtils.findField(DomainType.class, "metaAnnotated");
 		mergedAnnotations = MergedAnnotations.from(metaAnnotatedField);
 		rootAnnotation = mergedAnnotations.get(RootAnnotation.class).synthesize();
 		assertThat(rootAnnotation.flag()).isTrue();
-		assertThat(rootAnnotation).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(rootAnnotation);
 
 		Field metaMetaAnnotatedField = ReflectionUtils.findField(DomainType.class, "metaMetaAnnotated");
 		mergedAnnotations = MergedAnnotations.from(metaMetaAnnotatedField);
 		rootAnnotation = mergedAnnotations.get(RootAnnotation.class).synthesize();
 		assertThat(rootAnnotation.flag()).isTrue();
-		assertThat(rootAnnotation).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(rootAnnotation);
 	}
 
 	@Test  // gh-28704
@@ -1578,13 +1599,13 @@ class MergedAnnotationsTests {
 				mergedAnnotations.get(EnableWebSecurity.class);
 		assertThat(enableWebSecurityAnnotation.isSynthesizable()).isFalse();
 		EnableWebSecurity enableWebSecurity = enableWebSecurityAnnotation.synthesize();
-		assertThat(enableWebSecurity).isNotInstanceOf(SynthesizedAnnotation.class);
+		assertNotSynthesized(enableWebSecurity);
 
 		MergedAnnotation<EnableGlobalAuthentication> enableGlobalAuthenticationMergedAnnotation =
 				mergedAnnotations.get(EnableGlobalAuthentication.class);
 		assertThat(enableGlobalAuthenticationMergedAnnotation.isSynthesizable()).isFalse();
 		EnableGlobalAuthentication enableGlobalAuthentication = enableGlobalAuthenticationMergedAnnotation.synthesize();
-		assertThat(enableGlobalAuthentication).isNotInstanceOf(SynthesizedAnnotation.class);
+		assertNotSynthesized(enableGlobalAuthentication);
 	}
 
 	/**
@@ -1603,8 +1624,8 @@ class MergedAnnotationsTests {
 		RequestMapping synthesizedWebMapping1 = mergedAnnotation1.synthesize();
 		RequestMapping synthesizedWebMapping2 = MergedAnnotation.from(webMapping).synthesize();
 
-		assertThat(synthesizedWebMapping1).isInstanceOf(SynthesizedAnnotation.class);
-		assertThat(synthesizedWebMapping2).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesizedWebMapping1);
+		assertSynthesized(synthesizedWebMapping2);
 		assertThat(synthesizedWebMapping1).isEqualTo(synthesizedWebMapping2);
 
 		// Synthesizing an annotation from a different MergedAnnotation results in a different synthesized annotation instance.
@@ -1734,7 +1755,7 @@ class MergedAnnotationsTests {
 		MergedAnnotation<ImplicitAliasesTestConfiguration> mergedAnnotation = MergedAnnotation.from(config);
 		assertThat(mergedAnnotation.isSynthesizable()).isTrue();
 		ImplicitAliasesTestConfiguration synthesized = mergedAnnotation.synthesize();
-		assertThat(synthesized).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesized);
 		assertThat(synthesized.value()).isEqualTo(expected);
 		assertThat(synthesized.location1()).isEqualTo(expected);
 		assertThat(synthesized.xmlFile()).isEqualTo(expected);
@@ -1765,7 +1786,7 @@ class MergedAnnotationsTests {
 		assertThat(mergedAnnotation.isSynthesizable()).isTrue();
 		ImplicitAliasesWithImpliedAliasNamesOmittedTestConfiguration synthesized =
 				mergedAnnotation.synthesize();
-		assertThat(synthesized).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesized);
 		assertThat(synthesized.value()).isEqualTo(expected);
 		assertThat(synthesized.location()).isEqualTo(expected);
 		assertThat(synthesized.xmlFile()).isEqualTo(expected);
@@ -1777,7 +1798,7 @@ class MergedAnnotationsTests {
 				ImplicitAliasesForAliasPairTestConfigurationClass.class.getAnnotation(
 						ImplicitAliasesForAliasPairTestConfiguration.class);
 		ImplicitAliasesForAliasPairTestConfiguration synthesized = MergedAnnotation.from(config).synthesize();
-		assertThat(synthesized).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesized);
 		assertThat(synthesized.xmlFile()).isEqualTo("test.xml");
 		assertThat(synthesized.groovyScript()).isEqualTo("test.xml");
 	}
@@ -1788,7 +1809,7 @@ class MergedAnnotationsTests {
 				TransitiveImplicitAliasesTestConfigurationClass.class.getAnnotation(
 						TransitiveImplicitAliasesTestConfiguration.class);
 		TransitiveImplicitAliasesTestConfiguration synthesized = MergedAnnotation.from(config).synthesize();
-		assertThat(synthesized).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesized);
 		assertThat(synthesized.xml()).isEqualTo("test.xml");
 		assertThat(synthesized.groovy()).isEqualTo("test.xml");
 	}
@@ -1800,7 +1821,7 @@ class MergedAnnotationsTests {
 						TransitiveImplicitAliasesForAliasPairTestConfiguration.class);
 		TransitiveImplicitAliasesForAliasPairTestConfiguration synthesized = MergedAnnotation.from(
 				config).synthesize();
-		assertThat(synthesized).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesized);
 		assertThat(synthesized.xml()).isEqualTo("test.xml");
 		assertThat(synthesized.groovy()).isEqualTo("test.xml");
 	}
@@ -1859,7 +1880,7 @@ class MergedAnnotationsTests {
 		Map<String, Object> map = Collections.singletonMap("value", "webController");
 		MergedAnnotation<Component> annotation = MergedAnnotation.of(Component.class, map);
 		Component synthesizedComponent = annotation.synthesize();
-		assertThat(synthesizedComponent).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesizedComponent);
 		assertThat(synthesizedComponent.value()).isEqualTo("webController");
 	}
 
@@ -1880,7 +1901,7 @@ class MergedAnnotationsTests {
 		MergedAnnotation<ComponentScanSingleFilter> annotation = MergedAnnotation.of(
 				ComponentScanSingleFilter.class, map);
 		ComponentScanSingleFilter synthesizedComponentScan = annotation.synthesize();
-		assertThat(synthesizedComponentScan).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesizedComponentScan);
 		assertThat(synthesizedComponentScan.value().pattern()).isEqualTo("newFoo");
 	}
 
@@ -1904,7 +1925,7 @@ class MergedAnnotationsTests {
 		MergedAnnotation<ComponentScan> annotation = MergedAnnotation.of(
 				ComponentScan.class, map);
 		ComponentScan synthesizedComponentScan = annotation.synthesize();
-		assertThat(synthesizedComponentScan).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesizedComponentScan);
 		assertThat(Arrays.stream(synthesizedComponentScan.excludeFilters()).map(
 				Filter::pattern)).containsExactly("newFoo", "newBar");
 	}
@@ -2023,7 +2044,7 @@ class MergedAnnotationsTests {
 		assertThat(component).isNotNull();
 		Map<String, Object> attributes = MergedAnnotation.from(component).asMap();
 		Component synthesized = MergedAnnotation.of(Component.class, attributes).synthesize();
-		assertThat(synthesized).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesized);
 		assertThat(synthesized).isEqualTo(component);
 	}
 
@@ -2182,7 +2203,7 @@ class MergedAnnotationsTests {
 		assertThat(annotation).isNotNull();
 		MergedAnnotation<Annotation> mergedAnnotation = MergedAnnotation.from(annotation);
 		Annotation synthesizedAnnotation = mergedAnnotation.synthesize();
-		assertThat(synthesizedAnnotation).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesizedAnnotation);
 		assertThat(mergedAnnotation.getString("name")).isEqualTo("test");
 		assertThat(mergedAnnotation.getString("path")).isEqualTo("/test");
 		assertThat(mergedAnnotation.getString("value")).isEqualTo("/test");
@@ -2193,10 +2214,10 @@ class MergedAnnotationsTests {
 		Hierarchy hierarchy = HierarchyClass.class.getAnnotation(Hierarchy.class);
 		assertThat(hierarchy).isNotNull();
 		Hierarchy synthesizedHierarchy = MergedAnnotation.from(hierarchy).synthesize();
-		assertThat(synthesizedHierarchy).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesizedHierarchy);
 		TestConfiguration[] configs = synthesizedHierarchy.value();
 		assertThat(configs).isNotNull();
-		assertThat(configs).allMatch(SynthesizedAnnotation.class::isInstance);
+		assertThat(configs).allMatch(AnnotationUtils::isSynthesizedAnnotation);
 		assertThat(configs).extracting(TestConfiguration::value).containsExactly("A", "B");
 		assertThat(configs).extracting(TestConfiguration::location).containsExactly("A", "B");
 
@@ -2217,7 +2238,7 @@ class MergedAnnotationsTests {
 		assertThat(charsContainer).isNotNull();
 		CharsContainer synthesizedCharsContainer = MergedAnnotation.from(
 				charsContainer).synthesize();
-		assertThat(synthesizedCharsContainer).isInstanceOf(SynthesizedAnnotation.class);
+		assertSynthesized(synthesizedCharsContainer);
 		char[] chars = synthesizedCharsContainer.chars();
 		assertThat(chars).containsExactly('x', 'y', 'z');
 		// Alter array returned from synthesized annotation
@@ -3830,5 +3851,13 @@ class MergedAnnotationsTests {
 
 	}
 	// @formatter:on
+
+	static void assertSynthesized(Annotation annotation) {
+		assertThat(AnnotationUtils.isSynthesizedAnnotation(annotation)).as("synthesized annotation").isTrue();
+	}
+
+	static void assertNotSynthesized(Annotation annotation) {
+		assertThat(AnnotationUtils.isSynthesizedAnnotation(annotation)).as("synthesized annotation").isFalse();
+	}
 
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/MessagingAnnotationsRuntimeHints.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/MessagingAnnotationsRuntimeHints.java
@@ -34,8 +34,10 @@ import org.springframework.stereotype.Controller;
 public class MessagingAnnotationsRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 		Stream.of(Controller.class, Header.class, Headers.class, Payload.class).forEach(annotationType ->
 				RuntimeHintsUtils.registerSynthesizedAnnotation(hints, annotationType));
 	}
+
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/SimpAnnotationsRuntimeHints.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/SimpAnnotationsRuntimeHints.java
@@ -30,7 +30,9 @@ import org.springframework.aot.hint.support.RuntimeHintsUtils;
 public class SimpAnnotationsRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
 		RuntimeHintsUtils.registerSynthesizedAnnotation(hints, SendToUser.class);
 	}
+
 }

--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/TransactionRuntimeHints.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/TransactionRuntimeHints.java
@@ -34,10 +34,12 @@ import org.springframework.transaction.TransactionDefinition;
 class TransactionRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
 		RuntimeHintsUtils.registerSynthesizedAnnotation(hints, Transactional.class);
 		hints.reflection().registerTypes(TypeReference.listOf(
 						Isolation.class, Propagation.class, TransactionDefinition.class),
 				builder -> builder.withMembers(MemberCategory.DECLARED_FIELDS));
 	}
+
 }

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/WebAnnotationsRuntimeHintsRegistrar.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/WebAnnotationsRuntimeHintsRegistrar.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Controller;
 public final class WebAnnotationsRuntimeHintsRegistrar implements RuntimeHintsRegistrar {
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 		Stream.of(Controller.class, ControllerAdvice.class, CookieValue.class,
 						CrossOrigin.class, MatrixVariable.class, ModelAttribute.class,


### PR DESCRIPTION
## Overview

This PR has two commits: one that stops using `SynthesizedAnnotation` and a second that deprecates `SynthesizedAnnotation`.

If we decide to get rid of `SynthesizedAnnotation`, we can subsequently remove it completely for Spring Framework 6.0.

## Discussion

`SynthesizedAnnotation` was originally introduced as a convenience for easily detecting if an annotation had been _synthesized_ by Spring via a simple `if (myAnnotation instanceof SynthesizedAnnotation)` check.

However, the introduction of `SynthesizedAnnotation` in the JDK proxy for an annotation results in a separate proxy class for Spring's synthesized annotations, and this causes issues with GraalVM native images since users and framework developers must always ensure that the additional proxy classes are registered.

This PR completely removes the use of `SynthesizedAnnotation` in synthesized proxies which allows the JDK proxy class for the annotation to be reused within a GraalVM native image. See [this project](https://github.com/sbrannen/graalvm-playground/tree/master/synthesized_annotations) for a demonstration.

Instead of checking if an annotation implements `SynthesizedAnnotation` (to determine if the annotation needs to be synthesized), the PR uses a `Proxy.getInvocationHandler(annotation) instanceof SynthesizedMergedAnnotationInvocationHandler)` check to determine if Spring synthesized the annotation.

## Drawbacks

At one point in 2015, @jhoeller used `Proxy.getInvocationHandler` to perform the "is synthesized" check; however, he reverted that due to #18402. See https://github.com/spring-projects/spring-framework/issues/18402#issuecomment-453434657 for details.

## Related Issues

- #18271
- #18402
- #29053 
- #29054

## Deliverables

- [x] Determine if we can make `Proxy.getInvocationHandler` work without negative side effects such as those raised in [#18402](https://github.com/spring-projects/spring-framework/issues/18402)