### PR TITLE
Polish resolveArgument method in RequestResponseBodyMethodProcessor

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessor.java
@@ -132,9 +132,9 @@ public class RequestResponseBodyMethodProcessor extends AbstractMessageConverter
 
 		parameter = parameter.nestedIfOptional();
 		Object arg = readWithMessageConverters(webRequest, parameter, parameter.getNestedGenericParameterType());
-		String name = Conventions.getVariableNameForParameter(parameter);
 
 		if (binderFactory != null) {
+			String name = Conventions.getVariableNameForParameter(parameter);
 			ResolvableType type = ResolvableType.forMethodParameter(parameter);
 			WebDataBinder binder = binderFactory.createBinder(webRequest, arg, name, type);
 			if (arg != null) {


### PR DESCRIPTION
```java
String name = Conventions.getVariableNameForParameter(parameter);
```
The above code is only used in conditional statements.
So I moved it into the conditional statements.
With this, we can expect a slight performance improvement in some case.