### PR TITLE
Adding Reminder Information to websocket doc

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/websocket/fallback.adoc
+++ b/framework-docs/modules/ROOT/pages/web/websocket/fallback.adoc
@@ -103,6 +103,14 @@ You can enable SockJS through Java configuration, as the following example shows
 	}
 ----
 
+[IMPORTANT]
+
+====
+If SockJS is not used, please do not use `withSockJS()`, as this will cause websocket to be unable to connect.
+====
+
+
+
 The following example shows the XML configuration equivalent of the preceding example:
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]


### PR DESCRIPTION
I didn't use SockJS when I first started using Stomp, but the entire document used this option, which caused me to be unable to connect to the browser. Later, when I discovered this option, I was able to restore it to normal. I think it is necessary to provide a reminder to prevent spending time investigating such worthless issues.