### PR TITLE
Change Kotlin `Any` to be a nullable type in AOP refdoc examples

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/aop/ataspectj/advice.adoc
+++ b/framework-docs/modules/ROOT/pages/core/aop/ataspectj/advice.adoc
@@ -176,7 +176,7 @@ Kotlin::
 		@AfterReturning(
 			pointcut = "execution(* com.xyz.dao.*.*(..))",
 			returning = "retVal")
-		fun doAccessCheck(retVal: Any) {
+		fun doAccessCheck(retVal: Any?) {
 			// ...
 		}
 	}
@@ -448,7 +448,7 @@ Kotlin::
 	class AroundExample {
 
 		@Around("execution(* com.xyz..service.*.*(..))")
-		fun doBasicProfiling(pjp: ProceedingJoinPoint): Any {
+		fun doBasicProfiling(pjp: ProceedingJoinPoint): Any? {
 			// start stopwatch
 			val retVal = pjp.proceed()
 			// stop stopwatch
@@ -888,7 +888,7 @@ Kotlin::
 			"com.xyz.CommonPointcuts.inDataAccessLayer() && " +
 			"args(accountHolderNamePattern)") // <1>
 	fun preProcessQueryPattern(pjp: ProceedingJoinPoint,
-							accountHolderNamePattern: String): Any {
+							accountHolderNamePattern: String): Any? {
 		val newPattern = preProcess(accountHolderNamePattern)
 		return pjp.proceed(arrayOf<Any>(newPattern))
 	}

--- a/framework-docs/modules/ROOT/pages/core/aop/ataspectj/example.adoc
+++ b/framework-docs/modules/ROOT/pages/core/aop/ataspectj/example.adoc
@@ -85,7 +85,7 @@ Kotlin::
 		}
 
 		@Around("com.xyz.CommonPointcuts.businessService()") // <1>
-		fun doConcurrentOperation(pjp: ProceedingJoinPoint): Any {
+		fun doConcurrentOperation(pjp: ProceedingJoinPoint): Any? {
 			var numAttempts = 0
 			var lockFailureException: PessimisticLockingFailureException
 			do {
@@ -173,7 +173,7 @@ Kotlin::
 ----
 	@Around("execution(* com.xyz..service.*.*(..)) && " +
 			"@annotation(com.xyz.service.Idempotent)")
-	fun doConcurrentOperation(pjp: ProceedingJoinPoint): Any {
+	fun doConcurrentOperation(pjp: ProceedingJoinPoint): Any? {
 		// ...
 	}
 ----


### PR DESCRIPTION
When using "Any" as return type, as suggested by the [documentation example](https://docs.spring.io/spring-framework/reference/core/aop/ataspectj/example.html), in a `@Around`-Aspect calls to void methods with `pjp.proceed()` will fail, with a cryptic NullPointerException error:

`java.lang.NullPointerException: pjp.proceed() must not be null`

I have made an example project to showcase this behavior:
[spring-aop-docs-bug
](https://github.com/AlmostFamiliar/spring-aop-docs-bug)