### PR TITLE
Fix log level on error with @TransactionalEventListener

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationUtils.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationUtils.java
@@ -108,7 +108,7 @@ public abstract class TransactionSynchronizationUtils {
 				synchronization.beforeCompletion();
 			}
 			catch (Throwable ex) {
-				logger.debug("TransactionSynchronization.beforeCompletion threw exception", ex);
+				logger.error("TransactionSynchronization.beforeCompletion threw exception", ex);
 			}
 		}
 	}
@@ -172,7 +172,7 @@ public abstract class TransactionSynchronizationUtils {
 					synchronization.afterCompletion(completionStatus);
 				}
 				catch (Throwable ex) {
-					logger.debug("TransactionSynchronization.afterCompletion threw exception", ex);
+					logger.error("TransactionSynchronization.afterCompletion threw exception", ex);
 				}
 			}
 		}


### PR DESCRIPTION
Synchronous methods with `@TransactionalEventListener` logs in debug level.
However, most production logs are filtered by error level. Thus most developers cannot detect `@TransactionalEventListener` method throws error whether or not.

It was changed from https://github.com/spring-projects/spring-framework/commit/95110d825715a70dbc7fadc0e3ebd42f44e6bdfb. I think this changed an error because it is not related to  commit message.

ref: https://github.com/spring-projects/spring-framework/issues/17162