### PR TITLE
Use `Long.parseLong(CharSequence,int,int,int)` to avoid intermediate `String` creation

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/unit/DataSize.java
+++ b/spring-core/src/main/java/org/springframework/util/unit/DataSize.java
@@ -174,10 +174,11 @@ public final class DataSize implements Comparable<DataSize>, Serializable {
 	public static DataSize parse(CharSequence text, @Nullable DataUnit defaultUnit) {
 		Assert.notNull(text, "Text must not be null");
 		try {
-			Matcher matcher = DataSizeUtils.PATTERN.matcher(StringUtils.trimAllWhitespace(text));
+			CharSequence trimmedText = StringUtils.trimAllWhitespace(text);
+			Matcher matcher = DataSizeUtils.PATTERN.matcher(trimmedText);
 			Assert.state(matcher.matches(), "Does not match data size pattern");
 			DataUnit unit = DataSizeUtils.determineDataUnit(matcher.group(2), defaultUnit);
-			long amount = Long.parseLong(matcher.group(1));
+			long amount = Long.parseLong(trimmedText, matcher.start(1), matcher.end(1), 10);
 			return DataSize.of(amount, unit);
 		}
 		catch (Exception ex) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaderAccessor.java
@@ -239,11 +239,11 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 
 	public long[] getHeartbeat() {
 		String rawValue = getFirstNativeHeader(STOMP_HEARTBEAT_HEADER);
-		String[] rawValues = StringUtils.split(rawValue, ",");
-		if (rawValues == null) {
+		int pos = rawValue != null ? rawValue.indexOf(',') : -1;
+		if (pos == -1) {
 			return Arrays.copyOf(DEFAULT_HEARTBEAT, 2);
 		}
-		return new long[] {Long.parseLong(rawValues[0]), Long.parseLong(rawValues[1])};
+		return new long[] {Long.parseLong(rawValue, 0, pos, 10), Long.parseLong(rawValue, pos + 1, rawValue.length(), 10)};
 	}
 
 	public void setAcceptVersion(String acceptVersion) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaders.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaders.java
@@ -280,11 +280,11 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	@Nullable
 	public long[] getHeartbeat() {
 		String rawValue = getFirst(HEARTBEAT);
-		String[] rawValues = StringUtils.split(rawValue, ",");
-		if (rawValues == null) {
+		int pos = rawValue != null ? rawValue.indexOf(',') : -1;
+		if (pos == -1) {
 			return null;
 		}
-		return new long[] {Long.parseLong(rawValues[0]), Long.parseLong(rawValues[1])};
+		return new long[] {Long.parseLong(rawValue, 0, pos, 10), Long.parseLong(rawValue, pos + 1, rawValue.length(), 10)};
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/HttpRange.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpRange.java
@@ -147,9 +147,9 @@ public abstract class HttpRange {
 		Assert.hasLength(range, "Range String must not be empty");
 		int dashIdx = range.indexOf('-');
 		if (dashIdx > 0) {
-			long firstPos = Long.parseLong(range.substring(0, dashIdx));
+			long firstPos = Long.parseLong(range, 0, dashIdx, 10);
 			if (dashIdx < range.length() - 1) {
-				Long lastPos = Long.parseLong(range.substring(dashIdx + 1));
+				Long lastPos = Long.parseLong(range, dashIdx + 1, range.length(), 10);
 				return new ByteRange(firstPos, lastPos);
 			}
 			else {
@@ -157,7 +157,7 @@ public abstract class HttpRange {
 			}
 		}
 		else if (dashIdx == 0) {
-			long suffixLength = Long.parseLong(range.substring(1));
+			long suffixLength = Long.parseLong(range, 1, range.length(), 10);
 			return new SuffixByteRange(suffixLength);
 		}
 		else {


### PR DESCRIPTION
Where possible, switch to the `Long.parseLong` variant that accepts a start and end index for the supplied `CharSequence`, thus avoiding making an unnecessary copy of the input.