### PR TITLE
Make GeneratorStrategy.generate unreachable on native

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/nativex/feature/PreComputeFieldFeature.java
+++ b/spring-core/src/main/java/org/springframework/aot/nativex/feature/PreComputeFieldFeature.java
@@ -34,6 +34,7 @@ class PreComputeFieldFeature implements Feature {
 
 	private static Pattern[] patterns = {
 			Pattern.compile(Pattern.quote("org.springframework.core.NativeDetector#imageCode")),
+			Pattern.compile(Pattern.quote("org.springframework.cglib.core.AbstractClassGenerator#imageCode")),
 			Pattern.compile(Pattern.quote("org.springframework.") + ".*#.*Present"),
 			Pattern.compile(Pattern.quote("org.springframework.") + ".*#.*PRESENT"),
 			Pattern.compile(Pattern.quote("reactor.") + ".*#.*Available")

--- a/spring-core/src/main/java/org/springframework/cglib/core/AbstractClassGenerator.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/AbstractClassGenerator.java
@@ -43,6 +43,9 @@ abstract public class AbstractClassGenerator<T> implements ClassGenerator {
 	private static final boolean DEFAULT_USE_CACHE =
 			Boolean.parseBoolean(System.getProperty("cglib.useCache", "true"));
 
+	// See https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/ImageInfo.java
+	private static final boolean imageCode = (System.getProperty("org.graalvm.nativeimage.imagecode") != null);
+
 
 	private GeneratorStrategy strategy = DefaultGeneratorStrategy.INSTANCE;
 
@@ -359,6 +362,12 @@ abstract public class AbstractClassGenerator<T> implements ClassGenerator {
 					// ignore
 				}
 			}
+			// SPRING PATCH BEGIN
+			if (imageCode) {
+				throw new UnsupportedOperationException("CGLIB runtime enhancement not supported on native image. " +
+						"Make sure to include a pre-generated class on the classpath instead: " + getClassName());
+			}
+			// SPRING PATCH END
 			byte[] b = strategy.generate(this);
 			String className = ClassNameReader.getClassName(new ClassReader(b));
 			ProtectionDomain protectionDomain = getProtectionDomain();


### PR DESCRIPTION
Allows to save around `0.5M` of RSS memory by avoiding to make those classes reachable:
```
org.springframework.cglib.core.Block
org.springframework.cglib.core.ClassEmitter
org.springframework.cglib.core.ClassEmitter$1
org.springframework.cglib.core.ClassEmitter$2
org.springframework.cglib.core.ClassEmitter$3
org.springframework.cglib.core.ClassEmitter$FieldInfo
org.springframework.cglib.core.ClassInfo
org.springframework.cglib.core.ClassNameReader
org.springframework.cglib.core.ClassNameReader$1
org.springframework.cglib.core.ClassTransformer
org.springframework.cglib.core.CodeEmitter
org.springframework.cglib.core.CodeEmitter$State
org.springframework.cglib.core.DebuggingClassWriter
org.springframework.cglib.core.DefaultGeneratorStrategy
org.springframework.cglib.core.DuplicatesPredicate
org.springframework.cglib.core.EmitUtils
org.springframework.cglib.core.EmitUtils$1
org.springframework.cglib.core.EmitUtils$10
org.springframework.cglib.core.EmitUtils$11
org.springframework.cglib.core.EmitUtils$12
org.springframework.cglib.core.EmitUtils$13
org.springframework.cglib.core.EmitUtils$14
org.springframework.cglib.core.EmitUtils$15
org.springframework.cglib.core.EmitUtils$16
org.springframework.cglib.core.EmitUtils$2
org.springframework.cglib.core.EmitUtils$3
org.springframework.cglib.core.EmitUtils$4
org.springframework.cglib.core.EmitUtils$5
org.springframework.cglib.core.EmitUtils$6
org.springframework.cglib.core.EmitUtils$ArrayDelimiters
org.springframework.cglib.core.Local
org.springframework.cglib.core.LocalVariablesSorter
org.springframework.cglib.core.LocalVariablesSorter$State
org.springframework.cglib.core.MethodInfo
org.springframework.cglib.core.MethodInfoTransformer
org.springframework.cglib.core.MethodWrapper
org.springframework.cglib.core.MethodWrapper$MethodWrapperKey
org.springframework.cglib.core.ReflectUtils$1
org.springframework.cglib.core.ReflectUtils$2
org.springframework.cglib.core.ReflectUtils$3
org.springframework.cglib.core.RejectModifierPredicate
org.springframework.cglib.core.VisibilityPredicate
org.springframework.cglib.proxy.BridgeMethodResolver
org.springframework.cglib.proxy.BridgeMethodResolver$BridgedFinder
org.springframework.cglib.proxy.BridgeMethodResolver$BridgedFinder$1
org.springframework.cglib.proxy.Enhancer$1
org.springframework.cglib.proxy.Enhancer$2
org.springframework.cglib.proxy.Enhancer$3
org.springframework.cglib.proxy.Enhancer$4
org.springframework.cglib.proxy.Enhancer$5
org.springframework.cglib.proxy.Enhancer$6
org.springframework.cglib.proxy.MethodInterceptorGenerator$1
org.springframework.cglib.proxy.MethodInterceptorGenerator$2
org.springframework.cglib.proxy.NoOpGenerator
org.springframework.cglib.reflect.FastClassEmitter
org.springframework.cglib.reflect.FastClassEmitter$1
org.springframework.cglib.reflect.FastClassEmitter$2
org.springframework.cglib.reflect.FastClassEmitter$3
org.springframework.cglib.reflect.FastClassEmitter$4
org.springframework.cglib.reflect.FastClassEmitter$GetIndexCallback
org.springframework.cglib.transform.TransformingClassGenerator
org.springframework.context.annotation.ConfigurationClassEnhancer$BeanFactoryAwareGeneratorStrategy
org.springframework.context.annotation.ConfigurationClassEnhancer$BeanFactoryAwareGeneratorStrategy$1
```