### PR TITLE
Shutdown tasks annotated with @Scheduled when waitForTasksToCompleteOnShutdown is true

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -593,16 +593,10 @@ public class ScheduledAnnotationBeanPostProcessor
 
 	@Override
 	public void destroy() {
+		this.registrar.destroy();
 		synchronized (this.scheduledTasks) {
-			Collection<Set<ScheduledTask>> allTasks = this.scheduledTasks.values();
-			for (Set<ScheduledTask> tasks : allTasks) {
-				for (ScheduledTask task : tasks) {
-					task.cancel();
-				}
-			}
 			this.scheduledTasks.clear();
 		}
-		this.registrar.destroy();
 	}
 
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/config/ScheduledTaskRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/config/ScheduledTaskRegistrar.java
@@ -34,6 +34,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ExecutorConfigurationSupport;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -552,6 +553,9 @@ public class ScheduledTaskRegistrar implements ScheduledTaskHolder, Initializing
 
 	@Override
 	public void destroy() {
+		if (this.taskScheduler instanceof ExecutorConfigurationSupport) {
+			((ExecutorConfigurationSupport) this.taskScheduler).shutdown();
+		}
 		for (ScheduledTask task : this.scheduledTasks) {
 			task.cancel();
 		}


### PR DESCRIPTION
Shutdown tasks annotated with @Scheduled when waitForTasksToCompleteOnShutdown is true

1. ScheduledTaskRegistrar: shutdown taskScheduler of ExecutorConfigurationSupport type in destroy()
2. ScheduledAnnotationBeanPostProcessor: do not cancel tasks in destroy(), taskRegistrar cancel them

Closes gh-26482