### PR TITLE
Early return to simplify the structure and use instanceof new feature

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -961,26 +961,27 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 	 * freshly (re-)building it if necessary.
 	 * @since 5.3
 	 */
-	BeanPostProcessorCache getBeanPostProcessorCache() {
-		BeanPostProcessorCache bppCache = this.beanPostProcessorCache;
-		if (bppCache == null) {
-			bppCache = new BeanPostProcessorCache();
-			for (BeanPostProcessor bpp : this.beanPostProcessors) {
-				if (bpp instanceof InstantiationAwareBeanPostProcessor instantiationAwareBpp) {
-					bppCache.instantiationAware.add(instantiationAwareBpp);
-					if (bpp instanceof SmartInstantiationAwareBeanPostProcessor smartInstantiationAwareBpp) {
-						bppCache.smartInstantiationAware.add(smartInstantiationAwareBpp);
-					}
-				}
-				if (bpp instanceof DestructionAwareBeanPostProcessor destructionAwareBpp) {
-					bppCache.destructionAware.add(destructionAwareBpp);
-				}
-				if (bpp instanceof MergedBeanDefinitionPostProcessor mergedBeanDefBpp) {
-					bppCache.mergedDefinition.add(mergedBeanDefBpp);
+	AbstractBeanFactory.BeanPostProcessorCache getBeanPostProcessorCache() {
+		AbstractBeanFactory.BeanPostProcessorCache bppCache = this.beanPostProcessorCache;
+		if (null != bppCache) {
+			return bppCache;
+		}
+		bppCache = new AbstractBeanFactory.BeanPostProcessorCache();
+		for (BeanPostProcessor bpp : this.beanPostProcessors) {
+			if (bpp instanceof InstantiationAwareBeanPostProcessor instantiationAwareBpp) {
+				bppCache.instantiationAware.add(instantiationAwareBpp);
+				if (bpp instanceof SmartInstantiationAwareBeanPostProcessor smartInstantiationAwareBpp) {
+					bppCache.smartInstantiationAware.add(smartInstantiationAwareBpp);
 				}
 			}
-			this.beanPostProcessorCache = bppCache;
+			if (bpp instanceof DestructionAwareBeanPostProcessor destructionAwareBpp) {
+				bppCache.destructionAware.add(destructionAwareBpp);
+			}
+			if (bpp instanceof MergedBeanDefinitionPostProcessor mergedBeanDefBpp) {
+				bppCache.mergedDefinition.add(mergedBeanDefBpp);
+			}
 		}
+		this.beanPostProcessorCache = bppCache;
 		return bppCache;
 	}
 


### PR DESCRIPTION
1. Early return to simplify the code structure;
2. The spring new version start to use JDK 17. Use the instanceof new feature to simplify code;