### PR TITLE
Improve documentation on inferred destruction callbacks #30745

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/factory-nature.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/factory-nature.adoc
@@ -189,24 +189,28 @@ Java::
 +
 [source,java,indent=0,subs="verbatim,quotes",role="primary"]
 ----
-	public class ExampleBean {
+	public class ExampleBean implements DisposableBean {
+        public void destroy() throws Exception {
+            // do some destruction work (like releasing pooled connections)
+        }
+    }
 
-		public void cleanup() {
-			// do some destruction work (like releasing pooled connections)
-		}
-	}
 ----
 
 Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 ----
-	class ExampleBean {
+	class ExampleBean : DisposableBean {
+        override fun destroy() {
+            // Perform cleanup and destruction tasks, e.g., releasing pooled connections
+        }
 
-		fun cleanup() {
-			// do some destruction work (like releasing pooled connections)
-		}
-	}
+        fun cleanup() {
+            // This function can still be used for cleanup tasks
+        }
+    }
+
 ----
 ======
 


### PR DESCRIPTION
In the "Java" code snippet, the class `ExampleBean` is missing the `implements DisposableBean` declaration. Correction: Ensure the class implements the `DisposableBean` interface.

1. Added : `DisposableBean` after the class name to indicate that the class is implementing the `DisposableBean` interface. 
2. Added the `override` keyword before the destroy method to indicate that it's being overridden from the `DisposableBean` interface. 
3. Retained the `cleanup` function as-is, in case you have additional cleanup tasks you want to perform that are specific to this class.