### PR TITLE
Improve performance of canRead() in HttpMessageReader's

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeType.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,7 +268,8 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 	 * @return whether the subtype is a wildcard
 	 */
 	public boolean isWildcardSubtype() {
-		return WILDCARD_TYPE.equals(getSubtype()) || getSubtype().startsWith("*+");
+		String subtype = getSubtype();
+		return WILDCARD_TYPE.equals(subtype) || subtype.startsWith("*+");
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -181,7 +181,7 @@ public abstract class MimeTypeUtils {
 
 	static {
 		// Not using "parseMimeType" to avoid static init cost
-		ALL = new MimeType("*", "*");
+		ALL = new MimeType(MimeType.WILDCARD_TYPE, MimeType.WILDCARD_TYPE);
 		APPLICATION_GRAPHQL = new MimeType("application", "graphql+json");
 		APPLICATION_JSON = new MimeType("application", "json");
 		APPLICATION_OCTET_STREAM = new MimeType("application", "octet-stream");

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -435,7 +435,7 @@ public class MediaType extends MimeType implements Serializable {
 
 	static {
 		// Not using "valueOf' to avoid static init cost
-		ALL = new MediaType("*", "*");
+		ALL = new MediaType(MimeType.WILDCARD_TYPE, MimeType.WILDCARD_TYPE);
 		APPLICATION_ATOM_XML = new MediaType("application", "atom+xml");
 		APPLICATION_CBOR = new MediaType("application", "cbor");
 		APPLICATION_FORM_URLENCODED = new MediaType("application", "x-www-form-urlencoded");

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
@@ -104,12 +104,14 @@ public class FormHttpMessageReader extends LoggingCodecSupport
 
 	@Override
 	public boolean canRead(ResolvableType elementType, @Nullable MediaType mediaType) {
-		boolean multiValueUnresolved =
-				elementType.hasUnresolvableGenerics() &&
-						MultiValueMap.class.isAssignableFrom(elementType.toClass());
-
-		return ((MULTIVALUE_STRINGS_TYPE.isAssignableFrom(elementType) || multiValueUnresolved) &&
-				(mediaType == null || MediaType.APPLICATION_FORM_URLENCODED.isCompatibleWith(mediaType)));
+		if (mediaType == null || MediaType.APPLICATION_FORM_URLENCODED.isCompatibleWith(mediaType)) {
+			if (MultiValueMap.class.isAssignableFrom(elementType.toClass()) &&
+					elementType.hasUnresolvableGenerics()) {
+				return true;
+			}
+			return MULTIVALUE_STRINGS_TYPE.isAssignableFrom(elementType);
+		}
+		return false;
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Decoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Decoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,15 +97,15 @@ public abstract class AbstractJackson2Decoder extends Jackson2CodecSupport imple
 
 	@Override
 	public boolean canDecode(ResolvableType elementType, @Nullable MimeType mimeType) {
+		// Skip String: CharSequenceDecoder + "*/*" comes after
+		if (CharSequence.class.isAssignableFrom(elementType.toClass()) || !supportsMimeType(mimeType)) {
+			return false;
+		}
 		ObjectMapper mapper = selectObjectMapper(elementType, mimeType);
 		if (mapper == null) {
 			return false;
 		}
 		JavaType javaType = mapper.constructType(elementType.getType());
-		// Skip String: CharSequenceDecoder + "*/*" comes after
-		if (CharSequence.class.isAssignableFrom(elementType.toClass()) || !supportsMimeType(mimeType)) {
-			return false;
-		}
 		if (!logger.isDebugEnabled()) {
 			return mapper.canDeserialize(javaType);
 		}

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,19 +81,21 @@ public class MultipartHttpMessageReader extends LoggingCodecSupport
 		return MIME_TYPES;
 	}
 
-	@Override
-	public boolean canRead(ResolvableType elementType, @Nullable MediaType mediaType) {
-		if (MULTIPART_VALUE_TYPE.isAssignableFrom(elementType)) {
-			if (mediaType == null) {
+	private boolean supportsMediaType(@Nullable MediaType mediaType) {
+		if (mediaType == null) {
+			return true;
+		}
+		for (MediaType supportedMediaType : MIME_TYPES) {
+			if (supportedMediaType.isCompatibleWith(mediaType)) {
 				return true;
-			}
-			for (MediaType supportedMediaType : MIME_TYPES) {
-				if (supportedMediaType.isCompatibleWith(mediaType)) {
-					return true;
-				}
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public boolean canRead(ResolvableType elementType, @Nullable MediaType mediaType) {
+		return supportsMediaType(mediaType) && MULTIPART_VALUE_TYPE.isAssignableFrom(elementType);
 	}
 
 


### PR DESCRIPTION
* A lot of the decoders use MimeType.ALL, so use MimeType.WILDCARD_TYPE for faster String.equals() using reference comparisons, specifically in MimeType.isWildcardType().
* Move cheaper checks to the front of the canRead implementations. The media/mime checks appear to be cheaper than Class.isAssignableFrom which is cheaper than the ResolvableType checks, so putting them in the correct order (while preserving the and/or logic) gives an improvement. 

before icicle graph for CPU from my [stress test](https://gist.github.com/yuzawa-san/5102be26fb9e4472419c23b39c4524b2). this is for a JSON payload, thus the other readers should be skipped and take as little cpu as possible:
<img width="1459" alt="image" src="https://user-images.githubusercontent.com/1082334/227729518-ed2e0512-8209-43e7-bcc4-3b9abafbce3d.png">

after (see how MultipartHttpMessageReader and FormHttpMessageReader have shrunk):
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/1082334/227729533-b703aa78-d64e-47d2-860d-0ae84bb6dc87.png">
