### PR TITLE
Add missing @Nullable in SettableListenableFuture

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/concurrent/SettableListenableFuture.java
+++ b/spring-core/src/main/java/org/springframework/util/concurrent/SettableListenableFuture.java
@@ -116,7 +116,7 @@ public class SettableListenableFuture<T> implements ListenableFuture<T> {
 	 * {@link java.util.concurrent.CancellationException} if the future has been cancelled.
 	 * @return the value associated with this future
 	 */
-	@Override
+	@Override  @Nullable
 	public T get() throws InterruptedException, ExecutionException {
 		return this.settableTask.get();
 	}


### PR DESCRIPTION
### Add `@Nullable` to return type of `org.springframework.util.concurrent.SettableListenableFuture::get()`

Supporting test traces illustrating the use of `null` in actual program behaviour: 
```
org.springframework.util.concurrent.SettableListenableFuture::get:119
org.springframework.util.concurrent.SettableListenableFutureTests::nullIsAcceptedAsValueToSet:223
```

This issue has been found by an automated analysis and confirmed by manual inspection. 
A description of the analysis performed can be found here: (https://github.com/jensdietrich/null-annotation-inference).  