### PR TITLE
Optimize MultiValueMap iteration operations

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
+++ b/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.Spliterator;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -284,6 +285,11 @@ public class LinkedCaseInsensitiveMap<V> implements Map<String, V>, Serializable
 			this.entrySet = entrySet;
 		}
 		return entrySet;
+	}
+
+	@Override
+	public void forEach(BiConsumer<? super String, ? super V> action) {
+		this.targetMap.forEach(action);
 	}
 
 	@Override

--- a/spring-core/src/main/java/org/springframework/util/MultiValueMapAdapter.java
+++ b/spring-core/src/main/java/org/springframework/util/MultiValueMapAdapter.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import org.springframework.lang.Nullable;
 
@@ -69,15 +70,13 @@ public class MultiValueMapAdapter<K, V> implements MultiValueMap<K, V>, Serializ
 
 	@Override
 	public void addAll(K key, List<? extends V> values) {
-		List<V> currentValues = this.targetMap.computeIfAbsent(key, k -> new ArrayList<>(1));
+		List<V> currentValues = this.targetMap.computeIfAbsent(key, k -> new ArrayList<>(values.size()));
 		currentValues.addAll(values);
 	}
 
 	@Override
 	public void addAll(MultiValueMap<K, V> values) {
-		for (Entry<K, List<V>> entry : values.entrySet()) {
-			addAll(entry.getKey(), entry.getValue());
-		}
+		values.forEach(this::addAll);
 	}
 
 	@Override
@@ -140,6 +139,12 @@ public class MultiValueMapAdapter<K, V> implements MultiValueMap<K, V>, Serializ
 
 	@Override
 	@Nullable
+	public List<V> putIfAbsent(K key, List<V> value) {
+		return this.targetMap.putIfAbsent(key, value);
+	}
+
+	@Override
+	@Nullable
 	public List<V> remove(Object key) {
 		return this.targetMap.remove(key);
 	}
