### PR TITLE
Use `Collections.emptyEnumeration` where appropriate

### DIFF
--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/index/CandidateComponentsTestClassLoader.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/index/CandidateComponentsTestClassLoader.java
@@ -42,8 +42,7 @@ public class CandidateComponentsTestClassLoader extends ClassLoader {
 	 * @see org.springframework.context.index.CandidateComponentsIndexLoader#COMPONENTS_RESOURCE_LOCATION
 	 */
 	public static ClassLoader disableIndex(ClassLoader classLoader) {
-		return new CandidateComponentsTestClassLoader(classLoader,
-				Collections.enumeration(Collections.emptyList()));
+		return new CandidateComponentsTestClassLoader(classLoader, Collections.emptyEnumeration());
 	}
 
 	/**

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/SimpleServletPostProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/SimpleServletPostProcessor.java
@@ -170,7 +170,7 @@ public class SimpleServletPostProcessor implements
 
 		@Override
 		public Enumeration<String> getInitParameterNames() {
-			return Collections.enumeration(Collections.emptySet());
+			return Collections.emptyEnumeration();
 		}
 	}
 


### PR DESCRIPTION
Use the empty `Enumeration` singleton returned by `Collections.emptyEnumeration`; there were a couple places that explicitly passed an empty collection to `Collections.enumeration`, which may as well just use `Collections.emptyEnumeration`.