### PR TITLE
Use cached playbook in build dir

### DIFF
--- a/lib/antora/templates/per-branch-antora-playbook.yml
+++ b/lib/antora/templates/per-branch-antora-playbook.yml
@@ -14,7 +14,7 @@ site:
   title: Spring Framework Reference
 content:
   sources:
-  - url: ./..
+  - url: ./../..
     branches: HEAD
     start_path: framework-docs
     worktrees: true


### PR DESCRIPTION
This is an update to the per branch build to allow placing the playbook in the build dir. It needs to happen with gh-30465