### PR TITLE
Update comment in Javadoc of ServletRequestPathFilter DispatcherServlet relating to DispatcherServlet

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/ServletRequestPathFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/ServletRequestPathFilter.java
@@ -36,10 +36,9 @@ import org.springframework.web.util.ServletRequestPathUtils;
  * {@link org.springframework.web.util.pattern.PathPattern}s are in use anywhere
  * in an application instead of String pattern matching with
  * {@link org.springframework.util.PathMatcher}.
- * <p>Note that in Spring MVC, the {@code DispatcherServlet} will also parse and
+ * <p>Note that in Spring MVC, the {@code DispatcherServlet} will always parse and
  * cache the {@code RequestPath} if it detects that parsed {@code PathPatterns}
- * are enabled for any {@code HandlerMapping} but it will skip doing that if it
- * finds the {@link ServletRequestPathUtils#PATH_ATTRIBUTE} already exists.
+ * are enabled for any {@code HandlerMapping}.
  *
  * @author Rossen Stoyanchev
  * @since 5.3


### PR DESCRIPTION
The following behavior documented by `org.springframework.web.filter.ServletRequestPathFilter` does not hold true with current version:

> DispatcherServlet will parse and cache the `RequestPath` if it detects that parsed `PathPatterns` are enabled for any `HandlerMapping` but it will skip doing that if `ServletRequestPathUtils#PATH_ATTRIBUTE` already exists.

This PR adds the logic to skip parse and cache `RequestPath` if `ServletRequestPathUtils.PATH_ATTRIBUTE` already exists. 

The exception where multiple parsing must happen is for Forward requests.