### PR TITLE
Remove PDF link from Antora based reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/index.adoc
+++ b/framework-docs/modules/ROOT/pages/index.adoc
@@ -22,8 +22,6 @@ xref:testing/appendix.adoc[Appendix] :: Spring properties.
 https://github.com/spring-projects/spring-framework/wiki[Wiki] :: What's New,
 Upgrade Notes, Supported Versions, additional cross-version information.
 
-NOTE: This documentation is also available in {docs-spring-framework}/reference/pdf/spring-framework.pdf[PDF] format.
-
 Rod Johnson, Juergen Hoeller, Keith Donald, Colin Sampaleanu, Rob Harrop, Thomas Risberg,
 Alef Arendsen, Darren Davison, Dmitriy Kopylenko, Mark Pollack, Thierry Templier, Erwin
 Vervaet, Portia Tung, Ben Hale, Adrian Colyer, John Lewis, Costin Leau, Mark Fisher, Sam


### PR DESCRIPTION
The Antora build introduced in #30414 does not generate PDF links, and this change removes the link to it.