### PR TITLE
Fix invalid type name in RSocket section of the reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/rsocket.adoc
+++ b/framework-docs/modules/ROOT/pages/rsocket.adoc
@@ -1089,7 +1089,7 @@ Now you can create a proxy that performs requests when methods are called:
 	RSocketRequester requester = ... ;
 	RSocketServiceProxyFactory factory = RSocketServiceProxyFactory.builder(requester).build();
 
-	RepositoryService service = factory.createClient(RadarService.class);
+	RadarService service = factory.createClient(RadarService.class);
 ----
 
 You can also implement the interface to handle requests as a responder.


### PR DESCRIPTION
There seems to be a typo in the `@RSocketExchange` documentation. The code sample declares the type of the generated proxy as `RepositoryService` but `RadarService` does not extend any interface. I assume it should be `RadarService` instead.