### PR TITLE
Fix link text from "null" to "Component Classes" in Testing chapter

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/annotations/integration-spring/annotation-contextconfiguration.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/annotations/integration-spring/annotation-contextconfiguration.adoc
@@ -10,7 +10,7 @@ Resource locations are typically XML configuration files or Groovy scripts locat
 classpath, while component classes are typically `@Configuration` classes. However,
 resource locations can also refer to files and scripts in the file system, and component
 classes can be `@Component` classes, `@Service` classes, and so on. See
-xref:testing/testcontext-framework/ctx-management/javaconfig.adoc#testcontext-ctx-management-javaconfig-component-classes[null] for further details.
+xref:testing/testcontext-framework/ctx-management/javaconfig.adoc#testcontext-ctx-management-javaconfig-component-classes[Component Classes] for further details.
 
 The following example shows a `@ContextConfiguration` annotation that refers to an XML
 file:


### PR DESCRIPTION
@pivotal-cla This is an Obvious Fix

This fixes the text of a link with the value "null" to "Component Classes".