### PR TITLE
Fixed circular reference exception using @Async annotation

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AbstractAdvisingBeanPostProcessor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AbstractAdvisingBeanPostProcessor.java
@@ -16,7 +16,9 @@
 
 package org.springframework.aop.framework;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.aop.Advisor;
@@ -43,6 +45,8 @@ public abstract class AbstractAdvisingBeanPostProcessor extends ProxyProcessorSu
 	protected boolean beforeExistingAdvisors = false;
 
 	private final Map<Class<?>, Boolean> eligibleBeans = new ConcurrentHashMap<>(256);
+
+	protected final Set<Object> resolvedBean = new HashSet<>(16);
 
 
 	/**
@@ -88,6 +92,10 @@ public abstract class AbstractAdvisingBeanPostProcessor extends ProxyProcessorSu
 	public Object postProcessAfterInitialization(Object bean, String beanName) {
 		if (this.advisor == null || bean instanceof AopInfrastructureBean) {
 			// Ignore AOP infrastructure such as scoped proxies.
+			return bean;
+		}
+
+		if(!this.resolvedBean.add(bean)){
 			return bean;
 		}
 

--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/AsyncAnnotationBeanPostProcessor.java
@@ -154,4 +154,9 @@ public class AsyncAnnotationBeanPostProcessor extends AbstractBeanFactoryAwareAd
 		this.advisor = advisor;
 	}
 
+	@Override
+	public Object getEarlyBeanReference(Object bean, String beanName) throws BeansException {
+		return super.postProcessAfterInitialization(bean, beanName);
+	}
+
 }


### PR DESCRIPTION
### Problem description

Using the `@Async` annotation when `beanA` and `beanB` are circularly referenced will throw an error.

### Reasons

The bean with `@Async` annotation is created as a proxy instance during initialization, and the bean that is retrieved from the cache of the earlier singleton is still the original instance.

### Solution

When the bean is fetched from the cache of the earlier singleton, it will be created as a proxy instance. The initialization phase will be checked and processing will be skipped if the proxy instance has already been created.

### Source Code

- [BeanA](https://github.com/wangzhengsi/0321Code/blob/master/src/main/java/com/tempura/test/service/BeanA.java)

- [BeanB](https://github.com/wangzhengsi/0321Code/blob/master/src/main/java/com/tempura/test/service/BeanB.java)

### Error message

```
org.springframework.beans.factory.BeanCurrentlyInCreationException: Error creating bean with name 'beanA': Bean with name 'beanA' has been injected into other beans [beanB] in its raw version as part of a circular reference, but has eventually been wrapped. This means that said other beans do not use the final version of the bean. This is often the result of over-eager type matching - consider using 'getBeanNamesOfType' with the 'allowEagerInit' flag turned off, for example.
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:622) ~[spring-beans-5.1.9.RELEASE.jar:5.1.9.RELEASE]