### PR TITLE
Introduce `getContentAsString()` in `ContentCachingRequestWrapper`

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -194,6 +195,14 @@ public class ContentCachingRequestWrapper extends HttpServletRequestWrapper {
 	 */
 	public byte[] getContentAsByteArray() {
 		return this.cachedContent.toByteArray();
+	}
+
+	/**
+	 * Return the cached request content as a String. The Charset used to decode
+	 * the cached content is the same as returned by getCharacterEncoding.
+	 */
+	public String getContentAsString() {
+		return this.cachedContent.toString(Charset.forName(getCharacterEncoding()));
 	}
 
 	/**


### PR DESCRIPTION
Add a method, `getContentAsString`, to `ContentCachingRequestWrapper`. Having a method directly on `ContentCachingRequestWrapper` allows delegating to the `toString(Charset)` method of `ByteArrayOutputStream`, avoiding an extra copy that calling `getContentAsByteArray` and then converting to a `String` would.

In practice I've seen a lot of usages of `ContentCachingRequestWrapper` where `getContentAsByteArray` is called and the returned bytes are immediately decoded to a `String`; this method would allow a user to avoid the overhead of the extra copy that incurs.