### PR TITLE
Upgrade to spring-doc-actions 0.0.8

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,14 +34,14 @@ jobs:
     - name: Run Antora
       run: ./gradlew antora
     - name: Publish Docs
-      uses: spring-io/spring-doc-actions/rsync-antora-reference@v0.0.5
+      uses: spring-io/spring-doc-actions/rsync-antora-reference@v0.0.8
       with:
         docs-username: ${{ secrets.DOCS_USERNAME }}
         docs-host: ${{ secrets.DOCS_HOST }}
         docs-ssh-key: ${{ secrets.DOCS_SSH_KEY }}
         docs-ssh-host-key: ${{ secrets.DOCS_SSH_HOST_KEY }}
     - name: Bust Clouflare Cache
-      uses: spring-io/spring-doc-actions/bust-cloudflare-antora-cache@v0.0.7
+      uses: spring-io/spring-doc-actions/bust-cloudflare-antora-cache@v0.0.8
       with:
         context-root: spring-framework
         cloudflare-zone-id: ${{ secrets.CLOUDFLARE_ZONE_ID }}


### PR DESCRIPTION
This will ensure that the cloudflare cache is busted upon deploying updates to the UI