### PR TITLE
Introduce `SqlServerSequenceMaxValueIncrementer` for SQL Server sequences

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/incrementer/SqlServerSequenceMaxValueIncrementer.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/incrementer/SqlServerSequenceMaxValueIncrementer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.jdbc.support.incrementer;
+
+import javax.sql.DataSource;
+
+/**
+ * Incrementer for SQL Server sequences.
+ *
+ * @author Mahmoud Ben Hassine
+ * @since 6.0
+ */
+public class SqlServerSequenceMaxValueIncrementer extends AbstractSequenceMaxValueIncrementer {
+
+	/**
+	 * Default constructor for bean property style usage.
+	 * @see #setDataSource
+	 * @see #setIncrementerName
+	 */
+	public SqlServerSequenceMaxValueIncrementer() {
+	}
+
+	/**
+	 * Convenience constructor.
+	 * @param dataSource the DataSource to use
+	 * @param incrementerName the name of the sequence to use
+	 */
+	public SqlServerSequenceMaxValueIncrementer(DataSource dataSource, String incrementerName) {
+		super(dataSource, incrementerName);
+	}
+
+	@Override
+	protected String getSequenceQuery() {
+		return "select next value for " + getIncrementerName();
+	}
+
+}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/DataFieldMaxValueIncrementerTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/DataFieldMaxValueIncrementerTests.java
@@ -32,6 +32,7 @@ import org.springframework.jdbc.support.incrementer.MariaDBSequenceMaxValueIncre
 import org.springframework.jdbc.support.incrementer.MySQLMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.OracleSequenceMaxValueIncrementer;
 import org.springframework.jdbc.support.incrementer.PostgresSequenceMaxValueIncrementer;
+import org.springframework.jdbc.support.incrementer.SqlServerSequenceMaxValueIncrementer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -221,6 +222,28 @@ class DataFieldMaxValueIncrementerTests {
 		given(resultSet.getLong(1)).willReturn(10L, 12L);
 
 		PostgresSequenceMaxValueIncrementer incrementer = new PostgresSequenceMaxValueIncrementer();
+		incrementer.setDataSource(dataSource);
+		incrementer.setIncrementerName("myseq");
+		incrementer.setPaddingLength(5);
+		incrementer.afterPropertiesSet();
+
+		assertThat(incrementer.nextStringValue()).isEqualTo("00010");
+		assertThat(incrementer.nextIntValue()).isEqualTo(12);
+
+		verify(resultSet, times(2)).close();
+		verify(statement, times(2)).close();
+		verify(connection, times(2)).close();
+	}
+
+	@Test
+	void sqlServerSequenceMaxValueIncrementer() throws SQLException {
+		given(dataSource.getConnection()).willReturn(connection);
+		given(connection.createStatement()).willReturn(statement);
+		given(statement.executeQuery("select next value for myseq")).willReturn(resultSet);
+		given(resultSet.next()).willReturn(true);
+		given(resultSet.getLong(1)).willReturn(10L, 12L);
+
+		SqlServerSequenceMaxValueIncrementer incrementer = new SqlServerSequenceMaxValueIncrementer();
 		incrementer.setDataSource(dataSource);
 		incrementer.setIncrementerName("myseq");
 		incrementer.setPaddingLength(5);


### PR DESCRIPTION
This PR introduces a `DataFieldMaxValueIncrementer` for SQL Server sequences. 

Currently, [Spring Batch](https://github.com/spring-projects/spring-batch/blob/main/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/database/support/SqlServerSequenceMaxValueIncrementer.java) and [Spring Cloud Task](https://github.com/spring-cloud/spring-cloud-task/blob/main/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SqlServerSequenceMaxValueIncrementer.java) are using duplicate copies of this incrementer.

It would be great if it is provided by Spring Framework to be used by other  projects and avoid code duplication and maintenance.