### PR TITLE
Add Javadoc since for CLIENT_NAME enums

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/observation/ClientHttpObservationDocumentation.java
+++ b/spring-web/src/main/java/org/springframework/http/client/observation/ClientHttpObservationDocumentation.java
@@ -92,6 +92,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 
 		/**
 		 * Client name derived from the request URI host.
+		 * @since 6.0.5
 		 */
 		CLIENT_NAME {
 			@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientHttpObservationDocumentation.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientHttpObservationDocumentation.java
@@ -88,6 +88,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 
 		/**
 		 * Client name derived from the request URI host.
+		 * @since 6.0.5
 		 */
 		CLIENT_NAME {
 			@Override


### PR DESCRIPTION
This PR adds Javadoc `@since` tags for the `CLIENT_NAME` enums for the HTTP client observability.

See gh-29839