### PR TITLE
Ensure createDateTimeFormatterInOrderOfPropertyPriority test pass when openjdk version 21-ea

### DIFF
--- a/spring-context/src/test/java/org/springframework/format/datetime/standard/DateTimeFormatterFactoryTests.java
+++ b/spring-context/src/test/java/org/springframework/format/datetime/standard/DateTimeFormatterFactoryTests.java
@@ -79,7 +79,7 @@ public class DateTimeFormatterFactoryTests {
 		factory.setStylePattern("SS");
 		String value = applyLocale(factory.createDateTimeFormatter()).format(dateTime);
 		assertThat(value).startsWith("10/21/09");
-		assertThat(value).endsWith("12:10 PM");
+		assertThat(value.replaceAll(" ", " ")).endsWith("12:10 PM");
 
 		factory.setIso(ISO.DATE);
 		assertThat(applyLocale(factory.createDateTimeFormatter()).format(dateTime)).isEqualTo("2009-10-21");


### PR DESCRIPTION
## The space character returns [NNBSP] when using JDK 21-ea

![image](https://github.com/spring-projects/spring-framework/assets/3048393/9668671e-45f9-4bb5-bea0-f33751ecad38)

```cmd
$java -version
openjdk version "21-ea" 2023-09-19
OpenJDK Runtime Environment Zulu21+57-CA (build 21-ea+22)
OpenJDK 64-Bit Server VM Zulu21+57-CA (build 21-ea+22, mixed mode, sharing)
```

## Fix bug
![image](https://github.com/spring-projects/spring-framework/assets/3048393/d67cef89-cf63-4da1-8037-f15176547aab)

## Reference

OpenJDK Bug [JDK-8304925](https://bugs.openjdk.org/browse/JDK-8304925)