### PR TITLE
Remove classpath detection of ChannelOperationsId

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
@@ -39,7 +39,6 @@ import org.springframework.http.HttpLogging;
 import org.springframework.http.HttpMethod;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -51,10 +50,6 @@ import org.springframework.util.MultiValueMap;
  * @since 5.0
  */
 class ReactorServerHttpRequest extends AbstractServerHttpRequest {
-
-	/** Reactor Netty 1.0.5+. */
-	static final boolean reactorNettyRequestChannelOperationsIdPresent = ClassUtils.isPresent(
-			"reactor.netty.ChannelOperationsId", ReactorServerHttpRequest.class.getClassLoader());
 
 	private static final Log logger = HttpLogging.forLogName(ReactorServerHttpRequest.class);
 
@@ -212,11 +207,9 @@ class ReactorServerHttpRequest extends AbstractServerHttpRequest {
 
 	@Override
 	protected String initLogPrefix() {
-		if (reactorNettyRequestChannelOperationsIdPresent) {
-			String id = (ChannelOperationsIdHelper.getId(this.request));
-			if (id != null) {
-				return id;
-			}
+		String id = (ChannelOperationsIdHelper.getId(this.request));
+		if (id != null) {
+			return id;
 		}
 		if (this.request instanceof Connection) {
 			return ((Connection) this.request).channel().id().asShortText() +

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpResponse.java
@@ -127,10 +127,8 @@ class ReactorServerHttpResponse extends AbstractServerHttpResponse implements Ze
 	@Override
 	protected void touchDataBuffer(DataBuffer buffer) {
 		if (logger.isDebugEnabled()) {
-			if (ReactorServerHttpRequest.reactorNettyRequestChannelOperationsIdPresent) {
-				if (ChannelOperationsIdHelper.touch(buffer, this.response)) {
-					return;
-				}
+			if (ChannelOperationsIdHelper.touch(buffer, this.response)) {
+				return;
 			}
 			this.response.withConnection(connection -> {
 				ChannelId id = connection.channel().id();


### PR DESCRIPTION
`reactor.netty.ChannelOperationsId` is available in `Reactor Netty 1.1.x` from the very beginning.