### PR TITLE
NoUniqueBeanDefinitionException should make sure beansNameFound is serializable

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/DependencyDescriptor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/DependencyDescriptor.java
@@ -21,6 +21,7 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 
@@ -215,7 +216,7 @@ public class DependencyDescriptor extends InjectionPoint implements Serializable
 	 */
 	@Nullable
 	public Object resolveNotUnique(ResolvableType type, Map<String, Object> matchingBeans) throws BeansException {
-		throw new NoUniqueBeanDefinitionException(type, matchingBeans.keySet());
+		throw new NoUniqueBeanDefinitionException(type, new HashSet<>( matchingBeans.keySet() ));
 	}
 
 	/**

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -1284,7 +1285,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 				return new NamedBeanHolder<>(candidateName, (T) beanInstance);
 			}
 			if (!nonUniqueAsNull) {
-				throw new NoUniqueBeanDefinitionException(requiredType, candidates.keySet());
+				throw new NoUniqueBeanDefinitionException(requiredType, new HashSet<>(candidates.keySet()));
 			}
 		}
 


### PR DESCRIPTION
Seen in Spring 5.3.18. `LinkedHashMap.keySet()` tends to return a `java.util.LinkedHashMap$LinkedKeySet` instance, which is not serializable. This becomes a problem then when you e.g. try to propagate the `NoUniqueBeanDefinitionException` error across a network boundary (our use case).

Wrapping these in `HashSet`s seem like the simplest way around. The only other call site was passing in an `Arrays.asList()` object, and `asList` is explicitly defined to return a serializable list.

(If this change is considered good/safe, it would perhaps be worth back-porting this to the Spring 5 branch as well. It does indeed change the semantics, but it could also arguably be considered a back-port safe bug fix.)

Thanks for a great project! :pray: 