### PR TITLE
Optimize initial size in ContentCachingRequestWrapper when contentCacheLimit set

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
@@ -55,6 +55,8 @@ import org.springframework.lang.Nullable;
  */
 public class ContentCachingRequestWrapper extends HttpServletRequestWrapper {
 
+	private static final int DEFAULT_INITIAL_BUFFER_SIZE_WHEN_UNKNOWN = 1024;
+
 	private final ByteArrayOutputStream cachedContent;
 
 	@Nullable
@@ -74,7 +76,8 @@ public class ContentCachingRequestWrapper extends HttpServletRequestWrapper {
 	public ContentCachingRequestWrapper(HttpServletRequest request) {
 		super(request);
 		int contentLength = request.getContentLength();
-		this.cachedContent = new ByteArrayOutputStream(contentLength >= 0 ? contentLength : 1024);
+		this.cachedContent = new ByteArrayOutputStream(contentLength >= 0 ?
+				contentLength : DEFAULT_INITIAL_BUFFER_SIZE_WHEN_UNKNOWN);
 		this.contentCacheLimit = null;
 	}
 
@@ -87,7 +90,9 @@ public class ContentCachingRequestWrapper extends HttpServletRequestWrapper {
 	 */
 	public ContentCachingRequestWrapper(HttpServletRequest request, int contentCacheLimit) {
 		super(request);
-		this.cachedContent = new ByteArrayOutputStream(contentCacheLimit);
+		int contentLength = request.getContentLength();
+		int guessedInitBufferSize = contentLength >= 0 ? contentLength : DEFAULT_INITIAL_BUFFER_SIZE_WHEN_UNKNOWN;
+		this.cachedContent = new ByteArrayOutputStream(Math.min(guessedInitBufferSize, contentCacheLimit));
 		this.contentCacheLimit = contentCacheLimit;
 	}
 


### PR DESCRIPTION
To avoid over-allocating the initial buffer for content caching:
1. If the content size is known and is smaller than the content limit, use that
2. If the content size is unknown use the default initial buffer size (or content limit if smaller) and allow it to grow as needed

This allows for scenarios where limiting behavior is desired to avoid overly large caching but at the same time the majority of requests are not near that limit. For example, allowing a maximum of 1MB content caching but the majority of requests are in the single digit KB size. Rather than allocate the worst case 1MB byte arrays per request these can be scaled in to be more appropriately sized.