### PR TITLE
Introduce null-safe index operator in SpEL

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/Indexer.java
@@ -91,9 +91,12 @@ public class Indexer extends SpelNodeImpl {
 	@Nullable
 	private IndexedType indexedType;
 
+	private final boolean nullSafe;
 
-	public Indexer(int startPos, int endPos, SpelNodeImpl expr) {
+
+	public Indexer(boolean nullSafe, int startPos, int endPos, SpelNodeImpl expr) {
 		super(startPos, endPos, expr);
+		this.nullSafe = nullSafe;
 	}
 
 
@@ -142,6 +145,9 @@ public class Indexer extends SpelNodeImpl {
 
 		// Raise a proper exception in case of a null target
 		if (target == null) {
+			if (this.nullSafe) {
+				return ValueRef.NullValueRef.INSTANCE;
+			}
 			throw new SpelEvaluationException(getStartPosition(), SpelMessage.CANNOT_INDEX_INTO_NULL_VALUE);
 		}
 		// At this point, we need a TypeDescriptor for a non-null target object

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
@@ -375,7 +375,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 	@Nullable
 	private SpelNodeImpl eatNonDottedNode() {
 		if (peekToken(TokenKind.LSQUARE)) {
-			if (maybeEatIndexer()) {
+			if (maybeEatIndexer(false)) {
 				return pop();
 			}
 		}
@@ -395,7 +395,8 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		Token t = takeToken();  // it was a '.' or a '?.'
 		boolean nullSafeNavigation = (t.kind == TokenKind.SAFE_NAVI);
 		if (maybeEatMethodOrProperty(nullSafeNavigation) || maybeEatFunctionOrVar() ||
-				maybeEatProjection(nullSafeNavigation) || maybeEatSelection(nullSafeNavigation)) {
+				maybeEatProjection(nullSafeNavigation) || maybeEatSelection(nullSafeNavigation) ||
+				maybeEatIndexer(nullSafeNavigation)) {
 			return pop();
 		}
 		if (peekToken() == null) {
@@ -513,7 +514,8 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		else if (maybeEatBeanReference()) {
 			return pop();
 		}
-		else if (maybeEatProjection(false) || maybeEatSelection(false) || maybeEatIndexer()) {
+		else if (maybeEatProjection(false) || maybeEatSelection(false) ||
+				maybeEatIndexer(false)) {
 			return pop();
 		}
 		else if (maybeEatInlineListOrMap()) {
@@ -678,7 +680,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		return true;
 	}
 
-	private boolean maybeEatIndexer() {
+	private boolean maybeEatIndexer(boolean nullSafeNavigation) {
 		Token t = peekToken();
 		if (!peekToken(TokenKind.LSQUARE, true)) {
 			return false;
@@ -687,7 +689,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		SpelNodeImpl expr = eatExpression();
 		Assert.state(expr != null, "No node");
 		eatToken(TokenKind.RSQUARE);
-		this.constructedNodes.push(new Indexer(t.startPos, t.endPos, expr));
+		this.constructedNodes.push(new Indexer(nullSafeNavigation, t.startPos, t.endPos, expr));
 		return true;
 	}
 

--- a/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/IndexingTests.java
@@ -409,4 +409,23 @@ class IndexingTests {
 
 	public List listOfMapsNotGeneric;
 
+	@Test
+	void nullSafeIndex() {
+		ContextWithNullCollections testContext = new ContextWithNullCollections();
+		StandardEvaluationContext context = new StandardEvaluationContext(testContext);
+		Expression expr = new SpelExpressionParser().parseRaw("nullList?.[4]");
+		assertThat(expr.getValue(context)).isNull();
+
+		expr = new SpelExpressionParser().parseRaw("nullArray?.[4]");
+		assertThat(expr.getValue(context)).isNull();
+
+		expr = new SpelExpressionParser().parseRaw("nullMap:?.[4]");
+		assertThat(expr.getValue(context)).isNull();
+	}
+
+	public static class ContextWithNullCollections {
+		public List nullList = null;
+		public String[] nullArray = null;
+		public Map nullMap = null;
+	}
 }

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelReproTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelReproTests.java
@@ -156,6 +156,16 @@ class SpelReproTests extends AbstractExpressionTests {
 	}
 
 	@Test
+	void SPR16929() {
+		C testContext = new C();
+		testContext.ls = null;
+		StandardEvaluationContext context = new StandardEvaluationContext(testContext);
+		context.addPropertyAccessor(new MapAccessor());
+		Expression expr = new SpelExpressionParser().parseRaw("ls?.[4]");
+		assertThat(expr.getValue(context)).isNull();
+	}
+
+	@Test
 	void SPR5847() {
 		StandardEvaluationContext context = new StandardEvaluationContext(new TestProperties());
 		String name = null;


### PR DESCRIPTION
Introduce SpEL support for syntax like `collection?.[expr]` for null-safe indexing into lists, arrays, maps, etc.

- see #21468
