### PR TITLE
Fix invalid link in transaction resources

### DIFF
--- a/framework-docs/modules/ROOT/pages/data-access/transaction/resources.adoc
+++ b/framework-docs/modules/ROOT/pages/data-access/transaction/resources.adoc
@@ -4,7 +4,7 @@
 
 For more information about the Spring Framework's transaction support, see:
 
-* https://www.infoworld.com/article/2077963/distributed-transactions-in-spring--with-and-without-xa.html[Distributed
+* link:++https://www.infoworld.com/article/2077963/distributed-transactions-in-spring--with-and-without-xa.html++[Distributed
   transactions in Spring, with and without XA] is a JavaWorld presentation in which
   Spring's David Syer guides you through seven patterns for distributed
   transactions in Spring applications, three of them with XA and four without.


### PR DESCRIPTION
Hello. I found that `Distributed transactions in Spring, with and without XA` url in Spring Framework - Data Access - Transaction Management - Further Resources is not linked to the valid url.
https://docs.spring.io/spring-framework/reference/data-access/transaction/resources.html

https://www.infoworld.com/article/2077963/distributed-transactions-in-spring--with-and-without-xa.html

This url contains double dash (--). In that case, asciidoctor use some specific methods described in followed links.

https://docs.asciidoctor.org/asciidoc/latest/macros/complex-urls/
https://github.com/asciidoctor/asciidoctor/issues/3965

I fix this problem using link prefix and double plus line macro(++) because it preserve the original url.

There are another solutions to solve this problem. If you don't like this way, please edit this document page.