### PR TITLE
Replace use of `Collections.unmodifiable*()` methods where appropriate

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/support/AbstractCacheManager.java
+++ b/spring-context/src/main/java/org/springframework/cache/support/AbstractCacheManager.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cache.Cache;
@@ -64,13 +65,13 @@ public abstract class AbstractCacheManager implements CacheManager, Initializing
 		synchronized (this.cacheMap) {
 			this.cacheNames = Collections.emptySet();
 			this.cacheMap.clear();
-			Set<String> cacheNames = new LinkedHashSet<>(caches.size());
 			for (Cache cache : caches) {
 				String name = cache.getName();
 				this.cacheMap.put(name, decorateCache(cache));
-				cacheNames.add(name);
 			}
-			this.cacheNames = Collections.unmodifiableSet(cacheNames);
+			this.cacheNames = caches.stream()
+					.map(Cache::getName)
+					.collect(Collectors.toUnmodifiableSet());
 		}
 	}
 

--- a/spring-context/src/main/java/org/springframework/format/datetime/DateFormatter.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/DateFormatter.java
@@ -19,9 +19,7 @@ package org.springframework.format.datetime;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Collections;
 import java.util.Date;
-import java.util.EnumMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -49,15 +47,10 @@ public class DateFormatter implements Formatter<Date> {
 
 	private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
-	private static final Map<ISO, String> ISO_PATTERNS;
-
-	static {
-		Map<ISO, String> formats = new EnumMap<>(ISO.class);
-		formats.put(ISO.DATE, "yyyy-MM-dd");
-		formats.put(ISO.TIME, "HH:mm:ss.SSSXXX");
-		formats.put(ISO.DATE_TIME, "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-		ISO_PATTERNS = Collections.unmodifiableMap(formats);
-	}
+	private static final Map<ISO, String> ISO_PATTERNS = Map.of(
+			ISO.DATE, "yyyy-MM-dd",
+			ISO.TIME, "HH:mm:ss.SSSXXX",
+			ISO.DATE_TIME, "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
 
 	@Nullable

--- a/spring-test/src/main/java/org/springframework/mock/web/HeaderValueHolder.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/HeaderValueHolder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.mock.web;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -61,11 +60,7 @@ class HeaderValueHolder {
 	}
 
 	List<String> getStringValues() {
-		List<String> stringList = new ArrayList<>(this.values.size());
-		for (Object value : this.values) {
-			stringList.add(value.toString());
-		}
-		return Collections.unmodifiableList(stringList);
+		return this.values.stream().map(Object::toString).toList();
 	}
 
 	@Nullable

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultExchangeStrategiesBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultExchangeStrategiesBuilder.java
@@ -16,8 +16,6 @@
 
 package org.springframework.web.reactive.function.client;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -88,7 +86,7 @@ final class DefaultExchangeStrategiesBuilder implements ExchangeStrategies.Build
 		}
 
 		private static <T> List<T> unmodifiableCopy(List<? extends T> list) {
-			return Collections.unmodifiableList(new ArrayList<>(list));
+			return List.copyOf(list);
 		}
 
 		@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultHandlerStrategiesBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultHandlerStrategiesBuilder.java
@@ -17,7 +17,6 @@
 package org.springframework.web.reactive.function.server;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -135,7 +134,7 @@ class DefaultHandlerStrategiesBuilder implements HandlerStrategies.Builder {
 		}
 
 		private static <T> List<T> unmodifiableCopy(List<? extends T> list) {
-			return Collections.unmodifiableList(new ArrayList<>(list));
+			return List.copyOf(list);
 		}
 
 		@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultRenderingResponseBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultRenderingResponseBuilder.java
@@ -171,7 +171,7 @@ final class DefaultRenderingResponseBuilder implements RenderingResponse.Builder
 
 			super(statusCode, headers, cookies, Collections.emptyMap());
 			this.name = name;
-			this.model = Collections.unmodifiableMap(new LinkedHashMap<>(model));
+			this.model = Map.copyOf(model);
 		}
 
 		@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerRequest.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerRequest.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.security.Principal;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -88,7 +87,7 @@ class DefaultServerRequest implements ServerRequest {
 
 	DefaultServerRequest(ServerWebExchange exchange, List<HttpMessageReader<?>> messageReaders) {
 		this.exchange = exchange;
-		this.messageReaders = Collections.unmodifiableList(new ArrayList<>(messageReaders));
+		this.messageReaders = List.copyOf(messageReaders);
 		this.headers = new DefaultHeaders();
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctions.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctions.java
@@ -1175,7 +1175,7 @@ public abstract class RouterFunctions {
 				return Collections.emptyMap();
 			}
 			else {
-				return Collections.unmodifiableMap(new LinkedHashMap<>(attributes));
+				return Map.copyOf(attributes);
 			}
 		}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/AbstractHandlerMethodMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/AbstractHandlerMethodMapping.java
@@ -107,9 +107,8 @@ public abstract class AbstractHandlerMethodMapping<T> extends AbstractHandlerMap
 	public Map<T, HandlerMethod> getHandlerMethods() {
 		this.mappingRegistry.acquireReadLock();
 		try {
-			return Collections.unmodifiableMap(
-					this.mappingRegistry.getRegistrations().entrySet().stream()
-							.collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().handlerMethod)));
+			return this.mappingRegistry.getRegistrations().entrySet().stream()
+					.collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> entry.getValue().handlerMethod));
 		}
 		finally {
 			this.mappingRegistry.releaseReadLock();

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/OriginHandshakeInterceptor.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/OriginHandshakeInterceptor.java
@@ -19,9 +19,9 @@ package org.springframework.web.socket.server.support;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -95,9 +95,8 @@ public class OriginHandshakeInterceptor implements HandshakeInterceptor {
 	 * @since 4.1.5
 	 */
 	public Collection<String> getAllowedOrigins() {
-		List<String> allowedOrigins = this.corsConfiguration.getAllowedOrigins();
-		return (CollectionUtils.isEmpty(allowedOrigins) ? Collections.emptySet() :
-				Collections.unmodifiableSet(new LinkedHashSet<>(allowedOrigins)));
+		return (CollectionUtils.isEmpty(this.corsConfiguration.getAllowedOrigins()) ? Collections.emptySet() :
+				Set.copyOf(this.corsConfiguration.getAllowedOrigins()));
 	}
 
 	/**
@@ -119,9 +118,8 @@ public class OriginHandshakeInterceptor implements HandshakeInterceptor {
 	 * @since 5.3.2
 	 */
 	public Collection<String> getAllowedOriginPatterns() {
-		List<String> allowedOriginPatterns = this.corsConfiguration.getAllowedOriginPatterns();
-		return (CollectionUtils.isEmpty(allowedOriginPatterns) ? Collections.emptySet() :
-				Collections.unmodifiableSet(new LinkedHashSet<>(allowedOriginPatterns)));
+		return (CollectionUtils.isEmpty(this.corsConfiguration.getAllowedOriginPatterns()) ? Collections.emptySet() :
+				Set.copyOf(this.corsConfiguration.getAllowedOriginPatterns()));
 	}
 
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/TransportType.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/TransportType.java
@@ -17,10 +17,9 @@
 package org.springframework.web.socket.sockjs.transport;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.lang.Nullable;
@@ -47,15 +46,8 @@ public enum TransportType {
 	HTML_FILE("htmlfile", HttpMethod.GET, "cors", "jsessionid", "no_cache");
 
 
-	private static final Map<String, TransportType> TRANSPORT_TYPES;
-
-	static {
-		Map<String, TransportType> transportTypes = new HashMap<>();
-		for (TransportType type : values()) {
-			transportTypes.put(type.value, type);
-		}
-		TRANSPORT_TYPES = Collections.unmodifiableMap(transportTypes);
-	}
+	private static final Map<String, TransportType> TRANSPORT_TYPES =
+			Arrays.stream(values()).collect(Collectors.toUnmodifiableMap(type -> type.value, type -> type));
 
 	@Nullable
 	public static TransportType fromValue(String value) {


### PR DESCRIPTION
There seems to be a better place to use the Collections.of() or Stream API than the Collections.unmodifiableXXX() method.
Therefore, I suggest an alternative method in the following cases:

1. If you needs information that is copied rather than the original
  In some cases, a new collection object was created within a function and the created object was returned through an UnmodifiableXXX() method.
  Removed unnecessary object creation through Collection.copyOf() method.

2. When a static block is used to create an immutable collection upon initialization
  Removed unnecessary static blocks by using collection.of() or Stream api.

3. When creating a new Collection object and putting content through an unnecessary for statement
  Remove unnecessary object creation and for statement through Stream api