### PR TITLE
`Validator` factory methods with `BiConsumer`

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/Validator.java
+++ b/spring-context/src/main/java/org/springframework/validation/Validator.java
@@ -114,11 +114,10 @@ public interface Validator {
 	 *             "password and confirm password must be same.");
 	 *       }
 	 *     });</pre>
-	 *
 	 * @param targetClass  the class of the object that is to be validated
-	 * @return The {@link Function} that takes the {@link BiConsumer} containing the validation logic and
-	 * returns the {@link Validator} instance
 	 * @param <T> the type of the object that is to be validated
+	 * @return the {@link Function} that takes the {@link BiConsumer} containing the validation logic and
+	 * returns the {@link Validator} instance
 	 */
 	static <T> Function<BiConsumer<T, Errors>, Validator> of(Class<T> targetClass) {
 		Assert.notNull(targetClass, "'targetClass' must not be null.");

--- a/spring-context/src/main/java/org/springframework/validation/Validator.java
+++ b/spring-context/src/main/java/org/springframework/validation/Validator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,11 @@
  */
 
 package org.springframework.validation;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.springframework.util.Assert;
 
 /**
  * A validator for application-specific objects.
@@ -59,6 +64,7 @@ package org.springframework.validation;
  * application.
  *
  * @author Rod Johnson
+ * @author Toshiaki Maki
  * @see SmartValidator
  * @see Errors
  * @see ValidationUtils
@@ -92,4 +98,40 @@ public interface Validator {
 	 */
 	void validate(Object target, Errors errors);
 
+	/**
+	 * Returns the {@link Function} that takes the {@link BiConsumer} containing validation logic for the specific type
+	 * <code>&lt;T&gt;</code> and returns the {@link Validator} instance.<br>
+	 * This validator implements the <i>typical</i> {@link #supports(Class)} method
+	 * for the given <code>&lt;T&gt;</code>.<br>
+	 *
+	 * By using this {@link #of(Class)} method, a {@link Validator}  can be implemented as follows:
+	 *
+	 * <pre class="code">Validator passwordEqualsValidator = Validator.of(PasswordResetForm.class)
+	 *     .apply((form, errors) -> {
+	 *       if (!Objects.equals(form.getPassword(), form.getConfirmPassword())) {
+	 *         errors.rejectValue("confirmPassword",
+	 *             "PasswordEqualsValidator.passwordResetForm.password",
+	 *             "password and confirm password must be same.");
+	 *       }
+	 *     });</pre>
+	 *
+	 * @param targetClass  the class of the object that is to be validated
+	 * @return The {@link Function} that takes the {@link BiConsumer} containing the validation logic and
+	 * returns the {@link Validator} instance
+	 * @param <T> the type of the object that is to be validated
+	 */
+	static <T> Function<BiConsumer<T, Errors>, Validator> of(Class<T> targetClass) {
+		Assert.notNull(targetClass, "'targetClass' must not be null.");
+		return validator -> new Validator() {
+			@Override
+			public boolean supports(Class<?> clazz) {
+				return targetClass.isAssignableFrom(clazz);
+			}
+
+			@Override
+			public void validate(Object target, Errors errors) {
+				validator.accept(targetClass.cast(target), errors);
+			}
+		};
+	}
 }

--- a/spring-context/src/main/java/org/springframework/validation/Validator.java
+++ b/spring-context/src/main/java/org/springframework/validation/Validator.java
@@ -17,7 +17,6 @@
 package org.springframework.validation;
 
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 
 import org.springframework.util.Assert;
 
