### PR TITLE
Support DispatcherType.INCLUDE in DefaultServletHttpRequestHandler

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/DefaultServletHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/DefaultServletHttpRequestHandler.java
@@ -18,6 +18,7 @@ package org.springframework.web.servlet.resource;
 
 import java.io.IOException;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
@@ -125,7 +126,12 @@ public class DefaultServletHttpRequestHandler implements HttpRequestHandler, Ser
 			throw new IllegalStateException("A RequestDispatcher could not be located for the default servlet '" +
 					this.defaultServletName + "'");
 		}
-		rd.forward(request, response);
+		if (request.getDispatcherType() == DispatcherType.INCLUDE) {
+			rd.include(request, response);
+		}
+		else {
+			rd.forward(request, response);
+		}
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/DefaultServletHandlerConfigurerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/DefaultServletHandlerConfigurerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.web.servlet.config.annotation;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,6 +87,24 @@ public class DefaultServletHandlerConfigurerTests {
 		String expected = "defaultServlet";
 		assertThat(servletContext.url).as("The ServletContext was not called with the default servlet name").isEqualTo(expected);
 		assertThat(response.getForwardedUrl()).as("The request was not forwarded").isEqualTo(expected);
+	}
+
+	@Test
+	public void handleIncludeRequest() throws Exception {
+		configurer.enable();
+		SimpleUrlHandlerMapping handlerMapping = configurer.buildHandlerMapping();
+		DefaultServletHttpRequestHandler handler = (DefaultServletHttpRequestHandler) handlerMapping.getUrlMap().get("/**");
+
+		assertThat(handler).isNotNull();
+		assertThat(handlerMapping.getOrder()).isEqualTo(Integer.MAX_VALUE);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setDispatcherType(DispatcherType.INCLUDE);
+		handler.handleRequest(request, response);
+
+		String expected = "default";
+		assertThat(servletContext.url).as("The ServletContext was not called with the default servlet name").isEqualTo(expected);
+		assertThat(response.getIncludedUrl()).as("The request was not included").isEqualTo(expected);
 	}
 
 


### PR DESCRIPTION
When serving static resources by enabling the `DefaultServletHttpRequestHandler` you will get an `IllegalStateException` (Response already commited) error when importing a static resource.

I believe this is caused by the fact that `DefaultServletHttpRequestHandler.handleRequest(...)` is always calling `RequestDispatcher.forward(...)` which will set the response to commited. If it were to check the dispatcher type and instead call `RequestDispatcher.include(...)` when the dispatcher type of the request is set to `DispatcherType.INCLUDE`, then everything works as expected.

```
if (request.getDispatcherType() == DispatcherType.INCLUDE) {
	rd.include(request, response);
} else {
	rd.forward(request, response);
}
```