### PR TITLE
Align javadoc of DefaultParameterNameDiscoverer with its behavior

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/DefaultParameterNameDiscoverer.java
+++ b/spring-core/src/main/java/org/springframework/core/DefaultParameterNameDiscoverer.java
@@ -24,8 +24,7 @@ package org.springframework.core;
  *
  * <p>If a Kotlin reflection implementation is present,
  * {@link KotlinReflectionParameterNameDiscoverer} is added first in the list and
- * used for Kotlin classes and interfaces. When compiling or running as a GraalVM
- * native image, the {@code KotlinReflectionParameterNameDiscoverer} is not used.
+ * used for Kotlin classes and interfaces.
  *
  * <p>Further discoverers may be added through {@link #addDiscoverer(ParameterNameDiscoverer)}.
  *


### PR DESCRIPTION
As far as I can tell, the changes made in https://github.com/spring-projects/spring-framework/commit/c4e8ffece16db679ef4d92d97d7b3e8c748f0b5a left the javadoc of `DefaultParameterNameDiscoverer` out of alignment with its behavior. Assuming that I haven't missed `KotlinReflectionParameterNameDiscoverer` being skipped by some other mechanism, this PR align things again.