### PR TITLE
Use  overloaded method with java.net.URI of Reactor Netty HttpClient

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
@@ -107,7 +107,7 @@ public class ReactorClientHttpConnector implements ClientHttpConnector {
 
 		return this.httpClient
 				.request(io.netty.handler.codec.http.HttpMethod.valueOf(method.name()))
-				.uri(uri.toString())
+				.uri(uri)
 				.send((request, outbound) -> requestCallback.apply(adaptRequest(method, uri, request, outbound)))
 				.responseConnection((response, connection) -> {
 					responseRef.set(new ReactorClientHttpResponse(response, connection));

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpConnector.java
@@ -108,7 +108,7 @@ public class ReactorNetty2ClientHttpConnector implements ClientHttpConnector {
 
 		return this.httpClient
 				.request(io.netty5.handler.codec.http.HttpMethod.valueOf(method.name()))
-				.uri(uri.toString())
+				.uri(uri)
 				.send((request, outbound) -> requestCallback.apply(adaptRequest(method, uri, request, outbound)))
 				.responseConnection((response, connection) -> {
 					responseRef.set(new ReactorNetty2ClientHttpResponse(response, connection));


### PR DESCRIPTION
I was doing some flame graph analysis and found that despite passing a URI into the WebClient, a string version of the URI was being passed into the reactor-netty library where it was parsed again in the UriEndpointFactory: https://github.com/reactor/reactor-netty/blob/dfb1e18551bd51a6cc406acdb923b66c9d7bbada/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java#L497-L513

Later, the URI is constructed again further inside that library https://github.com/reactor/reactor-netty/blob/dfb1e18551bd51a6cc406acdb923b66c9d7bbada/reactor-netty-http/src/main/java/reactor/netty/http/HttpOperations.java#L429 I may take a stab at cleaning up that in https://github.com/reactor/reactor-netty/issues/829 once the URI is passed from spring. Ideally, I could make the URI passed into spring live all the way thru the lifecycle.

NOTE: this assumes a full URI is present like `http://example.com/blah` not `/blah`. When I hit breakpoints here, it appeared that they were all full URI's.