### PR TITLE
Fix typo in javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/pattern/PathPatternParser.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/PathPatternParser.java
@@ -134,7 +134,7 @@ public class PathPatternParser {
 	 * Shared, read-only instance of {@code PathPatternParser}. Uses default settings:
 	 * <ul>
 	 * <li>{@code matchOptionalTrailingSeparator=true}
-	 * <li>{@code caseSensitivetrue}
+	 * <li>{@code caseSensitive=true}
 	 * <li>{@code pathOptions=PathContainer.Options.HTTP_PATH}
 	 * </ul>
 	 */


### PR DESCRIPTION
I found equal sign is missing in javadoc and it feels like typo issue, so I fixed it.