### PR TITLE
Cache gradle dependencies to speed up workflows

### DIFF
--- a/.github/workflows/backport-bot.yml
+++ b/.github/workflows/backport-bot.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
       - name: Download BackportBot
         run: wget https://github.com/spring-io/backport-bot/releases/download/latest/backport-bot-0.0.1-SNAPSHOT.jar
       - name: Backport


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflow to apply **dependency caching**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Java projects can run faster on GitHub Actions by enabling dependency caching on the [setup-java](https://github.com/actions/setup-java) action. `setup-java` supports caching for both Gradle and Maven projects.

The following example enables caching for a Java project with Gradle:

```yaml
steps:
- uses: actions/checkout@v3
- uses: actions/setup-java@v3
  with:
    distribution: 'temurin'
    java-version: '17'
    cache: 'gradle'
- run: ./gradlew build
```

> It’s literally a one line change to pass the `cache: 'gradle'` input parameter.

## References
- [actions/setup-java#caching-packages-dependencies](https://github.com/actions/setup-java#caching-packages-dependencies)
- [How to build Gradle projects with GitHub Actions](https://tomgregory.com/build-gradle-projects-with-github-actions/#5_Enable_Gradle_caching)
- [Caching dependencies to speed up workflows | thearchivelog.dev](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)
