### PR TITLE
Improve class reading to provide additional parity with reflection

### DIFF
--- a/spring-core/src/main/java/org/springframework/asm/signature/SignatureReader.java
+++ b/spring-core/src/main/java/org/springframework/asm/signature/SignatureReader.java
@@ -1,0 +1,281 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.springframework.asm.signature;
+
+/**
+ * A parser for signature literals, as defined in the Java Virtual Machine Specification
+ * (JVMS), to visit them with a SignatureVisitor.
+ *
+ * @see <a href=
+ * "https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.9.1">JVMS
+ * 4.7.9.1</a>
+ * @author Thomas Hallgren
+ * @author Eric Bruneton
+ */
+public class SignatureReader {
+
+	/** The JVMS signature to be read. */
+	private final String signatureValue;
+
+	/**
+	 * Constructs a {@link SignatureReader} for the given signature.
+	 * @param signature A <i>JavaTypeSignature</i>, <i>ClassSignature</i> or
+	 * <i>MethodSignature</i>.
+	 */
+	public SignatureReader(final String signature) {
+		this.signatureValue = signature;
+	}
+
+	/**
+	 * Makes the given visitor visit the signature of this {@link SignatureReader}. This
+	 * signature is the one specified in the constructor (see {@link #SignatureReader}).
+	 * This method is intended to be called on a {@link SignatureReader} that was created
+	 * using a <i>ClassSignature</i> (such as the <code>signature</code> parameter of the
+	 * {@link org.springframework.asm.ClassVisitor#visit} method) or a
+	 * <i>MethodSignature</i> (such as the <code>signature</code> parameter of the
+	 * {@link org.springframework.asm.ClassVisitor#visitMethod} method).
+	 * @param signatureVistor the visitor that must visit this signature.
+	 */
+	public void accept(final SignatureVisitor signatureVistor) {
+		String signature = this.signatureValue;
+		int length = signature.length();
+		int offset; // Current offset in the parsed signature (parsed from left to right).
+		char currentChar; // The signature character at 'offset', or just before.
+
+		// If the signature starts with '<', it starts with TypeParameters, i.e. a formal
+		// type parameter
+		// identifier, followed by one or more pair ':',ReferenceTypeSignature (for its
+		// class bound and
+		// interface bounds).
+		if (signature.charAt(0) == '<') {
+			// Invariant: offset points to the second character of a formal type parameter
+			// name at the
+			// beginning of each iteration of the loop below.
+			offset = 2;
+			do {
+				// The formal type parameter name is everything between offset - 1 and the
+				// first ':'.
+				int classBoundStartOffset = signature.indexOf(':', offset);
+				signatureVistor.visitFormalTypeParameter(signature.substring(offset - 1, classBoundStartOffset));
+
+				// If the character after the ':' class bound marker is not the start of a
+				// ReferenceTypeSignature, it means the class bound is empty (which is a
+				// valid case).
+				offset = classBoundStartOffset + 1;
+				currentChar = signature.charAt(offset);
+				if (currentChar == 'L' || currentChar == '[' || currentChar == 'T') {
+					offset = parseType(signature, offset, signatureVistor.visitClassBound());
+				}
+
+				// While the character after the class bound or after the last parsed
+				// interface bound
+				// is ':', we need to parse another interface bound.
+				while ((currentChar = signature.charAt(offset++)) == ':') {
+					offset = parseType(signature, offset, signatureVistor.visitInterfaceBound());
+				}
+
+				// At this point a TypeParameter has been fully parsed, and we need to
+				// parse the next one
+				// (note that currentChar is now the first character of the next
+				// TypeParameter, and that
+				// offset points to the second character), unless the character just after
+				// this
+				// TypeParameter signals the end of the TypeParameters.
+			}
+			while (currentChar != '>');
+		}
+		else {
+			offset = 0;
+		}
+
+		// If the (optional) TypeParameters is followed by '(' this means we are parsing a
+		// MethodSignature, which has JavaTypeSignature type inside parentheses, followed
+		// by a Result
+		// type and optional ThrowsSignature types.
+		if (signature.charAt(offset) == '(') {
+			offset++;
+			while (signature.charAt(offset) != ')') {
+				offset = parseType(signature, offset, signatureVistor.visitParameterType());
+			}
+			// Use offset + 1 to skip ')'.
+			offset = parseType(signature, offset + 1, signatureVistor.visitReturnType());
+			while (offset < length) {
+				// Use offset + 1 to skip the first character of a ThrowsSignature, i.e.
+				// '^'.
+				offset = parseType(signature, offset + 1, signatureVistor.visitExceptionType());
+			}
+		}
+		else {
+			// Otherwise we are parsing a ClassSignature (by hypothesis on the method
+			// input), which has
+			// one or more ClassTypeSignature for the super class and the implemented
+			// interfaces.
+			offset = parseType(signature, offset, signatureVistor.visitSuperclass());
+			while (offset < length) {
+				offset = parseType(signature, offset, signatureVistor.visitInterface());
+			}
+		}
+	}
+
+	/**
+	 * Makes the given visitor visit the signature of this {@link SignatureReader}. This
+	 * signature is the one specified in the constructor (see {@link #SignatureReader}).
+	 * This method is intended to be called on a {@link SignatureReader} that was created
+	 * using a <i>JavaTypeSignature</i>, such as the <code>signature</code> parameter of
+	 * the {@link org.springframework.asm.ClassVisitor#visitField} or
+	 * {@link org.springframework.asm.MethodVisitor#visitLocalVariable} methods.
+	 * @param signatureVisitor the visitor that must visit this signature.
+	 */
+	public void acceptType(final SignatureVisitor signatureVisitor) {
+		parseType(signatureValue, 0, signatureVisitor);
+	}
+
+	/**
+	 * Parses a JavaTypeSignature and makes the given visitor visit it.
+	 * @param signature a string containing the signature that must be parsed.
+	 * @param startOffset index of the first character of the signature to parsed.
+	 * @param signatureVisitor the visitor that must visit this signature.
+	 * @return the index of the first character after the parsed signature.
+	 */
+	private static int parseType(final String signature, final int startOffset,
+			final SignatureVisitor signatureVisitor) {
+		int offset = startOffset; // Current offset in the parsed signature.
+		char currentChar = signature.charAt(offset++); // The signature character at
+														// 'offset'.
+
+		// Switch based on the first character of the JavaTypeSignature, which indicates
+		// its kind.
+		switch (currentChar) {
+		case 'Z':
+		case 'C':
+		case 'B':
+		case 'S':
+		case 'I':
+		case 'F':
+		case 'J':
+		case 'D':
+		case 'V':
+			// Case of a BaseType or a VoidDescriptor.
+			signatureVisitor.visitBaseType(currentChar);
+			return offset;
+
+		case '[':
+			// Case of an ArrayTypeSignature, a '[' followed by a JavaTypeSignature.
+			return parseType(signature, offset, signatureVisitor.visitArrayType());
+
+		case 'T':
+			// Case of TypeVariableSignature, an identifier between 'T' and ';'.
+			int endOffset = signature.indexOf(';', offset);
+			signatureVisitor.visitTypeVariable(signature.substring(offset, endOffset));
+			return endOffset + 1;
+
+		case 'L':
+			// Case of a ClassTypeSignature, which ends with ';'.
+			// These signatures have a main class type followed by zero or more inner
+			// class types
+			// (separated by '.'). Each can have type arguments, inside '<' and '>'.
+			int start = offset; // The start offset of the currently parsed main or inner
+								// class name.
+			boolean visited = false; // Whether the currently parsed class name has been
+										// visited.
+			boolean inner = false; // Whether we are currently parsing an inner class
+									// type.
+			// Parses the signature, one character at a time.
+			while (true) {
+				currentChar = signature.charAt(offset++);
+				if (currentChar == '.' || currentChar == ';') {
+					// If a '.' or ';' is encountered, this means we have fully parsed the
+					// main class name
+					// or an inner class name. This name may already have been visited it
+					// is was followed by
+					// type arguments between '<' and '>'. If not, we need to visit it
+					// here.
+					if (!visited) {
+						String name = signature.substring(start, offset - 1);
+						if (inner) {
+							signatureVisitor.visitInnerClassType(name);
+						}
+						else {
+							signatureVisitor.visitClassType(name);
+						}
+					}
+					// If we reached the end of the ClassTypeSignature return, otherwise
+					// start the parsing
+					// of a new class name, which is necessarily an inner class name.
+					if (currentChar == ';') {
+						signatureVisitor.visitEnd();
+						break;
+					}
+					start = offset;
+					visited = false;
+					inner = true;
+				}
+				else if (currentChar == '<') {
+					// If a '<' is encountered, this means we have fully parsed the main
+					// class name or an
+					// inner class name, and that we now need to parse TypeArguments.
+					// First, we need to
+					// visit the parsed class name.
+					String name = signature.substring(start, offset - 1);
+					if (inner) {
+						signatureVisitor.visitInnerClassType(name);
+					}
+					else {
+						signatureVisitor.visitClassType(name);
+					}
+					visited = true;
+					// Now, parse the TypeArgument(s), one at a time.
+					while ((currentChar = signature.charAt(offset)) != '>') {
+						switch (currentChar) {
+						case '*':
+							// Unbounded TypeArgument.
+							++offset;
+							signatureVisitor.visitTypeArgument();
+							break;
+						case '+':
+						case '-':
+							// Extends or Super TypeArgument. Use offset + 1 to skip the
+							// '+' or '-'.
+							offset = parseType(signature, offset + 1, signatureVisitor.visitTypeArgument(currentChar));
+							break;
+						default:
+							// Instanceof TypeArgument. The '=' is implicit.
+							offset = parseType(signature, offset, signatureVisitor.visitTypeArgument('='));
+							break;
+						}
+					}
+				}
+			}
+			return offset;
+
+		default:
+			throw new IllegalArgumentException();
+		}
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/asm/signature/SignatureVisitor.java
+++ b/spring-core/src/main/java/org/springframework/asm/signature/SignatureVisitor.java
@@ -1,0 +1,204 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.springframework.asm.signature;
+
+import org.springframework.asm.Opcodes;
+
+/**
+ * A visitor to visit a generic signature. The methods of this interface must be called in
+ * one of the three following orders (the last one is the only valid order for a
+ * {@link SignatureVisitor} that is returned by a method of this interface):
+ *
+ * <ul>
+ * <li><i>ClassSignature</i> = ( {@code visitFormalTypeParameter} {@code visitClassBound}?
+ * {@code
+ *       visitInterfaceBound}* )* ({@code visitSuperclass} {@code visitInterface}* )
+ * <li><i>MethodSignature</i> = ( {@code visitFormalTypeParameter}
+ * {@code visitClassBound}? {@code
+ *       visitInterfaceBound}* )* ({@code visitParameterType}* {@code visitReturnType}
+ * {@code
+ *       visitExceptionType}* )
+ * <li><i>TypeSignature</i> = {@code visitBaseType} | {@code visitTypeVariable} | {@code
+ *       visitArrayType} | ( {@code visitClassType} {@code visitTypeArgument}* ( {@code
+ *       visitInnerClassType} {@code visitTypeArgument}* )* {@code visitEnd} ) )
+ * </ul>
+ *
+ * @author Thomas Hallgren
+ * @author Eric Bruneton
+ */
+public abstract class SignatureVisitor {
+
+	/** Wildcard for an "extends" type argument. */
+	public static final char EXTENDS = '+';
+
+	/** Wildcard for a "super" type argument. */
+	public static final char SUPER = '-';
+
+	/** Wildcard for a normal type argument. */
+	public static final char INSTANCEOF = '=';
+
+	/**
+	 * The ASM API version implemented by this visitor. The value of this field must be
+	 * one of the {@code ASM}<i>x</i> values in {@link Opcodes}.
+	 */
+	protected final int api;
+
+	/**
+	 * Constructs a new {@link SignatureVisitor}.
+	 * @param api the ASM API version implemented by this visitor. Must be one of the
+	 * {@code
+	 *     ASM}<i>x</i> values in {@link Opcodes}.
+	 */
+	protected SignatureVisitor(final int api) {
+		if (api != Opcodes.ASM9 && api != Opcodes.ASM8 && api != Opcodes.ASM7 && api != Opcodes.ASM6
+				&& api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM10_EXPERIMENTAL) {
+			throw new IllegalArgumentException("Unsupported api " + api);
+		}
+		this.api = api;
+	}
+
+	/**
+	 * Visits a formal type parameter.
+	 * @param name the name of the formal parameter.
+	 */
+	public void visitFormalTypeParameter(final String name) {
+	}
+
+	/**
+	 * Visits the class bound of the last visited formal type parameter.
+	 * @return a non null visitor to visit the signature of the class bound.
+	 */
+	public SignatureVisitor visitClassBound() {
+		return this;
+	}
+
+	/**
+	 * Visits an interface bound of the last visited formal type parameter.
+	 * @return a non null visitor to visit the signature of the interface bound.
+	 */
+	public SignatureVisitor visitInterfaceBound() {
+		return this;
+	}
+
+	/**
+	 * Visits the type of the super class.
+	 * @return a non null visitor to visit the signature of the super class type.
+	 */
+	public SignatureVisitor visitSuperclass() {
+		return this;
+	}
+
+	/**
+	 * Visits the type of an interface implemented by the class.
+	 * @return a non null visitor to visit the signature of the interface type.
+	 */
+	public SignatureVisitor visitInterface() {
+		return this;
+	}
+
+	/**
+	 * Visits the type of a method parameter.
+	 * @return a non null visitor to visit the signature of the parameter type.
+	 */
+	public SignatureVisitor visitParameterType() {
+		return this;
+	}
+
+	/**
+	 * Visits the return type of the method.
+	 * @return a non null visitor to visit the signature of the return type.
+	 */
+	public SignatureVisitor visitReturnType() {
+		return this;
+	}
+
+	/**
+	 * Visits the type of a method exception.
+	 * @return a non null visitor to visit the signature of the exception type.
+	 */
+	public SignatureVisitor visitExceptionType() {
+		return this;
+	}
+
+	/**
+	 * Visits a signature corresponding to a primitive type.
+	 * @param descriptor the descriptor of the primitive type, or 'V' for {@code void} .
+	 */
+	public void visitBaseType(final char descriptor) {
+	}
+
+	/**
+	 * Visits a signature corresponding to a type variable.
+	 * @param name the name of the type variable.
+	 */
+	public void visitTypeVariable(final String name) {
+	}
+
+	/**
+	 * Visits a signature corresponding to an array type.
+	 * @return a non null visitor to visit the signature of the array element type.
+	 */
+	public SignatureVisitor visitArrayType() {
+		return this;
+	}
+
+	/**
+	 * Starts the visit of a signature corresponding to a class or interface type.
+	 * @param name the internal name of the class or interface (see
+	 * {@link org.springframework.asm.Type#getInternalName()}).
+	 */
+	public void visitClassType(final String name) {
+	}
+
+	/**
+	 * Visits an inner class.
+	 * @param name the local name of the inner class in its enclosing class.
+	 */
+	public void visitInnerClassType(final String name) {
+	}
+
+	/**
+	 * Visits an unbounded type argument of the last visited class or inner class type.
+	 */
+	public void visitTypeArgument() {
+	}
+
+	/**
+	 * Visits a type argument of the last visited class or inner class type.
+	 * @param wildcard '+', '-' or '='.
+	 * @return a non null visitor to visit the signature of the type argument.
+	 */
+	public SignatureVisitor visitTypeArgument(final char wildcard) {
+		return this;
+	}
+
+	/** Ends the visit of a signature corresponding to a class or interface type. */
+	public void visitEnd() {
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/asm/signature/SignatureWriter.java
+++ b/spring-core/src/main/java/org/springframework/asm/signature/SignatureWriter.java
@@ -1,0 +1,260 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.springframework.asm.signature;
+
+import org.springframework.asm.Opcodes;
+
+/**
+ * A SignatureVisitor that generates signature literals, as defined in the Java Virtual
+ * Machine Specification (JVMS).
+ *
+ * @see <a href=
+ * "https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.9.1">JVMS
+ * 4.7.9.1</a>
+ * @author Thomas Hallgren
+ * @author Eric Bruneton
+ */
+public class SignatureWriter extends SignatureVisitor {
+
+	/** The builder used to construct the visited signature. */
+	private final StringBuilder stringBuilder;
+
+	/** Whether the visited signature contains formal type parameters. */
+	private boolean hasFormals;
+
+	/** Whether the visited signature contains method parameter types. */
+	private boolean hasParameters;
+
+	/**
+	 * The stack used to keep track of class types that have arguments. Each element of
+	 * this stack is a boolean encoded in one bit. The top of the stack is the least
+	 * significant bit. The bottom of the stack is a sentinel element always equal to 1
+	 * (used to detect when the stack is full). Pushing false = {@code <<= 1}, pushing
+	 * true = {@code ( <<= 1) | 1}, popping = {@code >>>= 1}.
+	 *
+	 * <p>
+	 * Class type arguments must be surrounded with '&lt;' and '&gt;' and, because
+	 *
+	 * <ol>
+	 * <li>class types can be nested (because type arguments can themselves be class
+	 * types),
+	 * <li>SignatureWriter always returns 'this' in each visit* method (to avoid
+	 * allocating new SignatureWriter instances),
+	 * </ol>
+	 *
+	 * <p>
+	 * we need a stack to properly balance these angle brackets. A new element is pushed
+	 * on this stack for each new visited type, and popped when the visit of this type
+	 * ends (either in visitEnd, or because visitInnerClassType is called).
+	 */
+	private int argumentStack = 1;
+
+	/** Constructs a new {@link SignatureWriter}. */
+	public SignatureWriter() {
+		this(new StringBuilder());
+	}
+
+	private SignatureWriter(final StringBuilder stringBuilder) {
+		super(/* latest api = */ Opcodes.ASM9);
+		this.stringBuilder = stringBuilder;
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	// Implementation of the SignatureVisitor interface
+	// -----------------------------------------------------------------------------------------------
+
+	@Override
+	public void visitFormalTypeParameter(final String name) {
+		if (!hasFormals) {
+			hasFormals = true;
+			stringBuilder.append('<');
+		}
+		stringBuilder.append(name);
+		stringBuilder.append(':');
+	}
+
+	@Override
+	public SignatureVisitor visitClassBound() {
+		return this;
+	}
+
+	@Override
+	public SignatureVisitor visitInterfaceBound() {
+		stringBuilder.append(':');
+		return this;
+	}
+
+	@Override
+	public SignatureVisitor visitSuperclass() {
+		endFormals();
+		return this;
+	}
+
+	@Override
+	public SignatureVisitor visitInterface() {
+		return this;
+	}
+
+	@Override
+	public SignatureVisitor visitParameterType() {
+		endFormals();
+		if (!hasParameters) {
+			hasParameters = true;
+			stringBuilder.append('(');
+		}
+		return this;
+	}
+
+	@Override
+	public SignatureVisitor visitReturnType() {
+		endFormals();
+		if (!hasParameters) {
+			stringBuilder.append('(');
+		}
+		stringBuilder.append(')');
+		return this;
+	}
+
+	@Override
+	public SignatureVisitor visitExceptionType() {
+		stringBuilder.append('^');
+		return this;
+	}
+
+	@Override
+	public void visitBaseType(final char descriptor) {
+		stringBuilder.append(descriptor);
+	}
+
+	@Override
+	public void visitTypeVariable(final String name) {
+		stringBuilder.append('T');
+		stringBuilder.append(name);
+		stringBuilder.append(';');
+	}
+
+	@Override
+	public SignatureVisitor visitArrayType() {
+		stringBuilder.append('[');
+		return this;
+	}
+
+	@Override
+	public void visitClassType(final String name) {
+		stringBuilder.append('L');
+		stringBuilder.append(name);
+		// Pushes 'false' on the stack, meaning that this type does not have type
+		// arguments (as far as
+		// we can tell at this point).
+		argumentStack <<= 1;
+	}
+
+	@Override
+	public void visitInnerClassType(final String name) {
+		endArguments();
+		stringBuilder.append('.');
+		stringBuilder.append(name);
+		// Pushes 'false' on the stack, meaning that this type does not have type
+		// arguments (as far as
+		// we can tell at this point).
+		argumentStack <<= 1;
+	}
+
+	@Override
+	public void visitTypeArgument() {
+		// If the top of the stack is 'false', this means we are visiting the first type
+		// argument of the
+		// currently visited type. We therefore need to append a '<', and to replace the
+		// top stack
+		// element with 'true' (meaning that the current type does have type arguments).
+		if ((argumentStack & 1) == 0) {
+			argumentStack |= 1;
+			stringBuilder.append('<');
+		}
+		stringBuilder.append('*');
+	}
+
+	@Override
+	public SignatureVisitor visitTypeArgument(final char wildcard) {
+		// If the top of the stack is 'false', this means we are visiting the first type
+		// argument of the
+		// currently visited type. We therefore need to append a '<', and to replace the
+		// top stack
+		// element with 'true' (meaning that the current type does have type arguments).
+		if ((argumentStack & 1) == 0) {
+			argumentStack |= 1;
+			stringBuilder.append('<');
+		}
+		if (wildcard != '=') {
+			stringBuilder.append(wildcard);
+		}
+		// If the stack is full, start a nested one by returning a new SignatureWriter.
+		return (argumentStack & (1 << 31)) == 0 ? this : new SignatureWriter(stringBuilder);
+	}
+
+	@Override
+	public void visitEnd() {
+		endArguments();
+		stringBuilder.append(';');
+	}
+
+	/**
+	 * Returns the signature that was built by this signature writer.
+	 * @return the signature that was built by this signature writer.
+	 */
+	@Override
+	public String toString() {
+		return stringBuilder.toString();
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	// Utility methods
+	// -----------------------------------------------------------------------------------------------
+
+	/** Ends the formal type parameters section of the signature. */
+	private void endFormals() {
+		if (hasFormals) {
+			hasFormals = false;
+			stringBuilder.append('>');
+		}
+	}
+
+	/** Ends the type arguments of a class or inner class type. */
+	private void endArguments() {
+		// If the top of the stack is 'true', this means that some type arguments have
+		// been visited for
+		// the type whose visit is now ending. We therefore need to append a '>', and to
+		// pop one element
+		// from the stack.
+		if ((argumentStack & 1) == 1) {
+			stringBuilder.append('>');
+		}
+		argumentStack >>>= 1;
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/AnnotatedTypeMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/AnnotatedTypeMetadata.java
@@ -146,4 +146,17 @@ public interface AnnotatedTypeMetadata {
 						map.isEmpty() ? null : map, adaptations));
 	}
 
+	/**
+	 * Determine the name of the declaring class.
+	 * @since 6.x
+	 */
+	String getDeclaringClassName();
+
+	/**
+	 * Convenience method to get the {@link TypeMetadata} for the annotated type. For classes, their own type,
+	 * methods the return type, and the declared type for fields and parameters.
+	 * @since 6.x
+	 */
+	TypeMetadata getAnnotatedType();
+
 }

--- a/spring-core/src/main/java/org/springframework/core/type/AnnotationMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/AnnotationMetadata.java
@@ -38,7 +38,7 @@ import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
  * @see org.springframework.core.type.classreading.MetadataReader#getAnnotationMetadata()
  * @see AnnotatedTypeMetadata
  */
-public interface AnnotationMetadata extends ClassMetadata, AnnotatedTypeMetadata {
+public interface AnnotationMetadata extends ClassMetadata, BeanClassMetadata, AnnotatedTypeMetadata {
 
 	/**
 	 * Get the fully qualified class names of all annotation types that
@@ -123,6 +123,17 @@ public interface AnnotationMetadata extends ClassMetadata, AnnotatedTypeMetadata
 	 */
 	Set<MethodMetadata> getDeclaredMethods();
 
+	/**
+	 * Get the constructors annotated with the provided annotation class name.
+	 * @since 6.x
+	 */
+	Set<FieldMetadata> getAnnotatedFields(String annotationName);
+
+	/**
+	 * Get the constructors annotated with the provided annotation class name.
+	 * @since 6.x
+	 */
+	Set<ConstructorMetadata> getAnnotatedConstructors(String annotationName);
 
 	/**
 	 * Factory method to create a new {@link AnnotationMetadata} instance

--- a/spring-core/src/main/java/org/springframework/core/type/ArrayTypeMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/ArrayTypeMetadata.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+/**
+ * Describes an array type.
+ *
+ * @author Danny Thomas
+ */
+public interface ArrayTypeMetadata extends TypeMetadata {
+
+	/**
+	 * Determine the component type of this array.
+	 * @return the component type of this array
+	 */
+	TypeMetadata getComponentType();
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/BeanClassMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/BeanClassMetadata.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Interface that defines abstract bean metadata for a specific class.
+ *
+ * @author Danny Thomas
+ * @since 6.x
+ */
+public interface BeanClassMetadata {
+
+	/**
+	 * Determine if this class is a bean factory. Where a bean factory implements one of the following interfaces:
+	 * <p>
+	 * {@link org.springframework.beans.factory.FactoryBean}
+	 * {@link org.springframework.beans.factory.ObjectFactory}
+	 * @return true if the class implements a bean factory interface
+	 * @throws ClassMetadataNotFoundException if class metadata for the class hierarchy of
+	 * this class could not be loaded
+	 */
+	boolean isBeanFactory();
+
+	/**
+	 * If this class is a bean factory, as defined by {@link #isBeanFactory()}, return the type
+	 * that the factory returns.
+	 * @return the {@link TypeMetadata} for the given type. Null if this class is not a bean factory
+	 * @throws ClassMetadataNotFoundException if class metadata for the class hierarchy of
+	 * this class could not be loaded
+	 * @see #isBeanFactory()
+	 */
+	@Nullable
+	TypeMetadata getBeanFactoryTypeMetadata();
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/ClassMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/ClassMetadata.java
@@ -16,6 +16,8 @@
 
 package org.springframework.core.type;
 
+import java.util.Set;
+
 import org.springframework.lang.Nullable;
 
 /**
@@ -91,10 +93,23 @@ public interface ClassMetadata {
 
 	/**
 	 * Return whether the underlying class has a superclass.
+	 *
+	 * Note this differs from {@link Class#getSuperclass()}, and considers {@link Object} a super class.
 	 */
 	default boolean hasSuperClass() {
 		return (getSuperClassName() != null);
 	}
+
+	/**
+	 * Return the {@link ClassMetadata} for the enclosing class.
+	 * @throws ClassMetadataNotFoundException if class metadata for the super class could
+	 * not be loaded.
+	 * @returns the {@link ClassMetadata} for the enclosing class. Null if the
+	 * class isn't enclosed
+	 * @since 6.x
+	 */
+	@Nullable
+	ClassMetadata getEnclosingClassMetadata();
 
 	/**
 	 * Return the name of the superclass of the underlying class,
@@ -104,10 +119,30 @@ public interface ClassMetadata {
 	String getSuperClassName();
 
 	/**
+	 * Return the {@link ClassMetadata} for the super class.
+	 * @throws ClassMetadataNotFoundException if class metadata for the super class could
+	 * not be loaded.
+	 * @since 6.x
+	 */
+	@Nullable
+	ClassMetadata getSuperClassMetadata();
+
+	/**
 	 * Return the names of all interfaces that the underlying class
 	 * implements, or an empty array if there are none.
 	 */
 	String[] getInterfaceNames();
+
+	/**
+	 * Return the {@link ClassMetadata} of the interfaces this class directly
+	 * implements.
+	 * @return a set of {@link ClassMetadata} containing the interface classes
+	 * for the class
+	 * @throws ClassMetadataNotFoundException if class metadata for the interface classes
+	 * coudl not be loaded.
+	 * @since 6.x
+	 */
+	Set<ClassMetadata> getInterfaceClassMetadata();
 
 	/**
 	 * Return the names of all classes declared as members of the class represented by
@@ -118,5 +153,104 @@ public interface ClassMetadata {
 	 * @since 3.1
 	 */
 	String[] getMemberClassNames();
+
+	/**
+	 * Return the {@link ClassMetadata} of the member clases of this class.
+	 * @return a set of {@link ClassMetadata} containing the interface classes
+	 * for the class
+	 * @throws ClassMetadataNotFoundException if class metadata for the interface classes
+	 * coudl not be loaded.
+	 * @since 6.x
+	 */
+	Set<ClassMetadata> getMemberClassMetadata();
+
+	/**
+	 * Satisfies {@link Class#isEnum()}.
+	 * @since 6.x
+	 */
+	boolean isEnum();
+
+	/**
+	 * Satisfies {@link Class#isPrimitive()}.
+	 * @since 6.x
+	 */
+	boolean isPrimitive();
+
+	/**
+	 * Satisfies {@link Class#isSynthetic()}.
+	 * @since 6.x
+	 */
+	boolean isSynthetic();
+
+	/**
+	 * Return the underlying modifiers for the class.
+	 * @since 6.x
+	 */
+	int getModifiers();
+
+	/**
+	 * Retrieve the method metadata for all user-declared methods on the underlying class,
+	 * preserving declaration order as far as possible.
+	 * @return a set of {@link MethodMetadata}
+	 * @since 6.x
+	 */
+	Set<MethodMetadata> getDeclaredMethods();
+
+	/**
+	 * Retrieve the method metadata for a given declared field.
+	 * @since 6.x
+	 */
+	FieldMetadata getDeclaredField(String name);
+
+	/**
+	 * Retrieve the method metadata for all user-declared fields on the underlying class,
+	 * preserving declaration order as far as possible.
+	 * @return a set of {@link FieldMetadata}
+	 * @since 6.x
+	 */
+	Set<FieldMetadata> getDeclaredFields();
+
+	/**
+	 * Retrieve the method metadata for all user-declared constructors.
+	 * @return a set of {@link ConstructorMetadata}
+	 * @since 6.x
+	 */
+	Set<ConstructorMetadata> getDeclaredConstructors();
+
+	/**
+	 * Determine if the given class is exactly this type.
+	 * @throws NullPointerException if clazz is null
+	 * @throws ClassMetadataNotFoundException if class metadata for the class hierarchy of
+	 * this class could not be loaded
+	 * @since 6.x
+	 */
+	boolean isType(Class<?> clazz);
+
+	/**
+	 * Determine if the given class name is exactly this type.
+	 * @throws NullPointerException if className is null
+	 * @throws ClassMetadataNotFoundException if class metadata for the class hierarchy of
+	 * this class could not be loaded
+	 * @since 6.x
+	 */
+	boolean isType(String className);
+
+	/**
+	 * Determine if the given type is, implements or extends the given class.
+	 * @throws NullPointerException if clazz is null
+	 * @throws ClassMetadataNotFoundException if class metadata for the class hierarchy of
+	 * this class could not be loaded
+	 * @since 6.x
+	 */
+	boolean isAssignableTo(Class<?> clazz);
+
+	/**
+	 * Determine if the given type is, implements or extends the given class.
+	 * @throws NullPointerException if className is null
+	 * @throws ClassMetadataNotFoundException if class metadata for the class hierarchy of
+	 * this class could not be loaded
+	 * @since 6.x
+	 */
+	boolean isAssignableTo(String className);
 
 }

--- a/spring-core/src/main/java/org/springframework/core/type/ClassMetadataNotFoundException.java
+++ b/spring-core/src/main/java/org/springframework/core/type/ClassMetadataNotFoundException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Exception equivalent for to {@link ClassNotFoundException} indicating that class
+ * metadata could not be loaded by
+ * {@link org.springframework.core.type.classreading.MetadataReader}.
+ * @author Danny Thomas
+ * @since 6.x
+ */
+public class ClassMetadataNotFoundException extends RuntimeException {
+
+	static final long serialVersionUID = 4007711655486657517L;
+
+	@Nullable
+	private final Throwable ex;
+
+	public ClassMetadataNotFoundException(String s) {
+		super(s, null); // Disallow initCause
+		this.ex = null;
+	}
+
+	public ClassMetadataNotFoundException(String s, Throwable e) {
+		super(s, null); // Disallow initCause
+		this.ex = e;
+	}
+
+	public Throwable getException() {
+		return this.ex;
+	}
+
+	public Throwable getCause() {
+		return this.ex;
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/ConstructorMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/ConstructorMetadata.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+/**
+ * Constructor method metadata.
+ *
+ * @author Danny Thomas
+ */
+public interface ConstructorMetadata extends ExecutableTypeMetadata {
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/ExecutableTypeMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/ExecutableTypeMetadata.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+import java.util.List;
+
+/**
+ * Interface that defines abstract access to the annotations of a constructor or method.
+ *
+ * @author Danny Thomas
+ */
+public interface ExecutableTypeMetadata extends AnnotatedTypeMetadata {
+
+	/**
+	 * Determine whether the underlying constructor is marked as 'final'.
+	 */
+	boolean isFinal();
+
+	/**
+	 * Determine whether the underlying constructor is marked as 'private'.
+	 */
+	boolean isPrivate();
+
+	/**
+	 * Determine whether the underlying method is overridable, i.e. not marked as static,
+	 * final, or private.
+	 */
+	boolean isOverridable();
+
+	/**
+	 * Get all annotated constructor parameters.
+	 */
+	List<ParameterMetadata> getParameters();
+
+	/**
+	 * Get the constructor parameters annotated with the given name.
+	 */
+	List<ParameterMetadata> getAnnotatedParameters(String annotationName);
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/FieldMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/FieldMetadata.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+/**
+ * Interface that defines abstract access to the annotations of a specific field, in a
+ * form that does not require that method's class to be loaded yet.
+ *
+ * @author Danny Thomas
+ */
+public interface FieldMetadata extends AnnotatedTypeMetadata {
+
+	/**
+	 * Get the name of the underlying field.
+	 */
+	String getFieldName();
+
+	/**
+	 * Get the type of the underlying field's declared type.
+	 */
+	TypeMetadata getFieldType();
+
+	/**
+	 * Determine whether the underlying field is declared as 'static'.
+	 */
+	boolean isStatic();
+
+	/**
+	 * Determine whether the underlying field is marked as 'final'.
+	 */
+	boolean isFinal();
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/MethodMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/MethodMetadata.java
@@ -29,7 +29,7 @@ package org.springframework.core.type;
  * @see AnnotationMetadata#getAnnotatedMethods
  * @see AnnotatedTypeMetadata
  */
-public interface MethodMetadata extends AnnotatedTypeMetadata {
+public interface MethodMetadata extends ExecutableTypeMetadata {
 
 	/**
 	 * Get the name of the underlying method.
@@ -48,12 +48,24 @@ public interface MethodMetadata extends AnnotatedTypeMetadata {
 	String getReturnTypeName();
 
 	/**
+	 * Get the type of underlying method's return type.
+	 * @since 6.x
+	 */
+	TypeMetadata getReturnType();
+
+	/**
 	 * Determine whether the underlying method is effectively abstract:
 	 * i.e. marked as abstract in a class or declared as a regular,
 	 * non-default method in an interface.
 	 * @since 4.2
 	 */
 	boolean isAbstract();
+
+	/**
+	 * Determine whether the underlying method is marked as 'default'.
+	 * @since 6.x
+	 */
+	boolean isDefault();
 
 	/**
 	 * Determine whether the underlying method is declared as 'static'.

--- a/spring-core/src/main/java/org/springframework/core/type/ParameterMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/ParameterMetadata.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+/**
+ * Method and constructor parameter {@link AnnotatedTypeMetadata}.
+ *
+ * @author Danny Thomas
+ * @since 6.x
+ */
+public interface ParameterMetadata extends AnnotatedTypeMetadata {
+
+	/**
+	 * Get the name of the method that declares the parameter.
+	 */
+	String getDeclaringMethodName();
+
+	/**
+	 * Determine if this parameter is a constructor parameter.
+	 * @return true if the parameter is for a constructor method
+	 */
+	default boolean isConstructorParameter() {
+		return getDeclaringMethodName().equals("<init>");
+	}
+
+	/**
+	 * Get the type of the method parameter.
+	 */
+	TypeMetadata getParameterType();
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/ParameterizedTypeMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/ParameterizedTypeMetadata.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+
+/**
+ * {@link TypeMetadata} that has generic parameters such as {@code Collection<String>}.
+ * Equivalent to {@link java.lang.reflect.ParameterizedType}.
+ *
+ * @author Danny Thomas
+ * @since 6.x
+ */
+public interface ParameterizedTypeMetadata extends TypeMetadata {
+
+	/**
+	 * Satisfies {@link ParameterizedType#getActualTypeArguments()} ()} ()}.
+	 */
+	List<TypeMetadata> getActualTypeArguments();
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/StandardAnnotationMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/StandardAnnotationMetadata.java
@@ -124,6 +124,18 @@ public class StandardAnnotationMetadata extends StandardClassMetadata implements
 				getIntrospectedClass(), annotationName, classValuesAsString, false);
 	}
 
+	// TODO Unimplemented until we have code review feedback on the class reader implementation
+
+	@Override
+	public String getDeclaringClassName() {
+		return null;
+	}
+
+	@Override
+	public TypeMetadata getAnnotatedType() {
+		return null;
+	}
+
 	@Override
 	public boolean hasAnnotatedMethods(String annotationName) {
 		if (AnnotationUtils.isCandidateClass(getIntrospectedClass(), annotationName)) {
@@ -163,7 +175,6 @@ public class StandardAnnotationMetadata extends StandardClassMetadata implements
 		return result;
 	}
 
-
 	private static boolean isAnnotatedMethod(Method method, String annotationName) {
 		return !method.isBridge() && method.getAnnotations().length > 0 &&
 				AnnotatedElementUtils.isAnnotated(method, annotationName);
@@ -171,6 +182,16 @@ public class StandardAnnotationMetadata extends StandardClassMetadata implements
 
 	static AnnotationMetadata from(Class<?> introspectedClass) {
 		return new StandardAnnotationMetadata(introspectedClass, true);
+	}
+
+	@Override
+	public Set<FieldMetadata> getAnnotatedFields(String annotationName) {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public Set<ConstructorMetadata> getAnnotatedConstructors(String annotationName) {
+		throw new UnsupportedOperationException("Unimplemented");
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/type/StandardClassMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/StandardClassMetadata.java
@@ -18,6 +18,7 @@ package org.springframework.core.type;
 
 import java.lang.reflect.Modifier;
 import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -31,7 +32,7 @@ import org.springframework.util.StringUtils;
  * @author Sam Brannen
  * @since 2.5
  */
-public class StandardClassMetadata implements ClassMetadata {
+public class StandardClassMetadata implements ClassMetadata, BeanClassMetadata {
 
 	private final Class<?> introspectedClass;
 
@@ -134,6 +135,98 @@ public class StandardClassMetadata implements ClassMetadata {
 	@Override
 	public String toString() {
 		return getClassName();
+	}
+
+	// TODO Unimplemented until we have code review feedback on the class reader implementation
+
+	@Override
+	public ClassMetadata getEnclosingClassMetadata() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public ClassMetadata getSuperClassMetadata() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public Set<ClassMetadata> getInterfaceClassMetadata() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public Set<ClassMetadata> getMemberClassMetadata() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isEnum() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isPrimitive() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isSynthetic() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public int getModifiers() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public Set<MethodMetadata> getDeclaredMethods() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public FieldMetadata getDeclaredField(String name) {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public Set<FieldMetadata> getDeclaredFields() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public Set<ConstructorMetadata> getDeclaredConstructors() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isType(Class<?> clazz) {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isType(String className) {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isAssignableTo(Class<?> clazz) {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isAssignableTo(String className) {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isBeanFactory() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public TypeMetadata getBeanFactoryTypeMetadata() {
+		throw new UnsupportedOperationException("Unimplemented");
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/type/StandardMethodMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/StandardMethodMetadata.java
@@ -18,6 +18,7 @@ package org.springframework.core.type;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -125,7 +126,8 @@ public class StandardMethodMetadata implements MethodMetadata {
 		return !isStatic() && !isFinal() && !isPrivate();
 	}
 
-	private boolean isPrivate() {
+	@Override
+	public boolean isPrivate() {
 		return Modifier.isPrivate(this.introspectedMethod.getModifiers());
 	}
 
@@ -163,6 +165,33 @@ public class StandardMethodMetadata implements MethodMetadata {
 	@Override
 	public String toString() {
 		return this.introspectedMethod.toString();
+	}
+
+	// TODO Unimplemented until we have code review feedback on the class reader implementation
+
+	@Override
+	public List<ParameterMetadata> getParameters() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public List<ParameterMetadata> getAnnotatedParameters(String annotationName) {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public TypeMetadata getAnnotatedType() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public TypeMetadata getReturnType() {
+		throw new UnsupportedOperationException("Unimplemented");
+	}
+
+	@Override
+	public boolean isDefault() {
+		throw new UnsupportedOperationException("Unimplemented");
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/type/TypeMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/TypeMetadata.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Describes the type of method and constructor parameters, field declarations.
+ *
+ * @author Danny Thomas
+ */
+public interface TypeMetadata {
+
+	/**
+	 * Get the name of this type.
+	 */
+	String getTypeName();
+
+	/**
+	 * Determine if this type is primitive.
+	 */
+	boolean isPrimitive();
+
+	/**
+	 * Determine if this type is void.
+	 */
+	boolean isVoid();
+
+	/**
+	 * Retrieve the class metadata for this type.
+	 * @return the {@link ClassMetadata} of the member clases of this class. Null if the type is not a class
+	 * @throws ClassMetadataNotFoundException if class metadata for the interface classes
+	 * could not be loaded.
+	 * @since 6.x
+	 */
+	@Nullable
+	ClassMetadata getClassMetadata();
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleAnnotationMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleAnnotationMetadata.java
@@ -16,14 +16,27 @@
 
 package org.springframework.core.type.classreading;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.springframework.asm.Opcodes;
 import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.ClassMetadata;
+import org.springframework.core.type.ClassMetadataNotFoundException;
+import org.springframework.core.type.ConstructorMetadata;
+import org.springframework.core.type.FieldMetadata;
 import org.springframework.core.type.MethodMetadata;
+import org.springframework.core.type.ParameterizedTypeMetadata;
+import org.springframework.core.type.TypeMetadata;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
@@ -38,9 +51,12 @@ import org.springframework.util.StringUtils;
  */
 final class SimpleAnnotationMetadata implements AnnotationMetadata {
 
+	private static final String[] PRIMITIVE_TYPE_NAMES = Stream.of(Boolean.TYPE, Character.TYPE, Byte.TYPE, Short.TYPE,
+			Integer.TYPE, Long.TYPE, Float.TYPE, Double.TYPE, Void.TYPE).map(Class::getName).toArray(String[]::new);
+
 	private final String className;
 
-	private final int access;
+	private final int modifiers;
 
 	@Nullable
 	private final String enclosingClassName;
@@ -50,31 +66,64 @@ final class SimpleAnnotationMetadata implements AnnotationMetadata {
 
 	private final boolean independentInnerClass;
 
-	private final Set<String> interfaceNames;
+	private final Set<String> interfaceClassNames;
 
 	private final Set<String> memberClassNames;
 
 	private final Set<MethodMetadata> declaredMethods;
 
+	private final Map<String, FieldMetadata> declaredFields;
+
+	private final Set<ConstructorMetadata> declaredConstructors;
+
 	private final MergedAnnotations annotations;
+
+	private final MetadataReaderFactory metadataReaderFactory;
+
+	@Nullable
+	private volatile ClassMetadata superClassMetadata;
+
+	@Nullable
+	private volatile ClassMetadata enclosingClassMetadata;
+
+	@Nullable
+	private volatile Set<ClassMetadata> interfaceClassMetadata;
+
+	@Nullable
+	private volatile Set<ClassMetadata> memberClassMetadata;
 
 	@Nullable
 	private Set<String> annotationTypes;
 
-
+	/**
+	 * Construct an instance of {@link SimpleAnnotationMetadata}.
+	 */
 	SimpleAnnotationMetadata(String className, int access, @Nullable String enclosingClassName,
-			@Nullable String superClassName, boolean independentInnerClass, Set<String> interfaceNames,
-			Set<String> memberClassNames, Set<MethodMetadata> declaredMethods, MergedAnnotations annotations) {
+				@Nullable String superClassName, boolean independentInnerClass, Set<String> interfaceNames,
+				Set<String> memberClassNames, Set<FieldMetadata> declaredFields,
+				Set<ConstructorMetadata> declaredConstructors, Set<MethodMetadata> declaredMethods,
+				MergedAnnotations annotations, MetadataReaderFactory metadataReaderFactory) {
 
 		this.className = className;
-		this.access = access;
+		this.modifiers = access;
+
 		this.enclosingClassName = enclosingClassName;
 		this.superClassName = superClassName;
-		this.independentInnerClass = independentInnerClass;
-		this.interfaceNames = interfaceNames;
+		this.interfaceClassNames = interfaceNames;
+
 		this.memberClassNames = memberClassNames;
-		this.declaredMethods = declaredMethods;
+		this.independentInnerClass = independentInnerClass;
+
+		this.declaredMethods = Collections.unmodifiableSet(declaredMethods);
+		this.declaredFields = new LinkedHashMap<>();
+		for (FieldMetadata declaredField : declaredFields) {
+			this.declaredFields.put(declaredField.getFieldName(), declaredField);
+		}
+		this.declaredConstructors = Collections.unmodifiableSet(declaredConstructors);
+
 		this.annotations = annotations;
+
+		this.metadataReaderFactory = metadataReaderFactory;
 	}
 
 	@Override
@@ -84,22 +133,32 @@ final class SimpleAnnotationMetadata implements AnnotationMetadata {
 
 	@Override
 	public boolean isInterface() {
-		return (this.access & Opcodes.ACC_INTERFACE) != 0;
-	}
-
-	@Override
-	public boolean isAnnotation() {
-		return (this.access & Opcodes.ACC_ANNOTATION) != 0;
+		return (this.modifiers & Opcodes.ACC_INTERFACE) != 0;
 	}
 
 	@Override
 	public boolean isAbstract() {
-		return (this.access & Opcodes.ACC_ABSTRACT) != 0;
+		return (this.modifiers & Opcodes.ACC_ABSTRACT) != 0;
+	}
+
+	@Override
+	public boolean isPrimitive() {
+		for (String primitiveTypeName : PRIMITIVE_TYPE_NAMES) {
+			if (this.className.equals(primitiveTypeName)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override
 	public boolean isFinal() {
-		return (this.access & Opcodes.ACC_FINAL) != 0;
+		return (this.modifiers & Opcodes.ACC_FINAL) != 0;
+	}
+
+	@Override
+	public int getModifiers() {
+		return this.modifiers;
 	}
 
 	@Override
@@ -121,7 +180,7 @@ final class SimpleAnnotationMetadata implements AnnotationMetadata {
 
 	@Override
 	public String[] getInterfaceNames() {
-		return StringUtils.toStringArray(this.interfaceNames);
+		return StringUtils.toStringArray(this.interfaceClassNames);
 	}
 
 	@Override
@@ -135,11 +194,20 @@ final class SimpleAnnotationMetadata implements AnnotationMetadata {
 	}
 
 	@Override
+	public String getDeclaringClassName() {
+		return this.getClassName();
+	}
+
+	@Override
+	public TypeMetadata getAnnotatedType() {
+		return new SimpleTypeMetadata(this);
+	}
+
+	@Override
 	public Set<String> getAnnotationTypes() {
 		Set<String> annotationTypes = this.annotationTypes;
 		if (annotationTypes == null) {
-			annotationTypes = Collections.unmodifiableSet(
-					AnnotationMetadata.super.getAnnotationTypes());
+			annotationTypes = Collections.unmodifiableSet(AnnotationMetadata.super.getAnnotationTypes());
 			this.annotationTypes = annotationTypes;
 		}
 		return annotationTypes;
@@ -147,34 +215,209 @@ final class SimpleAnnotationMetadata implements AnnotationMetadata {
 
 	@Override
 	public Set<MethodMetadata> getAnnotatedMethods(String annotationName) {
-		Set<MethodMetadata> result = new LinkedHashSet<>(4);
-		for (MethodMetadata annotatedMethod : this.declaredMethods) {
-			if (annotatedMethod.isAnnotated(annotationName)) {
-				result.add(annotatedMethod);
+		return filterIsAnnotated(this.declaredMethods, annotationName);
+	}
+
+	@Override
+	public Set<MethodMetadata> getDeclaredMethods() {
+		return this.declaredMethods;
+	}
+
+	@Override
+	public Set<FieldMetadata> getAnnotatedFields(String annotationName) {
+		return filterIsAnnotated(this.declaredFields.values(), annotationName);
+	}
+
+	@Override
+	public FieldMetadata getDeclaredField(String name) {
+		return this.declaredFields.get(name);
+	}
+
+	@Override
+	public Set<FieldMetadata> getDeclaredFields() {
+		return Collections.unmodifiableSet(new LinkedHashSet<>(this.declaredFields.values()));
+	}
+
+	@Override
+	public Set<ConstructorMetadata> getAnnotatedConstructors(String annotationName) {
+		return filterIsAnnotated(this.declaredConstructors, annotationName);
+	}
+
+	@Override
+	public Set<ConstructorMetadata> getDeclaredConstructors() {
+		return this.declaredConstructors;
+	}
+
+	@Override
+	public ClassMetadata getSuperClassMetadata() {
+		if (this.superClassName != null && this.superClassMetadata == null) {
+			this.superClassMetadata = readClassMetadata(this.superClassName);
+		}
+		return this.superClassMetadata;
+	}
+
+	@Override
+	public Set<ClassMetadata> getInterfaceClassMetadata() {
+		if (this.interfaceClassMetadata == null) {
+			Set<ClassMetadata> interfaceClassMetadata = new LinkedHashSet<>();
+			for (String interfaceClassName : this.interfaceClassNames) {
+				interfaceClassMetadata.add(readClassMetadata(interfaceClassName));
+			}
+			this.interfaceClassMetadata = interfaceClassMetadata;
+		}
+		return Objects.requireNonNull(this.interfaceClassMetadata);
+	}
+
+	@Override
+	public Set<ClassMetadata> getMemberClassMetadata() {
+		if (this.memberClassMetadata == null) {
+			Set<ClassMetadata> interfaceClassMetadata = new LinkedHashSet<>();
+			for (String interfaceClassName : this.memberClassNames) {
+				interfaceClassMetadata.add(readClassMetadata(interfaceClassName));
+			}
+			this.memberClassMetadata = interfaceClassMetadata;
+		}
+		return Objects.requireNonNull(this.memberClassMetadata);
+	}
+
+	@Override
+	public ClassMetadata getEnclosingClassMetadata() {
+		if (this.enclosingClassName != null && this.enclosingClassMetadata == null) {
+			this.enclosingClassMetadata = readClassMetadata(this.enclosingClassName);
+		}
+		return this.enclosingClassMetadata;
+	}
+
+	@Override
+	public boolean isType(Class<?> clazz) {
+		Objects.requireNonNull(clazz);
+		return isType(clazz.getName());
+	}
+
+	@Override
+	public boolean isType(String className) {
+		Objects.requireNonNull(className);
+		return this.className.equals(className);
+	}
+
+	@Override
+	public boolean isAssignableTo(Class<?> clazz) {
+		Objects.requireNonNull(clazz);
+		return isAssignableTo(clazz.getName());
+	}
+
+	@Override
+	public boolean isAssignableTo(String className) {
+		Objects.requireNonNull(className);
+		if (className.equals(this.className)) {
+			return true;
+		}
+		if (isPrimitive()) {
+			return false;
+		}
+		if (className.equals(Object.class.getName())) {
+			return true;
+		}
+		for (ClassMetadata interfaceType : getInterfaceClassMetadata()) {
+			if (interfaceType.getClassName().equals(className)) {
+				return true;
+			}
+		}
+		ClassMetadata superClassMetadata = getSuperClassMetadata();
+		return superClassMetadata != null && superClassMetadata.isAssignableTo(className);
+	}
+
+	@Override
+	public boolean isAnnotation() {
+		return (this.modifiers & Opcodes.ACC_ANNOTATION) != 0;
+	}
+
+	@Override
+	public boolean isEnum() {
+		return (this.modifiers & Opcodes.ACC_ENUM) != 0
+				&& (this.superClassName == null || this.superClassName.equals(Enum.class.getName()));
+	}
+
+	@Override
+	public boolean isSynthetic() {
+		return (this.modifiers & Opcodes.ACC_SYNTHETIC) != 0;
+	}
+
+	private <T extends AnnotatedTypeMetadata> Set<T> filterIsAnnotated(Collection<T> annotationMetadata, String annotationName) {
+		Set<T> result = new LinkedHashSet<>(annotationMetadata.size());
+		for (T metadata : annotationMetadata) {
+			if (metadata.isAnnotated(annotationName)) {
+				result.add(metadata);
 			}
 		}
 		return Collections.unmodifiableSet(result);
 	}
 
 	@Override
-	public Set<MethodMetadata> getDeclaredMethods() {
-		return Collections.unmodifiableSet(this.declaredMethods);
-	}
-
-
-	@Override
-	public boolean equals(@Nullable Object obj) {
-		return (this == obj || (obj instanceof SimpleAnnotationMetadata that && this.className.equals(that.className)));
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SimpleAnnotationMetadata metadata = (SimpleAnnotationMetadata) o;
+		return Objects.equals(this.className, metadata.className);
 	}
 
 	@Override
 	public int hashCode() {
-		return this.className.hashCode();
+		return Objects.hash(this.className);
 	}
 
 	@Override
 	public String toString() {
 		return this.className;
+	}
+
+	private ClassMetadata readClassMetadata(String className) {
+		try {
+			MetadataReader reader = this.metadataReaderFactory.getMetadataReader(className);
+			return reader.getAnnotationMetadata();
+		}
+		catch (IOException ex) {
+			throw new ClassMetadataNotFoundException("Could not load metadata for class " + className, ex);
+		}
+	}
+
+	// BeanClassMetadata methods
+
+	@Override
+	public boolean isBeanFactory() {
+		ClassMetadata classMetadata = this;
+		while(classMetadata != null) {
+			if (this.interfaceClassNames.contains("org.springframework.beans.factory.FactoryBean") ||
+					this.interfaceClassNames.contains("org.springframework.beans.factory.ObjectFactory")) {
+				return true;
+			}
+			classMetadata = classMetadata.getSuperClassMetadata();
+		}
+		return false;
+	}
+
+	@Override
+	public TypeMetadata getBeanFactoryTypeMetadata() {
+		TypeMetadata returnType = null;
+		if (isBeanFactory()) {
+			ClassMetadata classMetadata = this;
+			while(classMetadata != null && returnType == null) {
+				returnType = classMetadata.getDeclaredMethods().stream()
+						.filter(method -> method.getMethodName().equals("getObject") && method.getParameters().isEmpty())
+						.map(MethodMetadata::getReturnType)
+						.filter(ParameterizedTypeMetadata.class::isInstance)
+						.map(ParameterizedTypeMetadata.class::cast)
+						.findFirst()
+						.orElse(null);
+				classMetadata = classMetadata.getSuperClassMetadata();
+			}
+			Objects.requireNonNull(classMetadata, "Could not find return type for bean factory method");
+		}
+		return returnType;
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleAnnotationMetadataReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleAnnotationMetadataReadingVisitor.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
- * ASM class visitor that creates {@link SimpleAdditionalAnnotationMetadata}.
+ * ASM class visitor that creates {@link SimplennotationMetadata}.
  *
  * @author Phillip Webb
  * @author Juergen Hoeller

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleArrayTypeMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleArrayTypeMetadata.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import org.springframework.asm.Type;
+import org.springframework.core.type.ArrayTypeMetadata;
+import org.springframework.core.type.TypeMetadata;
+
+/**
+ * Simple implementation of {@link ArrayTypeMetadata}.
+ *
+ * @author Danny Thomas
+ * @since 6.x
+ */
+class SimpleArrayTypeMetadata extends SimpleTypeMetadata implements ArrayTypeMetadata {
+
+	private final TypeMetadata componentType;
+
+	SimpleArrayTypeMetadata(TypeMetadata componentType, MetadataReaderFactory metadataReaderFactory) {
+		super(Type.getType('[' + componentType.getTypeName()), metadataReaderFactory);
+		this.componentType = componentType;
+	}
+
+	@Override
+	public TypeMetadata getComponentType() {
+		return this.componentType;
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleConstructorMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleConstructorMetadata.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.asm.Opcodes;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.ConstructorMetadata;
+import org.springframework.core.type.ParameterMetadata;
+import org.springframework.core.type.TypeMetadata;
+import org.springframework.lang.Nullable;
+
+/**
+ * Simple implementation of {@link ConstructorMetadata}.
+ *
+ * @author Danny Thomas
+ */
+final class SimpleConstructorMetadata implements ConstructorMetadata {
+
+	private final int access;
+
+	private final String declaringClassName;
+
+	private final Object source;
+
+	private final MergedAnnotations annotations;
+
+	private final List<ParameterMetadata> parameters;
+
+	private AnnotationMetadata declaringClass;
+
+	SimpleConstructorMetadata(int access, String declaringClassName, Object source, MergedAnnotations annotations,
+				List<ParameterMetadata> parameters) {
+		this.access = access;
+		this.declaringClassName = declaringClassName;
+		this.source = source;
+		this.annotations = annotations;
+		this.parameters = parameters;
+	}
+
+	@Override
+	public String getDeclaringClassName() {
+		return this.declaringClassName;
+	}
+
+	@Override
+	public TypeMetadata getAnnotatedType() {
+		throw new UnsupportedOperationException("Constructor methods do not have return types");
+	}
+
+	@Override
+	public boolean isFinal() {
+		return (this.access & Opcodes.ACC_FINAL) != 0;
+	}
+
+	@Override
+	public boolean isOverridable() {
+		return !isFinal() && !isPrivate();
+	}
+
+	@Override
+	public boolean isPrivate() {
+		return (this.access & Opcodes.ACC_PRIVATE) != 0;
+	}
+
+	@Override
+	public MergedAnnotations getAnnotations() {
+		return this.annotations;
+	}
+
+	@Override
+	public List<ParameterMetadata> getParameters() {
+		return this.parameters;
+	}
+
+	@Override
+	public List<ParameterMetadata> getAnnotatedParameters(String annotationName) {
+		List<ParameterMetadata> result = new ArrayList<>(this.parameters.size());
+		for (ParameterMetadata metadata : this.parameters) {
+			if (metadata.isAnnotated(annotationName)) {
+				result.add(metadata);
+			}
+		}
+		return Collections.unmodifiableList(result);
+	}
+
+	@Override
+	public boolean equals(@Nullable Object obj) {
+		return ((this == obj) || ((obj instanceof SimpleConstructorMetadata)
+				&& this.source.equals(((SimpleConstructorMetadata) obj).source)));
+	}
+
+	@Override
+	public int hashCode() {
+		return this.source.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return this.source.toString();
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleFieldMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleFieldMetadata.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import org.springframework.asm.Opcodes;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.type.FieldMetadata;
+import org.springframework.core.type.TypeMetadata;
+import org.springframework.lang.Nullable;
+
+/**
+ * Simple implementation of {@link FieldMetadata}.
+ *
+ * @author Danny Thomas
+ */
+class SimpleFieldMetadata implements FieldMetadata {
+
+	private final String declaringClassName;
+
+	private final String fieldName;
+
+	private final int access;
+
+	private final TypeMetadata fieldType;
+
+	private final Object source;
+
+	private final MergedAnnotations annotations;
+
+	SimpleFieldMetadata(String declaringClassName, String fieldName, int access, TypeMetadata fieldType, Object source,
+			MergedAnnotations annotations) {
+
+		this.declaringClassName = declaringClassName;
+		this.fieldName = fieldName;
+		this.access = access;
+		this.fieldType = fieldType;
+		this.source = source;
+		this.annotations = annotations;
+	}
+
+	@Override
+	public String getFieldName() {
+		return this.fieldName;
+	}
+
+	@Override
+	public String getDeclaringClassName() {
+		return this.declaringClassName;
+	}
+
+	@Override
+	public TypeMetadata getAnnotatedType() {
+		return this.fieldType;
+	}
+
+	@Override
+	public TypeMetadata getFieldType() {
+		return this.fieldType;
+	}
+
+	@Override
+	public boolean isStatic() {
+		return (this.access & Opcodes.ACC_STATIC) != 0;
+	}
+
+	@Override
+	public boolean isFinal() {
+		return (this.access & Opcodes.ACC_FINAL) != 0;
+	}
+
+	@Override
+	public MergedAnnotations getAnnotations() {
+		return this.annotations;
+	}
+
+	@Override
+	public boolean equals(@Nullable Object obj) {
+		return ((this == obj)
+				|| ((obj instanceof SimpleFieldMetadata) && this.source.equals(((SimpleFieldMetadata) obj).source)));
+	}
+
+	@Override
+	public int hashCode() {
+		return this.source.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return this.source.toString();
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleFieldMetadataReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleFieldMetadataReadingVisitor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.springframework.asm.AnnotationVisitor;
+import org.springframework.asm.FieldVisitor;
+import org.springframework.asm.SpringAsmInfo;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.type.TypeMetadata;
+import org.springframework.lang.Nullable;
+
+/**
+ * {@link FieldVisitor} producing instances of {@link SimpleFieldMetadata}.
+ *
+ * @author Danny Thomas
+ */
+final class SimpleFieldMetadataReadingVisitor extends FieldVisitor {
+
+	@Nullable
+	private final ClassLoader classLoader;
+
+	private final Object source;
+
+	private final List<MergedAnnotation<?>> annotations = new ArrayList<>(4);
+
+	private final String declaringClassName;
+
+	private final int access;
+
+	private final String name;
+
+	private final TypeMetadata type;
+
+	private final Object value;
+
+	private final Consumer<SimpleFieldMetadata> consumer;
+
+	SimpleFieldMetadataReadingVisitor(@Nullable ClassLoader classLoader, Object source, String declaringClassName,
+			int access, String name, TypeMetadata type, Object value, Consumer<SimpleFieldMetadata> consumer) {
+
+		super(SpringAsmInfo.ASM_VERSION);
+		this.classLoader = classLoader;
+		this.source = source;
+		this.declaringClassName = declaringClassName;
+		this.access = access;
+		this.name = name;
+		this.type = type;
+		this.value = value;
+		this.consumer = consumer;
+	}
+
+	@Override
+	@Nullable
+	public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+		return MergedAnnotationReadingVisitor.get(this.classLoader, this.source, descriptor, visible, this.annotations::add);
+	}
+
+	@Override
+	public void visitEnd() {
+		MergedAnnotations annotations = MergedAnnotations.of(this.annotations);
+		SimpleFieldMetadata metadata = new SimpleFieldMetadata(this.declaringClassName, this.name, this.access,
+				this.type, this.source, annotations);
+		this.consumer.accept(metadata);
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMetadataReader.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMetadataReader.java
@@ -23,7 +23,6 @@ import org.springframework.asm.ClassReader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.ClassMetadata;
-import org.springframework.lang.Nullable;
 
 /**
  * {@link MetadataReader} implementation based on an ASM
@@ -43,8 +42,8 @@ final class SimpleMetadataReader implements MetadataReader {
 	private final AnnotationMetadata annotationMetadata;
 
 
-	SimpleMetadataReader(Resource resource, @Nullable ClassLoader classLoader) throws IOException {
-		SimpleAnnotationMetadataReadingVisitor visitor = new SimpleAnnotationMetadataReadingVisitor(classLoader);
+	SimpleMetadataReader(Resource resource, SimpleMetadataReaderFactory factory) throws IOException {
+		SimpleAnnotationMetadataReadingVisitor visitor = new SimpleAnnotationMetadataReadingVisitor(factory);
 		getClassReader(resource).accept(visitor, PARSING_OPTIONS);
 		this.resource = resource;
 		this.annotationMetadata = visitor.getMetadata();

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMetadataReaderFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMetadataReaderFactory.java
@@ -100,7 +100,7 @@ public class SimpleMetadataReaderFactory implements MetadataReaderFactory {
 
 	@Override
 	public MetadataReader getMetadataReader(Resource resource) throws IOException {
-		return new SimpleMetadataReader(resource, this.resourceLoader.getClassLoader());
+		return new SimpleMetadataReader(resource, this);
 	}
 
 }

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMethodMetadataReadingVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMethodMetadataReadingVisitor.java
@@ -49,7 +49,7 @@ import org.springframework.core.type.TypeMetadata;
 import org.springframework.lang.Nullable;
 
 /**
- * ASM method visitor that creates {@link SimpleAdditionalMethodMetadata}.
+ * ASM method visitor that creates {@link SimpleMethodMetadata}.
  *
  * @author Phillip Webb
  * @author Sam Brannen

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMethodSignature.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMethodSignature.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.core.type.TypeMetadata;
+
+/**
+ * Simple container for holding result of {@link SimpleMethodSignatureVisitor}.
+ *
+ * @author Danny Thomas
+ */
+public class SimpleMethodSignature {
+
+	private List<TypeMetadata> parameterTypes = new ArrayList<>();
+
+	private TypeMetadata returnType;
+
+	public void addTypeParameter(TypeMetadata parameterType) {
+		this.parameterTypes.add(parameterType);
+	}
+
+	public void setReturnType(TypeMetadata returnType) {
+		this.returnType = returnType;
+	}
+
+	public List<TypeMetadata> getParameterTypes() {
+		return this.parameterTypes;
+	}
+
+	public TypeMetadata getReturnType() {
+		return this.returnType;
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMethodSignatureVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMethodSignatureVisitor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.util.function.Consumer;
+
+import org.springframework.asm.SpringAsmInfo;
+import org.springframework.asm.Type;
+import org.springframework.asm.signature.SignatureVisitor;
+
+/**
+ * A {@link SignatureVisitor} producing {@link SimpleMethodSignature}.
+ *
+ * @author Danny Thomas
+ */
+public class SimpleMethodSignatureVisitor extends SignatureVisitor {
+
+	static final String OBJECT_TYPE_DESCRIPTOR = Type.getObjectType(Object.class.getName()).getDescriptor();
+
+	private final MetadataReaderFactory metadataReaderFactory;
+
+	private final Consumer<SimpleMethodSignature> consumer;
+
+	private final SimpleMethodSignature methodSignature;
+
+	protected SimpleMethodSignatureVisitor(MetadataReaderFactory metadataReaderFactory,
+			Consumer<SimpleMethodSignature> consumer) {
+		super(SpringAsmInfo.ASM_VERSION);
+		this.metadataReaderFactory = metadataReaderFactory;
+		this.consumer = consumer;
+		this.methodSignature = new SimpleMethodSignature();
+	}
+
+	@Override
+	public SignatureVisitor visitParameterType() {
+		return new SimpleTypeMetadataSignatureVisitor(OBJECT_TYPE_DESCRIPTOR, this.metadataReaderFactory,
+				this.methodSignature::addTypeParameter);
+	}
+
+	@Override
+	public SignatureVisitor visitReturnType() {
+		return new SimpleTypeMetadataSignatureVisitor(OBJECT_TYPE_DESCRIPTOR, this.metadataReaderFactory, returnType -> {
+			this.methodSignature.setReturnType(returnType);
+			this.consumer.accept(this.methodSignature);
+		});
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleParameterMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleParameterMetadata.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.util.Objects;
+
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.type.ParameterMetadata;
+import org.springframework.core.type.TypeMetadata;
+
+/**
+ * Simple implementation of {@link ParameterMetadata}.
+ *
+ * @author Danny Thomas
+ */
+final class SimpleParameterMetadata implements ParameterMetadata {
+
+	private final String declaringClassName;
+
+	private final String declaringMethodName;
+
+	private final TypeMetadata parameterType;
+
+	private final int parameterIndex;
+
+	private final Object source;
+
+	private final MergedAnnotations annotations;
+
+	SimpleParameterMetadata(String declaringClassName, String declaringMethodName, TypeMetadata parameterType,
+							int parameterIndex, Object source, MergedAnnotations annotations) {
+
+		this.declaringClassName = declaringClassName;
+		this.declaringMethodName = declaringMethodName;
+		this.parameterType = parameterType;
+		this.parameterIndex = parameterIndex;
+		this.source = source;
+		this.annotations = annotations;
+	}
+
+	@Override
+	public String getDeclaringClassName() {
+		return this.declaringClassName;
+	}
+
+	@Override
+	public TypeMetadata getAnnotatedType() {
+		return this.parameterType;
+	}
+
+	@Override
+	public String getDeclaringMethodName() {
+		return this.declaringMethodName;
+	}
+
+	@Override
+	public TypeMetadata getParameterType() {
+		return this.parameterType;
+	}
+
+	@Override
+	public MergedAnnotations getAnnotations() {
+		return this.annotations;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SimpleParameterMetadata that = (SimpleParameterMetadata) o;
+		return this.parameterIndex == that.parameterIndex && Objects.equals(this.parameterType, that.parameterType)
+				&& Objects.equals(this.source, that.source);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.parameterType, this.parameterIndex, this.source);
+	}
+
+	@Override
+	public String toString() {
+		return this.source.toString();
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleParameterizedTypeMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleParameterizedTypeMetadata.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.util.List;
+
+import org.springframework.asm.Type;
+import org.springframework.core.type.ParameterizedTypeMetadata;
+import org.springframework.core.type.TypeMetadata;
+
+/**
+ * Simple implementation of {@link ParameterizedTypeMetadata}.
+ *
+ * @author Danny Thomas
+ */
+final class SimpleParameterizedTypeMetadata extends SimpleTypeMetadata implements ParameterizedTypeMetadata {
+
+	private final List<TypeMetadata> parameterizedTypes;
+
+	SimpleParameterizedTypeMetadata(Type type, List<TypeMetadata> parameterizedTypes,
+			MetadataReaderFactory metadataReaderFactory) {
+		super(type, metadataReaderFactory);
+		this.parameterizedTypes = parameterizedTypes;
+	}
+
+	@Override
+	public List<TypeMetadata> getActualTypeArguments() {
+		return this.parameterizedTypes;
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleSource.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleSource.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.util.Objects;
+
+import org.springframework.asm.Type;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.lang.Nullable;
+
+/**
+ * Implementation of source object providing equals/hashCode identity for
+ * {@link AnnotatedTypeMetadata} classes.
+ *
+ * @author Danny Thomas
+ */
+final class SimpleSource {
+
+	private final String declaringClassName;
+
+	@Nullable
+	private final String name;
+
+	@Nullable
+	private final Type type;
+
+	@Nullable
+	private String toStringValue;
+
+	SimpleSource(String declaringClassName) {
+		this(declaringClassName, null, null);
+	}
+
+	SimpleSource(String declaringClassName, @Nullable String name, @Nullable String descriptor) {
+		this.declaringClassName = declaringClassName;
+		this.name = name;
+		this.type = descriptor == null ? null : Type.getType(descriptor);
+	}
+
+	public String getDeclaringClassName() {
+		return this.declaringClassName;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public Type getType() {
+		return this.type;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.declaringClassName, this.type, this.name, this.type);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SimpleSource that = (SimpleSource) o;
+		return Objects.equals(this.declaringClassName, that.declaringClassName) && Objects.equals(this.type, that.type)
+				&& Objects.equals(this.name, that.name);
+	}
+
+	@Override
+	public String toString() {
+		String value = this.toStringValue;
+		if (value == null) {
+			StringBuilder builder = new StringBuilder();
+			builder.append(this.declaringClassName);
+			if (this.name != null) {
+				builder.append('.');
+				builder.append(this.name);
+			}
+			if (this.type != null && this.type.getSort() == Type.METHOD) {
+				Type[] argumentTypes = this.type.getArgumentTypes();
+				builder.append('(');
+				for (int i = 0; i < argumentTypes.length; i++) {
+					if (i != 0) {
+						builder.append(',');
+					}
+					builder.append(argumentTypes[i].getClassName());
+				}
+				builder.append(')');
+			}
+			value = builder.toString();
+			this.toStringValue = value;
+		}
+		return value;
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleTypeMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleTypeMetadata.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.springframework.asm.Type;
+import org.springframework.core.type.ArrayTypeMetadata;
+import org.springframework.core.type.ClassMetadata;
+import org.springframework.core.type.ClassMetadataNotFoundException;
+import org.springframework.core.type.TypeMetadata;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Simple implementation of {@link TypeMetadata}.
+ *
+ * @author Danny Thomas
+ */
+class SimpleTypeMetadata implements TypeMetadata {
+
+	private final Type type;
+
+	@Nullable
+	private final MetadataReaderFactory metadataReaderFactory;
+
+	@Nullable
+	private volatile ClassMetadata classMetadata;
+
+	SimpleTypeMetadata(Type type, MetadataReaderFactory metadataReaderFactory) {
+		this(type, metadataReaderFactory, null);
+	}
+
+	SimpleTypeMetadata(ClassMetadata classMetadata) {
+		this(Type.getObjectType(classMetadata.getClassName()), null, classMetadata);
+	}
+
+	private SimpleTypeMetadata(Type type, @Nullable MetadataReaderFactory metadataReaderFactory, @Nullable ClassMetadata classMetadata) {
+		Assert.isTrue(metadataReaderFactory != null || classMetadata != null, "Either a metadata reader factory or class metadata must be provided");
+		this.type = type;
+		this.metadataReaderFactory = metadataReaderFactory;
+		this.classMetadata = classMetadata;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return this.type.equals(o);
+	}
+
+	@Override
+	public int hashCode() {
+		return this.type.hashCode();
+	}
+
+	@Override
+	public String getTypeName() {
+		return this.type.getClassName();
+	}
+
+	@Override
+	public boolean isPrimitive() {
+		return this.type.getSort() != Type.OBJECT;
+	}
+
+	@Override
+	public boolean isVoid() {
+		return this.type.getSort() == Type.VOID;
+	}
+
+	@Override
+	public ClassMetadata getClassMetadata() {
+		if (this.classMetadata != null) {
+			return this.classMetadata;
+		}
+		if (isPrimitive() || !(this instanceof ArrayTypeMetadata)) {
+			return null;
+		}
+		Objects.requireNonNull(this.metadataReaderFactory, "Metadata reader factory must be provided");
+		String typeName = getTypeName();
+		try {
+			MetadataReader reader = this.metadataReaderFactory.getMetadataReader(typeName);
+			this.classMetadata = reader.getAnnotationMetadata();
+			return this.classMetadata;
+		}
+		catch (IOException ex) {
+			throw new ClassMetadataNotFoundException("Could not load metadata for class " + typeName, ex);
+		}
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleTypeMetadataSignatureVisitor.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleTypeMetadataSignatureVisitor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.springframework.asm.SpringAsmInfo;
+import org.springframework.asm.Type;
+import org.springframework.asm.signature.SignatureVisitor;
+import org.springframework.core.type.TypeMetadata;
+import org.springframework.lang.Nullable;
+
+import static org.springframework.core.type.classreading.SimpleMethodSignatureVisitor.OBJECT_TYPE_DESCRIPTOR;
+
+/**
+ * A {@link SignatureVisitor} producing {@link TypeMetadata}.
+ *
+ * @author Danny Thomas
+ */
+public class SimpleTypeMetadataSignatureVisitor extends SignatureVisitor {
+
+	private final String descriptor;
+
+	private final MetadataReaderFactory metadataReaderFactory;
+
+	private final Consumer<TypeMetadata> consumer;
+
+	private final List<TypeMetadata> parameterTypes;
+
+	@Nullable
+	private String classType;
+
+	private boolean isArray;
+
+	SimpleTypeMetadataSignatureVisitor(String descriptor, MetadataReaderFactory metadataReaderFactory,
+				Consumer<TypeMetadata> consumer) {
+		super(SpringAsmInfo.ASM_VERSION);
+		this.descriptor = descriptor;
+		this.metadataReaderFactory = metadataReaderFactory;
+		this.consumer = consumer;
+		this.parameterTypes = new ArrayList<>();
+	}
+
+	@Override
+	public void visitClassType(String name) {
+		this.classType = 'L' + name + ';';
+	}
+
+	@Override
+	public void visitBaseType(char descriptor) {
+		produceTypeMetadata(String.valueOf(descriptor));
+	}
+
+	@Override
+	public void visitTypeVariable(String name) {
+		// Raw type variable, we purposefully don't try and resolve the bounds. Fallback
+		// to the raw type
+		produceTypeMetadata(this.descriptor);
+	}
+
+	@Override
+	public SignatureVisitor visitArrayType() {
+		this.isArray = true;
+		return this;
+	}
+
+	@Override
+	public SignatureVisitor visitTypeArgument(char wildcard) {
+		return new SimpleTypeMetadataSignatureVisitor(OBJECT_TYPE_DESCRIPTOR, this.metadataReaderFactory,
+				this.parameterTypes::add);
+	}
+
+	private void produceTypeMetadata(String descriptor) {
+		Objects.requireNonNull(descriptor);
+		Type type = Type.getType(descriptor);
+		TypeMetadata typeMetadata = this.parameterTypes.isEmpty() ? new SimpleTypeMetadata(type, this.metadataReaderFactory)
+				: new SimpleParameterizedTypeMetadata(type, this.parameterTypes, this.metadataReaderFactory);
+		if (this.isArray) {
+			typeMetadata = new SimpleArrayTypeMetadata(typeMetadata, this.metadataReaderFactory);
+		}
+		this.consumer.accept(typeMetadata);
+	}
+
+	@Override
+	public void visitEnd() {
+		produceTypeMetadata(this.classType);
+	}
+
+}

--- a/spring-core/src/test/java/org/springframework/core/type/AnnotationMetadataTests.java
+++ b/spring-core/src/test/java/org/springframework/core/type/AnnotationMetadataTests.java
@@ -141,9 +141,10 @@ class AnnotationMetadataTests {
 		assertThat(metadata.isConcrete()).isFalse();
 		assertThat(metadata.hasSuperClass()).isFalse();
 		assertThat(metadata.getSuperClassName()).isNull();
-		assertThat(metadata.getInterfaceNames()).hasSize(2);
+		assertThat(metadata.getInterfaceNames()).hasSize(3);
 		assertThat(metadata.getInterfaceNames()[0]).isEqualTo(ClassMetadata.class.getName());
-		assertThat(metadata.getInterfaceNames()[1]).isEqualTo(AnnotatedTypeMetadata.class.getName());
+		assertThat(metadata.getInterfaceNames()[1]).isEqualTo(BeanClassMetadata.class.getName());
+		assertThat(metadata.getInterfaceNames()[2]).isEqualTo(AnnotatedTypeMetadata.class.getName());
 		assertThat(metadata.getAnnotationTypes()).isEmpty();
 	}
 
@@ -404,7 +405,6 @@ class AnnotationMetadataTests {
 			assertThat(methodMetadata.isAnnotated(TestAutowired.class.getName())).isTrue();
 		}
 	}
-
 
 	// -------------------------------------------------------------------------
 

--- a/spring-core/src/test/java/org/springframework/core/type/classreading/MetadataReaderReflectionParityTests.java
+++ b/spring-core/src/test/java/org/springframework/core/type/classreading/MetadataReaderReflectionParityTests.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.ClassMetadata;
+import org.springframework.core.type.ClassMetadataNotFoundException;
+import org.springframework.core.type.FieldMetadata;
+import org.springframework.core.type.MethodMetadata;
+import org.springframework.core.type.ParameterizedTypeMetadata;
+import org.springframework.core.type.TypeMetadata;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class MetadataReaderReflectionParityTests {
+
+	private final SimpleMetadataReaderFactory factory = new SimpleMetadataReaderFactory();
+
+	@Test
+	public void readGenericField() throws IOException {
+		MetadataReader metadataReader = factory.getMetadataReader(TestClass.class.getName());
+		ClassMetadata classMetadata = metadataReader.getClassMetadata();
+
+		FieldMetadata field = classMetadata.getDeclaredField("stringPredicate");
+		TypeMetadata fieldType = field.getFieldType();
+
+		assertThat(fieldType).isInstanceOf(ParameterizedTypeMetadata.class);
+		assertThat(fieldType.getTypeName()).isEqualTo("java.util.function.Predicate");
+		String typeArgumentClass = ((ParameterizedTypeMetadata) fieldType).getActualTypeArguments().get(0).getTypeName();
+		assertThat(typeArgumentClass).isEqualTo("java.lang.String");
+	}
+
+	@Test
+	public void readGenericTypedMethod() throws IOException {
+		MetadataReader metadataReader = factory.getMetadataReader(TestClass.class.getName());
+		ClassMetadata classMetadata = metadataReader.getClassMetadata();
+
+		Set<MethodMetadata> declaredMethods = classMetadata.getDeclaredMethods();
+		MethodMetadata genericTypedMethod = declaredMethods.stream()
+				.filter(method -> method.getMethodName().equals("genericTyped")).findFirst().get();
+
+		TypeMetadata returnType = genericTypedMethod.getReturnType();
+		assertThat(returnType.getTypeName()).isEqualTo(Object.class.getName());
+	}
+
+	@Test
+	public void isType() throws IOException {
+		MetadataReader metadataReader = factory.getMetadataReader(StringBuilder.class.getName());
+		AnnotationMetadata metadata = metadataReader.getAnnotationMetadata();
+
+		assertThat(metadata.isType(StringBuilder.class)).isTrue();
+
+		// Direct interfaces
+		assertThat(metadata.isType(CharSequence.class)).isFalse();
+		assertThat(metadata.isType(Serializable.class)).isFalse();
+
+		// Super type
+		assertThat(metadata.isType("java.lang.AbstractStringBuilder")).isFalse();
+		assertThat(metadata.isType(Appendable.class)).isFalse();
+	}
+
+	@Test
+	public void fullTypeInformation() throws IOException {
+		MetadataReader metadataReader = factory.getMetadataReader(StringBuilder.class.getName());
+		ClassMetadata metadata = metadataReader.getClassMetadata();
+
+		assertThat(metadata.getSuperClassMetadata()).isNotNull();
+		assertThat(metadata.getSuperClassMetadata().getClassName()).isEqualTo("java.lang.AbstractStringBuilder");
+		Set<ClassMetadata> interfaceTypes = metadata.getInterfaceClassMetadata();
+		assertThat(interfaceTypes).isNotNull();
+		assertThat(interfaceTypes.size()).isEqualTo(3);
+		Iterator<ClassMetadata> iterator = interfaceTypes.iterator();
+		assertThat(iterator.next().getClassName()).isEqualTo("java.io.Serializable");
+		assertThat(iterator.next().getClassName()).isEqualTo("java.lang.Comparable");
+		assertThat(iterator.next().getClassName()).isEqualTo("java.lang.CharSequence");
+	}
+
+	@Test
+	public void isAssignableTo() throws IOException {
+		MetadataReader metadataReader = factory.getMetadataReader(StringBuilder.class.getName());
+		AnnotationMetadata metadata = metadataReader.getAnnotationMetadata();
+
+		// Direct interfaces
+		assertThat(metadata.isAssignableTo(CharSequence.class)).isTrue();
+		assertThat(metadata.isAssignableTo(Serializable.class)).isTrue();
+
+		// Super type
+		assertThat(metadata.isAssignableTo("java.lang.AbstractStringBuilder")).isTrue();
+		assertThat(metadata.isAssignableTo(Appendable.class)).isTrue();
+
+		// Object
+		assertThat(metadata.isAssignableTo(Object.class)).isTrue();
+	}
+
+	@Test
+	public void isAssignableToPrimitive() {
+		SimpleAnnotationMetadata metadata = forClass(Boolean.TYPE.getName());
+
+		assertThat(metadata.isAssignableTo(Boolean.TYPE)).isTrue();
+	}
+
+	@Test
+	public void isAssignableToPrimitiveNotObject() {
+		SimpleAnnotationMetadata metadata = forClass(Boolean.TYPE.getName());
+
+		assertThat(metadata.isAssignableTo(Object.class)).isFalse();
+	}
+
+	@Test
+	public void isAssignableToNullClassThrows() {
+		SimpleAnnotationMetadata metadata = forClass("java.lang.String");
+
+		assertThatThrownBy(() -> metadata.isAssignableTo((Class<?>) null))
+				.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	public void isAssignableToNullStringThrows() {
+		SimpleAnnotationMetadata metadata = forClass("java.lang.String");
+
+		assertThatThrownBy(() -> metadata.isAssignableTo((String) null))
+				.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	public void isAssignableToNonExistentMetadataThrows() {
+		SimpleAnnotationMetadata metadata = forClass(
+				StringBuilder.class.getName(), "java.lang.NonExistent");
+
+		assertThatThrownBy(() -> metadata.isAssignableTo(CharSequence.class))
+				.isInstanceOf(ClassMetadataNotFoundException.class)
+				.hasMessage("Could not load metadata for class java.lang.NonExistent");
+	}
+
+	@Test
+	public void isTypeNullClassThrows() {
+		SimpleAnnotationMetadata metadata = forClass("java.lang.String");
+
+		assertThatThrownBy(() -> metadata.isType((Class) null))
+				.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	public void isTypeNullStringThrows() {
+		SimpleAnnotationMetadata metadata = forClass("java.lang.String");
+
+		assertThatThrownBy(() -> metadata.isAssignableTo((String) null))
+				.isInstanceOf(NullPointerException.class);
+	}
+
+	private SimpleAnnotationMetadata forClass(String className) {
+		return new SimpleAnnotationMetadata(className, 0, null, null,
+				false, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MergedAnnotations.of(Collections.emptyList()), factory);
+	}
+
+	private SimpleAnnotationMetadata forClass(String className, String superClassName) {
+		return new SimpleAnnotationMetadata(className, 0, null, superClassName,
+				false, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MergedAnnotations.of(Collections.emptyList()), factory);
+	}
+
+	private static class TestClass<T> {
+
+		Predicate<String> stringPredicate;
+
+		T genericField;
+
+		String[] stringArray;
+
+		void voidReturn() {
+		}
+
+		String stringReturn() {
+			return "";
+		}
+
+		T genericReturn() {
+			return null;
+		}
+
+		<V extends CharSequence> V genericTyped(V charSequence) {
+			return null;
+		}
+
+	}
+
+}

--- a/spring-core/src/test/java/org/springframework/core/type/classreading/SimpleAnnotationMetadataTests.java
+++ b/spring-core/src/test/java/org/springframework/core/type/classreading/SimpleAnnotationMetadataTests.java
@@ -39,4 +39,6 @@ class SimpleAnnotationMetadataTests extends AbstractAnnotationMetadataTests {
 		}
 	}
 
+
+
 }


### PR DESCRIPTION
We've been working on startup performance internally and noticed bean post-processors in particular caused us a significant amount of class loading making lazy initialization of beans less effective due to their use of reflection causing quite a bit of early classloading.

I wrote an internal extension to `MetadataReader` that gave us parity with reflection for our internal processor implementations. I noticed `org.springframework.context.annotation.ConfigurationClassParser` already uses a `ResourceLoader` aware cached reader, so we're reading all of the bean classes once anyway, and could make our bean post-processors `ResourceLoaderAware` and avoid repeated reading overhead.

Seemed to me this would benefit you upstream, for instance, uses of `MethodIntrospector` like [ScheduledBeanLazyInitializationExcludeFilter](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/ScheduledBeanLazyInitializationExcludeFilter.java) cause similar problems, loading hundreds of classes in the application I'm looking at:

<img width="1476" alt="Screenshot 2023-04-14 at 6 03 48 pm" src="https://user-images.githubusercontent.com/1479220/231983186-d540de49-01e5-433d-8af7-e4224013df83.png">

Figured I'd run this by you upstream at this stage to get some feedback on what else would be required to get this landed so we're not maintaining a partial fork of this logic, and you can benefit from replacing reflection with class reading where it makes sense. I plan on taking tests I have here and roll them into the complete reflection vs classreading test suites you have, but was avoiding that work until I have some feedback that this is a direction you'd like to go in.

We've found using `MetadataReader` with `BeanDefinition` requires some boilerplate, that is less of a concern with reflection, so would be interested in if you think there should be something in `BeanDefinition` to do at least the "real" class name resolution:

```
String beanClassName = beanDefinition.getBeanClassName();
if (beanDefinition instanceof AbstractBeanDefinition) {
        // Deal with generated classes
	AbstractBeanDefinition abstractBeanDefinition = (AbstractBeanDefinition) beanDefinition;
	if (abstractBeanDefinition.hasBeanClass()) {
		beanClassName = ClassUtils.getUserClass(abstractBeanDefinition.getBeanClass()).getName();
	}
}
if (beanClassName == null && beanDefinition instanceof AnnotatedBeanDefinition) {
	MethodMetadata factoryMethodMetadata = ((AnnotatedBeanDefinition) beanDefinition)
			.getFactoryMethodMetadata();
	Objects.requireNonNull(factoryMethodMetadata,
			"No suitable factory method for beanDefinition for bean: " + beanName);
	beanClassName = factoryMethodMetadata.getReturnTypeName();
}
if (beanClassName == null {
	return null;
}
MetadataReader metadataReader = metadataReaderFactory.getMetadataReader(beanClassName);
return metadataReader.get().getAnnotationMetadata();
```
