### PR TITLE
Prefer request hostName and hostPort in ReactorServerHttpRequest

### DIFF
--- a/framework-platform/framework-platform.gradle
+++ b/framework-platform/framework-platform.gradle
@@ -11,7 +11,7 @@ dependencies {
 	api(platform("io.micrometer:micrometer-bom:1.10.4"))
 	api(platform("io.netty:netty-bom:4.1.89.Final"))
 	api(platform("io.netty:netty5-bom:5.0.0.Alpha5"))
-	api(platform("io.projectreactor:reactor-bom:2022.0.3"))
+	api(platform("io.projectreactor:reactor-bom:2022.0.4-SNAPSHOT"))
 	api(platform("io.rsocket:rsocket-bom:1.1.3"))
 	api(platform("org.apache.groovy:groovy-bom:4.0.8"))
 	api(platform("org.apache.logging.log4j:log4j-bom:2.19.0"))

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
@@ -79,36 +79,10 @@ class ReactorServerHttpRequest extends AbstractServerHttpRequest {
 
 	private static URI resolveBaseUrl(HttpServerRequest request) throws URISyntaxException {
 		String scheme = getScheme(request);
-
-		InetSocketAddress hostAddress = request.hostAddress();
-		if (hostAddress != null) {
-			return new URI(scheme, null, hostAddress.getHostString(), hostAddress.getPort(), null, null, null);
-		}
-
-		String header = request.requestHeaders().get(HttpHeaderNames.HOST);
-		if (header != null) {
-			final int portIndex;
-			if (header.startsWith("[")) {
-				portIndex = header.indexOf(':', header.indexOf(']'));
-			}
-			else {
-				portIndex = header.indexOf(':');
-			}
-			if (portIndex != -1) {
-				try {
-					return new URI(scheme, null, header.substring(0, portIndex),
-							Integer.parseInt(header, portIndex + 1, header.length(), 10), null, null, null);
-				}
-				catch (NumberFormatException ex) {
-					throw new URISyntaxException(header, "Unable to parse port", portIndex);
-				}
-			}
-			else {
-				return new URI(scheme, header, null, null);
-			}
-		}
-
-		throw new IllegalStateException("Neither local hostAddress nor HOST header available");
+		int port = request.hostPort();
+		return (scheme.equals("http") && (port != 80)) || (scheme.equals("https") && (port != 443)) ?
+				new URI(scheme, null, request.hostName(), port, null, null, null) :
+				new URI(scheme, request.hostName(), null, null);
 	}
 
 	private static String getScheme(HttpServerRequest request) {

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.net.ssl.SSLSession;
 
 import io.netty.channel.Channel;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.ssl.SslHandler;
 import org.apache.commons.logging.Log;
@@ -80,7 +79,8 @@ class ReactorServerHttpRequest extends AbstractServerHttpRequest {
 	private static URI resolveBaseUrl(HttpServerRequest request) throws URISyntaxException {
 		String scheme = getScheme(request);
 		int port = request.hostPort();
-		return (scheme.equals("http") && (port != 80)) || (scheme.equals("https") && (port != 443)) ?
+		return ((scheme.equals("http") || scheme.equals("ws")) && (port != 80)) ||
+				((scheme.equals("https") || scheme.equals("wss")) && (port != 443)) ?
 				new URI(scheme, null, request.hostName(), port, null, null, null) :
 				new URI(scheme, request.hostName(), null, null);
 	}


### PR DESCRIPTION
- Prefer request `hostName` and `hostPort` in `ReactorServerHttpRequest#resolveBaseUrl`
- The request `hostName` and `hostPort` are derived from the `Host`/`X-Forwarded-*`/`Forwarded` header associated with this request
- Do not add the port when it is the default one

Closes gh-30033