### PR TITLE
Support Named Parameters in Stored Procedures

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/object/SqlCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/object/SqlCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,6 +190,16 @@ public abstract class SqlCall extends RdbmsOperation {
 	protected CallableStatementCreator newCallableStatementCreator(@Nullable Map<String, ?> inParams) {
 		Assert.state(this.callableStatementFactory != null, "No CallableStatementFactory available");
 		return this.callableStatementFactory.newCallableStatementCreator(inParams);
+	}
+
+	/**
+	 * Return a CallableStatementCreator to perform an operation
+	 * with these parameters.
+	 * @param inParams parameters. May be {@code null}.
+	 */
+	protected CallableStatementCreator newNamedCallableStatementCreator(@Nullable Map<String, ?> inParams) {
+		Assert.state(this.callableStatementFactory != null, "No CallableStatementFactory available");
+		return this.callableStatementFactory.newNamedCallableStatementCreator(inParams);
 	}
 
 	/**

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/object/StoredProcedure.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/object/StoredProcedure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ public abstract class StoredProcedure extends SqlCall {
 	 */
 	public Map<String, Object> execute(Map<String, ?> inParams) throws DataAccessException {
 		validateParameters(inParams.values().toArray());
-		return getJdbcTemplate().call(newCallableStatementCreator(inParams), getDeclaredParameters());
+		return getJdbcTemplate().call(newNamedCallableStatementCreator(inParams), getDeclaredParameters());
 	}
 
 	/**


### PR DESCRIPTION
StoredProcedure binds by name or index depending on the method called.

The behavior after this PR is:
- if `#execute` is called with an array then indexed bind variables are used
- if `#execute` is called with a `Map` then named bind variables are used

This would be my expectation from reading the API.

The code has a couple of limitations:
- there is unfortunately quite a bit of copy and paste
- `SqlValue` and `SqlTypeValue` are not supported for named binds, they would need a `#setValue` or `#setTypeValue` method respectively that takes a parameter name rather than a parameter index

Existing users will get different behavior if they are calling the `Map` based method. This may break if:
- the supplied parameter names do not match the parameter names of the procedure
- if the driver does not support named parameters
- they use `SqlValue` or `SqlTypeValue`

Closes gh-9084