### PR TITLE
Fix two typos in integration.adoc and webflux.adoc

### DIFF
--- a/framework-docs/src/docs/asciidoc/integration.adoc
+++ b/framework-docs/src/docs/asciidoc/integration.adoc
@@ -4414,7 +4414,7 @@ asterisk.
 * Two numbers separated with a hyphen (`-`) express a range of numbers.
 The specified range is inclusive.
 * Following a range (or `*`) with `/` specifies the interval of the number's value through the range.
-* English names can also be used for the day-of-month and day-of-week fields.
+* English names can also be used for the month and day-of-week fields.
 Use the first three letters of the particular day or month (case does not matter).
 * The day-of-month and day-of-week fields can contain a `L` character, which has a different meaning
 ** In the day-of-month field, `L` stands for _the last day of the month_.

--- a/framework-docs/src/docs/asciidoc/web/webflux.adoc
+++ b/framework-docs/src/docs/asciidoc/web/webflux.adoc
@@ -1565,7 +1565,7 @@ extracts the name, version, and file extension:
 
 URI path patterns can also have embedded `${...}` placeholders that are resolved on startup
 through `PropertySourcesPlaceholderConfigurer` against local, system, environment, and
-other property sources. You ca use this to, for example, parameterize a base URL based on
+other property sources. You can use this to, for example, parameterize a base URL based on
 some external configuration.
 
 NOTE: Spring WebFlux uses `PathPattern` and the `PathPatternParser` for URI path matching support.


### PR DESCRIPTION
fix two typos  in integration.adoc and webflux.adoc

* change "English names can also be used for the day-of-month and day-of-week fields. " to "English names can also be used for the month and day-of-week fields."

* change "You ca use this" to "You can use this"