### PR TITLE
Fixed an error connecting to another database ignoring the "spring.datasource.url" setting in "application.properties"

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericTableMetaDataProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/GenericTableMetaDataProvider.java
@@ -20,11 +20,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -321,6 +317,9 @@ public class GenericTableMetaDataProvider implements TableMetaDataProvider {
 				tmd.setCatalogName(tables.getString("TABLE_CAT"));
 				tmd.setSchemaName(tables.getString("TABLE_SCHEM"));
 				tmd.setTableName(tables.getString("TABLE_NAME"));
+				if(!Objects.equals(tmd.catalogName, tables.getString("TABLE_CAT"))){
+					continue;
+				}
 				if (tmd.getSchemaName() == null) {
 					tableMeta.put(this.userName != null ? this.userName.toUpperCase() : "", tmd);
 				}


### PR DESCRIPTION
Fixed a bug where "catalogName" in "TableMetaData" and "DatabaseMetaData" were connected to different databases by directly putting data into the "tableMeta" variable without verifying whether the database names were the same.

1. problem situation
I had 2 databases (fast_sns, jdbchw).
The database "jdbchw" was connected even though "fast_sns" was specified in "spring.datasource.url" of "application.properties".
As a result of debugging, I found that it was a problem with the "next()" method of the While statement, and added a code to verify it.

<img width="987" alt="스크린샷 2023-08-08 오후 8 57 52" src="https://github.com/spring-projects/spring-framework/assets/74770498/bf27266e-0c11-4e55-ae3b-32d291c49f5d">
