### PR TITLE
Use `readNBytes` in ByteArrayHttpMessageConverter when contentLength is available

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
@@ -52,7 +52,15 @@ public class ByteArrayHttpMessageConverter extends AbstractHttpMessageConverter<
 
 	@Override
 	public byte[] readInternal(Class<? extends byte[]> clazz, HttpInputMessage inputMessage) throws IOException {
-		return inputMessage.getBody().readAllBytes();
+		long contentLength = inputMessage.getHeaders().getContentLength();
+		final int len;
+		if (contentLength >= 0 && contentLength <= Integer.MAX_VALUE) {
+			len = (int) contentLength;
+		}
+		else {
+			len = Integer.MAX_VALUE;
+		}
+		return inputMessage.getBody().readNBytes(len);
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/http/converter/ByteArrayHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/ByteArrayHttpMessageConverterTests.java
@@ -58,6 +58,16 @@ public class ByteArrayHttpMessageConverterTests {
 	}
 
 	@Test
+	public void readWithContentLengthHeaderSet() throws IOException {
+		byte[] body = new byte[]{0x1, 0x2, 0x3, 0x4, 0x5};
+		MockHttpInputMessage inputMessage = new MockHttpInputMessage(body);
+		inputMessage.getHeaders().setContentType(new MediaType("application", "octet-stream"));
+		inputMessage.getHeaders().setContentLength(body.length);
+		byte[] result = converter.read(byte[].class, inputMessage);
+		assertThat(result).as("Invalid result").isEqualTo(body);
+	}
+
+	@Test
 	public void write() throws IOException {
 		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
 		byte[] body = new byte[]{0x1, 0x2};


### PR DESCRIPTION
If the content length is available, pass it to readNBytes when reading the message body. When the content length is less than the internal buffer size in InputStream (8192), this avoids a copy, as readNBytes will return the buffer directly. When the content length is greater than the buffer size used in InputStream, passing the content length at least avoids over-allocating the final buffer (e.g., if the content length were 8193 bytes, 1 byte more than the default buffer size).

If the content length isn't present or is too large to represent as an integer, fall back to the default behavior of readAllBytes by passing in Integer.MAX_VALUE.