### PR TITLE
Allow `BeanPropertyRowMapper` subclass to add mapped properties dynamically

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/BeanPropertyRowMapper.java
@@ -273,6 +273,18 @@ public class BeanPropertyRowMapper<T> implements RowMapper<T> {
 	}
 
 	/**
+	* Add a mapped property to the existing map of properties.
+	* @param propertyName the property name
+	* @param propertyDescriptor the property descriptor
+	*/
+	protected void addProperty(String propertyName, PropertyDescriptor propertyDescriptor) {
+		if (propertyDescriptor.getWriteMethod() != null) {
+			this.mappedProperties.put(propertyName, propertyDescriptor);
+			this.mappedPropertyNames.add(propertyDescriptor.getName());
+		}
+	}
+
+	/**
 	 * Convert the given name to lower case.
 	 * By default, conversions will happen within the US locale.
 	 * @param name the original name

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/AbstractRowMapperTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/AbstractRowMapperTests.java
@@ -28,6 +28,7 @@ import java.util.Date;
 
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.PropertyAccessorFactory;
+import org.springframework.jdbc.core.test.AddPropertyPerson;
 import org.springframework.jdbc.core.test.ConcretePerson;
 import org.springframework.jdbc.core.test.ConstructorPerson;
 import org.springframework.jdbc.core.test.DatePerson;
@@ -89,6 +90,13 @@ public abstract class AbstractRowMapperTests {
 		assertThat(person.birth_date()).usingComparator(Date::compareTo).isEqualTo(new java.util.Date(1221222L));
 		assertThat(person.balance()).isEqualTo(new BigDecimal("1234.56"));
 		verifyPersonViaBeanWrapper(person);
+	}
+
+	protected void verifyPerson(AddPropertyPerson person) {
+		assertThat(person.getNickname()).isEqualTo("Bubba");
+		assertThat(person.getYear()).isEqualTo(22L);
+		assertThat(person.getDateOfBirth()).usingComparator(Date::compareTo).isEqualTo(new java.util.Date(1221222L));
+		assertThat(person.getBalance()).isEqualTo(new BigDecimal("1234.56"));
 	}
 
 	protected void verifyPersonViaBeanWrapper(Object person) {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/BeanPropertyRowMapperTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/BeanPropertyRowMapperTests.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.jdbc.core.test.AddPropertyBeanPropertyRowMapper;
+import org.springframework.jdbc.core.test.AddPropertyPerson;
 import org.springframework.jdbc.core.test.ConcretePerson;
 import org.springframework.jdbc.core.test.DatePerson;
 import org.springframework.jdbc.core.test.EmailPerson;
@@ -177,6 +179,16 @@ class BeanPropertyRowMapperTests extends AbstractRowMapperTests {
 	void underscoreName(String input, String expected) {
 		BeanPropertyRowMapper<?> mapper = new BeanPropertyRowMapper<>(Object.class);
 		assertThat(mapper.underscoreName(input)).isEqualTo(expected);
+	}
+
+	@Test
+	void staticQueryWithRowMapperAddProperty() throws Exception {
+		Mock mock = new Mock();
+		AddPropertyPerson person = mock.getJdbcTemplate().queryForObject(
+				"select name, age, birth_date, balance from people",
+				new AddPropertyBeanPropertyRowMapper<>(AddPropertyPerson.class));
+		verifyPerson(person);
+		mock.verifyClosed();
 	}
 
 }

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/test/AddPropertyBeanPropertyRowMapper.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/test/AddPropertyBeanPropertyRowMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.core.test;
+
+import it.fineco.services.common.jdbc.annotation.Column;
+import org.springframework.beans.BeanUtils;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+
+/**
+ * @author Giuseppe Milicia
+ */
+public class AddPropertyBeanPropertyRowMapper<T> extends BeanPropertyRowMapper<T> {
+
+	@Override
+	protected void initialize(Class<T> mappedClass) {
+		super.initialize(mappedClass);
+
+		for (PropertyDescriptor pd : BeanUtils.getPropertyDescriptors(mappedClass)) {
+			Method writeMethod = pd.getWriteMethod();
+			if (writeMethod != null) {
+				AddPropertyColumn columnAnnotation = writeMethod.getAnnotation(AddPropertyColumn.class);
+				super.addProperty(columnAnnotation.name(), pd);
+			}
+		}
+	}
+
+}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/test/AddPropertyColumn.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/test/AddPropertyColumn.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.core.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Giuseppe Milicia
+ */
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AddPropertyColumn {
+    String name();
+}
+

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/test/AddPropertyPerson.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/test/AddPropertyPerson.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.core.test;
+
+import java.math.BigDecimal;
+
+/**
+ * @author Giuseppe Milicia
+ */
+public class AddPropertyPerson {
+
+	private String nickname;
+
+	private long year;
+
+	private java.util.Date dateOfBirth;
+
+	private BigDecimal balance;
+
+	public AddPropertyPerson() {
+	}
+
+	public String getNickname() {
+		return nickname;
+	}
+
+	@AddPropertyColumn(name = "name")
+	public void setNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
+	public long getYear() {
+		return year;
+	}
+
+	@AddPropertyColumn(name = "age")
+	public void setYear(long year) {
+		this.year = year;
+	}
+
+	public java.util.Date getDateOfBirth() {
+		return dateOfBirth;
+	}
+
+	@AddPropertyColumn(name = "birth_date")
+	public void setDateOfBirth(java.util.Date dateOfBirth) {
+		this.dateOfBirth = dateOfBirth;
+	}
+
+	public BigDecimal getBalance() {
+		return balance;
+	}
+
+	@AddPropertyColumn(name = "balance")
+	public void setBalance(BigDecimal balance) {
+		this.balance = balance;
+	}
+
+}


### PR DESCRIPTION
This commit adds a new method `addProperty` that allows for the dynamic addition of mapped properties to the existing map of properties. The method takes in the name of the property and its descriptor, and only adds the property if it has a write method. This allows for greater flexibility in mapping properties and enables subclasses to add properties dynamically as needed, extending the functionality of the parent class.