### PR TITLE
Add HttpHeaders constructor with single value Map

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -1057,8 +1057,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		else if (HttpHeaders.ACCEPT_LANGUAGE.equalsIgnoreCase(name) &&
 				!this.headers.containsKey(HttpHeaders.ACCEPT_LANGUAGE)) {
 			try {
-				HttpHeaders headers = new HttpHeaders();
-				headers.add(HttpHeaders.ACCEPT_LANGUAGE, value.toString());
+				HttpHeaders headers = new HttpHeaders(HttpHeaders.ACCEPT_LANGUAGE, value.toString());
 				List<Locale> locales = headers.getAcceptLanguageAsLocales();
 				this.locales.clear();
 				this.locales.addAll(locales);

--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -690,8 +690,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 		}
 		else if (HttpHeaders.CONTENT_LANGUAGE.equalsIgnoreCase(name)) {
 			String contentLanguages = value.toString();
-			HttpHeaders headers = new HttpHeaders();
-			headers.add(HttpHeaders.CONTENT_LANGUAGE, contentLanguages);
+			HttpHeaders headers = new HttpHeaders(HttpHeaders.CONTENT_LANGUAGE, contentLanguages);
 			Locale language = headers.getContentLanguage();
 			setLocale(language != null ? language : Locale.getDefault());
 			// Since setLocale() sets the Content-Language header to the given

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -196,8 +196,7 @@ class DefaultWebTestClient implements WebTestClient {
 		DefaultRequestBodyUriSpec(HttpMethod httpMethod) {
 			this.httpMethod = httpMethod;
 			this.requestId = String.valueOf(requestIndex.incrementAndGet());
-			this.headers = new HttpHeaders();
-			this.headers.add(WebTestClient.WEBTESTCLIENT_REQUEST_ID, this.requestId);
+			this.headers = new HttpHeaders(WebTestClient.WEBTESTCLIENT_REQUEST_ID, this.requestId);
 		}
 
 		@Override

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/HeaderAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/HeaderAssertionTests.java
@@ -49,9 +49,7 @@ class HeaderAssertionTests {
 
 	@Test
 	void valueEquals() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("foo", "bar");
-		HeaderAssertions assertions = headerAssertions(headers);
+		HeaderAssertions assertions = headerAssertions(new HttpHeaders("foo", "bar"));
 
 		// Success
 		assertions.valueEquals("foo", "bar");
@@ -129,9 +127,7 @@ class HeaderAssertionTests {
 
 	@Test
 	void valueMatcher() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("foo", "bar");
-		HeaderAssertions assertions = headerAssertions(headers);
+		HeaderAssertions assertions = headerAssertions(new HttpHeaders("foo", "bar"));
 
 		assertions.value("foo", containsString("a"));
 	}

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -433,6 +433,18 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	}
 
 	/**
+	 * Construct a new {@code HttpHeaders} from single value header.
+	 * <p>This constructor is using a case-insensitive map structure.
+	 * @param singleKey the header name
+	 * @param singleValue the header value
+	 * @since 6.0
+	 */
+	public HttpHeaders(String singleKey, String singleValue) {
+		this();
+		this.headers.put(singleKey, new ArrayList<>(List.of(singleValue)));
+	}
+
+	/**
 	 * Construct a new {@code HttpHeaders} instance backed by an existing map.
 	 * <p>This constructor is available as an optimization for adapting to existing
 	 * headers map structures, primarily for internal use within the framework.

--- a/spring-web/src/main/java/org/springframework/web/HttpRequestMethodNotSupportedException.java
+++ b/spring-web/src/main/java/org/springframework/web/HttpRequestMethodNotSupportedException.java
@@ -149,9 +149,9 @@ public class HttpRequestMethodNotSupportedException extends ServletException imp
 		if (ObjectUtils.isEmpty(this.supportedMethods)) {
 			return HttpHeaders.EMPTY;
 		}
-		HttpHeaders headers = new HttpHeaders();
-		headers.add(HttpHeaders.ALLOW, StringUtils.arrayToDelimitedString(this.supportedMethods, ", "));
-		return headers;
+		return new HttpHeaders(
+				HttpHeaders.ALLOW, StringUtils.arrayToDelimitedString(this.supportedMethods, ", ")
+		);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/web/multipart/support/DefaultMultipartHttpServletRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/support/DefaultMultipartHttpServletRequest.java
@@ -144,9 +144,7 @@ public class DefaultMultipartHttpServletRequest extends AbstractMultipartHttpSer
 	public HttpHeaders getMultipartHeaders(String paramOrFileName) {
 		String contentType = getMultipartContentType(paramOrFileName);
 		if (contentType != null) {
-			HttpHeaders headers = new HttpHeaders();
-			headers.add(CONTENT_TYPE, contentType);
-			return headers;
+			return new HttpHeaders(CONTENT_TYPE, contentType);
 		}
 		else {
 			return null;

--- a/spring-web/src/test/java/org/springframework/http/client/MultipartBodyBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/MultipartBodyBuilderTests.java
@@ -49,8 +49,7 @@ public class MultipartBodyBuilderTests {
 		Resource logo = new ClassPathResource("/org/springframework/http/converter/logo.jpg");
 		builder.part("logo", logo).header("baz", "qux");
 
-		HttpHeaders entityHeaders = new HttpHeaders();
-		entityHeaders.add("foo", "bar");
+		HttpHeaders entityHeaders = new HttpHeaders("foo", "bar");
 		HttpEntity<String> entity = new HttpEntity<>("body", entityHeaders);
 		builder.part("entity", entity).header("baz", "qux");
 

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
@@ -698,8 +698,7 @@ class RestTemplateTests {
 		mockSentRequest(POST, "https://example.com", requestHeaders);
 		mockResponseStatus(HttpStatus.OK);
 
-		HttpHeaders entityHeaders = new HttpHeaders();
-		entityHeaders.add("MyHeader", "MyEntityValue");
+		HttpHeaders entityHeaders = new HttpHeaders("MyHeader", "MyEntityValue");
 		HttpEntity<Void> entity = new HttpEntity<>(null, entityHeaders);
 		template.exchange("https://example.com", POST, entity, Void.class);
 		assertThat(requestHeaders.get("MyHeader")).contains("MyEntityValue", "MyInterceptorValue");
@@ -721,9 +720,8 @@ class RestTemplateTests {
 		mockSentRequest(POST, "https://example.com", requestHeaders);
 		mockResponseStatus(HttpStatus.OK);
 
-		HttpHeaders entityHeaders = new HttpHeaders();
+		HttpHeaders entityHeaders = new HttpHeaders("MyHeader", "MyEntityValue");
 		entityHeaders.setContentType(contentType);
-		entityHeaders.add("MyHeader", "MyEntityValue");
 		HttpEntity<String> entity = new HttpEntity<>("Hello World", entityHeaders);
 		template.exchange("https://example.com", POST, entity, Void.class);
 		assertThat(requestHeaders.get("MyHeader")).contains("MyEntityValue", "MyInterceptorValue");

--- a/spring-web/src/test/java/org/springframework/web/server/adapter/ForwardedHeaderTransformerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/adapter/ForwardedHeaderTransformerTests.java
@@ -71,8 +71,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test
 	void forwardedHeader() throws Exception {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Forwarded", "host=84.198.58.199;proto=https");
+		HttpHeaders headers = new HttpHeaders("Forwarded", "host=84.198.58.199;proto=https");
 		ServerHttpRequest request = this.requestMutator.apply(getRequest(headers));
 
 		assertThat(request.getURI()).isEqualTo(URI.create("https://84.198.58.199/path"));
@@ -81,8 +80,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test
 	void xForwardedPrefix() throws Exception {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("X-Forwarded-Prefix", "/prefix");
+		HttpHeaders headers = new HttpHeaders("X-Forwarded-Prefix", "/prefix");
 		ServerHttpRequest request = this.requestMutator.apply(getRequest(headers));
 
 		assertThat(request.getURI()).isEqualTo(URI.create("https://example.com/prefix/path"));
@@ -92,8 +90,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test // gh-23305
 	void xForwardedPrefixShouldNotLeadToDecodedPath() throws Exception {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("X-Forwarded-Prefix", "/prefix");
+		HttpHeaders headers = new HttpHeaders("X-Forwarded-Prefix", "/prefix");
 		ServerHttpRequest request = MockServerHttpRequest
 				.method(HttpMethod.GET, URI.create("https://example.com/a%20b?q=a%2Bb"))
 				.headers(headers)
@@ -108,8 +105,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test
 	void xForwardedPrefixTrailingSlash() throws Exception {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("X-Forwarded-Prefix", "/prefix////");
+		HttpHeaders headers = new HttpHeaders("X-Forwarded-Prefix", "/prefix////");
 		ServerHttpRequest request = this.requestMutator.apply(getRequest(headers));
 
 		assertThat(request.getURI()).isEqualTo(URI.create("https://example.com/prefix/path"));
@@ -119,8 +115,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test // SPR-17525
 	void shouldNotDoubleEncode() throws Exception {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Forwarded", "host=84.198.58.199;proto=https");
+		HttpHeaders headers = new HttpHeaders("Forwarded", "host=84.198.58.199;proto=https");
 
 		ServerHttpRequest request = MockServerHttpRequest
 				.method(HttpMethod.GET, URI.create("https://example.com/a%20b?q=a%2Bb"))
@@ -135,8 +130,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test
 	void shouldConcatenatePrefixes() throws Exception {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("X-Forwarded-Prefix", "/first,/second");
+		HttpHeaders headers = new HttpHeaders("X-Forwarded-Prefix", "/first,/second");
 		ServerHttpRequest request = this.requestMutator.apply(getRequest(headers));
 
 		assertThat(request.getURI()).isEqualTo(URI.create("https://example.com/first/second/path"));
@@ -146,8 +140,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test
 	void shouldConcatenatePrefixesWithTrailingSlashes() throws Exception {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("X-Forwarded-Prefix", "/first/,/second//");
+		HttpHeaders headers = new HttpHeaders("X-Forwarded-Prefix", "/first/,/second//");
 		ServerHttpRequest request = this.requestMutator.apply(getRequest(headers));
 
 		assertThat(request.getURI()).isEqualTo(URI.create("https://example.com/first/second/path"));
@@ -157,8 +150,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test
 	void forwardedForNotPresent() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Forwarded", "host=84.198.58.199;proto=https");
+		HttpHeaders headers = new HttpHeaders("Forwarded", "host=84.198.58.199;proto=https");
 
 		InetSocketAddress remoteAddress = new InetSocketAddress("example.client", 47011);
 
@@ -174,8 +166,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test
 	void forwardedFor() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Forwarded", "for=\"203.0.113.195:4711\";host=84.198.58.199;proto=https");
+		HttpHeaders headers = new HttpHeaders("Forwarded", "for=\"203.0.113.195:4711\";host=84.198.58.199;proto=https");
 
 		InetSocketAddress remoteAddress = new InetSocketAddress("example.client", 47011);
 
@@ -193,8 +184,7 @@ class ForwardedHeaderTransformerTests {
 
 	@Test
 	void xForwardedFor() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("x-forwarded-for", "203.0.113.195, 70.41.3.18, 150.172.238.178");
+		HttpHeaders headers = new HttpHeaders("x-forwarded-for", "203.0.113.195, 70.41.3.18, 150.172.238.178");
 
 		ServerHttpRequest request = MockServerHttpRequest
 				.method(HttpMethod.GET, URI.create("https://example.com/a%20b?q=a%2Bb"))

--- a/spring-web/src/test/java/org/springframework/web/service/invoker/HttpRequestValuesTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/invoker/HttpRequestValuesTests.java
@@ -113,9 +113,7 @@ class HttpRequestValuesTests {
 
 	@Test
 	void requestPart() {
-		HttpHeaders entityHeaders = new HttpHeaders();
-		entityHeaders.add("foo", "bar");
-		HttpEntity<String> entity = new HttpEntity<>("body", entityHeaders);
+		HttpEntity<String> entity = new HttpEntity<>("body", new HttpHeaders("foo", "bar"));
 
 		HttpRequestValues requestValues = HttpRequestValues.builder()
 				.addRequestPart("form field", "form value")

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletRequest.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletRequest.java
@@ -1057,8 +1057,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		else if (HttpHeaders.ACCEPT_LANGUAGE.equalsIgnoreCase(name) &&
 				!this.headers.containsKey(HttpHeaders.ACCEPT_LANGUAGE)) {
 			try {
-				HttpHeaders headers = new HttpHeaders();
-				headers.add(HttpHeaders.ACCEPT_LANGUAGE, value.toString());
+				HttpHeaders headers = new HttpHeaders(HttpHeaders.ACCEPT_LANGUAGE, value.toString());
 				List<Locale> locales = headers.getAcceptLanguageAsLocales();
 				this.locales.clear();
 				this.locales.addAll(locales);

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletResponse.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockHttpServletResponse.java
@@ -690,8 +690,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
 		}
 		else if (HttpHeaders.CONTENT_LANGUAGE.equalsIgnoreCase(name)) {
 			String contentLanguages = value.toString();
-			HttpHeaders headers = new HttpHeaders();
-			headers.add(HttpHeaders.CONTENT_LANGUAGE, contentLanguages);
+			HttpHeaders headers = new HttpHeaders(HttpHeaders.CONTENT_LANGUAGE, contentLanguages);
 			Locale language = headers.getContentLanguage();
 			setLocale(language != null ? language : Locale.getDefault());
 			// Since setLocale() sets the Content-Language header to the given

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/RequestMappingInfoHandlerMappingTests.java
@@ -479,9 +479,7 @@ public class RequestMappingInfoHandlerMappingTests {
 
 		@RequestMapping(path = "/something", method = OPTIONS)
 		public HttpHeaders fooOptions() {
-			HttpHeaders headers = new HttpHeaders();
-			headers.add("Allow", "PUT,POST");
-			return headers;
+			return new HttpHeaders("Allow", "PUT,POST");
 		}
 
 		@RequestMapping(value = "/qux", method = RequestMethod.GET, produces = "application/xml")

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestMappingExceptionHandlingIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestMappingExceptionHandlingIntegrationTests.java
@@ -103,8 +103,7 @@ public class RequestMappingExceptionHandlingIntegrationTests extends AbstractReq
 	void exceptionFromMethodWithProducesCondition(HttpServer httpServer) throws Exception {
 		startServer(httpServer);
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Accept", "text/plain, application/problem+json");
+		HttpHeaders headers = new HttpHeaders("Accept", "text/plain, application/problem+json");
 		assertThatExceptionOfType(HttpStatusCodeException.class)
 				.isThrownBy(() -> performGet("/SPR-16318", headers, String.class))
 				.satisfies(ex -> {

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/DefaultRenderingBuilderTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/DefaultRenderingBuilderTests.java
@@ -101,8 +101,7 @@ public class DefaultRenderingBuilderTests {
 
 	@Test
 	public void httpHeaders() throws Exception {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("foo", "bar");
+		HttpHeaders headers = new HttpHeaders("foo", "bar");
 		Rendering rendering = Rendering.view("foo").headers(headers).build();
 
 		assertThat(rendering.headers()).isEqualTo(headers);

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/socket/WebSocketIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/socket/WebSocketIntegrationTests.java
@@ -130,8 +130,7 @@ class WebSocketIntegrationTests extends AbstractReactiveWebSocketIntegrationTest
 	void customHeader(WebSocketClient client, HttpServer server, Class<?> serverConfigClass) throws Exception {
 		startServer(client, server, serverConfigClass);
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("my-header", "my-value");
+		HttpHeaders headers = new HttpHeaders("my-header", "my-value");
 		AtomicReference<Object> headerRef = new AtomicReference<>();
 
 		this.client.execute(getUrl("/custom-header"), headers,

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
@@ -600,8 +600,7 @@ public class DispatcherServletTests {
 
 	@Test
 	public void noHandlerFoundExceptionMessage() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("foo", "bar");
+		HttpHeaders headers = new HttpHeaders("foo", "bar");
 		NoHandlerFoundException ex = new NoHandlerFoundException("GET", "/foo", headers);
 		assertThat(!ex.getMessage().contains("bar")).isTrue();
 		assertThat(!ex.toString().contains("bar")).isTrue();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMappingTests.java
@@ -531,9 +531,7 @@ class RequestMappingInfoHandlerMappingTests {
 
 		@RequestMapping(value = "/something", method = RequestMethod.OPTIONS)
 		public HttpHeaders fooOptions() {
-			HttpHeaders headers = new HttpHeaders();
-			headers.add("Allow", "PUT,POST");
-			return headers;
+			return new HttpHeaders("Allow", "PUT,POST");
 		}
 
 		@RequestMapping(value = "/qux", method = RequestMethod.GET, produces = "application/xml")

--- a/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransportTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/sockjs/client/RestTemplateXhrTransportTests.java
@@ -192,8 +192,7 @@ class RestTemplateXhrTransportTests {
 		transport.setTaskExecutor(new SyncTaskExecutor());
 
 		SockJsUrlInfo urlInfo = new SockJsUrlInfo(URI.create("https://example.com"));
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("h-foo", "h-bar");
+		HttpHeaders headers = new HttpHeaders("h-foo", "h-bar");
 		TransportRequest request = new DefaultTransportRequest(urlInfo, headers, headers,
 				transport, TransportType.XHR, CODEC);
 


### PR DESCRIPTION
Added constructor for HttpHeaders that accepts a Map.
This is useful in tests where we don't need to do a two step creation of HttpHeaders and then add the headers - it can be single line now.

Refactored few tests in existing code that could take advantage of the new constructor.