### PR TITLE
Avoid String allocations in MediaType.checkParameters

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -544,10 +544,10 @@ public class MediaType extends MimeType implements Serializable {
 	protected void checkParameters(String parameter, String value) {
 		super.checkParameters(parameter, value);
 		if (PARAM_QUALITY_FACTOR.equals(parameter)) {
-			value = unquote(value);
-			double d = Double.parseDouble(value);
+			String unquotedValue = unquote(value);
+			double d = Double.parseDouble(unquotedValue);
 			Assert.isTrue(d >= 0D && d <= 1D,
-					"Invalid quality value \"" + value + "\": should be between 0.0 and 1.0");
+					() -> "Invalid quality value \"" + value + "\": should be between 0.0 and 1.0");
 		}
 	}
 


### PR DESCRIPTION
Hi,

while investigating things for #29421 I noticed that a tiny, but noticeable, chunk of allocations is coming from `MediaType.checkParameters`.

<img width="1666" alt="image" src="https://user-images.githubusercontent.com/6304496/199967949-0fbf1af5-97af-439c-8e5e-6527af61006b.png">

Together with the actual String allocation, this accounts for 1.5-2% of allocations in the benchmarks. So not huge, but avoidable if you ask me.

Cheers,
Christoph