### PR TITLE
Provide method with `ContextView` instead of `Context` in `ServerWebExchangeContextFilter`

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/reactive/ServerWebExchangeContextFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/reactive/ServerWebExchangeContextFilter.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
@@ -32,7 +33,7 @@ import org.springframework.web.server.WebFilterChain;
  * exchange without explicitly passing it to components that participate in
  * request processing.
  *
- * <p>The convenience method {@link #get(Context)} looks up the exchange.
+ * <p>The convenience method {@link #getExchange(ContextView)} looks up the exchange.
  *
  * @author Rossen Stoyanchev
  * @since 5.2
@@ -58,8 +59,22 @@ public class ServerWebExchangeContextFilter implements WebFilter {
 	 * @param context the context in which to access the exchange
 	 * @return the exchange
 	 */
-	public static Optional<ServerWebExchange> get(Context context) {
+	public static Optional<ServerWebExchange> getExchange(ContextView context) {
 		return context.getOrEmpty(EXCHANGE_CONTEXT_ATTRIBUTE);
+	}
+
+
+	/**
+	 * Access the {@link ServerWebExchange} from the Reactor Context, if available,
+	 * which is if {@link ServerWebExchangeContextFilter} is configured for use
+	 * and the give context was obtained from a request processing chain.
+	 * @param context the context in which to access the exchange
+	 * @return the exchange
+	 * @deprecated use {@link #getExchange(ContextView)}
+	 */
+	@Deprecated(since = "6.0.6")
+	public static Optional<ServerWebExchange> get(Context context) {
+		return getExchange(context);
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/web/filter/reactive/ServerWebExchangeContextFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/reactive/ServerWebExchangeContextFilterTests.java
@@ -63,7 +63,7 @@ class ServerWebExchangeContextFilterTests {
 
 		public Mono<String> service() {
 			return Mono.just("result").contextWrite(context -> {
-				ServerWebExchangeContextFilter.get(context).ifPresent(exchangeRef::set);
+				ServerWebExchangeContextFilter.getExchange(context).ifPresent(exchangeRef::set);
 				return context;
 			});
 		}


### PR DESCRIPTION
Use `ContextView` in `ServerWebExchangeContextFilter#get`.

 * `Context` is a subclass of `ContextView`; hence, this is a non-breaking change.
 * It makes the convenience method more convenient because `Mono#transformDeferredContextual` and `Mono#deferContextual` provide `ContentView` instance. This avoids the need for a clunky cast or the unnecessary `.map(Context::of)`. 