### PR TITLE
JMS SingleConnectionFactory cached connection usage counter misbehavior

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/connection/SingleConnectionFactory.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/SingleConnectionFactory.java
@@ -679,11 +679,15 @@ public class SingleConnectionFactory implements ConnectionFactory, QueueConnecti
 			synchronized (connectionMonitor) {
 				if (this.locallyStarted) {
 					this.locallyStarted = false;
-					if (startedCount == 1 && connection != null) {
-						connection.stop();
+					try{
+						if (startedCount == 1 && connection != null) {
+							connection.stop();
+						}
 					}
-					if (startedCount > 0) {
-						startedCount--;
+					finally{
+						if (startedCount > 0) {
+							startedCount--;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The SingleConnectionFactory wraps the connection inside a ProxyClass. 
As the connection starts a counter gets increased.  
When the proxied connection gets stopped the counter is evaluated to see 
if there is any other usage of that connection. 
In case of being the last one, connection#stop is called. 
If connection#stop is called and an exception is thrown, 
the counter decrement is skipped and then it's never called again.