### PR TITLE
Add missing Javadoc for `RegisteredBean.resolveAutowiredArgument()`

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/RegisteredBean.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/RegisteredBean.java
@@ -212,6 +212,15 @@ public final class RegisteredBean {
 				.resolveConstructorOrFactoryMethod(getBeanName(), getMergedBeanDefinition());
 	}
 
+	/**
+	 * Resolve an autowired argument.
+	 * @param descriptor the descriptor for the dependency (field/method/constructor)
+	 * @param typeConverter the TypeConverter to use for populating arrays and collections
+	 * @param autowiredBeans a Set that all names of autowired beans (used for
+	 * resolving the given dependency) are supposed to be added to
+	 * @return the resolved object, or {@code null} if none found
+	 * @since 6.0.9
+	 */
 	@Nullable
 	public Object resolveAutowiredArgument(DependencyDescriptor descriptor, TypeConverter typeConverter,
 			Set<String> autowiredBeans) {


### PR DESCRIPTION
This PR adds Javadoc for `RegisteredBean.resolveAutowiredArgument()`.

See gh-30401