### PR TITLE
Always logging stack trace on bean dispose/close failed.

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
@@ -200,13 +200,7 @@ class DisposableBeanAdapter implements DisposableBean, Runnable, Serializable {
 				((DisposableBean) this.bean).destroy();
 			}
 			catch (Throwable ex) {
-				String msg = "Invocation of destroy method failed on bean with name '" + this.beanName + "'";
-				if (logger.isDebugEnabled()) {
-					logger.warn(msg, ex);
-				}
-				else {
-					logger.warn(msg + ": " + ex);
-				}
+				logger.warn("Invocation of destroy method failed on bean with name '" + this.beanName + "'", ex);
 			}
 		}
 
@@ -218,13 +212,7 @@ class DisposableBeanAdapter implements DisposableBean, Runnable, Serializable {
 				((AutoCloseable) this.bean).close();
 			}
 			catch (Throwable ex) {
-				String msg = "Invocation of close method failed on bean with name '" + this.beanName + "'";
-				if (logger.isDebugEnabled()) {
-					logger.warn(msg, ex);
-				}
-				else {
-					logger.warn(msg + ": " + ex);
-				}
+				logger.warn("Invocation of close method failed on bean with name '" + this.beanName + "'", ex);
 			}
 		}
 		else if (this.destroyMethods != null) {
@@ -283,14 +271,8 @@ class DisposableBeanAdapter implements DisposableBean, Runnable, Serializable {
 			destroyMethod.invoke(this.bean, args);
 		}
 		catch (InvocationTargetException ex) {
-			String msg = "Custom destroy method '" + destroyMethod.getName() + "' on bean with name '" +
-					this.beanName + "' threw an exception";
-			if (logger.isDebugEnabled()) {
-				logger.warn(msg, ex.getTargetException());
-			}
-			else {
-				logger.warn(msg + ": " + ex.getTargetException());
-			}
+			logger.warn("Custom destroy method '" + destroyMethod.getName() + "' on bean with name '" +
+					this.beanName + "' threw an exception", ex.getTargetException());
 		}
 		catch (Throwable ex) {
 			logger.warn("Failed to invoke custom destroy method '" + destroyMethod.getName() +


### PR DESCRIPTION
Motivation
====

I noticed that warn log on bean close faield is not enough for identify root cause in some case.

The actual log I received is as follows,

```
[WARN] (DisposableBeanAdapter.java:248) Invocation of close method failed on bean with name 'webHookEventDecatonClient': java.lang.NoSuchMethodError: 'void org.apache.kafka.clients.producer.Producer.close(long, java.util.concurrent.TimeUnit)'
```

Without stack trace, I can't identify what is wrong. I think printing stack trace is always good idea when logging warn based on exception.

Also, it is not clear why the contents of the Warn Log change depending on whether the Debug Flag is enabled or not.