### PR TITLE
Fix `SimpleJdbcCall` named parameter binding for Sybase ASE

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -677,7 +677,9 @@ public class CallMetaDataContext {
 	 * @since 4.2
 	 */
 	protected String createParameterBinding(SqlParameter parameter) {
-		return (isNamedBinding() ? parameter.getName() + " => ?" : "?");
+		Assert.state(this.metaDataProvider != null, "No CallMetaDataProvider available");
+
+		return (isNamedBinding() ? this.metaDataProvider.namedParamBindingToUse(parameter.getName()) : "?");
 	}
 
 	private static String lowerCase(@Nullable String paramName) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataProvider.java
@@ -180,4 +180,11 @@ public interface CallMetaDataProvider {
 	 */
 	boolean isSupportsSchemasInProcedureCalls();
 
+	/**
+	 * Returns the name of the named parameter to use for binding the given parameter name.
+	 * @param paramName the name of the parameter to bind
+	 * @return the name of the named parameter to use for binding the given parameter name,
+	 */
+	String namedParamBindingToUse(@Nullable String paramName);
+
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericCallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericCallMetaDataProvider.java
@@ -288,6 +288,16 @@ public class GenericCallMetaDataProvider implements CallMetaDataProvider {
 	}
 
 	/**
+	 * Returns the name of the named parameter to use for binding the given parameter name.
+	 * @param paramName the name of the parameter to bind
+	 * @return the name of the named parameter to use for binding the given parameter name,
+	 */
+	@Override
+	public String namedParamBindingToUse(@Nullable String paramName) {
+		return paramName + " => ?";
+	}
+
+	/**
 	 * Specify whether the database uses upper case for identifiers.
 	 */
 	protected void setStoresUpperCaseIdentifiers(boolean storesUpperCaseIdentifiers) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/SybaseCallMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/SybaseCallMetaDataProvider.java
@@ -60,4 +60,9 @@ public class SybaseCallMetaDataProvider extends GenericCallMetaDataProvider {
 				RETURN_VALUE_NAME.equals(parameterNameToUse(parameterName)));
 	}
 
+	@Override
+	public String namedParamBindingToUse(@Nullable String paramName) {
+		return paramName + " = ?";
+	}
+
 }

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/SimpleJdbcCallTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/SimpleJdbcCallTests.java
@@ -347,4 +347,17 @@ class SimpleJdbcCallTests {
 		verify(procedureColumnsResultSet).close();
 	}
 
+	@Test
+	void correctSybaseFunctionStatementNamed() throws Exception {
+		given(databaseMetaData.getDatabaseProductName()).willReturn("Sybase");
+		SimpleJdbcCall adder = new SimpleJdbcCall(dataSource)
+				.withoutProcedureColumnMetaDataAccess()
+				.withNamedBinding()
+				.withProcedureName("ADD_INVOICE")
+				.declareParameters(new SqlParameter("@AMOUNT", Types.NUMERIC))
+				.declareParameters(new SqlParameter("@CUSTID", Types.NUMERIC));
+		adder.compile();
+		verifyStatement(adder, "{call ADD_INVOICE(@AMOUNT = ?, @CUSTID = ?)}");
+	}
+
 }


### PR DESCRIPTION
This commit fixes an issue with Sybase named parameter binding in the code. The `namedParamBindingToUse` method has been updated to properly handle named parameters in Sybase stored procedures. Prior to this fix, the method may not have returned the correct named parameter for a given parameter name, causing issues with stored procedure execution.

This fix is necessary to ensure proper execution of Sybase stored procedures that use named parameters.

When working with Sybase ASE stored procedures, parameters should be supplied in the order of their create procedure statement, unless they are supplied in the form `@<parameter> = <value>`, in which case they can be supplied in any order. For more information, see the Sybase ASE documentation: https://help.sap.com/docs/SAP_ASE/b65d6a040c4a4709afd93068071b2a76/aa8728babc2b101491a4f578b9082925.html?locale=en-US