### PR TITLE
Use `EnumMap` for `DateFormatter.ISO_PATTERNS` again

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/datetime/DateFormatter.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/DateFormatter.java
@@ -19,7 +19,9 @@ package org.springframework.format.datetime;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -47,10 +49,15 @@ public class DateFormatter implements Formatter<Date> {
 
 	private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
-	private static final Map<ISO, String> ISO_PATTERNS = Map.of(
-			ISO.DATE, "yyyy-MM-dd",
-			ISO.TIME, "HH:mm:ss.SSSXXX",
-			ISO.DATE_TIME, "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+	private static final Map<ISO, String> ISO_PATTERNS;
+
+	static {
+		Map<ISO, String> formats = new EnumMap<>(ISO.class);
+		formats.put(ISO.DATE, "yyyy-MM-dd");
+		formats.put(ISO.TIME, "HH:mm:ss.SSSXXX");
+		formats.put(ISO.DATE_TIME, "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+		ISO_PATTERNS = Collections.unmodifiableMap(formats);
+	}
 
 
 	@Nullable


### PR DESCRIPTION
This PR changes to use `EnumMap` for `DateFormatter.ISO_PATTERNS` again by partially reverting ba136dcf40123445aa959786cdc006112d35774a as it seems to give better numbers as follows:

```
Benchmark                                          (iso)  Mode  Cnt   Score   Error   Units
EnumMapOfBenchmark.getNew                           DATE  avgt        2.643           ns/op
EnumMapOfBenchmark.getNew:·gc.alloc.rate            DATE  avgt       ≈ 10⁻⁴          MB/sec
EnumMapOfBenchmark.getNew:·gc.alloc.rate.norm       DATE  avgt       ≈ 10⁻⁷            B/op
EnumMapOfBenchmark.getNew:·gc.count                 DATE  avgt          ≈ 0          counts
EnumMapOfBenchmark.getNew                           TIME  avgt        2.656           ns/op
EnumMapOfBenchmark.getNew:·gc.alloc.rate            TIME  avgt       ≈ 10⁻⁴          MB/sec
EnumMapOfBenchmark.getNew:·gc.alloc.rate.norm       TIME  avgt       ≈ 10⁻⁷            B/op
EnumMapOfBenchmark.getNew:·gc.count                 TIME  avgt          ≈ 0          counts
EnumMapOfBenchmark.getNew                      DATE_TIME  avgt        4.507           ns/op
EnumMapOfBenchmark.getNew:·gc.alloc.rate       DATE_TIME  avgt       ≈ 10⁻⁴          MB/sec
EnumMapOfBenchmark.getNew:·gc.alloc.rate.norm  DATE_TIME  avgt       ≈ 10⁻⁷            B/op
EnumMapOfBenchmark.getNew:·gc.count            DATE_TIME  avgt          ≈ 0          counts
EnumMapOfBenchmark.getOld                           DATE  avgt        1.320           ns/op
EnumMapOfBenchmark.getOld:·gc.alloc.rate            DATE  avgt       ≈ 10⁻⁴          MB/sec
EnumMapOfBenchmark.getOld:·gc.alloc.rate.norm       DATE  avgt       ≈ 10⁻⁷            B/op
EnumMapOfBenchmark.getOld:·gc.count                 DATE  avgt          ≈ 0          counts
EnumMapOfBenchmark.getOld                           TIME  avgt        1.530           ns/op
EnumMapOfBenchmark.getOld:·gc.alloc.rate            TIME  avgt       ≈ 10⁻⁴          MB/sec
EnumMapOfBenchmark.getOld:·gc.alloc.rate.norm       TIME  avgt       ≈ 10⁻⁷            B/op
EnumMapOfBenchmark.getOld:·gc.count                 TIME  avgt          ≈ 0          counts
EnumMapOfBenchmark.getOld                      DATE_TIME  avgt        1.527           ns/op
EnumMapOfBenchmark.getOld:·gc.alloc.rate       DATE_TIME  avgt       ≈ 10⁻⁴          MB/sec
EnumMapOfBenchmark.getOld:·gc.alloc.rate.norm  DATE_TIME  avgt       ≈ 10⁻⁷            B/op
EnumMapOfBenchmark.getOld:·gc.count            DATE_TIME  avgt          ≈ 0          counts
```

See gh-29321
See also https://github.com/izeye/samples-jmh-gradle/blob/master/src/jmh/java/com/izeye/samples/jmh/EnumMapOfBenchmark.java