### PR TITLE
Support `SameSite` cookie attribute in `MockMvcHttpConnector`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/MockMvcHttpConnector.java
@@ -197,6 +197,7 @@ public class MockMvcHttpConnector implements ClientHttpConnector {
 							.path(cookie.getPath())
 							.secure(cookie.getSecure())
 							.httpOnly(cookie.isHttpOnly())
+							.sameSite(cookie.getAttribute("samesite"))
 							.build();
 			clientResponse.getCookies().add(httpCookie.getName(), httpCookie);
 		}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/client/standalone/resultmatches/CookieAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/client/standalone/resultmatches/CookieAssertionTests.java
@@ -50,6 +50,7 @@ public class CookieAssertionTests {
 		CookieLocaleResolver localeResolver = new CookieLocaleResolver();
 		localeResolver.setCookieDomain("domain");
 		localeResolver.setCookieHttpOnly(true);
+		localeResolver.setCookieSameSite("Strict");
 
 		client = MockMvcWebTestClient.bindToController(new SimpleController())
 				.interceptors(new LocaleChangeInterceptor())
@@ -107,6 +108,10 @@ public class CookieAssertionTests {
 		client.get().uri("/").exchange().expectCookie().httpOnly(COOKIE_NAME, true);
 	}
 
+	@Test
+	public void testSameSite() {
+		client.get().uri("/").exchange().expectCookie().sameSite(COOKIE_NAME, "Strict");
+	}
 
 	@Controller
 	private static class SimpleController {


### PR DESCRIPTION
Modified `MockMvcHttpConnector` to set `sameSite` using `Cookie.getAttribute`.

The test relies on `MockCookie` setting the `SameSite` attribute to pass.