### PR TITLE
Avoid `instanceof GenericHttpMessageConverter` checks

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
@@ -73,6 +73,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Rossen Stoyanchev
  * @author Brian Clozel
  * @author Juergen Hoeller
+ * @author Sebastien Deleuze
  * @since 3.1
  */
 public abstract class AbstractMessageConverterMethodProcessor extends AbstractMessageConverterMethodArgumentResolver
@@ -280,7 +281,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 		if (selectedMediaType != null) {
 			selectedMediaType = selectedMediaType.removeQualityValue();
 			for (HttpMessageConverter<?> converter : this.messageConverters) {
-				GenericHttpMessageConverter genericConverter = (converter instanceof GenericHttpMessageConverter ?
+				GenericHttpMessageConverter genericConverter = (this.genericConverterClasses.contains(converter.getClass()) ?
 						(GenericHttpMessageConverter<?>) converter : null);
 				if (genericConverter != null ?
 						((GenericHttpMessageConverter) converter).canWrite(targetType, valueType, selectedMediaType) :
@@ -383,7 +384,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 		}
 		Set<MediaType> result = new LinkedHashSet<>();
 		for (HttpMessageConverter<?> converter : this.messageConverters) {
-			if (converter instanceof GenericHttpMessageConverter && targetType != null) {
+			if (this.genericConverterClasses.contains(converter.getClass()) && targetType != null) {
 				if (((GenericHttpMessageConverter<?>) converter).canWrite(targetType, valueClass, null)) {
 					result.addAll(converter.getSupportedMediaTypes(valueClass));
 				}


### PR DESCRIPTION
As found by @dreis2211, `instanceof GenericHttpMessageConverter` checks slowdown significantly the iteration on converters in Spring MVC.

This commit introduces a default boolean `isGeneric()` method in `HttpMessageConverter` and a related override in `GenericHttpMessageConverter` in order to avoid this check.

This change increases the throughput of Techempower JSON benchmark by 6.38% and of a benchmark performed with hey (10s after 60s of warmup) by 5.5%.

@jhoeller @rstoyanchev @poutsma The gains are significant so I would would like to propose the inclusion of theses changes in Spring Framework 6. Not sure if that would be ok on `5.3.x` or not. Please let me know what you think about it.