### PR TITLE
CaffeineCacheManager:Modify the getCache method to reduce the probability of lock contention.

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
@@ -188,6 +188,10 @@ public class CaffeineCacheManager implements CacheManager {
 	@Override
 	@Nullable
 	public Cache getCache(String name) {
+		Cache cache = this.cacheMap.get(name);
+		if (cache != null) {
+			return cache;
+		}
 		return this.cacheMap.computeIfAbsent(name, cacheName ->
 				this.dynamic ? createCaffeineCache(cacheName) : null);
 	}


### PR DESCRIPTION
Firstly, check whether the cacheMap has cached objects to prevent multiple threads from entering the computeIfAbsent method when the Cache corresponding to the name exists under high concurrency, thereby reducing the probability of blocking and deadlocks.

Fixed: https://github.com/spring-projects/spring-framework/issues/30066