### PR TITLE
Release R2DBC connection when cleanup fails in transaction

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
@@ -370,7 +370,8 @@ public class R2dbcTransactionManager extends AbstractReactiveTransactionManager 
 						}
 						return ConnectionFactoryUtils.releaseConnection(con, obtainConnectionFactory());
 					}
-				} finally {
+				}
+				finally {
 					txObject.getConnectionHolder().clear();
 				}
 				return Mono.empty();

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
@@ -380,11 +380,12 @@ public class R2dbcTransactionManager extends AbstractReactiveTransactionManager 
 	}
 
 	private Mono<Void> safeCleanupStep(String stepDescription, Mono<Void> stepMono) {
-		if (!this.logger.isDebugEnabled()) {
+		if (!logger.isDebugEnabled()) {
 			return stepMono.onErrorComplete();
-		} else {
+		}
+		else {
 			return stepMono.doOnError(e ->
-							this.logger.debug(String.format("Error ignored during %s: %s", stepDescription, e)))
+							logger.debug(String.format("Error ignored during %s: %s", stepDescription, e)))
 					.onErrorComplete();
 		}
 	}

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
@@ -23,6 +23,7 @@ import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.R2dbcBadGrammarException;
+import io.r2dbc.spi.R2dbcTimeoutException;
 import io.r2dbc.spi.Statement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import org.springframework.r2dbc.BadSqlGrammarException;
 import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.transaction.IllegalTransactionStateException;
 import org.springframework.transaction.TransactionDefinition;
@@ -324,6 +326,31 @@ class R2dbcTransactionManagerUnitTests {
 		verify(connectionMock).rollbackTransaction();
 		verify(connectionMock).close();
 		verifyNoMoreInteractions(connectionMock);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testConnectionReleasedWhenRollbackFails() {
+		when(connectionMock.rollbackTransaction()).thenReturn(Mono.defer(() -> Mono.error(new R2dbcBadGrammarException("Rollback should fail"))), Mono.empty());
+
+		TransactionalOperator operator = TransactionalOperator.create(tm);
+
+		when(connectionMock.isAutoCommit()).thenReturn(true);
+		when(connectionMock.setAutoCommit(true)).thenReturn(Mono.defer(() -> Mono.error(new R2dbcTimeoutException("SET AUTOCOMMIT = 1 timed out"))));
+		when(connectionMock.setTransactionIsolationLevel(any())).thenReturn(Mono.empty());
+		when(connectionMock.setAutoCommit(false)).thenReturn(Mono.empty());
+
+		operator.execute(reactiveTransaction -> ConnectionFactoryUtils.getConnection(connectionFactoryMock)
+						.doOnNext(connection -> {
+							throw new IllegalStateException("Intentional error to trigger rollback");
+						}).then()).as(StepVerifier::create)
+				.verifyError(BadSqlGrammarException.class);
+
+		verify(connectionMock).isAutoCommit();
+		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));
+		verify(connectionMock, never()).commitTransaction();
+		verify(connectionMock).rollbackTransaction();
+		verify(connectionMock).close();
 	}
 
 	@Test

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/R2dbcTransactionManagerUnitTests.java
@@ -25,6 +25,7 @@ import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.R2dbcBadGrammarException;
 import io.r2dbc.spi.R2dbcTimeoutException;
 import io.r2dbc.spi.Statement;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -344,7 +345,10 @@ class R2dbcTransactionManagerUnitTests {
 						.doOnNext(connection -> {
 							throw new IllegalStateException("Intentional error to trigger rollback");
 						}).then()).as(StepVerifier::create)
-				.verifyError(BadSqlGrammarException.class);
+				.verifyErrorSatisfies(e -> Assertions.assertThat(e)
+						.isInstanceOf(BadSqlGrammarException.class)
+						.hasCause(new R2dbcBadGrammarException("Rollback should fail"))
+				);
 
 		verify(connectionMock).isAutoCommit();
 		verify(connectionMock).beginTransaction(any(io.r2dbc.spi.TransactionDefinition.class));


### PR DESCRIPTION
When using R2dbcTransactionManager, connection will not be released if it encounters error while doing `afterCleanup`.
As `afterCleanup` uses a database connection when doing `setAutoCommit(true)`, it can be failed under some conditions where the connection not reliable.

The problem is that when this issue occurs, the number of acquired connections are not decreased because the connection is not released. Also, if all the connections in the pool are depleted, the connection pool cannot allocate further connections and the request that needs database connections hang.

I created a project to easily reproduce this issue: https://github.com/FutureGadget/spring-r2dbc-connection-not-released

Since I use Spring 5.3.25 in production, I hope this fix to be backported at least to 5.3.25 and later versions.
Thank you.