### PR TITLE
Simplify `DefaultSingletonBeanRegistry.isDependent()`

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
@@ -453,11 +453,11 @@ public class DefaultSingletonBeanRegistry extends SimpleAliasRegistry implements
 		if (dependentBeans.contains(dependentBeanName)) {
 			return true;
 		}
+		if (alreadySeen == null) {
+			alreadySeen = new HashSet<>();
+		}
+		alreadySeen.add(beanName);
 		for (String transitiveDependency : dependentBeans) {
-			if (alreadySeen == null) {
-				alreadySeen = new HashSet<>();
-			}
-			alreadySeen.add(beanName);
 			if (isDependent(transitiveDependency, dependentBeanName, alreadySeen)) {
 				return true;
 			}


### PR DESCRIPTION
Move `alreadySeen` out of for-loop.