### PR TITLE
Avoid resizing of Maps created by CollectionUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,8 @@ public abstract class CollectionUtils {
 	 * @see #newLinkedHashMap(int)
 	 */
 	public static <K, V> HashMap<K, V> newHashMap(int expectedSize) {
-		return new HashMap<>((int) (expectedSize / DEFAULT_LOAD_FACTOR), DEFAULT_LOAD_FACTOR);
+		int capacity = (int) Math.ceil(expectedSize / (double) DEFAULT_LOAD_FACTOR);
+		return new HashMap<>(capacity, DEFAULT_LOAD_FACTOR);
 	}
 
 	/**
@@ -102,7 +103,8 @@ public abstract class CollectionUtils {
 	 * @see #newHashMap(int)
 	 */
 	public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(int expectedSize) {
-		return new LinkedHashMap<>((int) (expectedSize / DEFAULT_LOAD_FACTOR), DEFAULT_LOAD_FACTOR);
+		int capacity = (int) Math.ceil(expectedSize / (double) DEFAULT_LOAD_FACTOR);
+		return new LinkedHashMap<>(capacity, DEFAULT_LOAD_FACTOR);
 	}
 
 	/**


### PR DESCRIPTION
Hi,

I noticed that smaller maps with a size of 1 and 2 will be resized if you put the respective number of elements in it. This PR aligns the initial capacity calculation with the one from the JDK and thus fixes the contract:
```
	 * Instantiate a new {@link HashMap} with an initial capacity
	 * that can accommodate the specified number of elements without
	 * any immediate resize/rehash operations to be expected.
	 * 
```
I didn't add a test because it would access internals of `(Linked)HashMap` which felt pretty ugly and would probably need the internals to be opened. But let me know if I should try adding some.

I should note that this probably makes other cases a tiny bit slower, because the size is sometimes 1 higher than before. But then again. The contract is specific about the resizing not happening.

(A backport to 5.3 is as usual highly appreciated ;-) )

Cheers,
Christoph