### PR TITLE
Propagate WebClient attributes into underlying HTTP client request where possible

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/http/client/reactive/MockClientHttpRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/client/reactive/MockClientHttpRequest.java
@@ -120,6 +120,10 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest {
 	}
 
 	@Override
+	protected void applyAttributes() {
+	}
+
+	@Override
 	public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
 		return doCommit(() -> Mono.defer(() -> this.writeHandler.apply(Flux.from(body))));
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
@@ -94,6 +94,8 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 	@Nullable
 	private MultiValueMap<String, String> defaultCookies;
 
+	private boolean applyAttributes;
+
 	@Nullable
 	private List<ExchangeFilterFunction> filters;
 
@@ -155,6 +157,7 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 		}
 		this.defaultCookies = (other.defaultCookies != null ?
 				new LinkedMultiValueMap<>(other.defaultCookies) : null);
+		this.applyAttributes = other.applyAttributes;
 		this.filters = (other.filters != null ? new ArrayList<>(other.filters) : null);
 		this.entityResultConsumer = other.entityResultConsumer;
 		this.strategies = other.strategies;
@@ -211,6 +214,12 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 			this.defaultCookies = new LinkedMultiValueMap<>(3);
 		}
 		return this.defaultCookies;
+	}
+
+	@Override
+	public WebTestClient.Builder applyAttributes(boolean applyAttributes) {
+		this.applyAttributes = applyAttributes;
+		return this;
 	}
 
 	@Override
@@ -305,18 +314,18 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 				this.entityResultConsumer, this.responseTimeout, new DefaultWebTestClientBuilder(this));
 	}
 
-	private static ClientHttpConnector initConnector() {
+	private ClientHttpConnector initConnector() {
 		if (reactorNettyClientPresent) {
-			return new ReactorClientHttpConnector();
+			return new ReactorClientHttpConnector(applyAttributes);
 		}
 		else if (reactorNetty2ClientPresent) {
-			return new ReactorNetty2ClientHttpConnector();
+			return new ReactorNetty2ClientHttpConnector(applyAttributes);
 		}
 		else if (jettyClientPresent) {
-			return new JettyClientHttpConnector();
+			return new JettyClientHttpConnector(applyAttributes);
 		}
 		else if (httpComponentsClientPresent) {
-			return new HttpComponentsClientHttpConnector();
+			return new HttpComponentsClientHttpConnector(applyAttributes);
 		}
 		else {
 			return new JdkClientHttpConnector();

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
@@ -295,7 +295,7 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 			}
 		}
 		if (connectorToUse == null) {
-			connectorToUse = initConnector();
+			connectorToUse = initConnector(this.applyAttributes);
 		}
 		Function<ClientHttpConnector, ExchangeFunction> exchangeFactory = connector -> {
 			ExchangeFunction exchange = ExchangeFunctions.create(connector, initExchangeStrategies());
@@ -314,7 +314,7 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 				this.entityResultConsumer, this.responseTimeout, new DefaultWebTestClientBuilder(this));
 	}
 
-	private ClientHttpConnector initConnector() {
+	private static ClientHttpConnector initConnector(boolean applyAttributes) {
 		if (reactorNettyClientPresent) {
 			return new ReactorClientHttpConnector(applyAttributes);
 		}

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
@@ -295,7 +295,7 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 			}
 		}
 		if (connectorToUse == null) {
-			connectorToUse = initConnector(this.applyAttributes);
+			connectorToUse = initConnector();
 		}
 		Function<ClientHttpConnector, ExchangeFunction> exchangeFactory = connector -> {
 			ExchangeFunction exchange = ExchangeFunctions.create(connector, initExchangeStrategies());
@@ -314,22 +314,25 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 				this.entityResultConsumer, this.responseTimeout, new DefaultWebTestClientBuilder(this));
 	}
 
