### PR TITLE
Small Polish of MimeType

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeType.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeType.java
@@ -369,9 +369,7 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 						String thisSubtypeNoSuffix = getSubtype().substring(0, thisPlusIdx);
 						String thisSubtypeSuffix = getSubtype().substring(thisPlusIdx + 1);
 						String otherSubtypeSuffix = other.getSubtype().substring(otherPlusIdx + 1);
-						if (thisSubtypeSuffix.equals(otherSubtypeSuffix) && WILDCARD_TYPE.equals(thisSubtypeNoSuffix)) {
-							return true;
-						}
+						return thisSubtypeSuffix.equals(otherSubtypeSuffix) && WILDCARD_TYPE.equals(thisSubtypeNoSuffix);
 					}
 				}
 			}

--- a/spring-core/src/main/java/org/springframework/util/MimeType.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeType.java
@@ -301,7 +301,7 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 	@Nullable
 	public String getSubtypeSuffix() {
 		int suffixIndex = this.subtype.lastIndexOf('+');
-		if (suffixIndex != -1 && this.subtype.length() > suffixIndex) {
+		if (suffixIndex != -1) {
 			return this.subtype.substring(suffixIndex + 1);
 		}
 		return null;

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -331,6 +331,8 @@ class MimeTypeTests {
 		assertThat(type.getSubtypeSuffix()).isEqualTo("");
 		type = new MimeType("application", "vdn.some+thing+json");
 		assertThat(type.getSubtypeSuffix()).isEqualTo("json");
+		type = new MimeType("application", "+");
+		assertThat(type.getSubtypeSuffix()).isEqualTo("");
 	}
 
 	@Test  // gh-25350


### PR DESCRIPTION
Simplify if and return statements.

If there is a '+', I think the length of the subtype is always greater than the suffixIndex.
- '+' does not exist. -> lastIndexOf() returns -1.
- '+' exists -> '+' is in subType[0 .. subType.length()-1]
