### PR TITLE
Avoid wasted memory on empty maps and sets

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
@@ -107,15 +107,20 @@ public class InjectionMetadata {
 	}
 
 	public void checkConfigMembers(RootBeanDefinition beanDefinition) {
-		Set<InjectedElement> checkedElements = new LinkedHashSet<>(this.injectedElements.size());
-		for (InjectedElement element : this.injectedElements) {
-			Member member = element.getMember();
-			if (!beanDefinition.isExternallyManagedConfigMember(member)) {
-				beanDefinition.registerExternallyManagedConfigMember(member);
-				checkedElements.add(element);
-			}
+		if (this.injectedElements.isEmpty()) {
+			this.checkedElements = Set.of();
 		}
-		this.checkedElements = checkedElements;
+		else {
+			Set<InjectedElement> checkedElements = new LinkedHashSet<>(this.injectedElements.size());
+			for (InjectedElement element : this.injectedElements) {
+				Member member = element.getMember();
+				if (!beanDefinition.isExternallyManagedConfigMember(member)) {
+					beanDefinition.registerExternallyManagedConfigMember(member);
+					checkedElements.add(element);
+				}
+			}
+			this.checkedElements = checkedElements;
+		}
 	}
 
 	public void inject(Object target, @Nullable String beanName, @Nullable PropertyValues pvs) throws Throwable {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
@@ -108,10 +108,10 @@ public class InjectionMetadata {
 
 	public void checkConfigMembers(RootBeanDefinition beanDefinition) {
 		if (this.injectedElements.isEmpty()) {
-			this.checkedElements = Set.of();
+			this.checkedElements = Collections.emptySet();
 		}
 		else {
-			Set<InjectedElement> checkedElements = new LinkedHashSet<>(this.injectedElements.size()*4/3);
+			Set<InjectedElement> checkedElements = new LinkedHashSet<>(this.injectedElements.size()*4/3 + 1);
 			for (InjectedElement element : this.injectedElements) {
 				Member member = element.getMember();
 				if (!beanDefinition.isExternallyManagedConfigMember(member)) {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InjectionMetadata.java
@@ -111,7 +111,7 @@ public class InjectionMetadata {
 			this.checkedElements = Set.of();
 		}
 		else {
-			Set<InjectedElement> checkedElements = new LinkedHashSet<>(this.injectedElements.size());
+			Set<InjectedElement> checkedElements = new LinkedHashSet<>(this.injectedElements.size()*4/3);
 			for (InjectedElement element : this.injectedElements) {
 				Member member = element.getMember();
 				if (!beanDefinition.isExternallyManagedConfigMember(member)) {

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/MergedAnnotationReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/MergedAnnotationReadingVisitor.java
@@ -18,7 +18,11 @@ package org.springframework.core.type.classreading;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import org.springframework.asm.AnnotationVisitor;

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/MergedAnnotationReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/MergedAnnotationReadingVisitor.java
@@ -18,10 +18,7 @@ package org.springframework.core.type.classreading;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
 
 import org.springframework.asm.AnnotationVisitor;
@@ -93,7 +90,7 @@ class MergedAnnotationReadingVisitor<A extends Annotation> extends AnnotationVis
 	@Override
 	public void visitEnd() {
 		Map<String, Object> compactedAttributes
-				= this.attributes.size() == 0 ? Map.of() : this.attributes;
+				= this.attributes.size() == 0 ? Collections.emptyMap() : this.attributes;
 		MergedAnnotation<A> annotation = MergedAnnotation.of(
 				this.classLoader, this.source, this.annotationType, compactedAttributes);
 		this.consumer.accept(annotation);

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/MergedAnnotationReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/MergedAnnotationReadingVisitor.java
@@ -92,8 +92,10 @@ class MergedAnnotationReadingVisitor<A extends Annotation> extends AnnotationVis
 
 	@Override
 	public void visitEnd() {
+		Map<String, Object> compactedAttributes
+				= this.attributes.size() == 0 ? Map.of() : this.attributes;
 		MergedAnnotation<A> annotation = MergedAnnotation.of(
-				this.classLoader, this.source, this.annotationType, this.attributes);
+				this.classLoader, this.source, this.annotationType, compactedAttributes);
 		this.consumer.accept(annotation);
 	}
 


### PR DESCRIPTION
Empty LinkedHashMaps waste quite a lot of memory (250kb) for a medium size project

The PR introduces a simple fix

A screen from yourkit profiler:

![image](https://user-images.githubusercontent.com/6681790/209533160-3e2f724d-1afb-4b65-9acc-13c07dbc04fb.png)
