### PR TITLE
Switching thread context classloader during mvc method execution

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
@@ -241,7 +241,9 @@ public class InvocableHandlerMethod extends HandlerMethod {
 	@Nullable
 	protected Object doInvoke(Object... args) throws Exception {
 		Method method = getBridgedMethod();
+		ClassLoader beforeClassLoader = Thread.currentThread().getContextClassLoader();
 		try {
+			Thread.currentThread().setContextClassLoader(getBean().getClass().getClassLoader());
 			if (KotlinDetector.isKotlinReflectPresent()) {
 				if (KotlinDetector.isSuspendingFunction(method)) {
 					return invokeSuspendingFunction(method, getBean(), args);
@@ -273,6 +275,8 @@ public class InvocableHandlerMethod extends HandlerMethod {
 			else {
 				throw new IllegalStateException(formatInvokeError("Invocation failure", args), targetException);
 			}
+		} finally {
+			Thread.currentThread().setContextClassLoader(beforeClassLoader);
 		}
 	}
 


### PR DESCRIPTION
My project consists of a spring boot project and multiple extension packages (which can be understood as plugin).

Each extension package has its own spring application context and can use MVC related functions (such as defining controllers, interceptors, etc.), the extension package loader will load the Jar package through a custom URLCLassLoader and read the handlerMethods and interceptors in RequestMappingHandlerMapping and register them in the main springboot RequestMappingHandlerMapping.

When the main springboot program receives a request call and is scheduled through the DispatcherServlet, it will call the handler method registered with the extension package. At this time, the thread context classloader does not switch to the classLoader where the extension package is located.

At this point, the code implemented within the method may experience a ClassNotFoundException.