### PR TITLE
Fix incorrect jakarta.inject artifact version

### DIFF
--- a/framework-docs/src/docs/asciidoc/core/core-beans.adoc
+++ b/framework-docs/src/docs/asciidoc/core/core-beans.adoc
@@ -7189,7 +7189,7 @@ You can add the following dependency to your file pom.xml:
 	<dependency>
 		<groupId>jakarta.inject</groupId>
 		<artifactId>jakarta.inject-api</artifactId>
-		<version>1</version>
+		<version>2.0.0</version>
 	</dependency>
 ----
 =====


### PR DESCRIPTION
In the [documentation on using the JSR 330 Standard Annotations](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#beans-standard-annotations), the code example for the dependency declaration uses an incorrect version.

This pull request will change the version to the version that is mentioned in the text about the code block.