### PR TITLE
Optimize some iterations in BodyExtractor and BodyInserter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/AbstractClientHttpRequest.java
@@ -147,8 +147,10 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 			this.commitActions.add(writeAction);
 		}
 
-		List<? extends Publisher<Void>> actions = this.commitActions.stream()
-				.map(Supplier::get).toList();
+		List<Publisher<Void>> actions = new ArrayList<>(this.commitActions.size());
+		for (Supplier<? extends Publisher<Void>> commitAction : this.commitActions) {
+			actions.add(commitAction.get());
+		}
 
 		return Flux.concat(actions).then();
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyInserters.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyInserters.java
@@ -375,7 +375,8 @@ public abstract class BodyInserters {
 		MediaType mediaType = outputMessage.getHeaders().getContentType();
 		for (HttpMessageWriter<?> messageWriter : context.messageWriters()) {
 			if (messageWriter.canWrite(bodyType, mediaType)) {
-				return write(publisher, bodyType, mediaType, outputMessage, context, cast(messageWriter));
+				HttpMessageWriter<Object> typedMessageWriter = cast(messageWriter);
+				return write(publisher, bodyType, mediaType, outputMessage, context, typedMessageWriter);
 			}
 		}
 		return Mono.error(unsupportedError(bodyType, context, mediaType));


### PR DESCRIPTION
Using iterators for trivial findFirst and toList cases uses less CPU and memory (in these cases, not while costing readability)
Here is an icicle graph example of the CPU usage before 
<img width="1473" alt="image" src="https://user-images.githubusercontent.com/1082334/226135825-6ab57f25-6254-45d3-9816-b3d545210508.png">
and here it is after:
<img width="1468" alt="image" src="https://user-images.githubusercontent.com/1082334/226135943-2daad2fa-07bb-4422-a434-997eb18d60bb.png">
There was about a 10-15% overhead with the streams usage, which we can save on by doing this.