### PR TITLE
Update javadoc of Jackson-based decoders to reflect 2.14 baseline

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Decoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Decoder.java
@@ -52,9 +52,9 @@ import org.springframework.util.Assert;
 import org.springframework.util.MimeType;
 
 /**
- * Abstract base class for Jackson 2.9 decoding, leveraging non-blocking parsing.
+ * Abstract base class for Jackson 2.14 decoding, leveraging non-blocking parsing.
  *
- * <p>Compatible with Jackson 2.9.7 and higher.
+ * <p>Compatible with Jackson 2.14, as of Spring 6.0.
  *
  * @author Sebastien Deleuze
  * @author Rossen Stoyanchev

--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2JsonDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 
 /**
- * Decode a byte stream into JSON and convert to Object's with Jackson 2.9,
+ * Decode a byte stream into JSON and convert to Object's with Jackson 2.14,
  * leveraging non-blocking parsing.
  *
  * @author Sebastien Deleuze

--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2SmileDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2SmileDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.MimeType;
 
 /**
- * Decode a byte stream into Smile and convert to Object's with Jackson 2.9,
+ * Decode a byte stream into Smile and convert to Object's with Jackson 2.14,
  * leveraging non-blocking parsing.
  *
  * @author Sebastien Deleuze


### PR DESCRIPTION
I believe that the changes in https://github.com/spring-projects/spring-framework/commit/f99c02fc941c92ca01d45fe2ebb2dd5318f471b2 mean that the Jackson-based decoders now require Jackson 2.14. This PR updates their javadoc accordingly.