### PR TITLE
Add assert null validations for DefaultServerResponseBuilder

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerResponseBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerResponseBuilder.java
@@ -91,6 +91,7 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder header(String headerName, String... headerValues) {
+		Assert.notNull(headerName, "HeaderName must not be null");
 		for (String headerValue : headerValues) {
 			this.headers.add(headerName, headerValue);
 		}
@@ -99,6 +100,7 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder headers(Consumer<HttpHeaders> headersConsumer) {
+		Assert.notNull(headersConsumer, "HeadersConsumer must not be null");
 		headersConsumer.accept(this.headers);
 		return this;
 	}
@@ -112,18 +114,21 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder cookies(Consumer<MultiValueMap<String, ResponseCookie>> cookiesConsumer) {
+		Assert.notNull(cookiesConsumer, "CookiesConsumer must not be null");
 		cookiesConsumer.accept(this.cookies);
 		return this;
 	}
 
 	@Override
 	public ServerResponse.BodyBuilder allow(HttpMethod... allowedMethods) {
+		Assert.notNull(allowedMethods, "Http allowedMethod must not be null");
 		this.headers.setAllow(new LinkedHashSet<>(Arrays.asList(allowedMethods)));
 		return this;
 	}
 
 	@Override
 	public ServerResponse.BodyBuilder allow(Set<HttpMethod> allowedMethods) {
+		Assert.notNull(allowedMethods, "Http allowedMethod must not be null");
 		this.headers.setAllow(allowedMethods);
 		return this;
 	}
@@ -142,6 +147,7 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder eTag(String etag) {
+		Assert.notNull(etag, "etag must not be null");
 		if (!etag.startsWith("\"") && !etag.startsWith("W/\"")) {
 			etag = "\"" + etag;
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerResponseBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerResponseBuilder.java
@@ -70,6 +70,7 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder header(String headerName, String... headerValues) {
+		Assert.notNull(headerName, "HeaderName must not be null");
 		for (String headerValue : headerValues) {
 			this.headers.add(headerName, headerValue);
 		}
@@ -78,6 +79,7 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder headers(Consumer<HttpHeaders> headersConsumer) {
+		Assert.notNull(headersConsumer, "HeaderConsumer must not be null");
 		headersConsumer.accept(this.headers);
 		return this;
 	}
@@ -91,18 +93,21 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder cookies(Consumer<MultiValueMap<String, Cookie>> cookiesConsumer) {
+		Assert.notNull(cookiesConsumer, "CookiesConsumer must not be null");
 		cookiesConsumer.accept(this.cookies);
 		return this;
 	}
 
 	@Override
 	public ServerResponse.BodyBuilder allow(HttpMethod... allowedMethods) {
+		Assert.notNull(allowedMethods, "Http AllowedMethods must not be null");
 		this.headers.setAllow(new LinkedHashSet<>(Arrays.asList(allowedMethods)));
 		return this;
 	}
 
 	@Override
 	public ServerResponse.BodyBuilder allow(Set<HttpMethod> allowedMethods) {
+		Assert.notNull(allowedMethods, "Http AllowedMethods must not be null");
 		this.headers.setAllow(allowedMethods);
 		return this;
 	}
@@ -115,12 +120,14 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder contentType(MediaType contentType) {
+		Assert.notNull(contentType, "ContentType must not be null");
 		this.headers.setContentType(contentType);
 		return this;
 	}
 
 	@Override
 	public ServerResponse.BodyBuilder eTag(String etag) {
+		Assert.notNull(etag, "etag must not be null");
 		if (!etag.startsWith("\"") && !etag.startsWith("W/\"")) {
 			etag = "\"" + etag;
 		}


### PR DESCRIPTION
- Add Assert null validations to DefaultServerResponseBuilder in spring-webflux modules
- Add Assert null validations to DefaultServerResponseBuilder in spring-webmvc modules
- Provides consistency between implementation and spring package-info.