### PR TITLE
Improvement to allow customization of kotlin serializer in AbstractKotlinSerializationHttpMessageConverter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/AbstractKotlinSerializationHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/AbstractKotlinSerializationHttpMessageConverter.java
@@ -152,7 +152,7 @@ public abstract class AbstractKotlinSerializationHttpMessageConverter<T extends 
 		KSerializer<Object> serializer = serializerCache.get(type);
 		if (serializer == null) {
 			try {
-				serializer = SerializersKt.serializerOrNull(type);
+				serializer = serializerInternal(type);
 			}
 			catch (IllegalArgumentException ignored) {
 			}
@@ -165,6 +165,12 @@ public abstract class AbstractKotlinSerializationHttpMessageConverter<T extends 
 		}
 		return serializer;
 	}
+
+	/**
+	 * An abstract method that returns a KSerializer over the given type.
+	 */
+	@Nullable
+	protected abstract KSerializer<Object> serializerInternal(Type type) throws IllegalArgumentException;
 
 	private boolean hasPolymorphism(SerialDescriptor descriptor, Set<String> alreadyProcessed) {
 		alreadyProcessed.add(descriptor.getSerialName());

--- a/spring-web/src/main/java/org/springframework/http/converter/KotlinSerializationBinaryHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/KotlinSerializationBinaryHttpMessageConverter.java
@@ -17,11 +17,13 @@
 package org.springframework.http.converter;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 import kotlinx.serialization.BinaryFormat;
 import kotlinx.serialization.KSerializer;
 import kotlinx.serialization.SerializationException;
 
+import kotlinx.serialization.SerializersKt;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -75,5 +77,10 @@ public abstract class KotlinSerializationBinaryHttpMessageConverter<T extends Bi
 		catch (SerializationException ex) {
 			throw new HttpMessageNotWritableException("Could not write " + format + ": " + ex.getMessage(), ex);
 		}
+	}
+
+	@Override
+	protected KSerializer<Object> serializerInternal(Type type) throws IllegalArgumentException {
+		return SerializersKt.serializerOrNull(type);
 	}
 }

--- a/spring-web/src/main/java/org/springframework/http/converter/json/KotlinSerializationJsonHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/KotlinSerializationJsonHttpMessageConverter.java
@@ -16,10 +16,14 @@
 
 package org.springframework.http.converter.json;
 
+import kotlinx.serialization.KSerializer;
+import kotlinx.serialization.SerializersKt;
 import kotlinx.serialization.json.Json;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.KotlinSerializationStringHttpMessageConverter;
+
+import java.lang.reflect.Type;
 
 /**
  * Implementation of {@link org.springframework.http.converter.HttpMessageConverter}
@@ -52,5 +56,10 @@ public class KotlinSerializationJsonHttpMessageConverter extends KotlinSerializa
 	 */
 	public KotlinSerializationJsonHttpMessageConverter(Json json) {
 		super(json, MediaType.APPLICATION_JSON, new MediaType("application", "*+json"));
+	}
+
+	@Override
+	protected KSerializer<Object> serializerInternal(Type type) throws IllegalArgumentException {
+		return SerializersKt.serializerOrNull(type);
 	}
 }


### PR DESCRIPTION
I found that Page Generic Type does not work with kotlin serialization.

