### PR TITLE
Protect JMS connection creation against prepareConnection errors

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/connection/SingleConnectionFactory.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/SingleConnectionFactory.java
@@ -360,7 +360,9 @@ public class SingleConnectionFactory implements ConnectionFactory, QueueConnecti
 					con.close();
 				}
 				catch(Throwable th) {
-					logger.warn("Could not close new (not used as shared) JMS Connection", th);
+					if (logger.isDebugEnabled()) {
+						logger.debug("Could not close newly obtained JMS Connection that failed to prepare", th);
+					}
 				}
 				throw ex;
 			}


### PR DESCRIPTION
The creation of new JMS connection (after reset) is done in local method field (instead of instance field directly) to prevent situation, when connection is not correctly configured/prepared in case when JMSException from prepare() method is thrown.

See gh-29115