### PR TITLE
Clarify behavior of the Elvis SpEL operator in documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/expressions/language-ref/operator-elvis.adoc
+++ b/framework-docs/modules/ROOT/pages/core/expressions/language-ref/operator-elvis.adoc
@@ -38,7 +38,7 @@ Kotlin::
 ----
 ======
 
-NOTE: The SpEL Elvis operator actually also checks for empty Strings, in addition to null objects.
+NOTE: The SpEL Elvis operator also checks for _empty_ Strings in addition to `null` objects.
 The original snippet is thus only close to emulating the semantics of the operator (it would need an
 additional `!name.isEmpty()` check).
 

--- a/framework-docs/modules/ROOT/pages/core/expressions/language-ref/operator-elvis.adoc
+++ b/framework-docs/modules/ROOT/pages/core/expressions/language-ref/operator-elvis.adoc
@@ -38,6 +38,10 @@ Kotlin::
 ----
 ======
 
+NOTE: The SpEL Elvis operator actually also checks for empty Strings, in addition to null objects.
+The original snippet is thus only close to emulating the semantics of the operator (it would need an
+additional `!name.isEmpty()` check).
+
 The following listing shows a more complex example:
 
 [tabs]
@@ -53,7 +57,7 @@ Java::
 	String name = parser.parseExpression("name?:'Elvis Presley'").getValue(context, tesla, String.class);
 	System.out.println(name);  // Nikola Tesla
 
-	tesla.setName(null);
+	tesla.setName("");
 	name = parser.parseExpression("name?:'Elvis Presley'").getValue(context, tesla, String.class);
 	System.out.println(name);  // Elvis Presley
 ----
@@ -69,7 +73,7 @@ Kotlin::
 	var name = parser.parseExpression("name?:'Elvis Presley'").getValue(context, tesla, String::class.java)
 	println(name)  // Nikola Tesla
 
-	tesla.setName(null)
+	tesla.setName("")
 	name = parser.parseExpression("name?:'Elvis Presley'").getValue(context, tesla, String::class.java)
 	println(name)  // Elvis Presley
 ----

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/Elvis.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/Elvis.java
@@ -26,9 +26,9 @@ import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
 /**
- * Represents the elvis operator <code>?:</code>. For an expression <code>a?:b</code> if <code>a</code> is not null,
- * the value of the expression is <code>a</code>, if <code>a</code> is null then the value of the expression is
- * <code>b</code>.
+ * Represents the elvis operator <code>?:</code>. For an expression <code>a?:b</code> if <code>a</code> is not null
+ * nor the empty String, the value of the expression is <code>a</code>.
+ * If <code>a</code> is null or the empty String, then the value of the expression is <code>b</code>.
  *
  * @author Andy Clement
  * @author Juergen Hoeller
@@ -43,8 +43,8 @@ public class Elvis extends SpelNodeImpl {
 
 
 	/**
-	 * Evaluate the condition and if not null, return it.
-	 * If it is null, return the other value.
+	 * Evaluate the condition and if not null or the empty String, return it.
+	 * If it is null or the empty String, return the other value.
 	 * @param state the expression state
 	 * @throws EvaluationException if the condition does not evaluate correctly
 	 * to a boolean or there is a problem executing the chosen alternative

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/Elvis.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/Elvis.java
@@ -26,8 +26,8 @@ import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
 /**
- * Represents the elvis operator <code>?:</code>. For an expression <code>a?:b</code> if <code>a</code> is not null
- * nor the empty String, the value of the expression is <code>a</code>.
+ * Represents the Elvis operator <code>?:</code>. For an expression <code>a?:b</code> if <code>a</code> is neither null
+ * nor an empty String, the value of the expression is <code>a</code>.
  * If <code>a</code> is null or the empty String, then the value of the expression is <code>b</code>.
  *
  * @author Andy Clement
@@ -43,8 +43,8 @@ public class Elvis extends SpelNodeImpl {
 
 
 	/**
-	 * Evaluate the condition and if not null or the empty String, return it.
-	 * If it is null or the empty String, return the other value.
+	 * Evaluate the condition and if neither null nor an empty String, return it.
+	 * If it is null or an empty String, return the other value.
 	 * @param state the expression state
 	 * @throws EvaluationException if the condition does not evaluate correctly
 	 * to a boolean or there is a problem executing the chosen alternative


### PR DESCRIPTION
This commit improves both the javadoc and the reference guide section on
the Elvis SpEL operator to clarify that in addition to `null` objects,
empty Strings also lead the operator to evaluate to its second operand.

The reference guide's advanced snippet is modified to use such an empty
String instead of `null` to make that behavior prominent with some code.

See gh-30318
Closes gh-30352
