### PR TITLE
Support "multipart/mixed" and "multipart/related" in DefaultServerWebExchange

### DIFF
--- a/framework-docs/src/docs/asciidoc/web/webflux.adoc
+++ b/framework-docs/src/docs/asciidoc/web/webflux.adoc
@@ -610,8 +610,8 @@ The `DefaultServerWebExchange` uses the configured `HttpMessageReader` to parse 
 ----
 
 The `DefaultServerWebExchange` uses the configured
-`HttpMessageReader<MultiValueMap<String, Part>>` to parse `multipart/form-data` content
-into a `MultiValueMap`.
+`HttpMessageReader<MultiValueMap<String, Part>>` to parse `multipart/form-data`,  
+`multipart/mixed` and `multipart/related` content into a `MultiValueMap`.
 By default, this is the `DefaultPartHttpMessageReader`, which does not have any third-party
 dependencies.
 Alternatively, the `SynchronossPartHttpMessageReader` can be used, which is based on the
@@ -802,9 +802,9 @@ consistently for access to the cached form data versus reading from the raw requ
 ==== Multipart
 
 `MultipartHttpMessageReader` and `MultipartHttpMessageWriter` support decoding and
-encoding "multipart/form-data" content. In turn `MultipartHttpMessageReader` delegates to
-another `HttpMessageReader` for the actual parsing to a `Flux<Part>` and then simply
-collects the parts into a `MultiValueMap`.
+encoding "multipart/form-data", "multipart/mixed" and "multipart/related" content. 
+In turn `MultipartHttpMessageReader` delegates to another `HttpMessageReader` 
+for the actual parsing to a `Flux<Part>` and then simply collects the parts into a `MultiValueMap`.
 By default, the `DefaultPartHttpMessageReader` is used, but this can be changed through the
 `ServerCodecConfigurer`.
 For more information about the `DefaultPartHttpMessageReader`, refer to to the

--- a/spring-web/src/main/java/org/springframework/web/server/adapter/DefaultServerWebExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/DefaultServerWebExchange.java
@@ -163,9 +163,11 @@ public class DefaultServerWebExchange implements ServerWebExchange {
 
 		try {
 			MediaType contentType = request.getHeaders().getContentType();
-			if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType)) {
+			if (MediaType.MULTIPART_FORM_DATA.isCompatibleWith(contentType) ||
+				MediaType.MULTIPART_MIXED.isCompatibleWith(contentType) ||
+				MediaType.MULTIPART_RELATED.isCompatibleWith(contentType)) {
 				return ((HttpMessageReader<MultiValueMap<String, Part>>) configurer.getReaders().stream()
-						.filter(reader -> reader.canRead(MULTIPART_DATA_TYPE, MediaType.MULTIPART_FORM_DATA))
+						.filter(reader -> reader.canRead(MULTIPART_DATA_TYPE, contentType))
 						.findFirst()
 						.orElseThrow(() -> new IllegalStateException("No multipart HttpMessageReader.")))
 						.readMono(MULTIPART_DATA_TYPE, request, Hints.from(Hints.LOG_PREFIX_HINT, logPrefix))


### PR DESCRIPTION
`DefaultServerWebExchange` ignores "multipart/mixed" and "multipart/related" and returns an empty `MultiValueMap` although `MultipartHttpMessageReader` would be able to read the request.

This completes the server-side support for "multipart/mixed" and "multipart/related" in Webflux.

Closes gh-28591