### PR TITLE
Removed unnecessary function call in Mono.switchIfEmpty()

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/session/DefaultWebSessionManager.java
+++ b/spring-web/src/main/java/org/springframework/web/server/session/DefaultWebSessionManager.java
@@ -84,7 +84,7 @@ public class DefaultWebSessionManager implements WebSessionManager {
 	@Override
 	public Mono<WebSession> getSession(ServerWebExchange exchange) {
 		return Mono.defer(() -> retrieveSession(exchange)
-				.switchIfEmpty(createWebSession())
+				.switchIfEmpty(Mono.defer(this::createWebSession))
 				.doOnNext(session -> exchange.getResponse().beforeCommit(() -> save(exchange, session))));
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/server/session/DefaultWebSessionManagerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/session/DefaultWebSessionManagerTests.java
@@ -115,6 +115,16 @@ class DefaultWebSessionManagerTests {
 	}
 
 	@Test
+	void getSessionDoesNotCreateWebSessionWhenSessionIdsAreNotEmpty() {
+		String sessionId = this.updateSession.getId();
+		given(this.sessionIdResolver.resolveSessionIds(this.exchange)).willReturn(Collections.singletonList(sessionId));
+
+		this.sessionManager.getSession(this.exchange).block();
+
+		verify(this.sessionStore, never()).createWebSession();
+	}
+
+	@Test
 	void existingSession() {
 		String sessionId = this.updateSession.getId();
 		given(this.sessionIdResolver.resolveSessionIds(this.exchange)).willReturn(Collections.singletonList(sessionId));


### PR DESCRIPTION
In this code, the 'switchIfEmpty()' method always calls createWebSession().
If this is unintentional, it needs to be fix.
 
``` java
return Mono.defer(() -> retrieveSession(exchange)
		.switchIfEmpty(createWebSession())
		.doOnNext(session -> exchange.getResponse().beforeCommit(() -> save(exchange, session))));
```

Please review and let me know if I misunderstood.