### PR TITLE
Minor fixes in spring-websocket

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/client/standard/AnnotatedEndpointConnectionManager.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/client/standard/AnnotatedEndpointConnectionManager.java
@@ -33,7 +33,7 @@ import org.springframework.web.socket.handler.BeanCreatingHandlerProvider;
 /**
  * WebSocket {@link ConnectionManagerSupport connection manager} that connects
  * to the server via {@link WebSocketContainer} and handles the session with an
- * {@link javax.websocket.ClientEndpoint @ClientEndpoint} endpoint.
+ * {@link jakarta.websocket.ClientEndpoint @ClientEndpoint} endpoint.
  *
  * @author Rossen Stoyanchev
  * @since 4.0

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/SockJsServiceRegistration.java
@@ -102,7 +102,7 @@ public class SockJsServiceRegistration {
 	 * server. Since the iframe needs to load the SockJS javascript client library,
 	 * this property allows specifying where to load it from.
 	 * <p>By default this is set to point to
-	 * "https://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js". However it can
+	 * "<a href="https://cdn.jsdelivr.net/sockjs/1.0.0/sockjs.min.js">sockjs.min.js</a>". However, it can
 	 * also be set to point to a URL served by the application.
 	 * <p>Note that it's possible to specify a relative URL in which case the URL
 	 * must be relative to the iframe URL. For example assuming a SockJS endpoint

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/SessionDisconnectEvent.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/SessionDisconnectEvent.java
@@ -89,7 +89,7 @@ public class SessionDisconnectEvent extends AbstractSubProtocolEvent {
 
 	@Override
 	public String toString() {
-		return "SessionDisconnectEvent[sessionId=" + this.sessionId + ", " + this.status.toString() + "]";
+		return "SessionDisconnectEvent[sessionId=" + this.sessionId + ", " + this.status + "]";
 	}
 
 }

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/frame/AbstractSockJsMessageCodec.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/frame/AbstractSockJsMessageCodec.java
@@ -46,7 +46,7 @@ public abstract class AbstractSockJsMessageCodec implements SockJsMessageCodec {
 	}
 
 	/**
-	 * Apply standard JSON string quoting (see https://www.json.org/).
+	 * Apply standard JSON string quoting (see <a href="https://www.json.org/">json.org</a>).
 	 */
 	protected abstract char[] applyJsonQuoting(String content);
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
@@ -618,17 +618,17 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 						<!DOCTYPE html>
 						<html>
 						<head>
-						  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-						  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-						  <script>
-						    document.domain = document.domain;
-						    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
-						  </script>
-						  <script src="%s"></script>
+							<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+							<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+							<script>
+								document.domain = document.domain;
+								_sockjs_onload = function(){SockJS.bootstrap_iframe();};
+							</script>
+							<script src="%s"></script>
 						</head>
 						<body>
