### PR TITLE
Use KeyValue.NONE_VALUE where possible

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/observation/ClientHttpObservationDocumentation.java
+++ b/spring-web/src/main/java/org/springframework/http/client/observation/ClientHttpObservationDocumentation.java
@@ -16,6 +16,7 @@
 
 package org.springframework.http.client.observation;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
@@ -57,7 +58,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 	public enum LowCardinalityKeyNames implements KeyName {
 
 		/**
-		 * Name of HTTP request method or {@code "none"} if the request could not be created.
+		 * Name of HTTP request method or {@value KeyValue#NONE_VALUE} if the request could not be created.
 		 */
 		METHOD {
 			@Override
@@ -68,7 +69,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 		},
 
 		/**
-		 * URI template used for HTTP request, or {@code "none"} if none was provided.
+		 * URI template used for HTTP request, or {@value KeyValue#NONE_VALUE} if none was provided.
 		 */
 		URI {
 			@Override
@@ -89,7 +90,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 		},
 
 		/**
-		 * Name of the exception thrown during the exchange, or {@code "none"} if no exception happened.
+		 * Name of the exception thrown during the exchange, or {@value KeyValue#NONE_VALUE} if no exception happened.
 		 */
 		EXCEPTION {
 			@Override

--- a/spring-web/src/main/java/org/springframework/http/client/observation/DefaultClientRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/client/observation/DefaultClientRequestObservationConvention.java
@@ -37,9 +37,9 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 
 	private static final String DEFAULT_NAME = "http.client.requests";
 
-	private static final KeyValue URI_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.URI, "none");
+	private static final KeyValue URI_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.URI, KeyValue.NONE_VALUE);
 
-	private static final KeyValue METHOD_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.METHOD, "none");
+	private static final KeyValue METHOD_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.METHOD, KeyValue.NONE_VALUE);
 
 	private static final KeyValue STATUS_IO_ERROR = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.STATUS, "IO_ERROR");
 
@@ -49,11 +49,11 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 
 	private static final KeyValue HTTP_OUTCOME_UNKNOWN = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.OUTCOME, "UNKNOWN");
 
-	private static final KeyValue EXCEPTION_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.EXCEPTION, "none");
+	private static final KeyValue EXCEPTION_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.EXCEPTION, KeyValue.NONE_VALUE);
 
-	private static final KeyValue HTTP_URL_NONE = KeyValue.of(ClientHttpObservationDocumentation.HighCardinalityKeyNames.HTTP_URL, "none");
+	private static final KeyValue HTTP_URL_NONE = KeyValue.of(ClientHttpObservationDocumentation.HighCardinalityKeyNames.HTTP_URL, KeyValue.NONE_VALUE);
 
-	private static final KeyValue CLIENT_NAME_NONE = KeyValue.of(ClientHttpObservationDocumentation.HighCardinalityKeyNames.CLIENT_NAME, "none");
+	private static final KeyValue CLIENT_NAME_NONE = KeyValue.of(ClientHttpObservationDocumentation.HighCardinalityKeyNames.CLIENT_NAME, KeyValue.NONE_VALUE);
 
 
 	private final String name;

--- a/spring-web/src/main/java/org/springframework/http/observation/DefaultServerRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/observation/DefaultServerRequestObservationConvention.java
@@ -48,7 +48,7 @@ public class DefaultServerRequestObservationConvention implements ServerRequestO
 
 	private static final KeyValue URI_REDIRECTION = KeyValue.of(ServerHttpObservationDocumentation.LowCardinalityKeyNames.URI, "REDIRECTION");
 
-	private static final KeyValue EXCEPTION_NONE = KeyValue.of(ServerHttpObservationDocumentation.LowCardinalityKeyNames.EXCEPTION, "none");
+	private static final KeyValue EXCEPTION_NONE = KeyValue.of(ServerHttpObservationDocumentation.LowCardinalityKeyNames.EXCEPTION, KeyValue.NONE_VALUE);
 
 	private static final KeyValue HTTP_URL_UNKNOWN = KeyValue.of(ServerHttpObservationDocumentation.HighCardinalityKeyNames.HTTP_URL, "UNKNOWN");
 

--- a/spring-web/src/main/java/org/springframework/http/observation/ServerHttpObservationDocumentation.java
+++ b/spring-web/src/main/java/org/springframework/http/observation/ServerHttpObservationDocumentation.java
@@ -16,6 +16,7 @@
 
 package org.springframework.http.observation;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
