### PR TITLE
Use AssertJ static imports consistently

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/CollectionFactoryTests.java
+++ b/spring-core/src/test/java/org/springframework/core/CollectionFactoryTests.java
@@ -34,7 +34,6 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.util.LinkedMultiValueMap;
@@ -156,7 +155,7 @@ class CollectionFactoryTests {
 	@Test
 	void createApproximateCollectionFromEmptyHashSet() {
 		Collection<String> set = createApproximateCollection(new HashSet<String>(), 2);
-		Assertions.assertThat(set).isEmpty();
+		assertThat(set).isEmpty();
 	}
 
 	@Test

--- a/spring-core/src/test/kotlin/org/springframework/core/KotlinBridgeMethodResolverTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/KotlinBridgeMethodResolverTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.core
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class KotlinBridgeMethodResolverTests {
@@ -25,22 +25,22 @@ class KotlinBridgeMethodResolverTests {
 	fun findBridgedMethod() {
 		val unbridged = GenericRepository::class.java.getDeclaredMethod("delete", Int::class.java)
 		val bridged = GenericRepository::class.java.getDeclaredMethod("delete", Any::class.java)
-		Assertions.assertThat(unbridged.isBridge).isFalse
-		Assertions.assertThat(bridged.isBridge).isTrue
+		assertThat(unbridged.isBridge).isFalse
+		assertThat(bridged.isBridge).isTrue
 
-		Assertions.assertThat(BridgeMethodResolver.findBridgedMethod(unbridged)).`as`("Unbridged method not returned directly").isEqualTo(unbridged)
-		Assertions.assertThat(BridgeMethodResolver.findBridgedMethod(bridged)).`as`("Incorrect bridged method returned").isEqualTo(unbridged)
+		assertThat(BridgeMethodResolver.findBridgedMethod(unbridged)).`as`("Unbridged method not returned directly").isEqualTo(unbridged)
+		assertThat(BridgeMethodResolver.findBridgedMethod(bridged)).`as`("Incorrect bridged method returned").isEqualTo(unbridged)
 	}
 
 	@Test
 	fun findBridgedMethodWithArrays() {
 		val unbridged = GenericRepository::class.java.getDeclaredMethod("delete", Array<Int>::class.java)
 		val bridged = GenericRepository::class.java.getDeclaredMethod("delete", Array<Any>::class.java)
-		Assertions.assertThat(unbridged.isBridge).isFalse
-		Assertions.assertThat(bridged.isBridge).isTrue
+		assertThat(unbridged.isBridge).isFalse
+		assertThat(bridged.isBridge).isTrue
 
-		Assertions.assertThat(BridgeMethodResolver.findBridgedMethod(unbridged)).`as`("Unbridged method not returned directly").isEqualTo(unbridged)
-		Assertions.assertThat(BridgeMethodResolver.findBridgedMethod(bridged)).`as`("Incorrect bridged method returned").isEqualTo(unbridged)
+		assertThat(BridgeMethodResolver.findBridgedMethod(unbridged)).`as`("Unbridged method not returned directly").isEqualTo(unbridged)
+		assertThat(BridgeMethodResolver.findBridgedMethod(bridged)).`as`("Incorrect bridged method returned").isEqualTo(unbridged)
 	}
 }
 

--- a/spring-jdbc/src/test/kotlin/org/springframework/jdbc/core/KotlinDataClassRowMapperTests.kt
+++ b/spring-jdbc/src/test/kotlin/org/springframework/jdbc/core/KotlinDataClassRowMapperTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.jdbc.core
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.jdbc.core.test.ConstructorPerson
 import java.math.BigDecimal
@@ -31,7 +31,7 @@ class KotlinDataClassRowMapperTests : AbstractRowMapperTests() {
 			"select name, age, birth_date, balance from people",
 			DataClassRowMapper(ConstructorPerson::class.java)
 		)
-		Assertions.assertThat(result.size).isEqualTo(1)
+		assertThat(result.size).isEqualTo(1)
 		verifyPerson(result[0])
 		mock.verifyClosed()
 	}
@@ -43,8 +43,8 @@ class KotlinDataClassRowMapperTests : AbstractRowMapperTests() {
 			"select name, age, birth_date, balance from people",
 			DataClassRowMapper(KotlinPerson::class.java)
 		)
-		Assertions.assertThat(result.size).isEqualTo(1)
-		Assertions.assertThat(result[0].name).isEqualTo("Bubba appended by init")
+		assertThat(result.size).isEqualTo(1)
+		assertThat(result[0].name).isEqualTo("Bubba appended by init")
 	}
 
 

