### PR TITLE
Deprecate support for theme

### DIFF
--- a/spring-context/src/main/java/org/springframework/ui/context/HierarchicalThemeSource.java
+++ b/spring-context/src/main/java/org/springframework/ui/context/HierarchicalThemeSource.java
@@ -24,7 +24,9 @@ import org.springframework.lang.Nullable;
  *
  * @author Jean-Pierre Pawlak
  * @author Juergen Hoeller
+ * @deprecated as of 6.0, with no concrete replacement
  */
+@Deprecated
 public interface HierarchicalThemeSource extends ThemeSource {
 
 	/**

--- a/spring-context/src/main/java/org/springframework/ui/context/Theme.java
+++ b/spring-context/src/main/java/org/springframework/ui/context/Theme.java
@@ -28,7 +28,9 @@ import org.springframework.context.MessageSource;
  * @since 17.06.2003
  * @see ThemeSource
  * @see org.springframework.web.servlet.ThemeResolver
+ * @deprecated as of 6.0, with no direct replacement
  */
+@Deprecated
 public interface Theme {
 
 	/**

--- a/spring-context/src/main/java/org/springframework/ui/context/ThemeSource.java
+++ b/spring-context/src/main/java/org/springframework/ui/context/ThemeSource.java
@@ -26,7 +26,9 @@ import org.springframework.lang.Nullable;
  * @author Jean-Pierre Pawlak
  * @author Juergen Hoeller
  * @see Theme
+ * @deprecated as of 6.0, with no direct replacement
  */
+@Deprecated
 public interface ThemeSource {
 
 	/**

--- a/spring-context/src/main/java/org/springframework/ui/context/support/DelegatingThemeSource.java
+++ b/spring-context/src/main/java/org/springframework/ui/context/support/DelegatingThemeSource.java
@@ -31,7 +31,9 @@ import org.springframework.ui.context.ThemeSource;
  * @author Juergen Hoeller
  * @since 1.2.4
  * @see UiApplicationContextUtils
+ * @deprecated as of 6.0, with no direct replacement
  */
+@Deprecated
 public class DelegatingThemeSource implements HierarchicalThemeSource {
 
 	@Nullable

--- a/spring-context/src/main/java/org/springframework/ui/context/support/ResourceBundleThemeSource.java
+++ b/spring-context/src/main/java/org/springframework/ui/context/support/ResourceBundleThemeSource.java
@@ -42,7 +42,9 @@ import org.springframework.ui.context.ThemeSource;
  * @see #setBasenamePrefix
  * @see java.util.ResourceBundle
  * @see org.springframework.context.support.ResourceBundleMessageSource
+ * @deprecated as of 6.0, with no direct replacement
  */
+@Deprecated
 public class ResourceBundleThemeSource implements HierarchicalThemeSource, BeanClassLoaderAware {
 
 	protected final Log logger = LogFactory.getLog(getClass());

--- a/spring-context/src/main/java/org/springframework/ui/context/support/SimpleTheme.java
+++ b/spring-context/src/main/java/org/springframework/ui/context/support/SimpleTheme.java
@@ -26,7 +26,9 @@ import org.springframework.util.Assert;
  *
  * @author Juergen Hoeller
  * @since 17.06.2003
+ * @deprecated as of 6.0, with no concrete replacement
  */
+@Deprecated
 public class SimpleTheme implements Theme {
 
 	private final String name;

--- a/spring-context/src/main/java/org/springframework/ui/context/support/UiApplicationContextUtils.java
+++ b/spring-context/src/main/java/org/springframework/ui/context/support/UiApplicationContextUtils.java
@@ -31,7 +31,9 @@ import org.springframework.ui.context.ThemeSource;
  * @author Jean-Pierre Pawlak
  * @author Juergen Hoeller
  * @since 17.06.2003
+ * @deprecated as of 6.0, with no direct replacement
  */
+@Deprecated
 public abstract class UiApplicationContextUtils {
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
@@ -64,7 +64,6 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.servlet.resource.ResourceUrlProvider;
 import org.springframework.web.servlet.support.SessionFlashMapManager;
-import org.springframework.web.servlet.theme.FixedThemeResolver;
 import org.springframework.web.servlet.view.DefaultRequestToViewNameTranslator;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.util.UrlPathHelper;
@@ -394,6 +393,7 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 		return wac;
 	}
 
+	@SuppressWarnings("deprecation")
 	private void registerMvcSingletons(StubWebApplicationContext wac) {
 		StandaloneConfiguration config = new StandaloneConfiguration();
 		config.setApplicationContext(wac);
@@ -432,8 +432,10 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 
 		wac.addBeans(initViewResolvers(wac));
 		wac.addBean(DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME, this.localeResolver);
-		wac.addBean(DispatcherServlet.THEME_RESOLVER_BEAN_NAME, new FixedThemeResolver());
-		wac.addBean(DispatcherServlet.REQUEST_TO_VIEW_NAME_TRANSLATOR_BEAN_NAME, new DefaultRequestToViewNameTranslator());
+		wac.addBean(DispatcherServlet.THEME_RESOLVER_BEAN_NAME,
+				new org.springframework.web.servlet.theme.FixedThemeResolver());
+		wac.addBean(DispatcherServlet.REQUEST_TO_VIEW_NAME_TRANSLATOR_BEAN_NAME,
+				new DefaultRequestToViewNameTranslator());
 
 		this.flashMapManager = new SessionFlashMapManager();
 		wac.addBean(DispatcherServlet.FLASH_MAP_MANAGER_BEAN_NAME, this.flashMapManager);

--- a/spring-web/src/main/java/org/springframework/web/context/support/AbstractRefreshableWebApplicationContext.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/AbstractRefreshableWebApplicationContext.java
@@ -57,6 +57,7 @@ import org.springframework.web.context.ServletContextAware;
  * {@link org.springframework.context.support.AbstractApplicationContext},
  * this class detects a bean of type {@link org.springframework.ui.context.ThemeSource}
  * in the context, under the special bean name "themeSource".
+ * Theme support is deprecated as of 6.0
  *
  * <p><b>This is the web context to be subclassed for a different bean definition format.</b>
  * Such a context implementation can be specified as "contextClass" context-param
@@ -75,9 +76,9 @@ import org.springframework.web.context.ServletContextAware;
  * @since 1.1.3
  * @see #loadBeanDefinitions
  * @see org.springframework.web.context.ConfigurableWebApplicationContext#setConfigLocations
- * @see org.springframework.ui.context.ThemeSource
  * @see XmlWebApplicationContext
  */
+@SuppressWarnings("deprecation")
 public abstract class AbstractRefreshableWebApplicationContext extends AbstractRefreshableConfigApplicationContext
 		implements ConfigurableWebApplicationContext, ThemeSource {
 
@@ -95,6 +96,7 @@ public abstract class AbstractRefreshableWebApplicationContext extends AbstractR
 
 	/** the ThemeSource for this ApplicationContext. */
 	@Nullable
+	@Deprecated
 	private ThemeSource themeSource;
 
 
@@ -197,6 +199,7 @@ public abstract class AbstractRefreshableWebApplicationContext extends AbstractR
 	 * Initialize the theme capability.
 	 */
 	@Override
+	@Deprecated
 	protected void onRefresh() {
 		this.themeSource = UiApplicationContextUtils.initThemeSource(this);
 	}
@@ -215,6 +218,7 @@ public abstract class AbstractRefreshableWebApplicationContext extends AbstractR
 
 	@Override
 	@Nullable
+	@Deprecated
 	public Theme getTheme(String themeName) {
 		Assert.state(this.themeSource != null, "No ThemeSource available");
 		return this.themeSource.getTheme(themeName);

--- a/spring-web/src/main/java/org/springframework/web/context/support/GenericWebApplicationContext.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/GenericWebApplicationContext.java
@@ -52,6 +52,7 @@ import org.springframework.web.context.ServletContextAware;
  * <p>In addition to the special beans detected by
  * {@link org.springframework.context.support.AbstractApplicationContext AbstractApplicationContext},
  * this class detects a {@link ThemeSource} bean in the context, with the name "themeSource".
+ * Theme support is deprecated as of 6.0
  *
  * <p>If you wish to register annotated <em>component classes</em> with a
  * {@code GenericWebApplicationContext}, you can use an
@@ -77,6 +78,7 @@ import org.springframework.web.context.ServletContextAware;
  * @author Sam Brannen
  * @since 1.2
  */
+@SuppressWarnings("deprecation")
 public class GenericWebApplicationContext extends GenericApplicationContext
 		implements ConfigurableWebApplicationContext, ThemeSource {
 
@@ -84,6 +86,7 @@ public class GenericWebApplicationContext extends GenericApplicationContext
 	private ServletContext servletContext;
 
 	@Nullable
+	@Deprecated
 	private ThemeSource themeSource;
 
 
@@ -195,6 +198,7 @@ public class GenericWebApplicationContext extends GenericApplicationContext
 	 * Initialize the theme capability.
 	 */
 	@Override
+	@Deprecated
 	protected void onRefresh() {
 		this.themeSource = UiApplicationContextUtils.initThemeSource(this);
 	}
@@ -213,6 +217,7 @@ public class GenericWebApplicationContext extends GenericApplicationContext
 
 	@Override
 	@Nullable
+	@Deprecated
 	public Theme getTheme(String themeName) {
 		Assert.state(this.themeSource != null, "No ThemeSource available");
 		return this.themeSource.getTheme(themeName);

--- a/spring-web/src/main/java/org/springframework/web/context/support/StaticWebApplicationContext.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/StaticWebApplicationContext.java
@@ -50,11 +50,13 @@ import org.springframework.web.context.ServletContextAware;
  * {@link org.springframework.context.support.AbstractApplicationContext},
  * this class detects a bean of type {@link org.springframework.ui.context.ThemeSource}
  * in the context, under the special bean name "themeSource".
+ * Theme support is deprecated as of 6.0
  *
  * @author Rod Johnson
  * @author Juergen Hoeller
  * @see org.springframework.ui.context.ThemeSource
  */
+@SuppressWarnings("deprecation")
 public class StaticWebApplicationContext extends StaticApplicationContext
 		implements ConfigurableWebApplicationContext, ThemeSource {
 
@@ -68,6 +70,7 @@ public class StaticWebApplicationContext extends StaticApplicationContext
 	private String namespace;
 
 	@Nullable
+	@Deprecated
 	private ThemeSource themeSource;
 
 
@@ -186,6 +189,7 @@ public class StaticWebApplicationContext extends StaticApplicationContext
 	 * Initialize the theme capability.
 	 */
 	@Override
+	@Deprecated
 	protected void onRefresh() {
 		this.themeSource = UiApplicationContextUtils.initThemeSource(this);
 	}
@@ -198,6 +202,7 @@ public class StaticWebApplicationContext extends StaticApplicationContext
 
 	@Override
 	@Nullable
+	@Deprecated
 	public Theme getTheme(String themeName) {
 		Assert.state(this.themeSource != null, "No ThemeSource available");
 		return this.themeSource.getTheme(themeName);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -53,7 +53,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.server.RequestPath;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.lang.Nullable;
-import org.springframework.ui.context.ThemeSource;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.WebApplicationContext;
@@ -130,6 +129,7 @@ import org.springframework.web.util.WebUtils;
  * Implementations for a fixed theme and for cookie and session storage are included.
  * The ThemeResolver bean name is "themeResolver"; default is
  * {@link org.springframework.web.servlet.theme.FixedThemeResolver}.
+ * Theme support is deprecated as of 6.0
  * </ul>
  *
  * <p><b>NOTE: The {@code @RequestMapping} annotation will only be processed if a
@@ -170,6 +170,7 @@ public class DispatcherServlet extends FrameworkServlet {
 	public static final String LOCALE_RESOLVER_BEAN_NAME = "localeResolver";
 
 	/** Well-known name for the ThemeResolver object in the bean factory for this namespace. */
+	@Deprecated
 	public static final String THEME_RESOLVER_BEAN_NAME = "themeResolver";
 
 	/**
@@ -227,12 +228,14 @@ public class DispatcherServlet extends FrameworkServlet {
 	 * Request attribute to hold the current ThemeResolver, retrievable by views.
 	 * @see org.springframework.web.servlet.support.RequestContextUtils#getThemeResolver
 	 */
+	@Deprecated
 	public static final String THEME_RESOLVER_ATTRIBUTE = DispatcherServlet.class.getName() + ".THEME_RESOLVER";
 
 	/**
 	 * Request attribute to hold the current ThemeSource, retrievable by views.
 	 * @see org.springframework.web.servlet.support.RequestContextUtils#getThemeSource
 	 */
+	@Deprecated
 	public static final String THEME_SOURCE_ATTRIBUTE = DispatcherServlet.class.getName() + ".THEME_SOURCE";
 
 	/**
@@ -311,6 +314,7 @@ public class DispatcherServlet extends FrameworkServlet {
 
 	/** ThemeResolver used by this servlet. */
 	@Nullable
+	@Deprecated
 	private ThemeResolver themeResolver;
 
 	/** List of HandlerMappings used by this servlet. */
@@ -557,6 +561,7 @@ public class DispatcherServlet extends FrameworkServlet {
 	 * <p>If no bean is defined with the given name in the BeanFactory for this namespace,
 	 * we default to a FixedThemeResolver.
 	 */
+	@Deprecated
 	private void initThemeResolver(ApplicationContext context) {
 		try {
 			this.themeResolver = context.getBean(THEME_RESOLVER_BEAN_NAME, ThemeResolver.class);
@@ -799,8 +804,10 @@ public class DispatcherServlet extends FrameworkServlet {
 	 * @see #getWebApplicationContext()
 	 */
 	@Nullable
-	public final ThemeSource getThemeSource() {
-		return (getWebApplicationContext() instanceof ThemeSource ? (ThemeSource) getWebApplicationContext() : null);
+	@Deprecated
+	public final org.springframework.ui.context.ThemeSource getThemeSource() {
+		return (getWebApplicationContext() instanceof org.springframework.ui.context.ThemeSource ?
+				(org.springframework.ui.context.ThemeSource) getWebApplicationContext() : null);
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/ThemeResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/ThemeResolver.java
@@ -45,7 +45,9 @@ import org.springframework.lang.Nullable;
  * @since 17.06.2003
  * @see org.springframework.ui.context.Theme
  * @see org.springframework.ui.context.ThemeSource
+ * @deprecated as of 6.0, with no direct replacement
  */
+@Deprecated
 public interface ThemeResolver {
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/MvcNamespaceUtils.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/MvcNamespaceUtils.java
@@ -37,7 +37,6 @@ import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 import org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter;
 import org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter;
 import org.springframework.web.servlet.support.SessionFlashMapManager;
-import org.springframework.web.servlet.theme.FixedThemeResolver;
 import org.springframework.web.servlet.view.DefaultRequestToViewNameTranslator;
 import org.springframework.web.util.UrlPathHelper;
 
@@ -236,9 +235,10 @@ public abstract class MvcNamespaceUtils {
 	 * Registers an {@link FixedThemeResolver} under a well-known name
 	 * unless already registered.
 	 */
+	@Deprecated
 	private static void registerThemeResolver(ParserContext context, @Nullable Object source) {
 		if (!containsBeanInHierarchy(context, DispatcherServlet.THEME_RESOLVER_BEAN_NAME)) {
-			RootBeanDefinition beanDef = new RootBeanDefinition(FixedThemeResolver.class);
+			RootBeanDefinition beanDef = new RootBeanDefinition(org.springframework.web.servlet.theme.FixedThemeResolver.class);
 			beanDef.setSource(source);
 			beanDef.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			context.getRegistry().registerBeanDefinition(DispatcherServlet.THEME_RESOLVER_BEAN_NAME, beanDef);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -84,7 +84,6 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.RequestToViewNameTranslator;
-import org.springframework.web.servlet.ThemeResolver;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.function.support.HandlerFunctionAdapter;
 import org.springframework.web.servlet.function.support.RouterFunctionMapping;
@@ -107,7 +106,6 @@ import org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolv
 import org.springframework.web.servlet.resource.ResourceUrlProvider;
 import org.springframework.web.servlet.resource.ResourceUrlProviderExposingInterceptor;
 import org.springframework.web.servlet.support.SessionFlashMapManager;
-import org.springframework.web.servlet.theme.FixedThemeResolver;
 import org.springframework.web.servlet.view.DefaultRequestToViewNameTranslator;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.ViewResolverComposite;
@@ -1168,8 +1166,9 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	}
 
 	@Bean
-	public ThemeResolver themeResolver() {
-		return new FixedThemeResolver();
+	@Deprecated
+	public org.springframework.web.servlet.ThemeResolver themeResolver() {
+		return new org.springframework.web.servlet.theme.FixedThemeResolver();
 	}
 
 	@Bean

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/RequestContext.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/RequestContext.java
@@ -35,9 +35,6 @@ import org.springframework.context.i18n.LocaleContext;
 import org.springframework.context.i18n.SimpleTimeZoneAwareLocaleContext;
 import org.springframework.context.i18n.TimeZoneAwareLocaleContext;
 import org.springframework.lang.Nullable;
-import org.springframework.ui.context.Theme;
-import org.springframework.ui.context.ThemeSource;
-import org.springframework.ui.context.support.ResourceBundleThemeSource;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
@@ -48,7 +45,6 @@ import org.springframework.web.bind.EscapedErrors;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.LocaleResolver;
-import org.springframework.web.servlet.ThemeResolver;
 import org.springframework.web.util.HtmlUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UrlPathHelper;
@@ -83,6 +79,7 @@ public class RequestContext {
 	 * <p>Same as AbstractThemeResolver's default, but not linked in here to avoid package interdependencies.
 	 * @see org.springframework.web.servlet.theme.AbstractThemeResolver#ORIGINAL_DEFAULT_THEME_NAME
 	 */
+	@Deprecated
 	public static final String DEFAULT_THEME_NAME = "theme";
 
 	/**
@@ -111,8 +108,9 @@ public class RequestContext {
 	@Nullable
 	private TimeZone timeZone;
 
+	@Deprecated
 	@Nullable
-	private Theme theme;
+	private org.springframework.ui.context.Theme theme;
 
 	@Nullable
 	private Boolean defaultHtmlEscape;
@@ -392,7 +390,8 @@ public class RequestContext {
 	 * Return the current theme (never {@code null}).
 	 * <p>Resolved lazily for more efficiency when theme support is not being used.
 	 */
-	public Theme getTheme() {
+	@Deprecated
+	public org.springframework.ui.context.Theme getTheme() {
 		if (this.theme == null) {
 			// Lazily determine theme to use for this RequestContext.
 			this.theme = RequestContextUtils.getTheme(this.request);
@@ -409,12 +408,13 @@ public class RequestContext {
 	 * <p>The default implementation returns the default theme (with name "theme").
 	 * @return the fallback theme (never {@code null})
 	 */
-	protected Theme getFallbackTheme() {
-		ThemeSource themeSource = RequestContextUtils.getThemeSource(getRequest());
+	@Deprecated
+	protected org.springframework.ui.context.Theme getFallbackTheme() {
+		org.springframework.ui.context.ThemeSource themeSource = RequestContextUtils.getThemeSource(getRequest());
 		if (themeSource == null) {
-			themeSource = new ResourceBundleThemeSource();
+			themeSource = new org.springframework.ui.context.support.ResourceBundleThemeSource();
 		}
-		Theme theme = themeSource.getTheme(DEFAULT_THEME_NAME);
+		org.springframework.ui.context.Theme theme = themeSource.getTheme(DEFAULT_THEME_NAME);
 		if (theme == null) {
 			throw new IllegalStateException("No theme defined and no fallback theme found");
 		}
@@ -427,8 +427,9 @@ public class RequestContext {
 	 * @param theme the new theme
 	 * @see ThemeResolver#setThemeName
 	 */
-	public void changeTheme(@Nullable Theme theme) {
-		ThemeResolver themeResolver = RequestContextUtils.getThemeResolver(this.request);
+	@Deprecated
+	public void changeTheme(@Nullable org.springframework.ui.context.Theme theme) {
+		org.springframework.web.servlet.ThemeResolver themeResolver = RequestContextUtils.getThemeResolver(this.request);
 		if (themeResolver == null) {
 			throw new IllegalStateException("Cannot change theme if no ThemeResolver configured");
 		}
@@ -442,8 +443,9 @@ public class RequestContext {
 	 * @param themeName the name of the new theme
 	 * @see ThemeResolver#setThemeName
 	 */
+	@Deprecated
 	public void changeTheme(String themeName) {
-		ThemeResolver themeResolver = RequestContextUtils.getThemeResolver(this.request);
+		org.springframework.web.servlet.ThemeResolver themeResolver = RequestContextUtils.getThemeResolver(this.request);
 		if (themeResolver == null) {
 			throw new IllegalStateException("Cannot change theme if no ThemeResolver configured");
 		}
@@ -734,6 +736,7 @@ public class RequestContext {
 	 * @param defaultMessage the String to return if the lookup fails
 	 * @return the message
 	 */
+	@Deprecated
 	public String getThemeMessage(String code, String defaultMessage) {
 		String msg = getTheme().getMessageSource().getMessage(code, null, defaultMessage, getLocale());
 		return (msg != null ? msg : "");
@@ -748,6 +751,7 @@ public class RequestContext {
 	 * @param defaultMessage the String to return if the lookup fails
 	 * @return the message
 	 */
+	@Deprecated
 	public String getThemeMessage(String code, @Nullable Object[] args, String defaultMessage) {
 		String msg = getTheme().getMessageSource().getMessage(code, args, defaultMessage, getLocale());
 		return (msg != null ? msg : "");
@@ -762,6 +766,7 @@ public class RequestContext {
 	 * @param defaultMessage the String to return if the lookup fails
 	 * @return the message
 	 */
+	@Deprecated
 	public String getThemeMessage(String code, @Nullable List<?> args, String defaultMessage) {
 		String msg = getTheme().getMessageSource().getMessage(code, (args != null ? args.toArray() : null),
 				defaultMessage, getLocale());
@@ -776,6 +781,7 @@ public class RequestContext {
 	 * @return the message
 	 * @throws org.springframework.context.NoSuchMessageException if not found
 	 */
+	@Deprecated
 	public String getThemeMessage(String code) throws NoSuchMessageException {
 		return getTheme().getMessageSource().getMessage(code, null, getLocale());
 	}
@@ -789,6 +795,7 @@ public class RequestContext {
 	 * @return the message
 	 * @throws org.springframework.context.NoSuchMessageException if not found
 	 */
+	@Deprecated
 	public String getThemeMessage(String code, @Nullable Object[] args) throws NoSuchMessageException {
 		return getTheme().getMessageSource().getMessage(code, args, getLocale());
 	}
@@ -802,6 +809,7 @@ public class RequestContext {
 	 * @return the message
 	 * @throws org.springframework.context.NoSuchMessageException if not found
 	 */
+	@Deprecated
 	public String getThemeMessage(String code, @Nullable List<?> args) throws NoSuchMessageException {
 		return getTheme().getMessageSource().getMessage(code, (args != null ? args.toArray() : null), getLocale());
 	}
@@ -814,6 +822,7 @@ public class RequestContext {
 	 * @return the message
 	 * @throws org.springframework.context.NoSuchMessageException if not found
 	 */
+	@Deprecated
 	public String getThemeMessage(MessageSourceResolvable resolvable) throws NoSuchMessageException {
 		return getTheme().getMessageSource().getMessage(resolvable, getLocale());
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/RequestContextUtils.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/RequestContextUtils.java
@@ -28,8 +28,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.i18n.LocaleContext;
 import org.springframework.context.i18n.TimeZoneAwareLocaleContext;
 import org.springframework.lang.Nullable;
-import org.springframework.ui.context.Theme;
-import org.springframework.ui.context.ThemeSource;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.context.ContextLoader;
@@ -40,7 +38,6 @@ import org.springframework.web.servlet.FlashMap;
 import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.LocaleResolver;
-import org.springframework.web.servlet.ThemeResolver;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -187,8 +184,9 @@ public abstract class RequestContextUtils {
 	 * @return the current ThemeResolver, or {@code null} if not found
 	 */
 	@Nullable
-	public static ThemeResolver getThemeResolver(HttpServletRequest request) {
-		return (ThemeResolver) request.getAttribute(DispatcherServlet.THEME_RESOLVER_ATTRIBUTE);
+	@Deprecated
+	public static org.springframework.web.servlet.ThemeResolver getThemeResolver(HttpServletRequest request) {
+		return (org.springframework.web.servlet.ThemeResolver) request.getAttribute(DispatcherServlet.THEME_RESOLVER_ATTRIBUTE);
 	}
 
 	/**
@@ -198,8 +196,9 @@ public abstract class RequestContextUtils {
 	 * @return the current ThemeSource
 	 */
 	@Nullable
-	public static ThemeSource getThemeSource(HttpServletRequest request) {
-		return (ThemeSource) request.getAttribute(DispatcherServlet.THEME_SOURCE_ATTRIBUTE);
+	@Deprecated
+	public static org.springframework.ui.context.ThemeSource getThemeSource(HttpServletRequest request) {
+		return (org.springframework.ui.context.ThemeSource) request.getAttribute(DispatcherServlet.THEME_SOURCE_ATTRIBUTE);
 	}
 
 	/**
@@ -210,9 +209,10 @@ public abstract class RequestContextUtils {
 	 * @see #getThemeResolver
 	 */
 	@Nullable
-	public static Theme getTheme(HttpServletRequest request) {
-		ThemeResolver themeResolver = getThemeResolver(request);
-		ThemeSource themeSource = getThemeSource(request);
+	@Deprecated
+	public static org.springframework.ui.context.Theme getTheme(HttpServletRequest request) {
+		org.springframework.web.servlet.ThemeResolver themeResolver = getThemeResolver(request);
+		org.springframework.ui.context.ThemeSource themeSource = getThemeSource(request);
 		if (themeResolver != null && themeSource != null) {
 			String themeName = themeResolver.resolveThemeName(request);
 			return themeSource.getTheme(themeName);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/ThemeTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/ThemeTag.java
@@ -122,8 +122,10 @@ import org.springframework.context.NoSuchMessageException;
  * @see HtmlEscapeTag#setDefaultHtmlEscape
  * @see org.springframework.web.util.WebUtils#HTML_ESCAPE_CONTEXT_PARAM
  * @see ArgumentTag
+ * @deprecated as of 6.0, with no direct replacement
  */
 @SuppressWarnings("serial")
+@Deprecated
 public class ThemeTag extends MessageTag {
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/AbstractThemeResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/AbstractThemeResolver.java
@@ -25,7 +25,9 @@ import org.springframework.web.servlet.ThemeResolver;
  * @author Juergen Hoeller
  * @author Jean-Pierre Pawlak
  * @since 17.06.2003
+ * @deprecated as of 6.0, with no concrete replacement
  */
+@Deprecated
 public abstract class AbstractThemeResolver implements ThemeResolver {
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/CookieThemeResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/CookieThemeResolver.java
@@ -39,7 +39,9 @@ import org.springframework.web.util.WebUtils;
  * @author Juergen Hoeller
  * @since 17.06.2003
  * @see #setThemeName
+ * @deprecated as of 6.0, with no direct replacement
  */
+@Deprecated
 public class CookieThemeResolver extends CookieGenerator implements ThemeResolver {
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/FixedThemeResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/FixedThemeResolver.java
@@ -33,7 +33,9 @@ import org.springframework.lang.Nullable;
  * @author Juergen Hoeller
  * @since 17.06.2003
  * @see #setDefaultThemeName
+ * @deprecated as of 6.0, with no direct replacement
  */
+@Deprecated
 public class FixedThemeResolver extends AbstractThemeResolver {
 
 	@Override

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/SessionThemeResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/SessionThemeResolver.java
@@ -36,7 +36,9 @@ import org.springframework.web.util.WebUtils;
  * @author Juergen Hoeller
  * @since 17.06.2003
  * @see #setThemeName
+ * @deprecated as of 6.0, with no concrete replacement
  */
+@Deprecated
 public class SessionThemeResolver extends AbstractThemeResolver {
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/ThemeChangeInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/theme/ThemeChangeInterceptor.java
@@ -31,7 +31,9 @@ import org.springframework.web.servlet.support.RequestContextUtils;
  * @author Juergen Hoeller
  * @since 20.06.2003
  * @see org.springframework.web.servlet.ThemeResolver
+ * @deprecated as of 6.0, with no concrete replacement
  */
+@Deprecated
 public class ThemeChangeInterceptor implements HandlerInterceptor {
 
 	/**

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/ComplexWebApplicationContext.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/ComplexWebApplicationContext.java
@@ -64,8 +64,6 @@ import org.springframework.web.servlet.mvc.ParameterizableViewController;
 import org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter;
 import org.springframework.web.servlet.support.RequestContext;
 import org.springframework.web.servlet.support.RequestContextUtils;
-import org.springframework.web.servlet.theme.SessionThemeResolver;
-import org.springframework.web.servlet.theme.ThemeChangeInterceptor;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.util.WebUtils;
 
@@ -79,13 +77,16 @@ public class ComplexWebApplicationContext extends StaticWebApplicationContext {
 	@SuppressWarnings("deprecation")
 	public void refresh() throws BeansException {
 		registerSingleton(DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME, SessionLocaleResolver.class);
-		registerSingleton(DispatcherServlet.THEME_RESOLVER_BEAN_NAME, SessionThemeResolver.class);
+		registerSingleton(DispatcherServlet.THEME_RESOLVER_BEAN_NAME,
+				org.springframework.web.servlet.theme.SessionThemeResolver.class);
 
 		LocaleChangeInterceptor interceptor1 = new LocaleChangeInterceptor();
 		LocaleChangeInterceptor interceptor2 = new LocaleChangeInterceptor();
 		interceptor2.setParamName("locale2");
-		ThemeChangeInterceptor interceptor3 = new ThemeChangeInterceptor();
-		ThemeChangeInterceptor interceptor4 = new ThemeChangeInterceptor();
+		org.springframework.web.servlet.theme.ThemeChangeInterceptor interceptor3 =
+				new org.springframework.web.servlet.theme.ThemeChangeInterceptor();
+		org.springframework.web.servlet.theme.ThemeChangeInterceptor interceptor4 =
+				new org.springframework.web.servlet.theme.ThemeChangeInterceptor();
 		interceptor4.setParamName("theme2");
 		UserRoleAuthorizationInterceptor interceptor5 = new UserRoleAuthorizationInterceptor();
 		interceptor5.setAuthorizedRoles("role1", "role2");
@@ -126,7 +127,8 @@ public class ComplexWebApplicationContext extends StaticWebApplicationContext {
 		pvs = new MutablePropertyValues();
 		pvs.add("order", 0);
 		pvs.add("basename", "org.springframework.web.servlet.complexviews");
-		registerSingleton("viewResolver", org.springframework.web.servlet.view.ResourceBundleViewResolver.class, pvs);
+		registerSingleton("viewResolver",
+				org.springframework.web.servlet.view.ResourceBundleViewResolver.class, pvs);
 
 		pvs = new MutablePropertyValues();
 		pvs.add("suffix", ".jsp");
@@ -410,6 +412,7 @@ public class ComplexWebApplicationContext extends StaticWebApplicationContext {
 	public static class ComplexLocaleChecker implements MyHandler {
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public void doSomething(HttpServletRequest request) throws ServletException, IllegalAccessException {
 			WebApplicationContext wac = RequestContextUtils.findWebApplicationContext(request);
 			if (!(wac instanceof ComplexWebApplicationContext)) {
@@ -445,7 +448,8 @@ public class ComplexWebApplicationContext extends StaticWebApplicationContext {
 			if (!TimeZone.getDefault().equals(LocaleContextHolder.getTimeZone())) {
 				throw new ServletException("Incorrect TimeZone");
 			}
-			if (!(RequestContextUtils.getThemeResolver(request) instanceof SessionThemeResolver)) {
+			if (!(RequestContextUtils.getThemeResolver(request)
+					instanceof org.springframework.web.servlet.theme.SessionThemeResolver)) {
 				throw new ServletException("Incorrect ThemeResolver");
 			}
 			if (!"theme".equals(RequestContextUtils.getThemeResolver(request).resolveThemeName(request))) {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/SimpleWebApplicationContext.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/SimpleWebApplicationContext.java
@@ -42,10 +42,10 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
  * @author Juergen Hoeller
  * @since 21.05.2003
  */
+@SuppressWarnings("deprecation")
 public class SimpleWebApplicationContext extends StaticWebApplicationContext {
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public void refresh() throws BeansException {
 		registerSingleton("/locale.do", LocaleChecker.class);
 
@@ -67,7 +67,6 @@ public class SimpleWebApplicationContext extends StaticWebApplicationContext {
 	}
 
 
-	@SuppressWarnings("deprecation")
 	public static class LocaleChecker implements Controller, org.springframework.web.servlet.mvc.LastModified {
 
 		@Override

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/MvcNamespaceTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/MvcNamespaceTests.java
@@ -161,6 +161,8 @@ import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
  * @author Sam Brannen
  * @author Marten Deinum
  */
+
+@SuppressWarnings("deprecation")
 public class MvcNamespaceTests {
 
 	public static final String VIEWCONTROLLER_BEAN_NAME =

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/InterceptorRegistryTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/InterceptorRegistryTests.java
@@ -50,12 +50,14 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Rossen Stoyanchev
  * @author Eko Kurniawan Khannedy
  */
+@SuppressWarnings("deprecation")
 public class InterceptorRegistryTests {
 
 	private InterceptorRegistry registry;
 
 	private final HandlerInterceptor interceptor1 = new LocaleChangeInterceptor();
 
+	@Deprecated
 	private final HandlerInterceptor interceptor2 = new ThemeChangeInterceptor();
 
 	private TestWebRequestInterceptor webInterceptor1;
@@ -177,7 +179,6 @@ public class InterceptorRegistryTests {
 	}
 
 
-	@SuppressWarnings("deprecation")
 	private List<HandlerInterceptor> getInterceptorsForPath(String lookupPath) {
 		PathMatcher pathMatcher = new AntPathMatcher();
 		List<HandlerInterceptor> result = new ArrayList<>();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupportTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupportTests.java
@@ -69,7 +69,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.RequestToViewNameTranslator;
-import org.springframework.web.servlet.ThemeResolver;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.handler.BeanNameUrlHandlerMapping;
 import org.springframework.web.servlet.handler.ConversionServiceExposingInterceptor;
@@ -85,7 +84,6 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 import org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver;
 import org.springframework.web.servlet.resource.ResourceUrlProviderExposingInterceptor;
 import org.springframework.web.servlet.support.SessionFlashMapManager;
-import org.springframework.web.servlet.theme.FixedThemeResolver;
 import org.springframework.web.servlet.view.BeanNameViewResolver;
 import org.springframework.web.servlet.view.DefaultRequestToViewNameTranslator;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
@@ -335,12 +333,14 @@ public class WebMvcConfigurationSupportTests {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void defaultThemeResolverConfiguration() {
 		ApplicationContext context = initContext(WebConfig.class);
-		ThemeResolver themeResolver = context.getBean(THEME_RESOLVER_BEAN_NAME, ThemeResolver.class);
+		org.springframework.web.servlet.ThemeResolver themeResolver =
+				context.getBean(THEME_RESOLVER_BEAN_NAME, org.springframework.web.servlet.ThemeResolver.class);
 
 		assertThat(themeResolver).isNotNull();
-		assertThat(themeResolver).isInstanceOf(FixedThemeResolver.class);
+		assertThat(themeResolver).isInstanceOf(org.springframework.web.servlet.theme.FixedThemeResolver.class);
 	}
 
 	@Test

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/AbstractTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/AbstractTagTests.java
@@ -35,6 +35,7 @@ import org.springframework.web.testfixture.servlet.MockServletContext;
  * @author Juergen Hoeller
  * @author Sam Brannen
  */
+@SuppressWarnings("deprecation")
 public abstract class AbstractTagTests {
 
 	protected MockPageContext createPageContext() {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/ThemeTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/ThemeTagTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Juergen Hoeller
  * @author Alef Arendsen
  */
+@SuppressWarnings("deprecation")
 class ThemeTagTests extends AbstractTagTests {
 
 	@Test

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/theme/ThemeResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/theme/ThemeResolverTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Juergen Hoeller
  * @since 19.06.2003
  */
+@SuppressWarnings("deprecation")
 public class ThemeResolverTests {
 
 	private static final String TEST_THEME_NAME = "test.theme";

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
@@ -64,6 +64,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Sam Brannen
  * @since 18.06.2003
  */
+@SuppressWarnings("deprecation")
 public class ViewResolverTests {
 
 	private final StaticWebApplicationContext wac = new StaticWebApplicationContext();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/FreeMarkerMacroTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/freemarker/FreeMarkerMacroTests.java
@@ -57,6 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Sam Brannen
  * @since 25.01.2005
  */
+@SuppressWarnings("deprecation")
 public class FreeMarkerMacroTests {
 
 	private static final String TEMPLATE_FILE = "test.ftl";


### PR DESCRIPTION
This PR resolves the following issue #28868
I tried to apply the practices used in prior deprecation (ex : PropertyPlaceholderConfigurer, FailureCallback) which are : 

- Deprecate all classes fully related to theming
- Update javadoc with `@deprecated as of 6.0, with no direct replacement`
- Remove imports in other classes
- Deprecate methods and classes related to theming in other classes
- Update javadoc in other classes with `Theme support is deprecated as of 6.0`
- Suppress the deprecation warnings in test classes