### PR TITLE
Add since tags to sameSite() and attribute() in CookieResultMatchersDsl

### DIFF
--- a/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/CookieResultMatchersDsl.kt
+++ b/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/CookieResultMatchersDsl.kt
@@ -101,6 +101,7 @@ class CookieResultMatchersDsl internal constructor (private val actions: ResultA
 
 	/**
 	 * @see CookieResultMatchers.sameSite
+	 * @since 6.0.8
 	 */
 	fun sameSite(name: String, matcher: Matcher<String>) {
 		actions.andExpect(matchers.sameSite(name, matcher))
@@ -108,6 +109,7 @@ class CookieResultMatchersDsl internal constructor (private val actions: ResultA
 
 	/**
 	 * @see CookieResultMatchers.sameSite
+	 * @since 6.0.8
 	 */
 	fun sameSite(name: String, sameSite: String) {
 		actions.andExpect(matchers.sameSite(name, sameSite))
@@ -157,6 +159,7 @@ class CookieResultMatchersDsl internal constructor (private val actions: ResultA
 
 	/**
 	 * @see CookieResultMatchers.attribute
+	 * @since 6.0.8
 	 */
 	fun attribute(name: String, attributeName: String, matcher: Matcher<String>) {
 		actions.andExpect(matchers.attribute(name, attributeName, matcher))
@@ -164,6 +167,7 @@ class CookieResultMatchersDsl internal constructor (private val actions: ResultA
 
 	/**
 	 * @see CookieResultMatchers.attribute
+	 * @since 6.0.8
 	 */
 	fun attribute(name: String, attributeName: String, attributeValue: String) {
 		actions.andExpect(matchers.attribute(name, attributeName, attributeValue))


### PR DESCRIPTION
This PR adds `@since` tags to the new `sameSite()` and `attribute()` functions in the `CookieResultMatchersDsl`.

See gh-30285