### PR TITLE
Move blocking view resolution to boundedElastic

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/ViewResolutionResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/ViewResolutionResultHandler.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -268,6 +269,7 @@ public class ViewResolutionResultHandler extends HandlerResultHandlerSupport imp
 	private Mono<List<View>> resolveViews(String viewName, Locale locale) {
 		return Flux.fromIterable(getViewResolvers())
 				.concatMap(resolver -> resolver.resolveViewName(viewName, locale))
+				.subscribeOn(Schedulers.boundedElastic())
 				.collectList()
 				.map(views -> {
 					if (views.isEmpty()) {

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/ViewResolutionResultHandlerTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/view/ViewResolutionResultHandlerTests.java
@@ -30,6 +30,7 @@ import io.reactivex.rxjava3.core.Completable;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import org.springframework.context.support.StaticApplicationContext;
@@ -294,11 +295,14 @@ class ViewResolutionResultHandlerTests {
 		ViewResolutionResultHandler resultHandler = resultHandler(viewResolver);
 
 		MockServerWebExchange exchange = MockServerWebExchange.from(get("/account").accept(APPLICATION_JSON));
-		resultHandler.handleResult(exchange, handlerResult).block(Duration.ZERO);
 
-		MockServerHttpResponse response = exchange.getResponse();
-		assertThat(response.getStatusCode().value()).isEqualTo(303);
-		assertThat(response.getHeaders().getLocation().toString()).isEqualTo("/");
+		Mono.fromRunnable(() -> {
+			resultHandler.handleResult(exchange, handlerResult).block(Duration.ZERO);
+			MockServerHttpResponse response = exchange.getResponse();
+			assertThat(response.getStatusCode().value()).isEqualTo(303);
+			assertThat(response.getHeaders().getLocation().toString()).isEqualTo("/");
+		})
+				.subscribeOn(Schedulers.boundedElastic());
 	}
 
 


### PR DESCRIPTION
Hi! :) 

We used BlockHound to identify blocking operations in reactive spring modules; it turns out resolveViewName operation is blocking the reactive pipeline in webflux:


<img width="1602" alt="Screen Shot 2023-07-17 at 7 53 44 PM" src="https://github.com/spring-projects/spring-framework/assets/56495631/410af8ed-f8b5-4a14-b446-cacb5049ba5e">
This PR fixes the blocking call as well as updates a test to support the updated, reactive version.


The changes have been validated with build and test commands as mention in guidelines. 👍 