### PR TITLE
Fix integer multiplications by implicitly cast to long

### DIFF
--- a/spring-context/src/test/java/org/springframework/scheduling/concurrent/ScheduledExecutorFactoryBeanTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/concurrent/ScheduledExecutorFactoryBeanTests.java
@@ -218,7 +218,7 @@ class ScheduledExecutorFactoryBeanTests {
 
 	private static void pauseToLetTaskStart(int seconds) {
 		try {
-			Thread.sleep(seconds * 1000);
+			Thread.sleep(seconds * 1000L);
 		}
 		catch (InterruptedException ignored) {
 		}

--- a/spring-context/src/test/java/org/springframework/scripting/support/ScriptFactoryPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/scripting/support/ScriptFactoryPostProcessorTests.java
@@ -264,7 +264,7 @@ class ScriptFactoryPostProcessorTests {
 
 	private static void pauseToLetRefreshDelayKickIn(int secondsToPause) {
 		try {
-			Thread.sleep(secondsToPause * 1000);
+			Thread.sleep(secondsToPause * 1000L);
 		}
 		catch (InterruptedException ignored) {
 		}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
@@ -177,7 +177,7 @@ public final class MockMvcWebConnection implements WebConnection {
 	private static com.gargoylesoftware.htmlunit.util.Cookie createCookie(jakarta.servlet.http.Cookie cookie) {
 		Date expires = null;
 		if (cookie.getMaxAge() > -1) {
-			expires = new Date(System.currentTimeMillis() + cookie.getMaxAge() * 1000);
+			expires = new Date(System.currentTimeMillis() + cookie.getMaxAge() * 1000L);
 		}
 		BasicClientCookie result = new BasicClientCookie(cookie.getName(), cookie.getValue());
 		result.setDomain(cookie.getDomain());

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/FlashMap.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/FlashMap.java
@@ -113,7 +113,7 @@ public final class FlashMap extends HashMap<String, Object> implements Comparabl
 	 * @param timeToLive the number of seconds before expiration
 	 */
 	public void startExpirationPeriod(int timeToLive) {
-		this.expirationTime = System.currentTimeMillis() + timeToLive * 1000;
+		this.expirationTime = System.currentTimeMillis() + timeToLive * 1000L;
 	}
 
 	/**


### PR DESCRIPTION
The `Thread.sleep()` takes long value as a parameter, so instead of integer value we should use a long value