### PR TITLE
Add Http headers support in getForEntity

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestOperations.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestOperations.java
@@ -104,6 +104,20 @@ public interface RestOperations {
 			throws RestClientException;
 
 	/**
+	 * Retrieve an entity by doing a GET on the specified URL with the specified headers
+	 * The response is converted and stored in a {@link ResponseEntity}.
+	 * <p>URI Template variables are expanded using the given URI variables, if any.
+	 * @param url the URL
+	 * @param headers http headers
+	 * @param responseType the type of the return value
+	 * @param uriVariables the variables to expand the template
+	 * @return the entity
+	 * @since 6.1.0
+	 */
+	<T> ResponseEntity<T> getForEntity(String url, HttpHeaders headers, Class<T> responseType, Object... uriVariables)
+			throws RestClientException;
+
+	/**
 	 * Retrieve a representation by doing a GET on the URL.
 	 * The response is converted and stored in a {@link ResponseEntity}.
 	 * @param url the URL
@@ -112,6 +126,17 @@ public interface RestOperations {
 	 * @since 3.0.2
 	 */
 	<T> ResponseEntity<T> getForEntity(URI url, Class<T> responseType) throws RestClientException;
+
+	/**
+	 * Retrieve a representation by doing a GET on the URL with specified Http Headers
+	 * The response is converted and stored in a {@link ResponseEntity}.
+	 * @param url the URL
+	 * @param headers http headers
+	 * @param responseType the type of the return value
+	 * @return the converted object
+	 * @since 6.1.0
+	 */
+	<T> ResponseEntity<T> getForEntity(URI url, HttpHeaders headers, Class<T> responseType) throws RestClientException;
 
 
 	// HEAD

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
@@ -278,6 +278,29 @@ class RestTemplateTests {
 	}
 
 	@Test
+	void getForEntityWithHeaders() throws Exception {
+		HttpHeaders requestHeaders = new HttpHeaders();
+		requestHeaders.set("Authorization", "test");
+		mockSentRequest(GET, "https://example.com", requestHeaders);
+		mockTextPlainHttpMessageConverter();
+		mockResponseStatus(HttpStatus.OK);
+		String expected = "Hello World";
+		mockTextResponseBody(expected);
+
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "test");
+		ResponseEntity<String> result = template.getForEntity("https://example.com", headers, String.class);
+		assertThat(result.getBody()).as("Invalid GET result").isEqualTo(expected);
+		assertThat(requestHeaders.getFirst("Accept")).as("Invalid Accept header").isEqualTo(MediaType.TEXT_PLAIN_VALUE);
+		assertThat(result.getHeaders().getContentType()).as("Invalid Content-Type header").isEqualTo(MediaType.TEXT_PLAIN);
+		assertThat(result.getStatusCode()).as("Invalid status code").isEqualTo(HttpStatus.OK);
+
+		verify(response).close();
+	}
+
+
+	@Test
 	void getForObjectWithCustomUriTemplateHandler() throws Exception {
 		DefaultUriBuilderFactory uriTemplateHandler = new DefaultUriBuilderFactory();
 		template.setUriTemplateHandler(uriTemplateHandler);


### PR DESCRIPTION
# Motivation

Create support for Http headers in `getForEntity` to allow simpler code. Currently if one needs to add headers in a `GET` call one would have to use `restTemplate.exchange()` which is verbose and could different from coding convention of using `restTemplate.postForEntity()`, etc. 

## Use

```jave
HttpHeaders headers = new HttpHeaders();
headers.setBearerAuth("abcd);
ResponseEntity<Object> res = restTemplate.getForEntity(url , headers, Object.class);
```