### PR TITLE
Handle custom JMS acknowledgment modes as client acknowledge

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/support/JmsAccessor.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/JmsAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,7 +223,10 @@ public abstract class JmsAccessor implements InitializingBean {
 	 * @see jakarta.jms.Session#CLIENT_ACKNOWLEDGE
 	 */
 	protected boolean isClientAcknowledge(Session session) throws JMSException {
-		return (session.getAcknowledgeMode() == Session.CLIENT_ACKNOWLEDGE);
+		int mode = session.getAcknowledgeMode();
+		return (mode != Session.SESSION_TRANSACTED &&
+				mode != Session.AUTO_ACKNOWLEDGE &&
+				mode != Session.DUPS_OK_ACKNOWLEDGE);
 	}
 
 }

--- a/spring-jms/src/test/java/org/springframework/jms/support/JmsAccessorTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/support/JmsAccessorTests.java
@@ -31,17 +31,17 @@ import static org.mockito.Mockito.mock;
  * @author Chris Beams
  * @author Vedran Pavic
  */
-public class JmsAccessorTests {
+class JmsAccessorTests {
 
 	@Test
-	public void testChokesIfConnectionFactoryIsNotSupplied() throws Exception {
+	void testChokesIfConnectionFactoryIsNotSupplied() {
 		JmsAccessor accessor = new StubJmsAccessor();
 		assertThatIllegalArgumentException().isThrownBy(
 				accessor::afterPropertiesSet);
 	}
 
 	@Test
-	public void testSessionTransactedModeReallyDoesDefaultToFalse() throws Exception {
+	void testSessionTransactedModeReallyDoesDefaultToFalse() {
 		JmsAccessor accessor = new StubJmsAccessor();
 		assertThat(accessor.isSessionTransacted()).as("The [sessionTransacted] property of JmsAccessor must default to " +
 				"false. Change this test (and the attendant Javadoc) if you have " +
@@ -49,7 +49,7 @@ public class JmsAccessorTests {
 	}
 
 	@Test
-	public void testAcknowledgeModeReallyDoesDefaultToAutoAcknowledge() throws Exception {
+	void testAcknowledgeModeReallyDoesDefaultToAutoAcknowledge() {
 		JmsAccessor accessor = new StubJmsAccessor();
 		assertThat(accessor.getSessionAcknowledgeMode()).as("The [sessionAcknowledgeMode] property of JmsAccessor must default to " +
 				"[Session.AUTO_ACKNOWLEDGE]. Change this test (and the attendant " +
@@ -57,7 +57,7 @@ public class JmsAccessorTests {
 	}
 
 	@Test
-	public void testSetAcknowledgeModeNameChokesIfBadAckModeIsSupplied() throws Exception {
+	void testSetAcknowledgeModeNameChokesIfBadAckModeIsSupplied() {
 		assertThatIllegalArgumentException().isThrownBy(() ->
 				new StubJmsAccessor().setSessionAcknowledgeModeName("Tally ho chaps!"));
 	}

--- a/spring-jms/src/test/java/org/springframework/jms/support/JmsAccessorTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/support/JmsAccessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit tests for the {@link JmsAccessor} class.
  *
  * @author Rick Evans
  * @author Chris Beams
+ * @author Vedran Pavic
  */
 public class JmsAccessorTests {
 
@@ -59,6 +62,13 @@ public class JmsAccessorTests {
 				new StubJmsAccessor().setSessionAcknowledgeModeName("Tally ho chaps!"));
 	}
 
+	@Test
+	void testCustomAcknowledgeModeIsConsideredClientAcknowledge() throws Exception {
+		Session session = mock(Session.class);
+		given(session.getAcknowledgeMode()).willReturn(100);
+		JmsAccessor accessor = new StubJmsAccessor();
+		assertThat(accessor.isClientAcknowledge(session)).isTrue();
+	}
 
 	/**
 	 * Crummy, stub, do-nothing subclass of the JmsAccessor class for use in testing.


### PR DESCRIPTION
This commit updates `JmsAccessor` to handle custom JMS acknowledgment
modes as client acknowledge, which is useful when working with JMS
providers that provide non-standard variations of `CLIENT_ACKNOWLEDGE`,
such as AWS SQS and its `UNORDERED_ACKNOWLEDGE` mode.

---

The workaround (a quite tedious one) that I'm using at the moment is to subclass `DefaultJmsListenerContainerFactory` and `DefaultMessageListenerContainer` and override `#isClientAcknowledge` using something like this:

```java
class SqsJmsListenerContainerFactory extends DefaultJmsListenerContainerFactory {

    @Override
    protected DefaultMessageListenerContainer createContainerInstance() {
        return new DefaultMessageListenerContainer() {

            @Override
            protected boolean isClientAcknowledge(Session session) throws JMSException {
                return (session.getAcknowledgeMode() == SQSSession.UNORDERED_ACKNOWLEDGE);
            }

        };
    }

}
```

For reference, SQS [`UNORDERED_ACKNOWLEDGE`](https://github.com/awslabs/amazon-sqs-java-messaging-lib/blob/4cb91355cb92d9361a2179233c9db89383b1299e/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java#L108-L114) is described as:
> Non standard acknowledge mode. This is a variation of CLIENT_ACKNOWLEDGE where Clients need to remember to call acknowledge on message. Difference is that calling acknowledge on a message only acknowledge the message being called.