### PR TITLE
Support [package-]private init/destroy methods in AOT mode

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessor.java
@@ -182,7 +182,7 @@ public class InitDestroyAnnotationBeanPostProcessor implements DestructionAwareB
 	private static String[] safeMerge(@Nullable String[] existingNames, Collection<LifecycleMethod> detectedMethods) {
 		Stream<String> detectedNames = detectedMethods.stream().map(LifecycleMethod::getIdentifier);
 		Stream<String> mergedNames = (existingNames != null ?
-				Stream.concat(Stream.of(existingNames), detectedNames) : detectedNames);
+				Stream.concat(detectedNames, Stream.of(existingNames)) : detectedNames);
 		return mergedNames.distinct().toArray(String[]::new);
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -1841,18 +1841,22 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 	protected void invokeCustomInitMethod(String beanName, Object bean, RootBeanDefinition mbd, String initMethodName)
 			throws Throwable {
 
+		Class<?> beanClass = bean.getClass();
+		MethodDescriptor descriptor = MethodDescriptor.create(beanName, beanClass, initMethodName);
+		String methodName = descriptor.methodName();
+
 		Method initMethod = (mbd.isNonPublicAccessAllowed() ?
-				BeanUtils.findMethod(bean.getClass(), initMethodName) :
-				ClassUtils.getMethodIfAvailable(bean.getClass(), initMethodName));
+				BeanUtils.findMethod(descriptor.declaringClass(), methodName) :
+				ClassUtils.getMethodIfAvailable(beanClass, methodName));
 
 		if (initMethod == null) {
 			if (mbd.isEnforceInitMethod()) {
 				throw new BeanDefinitionValidationException("Could not find an init method named '" +
-						initMethodName + "' on bean with name '" + beanName + "'");
+						methodName + "' on bean with name '" + beanName + "'");
 			}
 			else {
 				if (logger.isTraceEnabled()) {
-					logger.trace("No default init method named '" + initMethodName +
+					logger.trace("No default init method named '" + methodName +
 							"' found on bean with name '" + beanName + "'");
 				}
 				// Ignore non-existent default lifecycle methods.
@@ -1861,9 +1865,9 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 		}
 
 		if (logger.isTraceEnabled()) {
-			logger.trace("Invoking init method '" + initMethodName + "' on bean with name '" + beanName + "'");
+			logger.trace("Invoking init method '" + methodName + "' on bean with name '" + beanName + "'");
 		}
-		Method methodToInvoke = ClassUtils.getInterfaceMethodIfPossible(initMethod, bean.getClass());
+		Method methodToInvoke = ClassUtils.getInterfaceMethodIfPossible(initMethod, beanClass);
 
 		try {
 			ReflectionUtils.makeAccessible(methodToInvoke);

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
@@ -255,12 +255,15 @@ class DisposableBeanAdapter implements DisposableBean, Runnable, Serializable {
 	private Method determineDestroyMethod(String destroyMethodName) {
 		try {
 			Class<?> beanClass = this.bean.getClass();
-			Method destroyMethod = findDestroyMethod(beanClass, destroyMethodName);
+			MethodDescriptor descriptor = MethodDescriptor.create(this.beanName, beanClass, destroyMethodName);
+			String methodName = descriptor.methodName();
+
+			Method destroyMethod = findDestroyMethod(descriptor.declaringClass(), methodName);
 			if (destroyMethod != null) {
 				return destroyMethod;
 			}
 			for (Class<?> beanInterface : beanClass.getInterfaces()) {
-				destroyMethod = findDestroyMethod(beanInterface, destroyMethodName);
+				destroyMethod = findDestroyMethod(beanInterface, methodName);
 				if (destroyMethod != null) {
 					return destroyMethod;
 				}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/MethodDescriptor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/MethodDescriptor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.support;
+
+import org.springframework.util.ClassUtils;
+
+/**
+ * Descriptor for a {@link java.lang.reflect.Method Method} which holds a
+ * reference to the method's {@linkplain #declaringClass declaring class},
+ * {@linkplain #methodName name}, and {@linkplain #parameterTypes parameter types}.
+ *
+ * @param declaringClass the method's declaring class
+ * @param methodName the name of the method
+ * @param parameterTypes the types of parameters accepted by the method
+ * @author Sam Brannen
+ * @since 6.0.11
+ */
+record MethodDescriptor(Class<?> declaringClass, String methodName, Class<?>... parameterTypes) {
+
+	/**
+	 * Create a {@link MethodDescriptor} for the supplied bean class and method name.
+	 * <p>The supplied {@code methodName} may be a {@linkplain Method#getName()
+	 * simple method name} or a
+	 * {@linkplain org.springframework.util.ClassUtils#getQualifiedMethodName(Method)
+	 * qualified method name}.
+	 * <p>If the method name is fully qualified, this utility will parse the
+	 * method name and its declaring class from the qualified method name and then
+	 * attempt to load the method's declaring class using the {@link ClassLoader}
+	 * of the supplied {@code beanClass}. Otherwise, the returned descriptor will
+	 * reference the supplied {@code beanClass} and {@code methodName}.
+	 * @param beanName the bean name in the factory (for debugging purposes)
+	 * @param beanClass the bean class
+	 * @param methodName the name of the method
+	 * @return a new {@code MethodDescriptor}; never {@code null}
+	 */
+	static MethodDescriptor create(String beanName, Class<?> beanClass, String methodName) {
+		try {
+			Class<?> declaringClass = beanClass;
+			String methodNameToUse = methodName;
+
+			// Parse fully-qualified method name if necessary.
+			int indexOfDot = methodName.lastIndexOf('.');
+			if (indexOfDot > 0) {
+				String className = methodName.substring(0, indexOfDot);
+				methodNameToUse = methodName.substring(indexOfDot + 1);
+				if (!beanClass.getName().equals(className)) {
+					declaringClass = ClassUtils.forName(className, beanClass.getClassLoader());
+				}
+			}
+			return new MethodDescriptor(declaringClass, methodNameToUse);
+		}
+		catch (Exception | LinkageError ex) {
+			throw new BeanDefinitionValidationException(
+					"Could not create MethodDescriptor for method '%s' on bean with name '%s': %s"
+						.formatted(methodName, beanName, ex.getMessage()));
+		}
+	}
+
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessorTests.java
@@ -70,8 +70,8 @@ class InitDestroyAnnotationBeanPostProcessorTests {
 		beanDefinition.setDestroyMethodNames("customDestroyMethod");
 		processAheadOfTime(beanDefinition);
 		RootBeanDefinition mergedBeanDefinition = getMergedBeanDefinition();
-		assertThat(mergedBeanDefinition.getInitMethodNames()).containsExactly("customInitMethod", "initMethod");
-		assertThat(mergedBeanDefinition.getDestroyMethodNames()).containsExactly("customDestroyMethod", "destroyMethod");
+		assertThat(mergedBeanDefinition.getInitMethodNames()).containsExactly("initMethod", "customInitMethod");
+		assertThat(mergedBeanDefinition.getDestroyMethodNames()).containsExactly("destroyMethod", "customDestroyMethod");
 	}
 
 	@Test
@@ -129,16 +129,16 @@ class InitDestroyAnnotationBeanPostProcessorTests {
 		RootBeanDefinition mergedBeanDefinition = getMergedBeanDefinition();
 		assertSoftly(softly -> {
 			softly.assertThat(mergedBeanDefinition.getInitMethodNames()).containsExactly(
-					"afterPropertiesSet",
-					"customInit",
 					CustomAnnotatedPrivateInitDestroyBean.class.getName() + ".privateInit", // fully-qualified private method
-					CustomAnnotatedPrivateSameNameInitDestroyBean.class.getName() + ".privateInit" // fully-qualified private method
+					CustomAnnotatedPrivateSameNameInitDestroyBean.class.getName() + ".privateInit", // fully-qualified private method
+					"afterPropertiesSet",
+					"customInit"
 				);
 			softly.assertThat(mergedBeanDefinition.getDestroyMethodNames()).containsExactly(
-					"destroy",
-					"customDestroy",
 					CustomAnnotatedPrivateSameNameInitDestroyBean.class.getName() + ".privateDestroy", // fully-qualified private method
-					CustomAnnotatedPrivateInitDestroyBean.class.getName() + ".privateDestroy" // fully-qualified private method
+					CustomAnnotatedPrivateInitDestroyBean.class.getName() + ".privateDestroy", // fully-qualified private method
+					"destroy",
+					"customDestroy"
 				);
 		});
 	}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionPropertiesCodeGeneratorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionPropertiesCodeGeneratorTests.java
@@ -376,6 +376,9 @@ class BeanDefinitionPropertiesCodeGeneratorTests {
 	@Nested
 	class InitDestroyMethodTests {
 
+		private final String privateInitMethod = InitDestroyBean.class.getName() + ".privateInit";
+		private final String privateDestroyMethod = InitDestroyBean.class.getName() + ".privateDestroy";
+
 		@BeforeEach
 		void setTargetType() {
 			beanDefinition.setTargetType(InitDestroyBean.class);
@@ -394,10 +397,17 @@ class BeanDefinitionPropertiesCodeGeneratorTests {
 		}
 
 		@Test
+		void privateInitMethod() {
+			beanDefinition.setInitMethodName(privateInitMethod);
+			compile((beanDef, compiled) -> assertThat(beanDef.getInitMethodNames()).containsExactly(privateInitMethod));
+			assertHasMethodInvokeHints(InitDestroyBean.class, "privateInit");
+		}
+
+		@Test
 		void multipleInitMethods() {
-			beanDefinition.setInitMethodNames("init", "init2");
-			compile((beanDef, compiled) -> assertThat(beanDef.getInitMethodNames()).containsExactly("init", "init2"));
-			assertHasMethodInvokeHints(InitDestroyBean.class, "init", "init2");
+			beanDefinition.setInitMethodNames("init", privateInitMethod);
+			compile((beanDef, compiled) -> assertThat(beanDef.getInitMethodNames()).containsExactly("init", privateInitMethod));
+			assertHasMethodInvokeHints(InitDestroyBean.class, "init", "privateInit");
 		}
 
 		@Test
@@ -413,10 +423,17 @@ class BeanDefinitionPropertiesCodeGeneratorTests {
 		}
 
 		@Test
+		void privateDestroyMethod() {
+			beanDefinition.setDestroyMethodName(privateDestroyMethod);
+			compile((beanDef, compiled) -> assertThat(beanDef.getDestroyMethodNames()).containsExactly(privateDestroyMethod));
+			assertHasMethodInvokeHints(InitDestroyBean.class, "privateDestroy");
+		}
+
+		@Test
 		void multipleDestroyMethods() {
-			beanDefinition.setDestroyMethodNames("destroy", "destroy2");
-			compile((beanDef, compiled) -> assertThat(beanDef.getDestroyMethodNames()).containsExactly("destroy", "destroy2"));
-			assertHasMethodInvokeHints(InitDestroyBean.class, "destroy", "destroy2");
+			beanDefinition.setDestroyMethodNames("destroy", privateDestroyMethod);
+			compile((beanDef, compiled) -> assertThat(beanDef.getDestroyMethodNames()).containsExactly("destroy", privateDestroyMethod));
+			assertHasMethodInvokeHints(InitDestroyBean.class, "destroy", "privateDestroy");
 		}
 
 	}
@@ -461,13 +478,15 @@ class BeanDefinitionPropertiesCodeGeneratorTests {
 		void init() {
 		}
 
-		void init2() {
+		@SuppressWarnings("unused")
+		private void privateInit() {
 		}
 
 		void destroy() {
 		}
 
-		void destroy2() {
+		@SuppressWarnings("unused")
+		private void privateDestroy() {
 		}
 
 	}

--- a/spring-context/src/test/java/org/springframework/context/aot/ApplicationContextAotGeneratorTests.java
+++ b/spring-context/src/test/java/org/springframework/context/aot/ApplicationContextAotGeneratorTests.java
@@ -257,9 +257,9 @@ class ApplicationContextAotGeneratorTests {
 			GenericApplicationContext freshApplicationContext = toFreshApplicationContext(initializer);
 			assertThat(freshApplicationContext.getBeanDefinitionNames()).containsOnly("initDestroyComponent");
 			InitDestroyComponent bean = freshApplicationContext.getBean(InitDestroyComponent.class);
-			assertThat(bean.events).containsExactly("customInit", "init");
+			assertThat(bean.events).containsExactly("init", "customInit");
 			freshApplicationContext.close();
-			assertThat(bean.events).containsExactly("customInit", "init", "customDestroy", "destroy");
+			assertThat(bean.events).containsExactly("init", "customInit", "destroy", "customDestroy");
 		});
 	}
 


### PR DESCRIPTION
## Overview

Prior to this commit, private (and non-visible package-private) init/destroy methods were not supported in AOT mode. The reason is that such methods are tracked using their fully-qualified method names, and the AOT support for init/destroy methods previously did not take fully-qualified method names into account. In addition, the invocation order of init/destroy methods differed between standard JVM mode and AOT mode.

This commit addresses these issues in the following ways.

- `AbstractAutowireCapableBeanFactory.invokeCustomInitMethod()`, `DisposableBeanAdapter.determineDestroyMethod()`, and `BeanDefinitionPropertiesCodeGenerator.addInitDestroyHint()` now parse fully-qualified method names to locate the correct init/destroy methods.

- `AbstractAutowireCapableBeanFactory` and `DisposableBeanAdapter` delegate to a new `MethodDescriptor` record which encapsulates the parsing of fully qualified method names; however, `BeanDefinitionPropertiesCodeGenerator` duplicates this logic since it resides in a different package, and we do not currently want to make `MethodDescriptor` public.

- Init/destroy methods detected via annotations (such as `@PostConstruct` and `@PreDestroy`) are now invoked _prior_ to init/destroy methods that are explicitly configured by name or convention. This aligns with the invocation order in standard JVM mode; however, `InitializingBean#afterPropertiesSet()` and `DisposableBean#destroy()` are still invoked before annotated init/destroy methods in AOT mode which differs from standard JVM mode.

- Unit and integration tests have been updated to test the revised behavior.

## Related Issues

- #10614
- #28083
- #30654 
- #30755
