### PR TITLE
Fix link in Javadoc of `PassThroughFilterChain`

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/PassThroughFilterChain.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/PassThroughFilterChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * Implementation of the {@link jakarta.servlet.FilterConfig} interface which
+ * Implementation of the {@link jakarta.servlet.FilterChain} interface which
  * simply passes the call through to a given Filter/FilterChain combination
  * (indicating the next Filter in the chain along with the FilterChain that it is
  * supposed to work on) or to a given Servlet (indicating the end of the chain).

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/PassThroughFilterChain.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/PassThroughFilterChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * Implementation of the {@link jakarta.servlet.FilterConfig} interface which
+ * Implementation of the {@link jakarta.servlet.FilterChain} interface which
  * simply passes the call through to a given Filter/FilterChain combination
  * (indicating the next Filter in the chain along with the FilterChain that it is
  * supposed to work on) or to a given Servlet (indicating the end of the chain).


### PR DESCRIPTION
The Javadoc in `PassThroughFilterChain` incorrectly says that it implements `FilterConfig`, when in fact it implements `FilterChain`.