### PR TITLE
Enhance MockMvcWebTestClient to allow applying RequestPostProcessors

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -68,7 +68,7 @@ import org.springframework.web.util.UriBuilderFactory;
  * @author Michał Rowicki
  * @since 5.0
  */
-class DefaultWebTestClient implements WebTestClient {
+public class DefaultWebTestClient implements WebTestClient {
 
 	private final WiretapConnector wiretapConnector;
 
@@ -91,7 +91,7 @@ class DefaultWebTestClient implements WebTestClient {
 	private final AtomicLong requestIndex = new AtomicLong();
 
 
-	DefaultWebTestClient(ClientHttpConnector connector,
+	protected DefaultWebTestClient(ClientHttpConnector connector,
 			Function<ClientHttpConnector, ExchangeFunction> exchangeFactory, UriBuilderFactory uriBuilderFactory,
 			@Nullable HttpHeaders headers, @Nullable MultiValueMap<String, String> cookies,
 			Consumer<EntityExchangeResult<?>> entityResultConsumer,

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
@@ -51,7 +51,7 @@ import org.springframework.web.util.UriBuilderFactory;
  * @author Rossen Stoyanchev
  * @since 5.0
  */
-class DefaultWebTestClientBuilder implements WebTestClient.Builder {
+public class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 
 	private static final boolean reactorNettyClientPresent;
 
@@ -77,54 +77,54 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 
 
 	@Nullable
-	private final WebHttpHandlerBuilder httpHandlerBuilder;
+	protected final WebHttpHandlerBuilder httpHandlerBuilder;
 
 	@Nullable
-	private final ClientHttpConnector connector;
+	protected final ClientHttpConnector connector;
 
 	@Nullable
-	private String baseUrl;
+	protected String baseUrl;
 
 	@Nullable
-	private UriBuilderFactory uriBuilderFactory;
+	protected UriBuilderFactory uriBuilderFactory;
 
 	@Nullable
-	private HttpHeaders defaultHeaders;
+	protected HttpHeaders defaultHeaders;
 
 	@Nullable
-	private MultiValueMap<String, String> defaultCookies;
+	protected MultiValueMap<String, String> defaultCookies;
 
 	@Nullable
-	private List<ExchangeFilterFunction> filters;
+	protected List<ExchangeFilterFunction> filters;
 
-	private Consumer<EntityExchangeResult<?>> entityResultConsumer = result -> {};
-
-	@Nullable
-	private ExchangeStrategies strategies;
+	protected Consumer<EntityExchangeResult<?>> entityResultConsumer = result -> {};
 
 	@Nullable
-	private List<Consumer<ExchangeStrategies.Builder>> strategiesConfigurers;
+	protected ExchangeStrategies strategies;
 
 	@Nullable
-	private Duration responseTimeout;
+	protected List<Consumer<ExchangeStrategies.Builder>> strategiesConfigurers;
+
+	@Nullable
+	protected Duration responseTimeout;
 
 
 	/** Determine connector via classpath detection. */
-	DefaultWebTestClientBuilder() {
+	protected DefaultWebTestClientBuilder() {
 		this(null, null);
 	}
 
 	/** Use HttpHandlerConnector with mock server. */
-	DefaultWebTestClientBuilder(WebHttpHandlerBuilder httpHandlerBuilder) {
+	protected DefaultWebTestClientBuilder(WebHttpHandlerBuilder httpHandlerBuilder) {
 		this(httpHandlerBuilder, null);
 	}
 
 	/** Use given connector. */
-	DefaultWebTestClientBuilder(ClientHttpConnector connector) {
+	protected DefaultWebTestClientBuilder(ClientHttpConnector connector) {
 		this(null, connector);
 	}
 
-	DefaultWebTestClientBuilder(
+	protected DefaultWebTestClientBuilder(
 			@Nullable WebHttpHandlerBuilder httpHandlerBuilder, @Nullable ClientHttpConnector connector) {
 
 		Assert.isTrue(httpHandlerBuilder == null || connector == null,
@@ -139,7 +139,7 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 	}
 
 	/** Copy constructor. */
-	DefaultWebTestClientBuilder(DefaultWebTestClientBuilder other) {
+	protected DefaultWebTestClientBuilder(DefaultWebTestClientBuilder other) {
 		this.httpHandlerBuilder = (other.httpHandlerBuilder != null ? other.httpHandlerBuilder.clone() : null);
 		this.connector = other.connector;
 		this.responseTimeout = other.responseTimeout;
@@ -323,7 +323,7 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 		}
 	}
 
-	private ExchangeStrategies initExchangeStrategies() {
+	protected ExchangeStrategies initExchangeStrategies() {
 		if (CollectionUtils.isEmpty(this.strategiesConfigurers)) {
 			return (this.strategies != null ? this.strategies : ExchangeStrategies.withDefaults());
 		}
@@ -333,7 +333,7 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 		return builder.build();
 	}
 
-	private UriBuilderFactory initUriBuilderFactory() {
+	protected UriBuilderFactory initUriBuilderFactory() {
 		if (this.uriBuilderFactory != null) {
 			return this.uriBuilderFactory;
 		}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/AbstractMockMvcServerSpec.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/AbstractMockMvcServerSpec.java
@@ -18,8 +18,6 @@ package org.springframework.test.web.servlet.client;
 
 import jakarta.servlet.Filter;
 
-import org.springframework.http.client.reactive.ClientHttpConnector;
-import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.servlet.DispatcherServletCustomizer;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
@@ -93,14 +91,13 @@ abstract class AbstractMockMvcServerSpec<B extends MockMvcWebTestClient.MockMvcS
 	protected abstract ConfigurableMockMvcBuilder<?> getMockMvcBuilder();
 
 	@Override
-	public WebTestClient.Builder configureClient() {
+	public MockMvcWebTestClient.Builder configureClient() {
 		MockMvc mockMvc = getMockMvcBuilder().build();
-		ClientHttpConnector connector = new MockMvcHttpConnector(mockMvc);
-		return WebTestClient.bindToServer(connector);
+		return MockMvcWebTestClient.bindToMockMvc(mockMvc);
 	}
 
 	@Override
-	public WebTestClient build() {
+	public MockMvcWebTestClient build() {
 		return configureClient().build();
 	}
 

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultMockMvcWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultMockMvcWebTestClient.java
@@ -1,0 +1,43 @@
+package org.springframework.test.web.servlet.client;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.test.web.reactive.server.DefaultWebTestClient;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.util.UriBuilderFactory;
+
+public class DefaultMockMvcWebTestClient extends DefaultWebTestClient implements MockMvcWebTestClient {
+	private final DefaultMockMvcWebTestClientBuilder builder;
+
+	DefaultMockMvcWebTestClient(ClientHttpConnector connector,
+			Function<ClientHttpConnector, ExchangeFunction> exchangeFactory, UriBuilderFactory uriBuilderFactory,
+			HttpHeaders headers, MultiValueMap<String, String> cookies,
+			Consumer<EntityExchangeResult<?>> entityResultConsumer, Duration responseTimeout,
+			DefaultMockMvcWebTestClientBuilder clientBuilder) {
+		super(connector, exchangeFactory, uriBuilderFactory, headers, cookies, entityResultConsumer, responseTimeout,
+				clientBuilder);
+		this.builder = clientBuilder;
+	}
+
+	@Override
+	public MockMvcWebTestClient.Builder mutate() {
+		return new DefaultMockMvcWebTestClientBuilder(builder);
+	}
+
+	@Override
+	public MockMvcWebTestClient mutateWith(RequestPostProcessor requestPostProcessor) {
+		return mutate().requestPostProcessor(requestPostProcessor).build();
+	}
+
+	@Override
+	public MockMvcWebTestClient mutateWith(MockMvcWebTestClientConfigurer configurer) {
+		return mutate().apply(configurer).build();
+	}
+}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultMockMvcWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultMockMvcWebTestClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.test.web.servlet.client;
 
 import java.time.Duration;
@@ -13,6 +29,11 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.util.UriBuilderFactory;
 
+/**
+ * Default implementation of {@link MockMvcWebTestClient}.
+ *
+ * @author Justin Tay
+ */
 public class DefaultMockMvcWebTestClient extends DefaultWebTestClient implements MockMvcWebTestClient {
 	private final DefaultMockMvcWebTestClientBuilder builder;
 
@@ -28,7 +49,7 @@ public class DefaultMockMvcWebTestClient extends DefaultWebTestClient implements
 
 	@Override
 	public MockMvcWebTestClient.Builder mutate() {
-		return new DefaultMockMvcWebTestClientBuilder(builder);
+		return new DefaultMockMvcWebTestClientBuilder(this.builder);
 	}
 
 	@Override

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultMockMvcWebTestClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultMockMvcWebTestClientBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.test.web.servlet.client;
 
 import java.time.Duration;
@@ -24,12 +40,17 @@ import org.springframework.web.reactive.function.client.ExchangeFunctions;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.util.UriBuilderFactory;
 
+/**
+ * Default implementation of {@link MockMvcWebTestClient.Builder}.
+ *
+ * @author Justin Tay
+ */
 public class DefaultMockMvcWebTestClientBuilder extends DefaultWebTestClientBuilder implements MockMvcWebTestClient.Builder {
-	
+
 	private MockMvc mockMvc;
-	private List<RequestPostProcessor> requestPostProcessors = new ArrayList<>(); 
+	private List<RequestPostProcessor> requestPostProcessors = new ArrayList<>();
 	private List<Consumer<MockHttpServletRequestBuilder>> requestBuilderCustomizers = new ArrayList<>();
-	
+
 	DefaultMockMvcWebTestClientBuilder(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;
 	}
@@ -41,48 +62,48 @@ public class DefaultMockMvcWebTestClientBuilder extends DefaultWebTestClientBuil
 		this.requestPostProcessors = new ArrayList<>(other.requestPostProcessors);
 		this.requestBuilderCustomizers = new ArrayList<>(other.requestBuilderCustomizers);
 	}
-	
+
 	@Override
 	public Builder mockMvc(MockMvc mockMvc) {
 		this.mockMvc = mockMvc;
 		return this;
 	}
-	
+
 	@Override
 	public Builder requestPostProcessors(Consumer<List<RequestPostProcessor>> requestPostProcessorsConsumer) {
-		requestPostProcessorsConsumer.accept(requestPostProcessors);
+		requestPostProcessorsConsumer.accept(this.requestPostProcessors);
 		return this;
 	}
 
 	@Override
 	public Builder requestPostProcessor(RequestPostProcessor requestPostProcessor) {
-		requestPostProcessors.add(requestPostProcessor);
+		this.requestPostProcessors.add(requestPostProcessor);
 		return this;
 	}
-	
+
 	@Override
 	public Builder requestBuilderCustomizer(Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer) {
 		this.requestBuilderCustomizers.add(requestBuilderCustomizer);
 		return this;
 	}
-	
+
 	@Override
 	public Builder requestBuilderCustomizers(Consumer<List<Consumer<MockHttpServletRequestBuilder>>> requestBuilderCustomizersConsumer) {
-		requestBuilderCustomizersConsumer.accept(requestBuilderCustomizers);
+		requestBuilderCustomizersConsumer.accept(this.requestBuilderCustomizers);
 		return this;
 	}
-	
+
 	@Override
 	public Builder apply(MockMvcWebTestClientConfigurer configurer) {
 		configurer.afterConfigurerAdded(this, this.httpHandlerBuilder, this.connector);
 		return this;
 	}
-	
+
 	@Override
 	public MockMvcWebTestClient build() {
-		ClientHttpConnector connectorToUse = new MockMvcHttpConnector(mockMvc, customizer -> {
-			requestPostProcessors.forEach(customizer::with);
-			requestBuilderCustomizers.forEach(builderCustomizer -> builderCustomizer.accept(customizer));
+		ClientHttpConnector connectorToUse = new MockMvcHttpConnector(this.mockMvc, customizer -> {
+			this.requestPostProcessors.forEach(customizer::with);
+			this.requestBuilderCustomizers.forEach(builderCustomizer -> builderCustomizer.accept(customizer));
 		});
 		Function<ClientHttpConnector, ExchangeFunction> exchangeFactory = connector -> {
 			ExchangeFunction exchange = ExchangeFunctions.create(connector, initExchangeStrategies());
@@ -100,7 +121,7 @@ public class DefaultMockMvcWebTestClientBuilder extends DefaultWebTestClientBuil
 				this.defaultCookies != null ? CollectionUtils.unmodifiableMultiValueMap(this.defaultCookies) : null,
 				this.entityResultConsumer, this.responseTimeout, new DefaultMockMvcWebTestClientBuilder(this));
 	}
-	
+
 	/* Override methods to return covariant return type */
 	@Override
 	public Builder baseUrl(String baseUrl) {

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultMockMvcWebTestClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultMockMvcWebTestClientBuilder.java
@@ -1,0 +1,200 @@
+package org.springframework.test.web.servlet.client;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.codec.ClientCodecConfigurer;
+import org.springframework.test.web.reactive.server.DefaultWebTestClientBuilder;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClientConfigurer;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient.Builder;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunctions;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.util.UriBuilderFactory;
+
+public class DefaultMockMvcWebTestClientBuilder extends DefaultWebTestClientBuilder implements MockMvcWebTestClient.Builder {
+	
+	private MockMvc mockMvc;
+	private List<RequestPostProcessor> requestPostProcessors = new ArrayList<>(); 
+	private List<Consumer<MockHttpServletRequestBuilder>> requestBuilderCustomizers = new ArrayList<>();
+	
+	DefaultMockMvcWebTestClientBuilder(MockMvc mockMvc) {
+		this.mockMvc = mockMvc;
+	}
+
+	/** Copy constructor. */
+	DefaultMockMvcWebTestClientBuilder(DefaultMockMvcWebTestClientBuilder other) {
+		super(other);
+		this.mockMvc = other.mockMvc;
+		this.requestPostProcessors = new ArrayList<>(other.requestPostProcessors);
+		this.requestBuilderCustomizers = new ArrayList<>(other.requestBuilderCustomizers);
+	}
+	
+	@Override
+	public Builder mockMvc(MockMvc mockMvc) {
+		this.mockMvc = mockMvc;
+		return this;
+	}
+	
+	@Override
+	public Builder requestPostProcessors(Consumer<List<RequestPostProcessor>> requestPostProcessorsConsumer) {
+		requestPostProcessorsConsumer.accept(requestPostProcessors);
+		return this;
+	}
+
+	@Override
+	public Builder requestPostProcessor(RequestPostProcessor requestPostProcessor) {
+		requestPostProcessors.add(requestPostProcessor);
+		return this;
+	}
+	
+	@Override
+	public Builder requestBuilderCustomizer(Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer) {
+		this.requestBuilderCustomizers.add(requestBuilderCustomizer);
+		return this;
+	}
+	
+	@Override
+	public Builder requestBuilderCustomizers(Consumer<List<Consumer<MockHttpServletRequestBuilder>>> requestBuilderCustomizersConsumer) {
+		requestBuilderCustomizersConsumer.accept(requestBuilderCustomizers);
+		return this;
+	}
+	
+	@Override
+	public Builder apply(MockMvcWebTestClientConfigurer configurer) {
+		configurer.afterConfigurerAdded(this, this.httpHandlerBuilder, this.connector);
+		return this;
+	}
+	
+	@Override
+	public MockMvcWebTestClient build() {
+		ClientHttpConnector connectorToUse = new MockMvcHttpConnector(mockMvc, customizer -> {
+			requestPostProcessors.forEach(customizer::with);
+			requestBuilderCustomizers.forEach(builderCustomizer -> builderCustomizer.accept(customizer));
+		});
+		Function<ClientHttpConnector, ExchangeFunction> exchangeFactory = connector -> {
+			ExchangeFunction exchange = ExchangeFunctions.create(connector, initExchangeStrategies());
+			if (CollectionUtils.isEmpty(this.filters)) {
+				return exchange;
+			}
+			return this.filters.stream()
+					.reduce(ExchangeFilterFunction::andThen)
+					.map(filter -> filter.apply(exchange))
+					.orElse(exchange);
+
+		};
+		return new DefaultMockMvcWebTestClient(connectorToUse, exchangeFactory, initUriBuilderFactory(),
+				this.defaultHeaders != null ? HttpHeaders.readOnlyHttpHeaders(this.defaultHeaders) : null,
+				this.defaultCookies != null ? CollectionUtils.unmodifiableMultiValueMap(this.defaultCookies) : null,
+				this.entityResultConsumer, this.responseTimeout, new DefaultMockMvcWebTestClientBuilder(this));
+	}
+	
+	/* Override methods to return covariant return type */
+	@Override
+	public Builder baseUrl(String baseUrl) {
+		super.baseUrl(baseUrl);
+		return this;
+	}
+
+	@Override
+	public Builder uriBuilderFactory(
+			UriBuilderFactory uriBuilderFactory) {
+		super.uriBuilderFactory(uriBuilderFactory);
+		return this;
+	}
+
+	@Override
+	public Builder defaultHeader(String header,
+			String... values) {
+		super.defaultHeader(header, values);
+		return this;
+	}
+
+	@Override
+	public Builder defaultHeaders(
+			Consumer<HttpHeaders> headersConsumer) {
+		super.defaultHeaders(headersConsumer);
+		return this;
+	}
+
+	@Override
+	public Builder defaultCookie(String cookie,
+			String... values) {
+		super.defaultCookie(cookie, values);
+		return this;
+	}
+
+	@Override
+	public Builder defaultCookies(
+			Consumer<MultiValueMap<String, String>> cookiesConsumer) {
+		super.defaultCookies(cookiesConsumer);
+		return this;
+	}
+
+	@Override
+	public Builder filter(ExchangeFilterFunction filter) {
+		super.filter(filter);
+		return this;
+	}
+
+	@Override
+	public Builder filters(
+			Consumer<List<ExchangeFilterFunction>> filtersConsumer) {
+		super.filters(filtersConsumer);
+		return this;
+	}
+
+	@Override
+	public Builder entityExchangeResultConsumer(
+			Consumer<EntityExchangeResult<?>> entityResultConsumer) {
+		super.entityExchangeResultConsumer(entityResultConsumer);
+		return this;
+	}
+
+	@Override
+	public Builder codecs(
+			Consumer<ClientCodecConfigurer> configurer) {
+		super.codecs(configurer);
+		return this;
+	}
+
+	@Override
+	public Builder exchangeStrategies(
+			ExchangeStrategies strategies) {
+		super.exchangeStrategies(strategies);
+		return this;
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public Builder exchangeStrategies(
+			Consumer<ExchangeStrategies.Builder> configurer) {
+		super.exchangeStrategies(configurer);
+		return this;
+	}
+
+	@Override
+	public Builder apply(
+			WebTestClientConfigurer configurer) {
+		super.apply(configurer);
+		return this;
+	}
+
+	@Override
+	public Builder responseTimeout(Duration timeout) {
+		super.responseTimeout(timeout);
+		return this;
+	}
+}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
@@ -82,7 +82,7 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 
 
 	private final MockMvc mockMvc;
-	
+
 	private final Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer;
 
 	public MockMvcHttpConnector(MockMvc mockMvc, Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer) {
@@ -149,8 +149,8 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 			if (!ObjectUtils.isEmpty(bytes)) {
 				requestBuilder.content(bytes);
 			}
-			if(requestBuilderCustomizer != null) {
-				requestBuilderCustomizer.accept(requestBuilder);
+			if(this.requestBuilderCustomizer != null) {
+				this.requestBuilderCustomizer.accept(requestBuilder);
 			}
 			return requestBuilder;
 		}
@@ -180,8 +180,8 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 								}))
 				.blockLast(TIMEOUT);
 
-		if(requestBuilderCustomizer != null) {
-			requestBuilderCustomizer.accept(requestBuilder);
+		if(this.requestBuilderCustomizer != null) {
+			this.requestBuilderCustomizer.accept(requestBuilder);
 		}
 		return requestBuilder;
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import jakarta.servlet.http.Cookie;
@@ -81,12 +82,13 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 
 
 	private final MockMvc mockMvc;
+	
+	private final Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer;
 
-
-	public MockMvcHttpConnector(MockMvc mockMvc) {
+	public MockMvcHttpConnector(MockMvc mockMvc, Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer) {
 		this.mockMvc = mockMvc;
+		this.requestBuilderCustomizer = requestBuilderCustomizer;
 	}
-
 
 	@Override
 	public Mono<ClientHttpResponse> connect(
@@ -147,6 +149,9 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 			if (!ObjectUtils.isEmpty(bytes)) {
 				requestBuilder.content(bytes);
 			}
+			if(requestBuilderCustomizer != null) {
+				requestBuilderCustomizer.accept(requestBuilder);
+			}
 			return requestBuilder;
 		}
 
@@ -175,6 +180,9 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 								}))
 				.blockLast(TIMEOUT);
 
+		if(requestBuilderCustomizer != null) {
+			requestBuilderCustomizer.accept(requestBuilder);
+		}
 		return requestBuilder;
 	}
 

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcWebTestClient.java
@@ -39,7 +39,6 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultHandler;
 import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.test.web.servlet.client.MockMvcWebTestClient.Builder;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
@@ -90,12 +89,12 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * @since 5.3
  */
 public interface MockMvcWebTestClient extends WebTestClient {
-	
+
 	/**
 	 * Return a builder to mutate properties of this web test client.
 	 */
 	Builder mutate();
-	
+
 	/**
 	 * Mutate the {@link MockMvcWebTestClient}, apply the given requestPostProcessor, and build
 	 * a new instance. Essentially a shortcut for:
@@ -106,7 +105,7 @@ public interface MockMvcWebTestClient extends WebTestClient {
 	 * @return the mutated test client
 	 */
 	MockMvcWebTestClient mutateWith(RequestPostProcessor requestPostProcessor);
-	
+
 	/**
 	 * Mutate the {@link MockMvcWebTestClient}, apply the given configurer, and build
 	 * a new instance. Essentially a shortcut for:
@@ -117,80 +116,6 @@ public interface MockMvcWebTestClient extends WebTestClient {
 	 * @return the mutated test client
 	 */
 	MockMvcWebTestClient mutateWith(MockMvcWebTestClientConfigurer configurer);
-
-	
-	/**
-	 * Steps for customizing the {@link WebClient} used to test with,
-	 * internally delegating to a
-	 * {@link org.springframework.web.reactive.function.client.WebClient.Builder
-	 * WebClient.Builder}.
-	 */
-	interface Builder extends WebTestClient.Builder {
-		Builder mockMvc(MockMvc mockMvc);
-		
-		Builder requestPostProcessor(RequestPostProcessor requestPostProcessor);
-		
-		Builder requestPostProcessors(Consumer<List<RequestPostProcessor>> requestPostProcessorsConsumer);
-		
-		Builder requestBuilderCustomizer(Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer);
-		
-		Builder requestBuilderCustomizers(Consumer<List<Consumer<MockHttpServletRequestBuilder>>> requestBuilderCustomizersConsumer);
-		
-		Builder apply(MockMvcWebTestClientConfigurer configurer);
-		
-		/* Override methods to return covariant return type */
-		@Override
-		Builder baseUrl(String baseUrl);
-
-		@Override
-		Builder uriBuilderFactory(UriBuilderFactory uriBuilderFactory);
-
-		@Override
-		Builder defaultHeader(String headerName, String... headerValues);
-		
-		@Override
-		Builder defaultHeaders(Consumer<HttpHeaders> headersConsumer);
-
-		@Override
-		Builder defaultCookie(String cookieName, String... cookieValues);
-		
-		@Override
-		Builder defaultCookies(Consumer<MultiValueMap<String, String>> cookiesConsumer);
-		
-		@Override
-		Builder filter(ExchangeFilterFunction filter);
-		
-		@Override
-		Builder filters(Consumer<List<ExchangeFilterFunction>> filtersConsumer);
-		
-		@Override
-		Builder entityExchangeResultConsumer(Consumer<EntityExchangeResult<?>> consumer);
-		
-		@Override
-		Builder codecs(Consumer<ClientCodecConfigurer> configurer);
-		
-		@Override
-		Builder exchangeStrategies(ExchangeStrategies strategies);
-		
-		@Override
-		@SuppressWarnings("deprecation")
-		Builder exchangeStrategies(
-				Consumer<ExchangeStrategies.Builder> configurer);
-		
-		@Override
-		Builder responseTimeout(Duration timeout);
-		
-		@Override
-		Builder apply(WebTestClientConfigurer configurer);
-		
-		/**
-		 * Build the {@link WebTestClient} instance.
-		 */
-		@Override
-		MockMvcWebTestClient build();
-		
-	}
-	
 
 	/**
 	 * Begin creating a {@link WebTestClient} by providing the {@code @Controller}
@@ -214,7 +139,7 @@ public interface MockMvcWebTestClient extends WebTestClient {
 	static MockMvcServerSpec<?> bindToApplicationContext(WebApplicationContext context) {
 		return new ApplicationContextMockMvcSpec(context);
 	}
-	
+
 	/**
 	 * Begin creating a {@link WebTestClient} by providing an already
 	 * initialized {@link MockMvc} instance to use as the server.
@@ -504,4 +429,74 @@ public interface MockMvcWebTestClient extends WebTestClient {
 		ControllerSpec customHandlerMapping(Supplier<RequestMappingHandlerMapping> factory);
 	}
 
+	/**
+	 * Steps for customizing the {@link WebClient} used to test with,
+	 * internally delegating to a
+	 * {@link org.springframework.web.reactive.function.client.WebClient.Builder
+	 * WebClient.Builder}.
+	 */
+	interface Builder extends WebTestClient.Builder {
+		Builder mockMvc(MockMvc mockMvc);
+
+		Builder requestPostProcessor(RequestPostProcessor requestPostProcessor);
+
+		Builder requestPostProcessors(Consumer<List<RequestPostProcessor>> requestPostProcessorsConsumer);
+
+		Builder requestBuilderCustomizer(Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer);
+
+		Builder requestBuilderCustomizers(Consumer<List<Consumer<MockHttpServletRequestBuilder>>> requestBuilderCustomizersConsumer);
+
+		Builder apply(MockMvcWebTestClientConfigurer configurer);
+
+		/* Override methods to return covariant return type */
+		@Override
+		Builder baseUrl(String baseUrl);
+
+		@Override
+		Builder uriBuilderFactory(UriBuilderFactory uriBuilderFactory);
+
+		@Override
+		Builder defaultHeader(String headerName, String... headerValues);
+
+		@Override
+		Builder defaultHeaders(Consumer<HttpHeaders> headersConsumer);
+
+		@Override
+		Builder defaultCookie(String cookieName, String... cookieValues);
+
+		@Override
+		Builder defaultCookies(Consumer<MultiValueMap<String, String>> cookiesConsumer);
+
+		@Override
+		Builder filter(ExchangeFilterFunction filter);
+
+		@Override
+		Builder filters(Consumer<List<ExchangeFilterFunction>> filtersConsumer);
+
+		@Override
+		Builder entityExchangeResultConsumer(Consumer<EntityExchangeResult<?>> consumer);
+
+		@Override
+		Builder codecs(Consumer<ClientCodecConfigurer> configurer);
+
+		@Override
+		Builder exchangeStrategies(ExchangeStrategies strategies);
+
+		@Override
+		@SuppressWarnings("deprecation")
+		Builder exchangeStrategies(
+				Consumer<ExchangeStrategies.Builder> configurer);
+
+		@Override
+		Builder responseTimeout(Duration timeout);
+
+		@Override
+		Builder apply(WebTestClientConfigurer configurer);
+
+		/**
+		 * Build the {@link WebTestClient} instance.
+		 */
+		@Override
+		MockMvcWebTestClient build();
+	}
 }

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcWebTestClient.java
@@ -16,16 +16,22 @@
 
 package org.springframework.test.web.servlet.client;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import jakarta.servlet.Filter;
 
 import org.springframework.format.support.FormattingConversionService;
-import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.codec.ClientCodecConfigurer;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.lang.Nullable;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import org.springframework.test.web.reactive.server.ExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.reactive.server.WebTestClientConfigurer;
 import org.springframework.test.web.servlet.DispatcherServletCustomizer;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -33,14 +39,21 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultHandler;
 import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient.Builder;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcConfigurer;
 import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder;
+import org.springframework.util.MultiValueMap;
 import org.springframework.validation.Validator;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -48,6 +61,7 @@ import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.util.UriBuilderFactory;
 import org.springframework.web.util.pattern.PathPatternParser;
 
 /**
@@ -57,7 +71,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * <p>Provides static factory methods and specs to initialize {@code MockMvc}
  * to which the {@code WebTestClient} connects to. For example:
  * <pre class="code">
- * WebTestClient client = MockMvcWebTestClient.bindToController(myController)
+ * MockMvcWebTestClient client = MockMvcWebTestClient.bindToController(myController)
  *         .controllerAdvice(myControllerAdvice)
  *         .validator(myValidator)
  *         .build()
@@ -65,7 +79,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  *
  * <p>The client itself can also be configured. For example:
  * <pre class="code">
- * WebTestClient client = MockMvcWebTestClient.bindToController(myController)
+ * MockMvcWebTestClient client = MockMvcWebTestClient.bindToController(myController)
  *         .validator(myValidator)
  *         .configureClient()
  *         .baseUrl("/path")
@@ -75,7 +89,108 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * @author Rossen Stoyanchev
  * @since 5.3
  */
-public interface MockMvcWebTestClient {
+public interface MockMvcWebTestClient extends WebTestClient {
+	
+	/**
+	 * Return a builder to mutate properties of this web test client.
+	 */
+	Builder mutate();
+	
+	/**
+	 * Mutate the {@link MockMvcWebTestClient}, apply the given requestPostProcessor, and build
+	 * a new instance. Essentially a shortcut for:
+	 * <pre>
+	 * mutate().requestPostProcessor(requestPostProcessor).build();
+	 * </pre>
+	 * @param requestPostProcessor the requestPostProcessor to apply
+	 * @return the mutated test client
+	 */
+	MockMvcWebTestClient mutateWith(RequestPostProcessor requestPostProcessor);
+	
+	/**
+	 * Mutate the {@link MockMvcWebTestClient}, apply the given configurer, and build
+	 * a new instance. Essentially a shortcut for:
+	 * <pre>
+	 * mutate().apply(configurer).build();
+	 * </pre>
+	 * @param configurer the configurer to apply
+	 * @return the mutated test client
+	 */
+	MockMvcWebTestClient mutateWith(MockMvcWebTestClientConfigurer configurer);
+
+	
+	/**
+	 * Steps for customizing the {@link WebClient} used to test with,
+	 * internally delegating to a
+	 * {@link org.springframework.web.reactive.function.client.WebClient.Builder
+	 * WebClient.Builder}.
+	 */
+	interface Builder extends WebTestClient.Builder {
+		Builder mockMvc(MockMvc mockMvc);
+		
+		Builder requestPostProcessor(RequestPostProcessor requestPostProcessor);
+		
+		Builder requestPostProcessors(Consumer<List<RequestPostProcessor>> requestPostProcessorsConsumer);
+		
+		Builder requestBuilderCustomizer(Consumer<MockHttpServletRequestBuilder> requestBuilderCustomizer);
+		
+		Builder requestBuilderCustomizers(Consumer<List<Consumer<MockHttpServletRequestBuilder>>> requestBuilderCustomizersConsumer);
+		
+		Builder apply(MockMvcWebTestClientConfigurer configurer);
+		
+		/* Override methods to return covariant return type */
+		@Override
+		Builder baseUrl(String baseUrl);
+
+		@Override
+		Builder uriBuilderFactory(UriBuilderFactory uriBuilderFactory);
+
+		@Override
+		Builder defaultHeader(String headerName, String... headerValues);
+		
+		@Override
+		Builder defaultHeaders(Consumer<HttpHeaders> headersConsumer);
+
+		@Override
+		Builder defaultCookie(String cookieName, String... cookieValues);
+		
+		@Override
+		Builder defaultCookies(Consumer<MultiValueMap<String, String>> cookiesConsumer);
+		
+		@Override
+		Builder filter(ExchangeFilterFunction filter);
+		
+		@Override
+		Builder filters(Consumer<List<ExchangeFilterFunction>> filtersConsumer);
+		
+		@Override
+		Builder entityExchangeResultConsumer(Consumer<EntityExchangeResult<?>> consumer);
+		
+		@Override
+		Builder codecs(Consumer<ClientCodecConfigurer> configurer);
+		
+		@Override
+		Builder exchangeStrategies(ExchangeStrategies strategies);
+		
+		@Override
+		@SuppressWarnings("deprecation")
+		Builder exchangeStrategies(
+				Consumer<ExchangeStrategies.Builder> configurer);
+		
+		@Override
+		Builder responseTimeout(Duration timeout);
+		
+		@Override
+		Builder apply(WebTestClientConfigurer configurer);
+		
+		/**
+		 * Build the {@link WebTestClient} instance.
+		 */
+		@Override
+		MockMvcWebTestClient build();
+		
+	}
+	
 
 	/**
 	 * Begin creating a {@link WebTestClient} by providing the {@code @Controller}
@@ -99,14 +214,22 @@ public interface MockMvcWebTestClient {
 	static MockMvcServerSpec<?> bindToApplicationContext(WebApplicationContext context) {
 		return new ApplicationContextMockMvcSpec(context);
 	}
+	
+	/**
+	 * Begin creating a {@link WebTestClient} by providing an already
+	 * initialized {@link MockMvc} instance to use as the server.
+	 */
+	@Deprecated // Changing the return type causes Spring Boot to throw in MockMvcAutoConfiguration
+	static WebTestClient.Builder bindTo(MockMvc mockMvc) {
+		return bindToMockMvc(mockMvc);
+	}
 
 	/**
 	 * Begin creating a {@link WebTestClient} by providing an already
 	 * initialized {@link MockMvc} instance to use as the server.
 	 */
-	static WebTestClient.Builder bindTo(MockMvc mockMvc) {
-		ClientHttpConnector connector = new MockMvcHttpConnector(mockMvc);
-		return WebTestClient.bindToServer(connector);
+	static MockMvcWebTestClient.Builder bindToMockMvc(MockMvc mockMvc) {
+		return new DefaultMockMvcWebTestClientBuilder(mockMvc);
 	}
 
 	/**
@@ -226,12 +349,12 @@ public interface MockMvcWebTestClient {
 		/**
 		 * Proceed to configure and build the test client.
 		 */
-		WebTestClient.Builder configureClient();
+		Builder configureClient();
 
 		/**
 		 * Shortcut to build the test client.
 		 */
-		WebTestClient build();
+		MockMvcWebTestClient build();
 	}
 
 

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcWebTestClientConfigurer.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcWebTestClientConfigurer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.web.servlet.client;
+
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.lang.Nullable;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
+
+/**
+ * Contract that frameworks or applications can use to pre-package a set of
+ * customizations to a {@link MockMvcWebTestClient.Builder} and expose that
+ * as a shortcut.
+ *
+ * @author Rossen Stoyanchev
+ * @see MockServerConfigurer
+ */
+public interface MockMvcWebTestClientConfigurer {
+
+	/**
+	 * Invoked once only, immediately (i.e. before this method returns).
+	 * @param builder the MockMvcWebTestClient builder to make changes to
+	 * @param httpHandlerBuilder the builder for the "mock server" HttpHandler
+	 * this client was configured for "mock server" testing
+	 * @param connector the connector for "live" integration tests if this
+	 * server was configured for live integration testing
+	 */
+	void afterConfigurerAdded(MockMvcWebTestClient.Builder builder,
+			@Nullable WebHttpHandlerBuilder httpHandlerBuilder,
+			@Nullable ClientHttpConnector connector);
+
+}


### PR DESCRIPTION
Potentially fixes related issues like https://github.com/spring-projects/spring-security/issues/9257 and https://github.com/spring-projects/spring-security/issues/11334

This PR is unpolished and is just to illustrate the idea of allowing `mutateWith` on MockMvc `RequestPostProcessors` as I'm not even sure if this design approach would be acceptable.

The basic design idea is to have the `MockMvcWebTestClient` interface extend `WebTestClient` with some MockMvc specific methods.

```java
package com.example;

import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;

import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.TestInstance;
import org.junit.jupiter.api.TestInstance.Lifecycle;
import org.springframework.beans.factory.annotation.Autowired;
import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
import org.springframework.boot.test.context.SpringBootTest;
import org.springframework.test.context.ActiveProfiles;
import org.springframework.test.web.servlet.client.MockMvcWebTestClient;
import org.springframework.web.context.WebApplicationContext;

@SpringBootTest
@AutoConfigureMockMvc
@TestInstance(Lifecycle.PER_CLASS)
@ActiveProfiles("test")
class MockMvcTest {
	MockMvcWebTestClient client;

	@Autowired
	void setupClient(WebApplicationContext context) {
		client = MockMvcWebTestClient.bindToApplicationContext(context).apply(springSecurity()).build();
	}
	
	@Test
	void givenOidcLoginShouldReturnOk() {
		client.mutateWith(oidcLogin()).get().uri("/login-user").exchange().expectStatus()
				.isOk();
	}
}
```