### PR TITLE
Avoid unnecessary allocations in StompDecoder#unescape

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,9 +264,12 @@ public class StompDecoder {
 	 * <a href="https://stomp.github.io/stomp-specification-1.2.html#Value_Encoding">"Value Encoding"</a>.
 	 */
 	private String unescape(String inString) {
+		int index = inString.indexOf('\\');
+		if (index == -1) {
+			return inString;
+		}
 		StringBuilder sb = new StringBuilder(inString.length());
 		int pos = 0;  // position in the old string
-		int index = inString.indexOf('\\');
 
 		while (index >= 0) {
 			sb.append(inString, pos, index);


### PR DESCRIPTION
Hi,

I noticed in one of our applications that a tiny amount (0,5-1%) of allocations is caused by `StompDecoder#unescape`. The unfortunate bit is that there is actually no unescaping needed in most of the cases. This PR avoids unnecessary allocations if the String to unescape is not containing any `\` character.

Cheers,
Christoph