### PR TITLE
Remove extra copy of headers/cookies in WebClient

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -370,8 +370,8 @@ class DefaultWebTestClient implements WebTestClient {
 
 		private ClientRequest.Builder initRequestBuilder() {
 			ClientRequest.Builder builder = ClientRequest.create(this.httpMethod, initUri())
-					.headers(headers -> headers.addAll(initHeaders()))
-					.cookies(cookies -> cookies.addAll(initCookies()))
+					.headers(this::initHeaders)
+					.cookies(this::initCookies)
 					.attributes(attributes -> attributes.putAll(this.attributes));
 			if (this.httpRequestConsumer != null) {
 				builder.httpRequest(this.httpRequestConsumer);
@@ -383,28 +383,21 @@ class DefaultWebTestClient implements WebTestClient {
 			return (this.uri != null ? this.uri : uriBuilderFactory.expand(""));
 		}
 
-		private HttpHeaders initHeaders() {
-			if (CollectionUtils.isEmpty(defaultHeaders)) {
-				return this.headers;
+		private void initHeaders(HttpHeaders out) {
+			if (!CollectionUtils.isEmpty(defaultHeaders)) {
+				out.putAll(defaultHeaders);
 			}
-			HttpHeaders result = new HttpHeaders();
-			result.putAll(defaultHeaders);
-			result.putAll(this.headers);
-			return result;
+			if (!CollectionUtils.isEmpty(this.headers)) {
+				out.putAll(this.headers);
+			}
 		}
 
-		private MultiValueMap<String, String> initCookies() {
-			if (CollectionUtils.isEmpty(this.cookies)) {
-				return (defaultCookies != null ? defaultCookies : new LinkedMultiValueMap<>());
+		private void initCookies(MultiValueMap<String, String> out) {
+			if (!CollectionUtils.isEmpty(defaultCookies)) {
+				out.putAll(defaultCookies);
 			}
-			else if (CollectionUtils.isEmpty(defaultCookies)) {
-				return this.cookies;
-			}
-			else {
-				MultiValueMap<String, String> result = new LinkedMultiValueMap<>();
-				result.putAll(defaultCookies);
-				result.putAll(this.cookies);
-				return result;
+			if (!CollectionUtils.isEmpty(this.cookies)) {
+				out.putAll(this.cookies);
 			}
 		}
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -401,8 +401,6 @@ class DefaultWebClient implements WebClient {
 			return new HttpRequest() {
 				private final URI uri = initUri();
 
-				private final HttpHeaders headers = initHeaders();
-
 				@Override
 				public HttpMethod getMethod() {
 					return httpMethod;
@@ -415,7 +413,9 @@ class DefaultWebClient implements WebClient {
 
 				@Override
 				public HttpHeaders getHeaders() {
-					return this.headers;
+					HttpHeaders headers = new HttpHeaders();
+					initHeaders(headers);
+					return headers;
 				}
 			};
 		}
@@ -488,8 +488,8 @@ class DefaultWebClient implements WebClient {
 				defaultRequest.accept(this);
 			}
 			ClientRequest.Builder builder = ClientRequest.create(this.httpMethod, initUri())
-					.headers(headers -> headers.addAll(initHeaders()))
-					.cookies(cookies -> cookies.addAll(initCookies()))
+					.headers(this::initHeaders)
+					.cookies(this::initCookies)
 					.attributes(attributes -> attributes.putAll(this.attributes));
 			if (this.httpRequestConsumer != null) {
 				builder.httpRequest(this.httpRequestConsumer);
@@ -501,33 +501,21 @@ class DefaultWebClient implements WebClient {
 			return (this.uri != null ? this.uri : uriBuilderFactory.expand(""));
 		}
 
-		private HttpHeaders initHeaders() {
-			if (CollectionUtils.isEmpty(this.headers)) {
-				return (defaultHeaders != null ? defaultHeaders : new HttpHeaders());
+		private void initHeaders(HttpHeaders out) {
+			if (!CollectionUtils.isEmpty(defaultHeaders)) {
+				out.putAll(defaultHeaders);
 			}
-			else if (CollectionUtils.isEmpty(defaultHeaders)) {
-				return this.headers;
-			}
-			else {
-				HttpHeaders result = new HttpHeaders();
-				result.putAll(defaultHeaders);
-				result.putAll(this.headers);
-				return result;
+			if (!CollectionUtils.isEmpty(this.headers)) {
+				out.putAll(this.headers);
 			}
 		}
 
-		private MultiValueMap<String, String> initCookies() {
-			if (CollectionUtils.isEmpty(this.cookies)) {
-				return (defaultCookies != null ? defaultCookies : new LinkedMultiValueMap<>());
+		private void initCookies(MultiValueMap<String, String> out) {
+			if (!CollectionUtils.isEmpty(defaultCookies)) {
+				out.putAll(defaultCookies);
 			}
-			else if (CollectionUtils.isEmpty(defaultCookies)) {
-				return this.cookies;
-			}
-			else {
-				MultiValueMap<String, String> result = new LinkedMultiValueMap<>();
-				result.putAll(defaultCookies);
-				result.putAll(this.cookies);
-				return result;
+			if (!CollectionUtils.isEmpty(this.cookies)) {
+				out.putAll(this.cookies);
 			}
 		}
 	}


### PR DESCRIPTION
When using the reactive webclient with default headers (and cookies) AND headers (and cookies) specified at the request level, there is an additional intermediate map created prior to copying to the final ClientRequest. I believe this can be eliminated in the changes proposed here. 

Here is part of the icicle graph of memory allocations:
<img width="1452" alt="image" src="https://user-images.githubusercontent.com/1082334/223926838-ba9bed2a-6359-4de4-b6f9-c0430cfbf93e.png">

The stuff done in the middle section should go away and be done on the right. Additionally, the fixes in https://github.com/spring-projects/spring-framework/pull/29972 will improve the forEach and ReadOnlyHttpHeaders performance.

The final copy into the ClientRequest used `addAll` but I used `putAll` on the defaults and request-provided values in order to preserve the order of operations. Since it appears that nothing else is setting the headers/cookies on that ClientRequest.Builder using add vs put should not matter.