### PR TITLE
Make BeanNameViewResolver extensible and introduce JavaConfigViewResolver

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/BeanNameViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/BeanNameViewResolver.java
@@ -20,13 +20,8 @@ import java.util.Locale;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.lang.Nullable;
-import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.context.support.WebApplicationObjectSupport;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
@@ -49,22 +44,9 @@ import org.springframework.web.servlet.ViewResolver;
  * @since 18.06.2003
  * @see UrlBasedViewResolver
  */
-public class BeanNameViewResolver extends WebApplicationObjectSupport implements ViewResolver, Ordered, InitializingBean, DisposableBean {
+public class BeanNameViewResolver extends WebApplicationObjectSupport implements ViewResolver, Ordered {
 
 	private int order = Ordered.LOWEST_PRECEDENCE;  // default: same as non-Ordered
-
-	@Nullable
-	private ApplicationContext cachedContext;
-	@Nullable
-	private final ApplicationContext providedContext;
-
-	public BeanNameViewResolver() {
-		this.providedContext = null;
-	}
-
-	public BeanNameViewResolver(ApplicationContext context) {
-		this.providedContext=context;
-	}
 
 	/**
 	 * Specify the order value for this ViewResolver bean.
@@ -101,40 +83,12 @@ public class BeanNameViewResolver extends WebApplicationObjectSupport implements
 	}
 
 	/**
-	 * Initialize the view bean factory.
-	 * Synchronized because of access by parallel threads.
+	 * Initialize the view bean factory, this method can be overridden to provide a custom
+	 * way of providing a {@code BeanFactory} to obtain the views from.
+	 *
 	 * @throws BeansException in case of initialization errors
 	 */
-	protected synchronized BeanFactory initFactory() throws BeansException {
-		if (this.cachedContext != null) {
-			return this.cachedContext;
-		}
-
-		ApplicationContext applicationContext = obtainApplicationContext();
-		if (this.providedContext == null) {
-			this.cachedContext = applicationContext;
-		}
-		else {
-			if (this.providedContext instanceof ConfigurableApplicationContext cac) {
-				cac.setParent(applicationContext);
-				if (this.providedContext instanceof ConfigurableWebApplicationContext wac) {
-					wac.setServletContext(getServletContext());
-				}
-			}
-			this.cachedContext = this.providedContext;
-		}
-		return this.cachedContext;
-	}
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		initFactory();
-	}
-
-	@Override
-	public void destroy() throws Exception {
-		if (this.providedContext instanceof ConfigurableApplicationContext cac) {
-			cac.close();
-		}
+	protected BeanFactory initFactory() throws BeansException {
+		return obtainApplicationContext();
 	}
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/JavaConfigViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/JavaConfigViewResolver.java
@@ -1,0 +1,79 @@
+package org.springframework.web.servlet.view;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.xml.ResourceEntityResolver;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.core.io.Resource;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.context.support.GenericWebApplicationContext;
+
+/**
+ * A {@link org.springframework.web.servlet.ViewResolver} implementation that uses
+ * bean definitions from dedicated {@code @Configuration class} for view definitions.
+ *
+ * <p>Note: This {@code ViewResolver} implements the {@link Ordered} interface
+ * in order to allow for flexible participation in {@code ViewResolver} chaining.
+ * For example, some special views could be defined via this {@code ViewResolver}
+ * (giving it 0 as "order" value), while all remaining views could be resolved by
+ * a {@link UrlBasedViewResolver}.
+ *
+ * @author Marten Deinum
+ * @since 6.1
+ * @see BeanNameViewResolver
+ */
+public class JavaConfigViewResolver extends BeanNameViewResolver implements InitializingBean, DisposableBean {
+
+	private final Set<Class<?>> viewConfigureationClasses = new LinkedHashSet<>();
+
+	@Nullable
+	private ConfigurableApplicationContext cachedFactory;
+
+	public void register(Class<?>... viewConfigureationClasses) {
+		Assert.notEmpty(viewConfigureationClasses, "At least one configuration class must be specified");
+		Collections.addAll(this.viewConfigureationClasses, viewConfigureationClasses);
+	}
+
+	@Override
+	protected synchronized BeanFactory initFactory() throws BeansException {
+		if (this.cachedFactory != null) {
+			return this.cachedFactory;
+		}
+
+		ApplicationContext applicationContext = obtainApplicationContext();
+
+		// Create child ApplicationContext for views.
+		AnnotationConfigWebApplicationContext factory = new AnnotationConfigWebApplicationContext();
+		factory.setParent(applicationContext);
+		factory.setServletContext(getServletContext());
+		factory.register(viewConfigureationClasses.toArray(new Class<?>[0]));
+
+		factory.refresh();
+		this.cachedFactory = factory;
+		return factory;
+
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		this.initFactory();
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		if (this.cachedFactory != null) {
+			this.cachedFactory.close();
+		}
+	}
+}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
@@ -36,6 +36,8 @@ import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.PropertyValue;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.testfixture.beans.TestBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.web.context.support.ServletContextResource;
@@ -99,17 +101,10 @@ public class ViewResolverTests {
 	}
 
 	@Test
-	public void beanNameViewResolverWithProvidedContext() {
-		StaticWebApplicationContext providedWac = new StaticWebApplicationContext();
-		MutablePropertyValues pvs1 = new MutablePropertyValues();
-		pvs1.addPropertyValue(new PropertyValue("url", "/example1.jsp"));
-		providedWac.registerSingleton("example1", InternalResourceView.class, pvs1);
-		MutablePropertyValues pvs2 = new MutablePropertyValues();
-		pvs2.addPropertyValue(new PropertyValue("url", "/example2.jsp"));
-		providedWac.registerSingleton("example2", JstlView.class, pvs2);
-		BeanNameViewResolver vr = new BeanNameViewResolver(providedWac);
+	public void JavaConfigViewResolverWithProvidedContext() {
+		JavaConfigViewResolver vr = new JavaConfigViewResolver();
+		vr.register(TestConfiguration.class);
 		vr.setApplicationContext(this.wac);
-		providedWac.refresh();
 		this.wac.refresh();
 
 		View view = vr.resolveViewName("example1", Locale.getDefault());
@@ -120,8 +115,6 @@ public class ViewResolverTests {
 		assertThat(view).isInstanceOf(JstlView.class);
 		assertThat(((JstlView) view).getUrl()).as("Correct URL").isEqualTo("/example2.jsp");
 
-		assertThat(providedWac.getParent()).isEqualTo(this.wac);
-		assertThat(providedWac.getServletContext()).isEqualTo(this.wac.getServletContext());
 	}
 
 
@@ -599,6 +592,24 @@ public class ViewResolverTests {
 			if (!(location instanceof ServletContextResource)) {
 				throw new IllegalArgumentException("Expecting ServletContextResource, not " + location.getClass().getName());
 			}
+		}
+	}
+
+	@Configuration
+	public static class TestConfiguration {
+
+		@Bean
+		public InternalResourceView example1() {
+			InternalResourceView example1 = new InternalResourceView();
+			example1.setUrl("/example1.jsp");
+			return example1;
+		}
+
+		@Bean
+		public JstlView example2() {
+			JstlView example1 = new JstlView();
+			example1.setUrl("/example2.jsp");
+			return example1;
 		}
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/view/ViewResolverTests.java
@@ -99,6 +99,33 @@ public class ViewResolverTests {
 	}
 
 	@Test
+	public void beanNameViewResolverWithProvidedContext() {
+		StaticWebApplicationContext providedWac = new StaticWebApplicationContext();
+		MutablePropertyValues pvs1 = new MutablePropertyValues();
+		pvs1.addPropertyValue(new PropertyValue("url", "/example1.jsp"));
+		providedWac.registerSingleton("example1", InternalResourceView.class, pvs1);
+		MutablePropertyValues pvs2 = new MutablePropertyValues();
+		pvs2.addPropertyValue(new PropertyValue("url", "/example2.jsp"));
+		providedWac.registerSingleton("example2", JstlView.class, pvs2);
+		BeanNameViewResolver vr = new BeanNameViewResolver(providedWac);
+		vr.setApplicationContext(this.wac);
+		providedWac.refresh();
+		this.wac.refresh();
+
+		View view = vr.resolveViewName("example1", Locale.getDefault());
+		assertThat(view.getClass()).as("Correct view class").isEqualTo(InternalResourceView.class);
+		assertThat(((InternalResourceView) view).getUrl()).as("Correct URL").isEqualTo("/example1.jsp");
+
+		view = vr.resolveViewName("example2", Locale.getDefault());
+		assertThat(view).isInstanceOf(JstlView.class);
+		assertThat(((JstlView) view).getUrl()).as("Correct URL").isEqualTo("/example2.jsp");
+
+		assertThat(providedWac.getParent()).isEqualTo(this.wac);
+		assertThat(providedWac.getServletContext()).isEqualTo(this.wac.getServletContext());
+	}
+
+
+	@Test
 	public void urlBasedViewResolverOverridesCustomRequestContextAttributeWithNonNullValue() throws Exception {
 		assertThat(new TestView().getRequestContextAttribute())
 			.as("requestContextAttribute when instantiated directly")


### PR DESCRIPTION
With the`XmlViewResolver`/`ResourceBundleViewResolver` you could have multiple instances of it and provide and XML application context to configure the views. This comes in handy when allowing 1 controller to render 2 different things like an Excel or a PDF depending on the requested Content-Type. Those are now deprecated and there is no real replacement for this.

Prior to this commit the `BeanNameViewResolver` would always resolve the views from the configuration it was defined in. Passing in a pre-configured application context would result in an error at runtime. Now it is possible to pass in an application context through the constructor which will be used to resolve the views from. Making it possible to have multiple instances and have the functionality as with multiple `XmlViewResolver`/`ResourceBundleViewResolver` with a `ContentNegotiatingViewResolver`.

Closes: #29383