### PR TITLE
Add SpEL support for registered MethodHandles

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/expressions.adoc
+++ b/framework-docs/modules/ROOT/pages/core/expressions.adoc
@@ -47,7 +47,9 @@ The expression language supports the following functionality:
 * Inline maps
 * Ternary operator
 * Variables
-* User-defined functions
+* User-defined functions added to the context
+  * reflective invocation of `Method`
+  * various cases of `MethodHandle`
 * Collection projection
 * Collection selection
 * Templated expressions

--- a/framework-docs/modules/ROOT/pages/core/expressions/language-ref.adoc
+++ b/framework-docs/modules/ROOT/pages/core/expressions/language-ref.adoc
@@ -15,7 +15,7 @@ topics:
 * xref:core/expressions/language-ref/types.adoc[Types]
 * xref:core/expressions/language-ref/constructors.adoc[Constructors]
 * xref:core/expressions/language-ref/variables.adoc[Variables]
-* xref:core/expressions/language-ref/functions.adoc[Functions]
+* xref:core/expressions/language-ref/functions.adoc[User-Defined Functions]
 * xref:core/expressions/language-ref/bean-references.adoc[Bean References]
 * xref:core/expressions/language-ref/operator-ternary.adoc[Ternary Operator (If-Then-Else)]
 * xref:core/expressions/language-ref/operator-elvis.adoc[The Elvis Operator]

--- a/framework-docs/modules/ROOT/pages/core/expressions/language-ref/functions.adoc
+++ b/framework-docs/modules/ROOT/pages/core/expressions/language-ref/functions.adoc
@@ -3,7 +3,8 @@
 
 You can extend SpEL by registering user-defined functions that can be called within the
 expression string. The function is registered through the `EvaluationContext`. The
-following example shows how to register a user-defined function:
+following example shows how to register a user-defined function to be invoked via reflection
+(i.e. a `Method`):
 
 [tabs]
 ======
@@ -91,6 +92,98 @@ Kotlin::
 
 	val helloWorldReversed = parser.parseExpression(
 			"#reverseString('hello')").getValue(context, String::class.java)
