### PR TITLE
Skip array sort when the length of array not greater than 1

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -1472,7 +1472,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 			}
 			TypeConverter converter = (typeConverter != null ? typeConverter : getTypeConverter());
 			Object result = converter.convertIfNecessary(matchingBeans.values(), resolvedArrayType);
-			if (result instanceof Object[] array) {
+			if (result instanceof Object[] array && array.length > 1) {
 				Comparator<Object> comparator = adaptDependencyComparator(matchingBeans);
 				if (comparator != null) {
 					Arrays.sort(array, comparator);


### PR DESCRIPTION
Performance optimization(`org.springframework.beans.factory.support.DefaultListableBeanFactory#resolveMultipleBeans`):

For the sorting condition of `Collection`  is  `result instanceof List<?> list && list.size() > 1`, when the size of collection isn't greater than 1, it will skip sorting.

Similarly, skip array sort when the length of array not greater than 1.
