### PR TITLE
Add ClasspathFileUtil for easy getting files from resource directory

### DIFF
--- a/spring-core/src/main/kotlin/org/springframework/util/ResourceClasspathFileUtil.kt
+++ b/spring-core/src/main/kotlin/org/springframework/util/ResourceClasspathFileUtil.kt
@@ -1,0 +1,13 @@
+package org.springframework.util
+
+import java.io.File
+
+/**
+ * Class for reading files from classpath without defining classpath directory.
+ * E.g. you can load json files from classpath easily with this class.
+ * @param resourcePath path to resource in classpath.
+ *
+ * @author Alexander Ilinykh
+ */
+class ResourceClasspathFileUtil(resourcePath: String) :
+	File(ResourceClasspathFileUtil::class.java.classLoader.getResource(resourcePath)!!.toURI())

--- a/spring-core/src/test/kotlin/org/springframework/util/ResourceClasspathFileUtilTest.kt
+++ b/spring-core/src/test/kotlin/org/springframework/util/ResourceClasspathFileUtilTest.kt
@@ -1,0 +1,13 @@
+package org.springframework.util
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ResourceClasspathFileUtilTest {
+
+	@Test
+	fun correctReadFromClasspath() {
+		val file = ResourceClasspathFileUtil("org/springframework/util/classpathfileutildata.txt")
+		Assertions.assertThat(file.readText()).isEqualTo("Hello Spring!")
+	}
+}

--- a/spring-core/src/test/resources/org/springframework/util/classpathfileutildata.txt
+++ b/spring-core/src/test/resources/org/springframework/util/classpathfileutildata.txt
@@ -1,0 +1,1 @@
+Hello Spring!


### PR DESCRIPTION
We have some tests which needed a json example for reproduction. I think it would be better if we can ability to easy load them or other files from resource directory instead of defining them into class. It'll makes code more clarity and readable.

For example `val body = """
			{
				"bytes": [
					1,
					2
				],
				"array": [
					"Foo",
					"Bar"
				],
				"number": 42,
				"string": "Foo",
				"bool": true,
				"fraction": 42
			}
		""".trimIndent()`

can be changed to ` val body = ResourceClasspathFileUtil("org/springframework/request.json").readText()`