### PR TITLE
Improve debug logging in `RestTemplate#handleResponse` if `getStatusCode` raises `IOException`

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -908,7 +908,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 				logger.debug("Response " + statusCode);
 			}
 			catch (IOException ex) {
-				// ignore
+				logger.debug("Failed to get response status code", ex);
 			}
 		}
 		if (hasError) {


### PR DESCRIPTION
After enabling the DEBUG log level, the following exception was swallowed in our production environment.

```
org.springframework.web.client.ResourceAccessException: I/O error on GET request for "https://xxx.oktapreview.com/.well-known/openid-configuration": Permission denied: connect; nested exception is java.net.SocketException: Permission denied: connect
```