### PR TITLE
`@DynamicPropertySource` in `@Nested` test class cannot override dynamic properties from enclosing class

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/support/DynamicPropertiesContextCustomizerFactory.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DynamicPropertiesContextCustomizerFactory.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.TestContextAnnotationUtils;
  *
  * @author Phillip Webb
  * @author Sam Brannen
+ * @author Yanming Zhou
  * @since 5.2.5
  * @see DynamicPropertiesContextCustomizer
  */
@@ -54,10 +55,10 @@ class DynamicPropertiesContextCustomizerFactory implements ContextCustomizerFact
 	}
 
 	private void findMethods(Class<?> testClass, Set<Method> methods) {
-		methods.addAll(MethodIntrospector.selectMethods(testClass, this::isAnnotated));
 		if (TestContextAnnotationUtils.searchEnclosingClass(testClass)) {
 			findMethods(testClass.getEnclosingClass(), methods);
 		}
+		methods.addAll(MethodIntrospector.selectMethods(testClass, this::isAnnotated));
 	}
 
 	private boolean isAnnotated(Method method) {

--- a/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/nested/DynamicPropertySourceNestedTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit/jupiter/nested/DynamicPropertySourceNestedTests.java
@@ -39,6 +39,7 @@ import static org.springframework.test.context.NestedTestConfiguration.Enclosing
  * {@link SpringExtension} in a JUnit Jupiter environment.
  *
  * @author Sam Brannen
+ * @author Yanming Zhou
  * @since 5.3.2
  */
 @SpringJUnitConfig
@@ -125,6 +126,22 @@ class DynamicPropertySourceNestedTests {
 		}
 	}
 
+	@Nested
+	class DynamicPropertySourceOverrideEnclosingClassTests {
+
+		@DynamicPropertySource
+		static void overrideDynamicPropertyFromEnclosingClass(DynamicPropertyRegistry registry) {
+			registry.add(TEST_CONTAINER_PORT, () -> -999);
+		}
+
+		@Test
+		@DisplayName("@Service has values injected from @DynamicPropertySource in enclosing class and nested class")
+		void serviceHasInjectedValues(@Autowired Service service) {
+			assertThat(service.getIp()).isEqualTo("127.0.0.1");
+			assertThat(service.getPort()).isEqualTo(-999);
+		}
+
+	}
 
 	static abstract class DynamicPropertySourceSuperclass {
 


### PR DESCRIPTION
Fix https://github.com/spring-projects/spring-boot/issues/37040