### PR TITLE
Ensure all packages declare `package-info.java` with null-safety annotations

### DIFF
--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -130,7 +130,7 @@
 	<suppress files="sockjs[\\/]transport[\\/]TransportType" checks="JavadocVariable"/>
 	<suppress files="src[\\/]test[\\/]java[\\/]org[\\/]springframework[\\/]web[\\/]reactive[\\/]protobuf[\\/].*" checks=".*"/>
 
-	<!-- Suppress JavadocPackage checks on packages outside of src/main-->
+	<!-- Suppress JavadocPackage checks and package null safety annotations on packages outside of src/main-->
 	<!-- And outside 'framework-docs' module-->
 	<!-- And outside 'spring-core/src/main/java/org/springframework/asm' package-->
 	<!-- And outside 'spring-core/src/main/java/org/springframework/cglib' package-->
@@ -138,5 +138,7 @@
 	<!-- And outside 'spring-core/src/main/java/org/springframework/javapoet' package-->
 	<!-- And outside 'spring-core/src/main/java/org/springframework/lang' package-->
 	<suppress checks="JavadocPackage" files="(^(?!.*src[\\/]main[\\/]).*)|(.*framework-docs.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/asm.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/cglib.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/objenesis.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/javapoet.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/lang.*)"/>
+	<suppress checks="RegexpSinglelineJava" files="^(?!.*(package-info.java))" id="javaDocPackageNonNullFieldsAnnotation"/>
+	<suppress checks="RegexpSinglelineJava" files="^(?!.*(package-info.java))" id="javaDocPackageNonNullApiAnnotation"/>
 
 </suppressions>

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -130,4 +130,13 @@
 	<suppress files="sockjs[\\/]transport[\\/]TransportType" checks="JavadocVariable"/>
 	<suppress files="src[\\/]test[\\/]java[\\/]org[\\/]springframework[\\/]web[\\/]reactive[\\/]protobuf[\\/].*" checks=".*"/>
 
+	<!-- Suppress JavadocPackage checks on packages outside of src/main-->
+	<!-- And outside 'framework-docs' module-->
+	<!-- And outside 'spring-core/src/main/java/org/springframework/asm' package-->
+	<!-- And outside 'spring-core/src/main/java/org/springframework/cglib' package-->
+	<!-- And outside 'spring-core/src/main/java/org/springframework/objenesis' package-->
+	<!-- And outside 'spring-core/src/main/java/org/springframework/javapoet' package-->
+	<!-- And outside 'spring-core/src/main/java/org/springframework/lang' package-->
+	<suppress checks="JavadocPackage" files="(^(?!.*src[\\/]main[\\/]).*)|(.*framework-docs.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/asm.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/cglib.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/objenesis.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/javapoet.*)|(.*spring-core\/src\/main\/java\/org\/springframework\/lang.*)"/>
+
 </suppressions>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -240,4 +240,7 @@
 		<module name="io.spring.javaformat.checkstyle.check.SpringJavadocCheck"/>
 		<module name="io.spring.javaformat.checkstyle.check.SpringJUnit5Check"/>
  	</module>
+
+	<!--package-info checker -->
+	<module name="JavadocPackage"/>
 </module>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -239,6 +239,24 @@
 		<module name="io.spring.javaformat.checkstyle.check.SpringCatchCheck"/>
 		<module name="io.spring.javaformat.checkstyle.check.SpringJavadocCheck"/>
 		<module name="io.spring.javaformat.checkstyle.check.SpringJUnit5Check"/>
+		<!--package-info should contain null-safety annotations-->
+		<!--These two modules will fail to detect multiline annotations-->
+		<module name="RegexpSinglelineJavaCheck">
+			<property name="id" value="javaDocPackageNonNullFieldsAnnotation"/>
+			<property name="format" value="(@NonNullFields|@org\.springframework\.lang\.NonNullFields)"/>
+			<property name="minimum" value="1"/>
+			<property  name="maximum" value="1"/>
+			<property name="message" value="package-info.java is missing required null-safety annotation @NonNullFields."/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+		<module name="RegexpSinglelineJavaCheck">
+			<property name="id" value="javaDocPackageNonNullApiAnnotation"/>
+			<property name="format" value="(@NonNullApi|@org\.springframework\.lang\.NonNullApi)"/>
+			<property name="minimum" value="1"/>
+			<property  name="maximum" value="1"/>
+			<property name="message" value="package-info.java is missing required null-safety annotation @NonNullApi."/>
+			<property name="ignoreComments" value="true"/>
+		</module>
  	</module>
 
 	<!--package-info checker -->

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -246,6 +246,7 @@
 			<property name="format" value="(@NonNullFields|@org\.springframework\.lang\.NonNullFields)"/>
 			<property name="minimum" value="1"/>
 			<property  name="maximum" value="1"/>
+			<property name="severity" value="warning"/>
 			<property name="message" value="package-info.java is missing required null-safety annotation @NonNullFields."/>
 			<property name="ignoreComments" value="true"/>
 		</module>
@@ -254,6 +255,7 @@
 			<property name="format" value="(@NonNullApi|@org\.springframework\.lang\.NonNullApi)"/>
 			<property name="minimum" value="1"/>
 			<property  name="maximum" value="1"/>
+			<property name="severity" value="warning"/>
 			<property name="message" value="package-info.java is missing required null-safety annotation @NonNullApi."/>
 			<property name="ignoreComments" value="true"/>
 		</module>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -242,5 +242,7 @@
  	</module>
 
 	<!--package-info checker -->
-	<module name="JavadocPackage"/>
+	<module name="JavadocPackage">
+		<property name="severity" value="warning"/>
+	</module>
 </module>


### PR DESCRIPTION
## Overview

This commit adds the `JavadocPackage` Checkstyle module to the project's configuration file (`checkstyle.xml`). The module is configured to emit a warning message when a `package-info.java` file is missing, rather than throwing an exception. In addition, suppressions have been added to prevent the `JavadocPackage` checks from being applied to packages outside of the `src/main` directory. These suppressions ensure that the module only checks the packages that are relevant to the project and prevents false positives from being reported.

## Deliverables

- [x] Configure the [`JavadocPackage`](https://checkstyle.sourceforge.io/config_javadoc.html#JavadocPackage) Checkstyle module to require `package-info.java` files for all packages under `src/main`.
- [x] Determine if it is possible to require that `package-info.java` files include null-safety annotations – for example, via Checkstyle.
- [x] If it's possible to require that `package-info.java` files include null-safety annotations, configure the necessary infrastructure.
- [x] Introduce missing `package-info.java` files with package-level Javadoc and null-safety annotations.
