### PR TITLE
Introduce configuration to diable @Scheduled tasks

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessor.java
@@ -462,14 +462,15 @@ public class ScheduledAnnotationBeanPostProcessor
 				if (StringUtils.hasLength(fixedDelayString)) {
 					Assert.isTrue(!processedSchedule, errorMessage);
 					processedSchedule = true;
-					try {
-						fixedDelay = toDuration(fixedDelayString, scheduled.timeUnit());
+					if (!Scheduled.CRON_DISABLED.equals(fixedDelayString)) {
+						try {
+							fixedDelay = toDuration(fixedDelayString, scheduled.timeUnit());
+						} catch (RuntimeException ex) {
+							throw new IllegalArgumentException(
+									"Invalid fixedDelayString value \"" + fixedDelayString + "\" - cannot parse into long");
+						}
+						tasks.add(this.registrar.scheduleFixedDelayTask(new FixedDelayTask(runnable, fixedDelay, initialDelay)));
 					}
-					catch (RuntimeException ex) {
-						throw new IllegalArgumentException(
-								"Invalid fixedDelayString value \"" + fixedDelayString + "\" - cannot parse into long");
-					}
-					tasks.add(this.registrar.scheduleFixedDelayTask(new FixedDelayTask(runnable, fixedDelay, initialDelay)));
 				}
 			}
 
@@ -488,14 +489,15 @@ public class ScheduledAnnotationBeanPostProcessor
 				if (StringUtils.hasLength(fixedRateString)) {
 					Assert.isTrue(!processedSchedule, errorMessage);
 					processedSchedule = true;
-					try {
-						fixedRate = toDuration(fixedRateString, scheduled.timeUnit());
+					if (!Scheduled.CRON_DISABLED.equals(fixedRateString)) {
+						try {
+							fixedRate = toDuration(fixedRateString, scheduled.timeUnit());
+						} catch (RuntimeException ex) {
+							throw new IllegalArgumentException(
+									"Invalid fixedRateString value \"" + fixedRateString + "\" - cannot parse into long");
+						}
+						tasks.add(this.registrar.scheduleFixedRateTask(new FixedRateTask(runnable, fixedRate, initialDelay)));
 					}
-					catch (RuntimeException ex) {
-						throw new IllegalArgumentException(
-								"Invalid fixedRateString value \"" + fixedRateString + "\" - cannot parse into long");
-					}
-					tasks.add(this.registrar.scheduleFixedRateTask(new FixedRateTask(runnable, fixedRate, initialDelay)));
 				}
 			}
 

--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorTests.java
@@ -519,6 +519,23 @@ class ScheduledAnnotationBeanPostProcessorTests {
 
 	@ParameterizedTest
 	@CsvSource(textBlock = """
+		InactiveCron
+		InactiveFixedDelay
+		InactiveFixedRate
+	""")
+	void inactiveTask(@NameToClass Class<?> beanClass) {
+		BeanDefinition processorDefinition = new RootBeanDefinition(ScheduledAnnotationBeanPostProcessor.class);
+		BeanDefinition targetDefinition = new RootBeanDefinition(beanClass);
+		context.registerBeanDefinition("postProcessor", processorDefinition);
+		context.registerBeanDefinition("target", targetDefinition);
+		context.refresh();
+
+		ScheduledTaskHolder postProcessor = context.getBean("postProcessor", ScheduledTaskHolder.class);
+		assertThat(postProcessor.getScheduledTasks().isEmpty()).isTrue();
+	}
+
+	@ParameterizedTest
+	@CsvSource(textBlock = """
 		PropertyPlaceholderWithFixedDelay, 5000, 1000, 5_000, 1_000
 		PropertyPlaceholderWithFixedDelay, PT5S, PT1S, 5_000, 1_000
 		PropertyPlaceholderWithFixedDelayInSeconds, 5000, 1000, 5_000_000, 1_000_000
@@ -1049,6 +1066,27 @@ class ScheduledAnnotationBeanPostProcessorTests {
 					throw new ArgumentConversionException("Failed to convert class name to Class", ex);
 				}
 			}
+		}
+	}
+
+	static class InactiveCron {
+
+		@Scheduled(cron = "-")
+		void inactive() {
+		}
+	}
+
+	static class InactiveFixedDelay {
+
+		@Scheduled(fixedDelayString = "-")
+		void inactive() {
+		}
+	}
+
+	static class InactiveFixedRate {
+
+		@Scheduled(fixedRateString = "-")
+		void inactive() {
 		}
 	}
 


### PR DESCRIPTION
Prior to this commit, only cron @Scheduled tasks can be disabled with the special cron expression value that indicates a disabled trigger: "-".

This commit enables this configuration to fixedDelay and fixedRate @Scheduled tasks.

Fixes gh-28073