### PR TITLE
Quote '?' in Quoted Printable filename

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -599,7 +599,7 @@ public final class ContentDisposition {
 	}
 
 	private static boolean isPrintable(byte c) {
-		return (c >= '!' && c <= '<') || (c >= '>' && c <= '~');
+		return (c >= '!' && c <= '<') || (c >= '@' && c <= '~') || c == '>';
 	}
 
 	private static String encodeQuotedPairs(String filename) {

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -325,4 +325,20 @@ class ContentDispositionTests {
 		assertThat(parsed.toString()).isEqualTo(cd.toString());
 	}
 
+	@Test // gh-30252
+	void parseFormattedWithQuestionMark() {
+		String filename = "filename with ?问号.txt";
+		ContentDisposition cd = ContentDisposition.attachment()
+				.filename(filename, StandardCharsets.UTF_8)
+				.build();
+		String[] parts = cd.toString().split("; ");
+
+		String quotedPrintableFilename = parts[0] + "; " + parts[1];
+		assertThat(ContentDisposition.parse(quotedPrintableFilename).getFilename())
+				.isEqualTo(filename);
+
+		String rfc5987Filename = parts[0] + "; " + parts[2];
+		assertThat(ContentDisposition.parse(rfc5987Filename).getFilename())
+				.isEqualTo(filename);
+	}
 }


### PR DESCRIPTION
# Bad case
```java
String filename = "filename with ?问号.txt";
ContentDisposition cd = ContentDisposition.attachment()
    .filename(filename, StandardCharsets.UTF_8)
    .build();
String[] parts = cd.toString().split("; ");

// attachment; filename="=?UTF-8?Q?filename=20with=20?=E9=97=AE=E5=8F=B7.txt?="
String quotedPrintableFilename = parts[0] + "; " + parts[1];
// expected: filename with ?问号.txt
// actual: filename with
System.out.println(ContentDisposition.parse(quotedPrintableFilename).getFilename());
```

# Cause
In previous implementation, the question mark (?) is not quoted. If a quoted character (=E9=97=AE) follows, the combination "?=" will be interpreted as end mark of "encoded-word".

> 8-bit values which correspond to printable ASCII characters other than "=", "?", and "_" (underscore), MAY be represented as those characters.
> https://www.rfc-editor.org/rfc/rfc2047#section-4.2