@@ -55,7 +56,7 @@ public enum ServerHttpObservationDocumentation implements ObservationDocumentati
 	public enum LowCardinalityKeyNames implements KeyName {
 
 		/**
-		 * Name of HTTP request method or {@code "none"} if the request was not received properly.
+		 * Name of HTTP request method or {@value KeyValue#NONE_VALUE} if the request was not received properly.
 		 */
 		METHOD {
 			@Override
@@ -88,7 +89,7 @@ public enum ServerHttpObservationDocumentation implements ObservationDocumentati
 		},
 
 		/**
-		 * Name of the exception thrown during the exchange, or {@code "none"} if no exception happened.
+		 * Name of the exception thrown during the exchange, or {@value KeyValue#NONE_VALUE}} if no exception happened.
 		 */
 		EXCEPTION {
 			@Override

--- a/spring-web/src/main/java/org/springframework/http/observation/reactive/DefaultServerRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/observation/reactive/DefaultServerRequestObservationConvention.java
@@ -50,7 +50,7 @@ public class DefaultServerRequestObservationConvention implements ServerRequestO
 
 	private static final KeyValue URI_REDIRECTION = KeyValue.of(ServerHttpObservationDocumentation.LowCardinalityKeyNames.URI, "REDIRECTION");
 
-	private static final KeyValue EXCEPTION_NONE = KeyValue.of(ServerHttpObservationDocumentation.LowCardinalityKeyNames.EXCEPTION, "none");
+	private static final KeyValue EXCEPTION_NONE = KeyValue.of(ServerHttpObservationDocumentation.LowCardinalityKeyNames.EXCEPTION, KeyValue.NONE_VALUE);
 
 	private static final KeyValue HTTP_URL_UNKNOWN = KeyValue.of(ServerHttpObservationDocumentation.HighCardinalityKeyNames.HTTP_URL, "UNKNOWN");
 

--- a/spring-web/src/main/java/org/springframework/http/observation/reactive/ServerHttpObservationDocumentation.java
+++ b/spring-web/src/main/java/org/springframework/http/observation/reactive/ServerHttpObservationDocumentation.java
@@ -16,6 +16,7 @@
 
 package org.springframework.http.observation.reactive;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
@@ -55,7 +56,7 @@ public enum ServerHttpObservationDocumentation implements ObservationDocumentati
 	public enum LowCardinalityKeyNames implements KeyName {
 
 		/**
-		 * Name of HTTP request method or {@code "none"} if the request was not received properly.
+		 * Name of HTTP request method or {@value KeyValue#NONE_VALUE} if the request was not received properly.
 		 */
 		METHOD {
 			@Override
@@ -88,7 +89,7 @@ public enum ServerHttpObservationDocumentation implements ObservationDocumentati
 		},
 
 		/**
-		 * Name of the exception thrown during the exchange, or {@code "none"} if no exception happened.
+		 * Name of the exception thrown during the exchange, or {@value KeyValue#NONE_VALUE} if no exception happened.
 		 */
 		EXCEPTION {
 			@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientHttpObservationDocumentation.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientHttpObservationDocumentation.java
@@ -16,6 +16,7 @@
 
 package org.springframework.web.reactive.function.client;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
@@ -54,7 +55,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 	public enum LowCardinalityKeyNames implements KeyName {
 
 		/**
-		 * Name of HTTP request method or {@code "none"} if the request could not be created.
+		 * Name of HTTP request method or {@value KeyValue#NONE_VALUE} if the request could not be created.
 		 */
 		METHOD {
 			@Override
@@ -65,7 +66,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 		},
 
 		/**
-		 * URI template used for HTTP request, or {@code "none"} if none was provided.
+		 * URI template used for HTTP request, or {@value KeyValue#NONE_VALUE} if none was provided.
 		 */
 		URI {
 			@Override
@@ -86,7 +87,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 		},
 
 		/**
-		 * Name of the exception thrown during the exchange, or {@code "none"} if no exception happened.
+		 * Name of the exception thrown during the exchange, or {@value KeyValue#NONE_VALUE} if no exception happened.
 		 */
 		EXCEPTION {
 			@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConvention.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConvention.java
@@ -36,9 +36,9 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 
 	private static final String DEFAULT_NAME = "http.client.requests";
 
-	private static final KeyValue URI_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.URI, "none");
+	private static final KeyValue URI_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.URI, KeyValue.NONE_VALUE);
 
-	private static final KeyValue METHOD_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.METHOD, "none");
+	private static final KeyValue METHOD_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.METHOD, KeyValue.NONE_VALUE);
 
 	private static final KeyValue STATUS_IO_ERROR = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.STATUS, "IO_ERROR");
 
@@ -48,11 +48,11 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 
 	private static final KeyValue HTTP_OUTCOME_UNKNOWN = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.OUTCOME, "UNKNOWN");
 
-	private static final KeyValue EXCEPTION_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.EXCEPTION, "none");
+	private static final KeyValue EXCEPTION_NONE = KeyValue.of(ClientHttpObservationDocumentation.LowCardinalityKeyNames.EXCEPTION, KeyValue.NONE_VALUE);
 
-	private static final KeyValue HTTP_URL_NONE = KeyValue.of(ClientHttpObservationDocumentation.HighCardinalityKeyNames.HTTP_URL, "none");
+	private static final KeyValue HTTP_URL_NONE = KeyValue.of(ClientHttpObservationDocumentation.HighCardinalityKeyNames.HTTP_URL, KeyValue.NONE_VALUE);
 
-	private static final KeyValue CLIENT_NAME_NONE = KeyValue.of(ClientHttpObservationDocumentation.HighCardinalityKeyNames.CLIENT_NAME, "none");
+	private static final KeyValue CLIENT_NAME_NONE = KeyValue.of(ClientHttpObservationDocumentation.HighCardinalityKeyNames.CLIENT_NAME, KeyValue.NONE_VALUE);
 
 	private final String name;
 


### PR DESCRIPTION
This PR changes to use `KeyValue.NONE_VALUE` where possible.

See https://github.com/micrometer-metrics/micrometer/issues/3458