### PR TITLE
Improve Netty code sample

### DIFF
--- a/framework-docs/src/docs/asciidoc/web/webflux.adoc
+++ b/framework-docs/src/docs/asciidoc/web/webflux.adoc
@@ -387,7 +387,7 @@ The code snippets below show using the `HttpHandler` adapters with each server A
 ----
 	HttpHandler handler = ...
 	ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(handler);
-	HttpServer.create().host(host).port(port).handle(adapter).bind().block();
+	HttpServer.create().host(host).port(port).handle(adapter).bindNow().onDispose().block();
 ----
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin


### PR DESCRIPTION
The previous code read 

```
HttpServer.create().host(host).port(port).handle(adapter).bind().block();
```
Which doesn't block and terminates after the `block` The proper way to block is to register on the dispose callback.  See https://projectreactor.io/docs/netty/release/reference/index.html#_starting_and_stopping

```
HttpServer.create().host(host).port(port).handle(adapter).bindNow().onDispose().block();
```