### PR TITLE
Allow TransactionAwareDataSourceProxy to eagerly fetch the connection

### DIFF
--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/DataSourceTransactionManagerTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/DataSourceTransactionManagerTests.java
@@ -53,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
@@ -64,6 +65,7 @@ import static org.springframework.core.testfixture.TestGroup.LONG_RUNNING;
 
 /**
  * @author Juergen Hoeller
+ * @author Réda Housni Alaoui
  * @since 04.07.2003
  * @see org.springframework.jdbc.support.JdbcTransactionManagerTests
  */
@@ -1182,6 +1184,40 @@ public class DataSourceTransactionManagerTests  {
 		ordered.verify(con).commit();
 		ordered.verify(con).setAutoCommit(true);
 		verify(con, times(2)).close();
+	}
+
+	@Test
+	public void testTransactionAwareDataSourceProxyWithObtainTransactionalConnectionEagerly() throws SQLException {
+		given(con.getAutoCommit()).willReturn(true);
+		given(con.getWarnings()).willThrow(new SQLException());
+
+		TransactionTemplate tt = new TransactionTemplate(tm);
+		boolean condition1 = !TransactionSynchronizationManager.hasResource(ds);
+		assertThat(condition1).as("Hasn't thread connection").isTrue();
+		tt.execute(new TransactionCallbackWithoutResult() {
+			@Override
+			protected void doInTransactionWithoutResult(TransactionStatus status) {
+				// something transactional
+				assertThat(DataSourceUtils.getConnection(ds)).isEqualTo(con);
+				TransactionAwareDataSourceProxy dsProxy = new TransactionAwareDataSourceProxy(ds);
+				dsProxy.setObtainTransactionalConnectionEagerly(true);
+				try {
+					Connection connection = dsProxy.getConnection();
+					assertThatThrownBy(connection::getWarnings).isInstanceOf(SQLException.class);
+				}
+				catch (SQLException ex) {
+					throw new UncategorizedSQLException("", "", ex);
+				}
+			}
+		});
+
+		boolean condition = !TransactionSynchronizationManager.hasResource(ds);
+		assertThat(condition).as("Hasn't thread connection").isTrue();
+		InOrder ordered = inOrder(con);
+		ordered.verify(con).setAutoCommit(false);
+		ordered.verify(con).commit();
+		ordered.verify(con).setAutoCommit(true);
+		verify(con).close();
 	}
 
 	/**


### PR DESCRIPTION
Fix #29418 

Adds an `obtainTransactionalConnectionEagerly` flag allowing to retrieve the underlying connection during `getConnection` call. I think this flag should be always true to make sure the effective connection is fetched during the transaction covering `getConnection`. But I thought you would want to avoid breaking the current behaviour, so the flag is false by default.