### PR TITLE
Eliminate redundant lookups of classes and annotations

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/InjectionPoint.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/InjectionPoint.java
@@ -48,6 +48,8 @@ public class InjectionPoint {
 	@Nullable
 	private volatile Annotation[] fieldAnnotations;
 
+	@Nullable
+	private volatile Annotation[] methodParameterAnnotations;
 
 	/**
 	 * Create an injection point descriptor for a method or constructor parameter.
@@ -76,6 +78,7 @@ public class InjectionPoint {
 				new MethodParameter(original.methodParameter) : null);
 		this.field = original.field;
 		this.fieldAnnotations = original.fieldAnnotations;
+		this.methodParameterAnnotations = original.methodParameterAnnotations;
 	}
 
 	/**
@@ -129,7 +132,13 @@ public class InjectionPoint {
 			return fieldAnnotations;
 		}
 		else {
-			return obtainMethodParameter().getParameterAnnotations();
+			Annotation[] methodParameterAnnotations = this.methodParameterAnnotations;
+			if (methodParameterAnnotations == null) {
+				methodParameterAnnotations =
+						obtainMethodParameter().getParameterAnnotations();
+				this.methodParameterAnnotations = methodParameterAnnotations;
+			}
+			return methodParameterAnnotations;
 		}
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/MethodInvoker.java
+++ b/spring-core/src/main/java/org/springframework/util/MethodInvoker.java
@@ -155,7 +155,8 @@ public class MethodInvoker {
 	 * @see #invoke
 	 */
 	public void prepare() throws ClassNotFoundException, NoSuchMethodException {
-		if (this.staticMethod != null) {
+		Class<?> targetClass = getTargetClass();
+		if (targetClass == null && this.staticMethod != null) {
 			int lastDotIndex = this.staticMethod.lastIndexOf('.');
 			if (lastDotIndex == -1 || lastDotIndex == this.staticMethod.length()) {
 				throw new IllegalArgumentException(
@@ -164,11 +165,12 @@ public class MethodInvoker {
 			}
 			String className = this.staticMethod.substring(0, lastDotIndex);
 			String methodName = this.staticMethod.substring(lastDotIndex + 1);
-			this.targetClass = resolveClassName(className);
+			targetClass = resolveClassName(className);
+			this.targetClass = targetClass;
 			this.targetMethod = methodName;
+
 		}
 
-		Class<?> targetClass = getTargetClass();
 		String targetMethod = getTargetMethod();
 		Assert.notNull(targetClass, "Either 'targetClass' or 'targetObject' is required");
 		Assert.notNull(targetMethod, "Property 'targetMethod' is required");


### PR DESCRIPTION
Repeatedly instantiating beans can trigger redundant lookups of classes and parameter annotations, and in certain applications become noticeable performance issues.  This change eliminates the redundant work by a) changing MethodInvoker.prepare() to only lookup targetClass when it's missing, and b) changing InjectionPoint to cache the method annotations similarly to the existing caching for field annotations.

Closes: #30883