@@ -167,6 +172,11 @@ public class MultiValueMapAdapter<K, V> implements MultiValueMap<K, V>, Serializ
 	@Override
 	public Set<Entry<K, List<V>>> entrySet() {
 		return this.targetMap.entrySet();
+	}
+
+	@Override
+	public void forEach(BiConsumer<? super K, ? super List<V>> action) {
+		this.targetMap.forEach(action);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -40,6 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1819,6 +1820,16 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	@Override
 	public Set<Entry<String, List<String>>> entrySet() {
 		return this.headers.entrySet();
+	}
+
+	@Override
+	public void forEach(BiConsumer<? super String, ? super List<String>> action) {
+		this.headers.forEach(action);
+	}
+
+	@Override
+	public List<String> putIfAbsent(String key, List<String> value) {
+		return this.headers.putIfAbsent(key, value);
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/http/ReadOnlyHttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/ReadOnlyHttpHeaders.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import org.springframework.lang.Nullable;
@@ -153,6 +154,11 @@ class ReadOnlyHttpHeaders extends HttpHeaders {
 				.collect(Collectors.collectingAndThen(
 						Collectors.toCollection(LinkedHashSet::new), // Retain original ordering of entries
 						Collections::unmodifiableSet));
+	}
+
+	@Override
+	public void forEach(BiConsumer<? super String, ? super List<String>> action) {
+		this.headers.forEach((k, vs) -> action.accept(k, Collections.unmodifiableList(vs)));
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
@@ -18,7 +18,6 @@ package org.springframework.http.client.reactive;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.Collection;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
@@ -129,9 +128,10 @@ class ReactorClientHttpRequest extends AbstractClientHttpRequest implements Zero
 
 	@Override
 	protected void applyCookies() {
-		getCookies().values().stream().flatMap(Collection::stream)
-				.map(cookie -> new DefaultCookie(cookie.getName(), cookie.getValue()))
-				.forEach(this.request::addCookie);
+		getCookies().values().forEach(values -> values.forEach(value -> {
+			DefaultCookie cookie = new DefaultCookie(value.getName(), value.getValue());
+			this.request.addCookie(cookie);
+		}));
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpRequest.java
@@ -18,7 +18,6 @@ package org.springframework.http.client.reactive;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.Collection;
 
 import io.netty5.buffer.Buffer;
 import io.netty5.handler.codec.http.headers.DefaultHttpCookiePair;
@@ -130,9 +129,10 @@ class ReactorNetty2ClientHttpRequest extends AbstractClientHttpRequest implement
 
 	@Override
 	protected void applyCookies() {
-		getCookies().values().stream().flatMap(Collection::stream)
-				.map(cookie -> new DefaultHttpCookiePair(cookie.getName(), cookie.getValue()))
-				.forEach(this.request::addCookie);
+		getCookies().values().forEach(values -> values.forEach(value -> {
+			DefaultHttpCookiePair cookie = new DefaultHttpCookiePair(value.getName(), value.getValue());
+			this.request.addCookie(cookie);
+		}));
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
@@ -704,6 +704,31 @@ public class HttpHeadersTests {
 		assertThat(readOnlyHttpHeaders.entrySet()).extracting(Entry::getKey).containsExactly(expectedKeys);
 	}
 
+	@Test
+	void readOnlyHttpHeadersCopyOrderTest() {
+		headers.add("aardvark", "enigma");
+		headers.add("beaver", "enigma");
+		headers.add("cat", "enigma");
+		headers.add("dog", "enigma");
+		headers.add("elephant", "enigma");
+
+		String[] expectedKeys = new String[] { "aardvark", "beaver", "cat", "dog", "elephant" };
+
+		HttpHeaders readOnlyHttpHeaders = HttpHeaders.readOnlyHttpHeaders(headers);
+
+		HttpHeaders forEachHeaders = new HttpHeaders();
+		readOnlyHttpHeaders.forEach(forEachHeaders::putIfAbsent);
+		assertThat(forEachHeaders.entrySet()).extracting(Entry::getKey).containsExactly(expectedKeys);
+
+		HttpHeaders putAllHeaders = new HttpHeaders();
+		putAllHeaders.putAll(readOnlyHttpHeaders);
+		assertThat(putAllHeaders.entrySet()).extracting(Entry::getKey).containsExactly(expectedKeys);
+
+		HttpHeaders addAllHeaders = new HttpHeaders();
+		addAllHeaders.addAll(readOnlyHttpHeaders);
+		assertThat(addAllHeaders.entrySet()).extracting(Entry::getKey).containsExactly(expectedKeys);
+	}
+
 	@Test // gh-25034
 	void equalsUnwrapsHttpHeaders() {
 		HttpHeaders headers1 = new HttpHeaders();

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestBuilder.java
@@ -255,10 +255,7 @@ final class DefaultClientRequestBuilder implements ClientRequest.Builder {
 		public Mono<Void> writeTo(ClientHttpRequest request, ExchangeStrategies strategies) {
 			HttpHeaders requestHeaders = request.getHeaders();
 			if (!this.headers.isEmpty()) {
-				this.headers.entrySet().stream()
-						.filter(entry -> !requestHeaders.containsKey(entry.getKey()))
-						.forEach(entry -> requestHeaders
-								.put(entry.getKey(), entry.getValue()));
+				this.headers.forEach(requestHeaders::putIfAbsent);
 			}
 
 			MultiValueMap<String, HttpCookie> requestCookies = request.getCookies();

--- a/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketHttpHeaders.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketHttpHeaders.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
@@ -293,6 +294,16 @@ public class WebSocketHttpHeaders extends HttpHeaders {
 	@Override
 	public Set<Entry<String, List<String>>> entrySet() {
 		return this.headers.entrySet();
+	}
+
+	@Override
+	public void forEach(BiConsumer<? super String, ? super List<String>> action) {
+		this.headers.forEach(action);
+	}
+
+	@Override
+	public List<String> putIfAbsent(String key, List<String> value) {
+		return this.headers.putIfAbsent(key, value);
 	}
 
 


### PR DESCRIPTION
I was doing some flame graph analysis and found that ReadOnlyHttpHeaders.entrySet() was a small hotspot in my codebase. I looked into its implementation and found that some care was taken in the past to fully copy over the entrySet to into a new and [properly ordered](https://github.com/spring-projects/spring-framework/issues/23551) set. The main hotspot in my specific codebase was in BodyInserterRequest.writeTo() which was called every time I used the reactive WebClient. I found that the entrySet() could be avoided and replaced with a forEach with putIfAbsent. The putIfAbsent is particularly useful since in the primary implementation I found it has to hash/normalize keys only once instead of twice like it was doing currently:
https://github.com/spring-projects/spring-framework/blob/b23316302d578694c6915d5fc9ef24b571110ffc/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java#L209-L223
In order to make sure the fast path is taken, I had to make sure the whole call chain avoided the Map class' default implementations (which use the slow entrySet() or a naive putIfAbsent). this allowed us to get to LinkedCaseInsensitiveMap's implementations. The forEach is optimized in LinkedHashMap as well. This foregoes the need to create entrySets and iterators (all with immutability) which saves memory allocations. Here is a stack trace from a breakpoint in LinkedCaseInsensitiveMap.putIfAbsent() (note how the fast path is taken):
<img width="527" alt="image" src="https://user-images.githubusercontent.com/1082334/218911000-2f593677-5737-47cc-afce-77b04db5a087.png">

Some other minor optimizations were included: presizing list in MultiValueMapAdapter.addAll,  use forEach in implementation of MultiValueMapAdapter.addAll (this avoids that slow entrySet path)

ASIDE: I think I found a bug in the ReadOnlyHttpHeaders.entrySet(). It appears that it leaks a mutable value list. See the following code:

```java
HttpHeaders src = new HttpHeaders();
src.set("foo", "bar");
src = HttpHeaders.readOnlyHttpHeaders(src);
src.entrySet().iterator().next().getValue().add("blah") // this should throw since ["bar"] is should be unmodifiable.
assertThat(src.get("foo").size()).isEqualTo(2); // should really be 1?
```
That code currently works, but should it? I have a fix, but I'll save that for a separate PR if you want.

I can also look into adding forEach implementations in things like NettyHeadersAdapter later.