### PR TITLE
Update `Pointcuts` to match getter methods by also excluding `void` return type

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/support/Pointcuts.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/Pointcuts.java
@@ -126,7 +126,8 @@ public abstract class Pointcuts {
 		@Override
 		public boolean matches(Method method, Class<?> targetClass) {
 			return (method.getName().startsWith("get") &&
-					method.getParameterCount() == 0);
+					method.getParameterCount() == 0 &&
+				    method.getReturnType() != Void.TYPE);
 		}
 
 		private Object readResolve() {

--- a/spring-aop/src/main/java/org/springframework/aop/support/Pointcuts.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/Pointcuts.java
@@ -126,8 +126,8 @@ public abstract class Pointcuts {
 		@Override
 		public boolean matches(Method method, Class<?> targetClass) {
 			return (method.getName().startsWith("get") &&
-					method.getParameterCount() == 0 &&
-				    method.getReturnType() != Void.TYPE);
+					method.getParameterCount() == 0 && 
+					method.getReturnType() != Void.TYPE);
 		}
 
 		private Object readResolve() {


### PR DESCRIPTION
A getter method should always have a return type other than `void`.