### PR TITLE
Stop using deprecated `AbstractArchiveTask.archivePath` in Gradle build

### DIFF
--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -110,12 +110,12 @@ jar {
 	manifest.attributes["Dependencies"] = "jdk.unsupported"  // for WildFly (-> Objenesis 3.2)
 
 	dependsOn javapoetRepackJar
-	from(zipTree(javapoetRepackJar.archivePath)) {
+	from(zipTree(javapoetRepackJar.archiveFile)) {
 		include "org/springframework/javapoet/**"
 	}
 
 	dependsOn objenesisRepackJar
-	from(zipTree(objenesisRepackJar.archivePath)) {
+	from(zipTree(objenesisRepackJar.archiveFile)) {
 		include "org/springframework/objenesis/**"
 	}
 }
@@ -147,7 +147,7 @@ eclipse {
 				def pattern = ~/\/spring-\w+-repack-/
 				entries.forEach {
 					if (pattern.matcher(it.path).find()) {
-						def sourcesJar = it.path.replace('.jar', '-sources.jar');
+						def sourcesJar = it.path.replace('.jar', '-sources.jar')
 						it.sourcePath = fileReference(file(sourcesJar))
 					}
 				}


### PR DESCRIPTION
The AbstractArchiveTask.archivePath property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the archiveFile property instead. See https://docs.gradle.org/8.1.1/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archivePath for more details.