### PR TITLE
Lenient handling of unencoded URIs in ForwardedHeaderTransformer

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/ForwardedHeaderTransformer.java
@@ -100,7 +100,8 @@ public class ForwardedHeaderTransformer implements Function<ServerHttpRequest, S
 		if (hasForwardedHeaders(request)) {
 			ServerHttpRequest.Builder builder = request.mutate();
 			if (!this.removeOnly) {
-				URI uri = UriComponentsBuilder.fromHttpRequest(request).build(true).toUri();
+				boolean isEncoded = request.getURI().toString().contains("%");
+				URI uri = UriComponentsBuilder.fromHttpRequest(request).build(isEncoded).toUri();
 				builder.uri(uri);
 				String prefix = getForwardedPrefix(request);
 				if (prefix != null) {

--- a/spring-web/src/test/java/org/springframework/web/server/adapter/ForwardedHeaderTransformerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/adapter/ForwardedHeaderTransformerTests.java
@@ -134,6 +134,21 @@ class ForwardedHeaderTransformerTests {
 	}
 
 	@Test
+	void shouldHandleUnencodedUri() throws Exception {
+			HttpHeaders headers = new HttpHeaders();
+			headers.add("Forwarded", "host=84.198.58.199;proto=https");
+			ServerHttpRequest request = MockServerHttpRequest
+							.method(HttpMethod.GET, URI.create("https://example.com/a?q=1+1=2"))
+							.headers(headers)
+							.build();
+
+			request = this.requestMutator.apply(request);
+
+			assertThat(request.getURI()).isEqualTo(URI.create("https://84.198.58.199/a?q=1+1=2"));
+			assertForwardedHeadersRemoved(request);
+	}
+
+	@Test
 	void shouldConcatenatePrefixes() throws Exception {
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("X-Forwarded-Prefix", "/first,/second");


### PR DESCRIPTION
Currently `ForwardedHeaderTransformer` assumes the url is url encoded which is not necessarily the case.

I experienced an issue where the a query parameter as part of the OpenID Connect flow contains a "=" character which fails the `verifyUriComponent` check in `HierarchicalUriComponents`.