### PR TITLE
Fix manipulating property sources example in Javadoc for `ConfigurableEnvironment`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/ConfigurableEnvironment.java
+++ b/spring-core/src/main/java/org/springframework/core/env/ConfigurableEnvironment.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * <pre class="code">
  * ConfigurableEnvironment environment = new StandardEnvironment();
  * MutablePropertySources propertySources = environment.getPropertySources();
- * Map&lt;String, String&gt; myMap = new HashMap&lt;&gt;();
+ * Map&lt;String, Object&gt; myMap = new HashMap&lt;&gt;();
  * myMap.put("xyz", "myValue");
  * propertySources.addFirst(new MapPropertySource("MY_MAP", myMap));
  * </pre>


### PR DESCRIPTION
The Manipulating property sources example is stating the MutablePropertySources expect a `Map<String,String>` whereas is a `Map<String,Object>`