### PR TITLE
Add support for JSR-330 and Jakarta `@Inject` for autowiring test constructors

### DIFF
--- a/spring-test/spring-test.gradle
+++ b/spring-test/spring-test.gradle
@@ -76,6 +76,7 @@ dependencies {
 	}
 	testImplementation("io.projectreactor.netty:reactor-netty-http")
 	testImplementation("de.bechte.junit:junit-hierarchicalcontextrunner")
+	testImplementation("javax.inject:javax.inject:1")
 	testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
 		exclude group: "junit", module: "junit"
 	}

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/InjectAnnotationIntegrationTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/InjectAnnotationIntegrationTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Common test implementation for integration tests in order to verify support
+ * for {@link jakarta.inject.Inject} and {@link javax.inject.Inject}.
+ *
+ * @author Florian Lehmann
+ * @since 6.0.5
+ */
+@SpringJUnitConfig
+public abstract class InjectAnnotationIntegrationTests {
+
+	private final String foo;
+
+	public InjectAnnotationIntegrationTests(String foo) {
+		this.foo = foo;
+	}
+
+	@Test
+	public void beanInjected() {
+		assertThat(this.foo).isEqualTo("foo");
+	}
+
+	@Configuration
+	static class Config {
+
+		@Bean
+		String foo() {
+			return "foo";
+		}
+
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/JakartaInjectAnnotationIntegrationTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/JakartaInjectAnnotationIntegrationTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit.jupiter;
+
+import jakarta.inject.Inject;
+
+/**
+ * Integration tests which verify support for {@link jakarta.inject.Inject}.
+ *
+ * @author Florian Lehmann
+ * @since 6.0.5
+ */
+@SpringJUnitConfig
+public class JakartaInjectAnnotationIntegrationTests extends InjectAnnotationIntegrationTests {
+
+	@Inject
+	public JakartaInjectAnnotationIntegrationTests(String foo) {
+		super(foo);
+	}
+
+}

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/JavaxInjectAnnotationIntegrationTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/JavaxInjectAnnotationIntegrationTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.context.junit.jupiter;
+
+import javax.inject.Inject;
+
+/**
+ * Integration tests which verify support for {@link javax.inject.Inject}.
+ *
+ * @author Florian Lehmann
+ * @since 6.0.5
+ */
+@SpringJUnitConfig
+public class JavaxInjectAnnotationIntegrationTests extends InjectAnnotationIntegrationTests {
+
+	@Inject
+	public JavaxInjectAnnotationIntegrationTests(String foo) {
+		super(foo);
+	}
+
+}


### PR DESCRIPTION
## Overview

Spring 3.0 added support for JSR-330. However, the `spring-test` module is only supporting `@Autowired` for dependency injection.

This PR intends to add `@Inject` support for `spring-test`. Since Spring Framework 6 still supports `@javax.inject.Inject` in addition to `@jakarta.inject.Inject`, this PR reintroduces support for `@javax.inject.Inject` in `spring-test` as well.

## Examples

The following test passes:

```java
package com.example.demo;

import org.junit.jupiter.api.Test;
import org.springframework.beans.factory.annotation.Autowired;
import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Configuration;
import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;

import static org.assertj.core.api.Assertions.assertThat;

@SpringJUnitConfig
public class FooTests {

	private final String foo;

	@Autowired
	public FooTests(String foo) {
		this.foo = foo;
	}

	@Test
	public void beanInjected() {
		assertThat(this.foo).isEqualTo("foo");
	}

	@Configuration
	static class Config {

		@Bean
		String foo() {
			return "foo";
		}

	}
}
```

However, if `@Autowired` is replaced with `@javax.inject.Inject` the test fails:

```java
package com.example.demo;

import jakarta.inject.Inject;
import org.junit.jupiter.api.Test;
import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Configuration;
import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;

import static org.assertj.core.api.Assertions.assertThat;

@SpringJUnitConfig
public class FooTests {

	private final String foo;

	@Inject
	public FooTests(String foo) {
		this.foo = foo;
	}

	@Test
	public void beanInjected() {
		assertThat(this.foo).isEqualTo("foo");
	}

	@Configuration
	static class Config {

		@Bean
		String foo() {
			return "foo";
		}

	}
}
```

## Error

> org.junit.jupiter.api.extension.ParameterResolutionException: No ParameterResolver registered for parameter [java.lang.String foo] in constructor [public com.example.demo.FooTests(java.lang.String)].
