### PR TITLE
Download the playbook to build dir

### DIFF
--- a/framework-docs/framework-docs.gradle
+++ b/framework-docs/framework-docs.gradle
@@ -11,7 +11,7 @@ apply from: "${rootDir}/gradle/publications.gradle"
 
 antora {
 	version = '3.2.0-alpha.2'
-	playbook = 'cached-antora-playbook.yml'
+	playbook = layout.buildDirectory.file('cached-antora-playbook.yml').get().getAsFile()
 	playbookProvider {
 		repository = 'spring-projects/spring-framework'
 		branch = 'docs-build'


### PR DESCRIPTION
Download the cached playbook to the build dir

- This should be merged into main as well
- It needs to happen at the same time as the update to docs-build branch gh-30466

NOTE: CI fails because of the fact that the other PR needs to also be merged