### PR TITLE
Order metric labels in ObservationConventions

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/observation/DefaultClientRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/client/observation/DefaultClientRequestObservationConvention.java
@@ -90,7 +90,7 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 
 	@Override
 	public KeyValues getLowCardinalityKeyValues(ClientRequestObservationContext context) {
-		return KeyValues.of(uri(context), method(context), status(context), clientName(context), exception(context), outcome(context));
+		return KeyValues.of(clientName(context), exception(context), method(context), outcome(context), status(context), uri(context));
 	}
 
 	protected KeyValue uri(ClientRequestObservationContext context) {

--- a/spring-web/src/main/java/org/springframework/http/server/observation/DefaultServerRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/server/observation/DefaultServerRequestObservationConvention.java
@@ -91,7 +91,7 @@ public class DefaultServerRequestObservationConvention implements ServerRequestO
 
 	@Override
 	public KeyValues getLowCardinalityKeyValues(ServerRequestObservationContext context) {
-		return KeyValues.of(method(context), uri(context), status(context), exception(context), outcome(context));
+		return KeyValues.of(exception(context), method(context), outcome(context), status(context), uri(context));
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/observation/DefaultServerRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/observation/DefaultServerRequestObservationConvention.java
@@ -91,7 +91,7 @@ public class DefaultServerRequestObservationConvention implements ServerRequestO
 
 	@Override
 	public KeyValues getLowCardinalityKeyValues(ServerRequestObservationContext context) {
-		return KeyValues.of(method(context), uri(context), status(context), exception(context), outcome(context));
+		return KeyValues.of(exception(context), method(context), outcome(context), status(context), uri(context));
 	}
 
 	@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConvention.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConvention.java
@@ -94,7 +94,7 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 
 	@Override
 	public KeyValues getLowCardinalityKeyValues(ClientRequestObservationContext context) {
-		return KeyValues.of(uri(context), method(context), status(context), clientName(context), exception(context), outcome(context));
+		return KeyValues.of(clientName(context), exception(context), method(context), outcome(context), status(context), uri(context));
 	}
 
 	protected KeyValue uri(ClientRequestObservationContext context) {


### PR DESCRIPTION
I was using [my stress test with actuator](https://gist.github.com/yuzawa-san/5102be26fb9e4472419c23b39c4524b2) to do some QA-ing of https://github.com/spring-projects/spring-framework/pull/30218 and found one more optimization. Java's TimSort (used in micrometer's Arrays.sort() operation) runs faster if the input is [already](https://lemire.me/blog/2016/09/28/sorting-already-sorted-arrays-is-much-faster/) [sorted](https://medium.com/@rylanbauermeister/understanding-timsort-191c758a42f3). i'll run over to micrometer to see if this can be relaxed since it seems to be sorting a whole bunch of times before finalizing it when it could be sorting once at the end, but that is another story.

before cpu:

<img width="1473" alt="image" src="https://user-images.githubusercontent.com/1082334/228408719-a6c79b44-27f5-4acd-9735-e0f3c034ff3c.png">


after cpu (note how the Integer.toString got bigger (as a portion) since the sort got smaller. also see how ComparableTimSort.countRunAndMakeAscending is fully used to find that the input is monotonically ascending):

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/1082334/228408814-dc7a61fe-7bf0-4243-bd40-6eb7d0dcc08f.png">
