### PR TITLE
Set detail from reason in both constructors of ResponseStatusException

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/MethodNotAllowedException.java
+++ b/spring-web/src/main/java/org/springframework/web/server/MethodNotAllowedException.java
@@ -56,7 +56,9 @@ public class MethodNotAllowedException extends ResponseStatusException {
 		}
 		this.method = method;
 		this.httpMethods = Collections.unmodifiableSet(new LinkedHashSet<>(supportedMethods));
-		setDetail(this.httpMethods.isEmpty() ? getReason() : "Supported methods: " + this.httpMethods);
+		if (!this.httpMethods.isEmpty()) {
+			setDetail("Supported methods: " + this.httpMethods);
+		}
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/web/server/MissingRequestValueException.java
+++ b/spring-web/src/main/java/org/springframework/web/server/MissingRequestValueException.java
@@ -42,7 +42,6 @@ public class MissingRequestValueException extends ServerWebInputException {
 		this.name = name;
 		this.type = type;
 		this.label = label;
-		setDetail(getReason());
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/web/server/ResponseStatusException.java
+++ b/spring-web/src/main/java/org/springframework/web/server/ResponseStatusException.java
@@ -76,8 +76,7 @@ public class ResponseStatusException extends ErrorResponseException {
 	 * @param cause a nested exception (optional)
 	 */
 	public ResponseStatusException(HttpStatusCode status, @Nullable String reason, @Nullable Throwable cause) {
-		super(status, cause);
-		this.reason = reason;
+		this(status, reason, cause, null, null);
 	}
 
 	/**

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/annotation/ResponseStatusExceptionResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/annotation/ResponseStatusExceptionResolverTests.java
@@ -111,7 +111,7 @@ public class ResponseStatusExceptionResolverTests {
 	}
 
 	@Test // SPR-12903
-	public void nestedException() throws Exception {
+	public void nestedException() {
 		Exception cause = new StatusCodeAndReasonMessageException();
 		TypeMismatchException ex = new TypeMismatchException("value", ITestBean.class, cause);
 		ModelAndView mav = exceptionResolver.resolveException(request, response, null, ex);
@@ -119,14 +119,14 @@ public class ResponseStatusExceptionResolverTests {
 	}
 
 	@Test
-	public void responseStatusException() throws Exception {
+	public void responseStatusException() {
 		ResponseStatusException ex = new ResponseStatusException(HttpStatus.BAD_REQUEST);
 		ModelAndView mav = exceptionResolver.resolveException(request, response, null, ex);
 		assertResolved(mav, 400, null);
 	}
 
 	@Test  // SPR-15524
-	public void responseStatusExceptionWithReason() throws Exception {
+	public void responseStatusExceptionWithReason() {
 		ResponseStatusException ex = new ResponseStatusException(HttpStatus.BAD_REQUEST, "The reason");
 		ModelAndView mav = exceptionResolver.resolveException(request, response, null, ex);
 		assertResolved(mav, 400, "The reason");


### PR DESCRIPTION
- Leftover item that was not fully resolved in a27f2e994b632a63ca1bbd6f3de5d9b60246ccaa (#29567). Basically, `setDetail()` was added to one constructor, but not the other.
- Also some minor clean up I noticed while browsing the tests for the related classes

This fixes the issue I'm seeing where the detail is not present when using `spring.webflux.problemdetails.enabled=true` in Spring Boot.