--- a/spring-messaging/src/test/kotlin/org/springframework/messaging/converter/KotlinSerializationJsonMessageConverterTests.kt
+++ b/spring-messaging/src/test/kotlin/org/springframework/messaging/converter/KotlinSerializationJsonMessageConverterTests.kt
@@ -17,7 +17,8 @@
 package org.springframework.messaging.converter
 
 import kotlinx.serialization.Serializable
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import org.springframework.core.MethodParameter
 import org.springframework.messaging.support.MessageBuilder
@@ -50,12 +51,12 @@ class KotlinSerializationJsonMessageConverterTests {
 		val message = MessageBuilder.withPayload(payload.toByteArray(StandardCharsets.UTF_8)).build()
 		val result = converter.fromMessage(message, SerializableBean::class.java) as SerializableBean
 
-		Assertions.assertThat(result.bytes).containsExactly(0x1, 0x2)
-		Assertions.assertThat(result.array).containsExactly("Foo", "Bar")
-		Assertions.assertThat(result.number).isEqualTo(42)
-		Assertions.assertThat(result.string).isEqualTo("Foo")
-		Assertions.assertThat(result.bool).isTrue()
-		Assertions.assertThat(result.fraction).isEqualTo(42.0f)
+		assertThat(result.bytes).containsExactly(0x1, 0x2)
+		assertThat(result.array).containsExactly("Foo", "Bar")
+		assertThat(result.number).isEqualTo(42)
+		assertThat(result.string).isEqualTo("Foo")
+		assertThat(result.bool).isTrue()
+		assertThat(result.fraction).isEqualTo(42.0f)
 	}
 
 	@Test
@@ -82,13 +83,13 @@ class KotlinSerializationJsonMessageConverterTests {
 		val message = MessageBuilder.withPayload(payload.toByteArray(StandardCharsets.UTF_8)).build()
 		val result = converter.fromMessage(message, Array<SerializableBean>::class.java) as Array<SerializableBean>
 
-		Assertions.assertThat(result).hasSize(1)
-		Assertions.assertThat(result[0].bytes).containsExactly(0x1, 0x2)
-		Assertions.assertThat(result[0].array).containsExactly("Foo", "Bar")
-		Assertions.assertThat(result[0].number).isEqualTo(42)
-		Assertions.assertThat(result[0].string).isEqualTo("Foo")
-		Assertions.assertThat(result[0].bool).isTrue()
-		Assertions.assertThat(result[0].fraction).isEqualTo(42.0f)
+		assertThat(result).hasSize(1)
+		assertThat(result[0].bytes).containsExactly(0x1, 0x2)
+		assertThat(result[0].array).containsExactly("Foo", "Bar")
+		assertThat(result[0].number).isEqualTo(42)
+		assertThat(result[0].string).isEqualTo("Foo")
+		assertThat(result[0].bool).isTrue()
+		assertThat(result[0].fraction).isEqualTo(42.0f)
 	}
 
 	@Test
@@ -118,13 +119,13 @@ class KotlinSerializationJsonMessageConverterTests {
 		val message = MessageBuilder.withPayload(payload.toByteArray(StandardCharsets.UTF_8)).build()
 		val result = converter.fromMessage(message, typeOf<List<SerializableBean>>()::class.java, param) as List<SerializableBean>
 
-		Assertions.assertThat(result).hasSize(1)
-		Assertions.assertThat(result[0].bytes).containsExactly(0x1, 0x2)
-		Assertions.assertThat(result[0].array).containsExactly("Foo", "Bar")
-		Assertions.assertThat(result[0].number).isEqualTo(42)
-		Assertions.assertThat(result[0].string).isEqualTo("Foo")
-		Assertions.assertThat(result[0].bool).isTrue()
-		Assertions.assertThat(result[0].fraction).isEqualTo(42.0f)
+		assertThat(result).hasSize(1)
+		assertThat(result[0].bytes).containsExactly(0x1, 0x2)
+		assertThat(result[0].array).containsExactly("Foo", "Bar")
+		assertThat(result[0].number).isEqualTo(42)
+		assertThat(result[0].string).isEqualTo("Foo")
+		assertThat(result[0].bool).isTrue()
+		assertThat(result[0].fraction).isEqualTo(42.0f)
 	}
 
 	@Test