-						  <h2>Don't panic!</h2>
-						  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
+							<h2>Don't panic!</h2>
+							<p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
 						</body>
 						</html>""";
 

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
@@ -614,22 +614,23 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 	private class IframeHandler implements SockJsRequestHandler {
 
 		private static final String IFRAME_CONTENT =
-				"<!DOCTYPE html>\n" +
-				"<html>\n" +
-				"<head>\n" +
-				"  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />\n" +
-				"  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n" +
-				"  <script>\n" +
-				"    document.domain = document.domain;\n" +
-				"    _sockjs_onload = function(){SockJS.bootstrap_iframe();};\n" +
-				"  </script>\n" +
-				"  <script src=\"%s\"></script>\n" +
-				"</head>\n" +
-				"<body>\n" +
-				"  <h2>Don't panic!</h2>\n" +
-				"  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>\n" +
-				"</body>\n" +
-				"</html>";
+				"""
+						<!DOCTYPE html>
+						<html>
+						<head>
+						  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+						  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+						  <script>
+						    document.domain = document.domain;
+						    _sockjs_onload = function(){SockJS.bootstrap_iframe();};
+						  </script>
+						  <script src="%s"></script>
+						</head>
+						<body>
+						  <h2>Don't panic!</h2>
+						  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>
+						</body>
+						</html>""";
 
 		@Override
 		public void handle(ServerHttpRequest request, ServerHttpResponse response) throws IOException {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
@@ -149,7 +149,7 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 	 * server. Since the iframe needs to load the SockJS javascript client library,
 	 * this property allows specifying where to load it from.
 	 * <p>By default this is set to point to
-	 * "https://cdn.jsdelivr.net/sockjs/1.0.0/sockjs.min.js".
+	 * "<a href="https://cdn.jsdelivr.net/sockjs/1.0.0/sockjs.min.js">sockjs.min.js</a>".
 	 * However, it can also be set to point to a URL served by the application.
 	 * <p>Note that it's possible to specify a relative URL in which case the URL
 	 * must be relative to the iframe URL. For example assuming a SockJS endpoint

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/HtmlFileTransportHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/HtmlFileTransportHandler.java
@@ -60,18 +60,19 @@ public class HtmlFileTransportHandler extends AbstractHttpSendingTransportHandle
 
 	static {
 		StringBuilder sb = new StringBuilder(
-				"<!doctype html>\n" +
-				"<html><head>\n" +
-				"  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />\n" +
-				"  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n" +
-				"</head><body><h2>Don't panic!</h2>\n" +
-				"  <script>\n" +
-				"    document.domain = document.domain;\n" +
-				"    var c = parent.%s;\n" +
-				"    c.start();\n" +
-				"    function p(d) {c.message(d);};\n" +
-				"    window.onload = function() {c.stop();};\n" +
-				"  </script>"
+				"""
+						<!doctype html>
+						<html><head>
+						  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+						  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+						</head><body><h2>Don't panic!</h2>
+						  <script>
+						    document.domain = document.domain;
+						    var c = parent.%s;
+						    c.start();
+						    function p(d) {c.message(d);};
+						    window.onload = function() {c.stop();};
+						  </script>"""
 				);
 
 		while (sb.length() < MINIMUM_PARTIAL_HTML_CONTENT_LENGTH) {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/HtmlFileTransportHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/HtmlFileTransportHandler.java
@@ -61,18 +61,18 @@ public class HtmlFileTransportHandler extends AbstractHttpSendingTransportHandle
 	static {
 		StringBuilder sb = new StringBuilder(
 				"""
-						<!doctype html>
+						<!DOCTYPE html>
 						<html><head>