Reference Issue: [Issue-28389](https://github.com/spring-projects/spring-framework/issues/28389)

As a result of debugging and analysis, I found the following problems.

**[Problem]**
* For page types, `AbstractKotlinSerializationHttpMessageConverter.serialize()` always returns null, so `AbstractKotlinSerializationHttpMessageConverter.canWrite()` will return false. Therefore, KotlinSerialization is ignored by [`AbstractMessageConverterMethodProcessor.writeWithMessageConverters()`](https://github.com/spring-projects/spring-framework/blob/62cf2f0a4f6de789a3acec7778cce7eeea6c849e/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java#L286).
```Java
        @Override
	public boolean canWrite(@Nullable Type type, Class<?> clazz, @Nullable MediaType mediaType) {
		if (serializer(type != null ? GenericTypeResolver.resolveType(type, clazz) : clazz) != null) {
			return canWrite(mediaType);
		}
		else {
			return false;
		}
	}

        /**
	 * Tries to find a serializer that can marshall or unmarshall instances of the given type
	 * using kotlinx.serialization. If no serializer can be found, {@code null} is returned.
	 * <p>Resolved serializers are cached and cached results are returned on successive calls.
	 * @param type the type to find a serializer for
	 * @return a resolved serializer for the given type, or {@code null}
	 */
	@Nullable
	private KSerializer<Object> serializer(Type type) {
		KSerializer<Object> serializer = serializerCache.get(type);
		if (serializer == null) {
			try {
				serializer = SerializersKt.serializerOrNull(type);
			}
			catch (IllegalArgumentException ignored) {
			}
			if (serializer != null) {
				if (hasPolymorphism(serializer.getDescriptor(), new HashSet<>())) {
					return null;
				}
				serializerCache.put(type, serializer);
			}
		}
		return serializer;
	}
```
* Why does `AbstractKotlinSerializationHttpMessageConverter.serialize()` always return null? 
  * It always returns a PolymorphicSerializer instance because Page is an interface type in `Serializer sKt.serializeOrNull()`.
  * However, since the registered `KotlinSerializationJsonHttpMessageConverter` does [not support open Polymorphic Serialization](https://github.com/spring-projects/spring-framework/blob/42b16591ec9978f9e317035bad998e617e79bb7e/spring-web/src/main/java/org/springframework/http/converter/json/KotlinSerializationJsonHttpMessageConverter.java#L30), null is returned due to the `hasPolymorphism()` function.
![스크린샷, 2023-01-03 20-14-16](https://user-images.githubusercontent.com/50299857/210347612-073a35ee-92a9-4df3-a31e-82f664e27c3b.png)
![image](https://user-images.githubusercontent.com/50299857/210345461-b40ee34a-caef-44b3-b184-64ecf0ce4371.png)
![image](https://user-images.githubusercontent.com/50299857/210345709-3450637d-2df8-4b9c-9575-906b8f3590bd.png)

**[Temporarily Resolved]**
I understood the above problems and solved them by customizing `AbstractKotlinSerializationHttpMessageConverter` and registering it.

* Create PageSerializer
```Kotlin
class PageSerializer<T>(
    private val dataSerializer: KSerializer<List<T>>
) : KSerializer<Page<T>> {
    override val descriptor: SerialDescriptor = dataSerializer.descriptor
    override fun serialize(encoder: Encoder, value: Page<T>) = dataSerializer.serialize(encoder, value.content)
    override fun deserialize(decoder: Decoder) = PageImpl(dataSerializer.deserialize(decoder))
}
```
* Customize `AbstractKotlinSerializationHttpMessageConverter.serialize()` -> `CustomKotlinSerializationJsonHttpMessageConverter` class
```Kotlin
        @Suppress("UNCHECKED_CAST")
        @OptIn(ExperimentalSerializationApi::class)
        override fun serializerInternal(type: Type): KSerializer<Any>? {
            return when(type) {
                is ParameterizedType -> {
                    val rootClass = (type.rawType as Class<*>)
                    val args = (type.actualTypeArguments)
                    val argsSerializers = args.map { serializerOrNull(it) }
                    if (argsSerializers.isEmpty() && argsSerializers.first() == null) return null
                    when {
                        Page::class.java.isAssignableFrom(rootClass) ->
                            PageSerializer(ListSerializer(argsSerializers.first()!!.nullable)) as KSerializer<Any>?
                        else -> null
                    }
                }
                else -> serializerOrNull(type)
            }
        }
```
* Register CustomKotlinSerializationJsonHttpMessageConverter
```Kotlin
@Configuration
@EnableWebMvc
class WebConfig : WebMvcConfigurer {

    override fun configureMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
        converters.addAll(listOf(CustomKotlinSerializationJsonHttpMessageConverter(), MappingJackson2HttpMessageConverter()))
        println(converters)
    }
}
```

**As a result, it was successful.**
```Kotlin
@Serializable
data class UserDto(
    val id: Long,
    val name: String,
    val phone: String,
    @SerialName("isActive")
    @JsonProperty("isActiveJackson")
    val active: Boolean,
    val createdAt: String?,
    val updatedAt: String?
)
```
![스크린샷, 2023-01-03 20-47-12](https://user-images.githubusercontent.com/50299857/210351425-da0f693b-f05c-4ece-9192-21f2defe3303.png)

**[My opinion]**
I think it is a very inconvenient process for users to create and register CustomKotlinSerializationHttpMessageConverter as above every time. And since Page, Slice, etc. are the types that users use a lot, the above process will be more inconvenient.

I tried to solve it by forking the Spring-Data-Commons module that owns the Page class, but found out that the access specifier of `AbstractKotlinSerializationHttpMessageConverter.serialize()` was private, so I considered making serializeInternal abstract method.

If PR is allowed, I think I can expect the following two effects.
1. Expectations that can be extended by adding KotlinSerializationHttpMessageConverter for Page, Slice in Spring-Data-Commons Module
2. Expectations that users can expand by creating and registering the necessary custom serializers in the project as needed

**[Plan]**
* I will add KotlinSerializeHttpMessageConverter for Page and Slice in Spring-Data-Commons module like the contents of [Comment](https://github.com/spring-projects/spring-data-commons/issues/2752#issuecomment-1368726749).