### PR TITLE
Refactor AcceptHeaderLocaleResolver to implement LocaleContextResolver

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcWebTestClient.java
@@ -45,7 +45,7 @@ import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -335,9 +335,9 @@ public interface MockMvcWebTestClient {
 		/**
 		 * Provide the LocaleResolver to use.
 		 * <p>This is delegated to
-		 * {@link StandaloneMockMvcBuilder#setLocaleResolver(LocaleResolver)}.
+		 * {@link StandaloneMockMvcBuilder#setLocaleResolver(LocaleContextResolver)}.
 		 */
-		ControllerSpec localeResolver(LocaleResolver localeResolver);
+		ControllerSpec localeResolver(LocaleContextResolver localeResolver);
 
 		/**
 		 * Provide a custom FlashMapManager.

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/StandaloneMockMvcSpec.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/StandaloneMockMvcSpec.java
@@ -31,7 +31,7 @@ import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -135,7 +135,7 @@ class StandaloneMockMvcSpec extends AbstractMockMvcServerSpec<MockMvcWebTestClie
 	}
 
 	@Override
-	public StandaloneMockMvcSpec localeResolver(LocaleResolver localeResolver) {
+	public StandaloneMockMvcSpec localeResolver(LocaleContextResolver localeResolver) {
 		this.mockMvcBuilder.setLocaleResolver(localeResolver);
 		return this;
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
@@ -51,7 +51,7 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
@@ -121,7 +121,7 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 	@Nullable
 	private List<ViewResolver> viewResolvers;
 
-	private LocaleResolver localeResolver = new AcceptHeaderLocaleResolver();
+	private LocaleContextResolver localeResolver = new AcceptHeaderLocaleResolver();
 
 	@Nullable
 	private FlashMapManager flashMapManager;
@@ -297,7 +297,7 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 	 * Provide a LocaleResolver instance.
 	 * If not provided, the default one used is {@link AcceptHeaderLocaleResolver}.
 	 */
-	public StandaloneMockMvcBuilder setLocaleResolver(LocaleResolver localeResolver) {
+	public StandaloneMockMvcBuilder setLocaleResolver(LocaleContextResolver localeResolver) {
 		this.localeResolver = localeResolver;
 		return this;
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/LocaleContextResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/LocaleContextResolver.java
@@ -42,6 +42,7 @@ import org.springframework.lang.Nullable;
  * @see org.springframework.web.servlet.support.RequestContext#getTimeZone
  * @see org.springframework.web.servlet.support.RequestContextUtils#getTimeZone
  */
+@SuppressWarnings("deprecation")
 public interface LocaleContextResolver extends LocaleResolver {
 
 	/**
@@ -58,7 +59,6 @@ public interface LocaleContextResolver extends LocaleResolver {
 	 * the returned context, which again can be accessed through downcasting.
 	 * @param request the request to resolve the locale context for
 	 * @return the current locale context (never {@code null}
-	 * @see #resolveLocale(HttpServletRequest)
 	 * @see org.springframework.web.servlet.support.RequestContextUtils#getLocale
 	 * @see org.springframework.web.servlet.support.RequestContextUtils#getTimeZone
 	 */
@@ -72,7 +72,6 @@ public interface LocaleContextResolver extends LocaleResolver {
 	 * @param localeContext the new locale context, or {@code null} to clear the locale
 	 * @throws UnsupportedOperationException if the LocaleResolver implementation
 	 * does not support dynamic changing of the locale or time zone
-	 * @see #setLocale(HttpServletRequest, HttpServletResponse, Locale)
 	 * @see org.springframework.context.i18n.SimpleLocaleContext
 	 * @see org.springframework.context.i18n.SimpleTimeZoneAwareLocaleContext
 	 */

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/LocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/LocaleResolver.java
@@ -50,7 +50,9 @@ import org.springframework.lang.Nullable;
  * @see org.springframework.context.i18n.LocaleContextHolder
  * @see org.springframework.web.servlet.support.RequestContext#getLocale
  * @see org.springframework.web.servlet.support.RequestContextUtils#getLocale
+ * @deprecated since 6.0 in favor of {@link LocaleContextResolver}
  */
+@Deprecated(since = "6.0")
 public interface LocaleResolver {
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -80,7 +80,7 @@ import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.HandlerAdapter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerMapping;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.RequestToViewNameTranslator;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.function.support.HandlerFunctionAdapter;
@@ -1158,7 +1158,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	}
 
 	@Bean
-	public LocaleResolver localeResolver() {
+	public LocaleContextResolver localeResolver() {
 		return new AcceptHeaderLocaleResolver();
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/DispatcherServletWebRequest.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/DispatcherServletWebRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,12 @@ import org.springframework.web.servlet.support.RequestContextUtils;
  * {@link ServletWebRequest} subclass that is aware of
  * {@link org.springframework.web.servlet.DispatcherServlet}'s
  * request context, such as the Locale determined by the configured
- * {@link org.springframework.web.servlet.LocaleResolver}.
+ * {@link org.springframework.web.servlet.LocaleContextResolver}.
  *
  * @author Juergen Hoeller
  * @since 2.0
  * @see #getLocale()
- * @see org.springframework.web.servlet.LocaleResolver
+ * @see org.springframework.web.servlet.LocaleContextResolver
  */
 public class DispatcherServletWebRequest extends ServletWebRequest {
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleContextResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleContextResolver.java
@@ -16,6 +16,7 @@
 
 package org.springframework.web.servlet.i18n;
 
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.springframework.lang.Nullable;
@@ -32,11 +33,31 @@ import org.springframework.web.servlet.LocaleContextResolver;
  * @see #setDefaultLocale
  * @see #setDefaultTimeZone
  */
-public abstract class AbstractLocaleContextResolver extends AbstractLocaleResolver implements LocaleContextResolver {
+public abstract class AbstractLocaleContextResolver implements LocaleContextResolver {
+
+	@Nullable
+	private Locale defaultLocale;
 
 	@Nullable
 	private TimeZone defaultTimeZone;
 
+
+	/**
+	 * Set a default {@link Locale} that this resolver will return if no other
+	 * locale is found.
+	 */
+	public void setDefaultLocale(@Nullable Locale defaultLocale) {
+		this.defaultLocale = defaultLocale;
+	}
+
+	/**
+	 * Get the default {@link Locale} that this resolver is supposed to fall back
+	 * to, if any.
+	 */
+	@Nullable
+	protected Locale getDefaultLocale() {
+		return this.defaultLocale;
+	}
 
 	/**
 	 * Set a default {@link TimeZone} that this resolver will return if no other

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AbstractLocaleResolver.java
@@ -29,7 +29,9 @@ import org.springframework.web.servlet.LocaleResolver;
  * @author Juergen Hoeller
  * @since 1.2.9
  * @see #setDefaultLocale
+ * @deprecated since 6.0 in favor of {@link AbstractLocaleContextResolver}
  */
+@Deprecated(since = "6.0")
 public abstract class AbstractLocaleResolver implements LocaleResolver {
 
 	@Nullable

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
@@ -28,14 +28,14 @@ import org.springframework.context.i18n.LocaleContext;
 import org.springframework.context.i18n.SimpleLocaleContext;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 
 /**
- * {@link LocaleResolver} implementation that simply uses the primary locale
+ * {@link LocaleContextResolver} implementation that simply uses the primary locale
  * specified in the {@code Accept-Language} header of the HTTP request (that is,
  * the locale sent by the client browser, normally that of the client's OS).
  *
- * <p>Note: Does not support {@link #setLocale} since the {@code Accept-Language}
+ * <p>Note: Does not support {@link #setLocaleContext} since the {@code Accept-Language}
  * header can only be changed by changing the client's locale settings.
  *
  * @author Juergen Hoeller

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
@@ -24,6 +24,8 @@ import java.util.Locale;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.context.i18n.LocaleContext;
+import org.springframework.context.i18n.SimpleLocaleContext;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.LocaleResolver;
@@ -41,7 +43,7 @@ import org.springframework.web.servlet.LocaleResolver;
  * @since 27.02.2003
  * @see jakarta.servlet.http.HttpServletRequest#getLocale()
  */
-public class AcceptHeaderLocaleResolver extends AbstractLocaleResolver {
+public class AcceptHeaderLocaleResolver extends AbstractLocaleContextResolver {
 
 	private final List<Locale> supportedLocales = new ArrayList<>(4);
 
@@ -68,21 +70,21 @@ public class AcceptHeaderLocaleResolver extends AbstractLocaleResolver {
 
 
 	@Override
-	public Locale resolveLocale(HttpServletRequest request) {
+	public LocaleContext resolveLocaleContext(HttpServletRequest request) {
 		Locale defaultLocale = getDefaultLocale();
 		if (defaultLocale != null && request.getHeader("Accept-Language") == null) {
-			return defaultLocale;
+			return new SimpleLocaleContext(defaultLocale);
 		}
 		Locale requestLocale = request.getLocale();
 		List<Locale> supportedLocales = getSupportedLocales();
 		if (supportedLocales.isEmpty() || supportedLocales.contains(requestLocale)) {
-			return requestLocale;
+			return new SimpleLocaleContext(requestLocale);
 		}
 		Locale supportedLocale = findSupportedLocale(request, supportedLocales);
 		if (supportedLocale != null) {
-			return supportedLocale;
+			return new SimpleLocaleContext(supportedLocale);
 		}
-		return (defaultLocale != null ? defaultLocale : requestLocale);
+		return new SimpleLocaleContext(defaultLocale != null ? defaultLocale : requestLocale);
 	}
 
 	@Nullable
@@ -112,7 +114,8 @@ public class AcceptHeaderLocaleResolver extends AbstractLocaleResolver {
 	}
 
 	@Override
-	public void setLocale(HttpServletRequest request, @Nullable HttpServletResponse response, @Nullable Locale locale) {
+	public void setLocaleContext(HttpServletRequest request, @Nullable HttpServletResponse response,
+			@Nullable LocaleContext localeContext) {
 		throw new UnsupportedOperationException(
 				"Cannot change HTTP Accept-Language header - use a different locale resolution strategy");
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/CookieLocaleResolver.java
@@ -34,11 +34,11 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.util.WebUtils;
 
 /**
- * {@link LocaleResolver} implementation that uses a cookie sent back to the user
+ * {@link LocaleContextResolver} implementation that uses a cookie sent back to the user
  * in case of a custom setting, with a fallback to the configured default locale,
  * the request's {@code Accept-Language} header, or the default locale for the server.
  *

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/FixedLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/FixedLocaleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.springframework.context.i18n.TimeZoneAwareLocaleContext;
 import org.springframework.lang.Nullable;
 
 /**
- * {@link org.springframework.web.servlet.LocaleResolver} implementation
+ * {@link org.springframework.web.servlet.LocaleContextResolver} implementation
  * that always returns a fixed default locale and optionally time zone.
  * Default is the current JVM's default locale.
  *

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/LocaleChangeInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/LocaleChangeInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.context.i18n.SimpleLocaleContext;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.support.RequestContextUtils;
 
 /**
@@ -38,7 +39,7 @@ import org.springframework.web.servlet.support.RequestContextUtils;
  * @author Juergen Hoeller
  * @author Rossen Stoyanchev
  * @since 20.06.2003
- * @see org.springframework.web.servlet.LocaleResolver
+ * @see org.springframework.web.servlet.LocaleContextResolver
  */
 public class LocaleChangeInterceptor implements HandlerInterceptor {
 
@@ -116,13 +117,14 @@ public class LocaleChangeInterceptor implements HandlerInterceptor {
 		String newLocale = request.getParameter(getParamName());
 		if (newLocale != null) {
 			if (checkHttpMethod(request.getMethod())) {
-				LocaleResolver localeResolver = RequestContextUtils.getLocaleResolver(request);
+				LocaleContextResolver localeResolver = RequestContextUtils.getLocaleResolver(request);
 				if (localeResolver == null) {
 					throw new IllegalStateException(
 							"No LocaleResolver found: not in a DispatcherServlet request?");
 				}
 				try {
-					localeResolver.setLocale(request, response, parseLocaleValue(newLocale));
+					localeResolver.setLocaleContext(request, response,
+							new SimpleLocaleContext(parseLocaleValue(newLocale)));
 				}
 				catch (IllegalArgumentException ex) {
 					if (isIgnoreInvalidLocale()) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/SessionLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/SessionLocaleResolver.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
 import org.springframework.web.util.WebUtils;
 
 /**
- * {@link org.springframework.web.servlet.LocaleResolver} implementation that
+ * {@link org.springframework.web.servlet.LocaleContextResolver} implementation that
  * uses a locale attribute in the user's session in case of a custom setting,
  * with a fallback to the configured default locale, the request's
  * {@code Accept-Language} header, or the default locale for the server.

--- a/spring-webmvc/src/main/resources/org/springframework/web/servlet/DispatcherServlet.properties
+++ b/spring-webmvc/src/main/resources/org/springframework/web/servlet/DispatcherServlet.properties
@@ -2,7 +2,7 @@
 # Used as fallback when no matching beans are found in the DispatcherServlet context.
 # Not meant to be customized by application developers.
 
-org.springframework.web.servlet.LocaleResolver=org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver
+org.springframework.web.servlet.LocaleContextResolver=org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver
 
 org.springframework.web.servlet.ThemeResolver=org.springframework.web.servlet.theme.FixedThemeResolver
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/MvcNamespaceTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/MvcNamespaceTests.java
@@ -87,7 +87,7 @@ import org.springframework.web.method.support.InvocableHandlerMethod;
 import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.RequestToViewNameTranslator;
 import org.springframework.web.servlet.ThemeResolver;
@@ -232,7 +232,7 @@ public class MvcNamespaceTests {
 		assertThat(appContext.getBean(ConversionService.class)).isNotNull();
 		assertThat(appContext.getBean(LocalValidatorFactoryBean.class)).isNotNull();
 		assertThat(appContext.getBean(Validator.class)).isNotNull();
-		assertThat(appContext.getBean("localeResolver", LocaleResolver.class)).isNotNull();
+		assertThat(appContext.getBean("localeResolver", LocaleContextResolver.class)).isNotNull();
 		assertThat(appContext.getBean("themeResolver", ThemeResolver.class)).isNotNull();
 		assertThat(appContext.getBean("viewNameTranslator", RequestToViewNameTranslator.class)).isNotNull();
 		assertThat(appContext.getBean("flashMapManager", FlashMapManager.class)).isNotNull();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupportTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.RequestToViewNameTranslator;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.handler.BeanNameUrlHandlerMapping;
@@ -326,7 +326,7 @@ public class WebMvcConfigurationSupportTests {
 	@Test
 	public void defaultLocaleResolverConfiguration() {
 		ApplicationContext context = initContext(WebConfig.class);
-		LocaleResolver localeResolver = context.getBean(LOCALE_RESOLVER_BEAN_NAME, LocaleResolver.class);
+		LocaleContextResolver localeResolver = context.getBean(LOCALE_RESOLVER_BEAN_NAME, LocaleContextResolver.class);
 
 		assertThat(localeResolver).isNotNull();
 		assertThat(localeResolver).isInstanceOf(AcceptHeaderLocaleResolver.class);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolverTests.java
@@ -49,38 +49,38 @@ class AcceptHeaderLocaleResolverTests {
 
 	@Test
 	void resolve() {
-		assertThat(this.resolver.resolveLocale(request(CANADA))).isEqualTo(CANADA);
-		assertThat(this.resolver.resolveLocale(request(US, CANADA))).isEqualTo(US);
+		assertThat(this.resolver.resolveLocaleContext(request(CANADA)).getLocale()).isEqualTo(CANADA);
+		assertThat(this.resolver.resolveLocaleContext(request(US, CANADA)).getLocale()).isEqualTo(US);
 	}
 
 	@Test
 	void resolvePreferredSupported() {
 		this.resolver.setSupportedLocales(Collections.singletonList(CANADA));
-		assertThat(this.resolver.resolveLocale(request(US, CANADA))).isEqualTo(CANADA);
+		assertThat(this.resolver.resolveLocaleContext(request(US, CANADA)).getLocale()).isEqualTo(CANADA);
 	}
 
 	@Test
 	void resolvePreferredNotSupported() {
 		this.resolver.setSupportedLocales(Collections.singletonList(CANADA));
-		assertThat(this.resolver.resolveLocale(request(US, UK))).isEqualTo(US);
+		assertThat(this.resolver.resolveLocaleContext(request(US, UK)).getLocale()).isEqualTo(US);
 	}
 
 	@Test
 	void resolvePreferredAgainstLanguageOnly() {
 		this.resolver.setSupportedLocales(Collections.singletonList(ENGLISH));
-		assertThat(this.resolver.resolveLocale(request(GERMANY, US, UK))).isEqualTo(ENGLISH);
+		assertThat(this.resolver.resolveLocaleContext(request(GERMANY, US, UK)).getLocale()).isEqualTo(ENGLISH);
 	}
 
 	@Test
 	void resolvePreferredAgainstCountryIfPossible() {
 		this.resolver.setSupportedLocales(Arrays.asList(ENGLISH, UK));
-		assertThat(this.resolver.resolveLocale(request(GERMANY, US, UK))).isEqualTo(UK);
+		assertThat(this.resolver.resolveLocaleContext(request(GERMANY, US, UK)).getLocale()).isEqualTo(UK);
 	}
 
 	@Test
 	void resolvePreferredAgainstLanguageWithMultipleSupportedLocales() {
 		this.resolver.setSupportedLocales(Arrays.asList(GERMAN, US));
-		assertThat(this.resolver.resolveLocale(request(GERMANY, US, UK))).isEqualTo(GERMAN);
+		assertThat(this.resolver.resolveLocaleContext(request(GERMANY, US, UK)).getLocale()).isEqualTo(GERMAN);
 	}
 
 	@Test
@@ -91,18 +91,18 @@ class AcceptHeaderLocaleResolverTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Accept-Language", KOREA.toLanguageTag());
 		request.setPreferredLocales(Collections.singletonList(KOREA));
-		assertThat(this.resolver.resolveLocale(request)).isEqualTo(Locale.JAPAN);
+		assertThat(this.resolver.resolveLocaleContext(request).getLocale()).isEqualTo(Locale.JAPAN);
 	}
 
 	@Test
 	void defaultLocale() {
 		this.resolver.setDefaultLocale(JAPANESE);
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		assertThat(this.resolver.resolveLocale(request)).isEqualTo(JAPANESE);
+		assertThat(this.resolver.resolveLocaleContext(request).getLocale()).isEqualTo(JAPANESE);
 
 		request.addHeader("Accept-Language", US.toLanguageTag());
 		request.setPreferredLocales(Collections.singletonList(US));
-		assertThat(this.resolver.resolveLocale(request)).isEqualTo(US);
+		assertThat(this.resolver.resolveLocaleContext(request).getLocale()).isEqualTo(US);
 	}
 
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/CookieLocaleResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/CookieLocaleResolverTests.java
@@ -61,7 +61,7 @@ class CookieLocaleResolverTests {
 		request.setCookies(cookie);
 
 		resolver = new CookieLocaleResolver("LanguageKoekje");
-		Locale loc = resolver.resolveLocale(request);
+		Locale loc = resolver.resolveLocaleContext(request).getLocale();
 		assertThat(loc.getLanguage()).isEqualTo("nl");
 	}
 
@@ -141,8 +141,8 @@ class CookieLocaleResolverTests {
 	}
 
 	@Test
-	void setAndResolveLocale() {
-		resolver.setLocale(request, response, new Locale("nl", ""));
+	void setAndResolveLocaleContext() {
+		resolver.setLocaleContext(request, response, new SimpleLocaleContext(new Locale("nl", "")));
 
 		MockCookie cookie = MockCookie.parse(response.getHeader(HttpHeaders.SET_COOKIE));
 		assertThat(cookie).isNotNull();
@@ -152,19 +152,6 @@ class CookieLocaleResolverTests {
 		assertThat(cookie.getSecure()).isFalse();
 		assertThat(cookie.getSameSite()).isEqualTo("Lax");
 
-		request = new MockHttpServletRequest();
-		request.setCookies(cookie);
-
-		resolver = new CookieLocaleResolver();
-		Locale loc = resolver.resolveLocale(request);
-		assertThat(loc.getLanguage()).isEqualTo("nl");
-	}
-
-	@Test
-	void setAndResolveLocaleContext() {
-		resolver.setLocaleContext(request, response, new SimpleLocaleContext(new Locale("nl", "")));
-
-		Cookie cookie = response.getCookie(CookieLocaleResolver.DEFAULT_COOKIE_NAME);
 		request = new MockHttpServletRequest();
 		request.setCookies(cookie);
 
@@ -210,7 +197,7 @@ class CookieLocaleResolverTests {
 
 	@Test
 	void setAndResolveLocaleWithCountry() {
-		resolver.setLocale(request, response, new Locale("de", "AT"));
+		resolver.setLocaleContext(request, response, new SimpleLocaleContext(new Locale("de", "AT")));
 
 		MockCookie cookie = MockCookie.parse(response.getHeader(HttpHeaders.SET_COOKIE));
 		assertThat(cookie).isNotNull();
@@ -225,7 +212,7 @@ class CookieLocaleResolverTests {
 		request.setCookies(cookie);
 
 		resolver = new CookieLocaleResolver();
-		Locale loc = resolver.resolveLocale(request);
+		Locale loc = resolver.resolveLocaleContext(request).getLocale();
 		assertThat(loc.getLanguage()).isEqualTo("de");
 		assertThat(loc.getCountry()).isEqualTo("AT");
 	}
@@ -233,7 +220,7 @@ class CookieLocaleResolverTests {
 	@Test
 	void setAndResolveLocaleWithCountryAsLegacyJava() {
 		resolver.setLanguageTagCompliant(false);
-		resolver.setLocale(request, response, new Locale("de", "AT"));
+		resolver.setLocaleContext(request, response, new SimpleLocaleContext(new Locale("de", "AT")));
 
 		MockCookie cookie = MockCookie.parse(response.getHeader(HttpHeaders.SET_COOKIE));
 		assertThat(cookie).isNotNull();
@@ -248,7 +235,7 @@ class CookieLocaleResolverTests {
 		request.setCookies(cookie);
 
 		resolver = new CookieLocaleResolver();
-		Locale loc = resolver.resolveLocale(request);
+		Locale loc = resolver.resolveLocaleContext(request).getLocale();
 		assertThat(loc.getLanguage()).isEqualTo("de");
 		assertThat(loc.getCountry()).isEqualTo("AT");
 	}
@@ -261,7 +248,7 @@ class CookieLocaleResolverTests {
 		resolver.setCookieMaxAge(Duration.ofSeconds(10000));
 		resolver.setCookieSecure(true);
 		resolver.setCookieSameSite("Lax");
-		resolver.setLocale(request, response, new Locale("nl", ""));
+		resolver.setLocaleContext(request, response, new SimpleLocaleContext(new Locale("nl", "")));
 
 		MockCookie cookie = MockCookie.parse(response.getHeader(HttpHeaders.SET_COOKIE));
 		assertThat(cookie).isNotNull();
@@ -276,16 +263,8 @@ class CookieLocaleResolverTests {
 		request.setCookies(cookie);
 
 		resolver = new CookieLocaleResolver("LanguageKoek");
-		Locale loc = resolver.resolveLocale(request);
+		Locale loc = resolver.resolveLocaleContext(request).getLocale();
 		assertThat(loc.getLanguage()).isEqualTo("nl");
-	}
-
-	@Test
-	void resolveLocaleWithoutCookie() {
-		request.addPreferredLocale(Locale.TAIWAN);
-
-		Locale loc = resolver.resolveLocale(request);
-		assertThat(loc).isEqualTo(request.getLocale());
 	}
 
 	@Test
@@ -296,16 +275,6 @@ class CookieLocaleResolverTests {
 		assertThat(loc.getLocale()).isEqualTo(request.getLocale());
 		assertThat(loc).isInstanceOf(TimeZoneAwareLocaleContext.class);
 		assertThat(((TimeZoneAwareLocaleContext) loc).getTimeZone()).isNull();
-	}
-
-	@Test
-	void resolveLocaleWithoutCookieAndDefaultLocale() {
-		request.addPreferredLocale(Locale.TAIWAN);
-
-		resolver.setDefaultLocale(Locale.GERMAN);
-
-		Locale loc = resolver.resolveLocale(request);
-		assertThat(loc).isEqualTo(Locale.GERMAN);
 	}
 
 	@Test
@@ -322,16 +291,6 @@ class CookieLocaleResolverTests {
 	}
 
 	@Test
-	void resolveLocaleWithCookieWithoutLocale() {
-		request.addPreferredLocale(Locale.TAIWAN);
-		Cookie cookie = new Cookie(CookieLocaleResolver.DEFAULT_COOKIE_NAME, "");
-		request.setCookies(cookie);
-
-		Locale loc = resolver.resolveLocale(request);
-		assertThat(loc).isEqualTo(request.getLocale());
-	}
-
-	@Test
 	void resolveLocaleContextWithCookieWithoutLocale() {
 		request.addPreferredLocale(Locale.TAIWAN);
 		Cookie cookie = new Cookie(CookieLocaleResolver.DEFAULT_COOKIE_NAME, "");
@@ -341,23 +300,6 @@ class CookieLocaleResolverTests {
 		assertThat(loc.getLocale()).isEqualTo(request.getLocale());
 		assertThat(loc).isInstanceOf(TimeZoneAwareLocaleContext.class);
 		assertThat(((TimeZoneAwareLocaleContext) loc).getTimeZone()).isNull();
-	}
-
-	@Test
-	void setLocaleToNull() {
-		request.addPreferredLocale(Locale.TAIWAN);
-		Cookie cookie = new Cookie(CookieLocaleResolver.DEFAULT_COOKIE_NAME, Locale.UK.toString());
-		request.setCookies(cookie);
-
-		resolver.setLocale(request, response, null);
-		Locale locale = (Locale) request.getAttribute(CookieLocaleResolver.LOCALE_REQUEST_ATTRIBUTE_NAME);
-		assertThat(locale).isEqualTo(Locale.TAIWAN);
-
-		Cookie[] cookies = response.getCookies();
-		assertThat(cookies).hasSize(1);
-		Cookie localeCookie = cookies[0];
-		assertThat(localeCookie.getName()).isEqualTo(CookieLocaleResolver.DEFAULT_COOKIE_NAME);
-		assertThat(localeCookie.getValue()).isEqualTo("");
 	}
 
 	@Test
@@ -371,24 +313,6 @@ class CookieLocaleResolverTests {
 		assertThat(locale).isEqualTo(Locale.TAIWAN);
 		TimeZone timeZone = (TimeZone) request.getAttribute(CookieLocaleResolver.TIME_ZONE_REQUEST_ATTRIBUTE_NAME);
 		assertThat(timeZone).isNull();
-
-		Cookie[] cookies = response.getCookies();
-		assertThat(cookies).hasSize(1);
-		Cookie localeCookie = cookies[0];
-		assertThat(localeCookie.getName()).isEqualTo(CookieLocaleResolver.DEFAULT_COOKIE_NAME);
-		assertThat(localeCookie.getValue()).isEqualTo("");
-	}
-
-	@Test
-	void setLocaleToNullWithDefault() {
-		request.addPreferredLocale(Locale.TAIWAN);
-		Cookie cookie = new Cookie(CookieLocaleResolver.DEFAULT_COOKIE_NAME, Locale.UK.toString());
-		request.setCookies(cookie);
-
-		resolver.setDefaultLocale(Locale.CANADA_FRENCH);
-		resolver.setLocale(request, response, null);
-		Locale locale = (Locale) request.getAttribute(CookieLocaleResolver.LOCALE_REQUEST_ATTRIBUTE_NAME);
-		assertThat(locale).isEqualTo(Locale.CANADA_FRENCH);
 
 		Cookie[] cookies = response.getCookies();
 		assertThat(cookies).hasSize(1);
@@ -424,7 +348,7 @@ class CookieLocaleResolverTests {
 
 		resolver.setDefaultLocaleFunction(request -> Locale.GERMAN);
 
-		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.GERMAN);
+		assertThat(resolver.resolveLocaleContext(request).getLocale()).isEqualTo(Locale.GERMAN);
 	}
 
 	@Test

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/SessionLocaleResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/SessionLocaleResolverTests.java
@@ -22,6 +22,7 @@ import java.util.TimeZone;
 import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.context.i18n.SimpleLocaleContext;
 import org.springframework.context.i18n.TimeZoneAwareLocaleContext;
 import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 import org.springframework.web.testfixture.servlet.MockHttpServletResponse;
@@ -48,27 +49,27 @@ class SessionLocaleResolverTests {
 	void resolveLocale() {
 		request.getSession().setAttribute(SessionLocaleResolver.LOCALE_SESSION_ATTRIBUTE_NAME, Locale.GERMAN);
 
-		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.GERMAN);
+		assertThat(resolver.resolveLocaleContext(request).getLocale()).isEqualTo(Locale.GERMAN);
 	}
 
 	@Test
 	void setAndResolveLocale() {
-		resolver.setLocale(request, response, Locale.GERMAN);
-		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.GERMAN);
+		resolver.setLocaleContext(request, response, new SimpleLocaleContext(Locale.GERMAN));
+		assertThat(resolver.resolveLocaleContext(request).getLocale()).isEqualTo(Locale.GERMAN);
 
 		HttpSession session = request.getSession();
 		request = new MockHttpServletRequest();
 		request.setSession(session);
 		resolver = new SessionLocaleResolver();
 
-		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.GERMAN);
+		assertThat(resolver.resolveLocaleContext(request).getLocale()).isEqualTo(Locale.GERMAN);
 	}
 
 	@Test
 	void resolveLocaleWithoutSession() throws Exception {
 		request.addPreferredLocale(Locale.TAIWAN);
 
-		assertThat(resolver.resolveLocale(request)).isEqualTo(request.getLocale());
+		assertThat(resolver.resolveLocaleContext(request).getLocale()).isEqualTo(request.getLocale());
 	}
 
 	@Test
@@ -77,7 +78,7 @@ class SessionLocaleResolverTests {
 
 		resolver.setDefaultLocale(Locale.GERMAN);
 
-		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.GERMAN);
+		assertThat(resolver.resolveLocaleContext(request).getLocale()).isEqualTo(Locale.GERMAN);
 	}
 
 	@Test
@@ -85,7 +86,7 @@ class SessionLocaleResolverTests {
 		request.addPreferredLocale(Locale.TAIWAN);
 		request.getSession().setAttribute(SessionLocaleResolver.LOCALE_SESSION_ATTRIBUTE_NAME, Locale.GERMAN);
 
-		resolver.setLocale(request, response, null);
+		resolver.setLocaleContext(request, response, null);
 		Locale locale = (Locale) request.getSession().getAttribute(SessionLocaleResolver.LOCALE_SESSION_ATTRIBUTE_NAME);
 		assertThat(locale).isNull();
 
@@ -94,7 +95,7 @@ class SessionLocaleResolverTests {
 		request.addPreferredLocale(Locale.TAIWAN);
 		request.setSession(session);
 		resolver = new SessionLocaleResolver();
-		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.TAIWAN);
+		assertThat(resolver.resolveLocaleContext(request).getLocale()).isEqualTo(Locale.TAIWAN);
 	}
 
 	@Test
@@ -103,7 +104,7 @@ class SessionLocaleResolverTests {
 
 		resolver.setDefaultLocaleFunction(request -> Locale.GERMAN);
 
-		assertThat(resolver.resolveLocale(request)).isEqualTo(Locale.GERMAN);
+		assertThat(resolver.resolveLocaleContext(request).getLocale()).isEqualTo(Locale.GERMAN);
 	}
 
 	@Test

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/AbstractTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/AbstractTagTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.web.servlet.tags;
 
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
-import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.LocaleContextResolver;
 import org.springframework.web.servlet.SimpleWebApplicationContext;
 import org.springframework.web.servlet.ThemeResolver;
 import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
@@ -49,7 +49,7 @@ public abstract class AbstractTagTests {
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		if (inDispatcherServlet()) {
 			request.setAttribute(DispatcherServlet.WEB_APPLICATION_CONTEXT_ATTRIBUTE, wac);
-			LocaleResolver lr = new AcceptHeaderLocaleResolver();
+			LocaleContextResolver lr = new AcceptHeaderLocaleResolver();
 			request.setAttribute(DispatcherServlet.LOCALE_RESOLVER_ATTRIBUTE, lr);
 			ThemeResolver tr = new FixedThemeResolver();
 			request.setAttribute(DispatcherServlet.THEME_RESOLVER_ATTRIBUTE, tr);

--- a/src/docs/asciidoc/web/webmvc.adoc
+++ b/src/docs/asciidoc/web/webmvc.adoc
@@ -904,7 +904,7 @@ See <<mvc-config-view-resolvers>> under <<mvc-config>> for configuration details
 
 Most parts of Spring's architecture support internationalization, as the Spring web
 MVC framework does. `DispatcherServlet` lets you automatically resolve messages
-by using the client's locale. This is done with `LocaleResolver` objects.
+by using the client's locale. This is done with `LocaleContextResolver` objects.
 
 When a request comes in, the `DispatcherServlet` looks for a locale resolver and, if it
 finds one, it tries to use it to set the locale. By using the `RequestContext.getLocale()`
@@ -1013,7 +1013,7 @@ modifies the corresponding `HttpSession` attributes against the current `HttpSer
 
 You can enable changing of locales by adding the `LocaleChangeInterceptor` to one of the
 `HandlerMapping` definitions. It detects a parameter in the request and changes the locale
-accordingly, calling the `setLocale` method on the `LocaleResolver` in the dispatcher's
+accordingly, calling the `setLocale` method on the `LocaleContextResolver` in the dispatcher's
 application context. The next example shows that calls to all `{asterisk}.view` resources
 that contain a parameter named `siteLanguage` now changes the locale. So, for example,
 a request for the URL, `https://www.sf.net/home.view?siteLanguage=nl`, changes the site
@@ -1111,7 +1111,7 @@ background image with Dutch text on it.
 After you define themes, as described in the <<mvc-themeresolver-defining, preceding section>>,
 you decide which theme to use. The `DispatcherServlet` looks for a bean named `themeResolver`
 to find out which `ThemeResolver` implementation to use. A theme resolver works in much the same
-way as a `LocaleResolver`. It detects the theme to use for a particular request and can also
+way as a `LocaleContextResolver`. It detects the theme to use for a particular request and can also
 alter the request's theme. The following table describes the theme resolvers provided by Spring:
 
 [[mvc-theme-resolver-impls-tbl]]
@@ -2098,8 +2098,8 @@ and others) and is equivalent to `required=false`.
 | The HTTP method of the request.
 
 | `java.util.Locale`
-| The current request locale, determined by the most specific `LocaleResolver` available (in
-  effect, the configured `LocaleResolver` or `LocaleContextResolver`).
+| The current request locale, determined by the most specific `LocaleContextResolver` available (in
+  effect, the configured `LocaleContextResolver`).
 
 | `java.util.TimeZone` + `java.time.ZoneId`
 | The time zone associated with the current request, as determined by a `LocaleContextResolver`.
@@ -3932,8 +3932,8 @@ level, <<mvc-exceptionhandlers, HandlerExceptionResolver>> mechanism.
 | The HTTP method of the request.
 
 | `java.util.Locale`
-| The current request locale, determined by the most specific `LocaleResolver` available -- in
-  effect, the configured `LocaleResolver` or `LocaleContextResolver`.
+| The current request locale, determined by the most specific `LocaleContextResolver` available -- in
+  effect, the configured `LocaleContextResolver`.
 
 | `java.util.TimeZone`, `java.time.ZoneId`
 | The time zone associated with the current request, as determined by a `LocaleContextResolver`.


### PR DESCRIPTION
This PR wraps up efforts to improve `org.springframework.web.servlet.LocaleResolver` hierarchy started in:

- https://github.com/spring-projects/spring-framework/pull/27609
- https://github.com/spring-projects/spring-framework/pull/28779

The core change proposed here (first commit) is to refactor `AcceptHeaderLocaleResolver` to implement `LocaleContextResolver`, which makes the all locale resolvers provided by Spring MVC `LocaleContextResolver` based. It also aligns Spring MVC with Spring WebFlux, where all resolvers work with `LocaleContext` rather than plain `Locale`.

The two subsequent commits are optional, but could be helpful as they prepare ground to simplifying `LocaleResolver` hierarchy in the future:

- second commit deprecates `AbstractLocaleResolver` in favor of `AbstractLocaleContextResolver`, as nothing is using `AbstractLocaleResolver` after the first commit
- third commit is a bit more substantial as it deprecates `org.springframework.web.servlet.LocaleResolver` and reworks all the references to operate against `LocaleContextResolver` - while technically a breaking change, this only impacts those with custom `LocaleResolver` that don't implement `LocaleContextResolver`