### PR TITLE
Fix anchor in link to "Web on Reactive Stack" chapter

### DIFF
--- a/framework-docs/src/docs/asciidoc/index.adoc
+++ b/framework-docs/src/docs/asciidoc/index.adoc
@@ -13,7 +13,7 @@ Spring MVC Test, WebTestClient.
 JDBC, R2DBC, O/R Mapping, XML Marshalling.
 <<web.adoc#spring-web, Web Servlet>> :: Spring MVC, WebSocket, SockJS,
 STOMP Messaging.
-<<web-reactive.adoc#spring-webflux, Web Reactive>> :: Spring WebFlux, WebClient,
+<<web-reactive.adoc#spring-web-reactive, Web Reactive>> :: Spring WebFlux, WebClient,
 WebSocket, RSocket.
 <<integration.adoc#spring-integration, Integration>> :: REST Clients, JMS, JCA, JMX,
 Email, Tasks, Scheduling, Caching, Observability.


### PR DESCRIPTION
handle <<web-reactive.adoc#spring-webflux(**_Anchor doesn't resolve_**), Web Reactive>>