+----
+======
+
+The use of `MethodHandle` is also supported. This enables potentially more efficient use
+cases if the `MethodHandle` target and parameters have been fully bound prior to
+registration, but partially bound handles are also supported.
+
+Consider the `String#formatted(String, Object...)` instance method, which produces a
+message according to a template and a variable number of arguments.
+
+You can register and use the `formatted` method as a `MethodHandle`, as the following
+example shows:
+
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes",role="primary"]
+----
+	ExpressionParser parser = new SpelExpressionParser();
+	EvaluationContext context = SimpleEvaluationContext.forReadOnlyDataBinding().build();
+
+	MethodHandle mh = MethodHandles.lookup().findVirtual(String.class, "formatted",
+			MethodType.methodType(String.class, Object[].class));
+	context.setVariable("message", mh);
+
+	String message = parser.parseExpression("#message('Simple message: <%s>', 'Hello World', 'ignored')")
+			.getValue(context, String.class);
+	//returns "Simple message: <Hello World>"
+----
+
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
+----
+	val parser = SpelExpressionParser()
+	val context = SimpleEvaluationContext.forReadOnlyDataBinding().build()
+
+	val mh = MethodHandles.lookup().findVirtual(String::class.java, "formatted",
+			MethodType.methodType(String::class.java, Array<Any>::class.java))
+	context.setVariable("message", mh)
+
+	val message = parser.parseExpression("#message('Simple message: <%s>', 'Hello World', 'ignored')")
+			.getValue(context, String::class.java)
+----
+======
+
+As hinted above, binding a `MethodHandle` and registering the bound `MethodHandle` is also
+supported. This is likely to be more performant if both the target and all the arguments
+are bound. In that case no arguments are necessary in the SpEL expression, as the
+following example shows:
+
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes",role="primary"]
+----
+	ExpressionParser parser = new SpelExpressionParser();
+	EvaluationContext context = SimpleEvaluationContext.forReadOnlyDataBinding().build();
+
+	String template = "This is a %s message with %s words: <%s>";
+	Object varargs = new Object[] { "prerecorded", 3, "Oh Hello World!", "ignored" };
+	MethodHandle mh = MethodHandles.lookup().findVirtual(String.class, "formatted",
+			MethodType.methodType(String.class, Object[].class))
+			.bindTo(template)
+			.bindTo(varargs); //here we have to provide arguments in a single array binding
+	context.setVariable("message", mh);
+
+	String message = parser.parseExpression("#message()")
+			.getValue(context, String.class);
+	//returns "This is a prerecorded message with 3 words: <Oh Hello World!>"
+----
+
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
+----
+	val parser = SpelExpressionParser()
+	val context = SimpleEvaluationContext.forReadOnlyDataBinding().build()
+
+	val template = "This is a %s message with %s words: <%s>"
+	val varargs = arrayOf("prerecorded", 3, "Oh Hello World!", "ignored")
+
+	val mh = MethodHandles.lookup().findVirtual(String::class.java, "formatted",
+			MethodType.methodType(String::class.java, Array<Any>::class.java))
+			.bindTo(template)
+			.bindTo(varargs) //here we have to provide arguments in a single array binding
+	context.setVariable("message", mh)
+
+	val message = parser.parseExpression("#message()")
+			.getValue(context, String::class.java)
 ----
 ======
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/StandardEvaluationContext.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/StandardEvaluationContext.java
@@ -16,6 +16,7 @@
 
 package org.springframework.expression.spel.support;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -249,6 +250,10 @@ public class StandardEvaluationContext implements EvaluationContext {
 
 	public void registerFunction(String name, Method method) {
 		this.variables.put(name, method);
+	}
+
+	public void registerFunction(String name, MethodHandle methodHandle) {
+		this.variables.put(name, methodHandle);
 	}
 
 	@Override

--- a/spring-expression/src/test/java/org/springframework/expression/spel/ExpressionLanguageScenarioTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/ExpressionLanguageScenarioTests.java
@@ -189,6 +189,45 @@ public class ExpressionLanguageScenarioTests extends AbstractExpressionTests {
 	}
 
 	/**
+	 * Scenario: looking up your own MethodHandles and calling them from the expression
+	 */
+	@Test
+	public void testScenario_RegisteringJavaMethodsAsMethodHandlesAndCallingThem() throws SecurityException, NoSuchMethodException {
+		try {
+			// Create a parser
+			SpelExpressionParser parser = new SpelExpressionParser();
+			//this.context is already populated with all relevant MethodHandle examples
+
+			Expression expr = parser.parseRaw("#message('Message with %s words: <%s>', 2, 'Hello World', 'ignored')");
+			Object value = expr.getValue(this.context);
+			assertThat(value).isEqualTo("Message with 2 words: <Hello World>");
+
+			expr = parser.parseRaw("#messageTemplate('bound', 2, 'Hello World', 'ignored')");
+			value = expr.getValue(this.context);
+			assertThat(value).isEqualTo("This is a bound message with 2 words: <Hello World>");
+
+			expr = parser.parseRaw("#messageBound()");
+			value = expr.getValue(this.context);
+			assertThat(value).isEqualTo("This is a prerecorded message with 3 words: <Oh Hello World>");
+
+			Expression staticExpr = parser.parseRaw("#messageStatic('Message with %s words: <%s>', 2, 'Hello World', 'ignored')");
+			Object staticValue = staticExpr.getValue(this.context);
+			assertThat(staticValue).isEqualTo("Message with 2 words: <Hello World>");
+
+			staticExpr = parser.parseRaw("#messageStaticTemplate('bound', 2, 'Hello World', 'ignored')");
+			staticValue = staticExpr.getValue(this.context);
+			assertThat(staticValue).isEqualTo("This is a bound message with 2 words: <Hello World>");
+
+			staticExpr = parser.parseRaw("#messageStaticBound()");
+			staticValue = staticExpr.getValue(this.context);
+			assertThat(staticValue).isEqualTo("This is a prerecorded message with 3 words: <Oh Hello World>");
+		}
+		catch (EvaluationException | ParseException ex) {
+			throw new AssertionError(ex.getMessage(), ex);
+		}
+	}
+
+	/**
 	 * Scenario: add a property resolver that will get called in the resolver chain, this one only supports reading.
 	 */
 	@Test

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelDocumentationTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.expression.spel;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -413,6 +416,38 @@ class SpelDocumentationTests extends AbstractExpressionTests {
 
 		String helloWorldReversed = parser.parseExpression("#reverseString('hello world')").getValue(context, String.class);
 		assertThat(helloWorldReversed).isEqualTo("dlrow olleh");
+	}
+
+	@Test
+	void methodHandlesNotBound() throws Throwable {
+		ExpressionParser parser = new SpelExpressionParser();
+		StandardEvaluationContext context = new StandardEvaluationContext();
+
+		MethodHandle mh = MethodHandles.lookup().findVirtual(String.class, "formatted",
+				MethodType.methodType(String.class, Object[].class));
+		context.setVariable("message", mh);
+
+		String message = parser.parseExpression("#message('Simple message: <%s>', 'Hello World', 'ignored')")
+				.getValue(context, String.class);
+		assertThat(message).isEqualTo("Simple message: <Hello World>");
+	}
+
+	@Test
+	void methodHandlesFullyBound() throws Throwable {
+		ExpressionParser parser = new SpelExpressionParser();
+		StandardEvaluationContext context = new StandardEvaluationContext();
+
+		String template = "This is a %s message with %s words: <%s>";
+		Object varargs = new Object[] { "prerecorded", 3, "Oh Hello World!", "ignored" };
+		MethodHandle mh = MethodHandles.lookup().findVirtual(String.class, "formatted",
+						MethodType.methodType(String.class, Object[].class))
+				.bindTo(template)
+				.bindTo(varargs); //here we have to provide arguments in a single array binding
+		context.setVariable("message", mh);
+
+		String message = parser.parseExpression("#message()")
+				.getValue(context, String.class);
+		assertThat(message).isEqualTo("This is a prerecorded message with 3 words: <Oh Hello World!>");
 	}
 
 	// 7.5.10

--- a/spring-expression/src/test/java/org/springframework/expression/spel/TestScenarioCreator.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/TestScenarioCreator.java
@@ -16,6 +16,9 @@
 
 package org.springframework.expression.spel;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.Arrays;
 import java.util.GregorianCalendar;
 
@@ -37,6 +40,12 @@ class TestScenarioCreator {
 		setupRootContextObject(testContext);
 		populateVariables(testContext);
 		populateFunctions(testContext);
+		try {
+			populateMethodHandles(testContext);
+		}
+		catch (NoSuchMethodException | IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
 		return testContext;
 	}
 
@@ -60,6 +69,36 @@ class TestScenarioCreator {
 		catch (Exception ex) {
 			throw new IllegalStateException(ex);
 		}
+	}
+
+	/**
+	 * Register some Java {@code MethodHandle} as well known functions that can be called from an expression.
+	 * @param testContext the test evaluation context
+	 */
+	private static void populateMethodHandles(StandardEvaluationContext testContext) throws NoSuchMethodException, IllegalAccessException {
+		// #message(template, args...)
+		MethodHandle message = MethodHandles.lookup().findVirtual(String.class, "formatted",
+				MethodType.methodType(String.class, Object[].class));
+		testContext.registerFunction("message", message);
+		// #messageTemplate(args...)
+		MethodHandle messageWithParameters = message.bindTo("This is a %s message with %s words: <%s>");
+		testContext.registerFunction("messageTemplate", messageWithParameters);
+		// #messageTemplateBound()
+		MethodHandle messageBound = messageWithParameters
+				.bindTo(new Object[] { "prerecorded", 3, "Oh Hello World", "ignored"});
+		testContext.registerFunction("messageBound", messageBound);
+
+		//#messageStatic(template, args...)
+		MethodHandle messageStatic = MethodHandles.lookup().findStatic(TestScenarioCreator.class,
+				"message", MethodType.methodType(String.class, String.class, String[].class));
+		testContext.registerFunction("messageStatic", messageStatic);
+		//#messageStaticTemplate(args...)
+		MethodHandle messageStaticPartiallyBound = messageStatic.bindTo("This is a %s message with %s words: <%s>");
+		testContext.registerFunction("messageStaticTemplate", messageStaticPartiallyBound);
+		//#messageStaticBound()
+		MethodHandle messageStaticFullyBound = messageStaticPartiallyBound
+				.bindTo(new String[] { "prerecorded", "3", "Oh Hello World", "ignored"});
+		testContext.registerFunction("messageStaticBound", messageStaticFullyBound);
 	}
 
 	/**
@@ -115,6 +154,10 @@ class TestScenarioCreator {
 
 	public static String varargsFunction2(int i, String... strings) {
 		return String.valueOf(i) + "-" + Arrays.toString(strings);
+	}
+
+	public static String message(String template, String... args) {
+		return template.formatted((Object[]) args);
 	}
 
 }


### PR DESCRIPTION
This commit adds support for MethodHandles in SpEL, using the same
syntax as user-defined functions (which also covers reflective Methods).

The most benefit is expected with handles that capture a static method
with no arguments, or with fully bound handles (where all the arguments
have been bound, including a target instance as first bound argument
if necessary). Partially bound MethodHandle should also be supported.

A best effort approach is taken to detect varargs as there is no API
support to determine if an argument is a vararg or an explicit array,
unlike with Method. Argument conversions are also applied. Finally,
array repacking is not always necessary with varargs so it is only
performed when the vararg is the sole argument to the invoked method.

Closes gh-27099
Closes gh-30045
