### PR TITLE
Fix ErrorResponse#type documentation

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/ErrorResponse.java
+++ b/spring-web/src/main/java/org/springframework/web/ErrorResponse.java
@@ -227,7 +227,7 @@ public interface ErrorResponse {
 		Builder detailMessageArguments(Object... messageArguments);
 
 		/**
-		 * Set the underlying {@link ProblemDetail#setTitle(String)} field.
+		 * Set the underlying {@link ProblemDetail#setType(URI)} field.
 		 * @return the same builder instance
 		 */
 		Builder type(URI type);


### PR DESCRIPTION
The documentation of the type variable was wrong in the ErrorResponse class