-						  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-						  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+							<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+							<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 						</head><body><h2>Don't panic!</h2>
-						  <script>
-						    document.domain = document.domain;
-						    var c = parent.%s;
-						    c.start();
-						    function p(d) {c.message(d);};
-						    window.onload = function() {c.stop();};
-						  </script>"""
+							<script>
+								document.domain = document.domain;
+								var c = parent.%s;
+								c.start();
+								function p(d) {c.message(d);};
+								window.onload = function() {c.stop();};
+							</script>"""
 				);
 
 		while (sb.length() < MINIMUM_PARTIAL_HTML_CONTENT_LENGTH) {

--- a/spring-websocket/src/test/java/org/springframework/web/socket/adapter/standard/ConvertingEncoderDecoderSupportTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/adapter/standard/ConvertingEncoderDecoderSupportTests.java
@@ -244,7 +244,7 @@ public class ConvertingEncoderDecoderSupportTests {
 	private static class MyTypeToStringConverter implements Converter<MyType, String> {
 		@Override
 		public String convert(MyType source) {
-			return "_" + source.toString();
+			return "_" + source;
 		}
 	}
 
@@ -252,7 +252,7 @@ public class ConvertingEncoderDecoderSupportTests {
 	private static class MyTypeToBytesConverter implements Converter<MyType, byte[]> {
 		@Override
 		public byte[] convert(MyType source) {
-			return ("~" + source.toString()).getBytes();
+			return ("~" + source).getBytes();
 		}
 	}
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/client/WebSocketConnectionManagerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/client/WebSocketConnectionManagerTests.java
@@ -17,7 +17,6 @@
 package org.springframework.web.socket.client;
 
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -45,7 +44,7 @@ public class WebSocketConnectionManagerTests {
 
 	@Test
 	public void openConnection() throws Exception {
-		List<String> subprotocols = Arrays.asList("abc");
+		List<String> subprotocols = List.of("abc");
 
 		TestLifecycleWebSocketClient client = new TestLifecycleWebSocketClient(false);
 		WebSocketHandler handler = new TextWebSocketHandler();

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistrationTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompWebSocketEndpointRegistrationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.web.socket.config.annotation;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -72,7 +71,7 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 		Map.Entry<HttpRequestHandler, List<String>> entry = mappings.entrySet().iterator().next();
 		assertThat(((WebSocketHttpRequestHandler) entry.getKey()).getWebSocketHandler()).isNotNull();
 		assertThat(((WebSocketHttpRequestHandler) entry.getKey()).getHandshakeInterceptors().size()).isEqualTo(1);
-		assertThat(entry.getValue()).isEqualTo(Arrays.asList("/foo"));
+		assertThat(entry.getValue()).isEqualTo(List.of("/foo"));
 	}
 
 	@Test
@@ -190,7 +189,7 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 		assertThat(mappings.size()).isEqualTo(1);
 
 		Map.Entry<HttpRequestHandler, List<String>> entry = mappings.entrySet().iterator().next();
-		assertThat(entry.getValue()).isEqualTo(Arrays.asList("/foo"));
+		assertThat(entry.getValue()).isEqualTo(List.of("/foo"));
 
 		WebSocketHttpRequestHandler requestHandler = (WebSocketHttpRequestHandler) entry.getKey();
 		assertThat(requestHandler.getWebSocketHandler()).isNotNull();
@@ -214,7 +213,7 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 		assertThat(mappings.size()).isEqualTo(1);
 
 		Map.Entry<HttpRequestHandler, List<String>> entry = mappings.entrySet().iterator().next();
-		assertThat(entry.getValue()).isEqualTo(Arrays.asList("/foo"));
+		assertThat(entry.getValue()).isEqualTo(List.of("/foo"));
 
 		WebSocketHttpRequestHandler requestHandler = (WebSocketHttpRequestHandler) entry.getKey();
 		assertThat(requestHandler.getWebSocketHandler()).isNotNull();
@@ -238,7 +237,7 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 		assertThat(mappings.size()).isEqualTo(1);
 
 		Map.Entry<HttpRequestHandler, List<String>> entry = mappings.entrySet().iterator().next();
-		assertThat(entry.getValue()).isEqualTo(Arrays.asList("/foo/**"));
+		assertThat(entry.getValue()).isEqualTo(List.of("/foo/**"));
 
 		SockJsHttpRequestHandler requestHandler = (SockJsHttpRequestHandler) entry.getKey();
 		assertThat(requestHandler.getWebSocketHandler()).isNotNull();
@@ -270,7 +269,7 @@ public class WebMvcStompWebSocketEndpointRegistrationTests {
 		assertThat(mappings.size()).isEqualTo(1);
 
 		Map.Entry<HttpRequestHandler, List<String>> entry = mappings.entrySet().iterator().next();
-		assertThat(entry.getValue()).isEqualTo(Arrays.asList("/foo/**"));
+		assertThat(entry.getValue()).isEqualTo(List.of("/foo/**"));
 
 		SockJsHttpRequestHandler requestHandler = (SockJsHttpRequestHandler) entry.getKey();
 		assertThat(requestHandler.getWebSocketHandler()).isNotNull();

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/StompSubProtocolHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/StompSubProtocolHandlerTests.java
@@ -109,7 +109,11 @@ public class StompSubProtocolHandlerTests {
 
 		assertThat(this.session.getSentMessages().size()).isEqualTo(1);
 		WebSocketMessage<?> textMessage = this.session.getSentMessages().get(0);
-		assertThat(textMessage.getPayload()).isEqualTo(("CONNECTED\n" + "user-name:joe\n" + "\n" + "\u0000"));
+		assertThat(textMessage.getPayload()).isEqualTo(("""
+				CONNECTED
+				user-name:joe
+
+				\u0000"""));
 	}
 
 	@Test
@@ -123,7 +127,11 @@ public class StompSubProtocolHandlerTests {
 
 		assertThat(this.session.getSentMessages().size()).isEqualTo(1);
 		WebSocketMessage<?> textMessage = this.session.getSentMessages().get(0);
-		assertThat(textMessage.getPayload()).isEqualTo(("CONNECTED\n" + "user-name:joe\n" + "\n" + "\u0000"));
+		assertThat(textMessage.getPayload()).isEqualTo(("""
+				CONNECTED
+				user-name:joe
+
+				\u0000"""));
 	}
 
 	@Test
@@ -142,8 +150,13 @@ public class StompSubProtocolHandlerTests {
 
 		assertThat(this.session.getSentMessages().size()).isEqualTo(1);
 		TextMessage actual = (TextMessage) this.session.getSentMessages().get(0);
-		assertThat(actual.getPayload()).isEqualTo(("CONNECTED\n" + "version:1.2\n" + "heart-beat:15000,15000\n" +
-				"user-name:joe\n" + "\n" + "\u0000"));
+		assertThat(actual.getPayload()).isEqualTo(("""
+				CONNECTED
+				version:1.2
+				heart-beat:15000,15000
+				user-name:joe
+
+				\u0000"""));
 	}
 
 	@Test
@@ -161,8 +174,13 @@ public class StompSubProtocolHandlerTests {
 
 		assertThat(this.session.getSentMessages().size()).isEqualTo(1);
 		TextMessage actual = (TextMessage) this.session.getSentMessages().get(0);
-		assertThat(actual.getPayload()).isEqualTo(("CONNECTED\n" + "version:1.0\n" + "heart-beat:0,0\n" +
-				"user-name:joe\n" + "\n" + "\u0000"));
+		assertThat(actual.getPayload()).isEqualTo(("""
+				CONNECTED
+				version:1.0
+				heart-beat:0,0
+				user-name:joe
+
+				\u0000"""));
 	}
 
 	@Test
@@ -178,8 +196,12 @@ public class StompSubProtocolHandlerTests {
 
 		assertThat(this.session.getSentMessages().size()).isEqualTo(1);
 		TextMessage actual = (TextMessage) this.session.getSentMessages().get(0);
-		assertThat(actual.getPayload()).isEqualTo(("ERROR\n" + "message:Session closed.\n" + "content-length:0\n" +
-				"\n\u0000"));
+		assertThat(actual.getPayload()).isEqualTo(("""
+				ERROR
+				message:Session closed.
+				content-length:0
+
+				\u0000"""));
 	}
 
 	@Test
@@ -196,7 +218,11 @@ public class StompSubProtocolHandlerTests {
 
 		assertThat(this.session.getSentMessages().size()).isEqualTo(1);
 		TextMessage actual = (TextMessage) this.session.getSentMessages().get(0);
-		assertThat(actual.getPayload()).isEqualTo(("RECEIPT\n" + "receipt-id:message-123\n" + "\n\u0000"));
+		assertThat(actual.getPayload()).isEqualTo(("""
+				RECEIPT
+				receipt-id:message-123
+
+				\u0000"""));
 	}
 
 	@Test
@@ -391,7 +417,11 @@ public class StompSubProtocolHandlerTests {
 		assertThat(this.session.getSentMessages()).hasSize(1);
 		WebSocketMessage<?> textMessage = this.session.getSentMessages().get(0);
 		assertThat(textMessage.getPayload())
-				.isEqualTo("CONNECTED\n" + "user-name:__pete__@gmail.com\n" + "\n" + "\u0000");
+				.isEqualTo("""
+						CONNECTED
+						user-name:__pete__@gmail.com
+
+						\u0000""");
 	}
 
 	@Test
@@ -470,7 +500,11 @@ public class StompSubProtocolHandlerTests {
 
 		assertThat(this.session.getSentMessages().size()).isEqualTo(1);
 		textMessage = (TextMessage) this.session.getSentMessages().get(0);
-		assertThat(textMessage.getPayload()).isEqualTo(("CONNECTED\n" + "user-name:joe\n" + "\n" + "\u0000"));
+		assertThat(textMessage.getPayload()).isEqualTo(("""
+				CONNECTED
+				user-name:joe
+
+				\u0000"""));
 
 		this.protocolHandler.afterSessionEnded(this.session, CloseStatus.BAD_DATA, this.channel);
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/SubProtocolWebSocketHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/SubProtocolWebSocketHandlerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.web.socket.messaging;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +71,7 @@ public class SubProtocolWebSocketHandlerTests {
 	public void setup() {
 		this.webSocketHandler = new SubProtocolWebSocketHandler(this.inClientChannel, this.outClientChannel);
 		given(stompHandler.getSupportedProtocols()).willReturn(Arrays.asList("v10.stomp", "v11.stomp", "v12.stomp"));
-		given(mqttHandler.getSupportedProtocols()).willReturn(Arrays.asList("MQTT"));
+		given(mqttHandler.getSupportedProtocols()).willReturn(List.of("MQTT"));
 		this.session = new TestWebSocketSession();
 		this.session.setId("1");
 		this.session.setOpen(true);
@@ -133,7 +134,7 @@ public class SubProtocolWebSocketHandlerTests {
 
 	@Test
 	public void noSubProtocolOneHandler() throws Exception {
-		this.webSocketHandler.setProtocolHandlers(Arrays.asList(stompHandler));
+		this.webSocketHandler.setProtocolHandlers(List.of(stompHandler));
 		this.webSocketHandler.afterConnectionEstablished(session);
 
 		verify(this.stompHandler).afterSessionStarted(
@@ -164,7 +165,7 @@ public class SubProtocolWebSocketHandlerTests {
 		session1.setAcceptedProtocol("v12.stomp");
 		session2.setAcceptedProtocol("v12.stomp");
 
-		this.webSocketHandler.setProtocolHandlers(Arrays.asList(this.stompHandler));
+		this.webSocketHandler.setProtocolHandlers(List.of(this.stompHandler));
 		this.webSocketHandler.afterConnectionEstablished(session1);
 		this.webSocketHandler.afterConnectionEstablished(session2);
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/server/support/OriginHandshakeInterceptorTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/server/support/OriginHandshakeInterceptorTests.java
@@ -120,7 +120,7 @@ public class OriginHandshakeInterceptorTests extends AbstractHttpRequestTests {
 	public void sameOriginMatchWithAllowedOrigins() throws Exception {
 		this.servletRequest.addHeader(HttpHeaders.ORIGIN, "http://mydomain2.example");
 		this.servletRequest.setServerName("mydomain2.example");
-		OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor(Arrays.asList("http://mydomain1.example"));
+		OriginHandshakeInterceptor interceptor = new OriginHandshakeInterceptor(List.of("http://mydomain1.example"));
 		assertThat(interceptor.beforeHandshake(request, response, wsHandler, attributes)).isTrue();
 		assertThat(HttpStatus.FORBIDDEN.value()).isNotEqualTo(servletResponse.getStatus());
 	}

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransportTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransportTests.java
@@ -91,7 +91,7 @@ public class RestTemplateXhrTransportTests {
 		for (int i = 0; i < 2048; i++) {
 			sb.append('h');
 		}
-		String body = sb.toString() + "\n" + "o\n" + "a[\"foo\"]\n" + "c[3000,\"Go away!\"]";
+		String body = sb + "\n" + "o\n" + "a[\"foo\"]\n" + "c[3000,\"Go away!\"]";
 		ClientHttpResponse response = response(HttpStatus.OK, body);
 		connect(response);
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransportTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransportTests.java
@@ -75,7 +75,10 @@ public class RestTemplateXhrTransportTests {
 
 	@Test
 	public void connectReceiveAndClose() throws Exception {
-		String body = "o\n" + "a[\"foo\"]\n" + "c[3000,\"Go away!\"]";
+		String body = """
+				o
+				a["foo"]
+				c[3000,"Go away!"]""";
 		ClientHttpResponse response = response(HttpStatus.OK, body);
 		connect(response);
 
@@ -157,7 +160,11 @@ public class RestTemplateXhrTransportTests {
 
 	@Test
 	public void responseClosedAfterDisconnected() throws Exception {
-		String body = "o\n" + "c[3000,\"Go away!\"]\n" + "a[\"foo\"]\n";
+		String body = """
+				o
+				c[3000,"Go away!"]
+				a["foo"]
+				""";
 		ClientHttpResponse response = response(HttpStatus.OK, body);
 		connect(response);
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/support/SockJsServiceTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/support/SockJsServiceTests.java
@@ -238,14 +238,14 @@ public class SockJsServiceTests extends AbstractHttpRequestTests {
 
 		assertThat(this.servletResponse.getContentType()).isEqualTo("text/html;charset=UTF-8");
 		assertThat(this.servletResponse.getContentAsString().startsWith("<!DOCTYPE html>\n")).isTrue();
-		assertThat(this.servletResponse.getContentLength()).isEqualTo(490);
+		assertThat(this.servletResponse.getContentLength()).isEqualTo(479);
 		assertThat(this.response.getHeaders().getCacheControl()).isEqualTo("no-store, no-cache, must-revalidate, max-age=0");
-		assertThat(this.response.getHeaders().getETag()).isEqualTo("\"0096cbd37f2a5218c33bb0826a7c74cbf\"");
+		assertThat(this.response.getHeaders().getETag()).isEqualTo("\"096aaf2482e2a85effc0ab65a61993ae0\"");
 	}
 
 	@Test
 	public void handleIframeRequestNotModified() {
-		this.servletRequest.addHeader("If-None-Match", "\"0096cbd37f2a5218c33bb0826a7c74cbf\"");
+		this.servletRequest.addHeader("If-None-Match", "\"096aaf2482e2a85effc0ab65a61993ae0\"");
 		resetResponseAndHandleRequest("GET", "/echo/iframe.html", HttpStatus.NOT_MODIFIED);
 	}
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/handler/DefaultSockJsServiceTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/handler/DefaultSockJsServiceTests.java
@@ -187,7 +187,7 @@ public class DefaultSockJsServiceTests extends AbstractHttpRequestTests {
 	public void handleTransportRequestXhrSameOrigin() throws Exception {
 		String sockJsPath = sessionUrlPrefix + "xhr";
 		setRequest("POST", sockJsPrefix + sockJsPath);
-		this.service.setAllowedOrigins(Arrays.asList("https://mydomain1.example"));
+		this.service.setAllowedOrigins(List.of("https://mydomain1.example"));
 		this.servletRequest.addHeader(HttpHeaders.ORIGIN, "https://mydomain1.example");
 		this.servletRequest.setServerName("mydomain2.example");
 		this.service.handleRequest(this.request, this.response, sockJsPath, this.wsHandler);
@@ -199,7 +199,7 @@ public class DefaultSockJsServiceTests extends AbstractHttpRequestTests {
 	public void handleInvalidTransportType() throws Exception {
 		String sockJsPath = sessionUrlPrefix + "invalid";
 		setRequest("POST", sockJsPrefix + sockJsPath);
-		this.service.setAllowedOrigins(Arrays.asList("https://mydomain1.example"));
+		this.service.setAllowedOrigins(List.of("https://mydomain1.example"));
 		this.servletRequest.addHeader(HttpHeaders.ORIGIN, "https://mydomain2.example");
 		this.servletRequest.setServerName("mydomain2.example");
 		this.service.handleRequest(this.request, this.response, sockJsPath, this.wsHandler);

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/handler/HttpReceivingTransportHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/handler/HttpReceivingTransportHandlerTests.java
@@ -26,6 +26,8 @@ import org.springframework.web.socket.sockjs.transport.session.AbstractSockJsSes
 import org.springframework.web.socket.sockjs.transport.session.StubSockJsServiceConfig;
 import org.springframework.web.socket.sockjs.transport.session.TestHttpSockJsSession;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -44,7 +46,7 @@ public class HttpReceivingTransportHandlerTests extends AbstractHttpRequestTests
 
 	@Test
 	public void readMessagesXhr() throws Exception {
-		this.servletRequest.setContent("[\"x\"]".getBytes("UTF-8"));
+		this.servletRequest.setContent("[\"x\"]".getBytes(StandardCharsets.UTF_8));
 		handleRequest(new XhrReceivingTransportHandler());
 
 		assertThat(this.servletResponse.getStatus()).isEqualTo(204);
@@ -52,10 +54,10 @@ public class HttpReceivingTransportHandlerTests extends AbstractHttpRequestTests
 
 	@Test
 	public void readMessagesBadContent() throws Exception {
-		this.servletRequest.setContent("".getBytes("UTF-8"));
+		this.servletRequest.setContent("".getBytes(StandardCharsets.UTF_8));
 		handleRequestAndExpectFailure();
 
-		this.servletRequest.setContent("[\"x]".getBytes("UTF-8"));
+		this.servletRequest.setContent("[\"x]".getBytes(StandardCharsets.UTF_8));
 		handleRequestAndExpectFailure();
 	}
 
@@ -69,7 +71,7 @@ public class HttpReceivingTransportHandlerTests extends AbstractHttpRequestTests
 	@Test
 	public void delegateMessageException() throws Exception {
 		StubSockJsServiceConfig sockJsConfig = new StubSockJsServiceConfig();
-		this.servletRequest.setContent("[\"x\"]".getBytes("UTF-8"));
+		this.servletRequest.setContent("[\"x\"]".getBytes(StandardCharsets.UTF_8));
 
 		WebSocketHandler wsHandler = mock(WebSocketHandler.class);
 		TestHttpSockJsSession session = new TestHttpSockJsSession("1", sockJsConfig, wsHandler, null);

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/handler/HttpReceivingTransportHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/handler/HttpReceivingTransportHandlerTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.socket.sockjs.transport.handler;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.web.socket.AbstractHttpRequestTests;
@@ -25,8 +27,6 @@ import org.springframework.web.socket.sockjs.SockJsMessageDeliveryException;
 import org.springframework.web.socket.sockjs.transport.session.AbstractSockJsSession;
 import org.springframework.web.socket.sockjs.transport.session.StubSockJsServiceConfig;
 import org.springframework.web.socket.sockjs.transport.session.TestHttpSockJsSession;
-
-import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/session/WebSocketServerSockJsSessionTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/transport/session/WebSocketServerSockJsSessionTests.java
@@ -79,7 +79,7 @@ public class WebSocketServerSockJsSessionTests extends AbstractSockJsSessionTest
 	public void afterSessionInitialized() throws Exception {
 		this.session.initializeDelegateSession(this.webSocketSession);
 		assertThat(this.webSocketSession.getSentMessages()).isEqualTo(Collections.singletonList(new TextMessage("o")));
-		assertThat(this.session.heartbeatSchedulingEvents).isEqualTo(Arrays.asList("schedule"));
+		assertThat(this.session.heartbeatSchedulingEvents).isEqualTo(List.of("schedule"));
 		verify(this.webSocketHandler).afterConnectionEstablished(this.session);
 		verifyNoMoreInteractions(this.taskScheduler, this.webSocketHandler);
 	}


### PR DESCRIPTION
## Minor Fixes in spring-websocket
[Used Standard Charsets object](https://github.com/spring-projects/spring-framework/commit/5273af0ecf1aae26225bed2416d4548b98a05f41)


 
[Removed unnecessary call to toString](https://github.com/spring-projects/spring-framework/commit/57abf3df4a3e4c23741b90180e4b1915262e5760)


[Replaced concatenated strings with text blocks](https://github.com/spring-projects/spring-framework/commit/938ea47ca1162e15f49b0670dbec0a06ba2aeb5d)


[Removed Arrays.asList call with too few arguments](https://github.com/spring-projects/spring-framework/commit/fdae5f1e59eeca21c098f057d05c59f34252c662)


[Fixed Javadoc links](https://github.com/spring-projects/spring-framework/commit/994660114de4e52da9586aff89d4d2e74ee4a73f)

