### PR TITLE
Give `spring-core` access to `org.jboss.vfs` for `VfsUtils` support on WildFly

### DIFF
--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -107,7 +107,7 @@ dependencies {
 }
 
 jar {
-	manifest.attributes["Dependencies"] = "jdk.unsupported"  // for WildFly (-> Objenesis 3.2)
+	manifest.attributes["Dependencies"] = "jdk.unsupported,org.jboss.vfs" // for WildFly (Objenesis and VfsUtils)
 
 	dependsOn javapoetRepackJar
 	from(zipTree(javapoetRepackJar.archiveFile)) {


### PR DESCRIPTION
Give spring-core access to the org.jboss.vfs module to make VfsUtils work out of the box on WildFly 28+.

Starting from [WildFly 28](https://www.wildfly.org/news/2023/04/20/WildFly28-Released/#spring-and-resteasy-spring) deployments no longer have access by default to the `org.jboss.vfs` module. This causes the class initialization of `org.springframework.core.io.VfsUtils` to fail which causes `ConfigurationClassParser#parse` to fail (see stack tace below).

As a workaround applications can create a [jboss-deployment-structure.xml](https://docs.wildfly.org/29/Developer_Guide.html#jboss-deployment-structure-file) but a permanent fix is to add `org.jboss.vfs` to the existing [Dependencies](https://docs.wildfly.org/29/Developer_Guide.html#dependencies-manifest-entries) manifest header.

This is very similar to #25852

```
ERROR [org.jboss.msc.service.fail] MSC000001: Failed to start service jboss.deployment.unit."controller.war".undertow-deployment: org.jboss.msc.service.StartException in service jboss.deployment.unit."controller.war".undertow-deployment: java.lang.RuntimeException: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to parse configuration class [com.telekurs.pass.batch.controller.BatchControllerApplicationConfiguration]
        at org.wildfly.extension.undertow@28.0.0.Final//org.wildfly.extension.undertow.deployment.UndertowDeploymentService$1.run(UndertowDeploymentService.java:90)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at org.jboss.threads@2.4.0.Final//org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
        at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:1990)
        at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1486)
        at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1377)
        at java.base/java.lang.Thread.run(Thread.java:833)
        at org.jboss.threads@2.4.0.Final//org.jboss.threads.JBossThread.run(JBossThread.java:513)
Caused by: java.lang.RuntimeException: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to parse configuration class [com.acme.controller.AcmeControllerApplicationConfiguration]
        at io.undertow.servlet@2.3.5.Final//io.undertow.servlet.core.DeploymentManagerImpl.deploy(DeploymentManagerImpl.java:257)
        at org.wildfly.extension.undertow@28.0.0.Final//org.wildfly.extension.undertow.deployment.UndertowDeploymentService.startContext(UndertowDeploymentService.java:105)
        at org.wildfly.extension.undertow@28.0.0.Final//org.wildfly.extension.undertow.deployment.UndertowDeploymentService$1.run(UndertowDeploymentService.java:87)
        ... 8 more
Caused by: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to parse configuration class [om.acme.controller.AcmeControllerApplicationConfiguration]
        at deployment.controller.war//org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:178)
        at deployment.controller.war//org.springframework.context.annotation.ConfigurationClassPostProcessor.processConfigBeanDefinitions(ConfigurationClassPostProcessor.java:415)
        at deployment.controller.war//org.springframework.context.annotation.ConfigurationClassPostProcessor.postProcessBeanDefinitionRegistry(ConfigurationClassPostProcessor.java:287)
        at deployment.controller.war//org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanDefinitionRegistryPostProcessors(PostProcessorRegistrationDelegate.java:344)
        at deployment.controller.war//org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:115)
        at deployment.controller.war//org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:771)
        at deployment.controller.war//org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:589)
        at deployment.controller.war//org.springframework.web.context.ContextLoader.configureAndRefreshWebApplicationContext(ContextLoader.java:394)
        at deployment.controller.war//org.springframework.web.context.ContextLoader.initWebApplicationContext(ContextLoader.java:274)
        at deployment.controller.war//org.springframework.web.context.ContextLoaderListener.contextInitialized(ContextLoaderListener.java:102)
        at io.undertow.servlet@2.3.5.Final//io.undertow.servlet.core.ApplicationListeners.contextInitialized(ApplicationListeners.java:187)
        at io.undertow.servlet@2.3.5.Final//io.undertow.servlet.core.DeploymentManagerImpl$1.call(DeploymentManagerImpl.java:219)
        at io.undertow.servlet@2.3.5.Final//io.undertow.servlet.core.DeploymentManagerImpl$1.call(DeploymentManagerImpl.java:187)
        at io.undertow.servlet@2.3.5.Final//io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:42)
        at io.undertow.servlet@2.3.5.Final//io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
        at org.wildfly.extension.undertow@28.0.0.Final//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1430)
        at org.wildfly.extension.undertow@28.0.0.Final//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1430)
        at org.wildfly.extension.undertow@28.0.0.Final//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1430)
        at org.wildfly.extension.undertow@28.0.0.Final//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1430)
        at io.undertow.servlet@2.3.5.Final//io.undertow.servlet.core.DeploymentManagerImpl.deploy(DeploymentManagerImpl.java:255)
        ... 10 more
Caused by: java.lang.ExceptionInInitializerError
        at deployment.controller.war//org.springframework.core.io.support.PathMatchingResourcePatternResolver$VfsResourceMatchingDelegate.findMatchingResources(PathMatchingResourcePatternResolver.java:922)
        at deployment.controller.war//org.springframework.core.io.support.PathMatchingResourcePatternResolver.findPathMatchingResources(PathMatchingResourcePatternResolver.java:570)
        at deployment.controller.war//org.springframework.core.io.support.PathMatchingResourcePatternResolver.getResources(PathMatchingResourcePatternResolver.java:329)
        at deployment.controller.war//org.springframework.context.support.AbstractApplicationContext.getResources(AbstractApplicationContext.java:1432)
        at deployment.controller.war//org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider.scanCandidateComponents(ClassPathScanningCandidateComponentProvider.java:422)
        at deployment.controller.war//org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider.findCandidateComponents(ClassPathScanningCandidateComponentProvider.java:317)
        at deployment.controller.war//org.springframework.context.annotation.ClassPathBeanDefinitionScanner.doScan(ClassPathBeanDefinitionScanner.java:276)
        at deployment.controller.war//org.springframework.context.annotation.ComponentScanAnnotationParser.parse(ComponentScanAnnotationParser.java:128)
        at deployment.controller.war//org.springframework.context.annotation.ConfigurationClassParser.doProcessConfigurationClass(ConfigurationClassParser.java:289)
        at deployment.controller.war//org.springframework.context.annotation.ConfigurationClassParser.processConfigurationClass(ConfigurationClassParser.java:243)
        at deployment.controller.war//org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:196)
        at deployment.controller.war//org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:164)
        ... 29 more
Caused by: java.lang.IllegalStateException: Could not detect JBoss VFS infrastructure
        at deployment.controller.war//org.springframework.core.io.VfsUtils.<clinit>(VfsUtils.java:96)
        ... 41 more
Caused by: java.lang.ClassNotFoundException: org.jboss.vfs.VFS from [Module "deployment.controller.war" from Service Module Loader]
        at org.jboss.modules.ModuleClassLoader.findClass(ModuleClassLoader.java:200)
        at org.jboss.modules.ConcurrentClassLoader.performLoadClassUnchecked(ConcurrentClassLoader.java:410)
        at org.jboss.modules.ConcurrentClassLoader.performLoadClass(ConcurrentClassLoader.java:398)
        at org.jboss.modules.ConcurrentClassLoader.loadClass(ConcurrentClassLoader.java:116)
        at deployment.controller.war//org.springframework.core.io.VfsUtils.<clinit>(VfsUtils.java:73)
```