### PR TITLE
Upgrade to commons-fileupload 1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ configure(allprojects) { project ->
 			dependency "org.python:jython-standalone:2.7.1"
 			dependency "org.mozilla:rhino:1.7.11"
 
-			dependency "commons-fileupload:commons-fileupload:1.4"
+			dependency "commons-fileupload:commons-fileupload:1.5"
 			dependency "org.synchronoss.cloud:nio-multipart-parser:1.1.0"
 
 			dependency("org.dom4j:dom4j:2.1.3") {

--- a/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java
@@ -69,6 +69,7 @@ public abstract class CoroutinesUtils {
 	 * Invoke a suspending function and converts it to {@link Mono} or
 	 * {@link Flux}.
 	 */
+	@SuppressWarnings("deprecation")
 	public static Publisher<?> invokeSuspendingFunction(Method method, Object target, Object... args) {
 		KFunction<?> function = Objects.requireNonNull(ReflectJvmMapping.getKotlinFunction(method));
 		if (method.isAccessible() && !KCallablesJvm.isAccessible(function)) {

--- a/spring-web/src/main/java/org/springframework/web/multipart/commons/CommonsFileUploadSupport.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/commons/CommonsFileUploadSupport.java
@@ -98,6 +98,16 @@ public abstract class CommonsFileUploadSupport {
 	}
 
 	/**
+	 * Sets the maximum number of files allowed per request.
+     * -1 indicates no limit (the default).
+	 * @param fileCountMax the maximum upload size allowed
+	 * @see org.apache.commons.fileupload.FileUploadBase#setFileCountMax
+	 */
+	public void setFileCountMax(long fileCountMax) {
+		this.fileUpload.setFileCountMax(fileCountMax);
+	}
+
+	/**
 	 * Set the maximum allowed size (in bytes) before an upload gets rejected.
 	 * -1 indicates no limit (the default).
 	 * @param maxUploadSize the maximum upload size allowed
@@ -117,6 +127,7 @@ public abstract class CommonsFileUploadSupport {
 	public void setMaxUploadSizePerFile(long maxUploadSizePerFile) {
 		this.fileUpload.setFileSizeMax(maxUploadSizePerFile);
 	}
+
 
 	/**
 	 * Set the maximum allowed size (in bytes) before uploads are written to disk.
@@ -232,6 +243,7 @@ public abstract class CommonsFileUploadSupport {
 			actualFileUpload = newFileUpload(getFileItemFactory());
 			actualFileUpload.setSizeMax(fileUpload.getSizeMax());
 			actualFileUpload.setFileSizeMax(fileUpload.getFileSizeMax());
+			actualFileUpload.setFileCountMax(fileUpload.getFileCountMax());
 			actualFileUpload.setHeaderEncoding(encoding);
 		}
 

--- a/spring-web/src/main/java/org/springframework/web/multipart/commons/CommonsMultipartResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/commons/CommonsMultipartResolver.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.fileupload.FileCountLimitExceededException;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.FileUpload;
@@ -197,6 +198,9 @@ public class CommonsMultipartResolver extends CommonsFileUploadSupport
 		}
 		catch (FileUploadBase.FileSizeLimitExceededException ex) {
 			throw new MaxUploadSizeExceededException(fileUpload.getFileSizeMax(), ex);
+		}
+		catch (FileCountLimitExceededException ex) {
+			throw new MaxUploadSizeExceededException(fileUpload.getFileCountMax(), ex);
 		}
 		catch (FileUploadException ex) {
 			throw new MultipartException("Failed to parse multipart servlet request", ex);

--- a/spring-web/src/test/java/org/springframework/web/multipart/commons/CommonsMultipartResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/multipart/commons/CommonsMultipartResolverTests.java
@@ -147,6 +147,7 @@ public class CommonsMultipartResolverTests {
 		wac.getServletContext().setAttribute(WebUtils.TEMP_DIR_CONTEXT_ATTRIBUTE, new File("mytemp"));
 		wac.refresh();
 		MockCommonsMultipartResolver resolver = new MockCommonsMultipartResolver();
+		resolver.setFileCountMax(10);
 		resolver.setMaxUploadSize(1000);
 		resolver.setMaxInMemorySize(100);
 		resolver.setDefaultEncoding("enc");
@@ -154,6 +155,7 @@ public class CommonsMultipartResolverTests {
 			resolver.setResolveLazily(false);
 		}
 		resolver.setServletContext(wac.getServletContext());
+		assertThat(resolver.getFileUpload().getFileCountMax()).isEqualTo(10);
 		assertThat(resolver.getFileUpload().getSizeMax()).isEqualTo(1000);
 		assertThat(resolver.getFileItemFactory().getSizeThreshold()).isEqualTo(100);
 		assertThat(resolver.getFileUpload().getHeaderEncoding()).isEqualTo("enc");


### PR DESCRIPTION
fix  https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-3326457
potential DoS attack
upgrade commons-fileupload to latest version 1.5
add setFileCountMax
handle FileCountLimitExceededException
update test file 
add @SuppressWarnings("deprecation") in CorutinesUtils.java order to build project 