### PR TITLE
Use notEmpty() to check whether the collection/array is empty or not.

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/PropertySourceRegistry.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/PropertySourceRegistry.java
@@ -64,7 +64,7 @@ class PropertySourceRegistry {
 			encoding = null;
 		}
 		String[] locations = propertySource.getStringArray("value");
-		Assert.isTrue(locations.length > 0, "At least one @PropertySource(value) location is required");
+		Assert.notEmpty(locations, "At least one @PropertySource(value) location is required");
 		boolean ignoreResourceNotFound = propertySource.getBoolean("ignoreResourceNotFound");
 
 		Class<? extends PropertySourceFactory> factoryClass = propertySource.getClass("factory");

--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DataBufferUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DataBufferUtils.java
@@ -622,7 +622,7 @@ public abstract class DataBufferUtils {
 	 * @since 5.2
 	 */
 	public static Matcher matcher(byte[]... delimiters) {
-		Assert.isTrue(delimiters.length > 0, "Delimiters must not be empty");
+		Assert.notEmpty(delimiters, "Delimiters must not be empty");
 		return (delimiters.length == 1 ? createMatcher(delimiters[0]) : new CompositeMatcher(delimiters));
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/io/support/PropertySourceProcessor.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/PropertySourceProcessor.java
@@ -80,7 +80,7 @@ public class PropertySourceProcessor {
 		String name = descriptor.name();
 		String encoding = descriptor.encoding();
 		List<String> locations = descriptor.locations();
-		Assert.isTrue(locations.size() > 0, "At least one @PropertySource(value) location is required");
+		Assert.notEmpty(locations, "At least one @PropertySource(value) location is required");
 		boolean ignoreResourceNotFound = descriptor.ignoreResourceNotFound();
 		PropertySourceFactory factory = (descriptor.propertySourceFactory() != null ?
 				instantiateClass(descriptor.propertySourceFactory()) : defaultPropertySourceFactory);


### PR DESCRIPTION
When `collection` is `null`:
- `Assert.isTrue(collection.size() > 0, message)` will throw `NullPointerException`.
- `Assert.notEmpty(collection, message)` will throw `IllegalArgumentException`.