### PR TITLE
Update Reference Docs section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,13 +123,13 @@ define the source file coding standards we use along with some IDEA editor setti
 
 ### Reference Docs
 
-The reference documentation is in the [framework-docs/src/docs/asciidoc](framework-docs/src/docs/asciidoc) directory, in
+The reference documentation is in the [framework-docs/modules/ROOT](framework-docs/modules/ROOT) directory, in
 [Asciidoctor](https://asciidoctor.org/) format. For trivial changes, you may be able to browse,
 edit source files, and submit directly from GitHub.
 
-When making changes locally, execute `./gradlew :framework-docs:asciidoctor` and then browse the result under
-`framework-docs/build/docs/ref-docs/html5/index.html`.
+When making changes locally, execute `./gradlew :framework-docs:antora` and then browse the result under
+`framework-docs/build/site/index.html`.
 
-Asciidoctor also supports live editing. For more details see
-[AsciiDoc Tooling](https://docs.asciidoctor.org/asciidoctor/latest/tooling/).
+Spring-framework uses Antora to manage its documentation. For more details see
+[Antora official documentation](https://docs.antora.org/antora/latest/).
 


### PR DESCRIPTION
Updating mentions of AsciiDoctor with Antora since Spring now uses Antora to manage its documentation. 