### PR TITLE
Enable tabs-sync-option for the Antora based reference documentation

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -25,6 +25,7 @@ asciidoc:
   attributes:
     page-pagination: ''
     hide-uri-scheme: '@'
+    tabs-sync-option: '@'
     include-java: 'example$docs-src/main/java/org/springframework/docs'
 urls:
   latest_version_segment_strategy: redirect:to


### PR DESCRIPTION
This ensures that the tabs are synced across pages after the switch to the Antora in #30414.

See https://github.com/asciidoctor/asciidoctor-tabs#tabs-sync