-	private static ClientHttpConnector initConnector(boolean applyAttributes) {
+	private ClientHttpConnector initConnector() {
+		final ClientHttpConnector connector;
 		if (reactorNettyClientPresent) {
-			return new ReactorClientHttpConnector(applyAttributes);
+			connector = new ReactorClientHttpConnector();
 		}
 		else if (reactorNetty2ClientPresent) {
-			return new ReactorNetty2ClientHttpConnector(applyAttributes);
+			return new ReactorNetty2ClientHttpConnector();
 		}
 		else if (jettyClientPresent) {
-			return new JettyClientHttpConnector(applyAttributes);
+			connector = new JettyClientHttpConnector();
 		}
 		else if (httpComponentsClientPresent) {
-			return new HttpComponentsClientHttpConnector(applyAttributes);
+			connector = new HttpComponentsClientHttpConnector();
 		}
 		else {
-			return new JdkClientHttpConnector();
+			connector = new JdkClientHttpConnector();
 		}
+		connector.setApplyAttributes(this.applyAttributes);
+		return connector;
 	}
 
 	private ExchangeStrategies initExchangeStrategies() {

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/HttpHandlerConnector.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/HttpHandlerConnector.java
@@ -64,6 +64,8 @@ public class HttpHandlerConnector implements ClientHttpConnector {
 
 	private final HttpHandler handler;
 
+	private boolean applyAttributes = true;
+
 
 	/**
 	 * Constructor with the {@link HttpHandler} to handle requests with.
@@ -80,6 +82,16 @@ public class HttpHandlerConnector implements ClientHttpConnector {
 
 		return Mono.defer(() -> doConnect(httpMethod, uri, requestCallback))
 				.subscribeOn(Schedulers.parallel());
+	}
+
+	@Override
+	public void setApplyAttributes(boolean applyAttributes) {
+		this.applyAttributes = applyAttributes;
+	}
+
+	@Override
+	public boolean getApplyAttributes() {
+		return this.applyAttributes;
 	}
 
 	private Mono<ClientHttpResponse> doConnect(

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -426,6 +426,13 @@ public interface WebTestClient {
 		Builder defaultCookies(Consumer<MultiValueMap<String, String>> cookiesConsumer);
 
 		/**
+		 * Global option to specify whether or not attributes should be applied to every request,
+		 * if the used {@link ClientHttpConnector} allows it
+		 * @param applyAttributes whether or not to apply attributes
+		 */
+		Builder applyAttributes(boolean applyAttributes);
+
+		/**
 		 * Add the given filter to the filter chain.
 		 * @param filter the filter to be added to the chain
 		 */

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -427,7 +427,7 @@ public interface WebTestClient {
 
 		/**
 		 * Global option to specify whether or not attributes should be applied to every request,
-		 * if the used {@link ClientHttpConnector} allows it
+		 * if the used {@link ClientHttpConnector} allows it.
 		 * @param applyAttributes whether or not to apply attributes
 		 */
 		Builder applyAttributes(boolean applyAttributes);

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WiretapConnector.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WiretapConnector.java
@@ -55,6 +55,8 @@ class WiretapConnector implements ClientHttpConnector {
 
 	private final Map<String, ClientExchangeInfo> exchanges = new ConcurrentHashMap<>();
 
+	private boolean applyAttributes = true;
+
 
 	WiretapConnector(ClientHttpConnector delegate) {
 		this.delegate = delegate;
@@ -82,6 +84,16 @@ class WiretapConnector implements ClientHttpConnector {
 					this.exchanges.put(requestId, new ClientExchangeInfo(wrappedRequest, wrappedResponse));
 					return wrappedResponse;
 				});
+	}
+
+	@Override
+	public void setApplyAttributes(boolean applyAttributes) {
+		this.applyAttributes = applyAttributes;
+	}
+
+	@Override
+	public boolean getApplyAttributes() {
+		return this.applyAttributes;
 	}
 
 	/**

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
@@ -82,6 +82,8 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 
 	private final MockMvc mockMvc;
 
+	private boolean applyAttributes = true;
+
 
 	public MockMvcHttpConnector(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;
@@ -104,6 +106,16 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 		catch (Exception ex) {
 			return Mono.error(ex);
 		}
+	}
+
+	@Override
+	public void setApplyAttributes(boolean applyAttributes) {
+		this.applyAttributes = applyAttributes;
+	}
+
+	@Override
+	public boolean getApplyAttributes() {
+		return this.applyAttributes;
 	}
 
 	private RequestBuilder adaptRequest(

--- a/spring-test/src/test/java/org/springframework/test/web/reactive/server/WiretapConnectorTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/reactive/server/WiretapConnectorTests.java
@@ -18,6 +18,7 @@ package org.springframework.test.web.reactive.server;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -48,7 +49,22 @@ public class WiretapConnectorTests {
 	public void captureAndClaim() {
 		ClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, "/test");
 		ClientHttpResponse response = new MockClientHttpResponse(HttpStatus.OK);
-		ClientHttpConnector connector = (method, uri, fn) -> fn.apply(request).then(Mono.just(response));
+		ClientHttpConnector connector = new ClientHttpConnector() {
+			@Override
+			public Mono<ClientHttpResponse> connect(HttpMethod method, URI uri, Function<? super ClientHttpRequest, Mono<Void>> requestCallback) {
+				return requestCallback.apply(request).then(Mono.just(response));
+			}
+
+			@Override
+			public void setApplyAttributes(boolean applyAttributes) {
+
+			}
+
+			@Override
+			public boolean getApplyAttributes() {
+				return false;
+			}
+		};
 
 		ClientRequest clientRequest = ClientRequest.create(HttpMethod.GET, URI.create("/test"))
 				.header(WebTestClient.WEBTESTCLIENT_REQUEST_ID, "1").build();

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
@@ -161,7 +161,7 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 				Mono.fromRunnable(() -> {
 					applyHeaders();
 					applyCookies();
-					if (applyAttributes) {
+					if (this.applyAttributes) {
 						applyAttributes();
 					}
 					this.state.set(State.COMMITTED);

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
@@ -17,7 +17,10 @@
 package org.springframework.http.client.reactive;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -55,6 +58,10 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 
 	private final MultiValueMap<String, HttpCookie> cookies;
 
+	private final Map<String, Object> attributes;
+
+	private final boolean applyAttributes;
+
 	private final AtomicReference<State> state = new AtomicReference<>(State.NEW);
 
 	private final List<Supplier<? extends Publisher<Void>>> commitActions = new ArrayList<>(4);
@@ -64,13 +71,19 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 
 
 	public AbstractClientHttpRequest() {
-		this(new HttpHeaders());
+		this(new HttpHeaders(), false);
 	}
 
-	public AbstractClientHttpRequest(HttpHeaders headers) {
+	public AbstractClientHttpRequest(boolean applyAttributes) {
+		this(new HttpHeaders(), applyAttributes);
+	}
+
+	public AbstractClientHttpRequest(HttpHeaders headers, boolean applyAttributes) {
 		Assert.notNull(headers, "HttpHeaders must not be null");
 		this.headers = headers;
 		this.cookies = new LinkedMultiValueMap<>();
+		this.attributes = new LinkedHashMap<>();
+		this.applyAttributes = applyAttributes;
 	}
 
 
@@ -107,6 +120,14 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 	}
 
 	@Override
+	public Map<String, Object> getAttributes() {
+		if (State.COMMITTED.equals(this.state.get())) {
+			return Collections.unmodifiableMap(this.attributes);
+		}
+		return this.attributes;
+	}
+
+	@Override
 	public void beforeCommit(Supplier<? extends Mono<Void>> action) {
 		Assert.notNull(action, "Action must not be null");
 		this.commitActions.add(action);
@@ -140,6 +161,9 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 				Mono.fromRunnable(() -> {
 					applyHeaders();
 					applyCookies();
+					if (applyAttributes) {
+						applyAttributes();
+					}
 					this.state.set(State.COMMITTED);
 				}));
 
@@ -165,5 +189,11 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 	 * This method is called once only.
 	 */
 	protected abstract void applyCookies();
+
+	/**
+	 * Add additional attributes from {@link #getAttributes()} to the underlying request.
+	 * This method is called once only.
+	 */
+	protected abstract void applyAttributes();
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpConnector.java
@@ -49,14 +49,12 @@ public interface ClientHttpConnector {
 			Function<? super ClientHttpRequest, Mono<Void>> requestCallback);
 
 	/**
-	 * Set whether or not attributes should be applied to the underlying http-client
-	 *  library request
+	 * Set whether or not attributes should be applied to the underlying http-client library request.
 	 */
 	void setApplyAttributes(boolean applyAttributes);
 
 	/**
-	 * Whether or not attributes should be applied to the underlying http-client
-	 *  library request
+	 * Whether or not attributes should be applied to the underlying http-client library request.
 	 */
 	boolean getApplyAttributes();
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpConnector.java
@@ -48,4 +48,16 @@ public interface ClientHttpConnector {
 	Mono<ClientHttpResponse> connect(HttpMethod method, URI uri,
 			Function<? super ClientHttpRequest, Mono<Void>> requestCallback);
 
+	/**
+	 * Set whether or not attributes should be applied to the underlying http-client
+	 *  library request
+	 */
+	void setApplyAttributes(boolean applyAttributes);
+
+	/**
+	 * Whether or not attributes should be applied to the underlying http-client
+	 *  library request
+	 */
+	boolean getApplyAttributes();
+
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpRequest.java
@@ -17,6 +17,7 @@
 package org.springframework.http.client.reactive;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpMethod;
@@ -53,5 +54,10 @@ public interface ClientHttpRequest extends ReactiveHttpOutputMessage {
 	 * @since 5.3
 	 */
 	<T> T getNativeRequest();
+
+	/**
+	 * Return a mutable map of the request attributes.
+	 */
+	Map<String, Object> getAttributes();
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpRequestDecorator.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ClientHttpRequestDecorator.java
@@ -17,6 +17,7 @@
 package org.springframework.http.client.reactive;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
@@ -83,6 +84,11 @@ public class ClientHttpRequestDecorator implements ClientHttpRequest {
 	@Override
 	public <T> T getNativeRequest() {
 		return this.delegate.getNativeRequest();
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return this.delegate.getAttributes();
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpConnector.java
@@ -68,14 +68,6 @@ public class HttpComponentsClientHttpConnector implements ClientHttpConnector, C
 		this(HttpAsyncClients.createDefault());
 	}
 
-	/**
-	 * Constructor that creates and starts a new instance of {@link CloseableHttpAsyncClient}.
-	 * @param applyAttributes whether or not to apply request attributes to
-	 */
-	public HttpComponentsClientHttpConnector(boolean applyAttributes) {
-		this();
-		this.applyAttributes = applyAttributes;
-	}
 
 	/**
 	 * Constructor with a pre-configured {@link CloseableHttpAsyncClient} instance.
@@ -123,7 +115,7 @@ public class HttpComponentsClientHttpConnector implements ClientHttpConnector, C
 		}
 
 		HttpComponentsClientHttpRequest request = new HttpComponentsClientHttpRequest(method, uri,
-				context, this.dataBufferFactory, applyAttributes);
+				context, this.dataBufferFactory, this.applyAttributes);
 
 		return requestCallback.apply(request).then(Mono.defer(() -> execute(request, context)));
 	}

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpConnector.java
@@ -59,12 +59,21 @@ public class HttpComponentsClientHttpConnector implements ClientHttpConnector, C
 
 	private DataBufferFactory dataBufferFactory = DefaultDataBufferFactory.sharedInstance;
 
+	private boolean applyAttributes = true;
 
 	/**
 	 * Default constructor that creates and starts a new instance of {@link CloseableHttpAsyncClient}.
 	 */
 	public HttpComponentsClientHttpConnector() {
 		this(HttpAsyncClients.createDefault());
+	}
+
+	/**
+	 * Default constructor that creates and starts a new instance of {@link CloseableHttpAsyncClient}.
+	 */
+	public HttpComponentsClientHttpConnector(boolean applyAttributes) {
+		this();
+		this.applyAttributes = applyAttributes;
 	}
 
 	/**
@@ -113,9 +122,19 @@ public class HttpComponentsClientHttpConnector implements ClientHttpConnector, C
 		}
 
 		HttpComponentsClientHttpRequest request = new HttpComponentsClientHttpRequest(method, uri,
-				context, this.dataBufferFactory);
+				context, this.dataBufferFactory, applyAttributes);
 
 		return requestCallback.apply(request).then(Mono.defer(() -> execute(request, context)));
+	}
+
+	@Override
+	public void setApplyAttributes(boolean applyAttributes) {
+		this.applyAttributes = applyAttributes;
+	}
+
+	@Override
+	public boolean getApplyAttributes() {
+		return this.applyAttributes;
 	}
 
 	private Mono<ClientHttpResponse> execute(HttpComponentsClientHttpRequest request, HttpClientContext context) {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpConnector.java
@@ -69,7 +69,8 @@ public class HttpComponentsClientHttpConnector implements ClientHttpConnector, C
 	}
 
 	/**
-	 * Default constructor that creates and starts a new instance of {@link CloseableHttpAsyncClient}.
+	 * Constructor that creates and starts a new instance of {@link CloseableHttpAsyncClient}.
+	 * @param applyAttributes whether or not to apply request attributes to
 	 */
 	public HttpComponentsClientHttpConnector(boolean applyAttributes) {
 		this();

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
@@ -41,8 +41,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
-import reactor.netty.channel.ChannelOperations;
-import reactor.netty.http.client.HttpClientRequest;
 
 /**
  * {@link ClientHttpRequest} implementation for the Apache HttpComponents HttpClient 5.x.

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
@@ -41,6 +41,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
+import reactor.netty.channel.ChannelOperations;
+import reactor.netty.http.client.HttpClientRequest;
 
 /**
  * {@link ClientHttpRequest} implementation for the Apache HttpComponents HttpClient 5.x.
@@ -65,8 +67,8 @@ class HttpComponentsClientHttpRequest extends AbstractClientHttpRequest {
 
 
 	public HttpComponentsClientHttpRequest(HttpMethod method, URI uri, HttpClientContext context,
-			DataBufferFactory dataBufferFactory) {
-
+			DataBufferFactory dataBufferFactory, boolean applyAttributes) {
+		super(applyAttributes);
 		this.context = context;
 		this.httpRequest = new BasicHttpRequest(method.name(), uri);
 		this.dataBufferFactory = dataBufferFactory;
@@ -150,6 +152,17 @@ class HttpComponentsClientHttpRequest extends AbstractClientHttpRequest {
 					clientCookie.setPath(getURI().getPath());
 					cookieStore.addCookie(clientCookie);
 				});
+	}
+
+	/**
+	 * Applies the attributes to the {@link HttpClientContext}
+	 */
+	@Override
+	protected void applyAttributes() {
+		getAttributes().forEach((key, value) -> {
+			if(this.context.getAttribute(key) == null) {
+				this.context.setAttribute(key, value);
+			}});
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
@@ -153,14 +153,15 @@ class HttpComponentsClientHttpRequest extends AbstractClientHttpRequest {
 	}
 
 	/**
-	 * Applies the attributes to the {@link HttpClientContext}
+	 * Applies the attributes to the {@link HttpClientContext}.
 	 */
 	@Override
 	protected void applyAttributes() {
 		getAttributes().forEach((key, value) -> {
 			if(this.context.getAttribute(key) == null) {
 				this.context.setAttribute(key, value);
-			}});
+			}
+		});
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpConnector.java
@@ -96,7 +96,7 @@ public class JdkClientHttpConnector implements ClientHttpConnector {
 	public Mono<ClientHttpResponse> connect(
 			HttpMethod method, URI uri, Function<? super ClientHttpRequest, Mono<Void>> requestCallback) {
 
-		JdkClientHttpRequest jdkClientHttpRequest = new JdkClientHttpRequest(method, uri, this.bufferFactory);
+		JdkClientHttpRequest jdkClientHttpRequest = new JdkClientHttpRequest(method, uri, this.bufferFactory, getApplyAttributes());
 
 		return requestCallback.apply(jdkClientHttpRequest).then(Mono.defer(() -> {
 			HttpRequest httpRequest = jdkClientHttpRequest.getNativeRequest();
@@ -107,6 +107,21 @@ public class JdkClientHttpConnector implements ClientHttpConnector {
 			return Mono.fromCompletionStage(future)
 					.map(response -> new JdkClientHttpResponse(response, this.bufferFactory));
 		}));
+	}
+
+	/**
+	 * Sets nothing, since {@link HttpRequest} does not offer any possibility to add attributes
+	 */
+	@Override
+	public void setApplyAttributes(boolean applyAttributes) {
+	}
+
+	/**
+	 * Returns false, since {@link HttpRequest} does not offer any possibility to add attributes
+	 */
+	@Override
+	public boolean getApplyAttributes() {
+		return false;
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpConnector.java
@@ -110,14 +110,14 @@ public class JdkClientHttpConnector implements ClientHttpConnector {
 	}
 
 	/**
-	 * Sets nothing, since {@link HttpRequest} does not offer any possibility to add attributes
+	 * Sets nothing, since {@link JdkClientHttpConnector} does not offer any possibility to add attributes.
 	 */
 	@Override
 	public void setApplyAttributes(boolean applyAttributes) {
 	}
 
 	/**
-	 * Returns false, since {@link HttpRequest} does not offer any possibility to add attributes
+	 * Returns false, since {@link JdkClientHttpConnector} does not offer any possibility to add attributes.
 	 */
 	@Override
 	public boolean getApplyAttributes() {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpRequest.java
@@ -114,7 +114,7 @@ class JdkClientHttpRequest extends AbstractClientHttpRequest {
 	}
 
 	/**
-	 * Not implemented, since {@link HttpRequest} does not offer any possibility to add request attributes
+	 * Not implemented, since {@link HttpRequest} does not offer any possibility to add request attributes.
 	 */
 	@Override
 	protected void applyAttributes() {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpRequest.java
@@ -56,7 +56,8 @@ class JdkClientHttpRequest extends AbstractClientHttpRequest {
 	private final HttpRequest.Builder builder;
 
 
-	public JdkClientHttpRequest(HttpMethod httpMethod, URI uri, DataBufferFactory bufferFactory) {
+	public JdkClientHttpRequest(HttpMethod httpMethod, URI uri, DataBufferFactory bufferFactory, boolean applyAttributes) {
+		super(applyAttributes);
 		Assert.notNull(httpMethod, "HttpMethod is required");
 		Assert.notNull(uri, "URI is required");
 		Assert.notNull(bufferFactory, "DataBufferFactory is required");
@@ -110,6 +111,15 @@ class JdkClientHttpRequest extends AbstractClientHttpRequest {
 	protected void applyCookies() {
 		this.builder.header(HttpHeaders.COOKIE, getCookies().values().stream()
 				.flatMap(List::stream).map(HttpCookie::toString).collect(Collectors.joining(";")));
+	}
+
+	/**
+	 * Not implemented, since {@link HttpRequest} does not offer any possibility to add request attributes
+	 */
+	@Override
+	protected void applyAttributes() {
+		// TODO
+		throw new RuntimeException(String.format("Using attributes is not available for %s", HttpRequest.class.getName()));
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpConnector.java
@@ -46,12 +46,22 @@ public class JettyClientHttpConnector implements ClientHttpConnector {
 
 	private DataBufferFactory bufferFactory = DefaultDataBufferFactory.sharedInstance;
 
+	private boolean applyAttributes = true;
+
 
 	/**
 	 * Default constructor that creates a new instance of {@link HttpClient}.
 	 */
 	public JettyClientHttpConnector() {
 		this(new HttpClient());
+	}
+
+	/**
+	 *  Constructor that creates a new instance of {@link HttpClient}.
+	 */
+	public JettyClientHttpConnector(boolean applyAttributes) {
+		this();
+		this.applyAttributes = applyAttributes;
 	}
 
 	/**
@@ -120,9 +130,19 @@ public class JettyClientHttpConnector implements ClientHttpConnector {
 		}
 
 		Request jettyRequest = this.httpClient.newRequest(uri).method(method.toString());
-		JettyClientHttpRequest request = new JettyClientHttpRequest(jettyRequest, this.bufferFactory);
+		JettyClientHttpRequest request = new JettyClientHttpRequest(jettyRequest, this.bufferFactory, getApplyAttributes());
 
 		return requestCallback.apply(request).then(execute(request));
+	}
+
+	@Override
+	public void setApplyAttributes(boolean applyAttributes) {
+		this.applyAttributes = applyAttributes;
+	}
+
+	@Override
+	public boolean getApplyAttributes() {
+		return this.applyAttributes;
 	}
 
 	private Mono<ClientHttpResponse> execute(JettyClientHttpRequest request) {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpConnector.java
@@ -57,14 +57,6 @@ public class JettyClientHttpConnector implements ClientHttpConnector {
 	}
 
 	/**
-	 *  Constructor that creates a new instance of {@link HttpClient}.
-	 */
-	public JettyClientHttpConnector(boolean applyAttributes) {
-		this();
-		this.applyAttributes = applyAttributes;
-	}
-
-	/**
 	 * Constructor with an initialized {@link HttpClient}.
 	 */
 	public JettyClientHttpConnector(HttpClient httpClient) {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpRequest.java
@@ -53,7 +53,8 @@ class JettyClientHttpRequest extends AbstractClientHttpRequest {
 	private final ReactiveRequest.Builder builder;
 
 
-	public JettyClientHttpRequest(Request jettyRequest, DataBufferFactory bufferFactory) {
+	public JettyClientHttpRequest(Request jettyRequest, DataBufferFactory bufferFactory, boolean applyAttributes) {
+		super(applyAttributes);
 		this.jettyRequest = jettyRequest;
 		this.bufferFactory = bufferFactory;
 		this.builder = ReactiveRequest.newBuilder(this.jettyRequest).abortOnCancel(true);
@@ -128,6 +129,14 @@ class JettyClientHttpRequest extends AbstractClientHttpRequest {
 		getCookies().values().stream().flatMap(Collection::stream)
 				.map(cookie -> new HttpCookie(cookie.getName(), cookie.getValue()))
 				.forEach(this.jettyRequest::cookie);
+	}
+
+	/**
+	 * Applies the attributes to {@link Request#getAttributes()}
+	 */
+	@Override
+	protected void applyAttributes() {
+		getAttributes().forEach(this.jettyRequest::attribute);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpRequest.java
@@ -132,7 +132,7 @@ class JettyClientHttpRequest extends AbstractClientHttpRequest {
 	}
 
 	/**
-	 * Applies the attributes to {@link Request#getAttributes()}
+	 * Applies the attributes to {@link Request#getAttributes()}.
 	 */
 	@Override
 	protected void applyAttributes() {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
@@ -45,6 +45,7 @@ public class ReactorClientHttpConnector implements ClientHttpConnector {
 
 	private final HttpClient httpClient;
 
+	private boolean applyAttributes = true;
 
 	/**
 	 * Default constructor. Initializes {@link HttpClient} via:
@@ -54,6 +55,16 @@ public class ReactorClientHttpConnector implements ClientHttpConnector {
 	 */
 	public ReactorClientHttpConnector() {
 		this.httpClient = defaultInitializer.apply(HttpClient.create());
+	}
+
+	/**
+	 * Constructor with default initialized {@link HttpClient}
+	 * @param applyAttributes whether or not to apply request attributes to
+	 * the underlying http-library request
+	 */
+	public ReactorClientHttpConnector(boolean applyAttributes) {
+		this();
+		this.applyAttributes = applyAttributes;
 	}
 
 	/**
@@ -122,10 +133,20 @@ public class ReactorClientHttpConnector implements ClientHttpConnector {
 				});
 	}
 
+	@Override
+	public void setApplyAttributes(boolean applyAttributes) {
+		this.applyAttributes = applyAttributes;
+	}
+
+	@Override
+	public boolean getApplyAttributes() {
+		return this.applyAttributes;
+	}
+
 	private ReactorClientHttpRequest adaptRequest(HttpMethod method, URI uri, HttpClientRequest request,
 			NettyOutbound nettyOutbound) {
 
-		return new ReactorClientHttpRequest(method, uri, request, nettyOutbound);
+		return new ReactorClientHttpRequest(method, uri, request, nettyOutbound, applyAttributes);
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
@@ -58,16 +58,6 @@ public class ReactorClientHttpConnector implements ClientHttpConnector {
 	}
 
 	/**
-	 * Constructor with default initialized {@link HttpClient}
-	 * @param applyAttributes whether or not to apply request attributes to
-	 * the underlying http-library request
-	 */
-	public ReactorClientHttpConnector(boolean applyAttributes) {
-		this();
-		this.applyAttributes = applyAttributes;
-	}
-
-	/**
 	 * Constructor with externally managed Reactor Netty resources, including
 	 * {@link LoopResources} for event loop threads, and {@link ConnectionProvider}
 	 * for the connection pool.
@@ -146,7 +136,7 @@ public class ReactorClientHttpConnector implements ClientHttpConnector {
 	private ReactorClientHttpRequest adaptRequest(HttpMethod method, URI uri, HttpClientRequest request,
 			NettyOutbound nettyOutbound) {
 
-		return new ReactorClientHttpRequest(method, uri, request, nettyOutbound, applyAttributes);
+		return new ReactorClientHttpRequest(method, uri, request, nettyOutbound, this.applyAttributes);
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
@@ -19,13 +19,17 @@ package org.springframework.http.client.reactive;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Map;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
+import io.netty.util.AttributeKey;
+import org.eclipse.jetty.client.api.Request;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.NettyOutbound;
+import reactor.netty.channel.ChannelOperations;
 import reactor.netty.http.client.HttpClientRequest;
 
 import org.springframework.core.io.buffer.DataBuffer;
@@ -45,6 +49,8 @@ import org.springframework.http.ZeroCopyHttpOutputMessage;
  */
 class ReactorClientHttpRequest extends AbstractClientHttpRequest implements ZeroCopyHttpOutputMessage {
 
+	public final String ATTRIBUTES_CHANNEL_KEY = "attributes";
+
 	private final HttpMethod httpMethod;
 
 	private final URI uri;
@@ -56,7 +62,8 @@ class ReactorClientHttpRequest extends AbstractClientHttpRequest implements Zero
 	private final NettyDataBufferFactory bufferFactory;
 
 
-	public ReactorClientHttpRequest(HttpMethod method, URI uri, HttpClientRequest request, NettyOutbound outbound) {
+	public ReactorClientHttpRequest(HttpMethod method, URI uri, HttpClientRequest request, NettyOutbound outbound, boolean applyAttributes) {
+		super(applyAttributes);
 		this.httpMethod = method;
 		this.uri = uri;
 		this.request = request;
@@ -132,6 +139,17 @@ class ReactorClientHttpRequest extends AbstractClientHttpRequest implements Zero
 		getCookies().values().stream().flatMap(Collection::stream)
 				.map(cookie -> new DefaultCookie(cookie.getName(), cookie.getValue()))
 				.forEach(this.request::addCookie);
+	}
+
+	/**
+	 * Applies the request attributes to the {@link reactor.netty.http.client.HttpClientRequest} by setting
+	 * a single {@link Map} into the {@link reactor.netty.channel.ChannelOperations#channel()},
+	 * with {@link io.netty5.util.AttributeKey#name()} equal to {@link #ATTRIBUTES_CHANNEL_KEY}.
+	 */
+	@Override
+	protected void applyAttributes() {
+		((ChannelOperations<?, ?>) this.request)
+				.channel().attr(AttributeKey.valueOf(ATTRIBUTES_CHANNEL_KEY)).set(getAttributes());
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.util.AttributeKey;
-import org.eclipse.jetty.client.api.Request;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -49,7 +48,7 @@ import org.springframework.http.ZeroCopyHttpOutputMessage;
  */
 class ReactorClientHttpRequest extends AbstractClientHttpRequest implements ZeroCopyHttpOutputMessage {
 
-	public final String ATTRIBUTES_CHANNEL_KEY = "attributes";
+	public static final String ATTRIBUTES_CHANNEL_KEY = "attributes";
 
 	private final HttpMethod httpMethod;
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpConnector.java
@@ -46,6 +46,8 @@ public class ReactorNetty2ClientHttpConnector implements ClientHttpConnector {
 
 	private final HttpClient httpClient;
 
+	private boolean applyAttributes = true;
+
 
 	/**
 	 * Default constructor. Initializes {@link HttpClient} via:
@@ -55,6 +57,16 @@ public class ReactorNetty2ClientHttpConnector implements ClientHttpConnector {
 	 */
 	public ReactorNetty2ClientHttpConnector() {
 		this.httpClient = defaultInitializer.apply(HttpClient.create().wiretap(true));
+	}
+
+	/**
+	 * Constructor with default initialized {@link HttpClient}
+	 * @param applyAttributes whether or not to apply request attributes to
+	 * the underlying http-library request
+	 */
+	public ReactorNetty2ClientHttpConnector(boolean applyAttributes) {
+		this();
+		this.applyAttributes = applyAttributes;
 	}
 
 	/**
@@ -123,10 +135,20 @@ public class ReactorNetty2ClientHttpConnector implements ClientHttpConnector {
 				});
 	}
 
+	@Override
+	public void setApplyAttributes(boolean applyAttributes) {
+		this.applyAttributes = applyAttributes;
+	}
+
+	@Override
+	public boolean getApplyAttributes() {
+		return this.applyAttributes;
+	}
+
 	private ReactorNetty2ClientHttpRequest adaptRequest(HttpMethod method, URI uri, HttpClientRequest request,
 			NettyOutbound nettyOutbound) {
 
-		return new ReactorNetty2ClientHttpRequest(method, uri, request, nettyOutbound);
+		return new ReactorNetty2ClientHttpRequest(method, uri, request, nettyOutbound, getApplyAttributes());
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpConnector.java
@@ -60,16 +60,6 @@ public class ReactorNetty2ClientHttpConnector implements ClientHttpConnector {
 	}
 
 	/**
-	 * Constructor with default initialized {@link HttpClient}
-	 * @param applyAttributes whether or not to apply request attributes to
-	 * the underlying http-library request
-	 */
-	public ReactorNetty2ClientHttpConnector(boolean applyAttributes) {
-		this();
-		this.applyAttributes = applyAttributes;
-	}
-
-	/**
 	 * Constructor with externally managed Reactor Netty resources, including
 	 * {@link LoopResources} for event loop threads, and {@link ConnectionProvider}
 	 * for the connection pool.

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpRequest.java
@@ -21,14 +21,14 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 
-import io.netty5.util.AttributeKey;
 import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.http.headers.DefaultHttpCookiePair;
+import io.netty5.util.AttributeKey;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.netty5.channel.ChannelOperations;
 import reactor.netty5.NettyOutbound;
+import reactor.netty5.channel.ChannelOperations;
 import reactor.netty5.http.client.HttpClientRequest;
 
 import org.springframework.core.io.buffer.DataBuffer;
@@ -49,7 +49,7 @@ import org.springframework.http.ZeroCopyHttpOutputMessage;
  */
 class ReactorNetty2ClientHttpRequest extends AbstractClientHttpRequest implements ZeroCopyHttpOutputMessage {
 
-	public final String ATTRIBUTES_CHANNEL_KEY = "attributes";
+	public static final String ATTRIBUTES_CHANNEL_KEY = "attributes";
 
 	private final HttpMethod httpMethod;
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpRequest.java
@@ -19,12 +19,15 @@ package org.springframework.http.client.reactive;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Map;
 
+import io.netty5.util.AttributeKey;
 import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.http.headers.DefaultHttpCookiePair;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.netty5.channel.ChannelOperations;
 import reactor.netty5.NettyOutbound;
 import reactor.netty5.http.client.HttpClientRequest;
 
@@ -46,6 +49,8 @@ import org.springframework.http.ZeroCopyHttpOutputMessage;
  */
 class ReactorNetty2ClientHttpRequest extends AbstractClientHttpRequest implements ZeroCopyHttpOutputMessage {
 
+	public final String ATTRIBUTES_CHANNEL_KEY = "attributes";
+
 	private final HttpMethod httpMethod;
 
 	private final URI uri;
@@ -57,7 +62,8 @@ class ReactorNetty2ClientHttpRequest extends AbstractClientHttpRequest implement
 	private final Netty5DataBufferFactory bufferFactory;
 
 
-	public ReactorNetty2ClientHttpRequest(HttpMethod method, URI uri, HttpClientRequest request, NettyOutbound outbound) {
+	public ReactorNetty2ClientHttpRequest(HttpMethod method, URI uri, HttpClientRequest request, NettyOutbound outbound, boolean applyAttributes) {
+		super(applyAttributes);
 		this.httpMethod = method;
 		this.uri = uri;
 		this.request = request;
@@ -133,6 +139,17 @@ class ReactorNetty2ClientHttpRequest extends AbstractClientHttpRequest implement
 		getCookies().values().stream().flatMap(Collection::stream)
 				.map(cookie -> new DefaultHttpCookiePair(cookie.getName(), cookie.getValue()))
 				.forEach(this.request::addCookie);
+	}
+
+	/**
+	 * Applies the request attributes to the {@link reactor.netty.http.client.HttpClientRequest} by setting
+	 * a single {@link Map} into the {@link reactor.netty.channel.ChannelOperations#channel()},
+	 * with {@link AttributeKey#name()} equal to {@link #ATTRIBUTES_CHANNEL_KEY}.
+	 */
+	@Override
+	protected void applyAttributes() {
+		((ChannelOperations<?, ?>) this.request)
+				.channel().attr(AttributeKey.valueOf(ATTRIBUTES_CHANNEL_KEY)).set(getAttributes());
 	}
 
 	@Override

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/reactive/MockClientHttpRequest.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/reactive/MockClientHttpRequest.java
@@ -129,6 +129,10 @@ public class MockClientHttpRequest extends AbstractClientHttpRequest implements 
 	}
 
 	@Override
+	protected void applyAttributes() {
+	}
+
+	@Override
 	public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
 		return doCommit(() -> Mono.defer(() -> this.writeHandler.apply(Flux.from(body))));
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilder.java
@@ -268,6 +268,12 @@ final class DefaultClientRequestBuilder implements ClientRequest.Builder {
 					requestCookies.add(name, cookie);
 				}));
 			}
+
+			Map<String, Object> requestAttributes = request.getAttributes();
+			if (!this.attributes.isEmpty()) {
+				this.attributes.forEach((key, value) -> requestAttributes.put(key, value));
+			}
+
 			if (this.httpRequestConsumer != null) {
 				this.httpRequestConsumer.accept(request);
 			}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
@@ -344,20 +344,20 @@ final class DefaultWebClientBuilder implements WebClient.Builder {
 
 	private ClientHttpConnector initConnector() {
 		if (reactorNettyClientPresent) {
-			return new ReactorClientHttpConnector(applyAttributes);
+			return new ReactorClientHttpConnector(this.applyAttributes);
 		}
 		else if (reactorNetty2ClientPresent) {
-			return new ReactorNetty2ClientHttpConnector(applyAttributes);
+			return new ReactorNetty2ClientHttpConnector(this.applyAttributes);
 		}
 		else if (jettyClientPresent) {
-			return new JettyClientHttpConnector(applyAttributes);
+			return new JettyClientHttpConnector(this.applyAttributes);
 		}
 		else if (httpComponentsClientPresent) {
-			return new HttpComponentsClientHttpConnector(applyAttributes);
+			HttpComponentsClientHttpConnector httpComponentsClientHttpConnector = new HttpComponentsClientHttpConnector();
+			httpComponentsClientHttpConnector.setApplyAttributes(this.applyAttributes);
+			return httpComponentsClientHttpConnector;
 		}
 		else {
-			// TODO what if defaultAttributes is not empty? JdkClient cant apply attributes
-			//  -> throw Exception?
 			return new JdkClientHttpConnector();
 		}
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
@@ -343,23 +343,24 @@ final class DefaultWebClientBuilder implements WebClient.Builder {
 	}
 
 	private ClientHttpConnector initConnector() {
+		final ClientHttpConnector connector;
 		if (reactorNettyClientPresent) {
-			return new ReactorClientHttpConnector(this.applyAttributes);
+			connector = new ReactorClientHttpConnector();
 		}
 		else if (reactorNetty2ClientPresent) {
-			return new ReactorNetty2ClientHttpConnector(this.applyAttributes);
+			return new ReactorNetty2ClientHttpConnector();
 		}
 		else if (jettyClientPresent) {
-			return new JettyClientHttpConnector(this.applyAttributes);
+			connector = new JettyClientHttpConnector();
 		}
 		else if (httpComponentsClientPresent) {
-			HttpComponentsClientHttpConnector httpComponentsClientHttpConnector = new HttpComponentsClientHttpConnector();
-			httpComponentsClientHttpConnector.setApplyAttributes(this.applyAttributes);
-			return httpComponentsClientHttpConnector;
+			connector = new HttpComponentsClientHttpConnector();
 		}
 		else {
-			return new JdkClientHttpConnector();
+			connector = new JdkClientHttpConnector();
 		}
+		connector.setApplyAttributes(this.applyAttributes);
+		return connector;
 	}
 
 	private ExchangeStrategies initExchangeStrategies() {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -251,6 +251,13 @@ public interface WebClient {
 		Builder defaultCookies(Consumer<MultiValueMap<String, String>> cookiesConsumer);
 
 		/**
+		 * Global option to specify whether or not the request attributes should be applied
+		 * to the underlying http-client request, if the used {@link ClientHttpConnector} allows it.
+		 * @param applyAttributes whether or not to apply the attributes
+		 */
+		Builder applyAttributes(boolean applyAttributes);
+
+		/**
 		 * Provide a consumer to customize every request being built.
 		 * @param defaultRequest the consumer to use for modifying requests
 		 * @since 5.1

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
@@ -51,7 +51,12 @@ import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.http.client.reactive.*;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.HttpComponentsClientHttpConnector;
+import org.springframework.http.client.reactive.JdkClientHttpConnector;
+import org.springframework.http.client.reactive.JettyClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorNetty2ClientHttpConnector;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -256,8 +261,7 @@ class WebClientIntegrationTests {
 		Mono<ValueContainer<Pojo>> result = this.webClient.get()
 				.uri("/json").accept(MediaType.APPLICATION_JSON)
 				.retrieve()
-				.bodyToMono(new ParameterizedTypeReference<ValueContainer<Pojo>>() {
-				});
+				.bodyToMono(new ParameterizedTypeReference<ValueContainer<Pojo>>() {});
 
 		StepVerifier.create(result)
 				.assertNext(c -> assertThat(c.getContainerValue()).isEqualTo(new Pojo("foofoo", "barbar")))
@@ -451,8 +455,7 @@ class WebClientIntegrationTests {
 		});
 	}
 
-	@Test
-		// gh-24788
+	@Test // gh-24788
 	void retrieveJsonArrayAsBodilessEntityShouldReleasesConnection() {
 
 		// Constrain connection pool and make consecutive requests.
@@ -467,7 +470,7 @@ class WebClientIntegrationTests {
 				.baseUrl(this.server.url("/").toString())
 				.build();
 
-		for (int i = 1; i <= 2; i++) {
+		for (int i=1 ; i <= 2; i++) {
 
 			// Response must be large enough to circumvent eager prefetching
 
@@ -545,8 +548,7 @@ class WebClientIntegrationTests {
 		StepVerifier.create(result).verifyComplete();
 	}
 
-	@ParameterizedWebClientTest
-		// SPR-15946
+	@ParameterizedWebClientTest  // SPR-15946
 	void retrieve404(ClientHttpConnector connector) {
 		startServer(connector);
 
@@ -719,7 +721,7 @@ class WebClientIntegrationTests {
 				.expectErrorSatisfies(throwable -> {
 					assertThat(throwable).isInstanceOf(UnknownHttpStatusCodeException.class);
 					UnknownHttpStatusCodeException ex = (UnknownHttpStatusCodeException) throwable;
-					assertThat(ex.getMessage()).isEqualTo(("Unknown status code [" + errorStatus + "]"));
+					assertThat(ex.getMessage()).isEqualTo(("Unknown status code ["+errorStatus+"]"));
 					assertThat(ex.getRawStatusCode()).isEqualTo(errorStatus);
 					assertThat(ex.getStatusText()).isEqualTo("");
 					assertThat(ex.getHeaders().getContentType()).isEqualTo(MediaType.TEXT_PLAIN);
@@ -764,13 +766,11 @@ class WebClientIntegrationTests {
 		});
 	}
 
-	@ParameterizedWebClientTest
-		// SPR-16246
+	@ParameterizedWebClientTest  // SPR-16246
 	void postLargeTextFile(ClientHttpConnector connector) throws Exception {
 		startServer(connector);
 
-		prepareResponse(response -> {
-		});
+		prepareResponse(response -> {});
 
 		Resource resource = new ClassPathResource("largeTextFile.txt", getClass());
 		Flux<DataBuffer> body = DataBufferUtils.read(resource, DefaultDataBufferFactory.sharedInstance, 4096);
@@ -792,7 +792,8 @@ class WebClientIntegrationTests {
 				String actual = bos.toString(StandardCharsets.UTF_8);
 				String expected = Files.readString(resource.getFile().toPath(), StandardCharsets.UTF_8);
 				assertThat(actual).isEqualTo(expected);
-			} catch (IOException ex) {
+			}
+			catch (IOException ex) {
 				throw new UncheckedIOException(ex);
 			}
 		});
@@ -833,8 +834,7 @@ class WebClientIntegrationTests {
 				.uri("/greeting")
 				.retrieve()
 				.onStatus(HttpStatusCode::is5xxServerError, response -> Mono.just(new MyException("500 error!")))
-				.bodyToMono(new ParameterizedTypeReference<String>() {
-				});
+				.bodyToMono(new ParameterizedTypeReference<String>() {});
 
 		StepVerifier.create(result)
 				.expectError(MyException.class)
@@ -1348,7 +1348,8 @@ class WebClientIntegrationTests {
 						.replace("\n", "\r\n").getBytes(StandardCharsets.UTF_8));
 
 				socket.close();
-			} catch (IOException ex) {
+			}
+			catch (IOException ex) {
 				throw new RuntimeException(ex);
 			}
 		});
@@ -1373,7 +1374,8 @@ class WebClientIntegrationTests {
 	private void expectRequest(Consumer<RecordedRequest> consumer) {
 		try {
 			consumer.accept(this.server.takeRequest());
-		} catch (InterruptedException ex) {
+		}
+		catch (InterruptedException ex) {
 			throw new IllegalStateException(ex);
 		}
 	}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
@@ -51,8 +51,6 @@ import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import org.springframework.http.client.reactive.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -75,6 +73,12 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.HttpComponentsClientHttpConnector;
+import org.springframework.http.client.reactive.JdkClientHttpConnector;
+import org.springframework.http.client.reactive.JettyClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorNetty2ClientHttpConnector;
 import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.WebClient.ResponseSpec;
 import org.springframework.web.testfixture.xml.Pojo;
@@ -209,9 +213,7 @@ class WebClientIntegrationTests {
 		Mono<Void> result = this.webClient.get()
 				.uri("/pojo")
 				.attribute("foo","bar")
-				.httpRequest(clientHttpRequest -> {
-					nativeRequest.set(clientHttpRequest.getNativeRequest());
-				})
+				.httpRequest(clientHttpRequest -> nativeRequest.set(clientHttpRequest.getNativeRequest()))
 				.retrieve()
 				.bodyToMono(Void.class);
 		StepVerifier.create(result)
@@ -222,26 +224,31 @@ class WebClientIntegrationTests {
 			if (expectAttributesApplied) {
 				assertThat(attributes.get()).isNotNull();
 				assertThat(attributes.get()).containsEntry("foo", "bar");
-			} else {
+			}
+			else {
 				assertThat(attributes.get()).isNull();
 			}
-		} else if (nativeRequest.get() instanceof reactor.netty5.channel.ChannelOperations<?,?> nativeReq) {
+		}
+		else if (nativeRequest.get() instanceof reactor.netty5.channel.ChannelOperations<?,?> nativeReq) {
 			io.netty5.util.Attribute<Map<String, Object>> attributes = nativeReq.channel().attr(io.netty5.util.AttributeKey.valueOf("attributes"));
 			if (expectAttributesApplied) {
 				assertThat(attributes.get()).isNotNull();
 				assertThat(attributes.get()).containsEntry("foo", "bar");
-			} else {
+			}
+			else {
 				assertThat(attributes.get()).isNull();
 			}
-		} else if (nativeRequest.get() instanceof Request nativeReq) {
+		}
+		else if (nativeRequest.get() instanceof Request nativeReq) {
 			if (expectAttributesApplied) {
 				assertThat(nativeReq.getAttributes()).containsEntry("foo", "bar");
-			} else {
+			}
+			else {
 				assertThat(nativeReq.getAttributes()).doesNotContainEntry("foo", "bar");
 			}
-		} else if (nativeRequest.get() instanceof org.apache.hc.core5.http.HttpRequest nativeReq) {
+		}
+		else if (nativeRequest.get() instanceof org.apache.hc.core5.http.HttpRequest nativeReq) {
 			// TODO get attributes from HttpClientContext
-		} else if (nativeRequest.get() instanceof java.net.http.HttpRequest nativeReq) {
 		}
 	}
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
@@ -51,12 +51,8 @@ import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.http.client.reactive.ClientHttpConnector;
-import org.springframework.http.client.reactive.HttpComponentsClientHttpConnector;
-import org.springframework.http.client.reactive.JdkClientHttpConnector;
-import org.springframework.http.client.reactive.JettyClientHttpConnector;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.http.client.reactive.ReactorNetty2ClientHttpConnector;
+
+import org.springframework.http.client.reactive.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;


### PR DESCRIPTION
This PR Closes #26208 
As proposed by @tstavinoha (https://github.com/spring-projects/spring-framework/issues/26208#issuecomment-739817950) and @rstoyanchev (https://github.com/spring-projects/spring-framework/issues/26208#issuecomment-783324482), this adds the option `applyAttributes` to the `WebClient.Builder`. If it is set to `true`, the `ClientRequest.attributes()` will be copied over to the underlying http-client library HttpRequest. For this there are different implementations for the various `ClientHttpConnector` implementations:
* `JettyClientHttpRequest`: Attributes are set with the `org.eclipse.jetty.client.api.Request#attribute(String, Object)` method one by one
* `ReactorClientHttpRequest`: A single `Map<String, Object>` containing all request attributes is set to the Attribute `attributes` in the `reactor.netty.channel.ChannelOperations#channel()` (as proposed by https://github.com/spring-projects/spring-framework/issues/26208#issuecomment-783324482)
* `ReactorNetty2ClientHttpRequest`: Same as in `ReactorClientHttpRequest`, but with the `netty5` classes
* `HttpComponentsClientHttpRequest`: Attributes are set with the `org.apache.hc.client5.http.protocol.HttpClientContext#setAttribute(String, Object)` method one by one
* `JdkClientHttpRequest`: I still need some input on this one. **As far as I can see there is no possibility** to set request attributes to the `java.net.http.HttpRequest`? 

As suggested by https://github.com/spring-projects/spring-framework/issues/26208#issuecomment-739817950, `applyAttributes` defaults to `true` and the user can opt-out when using the Builder to create the Connector.