### PR TITLE
Replace StringBuffer with StringBuilder in CGLIB fork

### DIFF
--- a/spring-core/src/main/java/org/springframework/cglib/beans/BeanMap.java
+++ b/spring-core/src/main/java/org/springframework/cglib/beans/BeanMap.java
@@ -316,7 +316,7 @@ abstract public class BeanMap implements Map {
      */
     public String toString()
     {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append('{');
         for (Iterator it = keySet().iterator(); it.hasNext();) {
             Object key = it.next();

--- a/spring-core/src/main/java/org/springframework/cglib/core/TypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/TypeUtils.java
@@ -171,7 +171,7 @@ public class TypeUtils {
         int rparen = s.indexOf(')', lparen);
         String returnType = s.substring(0, space);
         String methodName = s.substring(space + 1, lparen);
-        StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
         sb.append('(');
         for (Iterator it = parseTypes(s, lparen + 1, rparen).iterator(); it.hasNext();) {
             sb.append(it.next());
@@ -195,7 +195,7 @@ public class TypeUtils {
     }
 
     public static Signature parseConstructor(Type[] types) {
-        StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
         sb.append("(");
         for (int i = 0; i < types.length; i++) {
             sb.append(types[i].getDescriptor());
@@ -233,7 +233,7 @@ public class TypeUtils {
         } else if (type.indexOf('.') < 0) {
             return map("java.lang." + type);
         } else {
-            StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
             int index = 0;
             while ((index = type.indexOf("[]", index) + 1) > 0) {
                 sb.append('[');
@@ -402,7 +402,7 @@ public class TypeUtils {
     }
 
     public static String escapeType(String s) {
-        StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
         for (int i = 0, len = s.length(); i < len; i++) {
             char c = s.charAt(i);
             switch (c) {

--- a/spring-core/src/main/java/org/springframework/cglib/reflect/FastClass.java
+++ b/spring-core/src/main/java/org/springframework/cglib/reflect/FastClass.java
@@ -196,7 +196,7 @@ abstract public class FastClass
     abstract public int getMaxIndex();
 
     protected static String getSignatureWithoutReturnType(String name, Class[] parameterTypes) {
-        StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
         sb.append(name);
         sb.append('(');
         for (int i = 0; i < parameterTypes.length; i++) {

--- a/spring-core/src/main/java/org/springframework/cglib/transform/ClassTransformerChain.java
+++ b/spring-core/src/main/java/org/springframework/cglib/transform/ClassTransformerChain.java
@@ -44,7 +44,7 @@ public class ClassTransformerChain extends AbstractClassTransformer {
     }
 
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
         sb.append("ClassTransformerChain{");
         for (int i = 0; i < chain.length; i++) {
             if (i > 0) {


### PR DESCRIPTION
This PR replaces `StringBuffer` with `StringBuilder` in the CGLIB fork.

I'm aware that any changes on the CGLIB fork are not accepted, but the CGLIB project itself is "unmaintained", so I'm not sure where this sort of change should go.