### PR TITLE
Fix remove the side effect of ConstructorArgumentValues#addIndexedArgumentValue using deep-copy.

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/ConstructorArgumentValues.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/ConstructorArgumentValues.java
@@ -109,7 +109,7 @@ public class ConstructorArgumentValues {
 	public void addIndexedArgumentValue(int index, ValueHolder newValue) {
 		Assert.isTrue(index >= 0, "Index must not be negative");
 		Assert.notNull(newValue, "ValueHolder must not be null");
-		addOrMergeIndexedArgumentValue(index, newValue);
+		addOrMergeIndexedArgumentValue(index, newValue.copy());
 	}
 
 	/**


### PR DESCRIPTION
Fix remove the side effect of `ConstructorArgumentValues#addIndexedArgumentValue` using **deep-copy**.

Like `org.springframework.beans.factory.config.ConstructorArgumentValues#addArgumentValues`
