### PR TITLE
Fix example in Javadoc for `MultipartBodyBuilder`

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
@@ -76,7 +76,7 @@ import org.springframework.util.MultiValueMap;
  *
  * Mono&lt;Void&gt; result = webClient.post()
  *     .uri("...")
- *     .body(multipartBody)
+ *     .body(BodyInserters.fromMultipartData(multipartBody))
  *     .retrieve()
  *     .bodyToMono(Void.class)
  * </pre>


### PR DESCRIPTION
The example of MultipartBodyBuilder was wrong, so it was corrected.