### PR TITLE
Polish #29727: Mention Kotlin andExpectAll in reference manual

### DIFF
--- a/framework-docs/src/docs/asciidoc/testing/spring-mvc-test-framework.adoc
+++ b/framework-docs/src/docs/asciidoc/testing/spring-mvc-test-framework.adoc
@@ -445,6 +445,17 @@ all failures will be tracked and reported.
 		content().contentType("application/json;charset=UTF-8"));
 ----
 
+[source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
+.Kotlin
+----
+	import org.springframework.test.web.servlet.get
+
+	mockMvc.get("/accounts/1").andExpectAll {
+		status { isOk() }
+		content { contentType(APPLICATION_JSON) }
+	}
+----
+
 `MockMvcResultMatchers.*` provides a number of expectations, some of which are further
 nested with more detailed expectations.
 


### PR DESCRIPTION
This just adds a Kotlin snippet alongside the Java snippet in the
reference manual.

Relates to gh-29727
Closes gh-27317
