### PR TITLE
Add possibility to escape property placeholders

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/env/PropertySourcesPropertyResolverTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/PropertySourcesPropertyResolverTests.java
@@ -313,11 +313,20 @@ class PropertySourcesPropertyResolverTests {
 				.withProperty("p1", "v1")
 				.withProperty("p2", "\\${p1:default}")
 				.withProperty("p3", "${p2}")
+				.withProperty("p4", "adc${p0:\\${p1}}")
+				.withProperty("p5", "adc${\\${p0}:${p1}}")
+				.withProperty("p6", "adc${p0:def\\${p1}}")
+				.withProperty("p7", "adc\\${")
+
 		);
 		ConfigurablePropertyResolver pr = new PropertySourcesPropertyResolver(ps);
 		assertThat(pr.getProperty("p1")).isEqualTo("v1");
 		assertThat(pr.getProperty("p2")).isEqualTo("${p1:default}");
 		assertThat(pr.getProperty("p3")).isEqualTo("${p1:default}");
+		assertThat(pr.getProperty("p4")).isEqualTo("adc${p1}");
+		assertThat(pr.getProperty("p5")).isEqualTo("adcv1");
+		assertThat(pr.getProperty("p6")).isEqualTo("adcdef${p1}");
+		assertThat(pr.getProperty("p7")).isEqualTo("adc\\${");
 	}
 
 	@Test

--- a/spring-core/src/test/java/org/springframework/util/PropertyPlaceholderHelperTests.java
+++ b/spring-core/src/test/java/org/springframework/util/PropertyPlaceholderHelperTests.java
@@ -108,4 +108,37 @@ class PropertyPlaceholderHelperTests {
 				helper.replacePlaceholders(text, props));
 	}
 
+	@Test
+	void escapedPlaceholder() {
+		String text = "foo=\\${foo},bar=${bar}";
+		Properties props = new Properties();
+		props.setProperty("bar", "foo");
+
+		assertThat(this.helper.replacePlaceholders(text, props)).isEqualTo("foo=${foo},bar=foo");
+	}
+
+	@Test
+	void escapedPlaceholderWithRecursionInProperty() {
+		String text = "foo=${bar}";
+		Properties props = new Properties();
+		props.setProperty("bar", "${baz}");
+		props.setProperty("baz", "\\${bar}");
+
+		assertThat(this.helper.replacePlaceholders(text, props)).isEqualTo("foo=${bar}");
+	}
+
+	@Test
+	void escapedPlaceholderWithRecursionInPlaceholder() {
+		String text = "foo=\\${b${inner}}";
+		Properties props = new Properties();
+		props.setProperty("inner", "ar");
+
+		assertThat(this.helper.replacePlaceholders(text, props)).isEqualTo("foo=${bar}");
+
+		text = "foo=${b\\${in${insideInner}r}}";
+		props = new Properties();
+		props.setProperty("insideInner", "ne");
+		assertThat(this.helper.replacePlaceholders(text, props)).isEqualTo("foo=${b${inner}}");
+	}
+
 }

--- a/spring-core/src/test/java/org/springframework/util/PropertyPlaceholderHelperTests.java
+++ b/spring-core/src/test/java/org/springframework/util/PropertyPlaceholderHelperTests.java
@@ -133,12 +133,12 @@ class PropertyPlaceholderHelperTests {
 		Properties props = new Properties();
 		props.setProperty("inner", "ar");
 
-		assertThat(this.helper.replacePlaceholders(text, props)).isEqualTo("foo=${bar}");
+		assertThat(this.helper.replacePlaceholders(text, props)).isEqualTo("foo=${b${inner}}");
 
 		text = "foo=${b\\${in${insideInner}r}}";
 		props = new Properties();
 		props.setProperty("insideInner", "ne");
-		assertThat(this.helper.replacePlaceholders(text, props)).isEqualTo("foo=${b${inner}}");
+		assertThat(this.helper.replacePlaceholders(text, props)).isEqualTo("foo=${b${in${insideInner}r}}");
 	}
 
 }


### PR DESCRIPTION
This commit allows to escape property placeholders to later processed by user. PropertyPlaceholderHelper allows to set custom escape character. "\" is used as the default one.

Closes gh-9628