### PR TITLE
Add support for `private` init/destroy methods in AOT mode

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessor.java
@@ -180,7 +180,7 @@ public class InitDestroyAnnotationBeanPostProcessor implements DestructionAwareB
 	}
 
 	private String[] safeMerge(@Nullable String[] existingNames, Collection<LifecycleElement> detectedElements) {
-		Stream<String> detectedNames = detectedElements.stream().map(LifecycleElement::getIdentifier);
+		Stream<String> detectedNames = detectedElements.stream().map(LifecycleElement::getMethod).map(Method::getName);
 		Stream<String> mergedNames = (existingNames != null ?
 				Stream.concat(Stream.of(existingNames), detectedNames) : detectedNames);
 		return mergedNames.distinct().toArray(String[]::new);

--- a/spring-beans/src/test/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessorTests.java
@@ -27,6 +27,7 @@ import org.springframework.beans.testfixture.beans.factory.generator.lifecycle.I
 import org.springframework.beans.testfixture.beans.factory.generator.lifecycle.Init;
 import org.springframework.beans.testfixture.beans.factory.generator.lifecycle.InitDestroyBean;
 import org.springframework.beans.testfixture.beans.factory.generator.lifecycle.MultiInitDestroyBean;
+import org.springframework.beans.testfixture.beans.factory.generator.lifecycle.PrivateInitDestroyBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,6 +53,15 @@ class InitDestroyAnnotationBeanPostProcessorTests {
 	@Test
 	void processAheadOfTimeWhenHasInitDestroyAnnotationsAddsMethodNames() {
 		RootBeanDefinition beanDefinition = new RootBeanDefinition(InitDestroyBean.class);
+		processAheadOfTime(beanDefinition);
+		RootBeanDefinition mergedBeanDefinition = getMergedBeanDefinition();
+		assertThat(mergedBeanDefinition.getInitMethodNames()).containsExactly("initMethod");
+		assertThat(mergedBeanDefinition.getDestroyMethodNames()).containsExactly("destroyMethod");
+	}
+
+	@Test
+	void processAheadOfTimeWhenHasPrivateInitDestroyAnnotationsAddsMethodNames() {
+		RootBeanDefinition beanDefinition = new RootBeanDefinition(PrivateInitDestroyBean.class);
 		processAheadOfTime(beanDefinition);
 		RootBeanDefinition mergedBeanDefinition = getMergedBeanDefinition();
 		assertThat(mergedBeanDefinition.getInitMethodNames()).containsExactly("initMethod");

--- a/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/factory/generator/lifecycle/PrivateInitDestroyBean.java
+++ b/spring-beans/src/testFixtures/java/org/springframework/beans/testfixture/beans/factory/generator/lifecycle/PrivateInitDestroyBean.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.testfixture.beans.factory.generator.lifecycle;
+
+public class PrivateInitDestroyBean {
+
+	@Init
+	private void initMethod() {
+	}
+
+	public void customInitMethod() {
+	}
+
+	@Destroy
+	private void destroyMethod() {
+	}
+
+	public void customDestroyMethod() {
+	}
+
+}


### PR DESCRIPTION
## Motivation

In AOT mode, if the init/destroy methods are private and auto-discovered thanks to an annotation, the generated code sets the init and destroy method names with the fully qualified name of the declaring class as prefix to prevent naming conflicts which causes an error of the following type when starting the application (native image or with `-Dspring.aot.enabled=true`):

``` 
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'demoBean': Could not find an init method named 'com.example.demo.DemoBean.init' on bean with name 'demoBean'
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1770) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:598) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:520) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:326) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:324) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:973) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:941) ~[spring-context-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:608) ~[spring-context-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:733) ~[spring-boot-3.2.0-SNAPSHOT.jar!/:3.2.0-SNAPSHOT]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:435) ~[spring-boot-3.2.0-SNAPSHOT.jar!/:3.2.0-SNAPSHOT]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:311) ~[spring-boot-3.2.0-SNAPSHOT.jar!/:3.2.0-SNAPSHOT]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1305) ~[spring-boot-3.2.0-SNAPSHOT.jar!/:3.2.0-SNAPSHOT]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1294) ~[spring-boot-3.2.0-SNAPSHOT.jar!/:3.2.0-SNAPSHOT]
	at com.example.demo.DemoApplication.main(DemoApplication.java:10) ~[classes!/:0.0.1-SNAPSHOT]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49) ~[demo-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:95) ~[demo-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:58) ~[demo-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:65) ~[demo-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
Caused by: org.springframework.beans.factory.support.BeanDefinitionValidationException: Could not find an init method named 'com.example.demo.DemoBean.init' on bean with name 'demoBean'
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1849) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1826) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1766) ~[spring-beans-6.0.10-SNAPSHOT.jar!/:6.0.10-SNAPSHOT]
```

Steps to reproduce:
* Create a demo project from https://start.spring.io/ with "GraalVM Native Support" as the only dependency
* Add the following Configuration and Bean classes

**Configuration class:**

```java
@Configuration
public class DemoConfiguration {

    @Bean
    public DemoBean demoBean() {
        return new DemoBean();
    }
}
```

**Bean class:**

```java
public class DemoBean {

    @PostConstruct
    private void init() {
        System.out.println("Init DemoBean");
    }

    @PreDestroy
    private void destroy() {
        System.out.println("Destroy DemoBean");
    }
}
```

## Modifications:

* Uses the name of the method instead of the identifier of the `LifecycleElement` even if it won't solve the potential naming conflict but it is a more specific use case
* Adds a unit test to illustrate the use case

## Result

The init and destroy methods are called when starting the application (native image or with `-Dspring.aot.enabled=true`).