### PR TITLE
Support ordering of AOP advice annotations at the method level

### DIFF
--- a/integration-tests/src/test/java/org/springframework/aop/framework/autoproxy/AspectJAutoProxyAdviceOrderIntegrationTests.java
+++ b/integration-tests/src/test/java/org/springframework/aop/framework/autoproxy/AspectJAutoProxyAdviceOrderIntegrationTests.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.core.annotation.Order;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -62,11 +63,11 @@ class AspectJAutoProxyAdviceOrderIntegrationTests {
 		void afterAdviceIsInvokedLast(@Autowired Echo echo, @Autowired AfterAdviceFirstAspect aspect) throws Exception {
 			assertThat(aspect.invocations).isEmpty();
 			assertThat(echo.echo(42)).isEqualTo(42);
-			assertThat(aspect.invocations).containsExactly("around - start", "before", "after returning", "after", "around - end");
+			assertThat(aspect.invocations).containsExactly("around - start", "before-1", "before", "after returning", "after", "around - end");
 
 			aspect.invocations.clear();
 			assertThatException().isThrownBy(() -> echo.echo(new Exception()));
-			assertThat(aspect.invocations).containsExactly("around - start", "before", "after throwing", "after", "around - end");
+			assertThat(aspect.invocations).containsExactly("around - start", "before-1", "before", "after throwing", "after", "around - end");
 		}
 	}
 
@@ -168,8 +169,15 @@ class AspectJAutoProxyAdviceOrderIntegrationTests {
 		}
 
 		@Before("echo()")
+		@Order(0)
 		void before() {
 			invocations.add("before");
+		}
+
+		@Before("echo()")
+		@Order(-1)
+		void before1() {
+			invocations.add("before-1");
 		}
 
 		@Around("echo()")

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/ReflectiveAspectJAdvisorFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/ReflectiveAspectJAdvisorFactory.java
@@ -47,6 +47,7 @@ import org.springframework.aop.framework.AopConfigException;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.OrderUtils;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.ConvertingComparator;
 import org.springframework.lang.Nullable;
@@ -91,7 +92,15 @@ public class ReflectiveAspectJAdvisorFactory extends AbstractAspectJAdvisorFacto
 					return (ann != null ? ann.getAnnotation() : null);
 				});
 		Comparator<Method> methodNameComparator = new ConvertingComparator<>(Method::getName);
-		adviceMethodComparator = adviceKindComparator.thenComparing(methodNameComparator);
+		Comparator<Method> methodOrderComparator = new ConvertingComparator<>(method -> {
+			final Integer order = OrderUtils.getOrder(method);
+			if (order == null) {
+				return Integer.MAX_VALUE;
+			}
+			return order;
+		});
+
+		adviceMethodComparator = adviceKindComparator.thenComparing(methodOrderComparator).thenComparing(methodNameComparator);
 	}
 
 


### PR DESCRIPTION
Make the advice methods support order annotation to sorting.