### PR TITLE
Assert non-null arguments in `DefaultServerRequestBuilder` methods

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerRequestBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerRequestBuilder.java
@@ -122,6 +122,7 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder header(String headerName, String... headerValues) {
+		Assert.notNull(headerName, "Header Name must not be null");
 		for (String headerValue : headerValues) {
 			this.headers.add(headerName, headerValue);
 		}
@@ -130,12 +131,14 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder headers(Consumer<HttpHeaders> headersConsumer) {
+		Assert.notNull(headersConsumer, "Header Consumer must not be null");
 		headersConsumer.accept(this.headers);
 		return this;
 	}
 
 	@Override
 	public ServerRequest.Builder cookie(String name, String... values) {
+		Assert.notNull(name, "Cookie Name must not be null");
 		for (String value : values) {
 			this.cookies.add(name, new HttpCookie(name, value));
 		}
@@ -144,6 +147,7 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder cookies(Consumer<MultiValueMap<String, HttpCookie>> cookiesConsumer) {
+		Assert.notNull(cookiesConsumer, "Cookie Consumer must not be null");
 		cookiesConsumer.accept(this.cookies);
 		return this;
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerRequestBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerRequestBuilder.java
@@ -178,12 +178,14 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder attribute(String name, Object value) {
+		Assert.notNull(name, "name must not be null");
 		this.attributes.put(name, value);
 		return this;
 	}
 
 	@Override
 	public ServerRequest.Builder attributes(Consumer<Map<String, Object>> attributesConsumer) {
+		Assert.notNull(attributesConsumer, "AttributesConsumer must not be null");
 		attributesConsumer.accept(this.attributes);
 		return this;
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerRequestBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerRequestBuilder.java
@@ -115,6 +115,7 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder header(String headerName, String... headerValues) {
+		Assert.notNull(headerName, "Header Name must not be null");
 		for (String headerValue : headerValues) {
 			this.headers.add(headerName, headerValue);
 		}
@@ -123,12 +124,14 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder headers(Consumer<HttpHeaders> headersConsumer) {
+		Assert.notNull(headersConsumer, "Header Consumer must not be null");
 		headersConsumer.accept(this.headers);
 		return this;
 	}
 
 	@Override
 	public ServerRequest.Builder cookie(String name, String... values) {
+		Assert.notNull(name, "Cookie Name must not be null");
 		for (String value : values) {
 			this.cookies.add(name, new Cookie(name, value));
 		}
@@ -137,6 +140,7 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder cookies(Consumer<MultiValueMap<String, Cookie>> cookiesConsumer) {
+		Assert.notNull(cookiesConsumer, "Cookie Consumer must not be null");
 		cookiesConsumer.accept(this.cookies);
 		return this;
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerRequestBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerRequestBuilder.java
@@ -147,30 +147,34 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder body(byte[] body) {
+		Assert.notNull(body, "body must not be null");
 		this.body = body;
 		return this;
 	}
 
 	@Override
 	public ServerRequest.Builder body(String body) {
+		Assert.notNull(body, "body must not be null");
 		return body(body.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Override
 	public ServerRequest.Builder attribute(String name, Object value) {
-		Assert.notNull(name, "'name' must not be null");
+		Assert.notNull(name, "name must not be null");
 		this.attributes.put(name, value);
 		return this;
 	}
 
 	@Override
 	public ServerRequest.Builder attributes(Consumer<Map<String, Object>> attributesConsumer) {
+		Assert.notNull(attributesConsumer, "AttributesConsumer must not be null");
 		attributesConsumer.accept(this.attributes);
 		return this;
 	}
 
 	@Override
 	public ServerRequest.Builder param(String name, String... values) {
+		Assert.notNull(name, "name must not be null");
 		for (String value : values) {
 			this.params.add(name, value);
 		}
@@ -179,12 +183,13 @@ class DefaultServerRequestBuilder implements ServerRequest.Builder {
 
 	@Override
 	public ServerRequest.Builder params(Consumer<MultiValueMap<String, String>> paramsConsumer) {
+		Assert.notNull(paramsConsumer, "paramsConsumer must not be null");
 		paramsConsumer.accept(this.params);
 		return this;
 	}
 
 	@Override
-	public ServerRequest.Builder remoteAddress(InetSocketAddress remoteAddress) {
+	public ServerRequest.Builder remoteAddress(@Nullable InetSocketAddress remoteAddress) {
 		this.remoteAddress = remoteAddress;
 		return this;
 	}


### PR DESCRIPTION
- Add Null check for Http Header Name , https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpHeaders.html#add(java.lang.String,java.lang.String). As per doc only header values can be nullable
- Add Null check for Http HeaderConsumer
- Add Null check for Cookie Name 
- Add Null check for CookierConsumer