### PR TITLE
Introduce caching for functional routing

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultResourceCacheLookupStrategy.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultResourceCacheLookupStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function.server;
+
+import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
+
+/**
+ * Default lookup that performs no caching.
+ * @author Jakob Fels
+ */
+public class DefaultResourceCacheLookupStrategy implements ResourceCacheLookupStrategy {
+
+	@Override
+	public CacheControl lookupCacheControl(Resource resource) {
+		return CacheControl.empty();
+	}
+
+}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/ResourceCacheLookupStrategy.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/ResourceCacheLookupStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function.server;
+
+import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
+
+/**
+ * Strategy interface to allow for looking up cache control for a given resource.
+ *
+ * @author Jakob Fels
+ */
+public interface ResourceCacheLookupStrategy {
+
+
+	static ResourceCacheLookupStrategy noCaching() {
+		return new DefaultResourceCacheLookupStrategy();
+	}
+
+	CacheControl lookupCacheControl(Resource resource);
+
+}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctionBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctionBuilder.java
@@ -242,8 +242,18 @@ class RouterFunctionBuilder implements RouterFunctions.Builder {
 	}
 
 	@Override
+	public RouterFunctions.Builder resources(String pattern, Resource location, ResourceCacheLookupStrategy resourceCacheLookupStrategy) {
+		return add(RouterFunctions.resources(pattern,location,resourceCacheLookupStrategy));
+	}
+
+	@Override
 	public RouterFunctions.Builder resources(Function<ServerRequest, Mono<Resource>> lookupFunction) {
 		return add(RouterFunctions.resources(lookupFunction));
+	}
+
+	@Override
+	public RouterFunctions.Builder resources(Function<ServerRequest, Mono<Resource>> lookupFunction, ResourceCacheLookupStrategy resourceCacheLookupStrategy) {
+		return add(RouterFunctions.resources(lookupFunction,resourceCacheLookupStrategy));
 	}
 
 	@Override

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/RouterFunctionBuilderTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/RouterFunctionBuilderTests.java
@@ -17,6 +17,7 @@
 package org.springframework.web.reactive.function.server;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,8 @@ import reactor.test.StepVerifier;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -127,6 +130,28 @@ public class RouterFunctionBuilderTests {
 				.map(ServerResponse::statusCode);
 
 		StepVerifier.create(responseMono)
+				.verifyComplete();
+	}
+
+	@Test
+	public void resourcesCaching() {
+		Resource resource = new ClassPathResource("/org/springframework/web/reactive/function/server/");
+		assertThat(resource.exists()).isTrue();
+
+		RouterFunction<ServerResponse> route = RouterFunctions.route()
+				.resources("/resources/**", resource, resource1 -> CacheControl.maxAge(Duration.ofSeconds(60)))
+				.build();
+
+		MockServerHttpRequest mockRequest = MockServerHttpRequest.get("https://localhost/resources/response.txt").build();
+		ServerRequest resourceRequest = new DefaultServerRequest(MockServerWebExchange.from(mockRequest), Collections.emptyList());
+
+		Mono<String> responseMono = route.route(resourceRequest)
+				.flatMap(handlerFunction -> handlerFunction.handle(resourceRequest))
+				.map(ServerResponse::headers)
+				.mapNotNull(HttpHeaders::getCacheControl);
+
+		StepVerifier.create(responseMono)
+				.expectNext("max-age=60")
 				.verifyComplete();
 	}
 


### PR DESCRIPTION
Currently the functional API does not support any kind of caching for resources. I was trying to replicate an nginx setup with multiple virtual hosts, each having their own assets folder.

So my code would contain something like:
```java
route.nest(
  RequestPredicates.headers(headers -> "www.exmple.com".equals(headers.host().getHostString())),
  builder -> builder
    .add(ResourcesHandler.resources("/**", getHostSpecificResourceDir())
```
With this setup, I saw no option to define any kind of caching for these resources, because `ResourceHandlerFunction` was returning an `EntityResponse` which could not be modified.

This PR introduces caching support for the `.resources` instruction. Implementing the `ResourceCacheLookupStrategy` interface allows for either defining a general caching rule (e.g. max-age=60 for all resources), or to define custom cache behaviour per file (e.g. max-age=3600 if resource is an xml file).

The default behaviour, if no strategy is provided, is to not cache at all, preserving the status quo.

I have signed the CLA
