### PR TITLE
Use String.equals() in LiteralPathElement

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/pattern/LiteralPathElement.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/LiteralPathElement.java
@@ -31,6 +31,8 @@ class LiteralPathElement extends PathElement {
 
 	private final char[] text;
 
+	private final String textString;
+
 	private final int len;
 
 	private final boolean caseSensitive;
@@ -50,6 +52,7 @@ class LiteralPathElement extends PathElement {
 				this.text[i] = Character.toLowerCase(literalText[i]);
 			}
 		}
+		this.textString = new String(this.text);
 	}
 
 
@@ -70,10 +73,9 @@ class LiteralPathElement extends PathElement {
 		}
 
 		if (this.caseSensitive) {
-			for (int i = 0; i < this.len; i++) {
-				if (value.charAt(i) != this.text[i]) {
-					return false;
-				}
+			// This typically uses a JVM intrinsic
+			if (!this.textString.equals(value)) {
+				return false;
 			}
 		}
 		else {
@@ -124,7 +126,7 @@ class LiteralPathElement extends PathElement {
 
 	@Override
 	public String toString() {
-		return "Literal(" + String.valueOf(this.text) + ")";
+		return "Literal(" + this.textString + ")";
 	}
 
 }


### PR DESCRIPTION
[String.equals()](https://github.com/openjdk/jdk/blob/jdk-17%2B0/src/java.base/share/classes/java/lang/String.java#L1027) eventually calls [StringLatin1.equals()](https://github.com/openjdk/jdk/blob/jdk-17%2B0/src/java.base/share/classes/java/lang/StringLatin1.java#L94) which uses processor-specific intrinsics. They are available for major architectures and typically use some sort of processor-optimized vector operations, which should be faster than the current for-loop.

Before:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/1082334/226176958-97a1f610-4bef-46ed-8ba2-24ace2eb8a9f.png">

After:
<img width="1462" alt="image" src="https://user-images.githubusercontent.com/1082334/226176837-02990df8-bd30-41f4-a9e0-9e2d671ac4bc.png">
