### PR TITLE
Use log4j-slf4j2-impl 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ configure([rootProject] + javaProjects) { project ->
 		testRuntimeOnly("org.junit.platform:junit-platform-suite-engine")
 		testRuntimeOnly("org.apache.logging.log4j:log4j-core")
 		testRuntimeOnly("org.apache.logging.log4j:log4j-jul")
-		testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl")
+		testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl")
 		// JSR-305 only used for non-required meta-annotations
 		compileOnly("com.google.code.findbugs:jsr305")
 		testCompileOnly("com.google.code.findbugs:jsr305")


### PR DESCRIPTION
Modified to slf4j2-impl in build.gradle
due to slf4j-api versions 1.7 x or earlier issue

Closes #30213 