### PR TITLE
Fix `@Aspect` `perthis` syntax in reference manual

### DIFF
--- a/framework-docs/src/docs/asciidoc/core/core-aop.adoc
+++ b/framework-docs/src/docs/asciidoc/core/core-aop.adoc
@@ -1778,7 +1778,7 @@ annotation. Consider the following example:
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]
 .Java
 ----
-	@Aspect("perthis(com.xyz.myapp.CommonPointcuts.businessService())")
+	@Aspect("perthis(execution(* com.xyz.myapp.CommonPointcuts.businessService()))")
 	public class MyAspect {
 
 		private int someState;
@@ -1792,7 +1792,7 @@ annotation. Consider the following example:
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin
 ----
-	@Aspect("perthis(com.xyz.myapp.CommonPointcuts.businessService())")
+	@Aspect("perthis(execution(* com.xyz.myapp.CommonPointcuts.businessService()))")
 	class MyAspect {
 
 		private val someState: Int = 0


### PR DESCRIPTION
In the Spring AOP manual, the sample code falsely reads in both Java and Kotlin examples as follows:

```java
@Aspect("perthis(com.xyz.myapp.CommonPointcuts.businessService())")
```

But inside `perthis` must be a valid pointcut, not just a method name, as I explained in [this StackOverflow answer](https://stackoverflow.com/a/75506704/1082681).

Thus, the example code should be changed to something like:

```java
@Aspect("perthis(execution(* com.xyz.myapp.CommonPointcuts.businessService()))")
```

@sbrannen, maybe you are the right person to review and merge this issue.