### PR TITLE
Use `computeIfAbsent()` in `ConcurrentMapCacheManager.getCache()`

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCacheManager.java
+++ b/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCacheManager.java
@@ -163,17 +163,11 @@ public class ConcurrentMapCacheManager implements CacheManager, BeanClassLoaderA
 	@Override
 	@Nullable
 	public Cache getCache(String name) {
-		Cache cache = this.cacheMap.get(name);
-		if (cache == null && this.dynamic) {
-			synchronized (this.cacheMap) {
-				cache = this.cacheMap.get(name);
-				if (cache == null) {
-					cache = createConcurrentMapCache(name);
-					this.cacheMap.put(name, cache);
-				}
-			}
+		if (this.dynamic) {
+			return this.cacheMap.computeIfAbsent(name, this::createConcurrentMapCache);
 		}
-		return cache;
+
+		return this.cacheMap.get(name);
 	}
 
 	private void recreateCaches() {


### PR DESCRIPTION
#25997 Replace explicit `synchronized` and implicit `synchronized` in `ConcurrentHashMap::put` with modern functional api.