### PR TITLE
Support PostgreSQL stored procedure `call` syntax in `CallMetaDataContext`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -644,7 +644,8 @@ public class CallMetaDataContext {
 		else {
 			if(this.metaDataProvider instanceof PostgresCallMetaDataProvider) {
 				callString = new StringBuilder("call ");
-			}else {
+			}
+			else {
 				callString = new StringBuilder("{call ");
 			}
 		}
@@ -671,7 +672,8 @@ public class CallMetaDataContext {
 		}
 		if(this.metaDataProvider instanceof PostgresCallMetaDataProvider) {
 			callString.append(")");
-		}else {		
+		}
+		else {
 			callString.append(")}");
 		}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -642,7 +642,11 @@ public class CallMetaDataContext {
 			parameterCount = -1;
 		}
 		else {
-			callString = new StringBuilder("{call ");
+			if(this.metaDataProvider instanceof PostgresCallMetaDataProvider) {
+				callString = new StringBuilder("call ");
+			}else {
+				callString = new StringBuilder("{call ");
+			}
 		}
 
 		if (StringUtils.hasLength(catalogNameToUse)) {
@@ -665,7 +669,11 @@ public class CallMetaDataContext {
 				parameterCount++;
 			}
 		}
-		callString.append(")}");
+		if(this.metaDataProvider instanceof PostgresCallMetaDataProvider) {
+			callString.append(")");
+		}else {		
+			callString.append(")}");
+		}
 
 		return callString.toString();
 	}


### PR DESCRIPTION
Fix for PostgreSQL stored procedure call fails due escaping call with curly braces,

- Addresses #30256