### PR TITLE
Use ObservationThreadLocalAccessor.KEY where possible

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/reactive/ServerHttpObservationFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/reactive/ServerHttpObservationFilter.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -58,11 +59,6 @@ public class ServerHttpObservationFilter implements WebFilter {
 
 	private static final Set<String> DISCONNECTED_CLIENT_EXCEPTIONS = Set.of("AbortedException",
 			"ClientAbortException", "EOFException", "EofException");
-
-	/**
-	 * Aligned with ObservationThreadLocalAccessor#KEY from micrometer-core.
-	 */
-	private static final String MICROMETER_OBSERVATION_KEY = "micrometer.observation";
 
 	private final ObservationRegistry observationRegistry;
 
@@ -123,7 +119,7 @@ public class ServerHttpObservationFilter implements WebFilter {
 					observationContext.setConnectionAborted(true);
 					observation.stop();
 				})
-				.contextWrite(context -> context.put(MICROMETER_OBSERVATION_KEY, observation));
+				.contextWrite(context -> context.put(ObservationThreadLocalAccessor.KEY, observation));
 	}
 
 	private void onTerminalSignal(Observation observation, ServerWebExchange exchange) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -74,11 +75,6 @@ class DefaultWebClient implements WebClient {
 			() -> new IllegalStateException("The underlying HTTP client completed without emitting a response."));
 
 	private static final DefaultClientRequestObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultClientRequestObservationConvention();
-
-	/**
-	 * Aligned with ObservationThreadLocalAccessor#KEY from micrometer-core.
-	 */
-	private static final String MICROMETER_OBSERVATION = "micrometer.observation";
 
 	private final ExchangeFunction exchangeFunction;
 
@@ -463,7 +459,7 @@ class DefaultWebClient implements WebClient {
 						DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, observationRegistry);
 				observationContext.setCarrier(requestBuilder);
 				observation
-						.parentObservation(contextView.getOrDefault(MICROMETER_OBSERVATION, null))
+						.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null))
 						.start();
 				ClientRequest request = requestBuilder.build();
 				observationContext.setUriTemplate((String) request.attribute(URI_TEMPLATE_ATTRIBUTE).orElse(null));


### PR DESCRIPTION
This PR changes to use `ObservationThreadLocalAccessor.KEY` where possible.