### PR TITLE
Code generation not applying shortcut if the target method is ambiguous

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/aot/InstanceSupplierCodeGenerator.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/aot/InstanceSupplierCodeGenerator.java
@@ -220,7 +220,9 @@ class InstanceSupplierCodeGenerator {
 			CodeBlock.Builder code = CodeBlock.builder();
 			code.add("$T.<$T>forFactoryMethod($T.class, $S)", BeanInstanceSupplier.class,
 					suppliedType, declaringClass, factoryMethod.getName());
-			code.add(".withGenerator($T::$L)", declaringClass, factoryMethod.getName());
+			if (!isFactoryMethodAmbiguous(factoryMethod.getName(), declaringClass)) {
+				code.add(".withGenerator($T::$L)", declaringClass, factoryMethod.getName());
+			}
 			return code.build();
 		}
 
@@ -228,6 +230,12 @@ class InstanceSupplierCodeGenerator {
 				buildGetInstanceMethodForFactoryMethod(method, beanName, factoryMethod,
 						declaringClass, dependsOnBean, PRIVATE_STATIC));
 		return generateReturnStatement(getInstanceMethod);
+	}
+	private boolean isFactoryMethodAmbiguous(String methodName, Class<?> declaringClass) {
+		long count = Arrays.stream(declaringClass.getMethods())
+				.filter(method -> method.getName().equals(methodName))
+				.count();
+		return count > 1;
 	}
 
 	private CodeBlock generateCodeForInaccessibleFactoryMethod(

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionMethodGeneratorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionMethodGeneratorTests.java
@@ -585,6 +585,13 @@ class BeanDefinitionMethodGeneratorTests {
 	}
 
 	@Test
+	void generateBeanDefinitionMethodWhenFactoryMethodIsAmbiguous() {
+		RootBeanDefinition beanDefinition = (RootBeanDefinition) BeanDefinitionBuilder
+				.rootBeanDefinition(DocumentBuilderFactory.class).setFactoryMethod("newNSInstance").getBeanDefinition();
+		testBeanDefinitionMethodInCurrentFile(DocumentBuilderFactory.class, beanDefinition);
+	}
+
+	@Test
 	void generateBeanDefinitionMethodWhenBeanIsOfPrimitiveType() {
 		RootBeanDefinition beanDefinition = (RootBeanDefinition) BeanDefinitionBuilder
 				.rootBeanDefinition(Boolean.class).setFactoryMethod("parseBoolean").addConstructorArgValue("true").getBeanDefinition();


### PR DESCRIPTION
Closes gh-29278

Added logic to check if target method is ambiguous while generating bean definition method

Please check [issue](https://github.com/spring-projects/spring-framework/issues/29278)