### PR TITLE
Fix test fixture value in `QualifierConfiguration`

### DIFF
--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/context/annotation/QualifierConfiguration.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/context/annotation/QualifierConfiguration.java
@@ -45,7 +45,7 @@ public class QualifierConfiguration {
 		@Bean
 		@Qualifier("2")
 		public String two() {
-			return "one";
+			return "two";
 		}
 
 	}


### PR DESCRIPTION
This PR fixes a typo in the `QualifierConfiguration` test fixture.