### PR TITLE
Support decoding empty DataBuffers for Decoders that support it

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/codec/ByteArrayDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ByteArrayDecoder.java
@@ -45,7 +45,7 @@ public class ByteArrayDecoder extends AbstractDataBufferDecoder<byte[]> {
 	}
 
 	@Override
-	public boolean canDecodeEmptyDataBuffer() {
+	public boolean canDecodeEmptyMessage() {
 		return true;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/codec/ByteArrayDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ByteArrayDecoder.java
@@ -45,6 +45,11 @@ public class ByteArrayDecoder extends AbstractDataBufferDecoder<byte[]> {
 	}
 
 	@Override
+	public boolean canDecodeEmptyDataBuffer() {
+		return true;
+	}
+
+	@Override
 	public byte[] decode(DataBuffer dataBuffer, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 

--- a/spring-core/src/main/java/org/springframework/core/codec/ByteBufferDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ByteBufferDecoder.java
@@ -48,6 +48,11 @@ public class ByteBufferDecoder extends AbstractDataBufferDecoder<ByteBuffer> {
 	}
 
 	@Override
+	public boolean canDecodeEmptyDataBuffer() {
+		return true;
+	}
+
+	@Override
 	public ByteBuffer decode(DataBuffer dataBuffer, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 

--- a/spring-core/src/main/java/org/springframework/core/codec/ByteBufferDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ByteBufferDecoder.java
@@ -48,7 +48,7 @@ public class ByteBufferDecoder extends AbstractDataBufferDecoder<ByteBuffer> {
 	}
 
 	@Override
-	public boolean canDecodeEmptyDataBuffer() {
+	public boolean canDecodeEmptyMessage() {
 		return true;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/codec/DataBufferDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/DataBufferDecoder.java
@@ -57,7 +57,7 @@ public class DataBufferDecoder extends AbstractDataBufferDecoder<DataBuffer> {
 	}
 
 	@Override
-	public boolean canDecodeEmptyDataBuffer() {
+	public boolean canDecodeEmptyMessage() {
 		return true;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/codec/DataBufferDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/DataBufferDecoder.java
@@ -57,6 +57,11 @@ public class DataBufferDecoder extends AbstractDataBufferDecoder<DataBuffer> {
 	}
 
 	@Override
+	public boolean canDecodeEmptyDataBuffer() {
+		return true;
+	}
+
+	@Override
 	public Flux<DataBuffer> decode(Publisher<DataBuffer> input, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 

--- a/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
@@ -54,11 +54,13 @@ public interface Decoder<T> {
 	boolean canDecode(ResolvableType elementType, @Nullable MimeType mimeType);
 
 	/**
-	 * Whether the decoder supports decoding messages from empty data buffers.
+	 * Whether the decoder supports decoding an Object of its target type from an
+	 * empty message. When it is true, the decoder will always return a non-null
+	 * value from its {@code decode} method when an empty message is decoded.
 	 * @return {@code true} if supported, {@code false} otherwise
 	 * @since 6.0.5
 	 */
-	default boolean canDecodeEmptyDataBuffer()  {
+	default boolean canDecodeEmptyMessage()  {
 		return false;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
@@ -54,7 +54,7 @@ public interface Decoder<T> {
 	boolean canDecode(ResolvableType elementType, @Nullable MimeType mimeType);
 
 	/**
-	 * Whether the decoder supports decoding messages from empty data buffers
+	 * Whether the decoder supports decoding messages from empty data buffers.
 	 * @return {@code true} if supported, {@code false} otherwise
 	 * @since 6.0.5
 	 */

--- a/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
@@ -54,6 +54,15 @@ public interface Decoder<T> {
 	boolean canDecode(ResolvableType elementType, @Nullable MimeType mimeType);
 
 	/**
+	 * Whether the decoder supports decoding messages from empty data buffers
+	 * @return {@code true} if supported, {@code false} otherwise
+	 * @since 6.0.5
+	 */
+	default boolean canDecodeEmptyDataBuffer()  {
+		return false;
+	}
+
+	/**
 	 * Decode a {@link DataBuffer} input stream into a Flux of {@code T}.
 	 * @param inputStream the {@code DataBuffer} input stream to decode
 	 * @param elementType the expected type of elements in the output stream;

--- a/spring-core/src/main/java/org/springframework/core/codec/Netty5BufferDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Netty5BufferDecoder.java
@@ -49,6 +49,11 @@ public class Netty5BufferDecoder extends AbstractDataBufferDecoder<Buffer> {
 	}
 
 	@Override
+	public boolean canDecodeEmptyDataBuffer() {
+		return true;
+	}
+
+	@Override
 	public Buffer decode(DataBuffer dataBuffer, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 

--- a/spring-core/src/main/java/org/springframework/core/codec/Netty5BufferDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Netty5BufferDecoder.java
@@ -49,7 +49,7 @@ public class Netty5BufferDecoder extends AbstractDataBufferDecoder<Buffer> {
 	}
 
 	@Override
-	public boolean canDecodeEmptyDataBuffer() {
+	public boolean canDecodeEmptyMessage() {
 		return true;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/codec/NettyByteBufDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/NettyByteBufDecoder.java
@@ -49,7 +49,7 @@ public class NettyByteBufDecoder extends AbstractDataBufferDecoder<ByteBuf> {
 	}
 
 	@Override
-	public boolean canDecodeEmptyDataBuffer() {
+	public boolean canDecodeEmptyMessage() {
 		return true;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/codec/NettyByteBufDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/NettyByteBufDecoder.java
@@ -49,6 +49,11 @@ public class NettyByteBufDecoder extends AbstractDataBufferDecoder<ByteBuf> {
 	}
 
 	@Override
+	public boolean canDecodeEmptyDataBuffer() {
+		return true;
+	}
+
+	@Override
 	public ByteBuf decode(DataBuffer dataBuffer, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 

--- a/spring-core/src/main/java/org/springframework/core/codec/ResourceDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ResourceDecoder.java
@@ -57,6 +57,11 @@ public class ResourceDecoder extends AbstractDataBufferDecoder<Resource> {
 	}
 
 	@Override
+	public boolean canDecodeEmptyDataBuffer() {
+		return true;
+	}
+
+	@Override
 	public Flux<Resource> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 

--- a/spring-core/src/main/java/org/springframework/core/codec/ResourceDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/ResourceDecoder.java
@@ -57,7 +57,7 @@ public class ResourceDecoder extends AbstractDataBufferDecoder<Resource> {
 	}
 
 	@Override
-	public boolean canDecodeEmptyDataBuffer() {
+	public boolean canDecodeEmptyMessage() {
 		return true;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
@@ -106,7 +106,7 @@ public final class StringDecoder extends AbstractDataBufferDecoder<String> {
 	}
 
 	@Override
-	public boolean canDecodeEmptyDataBuffer() {
+	public boolean canDecodeEmptyMessage() {
 		return true;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/StringDecoder.java
@@ -106,6 +106,11 @@ public final class StringDecoder extends AbstractDataBufferDecoder<String> {
 	}
 
 	@Override
+	public boolean canDecodeEmptyDataBuffer() {
+		return true;
+	}
+
+	@Override
 	public Flux<String> decode(Publisher<DataBuffer> input, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 

--- a/spring-core/src/testFixtures/java/org/springframework/core/testfixture/codec/AbstractDecoderTests.java
+++ b/spring-core/src/testFixtures/java/org/springframework/core/testfixture/codec/AbstractDecoderTests.java
@@ -450,14 +450,15 @@ public abstract class AbstractDecoderTests<D extends Decoder<?>> extends Abstrac
 	 * @param hints the hints used for decoding. May be {@code null}.
 	 */
 	protected void testDecodeToMonoEmptyBuffer(ResolvableType outputType, @Nullable MimeType mimeType,
-										 @Nullable Map<String, Object> hints) {
+			@Nullable Map<String, Object> hints) {
+
 		if (!this.decoder.canDecodeEmptyDataBuffer()) {
 			return;
 		}
 
 		DataBuffer buffer = this.bufferFactory.allocateBuffer(0);
 		Mono<?> result = this.decoder.decodeToMono(Mono.just(buffer), outputType, mimeType, hints)
-						.doOnNext(value -> releaseBufferIfIdentical(buffer, value));
+				.doOnNext(value -> releaseBufferIfIdentical(buffer, value));
 		StepVerifier.create(result)
 				.expectNextMatches(next -> outputType.toClass().isInstance(next))
 				.verifyComplete();

--- a/spring-core/src/testFixtures/java/org/springframework/core/testfixture/codec/AbstractDecoderTests.java
+++ b/spring-core/src/testFixtures/java/org/springframework/core/testfixture/codec/AbstractDecoderTests.java
@@ -269,7 +269,7 @@ public abstract class AbstractDecoderTests<D extends Decoder<?>> extends Abstrac
 	 * @param hints the hints used for decoding. May be {@code null}.
 	 */
 	protected void testDecodeEmptyBuffer(ResolvableType outputType, MimeType mimeType, Map<String, Object> hints) {
-		if (!this.decoder.canDecodeEmptyDataBuffer()) {
+		if (!this.decoder.canDecodeEmptyMessage()) {
 			return;
 		}
 		DataBuffer buffer = this.bufferFactory.allocateBuffer(0);
@@ -452,7 +452,7 @@ public abstract class AbstractDecoderTests<D extends Decoder<?>> extends Abstrac
 	protected void testDecodeToMonoEmptyBuffer(ResolvableType outputType, @Nullable MimeType mimeType,
 			@Nullable Map<String, Object> hints) {
 
-		if (!this.decoder.canDecodeEmptyDataBuffer()) {
+		if (!this.decoder.canDecodeEmptyMessage()) {
 			return;
 		}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
@@ -264,7 +264,7 @@ public class PayloadMethodArgumentResolver implements HandlerMethodArgumentResol
 	}
 
 	private boolean nonEmptyDataBuffer(DataBuffer buffer, Decoder<?> decoder) {
-		if (decoder.canDecodeEmptyDataBuffer()) {
+		if (decoder.canDecodeEmptyMessage()) {
 			return true;
 		}
 		if (buffer.readableByteCount() > 0) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
@@ -231,7 +231,7 @@ public class PayloadMethodArgumentResolver implements HandlerMethodArgumentResol
 			if (decoder.canDecode(elementType, mimeType)) {
 				if (adapter != null && adapter.isMultiValue()) {
 					Flux<?> flux = content
-							.filter(this::nonEmptyDataBuffer)
+							.filter(dataBuffer -> nonEmptyDataBuffer(dataBuffer, decoder))
 							.map(buffer -> decoder.decode(buffer, elementType, mimeType, hints))
 							.onErrorResume(ex -> Flux.error(handleReadError(parameter, message, ex)));
 					if (isContentRequired) {
@@ -245,7 +245,7 @@ public class PayloadMethodArgumentResolver implements HandlerMethodArgumentResol
 				else {
 					// Single-value (with or without reactive type wrapper)
 					Mono<?> mono = content.next()
-							.filter(this::nonEmptyDataBuffer)
+							.filter(dataBuffer -> nonEmptyDataBuffer(dataBuffer, decoder))
 							.map(buffer -> decoder.decode(buffer, elementType, mimeType, hints))
 							.onErrorResume(ex -> Mono.error(handleReadError(parameter, message, ex)));
 					if (isContentRequired) {
@@ -263,7 +263,10 @@ public class PayloadMethodArgumentResolver implements HandlerMethodArgumentResol
 				message, parameter, "Cannot decode to [" + targetType + "]" + message));
 	}
 
-	private boolean nonEmptyDataBuffer(DataBuffer buffer) {
+	private boolean nonEmptyDataBuffer(DataBuffer buffer, Decoder<?> decoder) {
+		if (decoder.canDecodeEmptyDataBuffer()) {
+			return true;
+		}
 		if (buffer.readableByteCount() > 0) {
 			return true;
 		}

--- a/spring-messaging/src/test/java/org/springframework/messaging/rsocket/RSocketClientToServerIntegrationTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/rsocket/RSocketClientToServerIntegrationTests.java
@@ -167,7 +167,7 @@ public class RSocketClientToServerIntegrationTests {
 	@Test // gh-26344
 	public void echoChannelWithEmptyInput() {
 		Flux<String> result = requester.route("echo-channel-empty").data(Flux.empty()).retrieveFlux(String.class);
-		StepVerifier.create(result).verifyComplete();
+		StepVerifier.create(result).expectNext(" echoed").verifyComplete();
 	}
 
 	@Test

--- a/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufDecoder.java
@@ -126,6 +126,11 @@ public class ProtobufDecoder extends ProtobufCodecSupport implements Decoder<Mes
 	}
 
 	@Override
+	public boolean canDecodeEmptyDataBuffer() {
+		return true;
+	}
+
+	@Override
 	public Flux<Message> decode(Publisher<DataBuffer> inputStream, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 

--- a/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufDecoder.java
@@ -126,7 +126,7 @@ public class ProtobufDecoder extends ProtobufCodecSupport implements Decoder<Mes
 	}
 
 	@Override
-	public boolean canDecodeEmptyDataBuffer() {
+	public boolean canDecodeEmptyMessage() {
 		return true;
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/codec/protobuf/ProtobufDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/protobuf/ProtobufDecoderTests.java
@@ -221,6 +221,11 @@ public class ProtobufDecoderTests extends AbstractDecoderTests<ProtobufDecoder> 
 		testDecode(input, Msg.class, step -> step.verifyError(DecodingException.class));
 	}
 
+	@Test
+	public void decodeEmpty() {
+		testDecodeEmptyBuffer(ResolvableType.forClass(Msg.class), null, null);
+	}
+
 	private Mono<DataBuffer> dataBuffer(Msg msg) {
 		return Mono.fromCallable(() -> {
 			byte[] bytes = msg.toByteArray();

--- a/spring-web/src/test/java/org/springframework/http/codec/protobuf/ProtobufDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/protobuf/ProtobufDecoderTests.java
@@ -223,7 +223,7 @@ public class ProtobufDecoderTests extends AbstractDecoderTests<ProtobufDecoder> 
 
 	@Test
 	public void decodeEmpty() {
-		testDecodeEmptyBuffer(ResolvableType.forClass(Msg.class), null, null);
+		testDecodeEmptyMessage(ResolvableType.forClass(Msg.class), null, null);
 	}
 
 	private Mono<DataBuffer> dataBuffer(Msg msg) {


### PR DESCRIPTION
Some decoders support decoding a proper payload from empty DataBuffers. One good example is the ProtobufDecoder.

This patch adds a method canDecodeEmptyDataBuffer() to the Decoder interface, allowing the Decoder to signal that it is able to do that.

In this case, the PayloadMethodArgumentResolver should pass the empty DataBuffer to the Decoder, and in all other cases behave like before.