### PR TITLE
Fix R2dbcTransactionManager debug log: don't log a Mono

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
@@ -200,7 +200,7 @@ public class R2dbcTransactionManager extends AbstractReactiveTransactionManager 
 				Mono<Connection> newCon = Mono.from(obtainConnectionFactory().create());
 				connectionMono = newCon.doOnNext(connection -> {
 					if (logger.isDebugEnabled()) {
-						logger.debug("Acquired Connection [" + newCon + "] for R2DBC transaction");
+						logger.debug("Acquired Connection [" + connection + "] for R2DBC transaction");
 					}
 					txObject.setConnectionHolder(new ConnectionHolder(connection), true);
 				});


### PR DESCRIPTION
Motivation:
There's an issue when logging the current connection inside R2dbcTransactionManager#doBegin :
the mono object is logged instead of the connection lambda parameter, resulting in wrong log
ex)
`2023-01-11 15:09:32.809 DEBUG 45809 --- [actor-tcp-nio-2] o.s.r.c.R2dbcTransactionManager          : Acquired Connection [MonoRetry] for R2DBC transaction`