### PR TITLE
Replace `Collections.unmodifiableList(new ArrayList(..))` with `List.copyOf()`

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
@@ -93,7 +93,7 @@ public class PayloadMethodArgumentResolver implements HandlerMethodArgumentResol
 			@Nullable ReactiveAdapterRegistry registry, boolean useDefaultResolution) {
 
 		Assert.isTrue(!CollectionUtils.isEmpty(decoders), "At least one Decoder is required");
-		this.decoders = Collections.unmodifiableList(new ArrayList<>(decoders));
+		this.decoders = List.copyOf(decoders);
 		this.validator = validator;
 		this.adapterRegistry = registry != null ? registry : ReactiveAdapterRegistry.getSharedInstance();
 		this.useDefaultResolution = useDefaultResolution;

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
@@ -17,7 +17,6 @@
 package org.springframework.messaging.handler.annotation.reactive;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/spring-messaging/src/main/java/org/springframework/messaging/rsocket/DefaultMetadataExtractor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/rsocket/DefaultMetadataExtractor.java
@@ -16,7 +16,6 @@
 
 package org.springframework.messaging.rsocket;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -73,7 +72,7 @@ public class DefaultMetadataExtractor implements MetadataExtractor, MetadataExtr
 	 * Constructor with list of decoders for de-serializing metadata entries.
 	 */
 	public DefaultMetadataExtractor(List<Decoder<?>> decoders) {
-		this.decoders = Collections.unmodifiableList(new ArrayList<>(decoders));
+		this.decoders = List.copyOf(decoders);
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/http/converter/AbstractHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/AbstractHttpMessageConverter.java
@@ -19,7 +19,6 @@ package org.springframework.http.converter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/spring-web/src/main/java/org/springframework/http/converter/AbstractHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/AbstractHttpMessageConverter.java
@@ -100,7 +100,7 @@ public abstract class AbstractHttpMessageConverter<T> implements HttpMessageConv
 	 */
 	public void setSupportedMediaTypes(List<MediaType> supportedMediaTypes) {
 		Assert.notEmpty(supportedMediaTypes, "MediaType List must not be empty");
-		this.supportedMediaTypes = Collections.unmodifiableList(new ArrayList<>(supportedMediaTypes));
+		this.supportedMediaTypes = List.copyOf(supportedMediaTypes);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -949,7 +949,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		public PathSegmentComponent(List<String> pathSegments) {
 			Assert.notNull(pathSegments, "List must not be null");
-			this.pathSegments = Collections.unmodifiableList(new ArrayList<>(pathSegments));
+			this.pathSegments = List.copyOf(pathSegments);
 		}
 
 		@Override


### PR DESCRIPTION
This PR replaces `Collections.unmodifiableList()` with `List.copyOf()`. 
It creates a new immutable list by copying the elements of the given list.
Using `List.copyOf()`  results in more readable and prevents unexpected bugs, and makes the code easier to maintain.