### PR TITLE
Enable `KotlinScriptTemplateTests` with Java 20

### DIFF
--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/script/KotlinScriptTemplateTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/script/KotlinScriptTemplateTests.java
@@ -33,14 +33,14 @@ import org.springframework.web.testfixture.http.server.reactive.MockServerHttpRe
 import org.springframework.web.testfixture.server.MockServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.condition.JRE.JAVA_20;
+import static org.junit.jupiter.api.condition.JRE.JAVA_21;
 
 /**
  * Unit tests for Kotlin script templates running on Kotlin JSR-223 support.
  *
  * @author Sebastien Deleuze
  */
-@DisabledForJreRange(min = JAVA_20, disabledReason = "Kotlin doesn't support Java 20+ yet")
+@DisabledForJreRange(min = JAVA_21, disabledReason = "Kotlin doesn't support Java 21+ yet")
 public class KotlinScriptTemplateTests {
 
 	@Test


### PR DESCRIPTION
This PR changes to enable the `KotlinScriptTemplateTests` with Java 20 as 66a1be2d86f9e56e41086a07245e31d099616303 says that Java 21 is not supported and `./gradlew :spring-webflux:test -PtestToolchain=20 --tests KotlinScriptTemplateTests` seems to work with this change.

See gh-29249