### PR TITLE
Fix RFC-7807 content negotiation

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
@@ -103,7 +103,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 			MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON,
 			MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_PROBLEM_XML
 	);
-	private final Set<MediaType> problemMediaTypes = new HashSet<>(problemMediaTypesByNormalType.values());
+	private final Set<MediaType> problemMediaTypes = new HashSet<>(this.problemMediaTypesByNormalType.values());
 
 	private final Set<String> safeExtensions = new HashSet<>();
 
@@ -263,7 +263,8 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 						.map(mediaType -> this.problemMediaTypesByNormalType.get(mediaType.toString()))
 						.filter(Objects::nonNull)
 						.collect(Collectors.toList());
-			} else {
+			}
+			else {
 				acceptableTypes.removeAll(this.problemMediaTypes);
 				producibleTypes.removeAll(this.problemMediaTypes);
 			}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java
@@ -33,9 +33,9 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java
@@ -246,10 +246,16 @@ public class HttpEntityMethodProcessorTests {
 							List.of(MediaType.APPLICATION_JSON_VALUE),
 							MediaType.APPLICATION_PROBLEM_JSON_VALUE),
 					new ContentNegotiationCase(
+							List.of(MediaType.APPLICATION_PROBLEM_JSON_VALUE),
+							MediaType.APPLICATION_PROBLEM_JSON_VALUE),
+					new ContentNegotiationCase(
 							List.of(MediaType.APPLICATION_PROBLEM_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE),
 							MediaType.APPLICATION_PROBLEM_JSON_VALUE),
 					new ContentNegotiationCase(
 							List.of("*/*"),
+							MediaType.APPLICATION_PROBLEM_JSON_VALUE),
+					new ContentNegotiationCase(
+							List.of(MediaType.APPLICATION_PDF_VALUE),
 							MediaType.APPLICATION_PROBLEM_JSON_VALUE),
 					new ContentNegotiationCase(
 							List.of("application/*+json"),

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
@@ -403,7 +403,7 @@ public class RequestResponseBodyMethodProcessorTests {
 	@Test
 	void problemDetailWhenJsonRequested() throws Exception {
 		this.servletRequest.addHeader("Accept", MediaType.APPLICATION_JSON_VALUE);
-		testProblemDetailMediaType(MediaType.APPLICATION_JSON_VALUE);
+		testProblemDetailMediaType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
 	}
 
 	@Test


### PR DESCRIPTION
This PR fixes #29588, where we discussed the intended behavior concerning content negotiation with RFC-7807 content types.
This is a solution that

- prefers RFC-7807 content types in case of returning a ProblemDetail (error response)
- excludes RFC-7807 content types in case of returning all other types (success response)

The test simply allows to add further test cases. Currently, there's no support for ProblemDetail serialized with JAXB (`application/problem+xml`), but if it is added in the future, the test adds test cases automatically.