### PR TITLE
Polish HttpStatus 103 EARLY_HINTS javadocs

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/result/StatusResultMatchers.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/result/StatusResultMatchers.java
@@ -148,13 +148,14 @@ public class StatusResultMatchers {
 	 * @see #isEarlyHints()
 	 * @deprecated in favor of {@link #isEarlyHints()}
 	 */
-	@Deprecated(since = "6.0")
+	@Deprecated(since = "6.0.5")
 	public ResultMatcher isCheckpoint() {
 		return isEarlyHints();
 	}
 
 	/**
 	 * Assert the response status code is {@code HttpStatus.EARLY_HINTS} (103).
+	 * @since 6.0.5
 	 */
 	public ResultMatcher isEarlyHints() {
 		return matcher(HttpStatus.valueOf(103));

--- a/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/StatusResultMatchersDsl.kt
+++ b/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/StatusResultMatchersDsl.kt
@@ -125,6 +125,7 @@ class StatusResultMatchersDsl internal constructor (private val actions: ResultA
 
 	/**
 	 * @see StatusResultMatchers.isEarlyHints
+	 * @since 6.0.5
 	 */
 	fun isEarlyHints() {
 		actions.andExpect(matchers.isEarlyHints())

--- a/spring-web/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatus.java
@@ -51,8 +51,9 @@ public enum HttpStatus implements HttpStatusCode {
 	 */
 	PROCESSING(102, Series.INFORMATIONAL, "Processing"),
 	/**
-	 * {code 103 Early Hints}.
+	 * {@code 103 Early Hints}.
 	 * @see <a href="https://tools.ietf.org/html/rfc8297">An HTTP Status Code for Indicating Hints</a>
+	 * @since 6.0.5
 	 */
 	EARLY_HINTS(103, Series.INFORMATIONAL, "Early Hints"),
 	/**
@@ -61,7 +62,7 @@ public enum HttpStatus implements HttpStatusCode {
 	 * resumable POST/PUT HTTP requests in HTTP/1.0</a>
 	 * @deprecated in favor of {@link #EARLY_HINTS} which will be returned from {@code HttpStatus.valueOf(103)}
 	 */
-	@Deprecated(since = "6.0")
+	@Deprecated(since = "6.0.5")
 	CHECKPOINT(103, Series.INFORMATIONAL, "Checkpoint"),
 
 	// 2xx Success

--- a/spring-web/src/main/java/org/springframework/http/HttpStatusCode.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatusCode.java
@@ -81,7 +81,8 @@ public sealed interface HttpStatusCode extends Serializable permits DefaultHttpS
 	 * <p>Useful for comparisons that take deprecated aliases into account or compare arbitrary implementations
 	 * of {@code HttpStatusCode} (e.g. in place of {@link HttpStatus#equals(Object) HttpStatus enum equality}).
 	 * @param other the other {@code HttpStatusCode} to compare
-	 * @return true if the two {@code HttpStatusCode} share the same integer {@code value()}, false otherwise
+	 * @return true if the two {@code HttpStatusCode} objects share the same integer {@code value()}, false otherwise
+	 * @since 6.0.5
 	 */
 	default boolean isSameCodeAs(HttpStatusCode other) {
 		return value() == other.value();


### PR DESCRIPTION
This PR polishes the "Deprecate HttpStatus 103 CHECKPOINT in favor of new EARLY_HINTS" changes a bit.

See gh-29816