### PR TITLE
Fix a syntax error in an XML listing in core-validation.adoc

### DIFF
--- a/framework-docs/src/docs/asciidoc/core/core-validation.adoc
+++ b/framework-docs/src/docs/asciidoc/core/core-validation.adoc
@@ -1634,7 +1634,7 @@ If you prefer XML-based configuration, you can use a
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/beans
-			https://www.springframework.org/schema/beans/spring-beans.xsd>
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 		<bean id="conversionService" class="org.springframework.format.support.FormattingConversionServiceFactoryBean">
 			<property name="registerDefaultFormatters" value="false" />


### PR DESCRIPTION
This is a simple fix to an XML listing in the core-validation doc (it adds a missing double-quote at the end of an attribute).
Fixing the syntax error also fixes the rendered syntax coloring.