### PR TITLE
getHandlerInternal support multiple calls and  avoid repeated lookupHandlerMethod

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
@@ -106,7 +106,7 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 		return super.getHandlerInternal(exchange)
 			.doOnTerminate(() -> ProducesRequestCondition.clearMediaTypesAttribute(exchange));
 	}
-	
+
 	/**
 	 * Expose URI template variables, matrix variables, and producible media types in the request.
 	 * @see HandlerMapping#URI_TEMPLATE_VARIABLES_ATTRIBUTE

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
@@ -98,17 +98,15 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 
 	@Override
 	public Mono<HandlerMethod> getHandlerInternal(ServerWebExchange exchange) {
-		return Mono.justOrEmpty(exchange.<HandlerMethod>getAttribute(BEST_MATCHING_HANDLER_ATTRIBUTE))
-			.switchIfEmpty(Mono.defer(() -> getHandlerAndCache(exchange)));
-	}
-
-	protected Mono<HandlerMethod> getHandlerAndCache(ServerWebExchange exchange) {
+		Object handler = exchange.getAttributes().get(BEST_MATCHING_HANDLER_ATTRIBUTE);
+		if (handler instanceof HandlerMethod) {
+			return Mono.just((HandlerMethod) handler);
+		}
 		exchange.getAttributes().remove(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
 		return super.getHandlerInternal(exchange)
-			.doOnNext(handler -> exchange.getAttributes().put(BEST_MATCHING_HANDLER_ATTRIBUTE, handler))
 			.doOnTerminate(() -> ProducesRequestCondition.clearMediaTypesAttribute(exchange));
 	}
-
+	
 	/**
 	 * Expose URI template variables, matrix variables, and producible media types in the request.
 	 * @see HandlerMapping#URI_TEMPLATE_VARIABLES_ATTRIBUTE

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
@@ -98,7 +98,7 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 
 	@Override
 	public Mono<HandlerMethod> getHandlerInternal(ServerWebExchange exchange) {
-		Object handler = exchange.getAttributes().get(BEST_MATCHING_HANDLER_ATTRIBUTE);
+		Object handler = exchange.getAttributes().get(HandlerMapping.BEST_MATCHING_HANDLER_ATTRIBUTE);
 		if (handler instanceof HandlerMethod) {
 			return Mono.just((HandlerMethod) handler);
 		}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
@@ -104,7 +104,7 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 		}
 		exchange.getAttributes().remove(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
 		return super.getHandlerInternal(exchange)
-			.doOnTerminate(() -> ProducesRequestCondition.clearMediaTypesAttribute(exchange));
+				.doOnTerminate(() -> ProducesRequestCondition.clearMediaTypesAttribute(exchange));
 	}
 
 	/**

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMapping.java
@@ -101,7 +101,7 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 		return Mono.justOrEmpty(exchange.<HandlerMethod>getAttribute(BEST_MATCHING_HANDLER_ATTRIBUTE))
 			.switchIfEmpty(Mono.defer(() -> getHandlerAndCache(exchange)));
 	}
-	
+
 	protected Mono<HandlerMethod> getHandlerAndCache(ServerWebExchange exchange) {
 		exchange.getAttributes().remove(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
 		return super.getHandlerInternal(exchange)


### PR DESCRIPTION
In some scenarios, we need to get `HandlerMethod` ahead of [org.springframework.web.reactive.DispatcherHandler](https://github.com/spring-projects/spring-framework/blob/f4e23fe204588a744b111b8c7f6bbd1dbeda97b0/spring-webflux/src/main/java/org/springframework/web/reactive/DispatcherHandler.java#L142), such as an implement of authentication by [WebFilter](https://github.com/spring-projects/spring-framework/blob/f4e23fe204588a744b111b8c7f6bbd1dbeda97b0/spring-web/src/main/java/org/springframework/web/server/WebFilter.java#L29) 

```java
public class AuthFilter implements WebFilter, Ordered {

    @Autowired
    private RequestMappingHandlerMapping handlerMapping;

    @Override
    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
        return handlerMapping.getHandler(exchange).switchIfEmpty(chain.filter(exchange))
            .flatMap(handler -> {
                    if (handler instanceof HandlerMethod) {
                        HandlerMethod methodHandle = (HandlerMethod) handler;
                        CheckPermission permission = methodHandle.getMethodAnnotation(CheckPermission.class);
                        if (Objects.isNull(permission)) {
                            permission = AnnotationUtils.findAnnotation(methodHandle.getBeanType(), CheckPermission.class);
                        }

                        if (Objects.nonNull(permission)) {
                            // TODO  do something..
                        }
                    }
                    return chain.filter(exchange);
                }
            );
    }
}
```
`HandlerMethod` is necessary but there is no alternative way to get it withon WebFilter, which limited the capabilities of WebFilter. so, we need call `getHandler`, however this may lead to repeated call of lookupHandlerMethod and unexpected execution of `exchange.getAttributes().remove(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);` as below:

https://github.com/spring-projects/spring-framework/blob/00da70e26b9cb5ece2a9499e7c1b449e856b4aea/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/AbstractHandlerMethodMapping.java#L293
 
To avoid duplicate search for `HandlerMethod` in  [`mapping.getHandler`](https://github.com/spring-projects/spring-framework/blob/f4e23fe204588a744b111b8c7f6bbd1dbeda97b0/spring-webflux/src/main/java/org/springframework/web/reactive/HandlerMapping.java#L98) , I suggest implementing a improved getHandlerInternal, in which `HandlerMethod` would be keep in attributes as long as it found.

```java
	@Override
	public Mono<HandlerMethod> getHandlerInternal(ServerWebExchange exchange) {
		return Mono.justOrEmpty(exchange.<HandlerMethod>getAttribute(BEST_MATCHING_HANDLER_ATTRIBUTE))
			.switchIfEmpty(Mono.defer(() -> getHandlerAndCache(exchange)));
	}

	protected Mono<HandlerMethod> getHandlerAndCache(ServerWebExchange exchange) {
		exchange.getAttributes().remove(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
		return super.getHandlerInternal(exchange)
			.doOnNext(handler -> exchange.getAttributes().put(BEST_MATCHING_HANDLER_ATTRIBUTE, handler))
			.doOnTerminate(() -> ProducesRequestCondition.clearMediaTypesAttribute(exchange));
	}

```

related issue：https://github.com/spring-projects/spring-framework/issues/20123