### PR TITLE
StringDecoder causes direct allocation of ByteBuffer

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
@@ -189,9 +189,8 @@ public final class StringDecoder extends AbstractDataBufferDecoder<String> {
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 
 		Charset charset = getCharset(mimeType);
-		CharBuffer charBuffer = charset.decode(dataBuffer.toByteBuffer());
+		String value = dataBuffer.toString(charset);
 		DataBufferUtils.release(dataBuffer);
-		String value = charBuffer.toString();
 		LogFormatUtils.traceDebug(logger, traceOn -> {
 			String formatted = LogFormatUtils.formatValue(value, !traceOn);
 			return Hints.getLogPrefix(hints) + "Decoded " + formatted;

--- a/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.core.codec;
 
-import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
@@ -129,8 +129,7 @@ public class FormHttpMessageReader extends LoggingCodecSupport
 
 		return DataBufferUtils.join(message.getBody(), this.maxInMemorySize)
 				.map(buffer -> {
-					CharBuffer charBuffer = charset.decode(buffer.toByteBuffer());
-					String body = charBuffer.toString();
+				    String body = buffer.toString(charset);
 					DataBufferUtils.release(buffer);
 					MultiValueMap<String, String> formData = parseFormData(charset, body);
 					logFormData(formData, hints);

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
@@ -17,7 +17,6 @@
 package org.springframework.http.codec;
 
 import java.net.URLDecoder;
-import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
@@ -128,7 +128,7 @@ public class FormHttpMessageReader extends LoggingCodecSupport
 
 		return DataBufferUtils.join(message.getBody(), this.maxInMemorySize)
 				.map(buffer -> {
-				    String body = buffer.toString(charset);
+					String body = buffer.toString(charset);
 					DataBufferUtils.release(buffer);
 					MultiValueMap<String, String> formData = parseFormData(charset, body);
 					logFormData(formData, hints);


### PR DESCRIPTION
Since my switch to Spring Boot 3, I have a lot of direct allocations in my metrics.
Indeed, my app use `StringDecoder` via, for example, `@RequestBody String body`

In `org.springframework.core.codec.StringDecoder`, when dataBuffer is backed by an NIO direct buffer, `decode` method use `dataBuffer.toByteBuffer()` which will call `java.nio.ByteBuffer.allocateDirect(int)`.

In `java.nio.ByteBuffer` javadoc we can read :
> The buffers returned by this method typically have somewhat higher allocation and deallocation costs than non-direct buffers. [...]
> It is therefore recommended that direct buffers be allocated primarily for large,
> long-lived buffers that are subject to the underlying system's native I/O operations.
> In general it is best to allocate direct buffers only when they yield a measurable
> gain in program performance.


Goal of this code in `StringDecoder` was to decode with a charset, so maybe it's better to use `dataBuffer.toString(charset)` which doesn't do direct allocation.
I see the same problem in `org.springframework.http.codec.FormHttpMessageReader`.


