### PR TITLE
Fix example in Javadoc for `@EnableWebSocket`

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/EnableWebSocket.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/EnableWebSocket.java
@@ -49,7 +49,7 @@ import org.springframework.context.annotation.Import;
  *         registry.addHandler(echoWebSocketHandler(), "/echo").withSockJS();
  * 	   }
  *
- *	   &#064;Override
+ *	   &#064;Bean
  *	   public WebSocketHandler echoWebSocketHandler() {
  *         return new EchoWebSocketHandler();
  *     }


### PR DESCRIPTION
The echoWebSocketHandler method is not in the WebSocketConfigurer interface. It should be the @Bean annotation