### PR TITLE
Update snakeyaml version because it contains a vulnerability

### DIFF
--- a/framework-platform/framework-platform.gradle
+++ b/framework-platform/framework-platform.gradle
@@ -139,6 +139,6 @@ dependencies {
 		api("org.webjars:webjars-locator-core:0.48")
 		api("org.xmlunit:xmlunit-assertj:2.9.0")
 		api("org.xmlunit:xmlunit-matchers:2.9.0")
-		api("org.yaml:snakeyaml:1.30")
+		api("org.yaml:snakeyaml:1.32")
 	}
 }


### PR DESCRIPTION
Hello.
I found that the snakeyaml vulnarability is in the spring-framework project.
https://nvd.nist.gov/vuln/detail/CVE-2022-25857

I updated to a non-vlunarable version.

Thank you.