### PR TITLE
`IllegalStateException` cannot be thrown in `SpringExtension`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/junit/jupiter/SpringExtension.java
+++ b/spring-test/src/main/java/org/springframework/test/context/junit/jupiter/SpringExtension.java
@@ -172,7 +172,7 @@ public class SpringExtension implements BeforeAllCallback, AfterAllCallback, Tes
 								testClass.getName(), Arrays.toString(methodsWithErrors)));
 			}, String.class);
 
-		if (errorMessage != NO_VIOLATIONS_DETECTED) {
+		if (!errorMessage.equals(NO_VIOLATIONS_DETECTED)) {
 			throw new IllegalStateException(errorMessage);
 		}
 	}
@@ -211,7 +211,7 @@ public class SpringExtension implements BeforeAllCallback, AfterAllCallback, Tes
 					published by other tests since the application context may be shared.""";
 		}, String.class);
 
-		if (errorMessage != NO_VIOLATIONS_DETECTED) {
+		if (!errorMessage.equals(NO_VIOLATIONS_DETECTED)) {
 			throw new IllegalStateException(errorMessage);
 		}
 	}


### PR DESCRIPTION
Fix incorrect string comparison:

The issue occurred when checking for the presence of specific error messages that determine whether to throw an IllegalStateException.

closes #30962