### PR TITLE
Fixed a deadlock issue that prevented the process from exiting

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -979,9 +979,8 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 			this.shutdownHook = new Thread(SHUTDOWN_HOOK_THREAD_NAME) {
 				@Override
 				public void run() {
-					synchronized (startupShutdownMonitor) {
-						doClose();
-					}
+					// This call is thread safe.
+					doClose();
 				}
 			};
 			Runtime.getRuntime().addShutdownHook(this.shutdownHook);


### PR DESCRIPTION
### how deadlocks occur?
1. when ApplicationContext call refresh() method,  **main thread will hold startupShutdownMonitor monitor**;
2. then call onRefresh() method, it will load the external WebServer and create it;
3. Let's say I implemented this WebServer,   i will check license before created it,  when the certification fails, I call System.exit(1), want to exit the process;
4. System.exit(1) will runHooks, ApplicationContext's shutdownHook will be call, It runs in another thread, name of 'SpringContextShutdownHook', it will wait the monitor **startupShutdownMonitor**, but the monitor still hold by main thread, to make matters worse, main thread blocking in onRefresh method, wait WebServer created.
5. so, deadlock occur!!
### Fix it:
shutdownHook does not need to acquire a monitor on startupShutdownMonitor , and doClose method is thread safe, it is enough to call it.