### PR TITLE
Fix nullable get method of title of ProblemDetail.java

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ProblemDetail.java
+++ b/spring-web/src/main/java/org/springframework/http/ProblemDetail.java
@@ -132,12 +132,6 @@ public class ProblemDetail {
 	 */
 	@Nullable
 	public String getTitle() {
-		if (this.title == null) {
-			HttpStatus httpStatus = HttpStatus.resolve(this.status);
-			if (httpStatus != null) {
-				return httpStatus.getReasonPhrase();
-			}
-		}
 		return this.title;
 	}
 


### PR DESCRIPTION
Although the ProblemDetail#getTitle method was marked as nullable, the method never returned null because of unnecessary nested logic.

Basically, I would like to set custom title if the title of ProblemDetail null. Since title field does not have protected access variable I cannot change it by overriding the `getTitle()` method. Therefore, we actually have two solutions:
1. Change access modifier of title field in order to manipulate it from extended class.
2. Remove logic in the get method.