### PR TITLE
Fix wrong asserted code in SQLExceptionSubclassTranslatorTests

### DIFF
--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/SQLExceptionSubclassTranslatorTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/SQLExceptionSubclassTranslatorTests.java
@@ -59,7 +59,7 @@ public class SQLExceptionSubclassTranslatorTests {
 		doTest(new SQLIntegrityConstraintViolationException("", "23505", 0), DuplicateKeyException.class);
 		doTest(new SQLIntegrityConstraintViolationException("", "23000", 1), DuplicateKeyException.class);
 		doTest(new SQLIntegrityConstraintViolationException("", "23000", 1062), DuplicateKeyException.class);
-		doTest(new SQLIntegrityConstraintViolationException("", "23505", 2627), DuplicateKeyException.class);
+		doTest(new SQLIntegrityConstraintViolationException("", "23000", 2627), DuplicateKeyException.class);
 		doTest(new SQLInvalidAuthorizationSpecException("", "", 0), PermissionDeniedDataAccessException.class);
 		doTest(new SQLNonTransientConnectionException("", "", 0), DataAccessResourceFailureException.class);
 		doTest(new SQLRecoverableException("", "", 0), RecoverableDataAccessException.class);


### PR DESCRIPTION
It seems to be a copy-and-paste error.

See a644245