### PR TITLE
Fix Transaction already completed issue

### DIFF
--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
@@ -27,12 +27,12 @@ import io.r2dbc.spi.Statement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.transaction.TransactionCommitException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.TransactionCommitException;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.reactive.TransactionSynchronization;
 import org.springframework.transaction.reactive.TransactionSynchronizationManager;

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
@@ -27,6 +27,7 @@ import io.r2dbc.spi.Statement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.TransactionCommitException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -262,7 +263,7 @@ class R2dbcTransactionManagerUnitTests {
 				.doOnNext(connection -> connection.createStatement("foo")).then()
 				.as(operator::transactional)
 				.as(StepVerifier::create)
-				.verifyError(IllegalTransactionStateException.class);
+				.verifyError(TransactionCommitException.class);
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));
@@ -315,7 +316,7 @@ class R2dbcTransactionManagerUnitTests {
 			return ConnectionFactoryUtils.getConnection(connectionFactoryMock)
 					.doOnNext(connection -> connection.createStatement("foo")).then();
 		}).as(StepVerifier::create)
-				.verifyError(IllegalTransactionStateException.class);
+				.verifyError(TransactionCommitException.class);
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));

--- a/spring-tx/src/main/java/org/springframework/transaction/TransactionCommitException.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/TransactionCommitException.java
@@ -5,7 +5,6 @@ package org.springframework.transaction;
  * Exception when reactive transaction manager fails on commit
  *
  * @author Vladyslav Zolotarov
- * @since 12.05.2022
  */
 @SuppressWarnings("serial")
 public class TransactionCommitException extends TransactionException {

--- a/spring-tx/src/main/java/org/springframework/transaction/TransactionCommitException.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/TransactionCommitException.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.transaction;
 
 
 /**
- * Exception when reactive transaction manager fails on commit
+ * Exception when reactive transaction manager fails on commit.
  *
  * @author Vladyslav Zolotarov
  */

--- a/spring-tx/src/main/java/org/springframework/transaction/TransactionCommitException.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/TransactionCommitException.java
@@ -1,0 +1,16 @@
+package org.springframework.transaction;
+
+
+/**
+ * Exception when reactive transaction manager fails on commit
+ *
+ * @author Vladyslav Zolotarov
+ * @since 12.05.2022
+ */
+@SuppressWarnings("serial")
+public class TransactionCommitException extends TransactionException {
+
+	public TransactionCommitException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+}

--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperatorImpl.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionalOperatorImpl.java
@@ -24,9 +24,9 @@ import reactor.core.publisher.Mono;
 import org.springframework.lang.Nullable;
 import org.springframework.transaction.ReactiveTransaction;
 import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.TransactionCommitException;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
-import org.springframework.transaction.TransactionCommitException;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.util.Assert;
 
@@ -123,7 +123,7 @@ final class TransactionalOperatorImpl implements TransactionalOperator {
 	private Mono<Void> commitWithErrorHandling(ReactiveTransaction reactiveTransaction) {
 		return this.transactionManager
 				.commit(reactiveTransaction)
-				.onErrorResume((ex) -> Mono.error(new TransactionCommitException("Transaction commit failed", ex)));
+				.onErrorResume(ex -> Mono.error(new TransactionCommitException("Transaction commit failed", ex)));
 	}
 
 	/**

--- a/spring-tx/src/test/java/org/springframework/transaction/reactive/ReactiveTestTransactionManager.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/reactive/ReactiveTestTransactionManager.java
@@ -16,9 +16,10 @@
 
 package org.springframework.transaction.reactive;
 
-import org.springframework.lang.Nullable;
+
 import reactor.core.publisher.Mono;
 
+import org.springframework.lang.Nullable;
 import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -91,7 +92,8 @@ class ReactiveTestTransactionManager extends AbstractReactiveTransactionManager 
 		Mono<Void> result = Mono.fromRunnable(() -> this.commit = true);
 		if (throwOnCommit != null) {
 			return result.then(Mono.error(throwOnCommit));
-		} else {
+		}
+		else {
 			return result;
 		}
 	}

--- a/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/reactive/TransactionalOperatorTests.java
@@ -21,12 +21,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
-import org.springframework.dao.ConcurrencyFailureException;
-import org.springframework.transaction.TransactionCommitException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.transaction.TransactionCommitException;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
I have encountered an issue when using **Reactive Transactions** with **PostgreSQL** in **Serialized Isolation** mode, that when commit fails with **ConcurrencyFailureException**, **TransactionalOperator** actually tries to call rollback on the transaction.

The issue is that in **ReactiveTransactionManager#rollback** method, it is stated in case if commit threw an exception - you should not call the rollback method.

Currently when **ReactiveTransactionManager#commit** fails, the **TransactionalOperator** actually calls the **rollbackOnException** and it causes the rollback method to throw **IllegalTransactionStateException** with message about the transaction already being complete.

My proposal to fix this, is to wrap and exceptions that rise from commit phase in **Flux/Mono.whenUsing** into a special **TransactionCommitException** that allows us the decide weather to rollback or no, and also propagate it upstream so that client could decide to retry on such an occasion.