### PR TITLE
TomcatRequestUpgradeStrategy is not compatible with Tomcat 10.1

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/upgrade/TomcatRequestUpgradeStrategy.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/upgrade/TomcatRequestUpgradeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,8 +121,6 @@ public class TomcatRequestUpgradeStrategy implements RequestUpgradeStrategy {
 		return this.maxBinaryMessageBufferSize;
 	}
 
-
-	@SuppressWarnings("deprecation")  // for old doUpgrade variant in Tomcat 9.0.55
 	@Override
 	public Mono<Void> upgrade(ServerWebExchange exchange, WebSocketHandler handler,
 			@Nullable String subProtocol, Supplier<HandshakeInfo> handshakeInfoFactory){
@@ -150,7 +148,7 @@ public class TomcatRequestUpgradeStrategy implements RequestUpgradeStrategy {
 
 					WsServerContainer container = getContainer(servletRequest);
 					try {
-						container.doUpgrade(servletRequest, servletResponse, config, Collections.emptyMap());
+						container.upgradeHttpToWebSocket(servletRequest, servletResponse, config, Collections.emptyMap());
 					}
 					catch (Exception ex) {
 						return Mono.error(ex);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/standard/TomcatRequestUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/standard/TomcatRequestUpgradeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,10 @@
 
 package org.springframework.web.socket.server.standard;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.websocket.Endpoint;
@@ -35,7 +33,7 @@ import org.springframework.web.socket.server.HandshakeFailureException;
 
 /**
  * A WebSocket {@code RequestUpgradeStrategy} for Apache Tomcat. Compatible with
- * all versions of Tomcat that support JSR-356, i.e. Tomcat 7.0.47+ and higher.
+ * Tomcat 10 and higher.
  *
  * <p>To modify properties of the underlying {@link jakarta.websocket.server.ServerContainer}
  * you can use {@link ServletServerContainerFactoryBean} in XML configuration or,
@@ -52,7 +50,6 @@ public class TomcatRequestUpgradeStrategy extends AbstractStandardUpgradeStrateg
 		return new String[] {"13"};
 	}
 
-	@SuppressWarnings("deprecation")  // for old doUpgrade variant in Tomcat 9.0.55
 	@Override
 	public void upgradeInternal(ServerHttpRequest request, ServerHttpResponse response,
 			@Nullable String selectedProtocol, List<Extension> selectedExtensions, Endpoint endpoint)
@@ -70,15 +67,11 @@ public class TomcatRequestUpgradeStrategy extends AbstractStandardUpgradeStrateg
 		endpointConfig.setExtensions(selectedExtensions);
 
 		try {
-			getContainer(servletRequest).doUpgrade(servletRequest, servletResponse, endpointConfig, pathParams);
+			getContainer(servletRequest).upgradeHttpToWebSocket(servletRequest, servletResponse, endpointConfig, pathParams);
 		}
-		catch (ServletException ex) {
+		catch (Exception ex) {
 			throw new HandshakeFailureException(
 					"Servlet request failed to upgrade to WebSocket: " + requestUrl, ex);
-		}
-		catch (IOException ex) {
-			throw new HandshakeFailureException(
-					"Response update failed during upgrade to WebSocket: " + requestUrl, ex);
 		}
 	}
 


### PR DESCRIPTION
**Affects:** 6.0.0-RC3

```
java.lang.NoSuchMethodError: 'void org.apache.tomcat.websocket.server.WsServerContainer.doUpgrade(jakarta.servlet.http.HttpServletRequest, jakarta.servlet.http.HttpServletResponse, jakarta.websocket.server.ServerEndpointConfig, java.util.Map)'
	at org.springframework.web.socket.server.standard.TomcatRequestUpgradeStrategy.upgradeInternal(TomcatRequestUpgradeStrategy.java:73) ~[spring-websocket-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.socket.server.standard.AbstractStandardUpgradeStrategy.upgrade(AbstractStandardUpgradeStrategy.java:136) ~[spring-websocket-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.socket.server.support.AbstractHandshakeHandler.doHandshake(AbstractHandshakeHandler.java:289) ~[spring-websocket-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.socket.sockjs.transport.handler.WebSocketTransportHandler.doHandshake(WebSocketTransportHandler.java:137) ~[spring-websocket-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.socket.sockjs.transport.TransportHandlingSockJsService.handleRawWebSocketRequest(TransportHandlingSockJsService.java:216) ~[spring-websocket-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.socket.sockjs.support.AbstractSockJsService.handleRequest(AbstractSockJsService.java:441) ~[spring-websocket-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.socket.sockjs.support.SockJsHttpRequestHandler.handleRequest(SockJsHttpRequestHandler.java:134) ~[spring-websocket-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter.handle(HttpRequestHandlerAdapter.java:52) ~[spring-webmvc-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1080) ~[spring-webmvc-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:973) ~[spring-webmvc-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1003) ~[spring-webmvc-6.0.0-RC3.jar:6.0.0-RC3]
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:895) ~[spring-webmvc-6.0.0-RC3.jar:6.0.0-RC3]
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:705) ~[tomcat-embed-core-10.1.1.jar:6.0]
```

`upgradeHttpToWebSocket(Object, Object, ServerEndpointConfig, Map<String, String>)` that was [added in Tomcat 10.0](https://github.com/apache/tomcat/commit/a182c5f23c3b836c5568eecd7e442d66e856494d) should be used instead.