### PR TITLE
Make QDox an implementation detail of spring-core-test

### DIFF
--- a/spring-core-test/spring-core-test.gradle
+++ b/spring-core-test/spring-core-test.gradle
@@ -4,10 +4,10 @@ dependencies {
 	api(project(":spring-core"))
 	api("org.junit.jupiter:junit-jupiter-api")
 	api("org.assertj:assertj-core")
-	api("com.thoughtworks.qdox:qdox")
 	compileOnly("org.junit.jupiter:junit-jupiter")
 	compileOnly("org.junit.platform:junit-platform-engine")
 	compileOnly("org.junit.platform:junit-platform-launcher")
+	implementation("com.thoughtworks.qdox:qdox")
 }
 
 jar {


### PR DESCRIPTION
Previously, `com.thoughtworks.qdox:qdox` was declared as an api dependency of spring-core-test despite it only being used in the module's internals. This resulted in it unnecessarily appearing on the compile classpath of consuming projects.

This PR moves qdox to be an implementation dependency, removing it from the compile classpath of consuming projects but ensuring that it's still available at runtime.