### PR TITLE
Support `@Scheduled` on Reactive methods and Kotlin suspending functions

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
@@ -452,17 +452,13 @@ registry denotes that by having the `getDescriptor().isDeferred()` method return
 	}
 ----
 
-All these types of methods must be declared without any arguments. Additionally, the `cron`
-configuration elements are not supported for these cases.
-
-Note that the `TaskExecutor`/`TaskScheduler` infrastructure is not used and the scheduling
-is instead performed by the Reactor library, which must be present at runtime.
-In the case of Kotlin suspending functions the `kotlinx.coroutines.reactor` bridge must
-also be present.
+All these types of methods must be declared without any arguments. In the case of Kotlin
+suspending functions the `kotlinx.coroutines.reactor` bridge must also be present to allow
+the framework to invoke a suspending function as a `Publisher`.
 
 The Spring Framework will obtain a `Publisher` out of the annotated method once and will
-create a timed `Flux` which regularly subscribes to said `Publisher`. These inner regular
-subscriptions happen according to the `fixedDelay`/`fixedRate` configuration.
+schedule a `Runnable` in which it subscribes to said `Publisher`. These inner regular
+subscriptions happen according to the `cron`/fixedDelay`/`fixedRate` configuration.
 
 If the `Publisher` emits `onNext` signal(s), these are ignored and discarded (the same way
 return values from synchronous `@Scheduled` methods are ignored).
@@ -502,8 +498,11 @@ seconds:
 
 [NOTE]
 ====
-The Spring Framework subscribes once to the underlying scheduling `Flux`, which can be
-cancelled by destroying the annotated bean or closing the application context.
+When destroying the annotated bean or closing the application context Spring Framework cancels
+scheduled tasks, which includes the next scheduled subscription to the `Publisher`.
+However, there is no tracking of individual subscriptions: once a subscription has started
+it can't be cancelled. For that reason, it is a pre-requisite that the `Publisher` is finite
+in addition to supporting multiple subsequent subscriptions.
 ====
 
 

--- a/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
@@ -499,10 +499,9 @@ seconds:
 [NOTE]
 ====
 When destroying the annotated bean or closing the application context Spring Framework cancels
-scheduled tasks, which includes the next scheduled subscription to the `Publisher`.
-However, there is no tracking of individual subscriptions: once a subscription has started
-it can't be cancelled. For that reason, it is a pre-requisite that the `Publisher` is finite
-in addition to supporting multiple subsequent subscriptions.
+scheduled tasks, which includes the next scheduled subscription to the `Publisher` as well
+as any past subscription that is still currently active (e.g. for long-running publishers,
+or even infinite publishers).
 ====
 
 

--- a/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
@@ -396,11 +396,11 @@ container and once through the `@Configurable` aspect), with the consequence of 
 [[scheduling-annotation-support-scheduled-reactive]]
 === The `@Scheduled` annotation on Reactive methods or Kotlin suspending functions
 
-As of Spring Framework 6.1, `@Scheduled` methods are also supported on two types
-of asynchronous methods:
+As of Spring Framework 6.1, `@Scheduled` methods are also supported on several types
+of reactive methods:
 
- - Reactive methods, i.e. methods with a `Publisher` return type (or any concrete
-implementation of `Publisher`) like in the following example:
+ - methods with a `Publisher` return type (or any concrete implementation of `Publisher`)
+like in the following example:
 
 [source,java,indent=0,subs="verbatim,quotes"]
 ----
@@ -409,6 +409,26 @@ implementation of `Publisher`) like in the following example:
 		// return an instance of Publisher
 	}
 ----
+
+ - methods with a return type that can be adapted to `Publisher` via the shared instance
+of the `ReactiveAdapterRegistry`, provided the type supports _deferred subscription_ like
+in the following example:
+
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+	@Scheduled(fixedDelay = 500)
+	public Single<String> rxjavaNonPublisher() {
+		return Single.just("example");
+	}
+----
+
+[NOTE]
+====
+The `CompletableFuture` class is an example of a type that can typically be adapted
+to `Publisher` but doesn't support deferred subscription. Its `ReactiveAdapter` in the
+registry denotes that by having the `getDescriptor().isDeferred()` method return `false`.
+====
+
 
  - Kotlin suspending functions, like in the following example:
 
@@ -420,8 +440,20 @@ implementation of `Publisher`) like in the following example:
 	}
 ----
 
-Both types of methods must be declared without any arguments. Additionally, the `cron`
-configuration elements are not supported for these two cases.
+ - methods that return a Kotlin `Flow` or `Deferred` instance, like in the following example:
+
+[source,kotlin,indent=0,subs="verbatim,quotes"]
+----
+	@Scheduled(fixedDelay = 500)
+	fun something(): Flow<Void> {
+		flow {
+			// do something asynchronous
+		}
+	}
+----
+
+All these types of methods must be declared without any arguments. Additionally, the `cron`
+configuration elements are not supported for these cases.
 
 Note that the `TaskExecutor`/`TaskScheduler` infrastructure is not used and the scheduling
 is instead performed by the Reactor library, which must be present at runtime.

--- a/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
@@ -393,6 +393,87 @@ container and once through the `@Configurable` aspect), with the consequence of 
 `@Scheduled` method being invoked twice.
 ====
 
+[[scheduling-annotation-support-scheduled-reactive]]
+=== The `@Scheduled` annotation on Reactive methods or Kotlin suspending functions
+
+As of Spring Framework 6.1, `@Scheduled` methods are also supported on two types
+of asynchronous methods:
+
+ - Reactive methods, i.e. methods with a `Publisher` return type (or any concrete
+implementation of `Publisher`) like in the following example:
+
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+	@Scheduled(fixedDelay = 500)
+	public Publisher<Void> reactiveSomething() {
+		// return an instance of Publisher
+	}
+----
+
+ - Kotlin suspending functions, like in the following example:
+
+[source,kotlin,indent=0,subs="verbatim,quotes"]
+----
+	@Scheduled(fixedDelay = 500)
+	suspend fun something() {
+		// do something asynchronous
+	}
+----
+
+Both types of methods must be declared without any arguments. Additionally, the `cron`
+configuration elements are not supported for these two cases.
+
+Note that the `TaskExecutor`/`TaskScheduler` infrastructure is not used and the scheduling
+is instead performed by the Reactor library, which must be present at runtime.
+In the case of Kotlin suspending functions the `kotlinx.coroutines.reactor` bridge must
+also be present.
+
+The Spring Framework will obtain a `Publisher` out of the annotated method once and will
+create a timed `Flux` which regularly subscribes to said `Publisher`. These inner regular
+subscriptions happen according to the `fixedDelay`/`fixedRate` configuration.
+
+If the `Publisher` emits `onNext` signal(s), these are ignored and discarded (the same way
+return values from synchronous `@Scheduled` methods are ignored).
+
+In the following example, the `Flux` emits `onNext("Hello"), onNext("World")` every 5
+seconds, but these values are unused:
+
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+	@Scheduled(initialDelay = 5000, fixedRate = 5000)
+	public Flux<String> reactiveSomething() {
+		return Flux.just("Hello", "World");
+	}
+----
+
+If the `Publisher` emits an `onError` signal, it is logged at WARN level and recovered.
+As a result, further scheduled subscription do happen despite the error.
+
+In the following example, the `Mono` subscription fails twice in the first five seconds
+then subscriptions start succeeding, printing a message to the standard output every five
+seconds:
+
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+	@Scheduled(initialDelay = 0, fixedRate = 5000)
+	public Mono<Void> reactiveSomething() {
+		AtomicInteger countdown = new AtomicInteger(2);
+
+		return Mono.defer(() -> {
+			if (countDown.get() == 0 || countDown.decrementAndGet() == 0) {
+				return Mono.fromRunnable(() -> System.out.println("Message"));
+			}
+			return Mono.error(new IllegalStateException("Cannot deliver message"));
+		})
+	}
+----
+
+[NOTE]
+====
+The Spring Framework subscribes once to the underlying scheduling `Flux`, which can be
+cancelled by destroying the annotated bean or closing the application context.
+====
+
 
 [[scheduling-annotation-support-async]]
 === The `@Async` annotation

--- a/spring-context/spring-context.gradle
+++ b/spring-context/spring-context.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testImplementation("org.awaitility:awaitility")
 	testImplementation("jakarta.inject:jakarta.inject-tck")
 	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+	testImplementation("io.reactivex.rxjava3:rxjava")
 	testRuntimeOnly("jakarta.xml.bind:jakarta.xml.bind-api")
 	testRuntimeOnly("org.glassfish:jakarta.el")
 	// Substitute for javax.management:jmxremote_optional:1.0.1_04 (not available on Maven Central)

--- a/spring-context/spring-context.gradle
+++ b/spring-context/spring-context.gradle
@@ -38,7 +38,7 @@ dependencies {
 	testImplementation("org.apache.commons:commons-pool2")
 	testImplementation("org.awaitility:awaitility")
 	testImplementation("jakarta.inject:jakarta.inject-tck")
-	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 	testRuntimeOnly("jakarta.xml.bind:jakarta.xml.bind-api")
 	testRuntimeOnly("org.glassfish:jakarta.el")
 	// Substitute for javax.management:jmxremote_optional:1.0.1_04 (not available on Maven Central)

--- a/spring-context/spring-context.gradle
+++ b/spring-context/spring-context.gradle
@@ -27,6 +27,7 @@ dependencies {
 	optional("org.jetbrains.kotlin:kotlin-reflect")
 	optional("org.jetbrains.kotlin:kotlin-stdlib")
 	optional("org.reactivestreams:reactive-streams")
+	optional("io.projectreactor:reactor-core")
 	testImplementation(project(":spring-core-test"))
 	testImplementation(testFixtures(project(":spring-aop")))
 	testImplementation(testFixtures(project(":spring-beans")))

--- a/spring-context/spring-context.gradle
+++ b/spring-context/spring-context.gradle
@@ -38,6 +38,7 @@ dependencies {
 	testImplementation("org.apache.commons:commons-pool2")
 	testImplementation("org.awaitility:awaitility")
 	testImplementation("jakarta.inject:jakarta.inject-tck")
+	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 	testImplementation("io.reactivex.rxjava3:rxjava")
 	testRuntimeOnly("jakarta.xml.bind:jakarta.xml.bind-api")

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableScheduling.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableScheduling.java
@@ -188,11 +188,6 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  * application context and any separate {@code DispatcherServlet} application contexts,
  * if you need to apply its behavior at multiple levels.
  *
- * <p><b>Note: {@code @EnableScheduling} and {@code @Scheduled} support of reactive methods
- * and Kotlin suspending functions uses Reactor infrastructure</b> instead of the
- * {@code ScheduledTaskRegistrar} infrastructure, so previously discussed task-related
- * aspects like {@code SchedulingConfigurer} don't apply to these two cases.
- *
  * @author Chris Beams
  * @author Juergen Hoeller
  * @since 3.1

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableScheduling.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableScheduling.java
@@ -189,7 +189,7 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  * if you need to apply its behavior at multiple levels.
  *
  * <p><b>Note: {@code @EnableScheduling} and {@code @Scheduled} support of reactive methods
- * and Kotlin suspending functions uses Reactor infrastructure instead of the
+ * and Kotlin suspending functions uses Reactor infrastructure</b> instead of the
  * {@code ScheduledTaskRegistrar} infrastructure, so previously discussed task-related
  * aspects like {@code SchedulingConfigurer} don't apply to these two cases.
  *

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableScheduling.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/EnableScheduling.java
@@ -188,6 +188,11 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  * application context and any separate {@code DispatcherServlet} application contexts,
  * if you need to apply its behavior at multiple levels.
  *
+ * <p><b>Note: {@code @EnableScheduling} and {@code @Scheduled} support of reactive methods
+ * and Kotlin suspending functions uses Reactor infrastructure instead of the
+ * {@code ScheduledTaskRegistrar} infrastructure, so previously discussed task-related
+ * aspects like {@code SchedulingConfigurer} don't apply to these two cases.
+ *
  * @author Chris Beams
  * @author Juergen Hoeller
  * @since 3.1

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -36,6 +36,18 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  * a {@code void} return type; if not, the returned value will be ignored
  * when called through the scheduler.
  *
+ * <p>Methods that return a reactive {@code Publisher} are supported provided the
+ * Reactor library is present at runtime: it is used to implement the scheduling by
+ * repeatedly subscribing to the returned Publisher, which is only produced once.
+ * The cron configuration is not supported for this type of method. Values emitted by
+ * the publisher are ignored and discarded. Errors are logged at WARN level, which
+ * doesn't prevent further iterations.
+ *
+ * <p>Kotlin suspending functions are also supported, provided the coroutine-Reactor
+ * bridge ({@code kotlinx.coroutine.reactor}) is present at runtime. This bridge is
+ * used to adapt the suspending function into a Reactor {@code Mono} which is treated
+ * the same way as in the reactive method case (see above).
+ *
  * <p>Processing of {@code @Scheduled} annotations is performed by
  * registering a {@link ScheduledAnnotationBeanPostProcessor}. This can be
  * done manually or, more conveniently, through the {@code <task:annotation-driven/>}

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -37,17 +37,18 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  * when called through the scheduler.
  *
  * <p>Methods that return a reactive {@code Publisher} or a type which can be adapted
- * to {@code Publisher} by the default {@code ReactiveAdapterRegistry} are supported
- * provided the Reactor library is present at runtime. Reactor is used to implement
- * the scheduling by repeatedly subscribing to the returned Publisher, which is only
- * produced once.
- * The cron configuration is not supported for this type of method. Values emitted by
- * the publisher are ignored and discarded. Errors are logged at WARN level, which
- * doesn't prevent further iterations.
+ * to {@code Publisher} by the default {@code ReactiveAdapterRegistry} are supported.
+ * The {@code Publisher} MUST be finite and MUST support multiple subsequent subscriptions
+ * (i.e. be cold).
+ * The returned Publisher is only produced once, and the scheduling infrastructure
+ * then periodically {@code subscribe()} to it according to configuration.
+ * Values emitted by the publisher are ignored. Errors are logged at WARN level, which
+ * doesn't prevent further iterations. If a {@code fixed delay} is configured, the
+ * subscription is blocked upon in order to respect the fixed delay semantics.
  *
- * <p>Kotlin suspending functions are also supported, provided the coroutine-Reactor
+ * <p>Kotlin suspending functions are also supported, provided the coroutine-reactor
  * bridge ({@code kotlinx.coroutine.reactor}) is present at runtime. This bridge is
- * used to adapt the suspending function into a Reactor {@code Mono} which is treated
+ * used to adapt the suspending function into a {@code Publisher} which is treated
  * the same way as in the reactive method case (see above).
  *
  * <p>Processing of {@code @Scheduled} annotations is performed by

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -38,8 +38,7 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  *
  * <p>Methods that return a reactive {@code Publisher} or a type which can be adapted
  * to {@code Publisher} by the default {@code ReactiveAdapterRegistry} are supported.
- * The {@code Publisher} MUST be finite and MUST support multiple subsequent subscriptions
- * (i.e. be cold).
+ * The {@code Publisher} MUST support multiple subsequent subscriptions (i.e. be cold).
  * The returned Publisher is only produced once, and the scheduling infrastructure
  * then periodically {@code subscribe()} to it according to configuration.
  * Values emitted by the publisher are ignored. Errors are logged at WARN level, which

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/Scheduled.java
@@ -36,9 +36,11 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
  * a {@code void} return type; if not, the returned value will be ignored
  * when called through the scheduler.
  *
- * <p>Methods that return a reactive {@code Publisher} are supported provided the
- * Reactor library is present at runtime: it is used to implement the scheduling by
- * repeatedly subscribing to the returned Publisher, which is only produced once.
+ * <p>Methods that return a reactive {@code Publisher} or a type which can be adapted
+ * to {@code Publisher} by the default {@code ReactiveAdapterRegistry} are supported
+ * provided the Reactor library is present at runtime. Reactor is used to implement
+ * the scheduling by repeatedly subscribing to the returned Publisher, which is only
+ * produced once.
  * The cron configuration is not supported for this type of method. Values emitted by
  * the publisher are ignored and discarded. Errors are logged at WARN level, which
  * doesn't prevent further iterations.

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -395,6 +395,16 @@ public class ScheduledAnnotationBeanPostProcessor
 		return bean;
 	}
 
+	/**
+	 * Process the given {@code @Scheduled} method declaration on the given bean,
+	 * attempting to distinguish {@link #processScheduledReactive(Scheduled, Method, Object) reactive}
+	 * method from {@link #processScheduledSync(Scheduled, Method, Object) synchronous} methods.
+	 * @param scheduled the {@code @Scheduled} annotation
+	 * @param method the method that the annotation has been declared on
+	 * @param bean the target bean instance
+	 * @see #processScheduledSync(Scheduled, Method, Object)
+	 * @see #processScheduledReactive(Scheduled, Method, Object)
+	 */
 	protected void processScheduled(Scheduled scheduled, Method method, Object bean) {
 		// Is method a Kotlin suspending function? Throws if true but reactor bridge isn't on the classpath.
 		// Is method returning a Publisher instance? Throws if true but Reactor isn't on the classpath.
@@ -406,7 +416,10 @@ public class ScheduledAnnotationBeanPostProcessor
 	}
 
 	/**
-	 * Process the given {@code @Scheduled} method declaration on the given bean.
+	 * Process the given {@code @Scheduled} method declaration on the given bean,
+	 * as a synchronous method. The method MUST take no arguments. Its return value
+	 * is ignored (if any) and the scheduled invocations of the method take place
+	 * using the underlying {@link TaskScheduler} infrastructure.
 	 * @param scheduled the {@code @Scheduled} annotation
 	 * @param method the method that the annotation has been declared on
 	 * @param bean the target bean instance
@@ -547,7 +560,7 @@ public class ScheduledAnnotationBeanPostProcessor
 	 * @param method the method that the annotation has been declared on, which
 	 * MUST either return a Publisher or be a Kotlin suspending function
 	 * @param bean the target bean instance
-	 * @see #createRunnable(Object, Method)
+	 * @see ScheduledAnnotationReactiveSupport
 	 */
 	protected void processScheduledReactive(Scheduled scheduled, Method method, Object bean) {
 		try {

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
@@ -57,7 +57,7 @@ abstract class ScheduledAnnotationReactiveSupport {
 		private final Duration initialDelay;
 		private final Duration otherDelay;
 		private final boolean isFixedRate;
-		private final String checkpoint;
+		protected final String checkpoint;
 		private final Disposable.Swap disposable;
 
 		private final Log logger = LogFactory.getLog(getClass());

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
@@ -89,6 +89,7 @@ abstract class ScheduledAnnotationReactiveSupport {
 					+ "#" + method.getName() + "()' [ScheduledAnnotationReactiveSupport]";
 		}
 
+
 		private Mono<Void> safeExecutionMono() {
 			Mono<Void> executionMono;
 			if (this.publisher instanceof Mono) {
@@ -97,8 +98,8 @@ abstract class ScheduledAnnotationReactiveSupport {
 			else {
 				executionMono = Flux.from(this.publisher).then();
 			}
-			if (this.logger.isWarnEnabled()) {
-				executionMono = executionMono.doOnError(ex -> this.logger.warn(
+			if (logger.isWarnEnabled()) {
+				executionMono = executionMono.doOnError(ex -> logger.warn(
 						"Ignored error in publisher from " + this.checkpoint, ex));
 			}
 			executionMono = executionMono.onErrorComplete();
@@ -124,6 +125,9 @@ abstract class ScheduledAnnotationReactiveSupport {
 							scheduledFlux
 					);
 				}
+				else {
+					scheduledFlux = Flux.concat(executionMono, scheduledFlux);
+				}
 			}
 			// Subscribe and ensure that errors can be traced back to the @Scheduled via a checkpoint
 			if (this.disposable.isDisposed()) {
@@ -135,6 +139,11 @@ abstract class ScheduledAnnotationReactiveSupport {
 
 		public void cancel() {
 			this.disposable.dispose();
+		}
+
+		@Override
+		public String toString() {
+			return this.checkpoint;
 		}
 	}
 }

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
@@ -71,7 +71,7 @@ abstract class ScheduledAnnotationReactiveSupport {
 			Assert.isTrue(method.getParameterCount() == 1,"Kotlin suspending functions may only be"
 					+ " annotated with @Scheduled if declared without arguments");
 			Assert.isTrue(coroutinesReactorPresent, "Kotlin suspending functions may only be annotated with"
-					+ " @Scheduled if the Coroutine-Reactor bridge (kotlinx.coroutines.reactive) is present at runtime");
+					+ " @Scheduled if the Coroutine-Reactor bridge (kotlinx.coroutines.reactor) is present at runtime");
 			return true;
 		}
 		ReactiveAdapterRegistry registry = ReactiveAdapterRegistry.getSharedInstance();
@@ -165,8 +165,8 @@ abstract class ScheduledAnnotationReactiveSupport {
 					}
 
 					@Override
-					public void onError(Throwable e) {
-						LOGGER.warn("Unexpected error occurred in scheduled reactive task", e);
+					public void onError(Throwable ex) {
+						LOGGER.warn("Unexpected error occurred in scheduled reactive task", ex);
 						latch.countDown();
 					}
 
@@ -178,8 +178,8 @@ abstract class ScheduledAnnotationReactiveSupport {
 				try {
 					latch.await();
 				}
-				catch (InterruptedException e) {
-					throw new RuntimeException(e);
+				catch (InterruptedException ex) {
+					throw new RuntimeException(ex);
 				}
 			};
 		}
@@ -195,8 +195,8 @@ abstract class ScheduledAnnotationReactiveSupport {
 			}
 
 			@Override
-			public void onError(Throwable e) {
-				LOGGER.warn("Unexpected error occurred in scheduled reactive task", e);
+			public void onError(Throwable ex) {
+				LOGGER.warn("Unexpected error occurred in scheduled reactive task", ex);
 			}
 
 			@Override

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scheduling.annotation;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.reactivestreams.Publisher;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Helper class for @{@link ScheduledAnnotationBeanPostProcessor} to support reactive cases
+ * without a dependency on optional classes.
+ * @author Simon Baslé
+ * @since 6.0.x //FIXME
+ */
+abstract class ScheduledAnnotationReactiveSupport {
+
+	static final boolean reactorPresent = ClassUtils.isPresent(
+			"reactor.core.publisher.Flux", ScheduledAnnotationReactiveSupport.class.getClassLoader());
+
+	static boolean isReactive(Method method) {
+		return Publisher.class.isAssignableFrom(method.getReturnType());
+	}
+
+	/**
+	 * Encapsulates the logic of {@code @Scheduled} on reactive types, using Reactor.
+	 */
+	static class ReactiveTask {
+
+		private final Publisher<?> publisher;
+		private final Duration initialDelay;
+		private final Duration otherDelay;
+		private final boolean isFixedRate;
+		private final String checkpoint;
+		private final Disposable.Swap disposable;
+
+		private final Log logger = LogFactory.getLog(getClass());
+
+
+		protected ReactiveTask(Method method, Object bean, Duration initialDelay,
+				Duration otherDelay, boolean isFixedRate) {
+
+			Assert.isTrue(method.getParameterCount() == 0, "Only no-arg methods may be annotated with @Scheduled");
+			Method invocableMethod = AopUtils.selectInvocableMethod(method, bean.getClass());
+			try {
+				ReflectionUtils.makeAccessible(invocableMethod);
+				Object r = invocableMethod.invoke(bean);
+				this.publisher = (Publisher<?>) r;
+			}
+			catch (InvocationTargetException ex) {
+				throw new IllegalArgumentException("Cannot obtain a Publisher from the @Scheduled reactive method", ex.getTargetException());
+			}
+			catch (IllegalAccessException ex) {
+				throw new IllegalArgumentException("Cannot obtain a Publisher from the @Scheduled reactive method", ex);
+			}
+
+			this.initialDelay = initialDelay;
+			this.otherDelay = otherDelay;
+			this.isFixedRate = isFixedRate;
+
+			this.disposable = Disposables.swap();
+			this.checkpoint = "@Scheduled '"+ method.getDeclaringClass().getName()
+					+ "#" + method.getName() + "()' [ScheduledAnnotationReactiveSupport]";
+		}
+
+		private Mono<Void> safeExecutionMono() {
+			Mono<Void> executionMono;
+			if (this.publisher instanceof Mono) {
+				executionMono = Mono.from(this.publisher).then();
+			}
+			else {
+				executionMono = Flux.from(this.publisher).then();
+			}
+			if (this.logger.isWarnEnabled()) {
+				executionMono = executionMono.doOnError(ex -> this.logger.warn(
+						"Ignored error in publisher from " + this.checkpoint, ex));
+			}
+			executionMono = executionMono.onErrorComplete();
+			return executionMono;
+		}
+
+		public void subscribe() {
+			if (this.disposable.isDisposed()) {
+				return;
+			}
+
+			final Mono<Void> executionMono = safeExecutionMono();
+			Flux<Void> scheduledFlux;
+			if (this.isFixedRate) {
+				scheduledFlux = Flux.interval(this.initialDelay, this.otherDelay)
+						.flatMap(it -> executionMono);
+			}
+			else {
+				scheduledFlux = Mono.delay(this.otherDelay).then(executionMono).repeat();
+				if (!this.initialDelay.isZero()) {
+					scheduledFlux = Flux.concat(
+							Mono.delay(this.initialDelay).then(executionMono),
+							scheduledFlux
+					);
+				}
+			}
+			// Subscribe and ensure that errors can be traced back to the @Scheduled via a checkpoint
+			if (this.disposable.isDisposed()) {
+				return;
+			}
+			this.disposable.update(scheduledFlux.checkpoint(this.checkpoint)
+					.subscribe(it -> {}, ex -> ReactiveTask.this.logger.error("Unexpected error occurred in scheduled reactive task", ex)));
+		}
+
+		public void cancel() {
+			this.disposable.dispose();
+		}
+	}
+}

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
@@ -97,7 +97,8 @@ abstract class ScheduledAnnotationReactiveSupport {
 	 * this method.
 	 */
 	static Publisher<?> getPublisherForReactiveMethod(Method method, Object bean) {
-		Assert.isTrue(method.getParameterCount() == 0, "Only no-arg reactive methods may be annotated with @Scheduled");
+		Assert.isTrue(method.getParameterCount() == 0, "Reactive methods may only be annotated with "
+				+ "@Scheduled if declared without arguments");
 		Method invocableMethod = AopUtils.selectInvocableMethod(method, bean.getClass());
 		try {
 			ReflectionUtils.makeAccessible(invocableMethod);
@@ -119,8 +120,9 @@ abstract class ScheduledAnnotationReactiveSupport {
 	 * this method.
 	 */
 	static Publisher<?> getPublisherForSuspendingFunction(Method method, Object bean) {
-		Assert.isTrue(method.getParameterCount() == 1,"Only no-args suspending functions may be "
-				+ "annotated with @Scheduled (with 1 self-referencing synthetic arg expected)");
+		//Note that suspending functions declared without args have a single Continuation parameter in reflective inspection
+		Assert.isTrue(method.getParameterCount() == 1,"Kotlin suspending functions may only be annotated "
+				+ "with @Scheduled if declared without arguments");
 
 		return CoroutinesUtils.invokeSuspendingFunction(method, bean, (Object[]) method.getParameters());
 	}
@@ -154,8 +156,8 @@ abstract class ScheduledAnnotationReactiveSupport {
 			this.isFixedRate = isFixedRate;
 
 			this.disposable = Disposables.swap();
-			this.checkpoint = "@Scheduled '"+ method.getDeclaringClass().getName()
-					+ "#" + method.getName() + "()' [ScheduledAnnotationReactiveSupport]";
+			this.checkpoint = "@Scheduled '"+ method.getName() + "()' in bean '"
+					+ method.getDeclaringClass().getName() + "'";
 		}
 
 		private Mono<Void> safeExecutionMono() {

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupport.java
@@ -41,7 +41,7 @@ import org.springframework.util.ReflectionUtils;
  * Helper class for @{@link ScheduledAnnotationBeanPostProcessor} to support reactive cases
  * without a dependency on optional classes.
  * @author Simon Baslé
- * @since 6.1.0 //FIXME
+ * @since 6.1.0
  */
 abstract class ScheduledAnnotationReactiveSupport {
 

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
@@ -141,13 +141,13 @@ class ScheduledAnnotationReactiveSupportTests {
 
 			//static helper method
 			assertThatIllegalArgumentException().isThrownBy(() -> getPublisherForReactiveMethod(m, target))
-					.withMessage("Only no-arg reactive methods may be annotated with @Scheduled")
+					.withMessage("Reactive methods may only be annotated with @Scheduled if declared without arguments")
 					.withNoCause();
 
 			//constructor of task
 			assertThatIllegalArgumentException().isThrownBy(() -> new ScheduledAnnotationReactiveSupport.ReactiveTask(
 							m, target, Duration.ZERO, Duration.ZERO, false, false))
-					.withMessage("Only no-arg reactive methods may be annotated with @Scheduled")
+					.withMessage("Reactive methods may only be annotated with @Scheduled if declared without arguments")
 					.withNoCause();
 		}
 
@@ -189,7 +189,7 @@ class ScheduledAnnotationReactiveSupportTests {
 			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
 					m, target, Duration.ZERO, Duration.ZERO, false, false);
 
-			assertThat(reactiveTask).hasToString("@Scheduled 'org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests$ReactiveMethods#mono()' [ScheduledAnnotationReactiveSupport]");
+		assertThat(reactiveTask).hasToString("@Scheduled 'mono()' in bean 'org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests$ReactiveMethods'");
 		}
 
 		@Test
@@ -257,9 +257,8 @@ class ScheduledAnnotationReactiveSupportTests {
 			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
 					m, target, Duration.ZERO, Duration.ofSeconds(10), true, false);
 
-			assertThat(reactiveTask.checkpoint).isEqualTo("@Scheduled 'org.springframework.scheduling.annotation"
-					+ ".ScheduledAnnotationReactiveSupportTests$ReactiveMethods#monoError()'"
-					+ " [ScheduledAnnotationReactiveSupport]");
+			assertThat(reactiveTask.checkpoint).isEqualTo("@Scheduled 'monoError()' in bean "
+					+ "'org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests$ReactiveMethods'");
 		}
 
 	}

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scheduling.annotation;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class ScheduledAnnotationReactiveSupportTests {
+
+	@Test
+	void ensureReactor() {
+		assertThat(ScheduledAnnotationReactiveSupport.reactorPresent).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "mono", "flux", "monoString", "fluxString", "publisherMono",
+			"publisherString", "monoThrows" }) //note: monoWithParams can't be found by this test
+	void checkIsReactive(String method) {
+		Method m = ReflectionUtils.findMethod(ReactiveMethods.class, method);
+		assertThat(ScheduledAnnotationReactiveSupport.isReactive(m)).as(m.getName()).isTrue();
+	}
+
+	@Test
+	void checkNotReactive() {
+		Method string = ReflectionUtils.findMethod(ReactiveMethods.class, "oops");
+		Method future = ReflectionUtils.findMethod(ReactiveMethods.class, "future");
+
+		assertThat(ScheduledAnnotationReactiveSupport.isReactive(string))
+				.as("String-returning").isFalse();
+		assertThat(ScheduledAnnotationReactiveSupport.isReactive(future))
+				.as("Future-returning").isFalse();
+	}
+
+	static class ReactiveMethods {
+
+		public String oops() {
+			return "oops";
+		}
+
+		public Mono<Void> mono() {
+			return Mono.empty();
+		}
+
+		public Flux<Void> flux() {
+			return Flux.empty();
+		}
+
+		public Mono<String> monoString() {
+			return Mono.just("example");
+		}
+
+		public Flux<String> fluxString() {
+			return Flux.just("example");
+		}
+
+		public Publisher<Void> publisherMono() {
+			return Mono.empty();
+		}
+
+		public Publisher<String> publisherString() {
+			return fluxString();
+		}
+
+		public CompletableFuture<String> future() {
+			return CompletableFuture.completedFuture("example");
+		}
+
+		public Mono<Void> monoWithParam(String param) {
+			return Mono.just(param).then();
+		}
+
+		public Mono<Void> monoThrows() {
+			throw new IllegalStateException("expected");
+		}
+
+		public Mono<Void> monoThrowsIllegalAccess() throws IllegalAccessException {
+			//simulate a reflection issue
+			throw new IllegalAccessException("expected");
+		}
+
+		AtomicInteger subscription = new AtomicInteger();
+
+		public Mono<Void> trackingMono() {
+			return Mono.<Void>empty()
+					.doOnSubscribe(s -> subscription.incrementAndGet());
+		}
+
+		public Mono<Void> monoError() {
+			return Mono.error(new IllegalStateException("expected"));
+		}
+
+	}
+
+	@Nested
+	class ReactiveTaskTests {
+
+		private ReactiveMethods target;
+
+		@BeforeEach
+		void init() {
+			this.target = new ReactiveMethods();
+		}
+
+		@Test
+		void rejectWithParams() {
+			Method m = ReflectionUtils.findMethod(ReactiveMethods.class, "monoWithParam", String.class);
+
+			assertThat(ScheduledAnnotationReactiveSupport.isReactive(m)).as("isReactive").isTrue();
+
+			assertThatIllegalArgumentException().isThrownBy(() -> new ScheduledAnnotationReactiveSupport.ReactiveTask(
+							m, target, Duration.ZERO, Duration.ZERO, false))
+					.withMessage("Only no-arg methods may be annotated with @Scheduled")
+					.withNoCause();
+		}
+
+		@Test
+		void rejectCantProducePublisher() {
+			Method m = ReflectionUtils.findMethod(ReactiveMethods.class, "monoThrows");
+
+			assertThatIllegalArgumentException().isThrownBy(() -> new ScheduledAnnotationReactiveSupport.ReactiveTask(
+							m, target, Duration.ZERO, Duration.ZERO, false))
+					.withMessage("Cannot obtain a Publisher from the @Scheduled reactive method")
+					.withCause(new IllegalStateException("expected"));
+		}
+
+		@Test
+		void rejectCantAccessMethod() {
+			Method m = ReflectionUtils.findMethod(ReactiveMethods.class, "monoThrowsIllegalAccess");
+
+			assertThatIllegalArgumentException().isThrownBy(() -> new ScheduledAnnotationReactiveSupport.ReactiveTask(
+							m, target, Duration.ZERO, Duration.ZERO, false))
+					.withMessage("Cannot obtain a Publisher from the @Scheduled reactive method")
+					.withCause(new IllegalAccessException("expected"));
+		}
+
+		@Test
+		void hasCheckpointToString() {
+			Method m = ReflectionUtils.findMethod(ReactiveMethods.class, "mono");
+			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
+					m, target, Duration.ZERO, Duration.ZERO, false);
+
+			assertThat(reactiveTask).hasToString("@Scheduled 'org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests$ReactiveMethods#mono()' [ScheduledAnnotationReactiveSupport]");
+		}
+
+		@Test
+		void cancelledEarlyPreventsSubscription() {
+			Method m = ReflectionUtils.findMethod(ReactiveMethods.class, "trackingMono");
+			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
+					m, target, Duration.ZERO, Duration.ofSeconds(10), false);
+			reactiveTask.cancel();
+			reactiveTask.subscribe();
+
+			assertThat(target.subscription).hasValue(0);
+		}
+
+		@Test
+		void noInitialDelayFixedDelay() throws InterruptedException {
+			Method m = ReflectionUtils.findMethod(target.getClass(), "trackingMono");
+			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
+					m, target, Duration.ZERO, Duration.ofSeconds(10), false);
+			reactiveTask.subscribe();
+			Thread.sleep(500);
+			reactiveTask.cancel();
+
+			assertThat(target.subscription).hasValue(1);
+		}
+
+		@Test
+		void noInitialDelayFixedRate() throws InterruptedException {
+			Method m = ReflectionUtils.findMethod(target.getClass(), "trackingMono");
+			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
+					m, target, Duration.ZERO, Duration.ofSeconds(10), true);
+			reactiveTask.subscribe();
+			Thread.sleep(500);
+			reactiveTask.cancel();
+
+			assertThat(target.subscription).hasValue(1);
+		}
+
+		@Test
+		void initialDelayFixedDelay() throws InterruptedException {
+			Method m = ReflectionUtils.findMethod(target.getClass(), "trackingMono");
+			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
+					m, target, Duration.ofSeconds(10), Duration.ofMillis(500), false);
+			reactiveTask.subscribe();
+			Thread.sleep(500);
+			reactiveTask.cancel();
+
+			assertThat(target.subscription).hasValue(0);
+		}
+
+		@Test
+		void initialDelayFixedRate() throws InterruptedException {
+			Method m = ReflectionUtils.findMethod(target.getClass(), "trackingMono");
+			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
+					m, target, Duration.ofSeconds(10), Duration.ofMillis(500), true);
+			reactiveTask.subscribe();
+			Thread.sleep(500);
+			reactiveTask.cancel();
+
+			assertThat(target.subscription).hasValue(0);
+		}
+
+		@Test
+		void monoErrorHasCheckpoint() throws InterruptedException {
+			Method m = ReflectionUtils.findMethod(target.getClass(), "monoError");
+			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
+					m, target, Duration.ZERO, Duration.ofSeconds(10), true);
+
+			reactiveTask.subscribe();
+			Thread.sleep(500);
+
+			reactiveTask.cancel();
+		}
+
+	}
+}

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
@@ -99,9 +99,7 @@ class ScheduledAnnotationReactiveSupportTests {
 				.withCause(new IllegalAccessException("expected"));
 	}
 
-	//FIXME find a way to test the case with fixedDelay effectively turning into a fixedRate ?
-
-	//FIXME test createCheckpointPublisherFor uses Reactor and checkpoint operator
+	//TODO find a way to test the case with fixedDelay effectively turning into a fixedRate ?
 
 	@Test
 	void hasCheckpointToString() {

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
@@ -66,10 +66,8 @@ class ScheduledAnnotationReactiveSupportTests {
 	void rejectReactiveAdaptableButNotDeferred() {
 		Method future = ReflectionUtils.findMethod(ReactiveMethods.class, "future");
 
-		assertThatIllegalArgumentException().isThrownBy(
-				() -> isReactive(future)
-		)
-						.withMessage("Reactive methods may only be annotated with @Scheduled if the return type supports deferred execution");
+		assertThatIllegalArgumentException().isThrownBy(() -> isReactive(future))
+				.withMessage("Reactive methods may only be annotated with @Scheduled if the return type supports deferred execution");
 	}
 
 	static class ReactiveMethods {
@@ -204,7 +202,7 @@ class ScheduledAnnotationReactiveSupportTests {
 			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
 					m, target, Duration.ZERO, Duration.ZERO, false);
 
-		assertThat(reactiveTask).hasToString("@Scheduled 'mono()' in bean 'org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests$ReactiveMethods'");
+			assertThat(reactiveTask).hasToString("@Scheduled 'mono()' in bean 'org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests$ReactiveMethods'");
 		}
 
 		@Test

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -238,10 +237,9 @@ class ScheduledAnnotationReactiveSupportTests {
 			final ScheduledAnnotationReactiveSupport.ReactiveTask reactiveTask = new ScheduledAnnotationReactiveSupport.ReactiveTask(
 					m, target, Duration.ZERO, Duration.ofSeconds(10), true);
 
-			reactiveTask.subscribe();
-			Thread.sleep(500);
-
-			reactiveTask.cancel();
+			assertThat(reactiveTask.checkpoint).isEqualTo("@Scheduled 'org.springframework.scheduling.annotation"
+					+ ".ScheduledAnnotationReactiveSupportTests$ReactiveMethods#monoError()'"
+					+ " [ScheduledAnnotationReactiveSupport]");
 		}
 
 	}

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationReactiveSupportTests.java
@@ -105,8 +105,15 @@ class ScheduledAnnotationReactiveSupportTests {
 
 	@Test
 	void hasCheckpointToString() {
-		//FIXME test checkpointing
-		assertThat("FIXME").isEqualTo("@Scheduled 'mono()' in bean 'org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests$ReactiveMethods'");
+		ReactiveMethods target = new ReactiveMethods();
+		Method m = ReflectionUtils.findMethod(ReactiveMethods.class, "mono");
+		Publisher<?> p = getPublisherFor(m, target);
+
+		assertThat(p.getClass().getName())
+				.as("checkpoint class")
+				.isEqualTo("reactor.core.publisher.FluxOnAssembly");
+
+		assertThat(p).hasToString("checkpoint(\"@Scheduled 'mono()' in bean 'org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests$ReactiveMethods'\")");
 	}
 
 	static class ReactiveMethods {

--- a/spring-context/src/test/kotlin/org/springframework/scheduling/annotation/KotlinScheduledAnnotationReactiveSupportTests.kt
+++ b/spring-context/src/test/kotlin/org/springframework/scheduling/annotation/KotlinScheduledAnnotationReactiveSupportTests.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scheduling.annotation
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupport.ReactiveTask
+import org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupport.checkKotlinRuntimeIfNeeded
+import org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupport.getPublisherForSuspendingFunction
+import org.springframework.scheduling.annotation.ScheduledAnnotationReactiveSupportTests.ReactiveMethods
+import org.springframework.util.ReflectionUtils
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.Continuation
+
+class KotlinScheduledAnnotationReactiveSupportTests {
+
+	@Test
+	fun ensureReactor() {
+		Assertions.assertThat(ScheduledAnnotationReactiveSupport.reactorPresent).isTrue
+	}
+
+	@Test
+	fun ensureKotlinCoroutineReactorBridge() {
+		Assertions.assertThat(ScheduledAnnotationReactiveSupport.coroutinesReactorPresent).isTrue
+	}
+
+	@Test
+	fun kotlinSuspendingFunctionIsNotReactive() {
+		val suspending = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspending", Continuation::class.java)
+		Assertions.assertThat(ScheduledAnnotationReactiveSupport.checkReactorRuntimeIfNeeded(suspending!!)).isFalse
+	}
+
+	internal class SuspendingFunctions {
+		suspend fun suspending() {
+		}
+
+		suspend fun suspendingReturns(): String = "suspended"
+
+		suspend fun withParam(param: String): String {
+			return param
+		}
+
+		suspend fun throwsIllegalState() {
+			throw IllegalStateException("expected")
+		}
+
+		var subscription = AtomicInteger()
+		suspend fun suspendingTracking() {
+			subscription.incrementAndGet()
+		}
+
+		fun notSuspending() { }
+	}
+
+
+	private var target: SuspendingFunctions? = null
+
+	@BeforeEach
+	fun init() {
+		target = SuspendingFunctions()
+	}
+
+	@Test
+	fun checkKotlinRuntimeIfNeeded() {
+		val suspendingMethod = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspending", Continuation::class.java)!!
+		val notSuspendingMethod = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "notSuspending")!!
+
+		assertThat(checkKotlinRuntimeIfNeeded(suspendingMethod)).describedAs("suspending").isTrue()
+		assertThat(checkKotlinRuntimeIfNeeded(notSuspendingMethod)).describedAs("not suspending").isFalse()
+	}
+
+	@Test
+	fun rejectWithParams() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "withParam", String::class.java, Continuation::class.java)
+
+		//static helper method
+		Assertions.assertThatIllegalArgumentException().isThrownBy { getPublisherForSuspendingFunction(m!!, target!!) }
+				.withMessage("Only no-args suspending functions may be annotated with @Scheduled (with 1 self-referencing synthetic arg expected)")
+				.withNoCause()
+
+		//constructor of task
+		Assertions.assertThatIllegalArgumentException().isThrownBy {
+			ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ZERO, false, true)
+		}
+				.withMessage("Only no-args suspending functions may be annotated with @Scheduled (with 1 self-referencing synthetic arg expected)")
+				.withNoCause()
+	}
+
+	@Test
+	fun rejectNotSuspending() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "notSuspending")
+
+		//static helper method
+		Assertions.assertThatIllegalArgumentException().isThrownBy { getPublisherForSuspendingFunction(m!!, target!!) }
+				.withMessage("Only no-args suspending functions may be annotated with @Scheduled (with 1 self-referencing synthetic arg expected)")
+				.withNoCause()
+
+		//constructor of task
+		Assertions.assertThatIllegalArgumentException().isThrownBy {
+			ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ZERO, false, true)
+		}
+				.withMessage("Only no-args suspending functions may be annotated with @Scheduled (with 1 self-referencing synthetic arg expected)")
+				.withNoCause()
+	}
+
+	@Test
+	fun suspendingThrowIsTurnedToMonoError() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "throwsIllegalState", Continuation::class.java)
+
+		val mono = Mono.from(getPublisherForSuspendingFunction(m!!, target!!))
+
+		Assertions.assertThatIllegalStateException().isThrownBy { mono.block() }
+				.withMessage("expected")
+				.withNoCause()
+
+		//constructor of task doesn't throw
+		Assertions.assertThatNoException().isThrownBy {
+			ReactiveTask(m, target!!, Duration.ZERO, Duration.ZERO, false, true)
+		}
+	}
+
+	@Test
+	fun turningSuspendingFunctionToMonoDoesntExecuteTheMethod() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspendingTracking", Continuation::class.java)
+		val mono = Mono.from(getPublisherForSuspendingFunction(m!!, target!!))
+
+		assertThat(target!!.subscription).hasValue(0)
+		mono.block()
+		assertThat(target!!.subscription).describedAs("after subscription").hasValue(1)
+	}
+
+	@Test
+	fun hasCheckpointToString() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspending", Continuation::class.java)
+		val reactiveTask = ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ZERO, false, true)
+		assertThat(reactiveTask).hasToString("@Scheduled 'org.springframework.scheduling.annotation.KotlinScheduledAnnotationReactiveSupportTests\$SuspendingFunctions#suspending()' [ScheduledAnnotationReactiveSupport]")
+	}
+
+	@Test
+	fun cancelledEarlyPreventsSubscription() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspendingTracking", Continuation::class.java)
+		val reactiveTask = ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ofSeconds(10), false, true)
+		reactiveTask.cancel()
+		reactiveTask.subscribe()
+		assertThat(target!!.subscription).hasValue(0)
+	}
+
+	@Test
+	fun multipleSubscriptionsTracked() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspendingTracking", Continuation::class.java)
+		val reactiveTask = ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ofMillis(500), false, true)
+		reactiveTask.subscribe()
+		Thread.sleep(1500)
+		reactiveTask.cancel()
+		assertThat(target!!.subscription).hasValueGreaterThanOrEqualTo(3)
+	}
+
+	@Test
+	@Throws(InterruptedException::class)
+	fun noInitialDelayFixedDelay() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspendingTracking", Continuation::class.java)
+		val reactiveTask = ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ofSeconds(10), false, true)
+		reactiveTask.subscribe()
+		Thread.sleep(500)
+		reactiveTask.cancel()
+		assertThat(target!!.subscription).hasValue(1)
+	}
+
+	@Test
+	@Throws(InterruptedException::class)
+	fun noInitialDelayFixedRate() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspendingTracking", Continuation::class.java)
+		val reactiveTask = ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ofSeconds(10), true, true)
+		reactiveTask.subscribe()
+		Thread.sleep(500)
+		reactiveTask.cancel()
+		assertThat(target!!.subscription).hasValue(1)
+	}
+
+	@Test
+	@Throws(InterruptedException::class)
+	fun initialDelayFixedDelay() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspendingTracking", Continuation::class.java)
+		val reactiveTask = ReactiveTask(m!!, target!!, Duration.ofSeconds(10), Duration.ofMillis(500), false, true)
+		reactiveTask.subscribe()
+		Thread.sleep(500)
+		reactiveTask.cancel()
+		assertThat(target!!.subscription).hasValue(0)
+	}
+
+	@Test
+	@Throws(InterruptedException::class)
+	fun initialDelayFixedRate() {
+		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspendingTracking", Continuation::class.java)
+		val reactiveTask = ReactiveTask(m!!, target!!, Duration.ofSeconds(10), Duration.ofMillis(500), true, true)
+		reactiveTask.subscribe()
+		Thread.sleep(500)
+		reactiveTask.cancel()
+		assertThat(target!!.subscription).hasValue(0)
+	}
+}

--- a/spring-context/src/test/kotlin/org/springframework/scheduling/annotation/KotlinScheduledAnnotationReactiveSupportTests.kt
+++ b/spring-context/src/test/kotlin/org/springframework/scheduling/annotation/KotlinScheduledAnnotationReactiveSupportTests.kt
@@ -93,14 +93,14 @@ class KotlinScheduledAnnotationReactiveSupportTests {
 
 		//static helper method
 		Assertions.assertThatIllegalArgumentException().isThrownBy { getPublisherForSuspendingFunction(m!!, target!!) }
-				.withMessage("Only no-args suspending functions may be annotated with @Scheduled (with 1 self-referencing synthetic arg expected)")
+				.withMessage("Kotlin suspending functions may only be annotated with @Scheduled if declared without arguments")
 				.withNoCause()
 
 		//constructor of task
 		Assertions.assertThatIllegalArgumentException().isThrownBy {
 			ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ZERO, false, true)
 		}
-				.withMessage("Only no-args suspending functions may be annotated with @Scheduled (with 1 self-referencing synthetic arg expected)")
+				.withMessage("Kotlin suspending functions may only be annotated with @Scheduled if declared without arguments")
 				.withNoCause()
 	}
 
@@ -110,14 +110,14 @@ class KotlinScheduledAnnotationReactiveSupportTests {
 
 		//static helper method
 		Assertions.assertThatIllegalArgumentException().isThrownBy { getPublisherForSuspendingFunction(m!!, target!!) }
-				.withMessage("Only no-args suspending functions may be annotated with @Scheduled (with 1 self-referencing synthetic arg expected)")
+				.withMessage("Kotlin suspending functions may only be annotated with @Scheduled if declared without arguments")
 				.withNoCause()
 
 		//constructor of task
 		Assertions.assertThatIllegalArgumentException().isThrownBy {
 			ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ZERO, false, true)
 		}
-				.withMessage("Only no-args suspending functions may be annotated with @Scheduled (with 1 self-referencing synthetic arg expected)")
+				.withMessage("Kotlin suspending functions may only be annotated with @Scheduled if declared without arguments")
 				.withNoCause()
 	}
 
@@ -151,7 +151,7 @@ class KotlinScheduledAnnotationReactiveSupportTests {
 	fun hasCheckpointToString() {
 		val m = ReflectionUtils.findMethod(SuspendingFunctions::class.java, "suspending", Continuation::class.java)
 		val reactiveTask = ReactiveTask(m!!, target!!, Duration.ZERO, Duration.ZERO, false, true)
-		assertThat(reactiveTask).hasToString("@Scheduled 'org.springframework.scheduling.annotation.KotlinScheduledAnnotationReactiveSupportTests\$SuspendingFunctions#suspending()' [ScheduledAnnotationReactiveSupport]")
+		assertThat(reactiveTask).hasToString("@Scheduled 'suspending()' in bean 'org.springframework.scheduling.annotation.KotlinScheduledAnnotationReactiveSupportTests\$SuspendingFunctions'")
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds support for `@Scheduled` annotation on reactive methods
and on Kotlin suspending functions (provided a bridge to Reactive Streams
is available at runtime).

Reactive methods are methods that return an instance of Publisher or an
instance of a class that the ReactiveAdapterRegistry can adapt to a
Publisher with deferred support.

Kotlin suspending functions are converted to Publisher as well, using
`CoroutineUtils` and the support of the `kotlinx.coroutines.reactor`
bridge.

The bean method that produces the `Publisher` is only called once, but
there can be multiple subscriptions to that instance as configured by
the annotation. The usual task-based infrastructure for synchronous code
is reused for the purpose of scheduling the subscriptions.

One special case is when a `fixedDelay` is used, as the non-blocking
nature of subscribing to a Publisher makes it harder to adhere to these
semantics. As a result, for that particular case only, the subscription
is done in a blocking fashion inside the scheduled task.

Publisher onNext events are ignored. Active subscriptions are tracked
by the processor so that long-running publishers and infinite publishers
are also supported, allowing for cancellation if the associated bean is
destroyed or if the context is stopped.

See gh-23533
Closes gh-29924