### PR TITLE
Introduce a method in `MockHttpServletRequestBuilder` to set remote address

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
@@ -104,6 +104,9 @@ public class MockHttpServletRequestBuilder
 	private MockHttpSession session;
 
 	@Nullable
+	private String remoteAddress;
+
+	@Nullable
 	private String characterEncoding;
 
 	@Nullable
@@ -527,6 +530,17 @@ public class MockHttpServletRequestBuilder
 	}
 
 	/**
+	 * Set the remote address of the request.
+	 * @param remoteAddress the remote address (IP)
+	 * @Since 6.1.0
+	 */
+	public MockHttpServletRequestBuilder remoteAddress(String remoteAddress) {
+		Assert.notNull(remoteAddress, "'remoteAddress' must not be null");
+		this.remoteAddress = remoteAddress;
+		return this;
+	}
+
+	/**
 	 * An extension point for further initialization of {@link MockHttpServletRequest}
 	 * in ways not built directly into the {@code MockHttpServletRequestBuilder}.
 	 * Implementation of this interface can have builder-style methods themselves
@@ -582,6 +596,9 @@ public class MockHttpServletRequestBuilder
 		}
 		if (this.session == null) {
 			this.session = parentBuilder.session;
+		}
+		if (this.remoteAddress == null) {
+			this.remoteAddress = parentBuilder.remoteAddress;
 		}
 
 		if (this.characterEncoding == null) {
@@ -686,6 +703,9 @@ public class MockHttpServletRequestBuilder
 		}
 		if (this.principal != null) {
 			request.setUserPrincipal(this.principal);
+		}
+		if (this.remoteAddress != null) {
+			request.setRemoteAddr(this.remoteAddress);
 		}
 		if (this.session != null) {
 			request.setSession(this.session);

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilder.java
@@ -532,10 +532,10 @@ public class MockHttpServletRequestBuilder
 	/**
 	 * Set the remote address of the request.
 	 * @param remoteAddress the remote address (IP)
-	 * @Since 6.1.0
+	 * @since 6.1
 	 */
 	public MockHttpServletRequestBuilder remoteAddress(String remoteAddress) {
-		Assert.notNull(remoteAddress, "'remoteAddress' must not be null");
+		Assert.hasText(remoteAddress, "'remoteAddress' must not be null or blank");
 		this.remoteAddress = remoteAddress;
 		return this;
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -557,6 +556,15 @@ class MockHttpServletRequestBuilderTests {
 		MockHttpServletRequest request = this.builder.buildRequest(this.servletContext);
 
 		assertThat(request.getUserPrincipal()).isEqualTo(user);
+	}
+
+	@Test
+	void remoteAddress() {
+		final String ip = "10.0.0.1";
+		this.builder.remoteAddress(ip);
+		MockHttpServletRequest request = this.builder.buildRequest(this.servletContext);
+
+		assertThat(request.getRemoteAddr()).isEqualTo(ip);
 	}
 
 	@Test  // SPR-12945

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
@@ -560,7 +560,7 @@ class MockHttpServletRequestBuilderTests {
 
 	@Test
 	void remoteAddress() {
-		final String ip = "10.0.0.1";
+		String ip = "10.0.0.1";
 		this.builder.remoteAddress(ip);
 		MockHttpServletRequest request = this.builder.buildRequest(this.servletContext);
 


### PR DESCRIPTION
Introduce a method in `MockHttpServletRequestBuilder` to set the remote server address.

This PR was discussed in gh-30484.