### PR TITLE
Increase number of TOC levels in generated PDF documentation

### DIFF
--- a/framework-docs/src/docs/asciidoc/page-layout.adoc
+++ b/framework-docs/src/docs/asciidoc/page-layout.adoc
@@ -1,4 +1,4 @@
 :toc: left
-:toclevels: 4
+:toclevels: 5
 :tabsize: 4
 :docinfo1:

--- a/framework-docs/src/docs/asciidoc/spring-framework.adocbook
+++ b/framework-docs/src/docs/asciidoc/spring-framework.adocbook
@@ -1,6 +1,7 @@
 :noheader:
 :toc:
 include::attributes.adoc[]
+include::page-layout.adoc[]
 = Spring Framework Documentation
 Rod Johnson; Juergen Hoeller; Keith Donald; Colin Sampaleanu; Rob Harrop; Thomas Risberg; Alef Arendsen; Darren Davison; Dmitriy Kopylenko; Mark Pollack; Thierry Templier; Erwin Vervaet; Portia Tung; Ben Hale; Adrian Colyer; John Lewis; Costin Leau; Mark Fisher; Sam Brannen; Ramnivas Laddad; Arjen Poutsma; Chris Beams; Tareq Abedrabbo; Andy Clement; Dave Syer; Oliver Gierke; Rossen Stoyanchev; Phillip Webb; Rob Winch; Brian Clozel; Stephane Nicoll; Sebastien Deleuze; Jay Bryant; Mark Paluch
 


### PR DESCRIPTION
This was introduced by 4b22a4a0d.

This is single pdf file now.
![image](https://user-images.githubusercontent.com/3364975/211140751-c2e45a20-74ea-4419-a321-ac82e2230913.png)

This is splitted file before.
![image](https://user-images.githubusercontent.com/3364975/211140846-a40e2f8b-34ba-4b5f-805c-a2896021c787.png)

