### PR TITLE
Remove `String.formatter()` from DefaultServerRequestObservationConvention

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/observation/DefaultServerRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/server/observation/DefaultServerRequestObservationConvention.java
@@ -84,7 +84,7 @@ public class DefaultServerRequestObservationConvention implements ServerRequestO
 	public String getContextualName(ServerRequestObservationContext context) {
 		String httpMethod = context.getCarrier().getMethod().toLowerCase();
 		if (context.getPathPattern() != null) {
-			return "http %s %s".formatted(httpMethod, context.getPathPattern());
+			return "http " + httpMethod + " " + context.getPathPattern();
 		}
 		return "http " + httpMethod;
 	}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/observation/DefaultServerRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/observation/DefaultServerRequestObservationConvention.java
@@ -84,7 +84,7 @@ public class DefaultServerRequestObservationConvention implements ServerRequestO
 	public String getContextualName(ServerRequestObservationContext context) {
 		String httpMethod = context.getCarrier().getMethod().name().toLowerCase();
 		if (context.getPathPattern() != null) {
-			return "http %s %s".formatted(httpMethod, context.getPathPattern());
+			return "http " + httpMethod + " " + context.getPathPattern();
 		}
 		return "http " + httpMethod;
 	}


### PR DESCRIPTION
The formatter is overkill since it has to parse the format string each time and we are only doing concatenation here. I see String.format is use elsewhere, typically in exception and debug log calls which is ok, but this was one notable place found in [my stress test](https://gist.github.com/yuzawa-san/5102be26fb9e4472419c23b39c4524b2) with actuator enabled.

before cpu:
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/1082334/228234767-4cb5ec31-b94f-49ed-927c-03d983bf0050.png">

after cpu (most of the time is spend in toLowerCase since the concat is cheaper than the String.formatter()):
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/1082334/228234981-fa51d12d-113c-4857-9ba9-a5c17ec0993b.png">
