### PR TITLE
Fix typo: "as describe in" -> "as described in"

### DIFF
--- a/src/docs/asciidoc/core/core-beans.adoc
+++ b/src/docs/asciidoc/core/core-beans.adoc
@@ -9263,7 +9263,7 @@ is not strictly required.
 --
 Because `@Configuration` is meta-annotated with `@Component`, `@Configuration`-annotated
 classes are automatically candidates for component scanning. Using the same scenario as
-describe in the previous example, we can redefine `system-test-config.xml` to take advantage of component-scanning.
+described in the previous example, we can redefine `system-test-config.xml` to take advantage of component-scanning.
 Note that, in this case, we need not explicitly declare
 `<context:annotation-config/>`, because `<context:component-scan/>` enables the same
 functionality.


### PR DESCRIPTION
This fixes a simple typo.

I believe this counts as an "obvious fix" with respect to the Contributor License Agreement.