### PR TITLE
add missing @Nullable annotation to org.springframework.beans.propert…

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/propertyeditors/CustomDateEditor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/propertyeditors/CustomDateEditor.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  */
 public class CustomDateEditor extends PropertyEditorSupport {
 
+	@Nullable
 	private final DateFormat dateFormat;
 
 	private final boolean allowEmpty;


### PR DESCRIPTION
### Add `@Nullable` to `org.springframework.beans.propertyeditors.CustomDateEditor::dateFormat (type signature: java.text.DateFormat)

Supporting test traces illustrating the use of `null` in actual program behaviour (max 3 is shown): 
```
org.springframework.beans.propertyeditors.CustomDateEditor::<init>:67
org.springframework.beans.propertyeditors.CustomEditorTests::testCustomDateEditor:725
```
```
org.springframework.beans.propertyeditors.CustomDateEditor::<init>:67
org.springframework.beans.propertyeditors.CustomEditorTests::testCustomDateEditorWithEmptyAsNull:733
```

This issue has been detected by an automated analysis. A description of the analysis performed can be found here: (https://github.com/jensdietrich/null-annotation-inference)
