### PR TITLE
CaffeineCacheManager supports async refreshing value

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
@@ -155,6 +155,9 @@ public class CaffeineCacheManager implements CacheManager {
 	/**
 	 * Set the Caffeine CacheLoader to use for building each individual
 	 * {@link CaffeineCache} instance, turning it into a LoadingCache.
+	 * <p>This manager is marked as synchronous, and any previously configured
+	 * {@link #setAsyncCacheLoader(AsyncCacheLoader) AsyncCacheLoader} is
+	 * discarded.
 	 * @see #createNativeCaffeineCache
 	 * @see com.github.benmanes.caffeine.cache.Caffeine#build(CacheLoader)
 	 * @see com.github.benmanes.caffeine.cache.LoadingCache
@@ -163,21 +166,26 @@ public class CaffeineCacheManager implements CacheManager {
 		if (!ObjectUtils.nullSafeEquals(this.cacheLoader, cacheLoader)) {
 			this.cacheLoader = cacheLoader;
 			this.async = false;
+			this.asyncCacheLoader = null;
 			refreshCommonCaches();
 		}
 	}
 
 	/**
-	 * Set the Caffeine CacheLoader to use for building each individual
-	 * {@link CaffeineCache} instance, turning it into a LoadingCache.
+	 * Set the Caffeine AsyncCacheLoader to use for building each individual
+	 * {@link CaffeineCache} instance, turning it into an AsyncLoadingCache
+	 * and exposing its {@code synchronous()} view.
+	 * <p>This manager is marked as asynchronous, and any previously configured
+	 * {@link #setCacheLoader(CacheLoader) CacheLoader} is discarded.
 	 * @see #createNativeCaffeineCache
-	 * @see com.github.benmanes.caffeine.cache.Caffeine#build(CacheLoader)
-	 * @see com.github.benmanes.caffeine.cache.LoadingCache
+	 * @see com.github.benmanes.caffeine.cache.Caffeine#buildAsync(AsyncCacheLoader)
+	 * @see com.github.benmanes.caffeine.cache.AsyncLoadingCache
 	 */
 	public void setAsyncCacheLoader(AsyncCacheLoader<Object, Object> asyncCacheLoader) {
 		if (!ObjectUtils.nullSafeEquals(this.asyncCacheLoader, asyncCacheLoader)) {
 			this.asyncCacheLoader = asyncCacheLoader;
 			this.async = true;
+			this.cacheLoader = null;
 			refreshCommonCaches();
 		}
 	}

--- a/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
@@ -52,6 +53,7 @@ import org.springframework.util.ObjectUtils;
  * @author Stephane Nicoll
  * @author Sam Brannen
  * @author Brian Clozel
+ * @author Zhuozhi Ji
  * @since 4.3
  * @see CaffeineCache
  */
@@ -62,9 +64,14 @@ public class CaffeineCacheManager implements CacheManager {
 	@Nullable
 	private CacheLoader<Object, Object> cacheLoader;
 
+	@Nullable
+	private AsyncCacheLoader<Object, Object> asyncCacheLoader;
+
 	private boolean allowNullValues = true;
 
 	private boolean dynamic = true;
+
+	private boolean async = false;
 
 	private final Map<String, Cache> cacheMap = new ConcurrentHashMap<>(16);
 
@@ -155,6 +162,22 @@ public class CaffeineCacheManager implements CacheManager {
 	public void setCacheLoader(CacheLoader<Object, Object> cacheLoader) {
 		if (!ObjectUtils.nullSafeEquals(this.cacheLoader, cacheLoader)) {
 			this.cacheLoader = cacheLoader;
+			this.async = false;
+			refreshCommonCaches();
+		}
+	}
+
+	/**
+	 * Set the Caffeine CacheLoader to use for building each individual
+	 * {@link CaffeineCache} instance, turning it into a LoadingCache.
+	 * @see #createNativeCaffeineCache
+	 * @see com.github.benmanes.caffeine.cache.Caffeine#build(CacheLoader)
+	 * @see com.github.benmanes.caffeine.cache.LoadingCache
+	 */
+	public void setAsyncCacheLoader(AsyncCacheLoader<Object, Object> asyncCacheLoader) {
+		if (!ObjectUtils.nullSafeEquals(this.asyncCacheLoader, asyncCacheLoader)) {
+			this.asyncCacheLoader = asyncCacheLoader;
+			this.async = true;
 			refreshCommonCaches();
 		}
 	}
@@ -257,7 +280,12 @@ public class CaffeineCacheManager implements CacheManager {
 	 * @see #createCaffeineCache
 	 */
 	protected com.github.benmanes.caffeine.cache.Cache<Object, Object> createNativeCaffeineCache(String name) {
-		return (this.cacheLoader != null ? this.cacheBuilder.build(this.cacheLoader) : this.cacheBuilder.build());
+		if (this.async) {
+			return (this.asyncCacheLoader != null ? this.cacheBuilder.buildAsync(this.asyncCacheLoader).synchronous() : this.cacheBuilder.build());
+		}
+		else {
+			return (this.cacheLoader != null ? this.cacheBuilder.build(this.cacheLoader) : this.cacheBuilder.build());
+		}
 	}
 
 	/**


### PR DESCRIPTION
Prior to this commit, the current `CaffeineCacheManager` supports setting the cache builder through `setCaffeine`, but only supports the synchronous `cacheLoader` (which cannot be set by Caffeine builder).

There is a useful feature in Caffeine: `refreshAfterWrite` which allows us to get the latest value of the cache as early as possible in the background (note that this itself is an asynchronous operation), instead of synchronously getting data from the data source when it expires.

The current `cacheLoader` can also be used to refresh the cache, but due to its synchronous blocking call characteristics, this will reduce the cache refresh rate, resulting in a lot of delay in the actual refresh time of many cache items. By using `asyncCacheLoader`, the blocking of the refresh thread can be avoided, thereby speeding up the cache refresh rate (how to implement efficient asynchronous calls is guaranteed by the `asyncCacheLoader` provider).

Because of the use of `com.github.benmanes.caffeine.cache.AsyncLoadingCache#synchronous`, it will create a new view for the cache, which will change the action of fetching the cache from asynchronous to synchronous, so this will not break the existing APIs