### PR TITLE
Restrict forwards in MockMvcWebConnection to 100

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
@@ -142,6 +142,9 @@ public final class MockMvcWebConnection implements WebConnection {
 			forwardedUrl = httpServletResponse.getForwardedUrl();
 			forwards += 1;
 		}
+		if (forwards == MAX_FORWARDS) {
+			throw new IllegalStateException("Forwarded more than " + forwards + " times in a row, potential infinite forward loop");
+		}
 		storeCookies(webRequest, httpServletResponse.getCookies());
 
 		return new MockWebResponseBuilder(startTime, webRequest, httpServletResponse).build();

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
@@ -68,6 +68,8 @@ public final class MockMvcWebConnection implements WebConnection {
 
 	private WebClient webClient;
 
+	private static int MAX_FORWARDS = 100;
+
 
 	/**
 	 * Create a new instance that assumes the context path of the application
@@ -133,10 +135,12 @@ public final class MockMvcWebConnection implements WebConnection {
 
 		MockHttpServletResponse httpServletResponse = getResponse(requestBuilder);
 		String forwardedUrl = httpServletResponse.getForwardedUrl();
-		while (forwardedUrl != null) {
+		int forwards = 0;
+		while (forwardedUrl != null && forwards < MAX_FORWARDS) {
 			requestBuilder.setForwardPostProcessor(new ForwardRequestPostProcessor(forwardedUrl));
 			httpServletResponse = getResponse(requestBuilder);
 			forwardedUrl = httpServletResponse.getForwardedUrl();
+			forwards += 1;
 		}
 		storeCookies(webRequest, httpServletResponse.getCookies());
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/ForwardController.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/ForwardController.java
@@ -31,4 +31,9 @@ public class ForwardController {
 		return "forward:/a";
 	}
 
+	@RequestMapping("/infiniteForward")
+	public String infiniteForward() {
+		return "forward:/infiniteForward";
+	}
+
 }

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnectionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnectionTests.java
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 
 /**
@@ -81,10 +82,10 @@ public class MockMvcWebConnectionTests {
 	}
 
 	@Test
-	public void infiniteForward() throws IOException {
+	public void infiniteForward() {
 		this.webClient.setWebConnection(new MockMvcWebConnection(this.mockMvc, this.webClient, ""));
-		Page page = this.webClient.getPage("http://localhost/infiniteForward");
-		assertThat(page.getWebResponse().getContentAsString()).isEmpty();
+		assertThatIllegalStateException().isThrownBy(() -> this.webClient.getPage("http://localhost/infiniteForward"))
+						.withMessage("Forwarded more than 100 times in a row, potential infinite forward loop");
 	}
 
 	@Test

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnectionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnectionTests.java
@@ -81,6 +81,13 @@ public class MockMvcWebConnectionTests {
 	}
 
 	@Test
+	public void infiniteForward() throws IOException {
+		this.webClient.setWebConnection(new MockMvcWebConnection(this.mockMvc, this.webClient, ""));
+		Page page = this.webClient.getPage("http://localhost/infiniteForward");
+		assertThat(page.getWebResponse().getContentAsString()).isEmpty();
+	}
+
+	@Test
 	@SuppressWarnings("resource")
 	public void contextPathDoesNotStartWithSlash() throws IOException {
 		assertThatIllegalArgumentException().isThrownBy(() ->


### PR DESCRIPTION
When a filter is configured to conditionally forward, and it is configured to handle FORWARD dispatches as well, and it prevents infinite forward loops by either extending OncePerRequestFilter or otherwise using request attributes, this can result in infinite forward loops in WebClient tests using MockMvcWebConnection. This change will restrict the maximum number of forwards in MockMvcWebConnection to 100.

Closes gh-29483