### PR TITLE
Move blocking writeResource operation to boundedElastic

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/ResourceHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ResourceHttpMessageWriter.java
@@ -49,6 +49,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.lang.Nullable;
 import org.springframework.util.MimeTypeUtils;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * {@code HttpMessageWriter} that can write a {@link Resource}.
@@ -110,7 +111,8 @@ public class ResourceHttpMessageWriter implements HttpMessageWriter<Resource> {
 			@Nullable MediaType mediaType, ReactiveHttpOutputMessage message, Map<String, Object> hints) {
 
 		return Mono.from(inputStream).flatMap(resource ->
-				writeResource(resource, elementType, mediaType, message, hints));
+				writeResource(resource, elementType, mediaType, message, hints))
+				.subscribeOn(Schedulers.boundedElastic());
 	}
 
 	private Mono<Void> writeResource(Resource resource, ResolvableType type, @Nullable MediaType mediaType,


### PR DESCRIPTION
Hi! 🙂 

We detected a blocking call in http-codec module with the help of BlockHound:
<img width="1047" alt="sf2-blocking" src="https://github.com/spring-projects/spring-framework/assets/56495631/e83cfe79-5ba2-4039-b54a-ecd82187e58d">

This PR fixes the blocking code so the pipeline remains reactive end to end. :)  We re-ran the tests and also compared the performance (CPU usage and latency) before and after the fix:

**Before**
<img width="1182" alt="sf-latency-before" src="https://github.com/spring-projects/spring-framework/assets/56495631/3817bf31-03b0-4e2b-bebc-4e2d7aeee055">
<img width="1381" alt="sf2-cpu-bef" src="https://github.com/spring-projects/spring-framework/assets/56495631/e5baf547-e161-4085-a5a4-6ca044ffa2f7">

**After**
<img width="1397" alt="sf2-cpu-aft" src="https://github.com/spring-projects/spring-framework/assets/56495631/9c3e8fba-594b-4394-94d9-12611145ba68">
<img width="1184" alt="sf2-latency-after" src="https://github.com/spring-projects/spring-framework/assets/56495631/701283be-5bff-48a9-86e5-2211276a9350">


 