### PR TITLE
Use actions/checkout@v3 for Gradle Wrapper Validation Action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,5 +9,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
This PR changes to use `actions/checkout@v3` for Gradle Wrapper Validation Action.