### PR TITLE
Add an error handler and an interceptor for RestTemplate

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/support/LogResponseInterceptor.java
+++ b/spring-web/src/main/java/org/springframework/http/client/support/LogResponseInterceptor.java
@@ -1,0 +1,53 @@
+package org.springframework.http.client.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * For debug log level, log for all http status
+ * For other log level, only log it when error happens
+ *
+ * @author hongxue.zou
+ * @see RestTemplate#setInterceptors(List)
+ */
+public class LogResponseInterceptor implements ClientHttpRequestInterceptor {
+
+	private final Log logger;
+
+	public LogResponseInterceptor() {
+		this.logger = LogFactory.getLog(LogResponseInterceptor.class);
+	}
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+		ClientHttpResponse response = execution.execute(request, body);
+		if (logger.isDebugEnabled() || response.getStatusCode().isError()) {
+			logResponse(response);
+		}
+		return response;
+	}
+
+	private void logResponse(ClientHttpResponse response) throws IOException {
+		StringBuilder error = new StringBuilder();
+		try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody(), StandardCharsets.UTF_8))) {
+			String line = bufferedReader.readLine();
+			while (line != null) {
+				error.append(line);
+				error.append('\n');
+				line = bufferedReader.readLine();
+			}
+			logger.warn("The response status is " + response.getStatusCode() + ", the response error is " + error);
+		}
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/client/NoExceptionResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/NoExceptionResponseErrorHandler.java
@@ -1,0 +1,29 @@
+package org.springframework.web.client;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+
+/**
+ * Swallow exception instead of throw it
+ *
+ * @author hongxue.zou
+ * @see RestTemplate#setErrorHandler(ResponseErrorHandler)
+ */
+public class NoExceptionResponseErrorHandler extends DefaultResponseErrorHandler {
+
+	private final Log logger;
+
+	public NoExceptionResponseErrorHandler() {
+		this.logger = LogFactory.getLog(NoExceptionResponseErrorHandler.class);
+	}
+
+	@Override
+	public void handleError(ClientHttpResponse response) throws IOException {
+		if (logger.isDebugEnabled()) {
+			logger.debug("The http status of response is " + response.getStatusCode());
+		}
+	}
+}


### PR DESCRIPTION
### Why Have This PR?
In daily development, functions are quite common. It's a default implementation also an example.

1. Do not throw the exception, check the HTTP status outside. [Reference](https://stackoverflow.com/questions/38093388/spring-resttemplate-exception-handling)
2. Log the response especially when an exception happens. [Reference](https://stackoverflow.com/questions/7952154/spring-resttemplate-how-to-enable-full-debugging-logging-of-requests-responses)