### PR TITLE
Optimize CorsConfiguration::checkHeaders

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -676,7 +676,8 @@ public class CorsConfiguration {
 		}
 
 		boolean allowAnyHeader = this.allowedHeaders.contains(ALL);
-		List<String> result = new ArrayList<>(requestHeaders.size());
+		int maxResultSize = allowAnyHeader ? requestHeaders.size() : Math.min(requestHeaders.size(), this.allowedHeaders.size());
+		List<String> result = new ArrayList<>(maxResultSize);
 		for (String requestHeader : requestHeaders) {
 			if (StringUtils.hasText(requestHeader)) {
 				requestHeader = requestHeader.trim();


### PR DESCRIPTION
In the checkHeaders method, if allowedHeaders contains * the result size can be requestHeaders.size(), but if this is not the case then the result size can only be as big as the minimum value of requestHeaders.size() and allowedHeaders.size(). requestHeaders.size() can be potentially big (user input) and allowedHeaders.size() could be small, so this saves memory in that case.