### PR TITLE
Conditions on overloaded beans not honored

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassBeanDefinitionReader.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassBeanDefinitionReader.java
@@ -178,13 +178,14 @@ class ConfigurationClassBeanDefinitionReader {
 		ConfigurationClass configClass = beanMethod.getConfigurationClass();
 		MethodMetadata metadata = beanMethod.getMetadata();
 		String methodName = metadata.getMethodName();
+		String methodSignature = metadata.getMethodSignature();
 
 		// Do we need to mark the bean as skipped by its condition?
 		if (this.conditionEvaluator.shouldSkip(metadata, ConfigurationPhase.REGISTER_BEAN)) {
-			configClass.skippedBeanMethods.add(methodName);
+			configClass.skippedBeanMethods.add(methodSignature);
 			return;
 		}
-		if (configClass.skippedBeanMethods.contains(methodName)) {
+		if (configClass.skippedBeanMethods.contains(methodSignature)) {
 			return;
 		}
 

--- a/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassWithConditionTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassWithConditionTests.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.stereotype.Component;
@@ -147,6 +149,12 @@ public class ConfigurationClassWithConditionTests {
 		Map<String, ExampleBean> beans = context.getBeansOfType(ExampleBean.class);
 		assertThat(beans).hasSize(1);
 		assertThat(beans.keySet().iterator().next()).isEqualTo("baz");
+	}
+
+	@Test
+	public void conditionOnOverloadedMethodHonored() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ConfigWithOverloadedConditionalBean.class);
+		assertThat(context.getBeansOfType(ExampleBean.class)).isNotEmpty();
 	}
 
 	@Test
@@ -363,6 +371,22 @@ public class ConfigurationClassWithConditionTests {
 		@Override
 		@Bean
 		public ExampleBean baz() {
+			return new ExampleBean();
+		}
+	}
+
+	@Configuration(enforceUniqueMethods = false)
+	static class ConfigWithOverloadedConditionalBean {
+
+		@Bean
+		@Conditional(NeverCondition.class)
+		ExampleBean user() {
+			return new ExampleBean();
+		}
+
+		@Bean
+		@Conditional(AlwaysCondition.class)
+		ExampleBean user(ApplicationContext context, Environment environment) {
 			return new ExampleBean();
 		}
 	}

--- a/spring-core/src/main/java/org/springframework/core/type/MethodMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/MethodMetadata.java
@@ -71,4 +71,9 @@ public interface MethodMetadata extends AnnotatedTypeMetadata {
 	 */
 	boolean isOverridable();
 
+	/**
+	 *
+	 * @return the underlying method's signature
+	 */
+	String getMethodSignature();
 }

--- a/spring-core/src/main/java/org/springframework/core/type/StandardMethodMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/StandardMethodMetadata.java
@@ -166,4 +166,10 @@ public class StandardMethodMetadata implements MethodMetadata {
 		return this.introspectedMethod.toString();
 	}
 
+	@Override
+	public String getMethodSignature(){
+		var stringify = this.toString();
+		return this.introspectedMethod.getName()
+				.concat(stringify.substring(stringify.indexOf('('), stringify.indexOf(')')+1));
+	}
 }

--- a/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMethodMetadata.java
+++ b/spring-core/src/main/java/org/springframework/core/type/classreading/SimpleMethodMetadata.java
@@ -116,4 +116,10 @@ final class SimpleMethodMetadata implements MethodMetadata {
 		return this.source.toString();
 	}
 
+	@Override
+	public String getMethodSignature(){
+		var stringify = this.toString();
+		return this.methodName
+				.concat(stringify.substring(stringify.indexOf('('), stringify.indexOf(')')+1));
+	}
 }


### PR DESCRIPTION
As pointed out in the issue #30688 the conditions on the overloaded beans aren't honored in all cases.
This is due to the fact that the `ConfigurationClassBeanDefinitionReader` class bases its logic about which bean method should be skipped on the method name only. The solution provides a brand-new method `String getMethodSignature();` in the `MethodMetadata` class, based on which will be decided if a bean should be skipped.