### PR TITLE
Add support for array/Map/List wrapped in `Optional` when using Bean Validation

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -389,7 +389,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 
 		Object propValue;
 		try {
-			propValue = getPropertyValue(getterTokens);
+			propValue = ObjectUtils.unwrapOptional(getPropertyValue(getterTokens));
 		}
 		catch (NotReadablePropertyException ex) {
 			throw new NotWritablePropertyException(getRootClass(), this.nestedPath + tokens.canonicalName,
@@ -642,6 +642,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 				// apply indexes and map keys
 				for (int i = 0; i < tokens.keys.length; i++) {
 					String key = tokens.keys[i];
+					value = ObjectUtils.unwrapOptional(value);
 					if (value == null) {
 						throw new NullValueInNestedPathException(getRootClass(), this.nestedPath + propertyName,
 								"Cannot access indexed value of property referenced in indexed " +

--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -676,7 +676,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 						}
 					}
 					else if (value instanceof Map map) {
-						Class<?> mapKeyType = ph.getResolvableType().getNested(i + 1).asMap().resolveGeneric(0);
+						Class<?> mapKeyType = ph.getMapKeyType(i + 1);
 						// IMPORTANT: Do not pass full property name in here - property editors
 						// must not kick in for map keys but rather only for map values.
 						TypeDescriptor typeDescriptor = TypeDescriptor.valueOf(mapKeyType);
@@ -1029,19 +1029,26 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 
 		public abstract ResolvableType getResolvableType();
 
-		@Nullable
-		public Class<?> getMapKeyType(int nestingLevel) {
-			return getResolvableType().getNested(nestingLevel).asMap().resolveGeneric(0);
+		private boolean isOptional() {
+			return Optional.class.equals(getResolvableType().getRawClass());
 		}
 
 		@Nullable
-		public Class<?> getMapValueType(int nestingLevel) {
-			return getResolvableType().getNested(nestingLevel).asMap().resolveGeneric(1);
+		public Class<?> getMapKeyType(final int nestingLevel) {
+			var newNestingLevel = isOptional() ? nestingLevel + 1 : nestingLevel;
+			return getResolvableType().getNested(newNestingLevel).asMap().resolveGeneric(0);
 		}
 
 		@Nullable
-		public Class<?> getCollectionType(int nestingLevel) {
-			return getResolvableType().getNested(nestingLevel).asCollection().resolveGeneric();
+		public Class<?> getMapValueType(final int nestingLevel) {
+			var newNestingLevel = isOptional() ? nestingLevel + 1 : nestingLevel;
+			return getResolvableType().getNested(newNestingLevel).asMap().resolveGeneric(1);
+		}
+
+		@Nullable
+		public Class<?> getCollectionType(final int nestingLevel) {
+			var newNestingLevel = isOptional() ? nestingLevel + 1 : nestingLevel;
+			return getResolvableType().getNested(newNestingLevel).asCollection().resolveGeneric();
 		}
 
 		@Nullable

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperGenericsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperGenericsTests.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -522,7 +521,7 @@ class BeanWrapperGenericsTests {
 	@Test
 	void testGenericOptionalOfLists() {
 		GenericBean<String> gb = new GenericBean<>();
-		Optional<List<Integer>> input = Optional.of(new ArrayList<>());
+		List<Integer> input = new ArrayList<>();
 		gb.setOptionalOfList(input);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("optionalOfList[0]", 5);
@@ -533,7 +532,7 @@ class BeanWrapperGenericsTests {
 	@Test
 	void testGenericOptionalOfListsWithElementConversion() {
 		GenericBean<String> gb = new GenericBean<>();
-		Optional<List<Integer>> input = Optional.of(new ArrayList<>());
+		List<Integer> input = new ArrayList<>();
 		gb.setOptionalOfList(input);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("optionalOfList[0]", "5");
@@ -544,7 +543,7 @@ class BeanWrapperGenericsTests {
 	@Test
 	void testGenericOptionalOfArrays() {
 		GenericBean<String> gb = new GenericBean<>();
-		Optional<Integer[]> input = Optional.of(new Integer[] {1, 2});
+		Integer[] input = new Integer[] {1, 2};
 		gb.setOptionalOfArray(input);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("optionalOfArray[1]", 3);
@@ -555,7 +554,7 @@ class BeanWrapperGenericsTests {
 	@Test
 	void testGenericOptionalOfArraysWithElementConversion() {
 		GenericBean<String> gb = new GenericBean<>();
-		Optional<Integer[]> input = Optional.of(new Integer[] {1, 2});
+		Integer[] input = new Integer[] {1, 2};
 		gb.setOptionalOfArray(input);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("optionalOfArray[1]", "3");
@@ -566,8 +565,8 @@ class BeanWrapperGenericsTests {
 	@Test
 	void testGenericOptionalOfMaps() {
 		GenericBean<String> gb = new GenericBean<>();
-		Optional<Map<Integer, Long>> list = Optional.of(new HashMap<>());
-		gb.setOptionalOfMap(list);
+		Map<Integer, Long> map = new HashMap<>();
+		gb.setOptionalOfMap(map);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("optionalOfMap[10]", 5L);
 		assertThat(bw.getPropertyValue("optionalOfMap[10]")).isEqualTo(5L);
@@ -577,7 +576,7 @@ class BeanWrapperGenericsTests {
 	@Test
 	void testGenericOptionalOfMapsWithElementConversion() {
 		GenericBean<String> gb = new GenericBean<>();
-		Optional<Map<Integer, Long>> list = Optional.of(new HashMap<>());
+		Map<Integer, Long> list = new HashMap<>();
 		gb.setOptionalOfMap(list);
 		BeanWrapper bw = new BeanWrapperImpl(gb);
 		bw.setPropertyValue("optionalOfMap[10]", "5");

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperGenericsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperGenericsTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -515,6 +516,73 @@ class BeanWrapperGenericsTests {
 
 		bw.setPropertyValue("data['message']", "it works!");
 		assertThat(data.get("message")).isEqualTo("it works!");
+	}
+
+
+	@Test
+	void testGenericOptionalOfLists() {
+		GenericBean<String> gb = new GenericBean<>();
+		Optional<List<Integer>> input = Optional.of(new ArrayList<>());
+		gb.setOptionalOfList(input);
+		BeanWrapper bw = new BeanWrapperImpl(gb);
+		bw.setPropertyValue("optionalOfList[0]", 5);
+		assertThat(bw.getPropertyValue("optionalOfList[0]")).isEqualTo(5);
+		assertThat(gb.getOptionalOfList().get().get(0)).isEqualTo(5);
+	}
+
+	@Test
+	void testGenericOptionalOfListsWithElementConversion() {
+		GenericBean<String> gb = new GenericBean<>();
+		Optional<List<Integer>> input = Optional.of(new ArrayList<>());
+		gb.setOptionalOfList(input);
+		BeanWrapper bw = new BeanWrapperImpl(gb);
+		bw.setPropertyValue("optionalOfList[0]", "5");
+		assertThat(bw.getPropertyValue("optionalOfList[0]")).isEqualTo(5);
+		assertThat(gb.getOptionalOfList().get().get(0)).isEqualTo(5);
+	}
+
+	@Test
+	void testGenericOptionalOfArrays() {
+		GenericBean<String> gb = new GenericBean<>();
+		Optional<Integer[]> input = Optional.of(new Integer[] {1, 2});
+		gb.setOptionalOfArray(input);
+		BeanWrapper bw = new BeanWrapperImpl(gb);
+		bw.setPropertyValue("optionalOfArray[1]", 3);
+		assertThat(bw.getPropertyValue("optionalOfArray[1]")).isEqualTo(3);
+		assertThat(gb.getOptionalOfArray().get()[1]).isEqualTo(3);
+	}
+
+	@Test
+	void testGenericOptionalOfArraysWithElementConversion() {
+		GenericBean<String> gb = new GenericBean<>();
+		Optional<Integer[]> input = Optional.of(new Integer[] {1, 2});
+		gb.setOptionalOfArray(input);
+		BeanWrapper bw = new BeanWrapperImpl(gb);
+		bw.setPropertyValue("optionalOfArray[1]", "3");
+		assertThat(bw.getPropertyValue("optionalOfArray[1]")).isEqualTo(3);
+		assertThat(gb.getOptionalOfArray().get()[1]).isEqualTo(3);
+	}
+
+	@Test
+	void testGenericOptionalOfMaps() {
+		GenericBean<String> gb = new GenericBean<>();
+		Optional<Map<Integer, Long>> list = Optional.of(new HashMap<>());
+		gb.setOptionalOfMap(list);
+		BeanWrapper bw = new BeanWrapperImpl(gb);
+		bw.setPropertyValue("optionalOfMap[10]", 5L);
+		assertThat(bw.getPropertyValue("optionalOfMap[10]")).isEqualTo(5L);
+		assertThat(gb.getOptionalOfMap().get().get(10)).isEqualTo(Long.valueOf(5));
+	}
+
+	@Test
+	void testGenericOptionalOfMapsWithElementConversion() {
+		GenericBean<String> gb = new GenericBean<>();
+		Optional<Map<Integer, Long>> list = Optional.of(new HashMap<>());
+		gb.setOptionalOfMap(list);
+		BeanWrapper bw = new BeanWrapperImpl(gb);
+		bw.setPropertyValue("optionalOfMap[10]", "5");
+		assertThat(bw.getPropertyValue("optionalOfMap[10]")).isEqualTo(5L);
+		assertThat(gb.getOptionalOfMap().get().get(10)).isEqualTo(Long.valueOf(5));
 	}
 
 

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperTests.java
@@ -230,6 +230,14 @@ class BeanWrapperTests extends AbstractPropertyAccessorTests {
 		assertThat(target.value.getName()).isEqualTo("y");
 		assertThat(target.getObject().get().getName()).isEqualTo("y");
 		assertThat(accessor.getPropertyValue("object.name")).isEqualTo("y");
+
+		accessor.setPropertyValue("object.someInteger", "5");
+		assertThat(target.value).isSameAs(tb);
+		assertThat(target.getObject().get()).isSameAs(tb);
+		assertThat(((Optional<TestBean>) accessor.getPropertyValue("object")).get()).isSameAs(tb);
+		assertThat(target.value.getSomeInteger()).isEqualTo(5);
+		assertThat(target.getObject().get().getSomeInteger()).isEqualTo(5);
+		assertThat(accessor.getPropertyValue("object.someInteger")).isEqualTo(5);
 	}
 
 	@Test

--- a/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/GenericBean.java
+++ b/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/GenericBean.java
@@ -78,11 +78,11 @@ public class GenericBean<T> {
 
 	private List<T> genericListProperty;
 
-	private Optional<List<Integer>> optionalOfList;
+	private List<Integer> optionalOfList;
 
-	private Optional<Integer[]> optionalOfArray;
+	private Integer[] optionalOfArray;
 
-	private Optional<Map<Integer, Long>> optionalOfMap;
+	private Map<Integer, Long> optionalOfMap;
 
 	public GenericBean() {
 	}
@@ -296,26 +296,26 @@ public class GenericBean<T> {
 	}
 
 	public Optional<List<Integer>> getOptionalOfList() {
-		return optionalOfList;
+		return Optional.ofNullable(optionalOfList);
 	}
 
-	public void setOptionalOfList(Optional<List<Integer>> optionalOfList) {
+	public void setOptionalOfList(List<Integer> optionalOfList) {
 		this.optionalOfList = optionalOfList;
 	}
 
 	public Optional<Integer[]> getOptionalOfArray() {
-		return optionalOfArray;
+		return Optional.ofNullable(optionalOfArray);
 	}
 
-	public void setOptionalOfArray(Optional<Integer[]> optionalOfArray) {
+	public void setOptionalOfArray(Integer[] optionalOfArray) {
 		this.optionalOfArray = optionalOfArray;
 	}
 
 	public Optional<Map<Integer, Long>> getOptionalOfMap() {
-		return optionalOfMap;
+		return Optional.ofNullable(optionalOfMap);
 	}
 
-	public void setOptionalOfMap(Optional<Map<Integer, Long>> optionalOfMap) {
+	public void setOptionalOfMap(Map<Integer, Long> optionalOfMap) {
 		this.optionalOfMap = optionalOfMap;
 	}
 

--- a/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/GenericBean.java
+++ b/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/GenericBean.java
@@ -26,8 +26,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.core.io.Resource;
 

--- a/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/GenericBean.java
+++ b/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/GenericBean.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Optional;
 
 import org.springframework.core.io.Resource;
 
@@ -77,6 +78,11 @@ public class GenericBean<T> {
 
 	private List<T> genericListProperty;
 
+	private Optional<List<Integer>> optionalOfList;
+
+	private Optional<Integer[]> optionalOfArray;
+
+	private Optional<Map<Integer, Long>> optionalOfMap;
 
 	public GenericBean() {
 	}
@@ -287,6 +293,30 @@ public class GenericBean<T> {
 
 	public void setStandardEnumMap(EnumMap<CustomEnum, Integer> standardEnumMap) {
 		this.standardEnumMap = standardEnumMap;
+	}
+
+	public Optional<List<Integer>> getOptionalOfList() {
+		return optionalOfList;
+	}
+
+	public void setOptionalOfList(Optional<List<Integer>> optionalOfList) {
+		this.optionalOfList = optionalOfList;
+	}
+
+	public Optional<Integer[]> getOptionalOfArray() {
+		return optionalOfArray;
+	}
+
+	public void setOptionalOfArray(Optional<Integer[]> optionalOfArray) {
+		this.optionalOfArray = optionalOfArray;
+	}
+
+	public Optional<Map<Integer, Long>> getOptionalOfMap() {
+		return optionalOfMap;
+	}
+
+	public void setOptionalOfMap(Optional<Map<Integer, Long>> optionalOfMap) {
+		this.optionalOfMap = optionalOfMap;
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/TestBean.java
+++ b/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/TestBean.java
@@ -96,6 +96,8 @@ public class TestBean implements BeanNameAware, BeanFactoryAware, ITestBean, IOt
 
 	private Number someNumber;
 
+	private Integer someInteger;
+
 	private Colour favouriteColour;
 
 	private Boolean someBoolean;
@@ -494,4 +496,11 @@ public class TestBean implements BeanNameAware, BeanFactoryAware, ITestBean, IOt
 		return this.name;
 	}
 
+	public Integer getSomeInteger() {
+		return someInteger;
+	}
+
+	public void setSomeInteger(Integer someInteger) {
+		this.someInteger = someInteger;
+	}
 }


### PR DESCRIPTION
This PR addresses #19935/#21461.

~~I'm not sure about the implementation. I wrote the tests that I think would be needed. Three of them are failing:~~

~~org.springframework.beans.BeanWrapperGenericsTests#testGenericOptionalOfListsWithElementConversion~~
~~org.springframework.beans.BeanWrapperGenericsTests#testGenericOptionalOfMaps~~
~~org.springframework.beans.BeanWrapperGenericsTests#testGenericOptionalOfMapsWithElementConversion~~

~~Some help here is appreciated.~~

Thanks!