### PR TITLE
Update versions in Javadoc

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
@@ -266,11 +266,11 @@ public enum SpelMessage {
 	MAX_ARRAY_ELEMENTS_THRESHOLD_EXCEEDED(Kind.ERROR, 1075,
 			"Array declares too many elements, exceeding the threshold of ''{0}''"),
 
-	/** @since 5.3.26 */
+	/** @since 5.2.23 */
 	MAX_REPEATED_TEXT_SIZE_EXCEEDED(Kind.ERROR, 1076,
 			"Repeated text results in too many characters, exceeding the threshold of ''{0}''"),
 
-	/** @since 5.3.26 */
+	/** @since 5.2.23 */
 	MAX_REGEX_LENGTH_EXCEEDED(Kind.ERROR, 1077,
 			"Regular expression contains too many characters, exceeding the threshold of ''{0}''");
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/OpMultiply.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/OpMultiply.java
@@ -56,7 +56,7 @@ public class OpMultiply extends Operator {
 
 	/**
 	 * Maximum number of characters permitted in repeated text.
-	 * @since 5.3.26
+	 * @since 5.2.23
 	 */
 	private static final int MAX_REPEATED_TEXT_SIZE = 256;
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/OperatorMatches.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/OperatorMatches.java
@@ -45,7 +45,7 @@ public class OperatorMatches extends Operator {
 
 	/**
 	 * Maximum number of characters permitted in a regular expression.
-	 * @since 5.3.26
+	 * @since 5.2.23
 	 */
 	private static final int MAX_REGEX_LENGTH = 256;
 
@@ -54,18 +54,18 @@ public class OperatorMatches extends Operator {
 
 	/**
 	 * Create a new {@link OperatorMatches} instance.
-	 * @deprecated as of Spring Framework 5.3.26 in favor of invoking
+	 * @deprecated as of Spring Framework 5.2.23 in favor of invoking
 	 * {@link #OperatorMatches(ConcurrentMap, int, int, SpelNodeImpl...)}
 	 * with a shared pattern cache instead
 	 */
-	@Deprecated(since = "5.3.26")
+	@Deprecated(since = "5.2.23")
 	public OperatorMatches(int startPos, int endPos, SpelNodeImpl... operands) {
 		this(new ConcurrentHashMap<>(), startPos, endPos, operands);
 	}
 
 	/**
 	 * Create a new {@link OperatorMatches} instance with a shared pattern cache.
-	 * @since 5.3.26
+	 * @since 5.2.23
 	 */
 	public OperatorMatches(ConcurrentMap<String, Pattern> patternCache, int startPos, int endPos, SpelNodeImpl... operands) {
 		super("matches", startPos, endPos, operands);


### PR DESCRIPTION
This PR updates versions in Javadoc for gh-30140, gh-30142, and gh-30144 as they are also backported to the 5.2.x branch.

See gh-30140
See gh-30142
See gh-30144