### PR TITLE
Docs: Remove duplicate in SpEL feature list

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/expressions.adoc
+++ b/framework-docs/modules/ROOT/pages/core/expressions.adoc
@@ -38,7 +38,6 @@ The expression language supports the following functionality:
 * Class expressions
 * Accessing properties, arrays, lists, and maps
 * Method invocation
-* Relational operators
 * Assignment
 * Calling constructors
 * Bean references


### PR DESCRIPTION
The "relational operators" feature was included twice in the list of SpEL feature list; as part of the "Boolean and relational operators" bullet point and as separate bullet point.