### PR TITLE
Remove non-empty filename check in `ContentDisposition` builder

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -807,14 +807,12 @@ public final class ContentDisposition {
 
 		@Override
 		public Builder filename(String filename) {
-			Assert.hasText(filename, "No filename");
 			this.filename = filename;
 			return this;
 		}
 
 		@Override
 		public Builder filename(String filename, Charset charset) {
-			Assert.hasText(filename, "No filename");
 			this.filename = filename;
 			this.charset = charset;
 			return this;


### PR DESCRIPTION
The ContentDisposition Builder must be consistent with ContentDisposition and accept a nullable filename.