@@ -134,7 +135,7 @@ class KotlinSerializationJsonMessageConverterTests {
 		""".trimIndent()
 
 		val message = MessageBuilder.withPayload(payload.toByteArray(StandardCharsets.UTF_8)).build()
-		Assertions.assertThatExceptionOfType(MessageConversionException::class.java).isThrownBy {
+		assertThatExceptionOfType(MessageConversionException::class.java).isThrownBy {
 			converter.fromMessage(message, SerializableBean::class.java)
 		}
 	}
@@ -145,7 +146,7 @@ class KotlinSerializationJsonMessageConverterTests {
 		val message = converter.toMessage(serializableBean, null)
 		val result = String((message!!.payload as ByteArray), StandardCharsets.UTF_8)
 
-		Assertions.assertThat(result)
+		assertThat(result)
 				.contains("\"bytes\":[1,2]")
 				.contains("\"array\":[\"Foo\",\"Bar\"]")
 				.contains("\"number\":42")
@@ -160,7 +161,7 @@ class KotlinSerializationJsonMessageConverterTests {
 		val message = converter.toMessage(serializableBean, null)
 		val result = String((message!!.payload as ByteArray), StandardCharsets.UTF_8)
 
-		Assertions.assertThat(result)
+		assertThat(result)
 				.contains("\"bytes\":[1,2]")
 				.contains("\"array\":[\"Foo\",\"Bar\"]")
 				.contains("\"number\":42")
@@ -179,7 +180,7 @@ class KotlinSerializationJsonMessageConverterTests {
 		val message = converter.toMessage(arrayOf(serializableBean), null)
 		val result = String((message!!.payload as ByteArray), StandardCharsets.UTF_8)
 
-		Assertions.assertThat(result).isEqualTo(expectedJson)
+		assertThat(result).isEqualTo(expectedJson)
 	}
 
 	@Test
@@ -195,7 +196,7 @@ class KotlinSerializationJsonMessageConverterTests {
 		val message = converter.toMessage(arrayListOf(serializableBean), null, param)
 		val result = String((message!!.payload as ByteArray), StandardCharsets.UTF_8)
 
-		Assertions.assertThat(result).isEqualTo(expectedJson)
+		assertThat(result).isEqualTo(expectedJson)
 	}
 
 	@Suppress("UNUSED_PARAMETER")

--- a/spring-test/src/test/kotlin/org/springframework/test/context/KotlinDynamicPropertySourceIntegrationTests.kt
+++ b/spring-test/src/test/kotlin/org/springframework/test/context/KotlinDynamicPropertySourceIntegrationTests.kt
@@ -15,7 +15,7 @@
  */
 package org.springframework.test.context
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -36,8 +36,8 @@ class KotlinDynamicPropertySourceIntegrationTests {
 
 	@Test
 	fun hasInjectedValues(@Autowired service: Service) {
-		Assertions.assertThat(service.ip).isEqualTo("127.0.0.1")
-		Assertions.assertThat(service.port).isEqualTo(4242)
+		assertThat(service.ip).isEqualTo("127.0.0.1")
+		assertThat(service.port).isEqualTo(4242)
 	}
 
 	@Configuration

--- a/spring-tx/src/test/kotlin/org/springframework/transaction/annotation/CoroutinesAnnotationTransactionInterceptorTests.kt
+++ b/spring-tx/src/test/kotlin/org/springframework/transaction/annotation/CoroutinesAnnotationTransactionInterceptorTests.kt
@@ -21,7 +21,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.springframework.aop.framework.ProxyFactory
 import org.springframework.transaction.interceptor.TransactionInterceptor
@@ -72,7 +73,7 @@ class CoroutinesAnnotationTransactionInterceptorTests {
 		proxyFactory.addAdvice(TransactionInterceptor(rtm, source))
 		val proxy = proxyFactory.proxy as TestWithCoroutines
 		runBlocking {
-			Assertions.assertThat(proxy.suspendingValueSuccess()).isEqualTo("foo")
+			assertThat(proxy.suspendingValueSuccess()).isEqualTo("foo")
 		}
 		assertReactiveGetTransactionAndCommitCount(1)
 	}
@@ -86,7 +87,7 @@ class CoroutinesAnnotationTransactionInterceptorTests {
 		runBlocking {
 			try {
 				proxy.suspendingValueFailure()
-				Assertions.fail("No exception thrown as expected")
+				fail("No exception thrown as expected")
 			}
 			catch (ex: IllegalStateException) {
 			}
@@ -101,7 +102,7 @@ class CoroutinesAnnotationTransactionInterceptorTests {
 		proxyFactory.addAdvice(TransactionInterceptor(rtm, source))
 		val proxy = proxyFactory.proxy as TestWithCoroutines
 		runBlocking {
-			Assertions.assertThat(proxy.suspendingFlowSuccess().toList()).containsExactly("foo", "foo")
+			assertThat(proxy.suspendingFlowSuccess().toList()).containsExactly("foo", "foo")
 		}
 		assertReactiveGetTransactionAndCommitCount(1)
 	}
@@ -113,19 +114,19 @@ class CoroutinesAnnotationTransactionInterceptorTests {
 		proxyFactory.addAdvice(TransactionInterceptor(rtm, source))
 		val proxy = proxyFactory.proxy as TestWithCoroutines
 		runBlocking {
-			Assertions.assertThat(proxy.flowSuccess().toList()).containsExactly("foo", "foo")
+			assertThat(proxy.flowSuccess().toList()).containsExactly("foo", "foo")
 		}
 		assertReactiveGetTransactionAndCommitCount(1)
 	}
 
 	private fun assertReactiveGetTransactionAndCommitCount(expectedCount: Int) {
-		Assertions.assertThat(rtm.begun).isEqualTo(expectedCount)
-		Assertions.assertThat(rtm.commits).isEqualTo(expectedCount)
+		assertThat(rtm.begun).isEqualTo(expectedCount)
+		assertThat(rtm.commits).isEqualTo(expectedCount)
 	}
 
 	private fun assertReactiveGetTransactionAndRollbackCount(expectedCount: Int) {
-		Assertions.assertThat(rtm.begun).isEqualTo(expectedCount)
-		Assertions.assertThat(rtm.rollbacks).isEqualTo(expectedCount)
+		assertThat(rtm.begun).isEqualTo(expectedCount)
+		assertThat(rtm.rollbacks).isEqualTo(expectedCount)
 	}
 
 	@Transactional

--- a/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
+++ b/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/AbstractCoroutinesTransactionAspectTests.kt
@@ -18,7 +18,7 @@ package org.springframework.transaction.interceptor
 
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -188,7 +188,7 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 			ex: Exception, shouldRollback: Boolean, rollbackException: Boolean) {
 		val txatt: TransactionAttribute = object : DefaultTransactionAttribute() {
 			override fun rollbackOn(t: Throwable): Boolean {
-				Assertions.assertThat(t).isSameAs(ex)
+				assertThat(t).isSameAs(ex)
 				return shouldRollback
 			}
 		}
@@ -218,9 +218,9 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 			}
 			catch (actual: Exception) {
 				if (rollbackException) {
-					Assertions.assertThat(actual).hasMessage(tex.message).isInstanceOf(tex::class.java)
+					assertThat(actual).hasMessage(tex.message).isInstanceOf(tex::class.java)
 				} else {
-					Assertions.assertThat(actual).hasMessage(ex.message).isInstanceOf(ex::class.java)
+					assertThat(actual).hasMessage(ex.message).isInstanceOf(ex::class.java)
 				}
 			}
 		}
@@ -259,7 +259,7 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 				itb.getName()
 			}
 			catch (actual: Exception) {
-				Assertions.assertThat(actual).isInstanceOf(CannotCreateTransactionException::class.java)
+				assertThat(actual).isInstanceOf(CannotCreateTransactionException::class.java)
 			}
 		}
 	}
@@ -291,11 +291,11 @@ abstract class AbstractCoroutinesTransactionAspectTests {
 				itb.setName(name)
 			}
 			catch (ex: Exception) {
-				Assertions.assertThat(ex).isInstanceOf(RuntimeException::class.java)
-				Assertions.assertThat(ex.cause).hasMessage(ex.message).isInstanceOf(ex::class.java)
+				assertThat(ex).isInstanceOf(RuntimeException::class.java)
+				assertThat(ex.cause).hasMessage(ex.message).isInstanceOf(ex::class.java)
 			}
 			// Should have invoked target and changed name
-			Assertions.assertThat(itb.getName()).isEqualTo(name)
+			assertThat(itb.getName()).isEqualTo(name)
 		}
 	}
 

--- a/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/CoroutinesTransactionInterceptorTests.kt
+++ b/spring-tx/src/test/kotlin/org/springframework/transaction/interceptor/CoroutinesTransactionInterceptorTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.transaction.interceptor
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.springframework.aop.framework.ProxyFactory
 import org.springframework.transaction.ReactiveTransactionManager
 
@@ -44,9 +44,9 @@ class CoroutinesTransactionInterceptorTests : AbstractCoroutinesTransactionAspec
 	override fun advised(target: Any, rtm: ReactiveTransactionManager, tas: TransactionAttributeSource): Any {
 		val ti = TransactionInterceptor()
 		ti.transactionManager = rtm
-		Assertions.assertThat(ti.transactionManager).isEqualTo(rtm)
+		assertThat(ti.transactionManager).isEqualTo(rtm)
 		ti.transactionAttributeSource = tas
-		Assertions.assertThat(ti.transactionAttributeSource).isEqualTo(tas)
+		assertThat(ti.transactionAttributeSource).isEqualTo(tas)
 		val pf = ProxyFactory(target)
 		pf.addAdvice(0, ti)
 		return pf.proxy

--- a/spring-web/src/test/kotlin/org/springframework/http/codec/cbor/KotlinSerializationCborDecoderTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/codec/cbor/KotlinSerializationCborDecoderTests.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.serializer
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -45,17 +45,17 @@ class KotlinSerializationCborDecoderTests : AbstractDecoderTests<KotlinSerializa
 	@Suppress("UsePropertyAccessSyntax", "DEPRECATION")
 	@Test
 	override fun canDecode() {
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_CBOR)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), null)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(String::class.java), null)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_CBOR)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), null)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClass(String::class.java), null)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
 
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), MediaType.APPLICATION_CBOR)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), MediaType.APPLICATION_CBOR)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), MediaType.APPLICATION_CBOR)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_CBOR)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Ordered::class.java), MediaType.APPLICATION_CBOR)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), MediaType.APPLICATION_CBOR)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), MediaType.APPLICATION_CBOR)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), MediaType.APPLICATION_CBOR)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_CBOR)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Ordered::class.java), MediaType.APPLICATION_CBOR)).isFalse()
 	}
 
 	@Test

--- a/spring-web/src/test/kotlin/org/springframework/http/codec/cbor/KotlinSerializationCborEncoderTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/codec/cbor/KotlinSerializationCborEncoderTests.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.encodeToByteArray
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -47,14 +47,14 @@ class KotlinSerializationCborEncoderTests : AbstractEncoderTests<KotlinSerializa
 	@Test
 	override fun canEncode() {
 		val pojoType = ResolvableType.forClass(Pojo::class.java)
-		Assertions.assertThat(encoder.canEncode(pojoType, MediaType.APPLICATION_CBOR)).isTrue()
-		Assertions.assertThat(encoder.canEncode(pojoType, null)).isTrue()
+		assertThat(encoder.canEncode(pojoType, MediaType.APPLICATION_CBOR)).isTrue()
+		assertThat(encoder.canEncode(pojoType, null)).isTrue()
 
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), MediaType.APPLICATION_CBOR)).isTrue()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), MediaType.APPLICATION_CBOR)).isFalse()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), MediaType.APPLICATION_CBOR)).isTrue()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_CBOR)).isTrue()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), MediaType.APPLICATION_CBOR)).isTrue()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), MediaType.APPLICATION_CBOR)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), MediaType.APPLICATION_CBOR)).isTrue()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_CBOR)).isTrue()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
 	}
 
 	@Test
@@ -90,11 +90,11 @@ class KotlinSerializationCborEncoderTests : AbstractEncoderTests<KotlinSerializa
 
 	@Test
 	fun canNotEncode() {
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(String::class.java), null)).isFalse()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClass(String::class.java), null)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
 		val sseType = ResolvableType.forClass(ServerSentEvent::class.java)
-		Assertions.assertThat(encoder.canEncode(sseType, MediaType.APPLICATION_CBOR)).isFalse()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(Ordered::class.java), MediaType.APPLICATION_CBOR)).isFalse()
+		assertThat(encoder.canEncode(sseType, MediaType.APPLICATION_CBOR)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClass(Ordered::class.java), MediaType.APPLICATION_CBOR)).isFalse()
 	}
 
 

--- a/spring-web/src/test/kotlin/org/springframework/http/codec/json/KotlinSerializationJsonDecoderTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/codec/json/KotlinSerializationJsonDecoderTests.kt
@@ -17,7 +17,7 @@
 package org.springframework.http.codec.json
 
 import kotlinx.serialization.Serializable
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.core.Ordered
 import org.springframework.core.ResolvableType
@@ -43,25 +43,25 @@ class KotlinSerializationJsonDecoderTests : AbstractDecoderTests<KotlinSerializa
 	@Test
 	override fun canDecode() {
 		val jsonSubtype = MediaType("application", "vnd.test-micro-type+json")
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_JSON)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), jsonSubtype)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), null)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(String::class.java), null)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java),
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_JSON)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), jsonSubtype)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), null)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClass(String::class.java), null)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java),
 				MediaType("application", "json", StandardCharsets.UTF_8))).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java),
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java),
 				MediaType("application", "json", StandardCharsets.US_ASCII))).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java),
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java),
 				MediaType("application", "json", StandardCharsets.ISO_8859_1))).isTrue()
 
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), MediaType.APPLICATION_JSON)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), MediaType.APPLICATION_JSON)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), MediaType.APPLICATION_JSON)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_JSON)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Ordered::class.java), MediaType.APPLICATION_JSON)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.NONE, MediaType.APPLICATION_JSON)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), MediaType.APPLICATION_JSON)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), MediaType.APPLICATION_JSON)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), MediaType.APPLICATION_JSON)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_JSON)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Ordered::class.java), MediaType.APPLICATION_JSON)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.NONE, MediaType.APPLICATION_JSON)).isFalse()
 	}
 
 	@Test

--- a/spring-web/src/test/kotlin/org/springframework/http/codec/json/KotlinSerializationJsonEncoderTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/codec/json/KotlinSerializationJsonEncoderTests.kt
@@ -17,7 +17,7 @@
 package org.springframework.http.codec.json
 
 import kotlinx.serialization.Serializable
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.core.Ordered
 import org.springframework.core.ResolvableType
@@ -43,20 +43,20 @@ class KotlinSerializationJsonEncoderTests : AbstractEncoderTests<KotlinSerializa
 	override fun canEncode() {
 		val pojoType = ResolvableType.forClass(Pojo::class.java)
 		val jsonSubtype = MediaType("application", "vnd.test-micro-type+json")
-		Assertions.assertThat(encoder.canEncode(pojoType, MediaType.APPLICATION_JSON)).isTrue()
-		Assertions.assertThat(encoder.canEncode(pojoType, jsonSubtype)).isTrue()
-		Assertions.assertThat(encoder.canEncode(pojoType, null)).isTrue()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java),
+		assertThat(encoder.canEncode(pojoType, MediaType.APPLICATION_JSON)).isTrue()
+		assertThat(encoder.canEncode(pojoType, jsonSubtype)).isTrue()
+		assertThat(encoder.canEncode(pojoType, null)).isTrue()
+		assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java),
 				MediaType("application", "json", StandardCharsets.UTF_8))).isTrue()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java),
+		assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java),
 				MediaType("application", "json", StandardCharsets.US_ASCII))).isTrue()
 
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), MediaType.APPLICATION_JSON)).isTrue()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), MediaType.APPLICATION_JSON)).isFalse()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), MediaType.APPLICATION_JSON)).isTrue()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_JSON)).isTrue()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.NONE, MediaType.APPLICATION_JSON)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), MediaType.APPLICATION_JSON)).isTrue()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), MediaType.APPLICATION_JSON)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), MediaType.APPLICATION_JSON)).isTrue()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_JSON)).isTrue()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.NONE, MediaType.APPLICATION_JSON)).isFalse()
 	}
 
 	@Test
@@ -88,11 +88,11 @@ class KotlinSerializationJsonEncoderTests : AbstractEncoderTests<KotlinSerializa
 
 	@Test
 	fun canNotEncode() {
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(String::class.java), null)).isFalse()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClass(String::class.java), null)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
 		val sseType = ResolvableType.forClass(ServerSentEvent::class.java)
-		Assertions.assertThat(encoder.canEncode(sseType, MediaType.APPLICATION_JSON)).isFalse()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(Ordered::class.java), MediaType.APPLICATION_JSON)).isFalse()
+		assertThat(encoder.canEncode(sseType, MediaType.APPLICATION_JSON)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClass(Ordered::class.java), MediaType.APPLICATION_JSON)).isFalse()
 	}
 
 

--- a/spring-web/src/test/kotlin/org/springframework/http/codec/protobuf/KotlinSerializationProtobufDecoderTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/codec/protobuf/KotlinSerializationProtobufDecoderTests.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoBuf
 import kotlinx.serialization.serializer
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.core.Ordered
 import org.springframework.core.ResolvableType
@@ -44,18 +44,18 @@ class KotlinSerializationCborDecoderTests : AbstractDecoderTests<KotlinSerializa
 	@Test
 	override fun canDecode() {
 		for (mimeType in listOf(MediaType.APPLICATION_PROTOBUF, MediaType.APPLICATION_OCTET_STREAM, MediaType("application", "vnd.google.protobuf"))) {
-			Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java),mimeType)).isTrue()
+			assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java),mimeType)).isTrue()
 
-			Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), mimeType)).isTrue()
-			Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), mimeType)).isFalse()
-			Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), mimeType)).isTrue()
-			Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), mimeType)).isTrue()
-			Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Ordered::class.java), mimeType)).isFalse()
+			assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), mimeType)).isTrue()
+			assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), mimeType)).isFalse()
+			assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), mimeType)).isTrue()
+			assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), mimeType)).isTrue()
+			assertThat(decoder.canDecode(ResolvableType.forClass(Ordered::class.java), mimeType)).isFalse()
 		}
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), null)).isTrue()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(String::class.java), null)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
-		Assertions.assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), null)).isTrue()
+		assertThat(decoder.canDecode(ResolvableType.forClass(String::class.java), null)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
+		assertThat(decoder.canDecode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
 	}
 
 	@Test

--- a/spring-web/src/test/kotlin/org/springframework/http/codec/protobuf/KotlinSerializationProtobufEncoderTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/codec/protobuf/KotlinSerializationProtobufEncoderTests.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.protobuf.ProtoBuf
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.core.Ordered
 import org.springframework.core.ResolvableType
@@ -52,18 +52,18 @@ class KotlinSerializationProtobufEncoderTests : AbstractEncoderTests<KotlinSeria
 	@Test
 	override fun canEncode() {
 		val pojoType = ResolvableType.forClass(Pojo::class.java)
-		Assertions.assertThat(encoder.canEncode(pojoType, null)).isTrue()
+		assertThat(encoder.canEncode(pojoType, null)).isTrue()
 
 		for (mimeType in ProtobufCodecSupport.MIME_TYPES) {
 			val mediaType = MediaType(mimeType)
-			Assertions.assertThat(encoder.canEncode(pojoType, mediaType)).isTrue()
+			assertThat(encoder.canEncode(pojoType, mediaType)).isTrue()
 
-			Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), mimeType)).isTrue()
-			Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), mimeType)).isFalse()
-			Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), mimeType)).isTrue()
-			Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), mimeType)).isTrue()
+			assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Int::class.java), mimeType)).isTrue()
+			assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Ordered::class.java), mimeType)).isFalse()
+			assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(List::class.java, Pojo::class.java), mimeType)).isTrue()
+			assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), mimeType)).isTrue()
 		}
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClassWithGenerics(ArrayList::class.java, Int::class.java), MediaType.APPLICATION_PDF)).isFalse()
 	}
 
 	@Test
@@ -99,12 +99,12 @@ class KotlinSerializationProtobufEncoderTests : AbstractEncoderTests<KotlinSeria
 
 	@Test
 	fun canNotEncode() {
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(String::class.java), null)).isFalse()
-		Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClass(String::class.java), null)).isFalse()
+		assertThat(encoder.canEncode(ResolvableType.forClass(Pojo::class.java), MediaType.APPLICATION_XML)).isFalse()
 		val sseType = ResolvableType.forClass(ServerSentEvent::class.java)
 		for (mediaType in mediaTypes) {
-			Assertions.assertThat(encoder.canEncode(sseType, mediaType)).isFalse()
-			Assertions.assertThat(encoder.canEncode(ResolvableType.forClass(Ordered::class.java), mediaType)).isFalse()
+			assertThat(encoder.canEncode(sseType, mediaType)).isFalse()
+			assertThat(encoder.canEncode(ResolvableType.forClass(Ordered::class.java), mediaType)).isFalse()
 		}
 	}
 


### PR DESCRIPTION
This PR changes to use AssertJ static imports consistently.