### PR TITLE
Set reason for WebSocket `CloseStatus.SESSION_NOT_RELIABLE`

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/CloseStatus.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/CloseStatus.java
@@ -145,7 +145,8 @@ public final class CloseStatus implements Serializable {
 	 * client that may be done during normal shutdown.
 	 * @since 4.0.3
 	 */
-	public static final CloseStatus SESSION_NOT_RELIABLE = new CloseStatus(4500);
+	public static final CloseStatus SESSION_NOT_RELIABLE = new CloseStatus(4500)
+			.withReason("Failed to send message within the configured send limit");
 
 
 	private final int code;


### PR DESCRIPTION
Providing a reason in `CloseStatus` gives a better understanding of the root cause on the WebSocket client side.