### PR TITLE
Support `@Bean` 'lite' mode when no `@Bean` methods are declared locally

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
@@ -349,7 +349,7 @@ class ConfigurationClassParser {
 		if (!memberClasses.isEmpty()) {
 			List<SourceClass> candidates = new ArrayList<>(memberClasses.size());
 			for (SourceClass memberClass : memberClasses) {
-				if (ConfigurationClassUtils.isConfigurationCandidate(memberClass.getMetadata()) &&
+				if (ConfigurationClassUtils.isConfigurationCandidate(memberClass.getMetadata(), this.metadataReaderFactory) &&
 						!memberClass.getMetadata().getClassName().equals(configClass.getMetadata().getClassName())) {
 					candidates.add(memberClass);
 				}

--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
@@ -490,7 +490,7 @@ public class ConfigurationClassPostProcessor implements BeanDefinitionRegistryPo
 				// or component class without @Bean methods.
 				boolean liteConfigurationCandidateWithoutBeanMethods =
 						(ConfigurationClassUtils.CONFIGURATION_CLASS_LITE.equals(configClassAttr) &&
-							annotationMetadata != null && !ConfigurationClassUtils.hasBeanMethods(annotationMetadata));
+							annotationMetadata != null && !ConfigurationClassUtils.hasBeanMethods(annotationMetadata, this.metadataReaderFactory));
 				if (!liteConfigurationCandidateWithoutBeanMethods) {
 					try {
 						abd.resolveBeanClass(this.beanClassLoader);

--- a/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,11 +69,13 @@ import org.springframework.util.Assert;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author Chris Beams
  * @author Juergen Hoeller
  * @author Sam Brannen
+ * @author Yanming Zhou
  */
 class ConfigurationClassPostProcessorTests {
 
@@ -1125,6 +1127,13 @@ class ConfigurationClassPostProcessorTests {
 	}
 
 
+	@Test
+	void testBeanNotDeclaredLocallyWithLiteMode() { // GH-30449
+		ConfigurableApplicationContext ctx = new AnnotationConfigApplicationContext(LiteConfiguration.class);
+		assertThatNoException().isThrownBy(() -> ctx.getBean("myTestBean"));
+		ctx.close();
+	}
+
 	// -------------------------------------------------------------------------
 
 	@Configuration
@@ -2036,6 +2045,18 @@ class ConfigurationClassPostProcessorTests {
 				}
 			};
 		}
+	}
+
+	static class LiteConfiguration extends BaseLiteConfiguration {
+
+	}
+
+	static class BaseLiteConfiguration {
+		@Bean
+		TestBean myTestBean() {
+			return new TestBean();
+		}
+
 	}
 
 }


### PR DESCRIPTION
ConfigurationClassUtils should check bean methods in super classes also
Fix GH-30449