### PR TITLE
Cache ServerHttpRequest::getMethod in AbstractServerHttpRequest

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorNetty2ServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorNetty2ServerHttpRequest.java
@@ -63,6 +63,8 @@ class ReactorNetty2ServerHttpRequest extends AbstractServerHttpRequest {
 
 	private final Netty5DataBufferFactory bufferFactory;
 
+	private final HttpMethod method;
+
 
 	public ReactorNetty2ServerHttpRequest(HttpServerRequest request, Netty5DataBufferFactory bufferFactory)
 			throws URISyntaxException {
@@ -71,6 +73,7 @@ class ReactorNetty2ServerHttpRequest extends AbstractServerHttpRequest {
 		Assert.notNull(bufferFactory, "DataBufferFactory must not be null");
 		this.request = request;
 		this.bufferFactory = bufferFactory;
+		this.method = HttpMethod.valueOf(request.method().name());
 	}
 
 	private static URI initUri(HttpServerRequest request) throws URISyntaxException {
@@ -141,7 +144,7 @@ class ReactorNetty2ServerHttpRequest extends AbstractServerHttpRequest {
 
 	@Override
 	public HttpMethod getMethod() {
-		return HttpMethod.valueOf(this.request.method().name());
+		return this.method;
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ReactorServerHttpRequest.java
@@ -61,6 +61,8 @@ class ReactorServerHttpRequest extends AbstractServerHttpRequest {
 
 	private final NettyDataBufferFactory bufferFactory;
 
+	private final HttpMethod method;
+
 
 	public ReactorServerHttpRequest(HttpServerRequest request, NettyDataBufferFactory bufferFactory)
 			throws URISyntaxException {
@@ -69,6 +71,7 @@ class ReactorServerHttpRequest extends AbstractServerHttpRequest {
 		Assert.notNull(bufferFactory, "DataBufferFactory must not be null");
 		this.request = request;
 		this.bufferFactory = bufferFactory;
+		this.method = HttpMethod.valueOf(request.method().name());
 	}
 
 	private static URI initUri(HttpServerRequest request) throws URISyntaxException {
@@ -111,7 +114,7 @@ class ReactorServerHttpRequest extends AbstractServerHttpRequest {
 
 	@Override
 	public HttpMethod getMethod() {
-		return HttpMethod.valueOf(this.request.method().name());
+		return this.method;
 	}
 
 	@Override


### PR DESCRIPTION
ServerHttpRequest.method() is called twice on each HttpMethodPredicate and within CorsUtils.isPreFlightRequest(). Each call has to do a roundtrip all the way into netty and it does a bunch of String hashing to resolve the proper Spring HttpMethod. I moved this work to be done once upon request construction since the field read is cheaper.