### PR TITLE
Fix AbstractMessageConverter not delegating to ContentTypeResolver when message header is null

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/converter/AbstractMessageConverter.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/converter/AbstractMessageConverter.java
@@ -251,7 +251,7 @@ public abstract class AbstractMessageConverter implements SmartMessageConverter 
 
 	@Nullable
 	protected MimeType getMimeType(@Nullable MessageHeaders headers) {
-		return (headers != null && this.contentTypeResolver != null ? this.contentTypeResolver.resolve(headers) : null);
+		return (this.contentTypeResolver != null ? this.contentTypeResolver.resolve(headers) : null);
 	}
 
 	/**

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/DefaultContentTypeResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/DefaultContentTypeResolverTests.java
@@ -97,4 +97,12 @@ public class DefaultContentTypeResolverTests {
 		assertThat(this.resolver.resolve(headers)).isEqualTo(MimeTypeUtils.APPLICATION_JSON);
 	}
 
+	@Test
+	public void resolveDefaultMimeTypeWithNoHeader() {
+		this.resolver.setDefaultMimeType(MimeTypeUtils.APPLICATION_JSON);
+		MessageHeaders headers = null;
+
+		assertThat(this.resolver.resolve(headers)).isEqualTo(MimeTypeUtils.APPLICATION_JSON);
+	}
+
 }

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/MessageConverterTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/MessageConverterTests.java
@@ -138,6 +138,18 @@ public class MessageConverterTests {
 		assertThat(message.getHeaders().get(MessageHeaders.CONTENT_TYPE)).isEqualTo(MimeTypeUtils.TEXT_PLAIN);
 	}
 
+	@Test
+	public void toMessageDefaultContentType() {
+		DefaultContentTypeResolver resolver = new DefaultContentTypeResolver();
+		resolver.setDefaultMimeType(MimeTypeUtils.TEXT_PLAIN);
+		TestMessageConverter converter = new TestMessageConverter();
+		converter.setContentTypeResolver(resolver);
+		converter.setStrictContentTypeMatch(true);
+
+		Message<?> message = converter.toMessage("ABC", null);
+		assertThat(message.getHeaders().get(MessageHeaders.CONTENT_TYPE)).isEqualTo(MimeTypeUtils.TEXT_PLAIN);
+	}
+
 
 	private static class TestMessageConverter extends AbstractMessageConverter {
 


### PR DESCRIPTION
### Versions
* Spring Messaging 6.0.3 / 5.3.24

### Problems
`DefaultContentTypeResolver#resolve` will return `defaultMimeType` if `null` is passed as `MessageHeaders`.
https://github.com/spring-projects/spring-framework/blob/0fbc94fae002a2bf25b62b0591dcadffab817b94/spring-messaging/src/main/java/org/springframework/messaging/converter/DefaultContentTypeResolver.java#L58-L63

However, `AbstractMessageConverter#getMimeType` does not call the `contentTypeResolver` if `null` is passed as `MessageHeaders`.
https://github.com/spring-projects/spring-framework/blob/0fbc94fae002a2bf25b62b0591dcadffab817b94/spring-messaging/src/main/java/org/springframework/messaging/converter/AbstractMessageConverter.java#L252-L255

Because of this, even if `DefaultContentTypeResolver#defaultMimeType` is set properly, it may be ignored.

> I've confirmed this issue with Spring Cloud Stream [`CompositeMessageConverter`](https://github.com/spring-cloud/spring-cloud-stream/blob/03690257b609780ba202973031404841980b943a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CompositeMessageConverterFactory.java#L82-L99).
> `ApplicationJsonMessageMarshallingConverter` (child converter of `CompositeMessageConverter`) has `strictContentTypeMatch=true`, so it thinks it's not a supported content type.

### Fixes

`ContentTypeResolver#resolve` accepts `null`, so `MessageConverter` should always delegate resolution to it.
Fix `AbstractMessageConverter#getMimeType` not checking the value of `MessageHeaders`.
