### PR TITLE
Http interface client supports request metadata customization

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpExchangeRequestValuesResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpExchangeRequestValuesResolver.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.service.invoker;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.util.StringValueResolver;
+import org.springframework.web.service.annotation.HttpExchange;
+
+/**
+ * {@link HttpRequestValuesResolver} implementation for resolving {@link HttpExchange} based annotations.
+ * @author Freeman Lau
+ * @since 6.1.0
+ */
+public class HttpExchangeRequestValuesResolver implements HttpRequestValuesResolver {
+
+	@Nullable
+	private final StringValueResolver embeddedValueResolver;
+
+	public HttpExchangeRequestValuesResolver(
+			@Nullable StringValueResolver embeddedValueResolver) {
+		this.embeddedValueResolver = embeddedValueResolver;
+	}
+
+	@Override
+	public boolean supports(Method method) {
+		return AnnotatedElementUtils.hasAnnotation(method, HttpExchange.class);
+	}
+
+	@Override
+	public HttpRequestValuesInitializer resolve(Method method, Class<?> serviceType) {
+		HttpExchange annot1 = AnnotatedElementUtils.findMergedAnnotation(serviceType,
+				HttpExchange.class);
+		HttpExchange annot2 = AnnotatedElementUtils.findMergedAnnotation(method,
+				HttpExchange.class);
+
+		Assert.notNull(annot2, "Expected HttpRequest annotation");
+
+		HttpMethod httpMethod = initHttpMethod(annot1, annot2);
+		String url = initUrl(annot1, annot2, this.embeddedValueResolver);
+		MediaType contentType = initContentType(annot1, annot2);
+		List<MediaType> acceptableMediaTypes = initAccept(annot1, annot2);
+
+		return new HttpRequestValuesInitializer(httpMethod, url, contentType,
+				acceptableMediaTypes);
+	}
+
+	@Nullable
+	private static HttpMethod initHttpMethod(@Nullable HttpExchange typeAnnot,
+			HttpExchange annot) {
+
+		String value1 = (typeAnnot != null ? typeAnnot.method() : null);
+		String value2 = annot.method();
+
+		if (StringUtils.hasText(value2)) {
+			return HttpMethod.valueOf(value2);
+		}
+
+		if (StringUtils.hasText(value1)) {
+			return HttpMethod.valueOf(value1);
+		}
+
+		return null;
+	}
+
+	@Nullable
+	private static String initUrl(@Nullable HttpExchange typeAnnot, HttpExchange annot,
+			@Nullable StringValueResolver embeddedValueResolver) {
+
+		String url1 = (typeAnnot != null ? typeAnnot.url() : null);
+		String url2 = annot.url();
+
+		if (embeddedValueResolver != null) {
+			url1 = (url1 != null ? embeddedValueResolver.resolveStringValue(url1) : null);
+			url2 = embeddedValueResolver.resolveStringValue(url2);
+		}
+
+		boolean hasUrl1 = StringUtils.hasText(url1);
+		boolean hasUrl2 = StringUtils.hasText(url2);
+
+		if (hasUrl1 && hasUrl2) {
+			return (url1 + (!url1.endsWith("/") && !url2.startsWith("/") ? "/" : "")
+					+ url2);
+		}
+
+		if (!hasUrl1 && !hasUrl2) {
+			return null;
+		}
+
+		return (hasUrl2 ? url2 : url1);
+	}
+
+	@Nullable
+	private static MediaType initContentType(@Nullable HttpExchange typeAnnot,
+			HttpExchange annot) {
+
+		String value1 = (typeAnnot != null ? typeAnnot.contentType() : null);
+		String value2 = annot.contentType();
+
+		if (StringUtils.hasText(value2)) {
+			return MediaType.parseMediaType(value2);
+		}
+
+		if (StringUtils.hasText(value1)) {
+			return MediaType.parseMediaType(value1);
+		}
+
+		return null;
+	}
+
+	@Nullable
+	private static List<MediaType> initAccept(@Nullable HttpExchange typeAnnot,
+			HttpExchange annot) {
+
+		String[] value1 = (typeAnnot != null ? typeAnnot.accept() : null);
+		String[] value2 = annot.accept();
+
+		if (!ObjectUtils.isEmpty(value2)) {
+			return MediaType.parseMediaTypes(Arrays.asList(value2));
+		}
+
+		if (!ObjectUtils.isEmpty(value1)) {
+			return MediaType.parseMediaTypes(Arrays.asList(value1));
+		}
+
+		return null;
+	}
+}

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValuesInitializer.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValuesInitializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.service.invoker;
+
+import java.util.List;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
+import org.springframework.web.service.annotation.HttpExchange;
+
+/**
+ * Factory for {@link HttpRequestValues} with values extracted from the type and
+ * method-level {@link HttpExchange @HttpRequest} annotations.
+ *
+ * @param httpMethod the HTTP method to use
+ * @param url the URL to use
+ * @param contentType the content type to use
+ * @param acceptMediaTypes the accept media types to use
+ * @author Freeman Lau
+ * @since 6.1.0
+ */
+public record HttpRequestValuesInitializer(@Nullable HttpMethod httpMethod,
+		@Nullable String url, @Nullable MediaType contentType,
+		@Nullable List<MediaType> acceptMediaTypes) {
+
+	public HttpRequestValues.Builder initializeRequestValuesBuilder() {
+		HttpRequestValues.Builder requestValues = HttpRequestValues.builder();
+		if (this.httpMethod != null) {
+			requestValues.setHttpMethod(this.httpMethod);
+		}
+		if (this.url != null) {
+			requestValues.setUriTemplate(this.url);
+		}
+		if (this.contentType != null) {
+			requestValues.setContentType(this.contentType);
+		}
+		if (this.acceptMediaTypes != null) {
+			requestValues.setAccept(this.acceptMediaTypes);
+		}
+		return requestValues;
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValuesResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValuesResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.service.invoker;
+
+import java.lang.reflect.Method;
+
+/**
+ * Resolve a method to generate http request metadata, such as http method, url, content type, accept media types.
+ * @author Freeman Lau
+ * @since 6.1.0
+ */
+public interface HttpRequestValuesResolver {
+
+	/**
+	 * Whether this resolver supports the given method.
+	 * @param method the method to check
+	 * @return {@code true} if this processor supports the given method
+	 */
+	boolean supports(Method method);
+
+	/**
+	 * Resolve the given method and return the {@link HttpRequestValuesInitializer}.
+	 * @param method      the method to process
+	 * @param serviceType http client interface type
+	 * @return the {@link HttpRequestValuesInitializer} to use for the given method
+	 */
+	HttpRequestValuesInitializer resolve(Method method, Class<?> serviceType);
+
+}

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceMethod.java
@@ -18,7 +18,6 @@ package org.springframework.web.service.invoker;
 
 import java.lang.reflect.Method;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -33,26 +32,21 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.ReactiveAdapter;
 import org.springframework.core.ReactiveAdapterRegistry;
-import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.SynthesizingMethodParameter;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.util.StringValueResolver;
-import org.springframework.web.service.annotation.HttpExchange;
 
 /**
- * Implements the invocation of an {@link HttpExchange @HttpExchange}-annotated,
+ * Implements the invocation of an annotated
  * {@link HttpServiceProxyFactory#createClient(Class) HTTP service proxy} method
  * by delegating to an {@link HttpClientAdapter} to perform actual requests.
  *
  * @author Rossen Stoyanchev
  * @author Sebastien Deleuze
+ * @author Freeman Lau
  * @since 6.0
  */
 final class HttpServiceMethod {
@@ -67,16 +61,15 @@ final class HttpServiceMethod {
 
 	private final ResponseFunction responseFunction;
 
-
 	HttpServiceMethod(
-			Method method, Class<?> containingClass, List<HttpServiceArgumentResolver> argumentResolvers,
-			HttpClientAdapter client, @Nullable StringValueResolver embeddedValueResolver,
+			Method method, List<HttpServiceArgumentResolver> argumentResolvers,
+			HttpRequestValuesInitializer requestValuesInitializer, HttpClientAdapter client,
 			ReactiveAdapterRegistry reactiveRegistry, @Nullable Duration blockTimeout) {
 
 		this.method = method;
 		this.parameters = initMethodParameters(method);
 		this.argumentResolvers = argumentResolvers;
-		this.requestValuesInitializer = HttpRequestValuesInitializer.create(method, containingClass, embeddedValueResolver);
+		this.requestValuesInitializer = requestValuesInitializer;
 		this.responseFunction = ResponseFunction.create(client, method, reactiveRegistry, blockTimeout);
 	}
 
@@ -129,142 +122,6 @@ final class HttpServiceMethod {
 							(StringUtils.hasText("No suitable resolver") ? ": " + "No suitable resolver" : ""));
 		}
 	}
-
-
-	/**
-	 * Factory for {@link HttpRequestValues} with values extracted from the type
-	 * and method-level {@link HttpExchange @HttpRequest} annotations.
-	 */
-	private record HttpRequestValuesInitializer(
-			@Nullable HttpMethod httpMethod, @Nullable String url,
-			@Nullable MediaType contentType, @Nullable List<MediaType> acceptMediaTypes) {
-
-		private HttpRequestValuesInitializer(
-				HttpMethod httpMethod, @Nullable String url,
-				@Nullable MediaType contentType, @Nullable List<MediaType> acceptMediaTypes) {
-
-			this.url = url;
-			this.httpMethod = httpMethod;
-			this.contentType = contentType;
-			this.acceptMediaTypes = acceptMediaTypes;
-		}
-
-		public HttpRequestValues.Builder initializeRequestValuesBuilder() {
-			HttpRequestValues.Builder requestValues = HttpRequestValues.builder();
-			if (this.httpMethod != null) {
-				requestValues.setHttpMethod(this.httpMethod);
-			}
-			if (this.url != null) {
-				requestValues.setUriTemplate(this.url);
-			}
-			if (this.contentType != null) {
-				requestValues.setContentType(this.contentType);
-			}
-			if (this.acceptMediaTypes != null) {
-				requestValues.setAccept(this.acceptMediaTypes);
-			}
-			return requestValues;
-		}
-
-
-		/**
-		 * Introspect the method and create the request factory for it.
-		 */
-		public static HttpRequestValuesInitializer create(
-				Method method, Class<?> containingClass, @Nullable StringValueResolver embeddedValueResolver) {
-
-			HttpExchange annot1 = AnnotatedElementUtils.findMergedAnnotation(containingClass, HttpExchange.class);
-			HttpExchange annot2 = AnnotatedElementUtils.findMergedAnnotation(method, HttpExchange.class);
-
-			Assert.notNull(annot2, "Expected HttpRequest annotation");
-
-			HttpMethod httpMethod = initHttpMethod(annot1, annot2);
-			String url = initUrl(annot1, annot2, embeddedValueResolver);
-			MediaType contentType = initContentType(annot1, annot2);
-			List<MediaType> acceptableMediaTypes = initAccept(annot1, annot2);
-
-			return new HttpRequestValuesInitializer(httpMethod, url, contentType, acceptableMediaTypes);
-		}
-
-		@Nullable
-		private static HttpMethod initHttpMethod(@Nullable HttpExchange typeAnnot, HttpExchange annot) {
-
-			String value1 = (typeAnnot != null ? typeAnnot.method() : null);
-			String value2 = annot.method();
-
-			if (StringUtils.hasText(value2)) {
-				return HttpMethod.valueOf(value2);
-			}
-
-			if (StringUtils.hasText(value1)) {
-				return HttpMethod.valueOf(value1);
-			}
-
-			return null;
-		}
-
-		@Nullable
-		private static String initUrl(
-				@Nullable HttpExchange typeAnnot, HttpExchange annot, @Nullable StringValueResolver embeddedValueResolver) {
-
-			String url1 = (typeAnnot != null ? typeAnnot.url() : null);
-			String url2 = annot.url();
-
-			if (embeddedValueResolver != null) {
-				url1 = (url1 != null ? embeddedValueResolver.resolveStringValue(url1) : null);
-				url2 = embeddedValueResolver.resolveStringValue(url2);
-			}
-
-			boolean hasUrl1 = StringUtils.hasText(url1);
-			boolean hasUrl2 = StringUtils.hasText(url2);
-
-			if (hasUrl1 && hasUrl2) {
-				return (url1 + (!url1.endsWith("/") && !url2.startsWith("/") ? "/" : "") + url2);
-			}
-
-			if (!hasUrl1 && !hasUrl2) {
-				return null;
-			}
-
-			return (hasUrl2 ? url2 : url1);
-		}
-
-		@Nullable
-		private static MediaType initContentType(@Nullable HttpExchange typeAnnot, HttpExchange annot) {
-
-			String value1 = (typeAnnot != null ? typeAnnot.contentType() : null);
-			String value2 = annot.contentType();
-
-			if (StringUtils.hasText(value2)) {
-				return MediaType.parseMediaType(value2);
-			}
-
-			if (StringUtils.hasText(value1)) {
-				return MediaType.parseMediaType(value1);
-			}
-
-			return null;
-		}
-
-		@Nullable
-		private static List<MediaType> initAccept(@Nullable HttpExchange typeAnnot, HttpExchange annot) {
-
-			String[] value1 = (typeAnnot != null ? typeAnnot.accept() : null);
-			String[] value2 = annot.accept();
-
-			if (!ObjectUtils.isEmpty(value2)) {
-				return MediaType.parseMediaTypes(Arrays.asList(value2));
-			}
-
-			if (!ObjectUtils.isEmpty(value1)) {
-				return MediaType.parseMediaTypes(Arrays.asList(value1));
-			}
-
-			return null;
-		}
-
-	}
-
 
 	/**
 	 * Function to execute a request, obtain a response, and adapt to the expected

--- a/spring-web/src/test/java/org/springframework/web/service/invoker/CustomHttpRequestValuesResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/invoker/CustomHttpRequestValuesResolverTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.service.invoker;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for custom {@link HttpRequestValuesResolver}.
+ *
+ * @author Freeman Lau
+ */
+class CustomHttpRequestValuesResolverTests {
+
+	private final TestHttpClientAdapter client = new TestHttpClientAdapter();
+
+	@Test
+	void testCustomHttpRequestValuesResolver() {
+		HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(client)
+				.customRequestValuesResolver(new CustomHttpRequestValuesResolver())
+				.build();
+		Service service = factory.createClient(Service.class);
+		service.execute();
+
+		assertThat(client.getRequestValues().getHttpMethod()).isEqualTo(HttpMethod.GET);
+		assertThat(client.getRequestValues().getUriTemplate()).isNotNull();
+		assertThat(client.getRequestValues().getUriTemplate()).hasToString("/execute");
+	}
+
+	private static final class CustomHttpRequestValuesResolver
+			implements HttpRequestValuesResolver {
+
+		@Override
+		public boolean supports(Method method) {
+			return AnnotatedElementUtils.hasAnnotation(method, GetMapping.class);
+		}
+
+		@Override
+		public HttpRequestValuesInitializer resolve(Method method, Class<?> serviceType) {
+			GetMapping anno = AnnotatedElementUtils.findMergedAnnotation(method,
+					GetMapping.class);
+
+			String url = anno.value()[0];
+			return new HttpRequestValuesInitializer(HttpMethod.GET, url, null, null);
+		}
+
+	}
+
+	private interface Service {
+
+		@GetMapping("/execute")
+		void execute();
+
+	}
+
+}


### PR DESCRIPTION
Now, `HttpServiceProxyFactory` supports passing `HttpRequestValuesResolver` to customize the request metadata.

```java
HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder()
				.customRequestValuesResolver(new CustomHttpRequestValuesResolver())
				.build();
```

The handling logic for `@HttpExchange` has been moved to `HttpExchangeRequestValuesResolver`.

Fixes #30733 