### PR TITLE
Fix SameSite attribute in MockMvcHttpConnector

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockCookie.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockCookie.java
@@ -39,15 +39,13 @@ import org.springframework.util.StringUtils;
 @SuppressWarnings("removal")
 public class MockCookie extends Cookie {
 
-	private static final long serialVersionUID = 4312531139502726325L;
+	private static final long serialVersionUID = 1198809317225300389L;
 
+	private static final String SAME_SITE = "SameSite";
+	private static final String EXPIRES = "Expires";
 
 	@Nullable
 	private ZonedDateTime expires;
-
-	@Nullable
-	private String sameSite;
-
 
 	/**
 	 * Construct a new {@link MockCookie} with the supplied name and value.
@@ -64,7 +62,7 @@ public class MockCookie extends Cookie {
 	 * @since 5.1.11
 	 */
 	public void setExpires(@Nullable ZonedDateTime expires) {
-		this.expires = expires;
+		setAttribute(EXPIRES, expires != null ? expires.format(DateTimeFormatter.RFC_1123_DATE_TIME) : null);
 	}
 
 	/**
@@ -85,7 +83,7 @@ public class MockCookie extends Cookie {
 	 * @see <a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis#section-4.1.2.7">RFC6265 bis</a>
 	 */
 	public void setSameSite(@Nullable String sameSite) {
-		this.sameSite = sameSite;
+		setAttribute(SAME_SITE, sameSite);
 	}
 
 	/**
@@ -94,9 +92,8 @@ public class MockCookie extends Cookie {
 	 */
 	@Nullable
 	public String getSameSite() {
-		return this.sameSite;
+		return getAttribute(SAME_SITE);
 	}
-
 
 	/**
 	 * Factory method that parses the value of the supplied "Set-Cookie" header.
@@ -122,7 +119,7 @@ public class MockCookie extends Cookie {
 			else if (StringUtils.startsWithIgnoreCase(attribute, "Max-Age")) {
 				cookie.setMaxAge(Integer.parseInt(extractAttributeValue(attribute, setCookieHeader)));
 			}
-			else if (StringUtils.startsWithIgnoreCase(attribute, "Expires")) {
+			else if (StringUtils.startsWithIgnoreCase(attribute, EXPIRES)) {
 				try {
 					cookie.setExpires(ZonedDateTime.parse(extractAttributeValue(attribute, setCookieHeader),
 							DateTimeFormatter.RFC_1123_DATE_TIME));
@@ -140,7 +137,7 @@ public class MockCookie extends Cookie {
 			else if (StringUtils.startsWithIgnoreCase(attribute, "HttpOnly")) {
 				cookie.setHttpOnly(true);
 			}
-			else if (StringUtils.startsWithIgnoreCase(attribute, "SameSite")) {
+			else if (StringUtils.startsWithIgnoreCase(attribute, SAME_SITE)) {
 				cookie.setSameSite(extractAttributeValue(attribute, setCookieHeader));
 			}
 			else if (StringUtils.startsWithIgnoreCase(attribute, "Comment")) {
@@ -158,6 +155,14 @@ public class MockCookie extends Cookie {
 	}
 
 	@Override
+	public void setAttribute(String name, @Nullable String value) {
+		if(EXPIRES.equalsIgnoreCase(name) && value != null) {
+			this.expires = ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME);
+		}
+		super.setAttribute(name, value);
+	}
+
+	@Override
 	public String toString() {
 		return new ToStringCreator(this)
 				.append("name", getName())
@@ -168,9 +173,9 @@ public class MockCookie extends Cookie {
 				.append("Comment", getComment())
 				.append("Secure", getSecure())
 				.append("HttpOnly", isHttpOnly())
-				.append("SameSite", this.sameSite)
+				.append(SAME_SITE, getSameSite())
 				.append("Max-Age", getMaxAge())
-				.append("Expires", (this.expires != null ?
+				.append(EXPIRES, (this.expires != null ?
 						DateTimeFormatter.RFC_1123_DATE_TIME.format(this.expires) : null))
 				.toString();
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
@@ -197,6 +197,7 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 							.path(cookie.getPath())
 							.secure(cookie.getSecure())
 							.httpOnly(cookie.isHttpOnly())
+							.sameSite(cookie.getAttribute("samesite"))
 							.build();
 			clientResponse.getCookies().add(httpCookie.getName(), httpCookie);
 		}

--- a/spring-test/src/test/java/org/springframework/mock/web/MockCookieTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockCookieTests.java
@@ -136,4 +136,37 @@ class MockCookieTests {
 		assertThat(cookie.getSameSite()).isEqualTo("Lax");
 	}
 
+	@Test
+	void setSameSiteShouldSetAttribute() {
+		MockCookie cookie = new MockCookie("SESSION", "123");
+		cookie.setSameSite("Strict");
+
+		assertThat(cookie.getAttribute("samesite")).isEqualTo("Strict");
+	}
+
+	@Test
+	void setExpiresShouldSetAttribute() {
+		MockCookie cookie = new MockCookie("SESSION", "123");
+		cookie.setExpires(ZonedDateTime.parse("Tue, 8 Oct 2019 19:50:00 GMT",
+				DateTimeFormatter.RFC_1123_DATE_TIME));
+
+		assertThat(cookie.getAttribute("expires")).isEqualTo("Tue, 8 Oct 2019 19:50:00 GMT");
+	}
+
+	@Test
+	void setAttributeSameSiteShouldSetSameSite() {
+		MockCookie cookie = new MockCookie("SESSION", "123");
+		cookie.setAttribute("samesite", "Lax");
+
+		assertThat(cookie.getSameSite()).isEqualTo("Lax");
+	}
+
+	@Test
+	void setAttributeExpiresShouldSetExpires() {
+		MockCookie cookie = new MockCookie("SESSION", "123");
+		cookie.setAttribute("expires", "Tue, 8 Oct 2019 19:50:00 GMT");
+
+		assertThat(cookie.getExpires()).isEqualTo(ZonedDateTime.parse("Tue, 8 Oct 2019 19:50:00 GMT",
+				DateTimeFormatter.RFC_1123_DATE_TIME));
+	}
 }

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/client/standalone/resultmatches/CookieAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/client/standalone/resultmatches/CookieAssertionTests.java
@@ -50,6 +50,7 @@ public class CookieAssertionTests {
 		CookieLocaleResolver localeResolver = new CookieLocaleResolver();
 		localeResolver.setCookieDomain("domain");
 		localeResolver.setCookieHttpOnly(true);
+		localeResolver.setCookieSameSite("Strict");
 
 		client = MockMvcWebTestClient.bindToController(new SimpleController())
 				.interceptors(new LocaleChangeInterceptor())
@@ -107,6 +108,10 @@ public class CookieAssertionTests {
 		client.get().uri("/").exchange().expectCookie().httpOnly(COOKIE_NAME, true);
 	}
 
+	@Test
+	public void testSameSite() {
+		client.get().uri("/").exchange().expectCookie().sameSite(COOKIE_NAME, "Strict");
+	}
 
 	@Controller
 	private static class SimpleController {


### PR DESCRIPTION
Fixes #30249

* Modified `MockCookie` to populate attributes using `setAttribute`.
* Modified `MockMvcHttpConnector` to set `sameSite` using `Cookie.getAttribute`
* Added tests