### PR TITLE
Fix build cache miss in runtimeHintsTest task

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentArgumentProvider.java
+++ b/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentArgumentProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.build.hint;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.process.CommandLineArgumentProvider;
+
+import java.util.Collections;
+
+/**
+ * Argument provider for registering the runtime hints agent with a Java process.
+ */
+public interface RuntimeHintsAgentArgumentProvider extends CommandLineArgumentProvider {
+
+	@Classpath
+	ConfigurableFileCollection getAgentJar();
+
+    @Input
+    SetProperty<String> getIncludedPackages();
+
+    @Input
+    SetProperty<String> getExcludedPackages();
+
+    @Override
+    default Iterable<String> asArguments() {
+        StringBuilder packages = new StringBuilder();
+        getIncludedPackages().get().forEach(packageName -> packages.append('+').append(packageName).append(','));
+        getExcludedPackages().get().forEach(packageName -> packages.append('-').append(packageName).append(','));
+        return Collections.singleton("-javaagent:" + getAgentJar().getSingleFile() + "=" + packages);
+    }
+}

--- a/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentExtension.java
+++ b/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentExtension.java
@@ -16,38 +16,15 @@
 
 package org.springframework.build.hint;
 
-import java.util.Collections;
-
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.SetProperty;
 
 /**
  * Entry point to the DSL extension for the {@link RuntimeHintsAgentPlugin} Gradle plugin.
  * @author Brian Clozel
  */
-public class RuntimeHintsAgentExtension {
+public interface RuntimeHintsAgentExtension {
 
-	private final SetProperty<String> includedPackages;
+	SetProperty<String> getIncludedPackages();
 
-	private final SetProperty<String> excludedPackages;
-
-	public RuntimeHintsAgentExtension(ObjectFactory objectFactory) {
-		this.includedPackages = objectFactory.setProperty(String.class).convention(Collections.singleton("org.springframework"));
-		this.excludedPackages = objectFactory.setProperty(String.class).convention(Collections.emptySet());
-	}
-
-	public SetProperty<String> getIncludedPackages() {
-		return this.includedPackages;
-	}
-
-	public SetProperty<String> getExcludedPackages() {
-		return this.excludedPackages;
-	}
-
-	String asJavaAgentArgument() {
-		StringBuilder builder = new StringBuilder();
-		this.includedPackages.get().forEach(packageName -> builder.append('+').append(packageName).append(','));
-		this.excludedPackages.get().forEach(packageName -> builder.append('-').append(packageName).append(','));
-		return builder.toString();
-	}
+	SetProperty<String> getExcludedPackages();
 }


### PR DESCRIPTION
The primary focus of this change is to address a build cache miss when executing the `runtimeHintsTest` task from two different locations. This can be reproduced by running experiment 3 of the the [gradle/gradle-enterprise-build-validation-scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts). For example:

```shell
./03-validate-local-build-caching-different-locations.sh \
  --git-repo https://github.com/spring-projects/spring-framework \
  --git-commit-id ac11b03cd3c37121232d0b556fe642103179cdc9 \
  --tasks runtimeHintsTest \
  --gradle-enterprise-server https://ge.solutions-team.gradle.com 
```

Note: You should omit the `--gradle-enterprise-server` parameter if you have permission to publish Build Scans to https://ge.spring.io. 

In the resulting Build Scan of the second execution, we can see [the r`untimeHintsTest` tasks were re-executed](https://ge.solutions-team.gradle.com/s/d7ult3lltgus4/timeline?cacheability=cacheable,overlapping-outputs,validation-failure&outcome=success,failed&sort=longest). Comparing the two builds, we can see [the two executions had differences in the `jvmArgs`](https://ge.solutions-team.gradle.com/c/wlrbfwpmj4lrw/d7ult3lltgus4/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure#vld65yjjwfmzw-jvmargs).

Additionally, I have made two extra changes to:

- Evaluate the `-javaagent` parameter lazily 
- Remove the cross project task reference to the `jar` task of `spring-core-test`. See [Sharing outputs between projects](https://docs.gradle.org/current/userguide/cross_project_publications.html) for why and how this is done.

Each change was made in a separate commit.