### PR TITLE
Add support for providing JNI runtime hints

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/hint/RuntimeHints.java
+++ b/spring-core/src/main/java/org/springframework/aot/hint/RuntimeHints.java
@@ -28,6 +28,7 @@ package org.springframework.aot.hint;
  * recorded as well.
  *
  * @author Stephane Nicoll
+ * @author Janne Valkealahti
  * @since 6.0
  */
 public class RuntimeHints {
@@ -40,6 +41,7 @@ public class RuntimeHints {
 
 	private final ProxyHints proxies = new ProxyHints();
 
+	private final ReflectionHints jni = new ReflectionHints();
 
 	/**
 	 * Provide access to reflection-based hints.
@@ -71,6 +73,14 @@ public class RuntimeHints {
 	 */
 	public ProxyHints proxies() {
 		return this.proxies;
+	}
+
+	/**
+	 * Provide access to jni-based hints.
+	 * @return jni hints
+	 */
+	public ReflectionHints jni() {
+		return this.jni;
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/aot/nativex/NativeConfigurationWriter.java
+++ b/spring-core/src/main/java/org/springframework/aot/nativex/NativeConfigurationWriter.java
@@ -29,6 +29,7 @@ import org.springframework.aot.hint.SerializationHints;
  *
  * @author Sebastien Deleuze
  * @author Stephane Nicoll
+ * @author Janne Valkealahti
  * @since 6.0
  * @see <a href="https://www.graalvm.org/22.1/reference-manual/native-image/BuildConfiguration/">Native Image Build Configuration</a>
  */
@@ -51,6 +52,9 @@ public abstract class NativeConfigurationWriter {
 		if (hints.resources().resourcePatterns().findAny().isPresent() ||
 				hints.resources().resourceBundles().findAny().isPresent()) {
 			writeResourceHints(hints.resources());
+		}
+		if (hints.jni().typeHints().findAny().isPresent()) {
+			writeJniHints(hints.jni());
 		}
 	}
 
@@ -80,6 +84,11 @@ public abstract class NativeConfigurationWriter {
 	private void writeResourceHints(ResourceHints hints) {
 		writeTo("resource-config.json", writer ->
 				ResourceHintsWriter.INSTANCE.write(writer, hints));
+	}
+
+	private void writeJniHints(ReflectionHints hints) {
+		writeTo("jni-config.json", writer ->
+				ReflectionHintsWriter.INSTANCE.write(writer, hints));
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/aot/nativex/ReflectionHintsWriter.java
+++ b/spring-core/src/main/java/org/springframework/aot/nativex/ReflectionHintsWriter.java
@@ -34,12 +34,15 @@ import org.springframework.lang.Nullable;
 
 /**
  * Write {@link ReflectionHints} to the JSON output expected by the GraalVM
- * {@code native-image} compiler, typically named {@code reflect-config.json}.
+ * {@code native-image} compiler, typically named {@code reflect-config.json}
+ * or {@code jni-config.json}.
  *
  * @author Sebastien Deleuze
  * @author Stephane Nicoll
+ * @author Janne Valkealahti
  * @since 6.0
  * @see <a href="https://www.graalvm.org/22.0/reference-manual/native-image/Reflection/">Reflection Use in Native Images</a>
+ * @see <a href="https://www.graalvm.org/22.0/reference-manual/native-image/JNI/">Java Native Interface (JNI) in Native Image</a>
  * @see <a href="https://www.graalvm.org/22.0/reference-manual/native-image/BuildConfiguration/">Native Image Build Configuration</a>
  */
 class ReflectionHintsWriter {

--- a/spring-core/src/test/java/org/springframework/aot/nativex/FileNativeConfigurationWriterTests.java
+++ b/spring-core/src/test/java/org/springframework/aot/nativex/FileNativeConfigurationWriterTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link FileNativeConfigurationWriter}.
  *
  * @author Sebastien Deleuze
+ * @author Janne Valkealahti
  */
 public class FileNativeConfigurationWriterTests {
 
@@ -147,6 +148,23 @@ public class FileNativeConfigurationWriterTests {
 						]
 					}
 				]""", "reflect-config.json");
+	}
+
+	@Test
+	void jniConfig() throws IOException, JSONException {
+		// same format as reflection so just test basic file generation
+		FileNativeConfigurationWriter generator = new FileNativeConfigurationWriter(tempDir);
+		RuntimeHints hints = new RuntimeHints();
+		ReflectionHints jniHints = hints.jni();
+		jniHints.registerType(StringDecoder.class, builder -> builder.onReachableType(String.class));
+		generator.write(hints);
+		assertEquals("""
+				[
+					{
+						"name": "org.springframework.core.codec.StringDecoder",
+						"condition": { "typeReachable": "java.lang.String" }
+					}
+				]""", "jni-config.json");
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds support generating graalvm `jni-config.json` file.

Configuration format for jni/reflection in graalvm is documented
to be exactly same so we can re-use facilities for reflection hints
which should be relatively clean for a user as also graalvm uses same
classes for both jni/reflection.

Closes gh-29007