### PR TITLE
Update inline comment in ProxyTransactionManagementConfiguration

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/ProxyTransactionManagementConfiguration.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/ProxyTransactionManagementConfiguration.java
@@ -58,7 +58,7 @@ public class ProxyTransactionManagementConfiguration extends AbstractTransaction
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	public TransactionAttributeSource transactionAttributeSource() {
-		// Accept protected @Transactional methods on CGLIB proxies, as of 6.0.
+		// Accept protected & package-private @Transactional methods on CGLIB proxies, as of 6.0.
 		return new AnnotationTransactionAttributeSource(false);
 	}
 


### PR DESCRIPTION
I apologize for the lack of clarity in my previous PR(#30793). 

The original comment explained that protected methods allow @transactional.
However, in practice, `package-private` method is also allowed.
So this should be clarified to avoid confusion.