@@ -99,15 +98,14 @@ public interface Validator {
 	void validate(Object target, Errors errors);
 
 	/**
-	 * Returns the {@link Function} that takes the {@link BiConsumer} containing validation logic for the specific type
+	 * Takes the {@link BiConsumer} containing the validation logic for the specific type
 	 * <code>&lt;T&gt;</code> and returns the {@link Validator} instance.<br>
 	 * This validator implements the <i>typical</i> {@link #supports(Class)} method
 	 * for the given <code>&lt;T&gt;</code>.<br>
 	 *
-	 * By using this {@link #of(Class)} method, a {@link Validator}  can be implemented as follows:
+	 * By using this method, a {@link Validator}  can be implemented as follows:
 	 *
-	 * <pre class="code">Validator passwordEqualsValidator = Validator.of(PasswordResetForm.class)
-	 *     .apply((form, errors) -> {
+	 * <pre class="code">Validator passwordEqualsValidator = Validator.of(PasswordResetForm.class, (form, errors) -> {
 	 *       if (!Objects.equals(form.getPassword(), form.getConfirmPassword())) {
 	 *         errors.rejectValue("confirmPassword",
 	 *             "PasswordEqualsValidator.passwordResetForm.password",
@@ -115,13 +113,13 @@ public interface Validator {
 	 *       }
 	 *     });</pre>
 	 * @param targetClass  the class of the object that is to be validated
+	 * @param delegate the validation logic to delegate for the specific type <code>&lt;T&gt;</code>
 	 * @param <T> the type of the object that is to be validated
-	 * @return the {@link Function} that takes the {@link BiConsumer} containing the validation logic and
-	 * returns the {@link Validator} instance
+	 * @return the {@link Validator} instance
 	 */
-	static <T> Function<BiConsumer<T, Errors>, Validator> of(Class<T> targetClass) {
+	static <T> Validator of(Class<T> targetClass, BiConsumer<T, Errors> delegate) {
 		Assert.notNull(targetClass, "'targetClass' must not be null.");
-		return validator -> new Validator() {
+		return new Validator() {
 			@Override
 			public boolean supports(Class<?> clazz) {
 				return targetClass.isAssignableFrom(clazz);
@@ -129,7 +127,7 @@ public interface Validator {
 
 			@Override
 			public void validate(Object target, Errors errors) {
-				validator.accept(targetClass.cast(target), errors);
+				delegate.accept(targetClass.cast(target), errors);
 			}
 		};
 	}

--- a/spring-context/src/test/java/org/springframework/validation/DataBinderTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/DataBinderTests.java
@@ -82,8 +82,7 @@ import static org.assertj.core.api.Assertions.entry;
  */
 class DataBinderTests {
 
-	Validator spouseValidator = Validator.of(TestBean.class)
-			.apply((tb, errors) -> {
+	Validator spouseValidator = Validator.of(TestBean.class, (tb, errors) -> {
 				if (tb == null || "XXX".equals(tb.getName())) {
 					errors.rejectValue("", "SPOUSE_NOT_AVAILABLE");
 					return;

--- a/spring-context/src/test/java/org/springframework/validation/DataBinderTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/DataBinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,17 @@ import static org.assertj.core.api.Assertions.entry;
  * @author Sam Brannen
  */
 class DataBinderTests {
+
+	Validator spouseValidator = Validator.of(TestBean.class)
+			.apply((tb, errors) -> {
+				if (tb == null || "XXX".equals(tb.getName())) {
+					errors.rejectValue("", "SPOUSE_NOT_AVAILABLE");
+					return;
+				}
+				if (tb.getAge() < 32) {
+					errors.rejectValue("age", "TOO_YOUNG", "simply too young");
+				}
+			});
 
 	@Test
 	void bindingNoErrors() throws BindException {
@@ -1144,7 +1155,6 @@ class DataBinderTests {
 		errors.setNestedPath("spouse");
 		assertThat(errors.getNestedPath()).isEqualTo("spouse.");
 		assertThat(errors.getFieldValue("age")).isEqualTo("argh");
-		Validator spouseValidator = new SpouseValidator();
 		spouseValidator.validate(tb.getSpouse(), errors);
 
 		errors.setNestedPath("");
@@ -1195,7 +1205,6 @@ class DataBinderTests {
 
 		errors.setNestedPath("spouse.");
 		assertThat(errors.getNestedPath()).isEqualTo("spouse.");
-		Validator spouseValidator = new SpouseValidator();
 		spouseValidator.validate(tb.getSpouse(), errors);
 
 		errors.setNestedPath("");
@@ -1267,7 +1276,6 @@ class DataBinderTests {
 
 		errors.setNestedPath("spouse.");
 		assertThat(errors.getNestedPath()).isEqualTo("spouse.");
-		Validator spouseValidator = new SpouseValidator();
 		spouseValidator.validate(tb.getSpouse(), errors);
 
 		errors.setNestedPath("");
@@ -1332,7 +1340,6 @@ class DataBinderTests {
 		testValidator.validate(tb, errors);
 		errors.setNestedPath("spouse.");
 		assertThat(errors.getNestedPath()).isEqualTo("spouse.");
-		Validator spouseValidator = new SpouseValidator();
 		spouseValidator.validate(tb.getSpouse(), errors);
 		errors.setNestedPath("");
 
@@ -1348,7 +1355,6 @@ class DataBinderTests {
 		TestBean tb = new TestBean();
 		tb.setName("XXX");
 		Errors errors = new BeanPropertyBindingResult(tb, "tb");
-		Validator spouseValidator = new SpouseValidator();
 		spouseValidator.validate(tb, errors);
 
 		assertThat(errors.hasGlobalErrors()).isTrue();
@@ -2159,28 +2165,6 @@ class DataBinderTests {
 			}
 		}
 	}
-
-
-	private static class SpouseValidator implements Validator {
-
-		@Override
-		public boolean supports(Class<?> clazz) {
-			return TestBean.class.isAssignableFrom(clazz);
-		}
-
-		@Override
-		public void validate(@Nullable Object obj, Errors errors) {
-			TestBean tb = (TestBean) obj;
-			if (tb == null || "XXX".equals(tb.getName())) {
-				errors.rejectValue("", "SPOUSE_NOT_AVAILABLE");
-				return;
-			}
-			if (tb.getAge() < 32) {
-				errors.rejectValue("age", "TOO_YOUNG", "simply too young");
-			}
-		}
-	}
-
 
 	@SuppressWarnings("unused")
 	private static class GrowingList<E> extends AbstractList<E> {

--- a/spring-context/src/test/java/org/springframework/validation/ValidationUtilsTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/ValidationUtilsTests.java
@@ -19,7 +19,6 @@ package org.springframework.validation;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.testfixture.beans.TestBean;
-import org.springframework.lang.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;

--- a/spring-context/src/test/java/org/springframework/validation/ValidationUtilsTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/ValidationUtilsTests.java
@@ -33,11 +33,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  */
 public class ValidationUtilsTests {
 
-	Validator emptyValidator = Validator.of(TestBean.class)
-			.apply((testBean, errors) -> ValidationUtils.rejectIfEmpty(errors, "name", "EMPTY", "You must enter a name!"));
+	Validator emptyValidator = Validator.of(TestBean.class, (testBean, errors) -> ValidationUtils.rejectIfEmpty(errors, "name", "EMPTY", "You must enter a name!"));
 
-	Validator emptyOrWhitespaceValidator = Validator.of(TestBean.class)
-			.apply((testBean, errors) -> ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "EMPTY_OR_WHITESPACE", "You must enter a name!"));
+	Validator emptyOrWhitespaceValidator = Validator.of(TestBean.class, (testBean, errors) -> ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "EMPTY_OR_WHITESPACE", "You must enter a name!"));
 
 	@Test
 	public void testInvokeValidatorWithNullValidator() throws Exception {

--- a/spring-context/src/test/java/org/springframework/validation/ValidationUtilsTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/ValidationUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,12 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  */
 public class ValidationUtilsTests {
 
+	Validator emptyValidator = Validator.of(TestBean.class)
+			.apply((testBean, errors) -> ValidationUtils.rejectIfEmpty(errors, "name", "EMPTY", "You must enter a name!"));
+
+	Validator emptyOrWhitespaceValidator = Validator.of(TestBean.class)
+			.apply((testBean, errors) -> ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "EMPTY_OR_WHITESPACE", "You must enter a name!"));
+
 	@Test
 	public void testInvokeValidatorWithNullValidator() throws Exception {
 		TestBean tb = new TestBean();
@@ -46,14 +52,14 @@ public class ValidationUtilsTests {
 	public void testInvokeValidatorWithNullErrors() throws Exception {
 		TestBean tb = new TestBean();
 		assertThatIllegalArgumentException().isThrownBy(() ->
-				ValidationUtils.invokeValidator(new EmptyValidator(), tb, null));
+				ValidationUtils.invokeValidator(emptyValidator, tb, null));
 	}
 
 	@Test
 	public void testInvokeValidatorSunnyDay() throws Exception {
 		TestBean tb = new TestBean();
 		Errors errors = new BeanPropertyBindingResult(tb, "tb");
-		ValidationUtils.invokeValidator(new EmptyValidator(), tb, errors);
+		ValidationUtils.invokeValidator(emptyValidator, tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isTrue();
 		assertThat(errors.getFieldError("name").getCode()).isEqualTo("EMPTY");
 	}
@@ -62,15 +68,14 @@ public class ValidationUtilsTests {
 	public void testValidationUtilsSunnyDay() throws Exception {
 		TestBean tb = new TestBean("");
 
-		Validator testValidator = new EmptyValidator();
 		tb.setName(" ");
 		Errors errors = new BeanPropertyBindingResult(tb, "tb");
-		testValidator.validate(tb, errors);
+		emptyValidator.validate(tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isFalse();
 
 		tb.setName("Roddy");
 		errors = new BeanPropertyBindingResult(tb, "tb");
-		testValidator.validate(tb, errors);
+		emptyValidator.validate(tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isFalse();
 	}
 
@@ -78,8 +83,7 @@ public class ValidationUtilsTests {
 	public void testValidationUtilsNull() throws Exception {
 		TestBean tb = new TestBean();
 		Errors errors = new BeanPropertyBindingResult(tb, "tb");
-		Validator testValidator = new EmptyValidator();
-		testValidator.validate(tb, errors);
+		emptyValidator.validate(tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isTrue();
 		assertThat(errors.getFieldError("name").getCode()).isEqualTo("EMPTY");
 	}
@@ -88,8 +92,7 @@ public class ValidationUtilsTests {
 	public void testValidationUtilsEmpty() throws Exception {
 		TestBean tb = new TestBean("");
 		Errors errors = new BeanPropertyBindingResult(tb, "tb");
-		Validator testValidator = new EmptyValidator();
-		testValidator.validate(tb, errors);
+		emptyValidator.validate(tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isTrue();
 		assertThat(errors.getFieldError("name").getCode()).isEqualTo("EMPTY");
 	}
@@ -115,32 +118,31 @@ public class ValidationUtilsTests {
 	@Test
 	public void testValidationUtilsEmptyOrWhitespace() throws Exception {
 		TestBean tb = new TestBean();
-		Validator testValidator = new EmptyOrWhitespaceValidator();
 
 		// Test null
 		Errors errors = new BeanPropertyBindingResult(tb, "tb");
-		testValidator.validate(tb, errors);
+		emptyOrWhitespaceValidator.validate(tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isTrue();
 		assertThat(errors.getFieldError("name").getCode()).isEqualTo("EMPTY_OR_WHITESPACE");
 
 		// Test empty String
 		tb.setName("");
 		errors = new BeanPropertyBindingResult(tb, "tb");
-		testValidator.validate(tb, errors);
+		emptyOrWhitespaceValidator.validate(tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isTrue();
 		assertThat(errors.getFieldError("name").getCode()).isEqualTo("EMPTY_OR_WHITESPACE");
 
 		// Test whitespace String
 		tb.setName(" ");
 		errors = new BeanPropertyBindingResult(tb, "tb");
-		testValidator.validate(tb, errors);
+		emptyOrWhitespaceValidator.validate(tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isTrue();
 		assertThat(errors.getFieldError("name").getCode()).isEqualTo("EMPTY_OR_WHITESPACE");
 
 		// Test OK
 		tb.setName("Roddy");
 		errors = new BeanPropertyBindingResult(tb, "tb");
-		testValidator.validate(tb, errors);
+		emptyOrWhitespaceValidator.validate(tb, errors);
 		assertThat(errors.hasFieldErrors("name")).isFalse();
 	}
 
@@ -161,34 +163,6 @@ public class ValidationUtilsTests {
 		assertThat(errors.getFieldError("name").getCode()).isEqualTo("EMPTY_OR_WHITESPACE");
 		assertThat(errors.getFieldError("name").getArguments()[0]).isEqualTo("arg");
 		assertThat(errors.getFieldError("name").getDefaultMessage()).isEqualTo("msg");
-	}
-
-
-	private static class EmptyValidator implements Validator {
-
-		@Override
-		public boolean supports(Class<?> clazz) {
-			return TestBean.class.isAssignableFrom(clazz);
-		}
-
-		@Override
-		public void validate(@Nullable Object obj, Errors errors) {
-			ValidationUtils.rejectIfEmpty(errors, "name", "EMPTY", "You must enter a name!");
-		}
-	}
-
-
-	private static class EmptyOrWhitespaceValidator implements Validator {
-
-		@Override
-		public boolean supports(Class<?> clazz) {
-			return TestBean.class.isAssignableFrom(clazz);
-		}
-
-		@Override
-		public void validate(@Nullable Object obj, Errors errors) {
-			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "EMPTY_OR_WHITESPACE", "You must enter a name!");
-		}
 	}
 
 }


### PR DESCRIPTION
This commit introduces `of` method in `Validator` to provide a way to create a validator for the specific type `<T>` using `BiConsumer<T, Errors>` and define the validator in a functional way.

```java
Validator passwordEqualsValidator = Validator.of(PasswordResetForm.class)
    .apply((form, errors) -> {
        if (!Objects.equals(form.getPassword(), form.getConfirmPassword())) {
            errors.rejectValue("confirmPassword",
                "PasswordEqualsValidator.passwordResetForm.password",
                "password and confirm password must be same.");
        }
    });
```

This also eliminates the boilerplate for implementing the `supports` method.

BONUS: Supporting BiConsumer allows us to magically adapt 3rd party Validators (like [YAVI](https://yavi.ik.am/#obtaining-a-bivalidator)) that return BiConsumer. 
(I'm the creator of YAVI.)

(original proposal)
```java
Validator validator = Validator.of(CartItem.class)
    .apply(ValidatorBuilder.<CartItem>of()
        .constraint(CartItem::itemId, "itemId", c -> c.notEmpty())
        .constraint(CartItem::amount, "amount", c -> c.greaterThanOrEqual(0))
        .constraint(CartItem::price, "price", c -> c.greaterThanOrEqual(0))
        .build(Errors::rejectValue));
```

(revised version)
```java
Validator validator = Validator.forInstanceOf(CartItem.class, ValidatorBuilder.<CartItem>of()
    .constraint(CartItem::itemId, "itemId", c -> c.notEmpty())
    .constraint(CartItem::amount, "amount", c -> c.greaterThanOrEqual(0))
    .constraint(CartItem::price, "price", c -> c.greaterThanOrEqual(0))
    .build(Errors::rejectValue));
```