### PR TITLE
Improve specificity of the `UriComponentsBuilder` `path()` method

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
@@ -263,7 +263,7 @@ public class DefaultUriBuilderFactory implements UriBuilderFactory {
 					result.pathSegment(segment);
 				}
 				if (path != null && path.endsWith("/")) {
-					result.path("/");
+					result.appendPath("/");
 				}
 			}
 		}
@@ -300,6 +300,13 @@ public class DefaultUriBuilderFactory implements UriBuilderFactory {
 		}
 
 		@Override
+		public DefaultUriBuilder appendPath(String path) {
+			this.uriComponentsBuilder.appendPath(path);
+			return this;
+		}
+
+		@Override
+		@Deprecated
 		public DefaultUriBuilder path(String path) {
 			this.uriComponentsBuilder.path(path);
 			return this;

--- a/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -919,7 +919,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		@Override
 		public void copyToUriComponentsBuilder(UriComponentsBuilder builder) {
-			builder.path(getPath());
+			builder.appendPath(getPath());
 		}
 
 		@Override

--- a/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriBuilder.java
@@ -79,6 +79,37 @@ public interface UriBuilder {
 
 	/**
 	 * Append to the path of this builder.
+	 * <p>The given value is appended as-is to previous {@link #appendPath(String) path}
+	 * values without inserting any additional slashes. For example:
+	 * <pre class="code">
+	 *
+	 * builder.appendPath("/first-").appendPath("value/").appendPath("/{id}").build("123")
+	 *
+	 * // Results is "/first-value/123"
+	 * </pre>
+	 * <p>By contrast {@link #pathSegment(String...) pathSegment} does insert
+	 * slashes between individual path segments. For example:
+	 * <pre class="code">
+	 *
+	 * builder.pathSegment("first-value", "second-value").path("/")
+	 *
+	 * // Results is "/first-value/second-value/"
+	 * </pre>
+	 * <p>The resulting full path is normalized to eliminate duplicate slashes.
+	 * <p><strong>Note:</strong> When inserting a URI variable value that
+	 * contains slashes in a {@link #appendPath(String) path}, whether those are
+	 * encoded depends on the configured encoding mode. For more details, see
+	 * {@link UriComponentsBuilder#encode()}, or otherwise if building URIs
+	 * indirectly via {@code WebClient} or {@code RestTemplate}, see its
+	 * {@link DefaultUriBuilderFactory#setEncodingMode encodingMode}.
+	 * Also see the <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#web-uri-encoding">
+	 * URI Encoding</a> section of the reference docs.
+	 * @param path the URI path
+	 */
+	UriBuilder appendPath(String path);
+
+	/**
+	 * Append to the path of this builder.
 	 * <p>The given value is appended as-is to previous {@link #path(String) path}
 	 * values without inserting any additional slashes. For example:
 	 * <pre class="code">
@@ -105,7 +136,9 @@ public interface UriBuilder {
 	 * Also see the <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#web-uri-encoding">
 	 * URI Encoding</a> section of the reference docs.
 	 * @param path the URI path
+	 * @deprecated in favor of {@link #appendPath(String)}
 	 */
+	@Deprecated
 	UriBuilder path(String path);
 
 	/**
@@ -129,7 +162,7 @@ public interface UriBuilder {
 	 *
 	 * // Results is "/ba%2Fz/a%2Fb"
 	 * </pre>
-	 * To insert a trailing slash, use the {@link #path} builder method:
+	 * To insert a trailing slash, use the {@link #appendPath} builder method:
 	 * <pre class="code">
 	 *
 	 * builder.pathSegment("first-value", "second-value").path("/")

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -50,7 +50,7 @@ import org.springframework.web.util.UriComponents.UriTemplateVariables;
  * <li>Create a {@code UriComponentsBuilder} with one of the static factory methods
  * (such as {@link #fromPath(String)} or {@link #fromUri(URI)})</li>
  * <li>Set the various URI components through the respective methods ({@link #scheme(String)},
- * {@link #userInfo(String)}, {@link #host(String)}, {@link #port(int)}, {@link #path(String)},
+ * {@link #userInfo(String)}, {@link #host(String)}, {@link #port(int)}, {@link #appendPath(String)},
  * {@link #pathSegment(String...)}, {@link #queryParam(String, Object...)}, and
  * {@link #fragment(String)}.</li>
  * <li>Build the {@link UriComponents} instance with the {@link #build()} method.</li>
@@ -180,7 +180,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	 */
 	public static UriComponentsBuilder fromPath(String path) {
 		UriComponentsBuilder builder = new UriComponentsBuilder();
-		builder.path(path);
+		builder.appendPath(path);
 		return builder;
 	}
 
@@ -251,7 +251,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 				if (StringUtils.hasLength(port)) {
 					builder.port(port);
 				}
-				builder.path(path);
+				builder.appendPath(path);
 				builder.query(query);
 			}
 			if (StringUtils.hasText(fragment)) {
@@ -295,7 +295,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 			if (StringUtils.hasLength(port)) {
 				builder.port(port);
 			}
-			builder.path(matcher.group(8));
+			builder.appendPath(matcher.group(8));
 			builder.query(matcher.group(10));
 			String fragment = matcher.group(12);
 			if (StringUtils.hasText(fragment)) {
@@ -551,7 +551,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	 * of the given {@link UriComponents} instance.
 	 * <p>For the semantics of each component (i.e. set vs append) check the
 	 * builder methods on this class. For example {@link #host(String)} sets
-	 * while {@link #path(String)} appends.
+	 * while {@link #appendPath(String)} appends.
 	 * @param uriComponents the UriComponents to copy from
 	 * @return this UriComponentsBuilder
 	 */
@@ -570,7 +570,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	/**
 	 * Set the URI scheme-specific-part. When invoked, this method overwrites
 	 * {@linkplain #userInfo(String) user-info}, {@linkplain #host(String) host},
-	 * {@linkplain #port(int) port}, {@linkplain #path(String) path}, and
+	 * {@linkplain #port(int) port}, {@linkplain #appendPath(String) path}, and
 	 * {@link #query(String) query}.
 	 * @param ssp the URI scheme-specific-part, may contain URI template parameters
 	 * @return this UriComponentsBuilder
@@ -617,10 +617,16 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	}
 
 	@Override
-	public UriComponentsBuilder path(String path) {
+	public UriComponentsBuilder appendPath(String path) {
 		this.pathBuilder.addPath(path);
 		resetSchemeSpecificPart();
 		return this;
+	}
+
+	@Override
+	@Deprecated
+	public UriComponentsBuilder path(String path) {
+		return appendPath(path);
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/web/util/DefaultUriBuilderFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/DefaultUriBuilderFactoryTests.java
@@ -43,7 +43,7 @@ public class DefaultUriBuilderFactoryTests {
 	@Test // SPR-17465
 	public void defaultSettingsWithBuilder() {
 		DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory();
-		URI uri = factory.builder().path("/foo/{id}").build("a/b");
+		URI uri = factory.builder().appendPath("/foo/{id}").build("a/b");
 		assertThat(uri.toString()).isEqualTo("/foo/a%2Fb");
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -73,7 +73,7 @@ class UriComponentsBuilderTests {
 	void plain() {
 		UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
 		UriComponents result = builder.scheme("https").host("example.com")
-				.path("foo").queryParam("bar").fragment("baz").build();
+				.appendPath("foo").queryParam("bar").fragment("baz").build();
 
 		assertThat(result.getScheme()).isEqualTo("https");
 		assertThat(result.getHost()).isEqualTo("example.com");
@@ -379,7 +379,7 @@ class UriComponentsBuilderTests {
 
 	@Test
 	void pathThenPath() {
-		UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/foo/bar").path("ba/z");
+		UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/foo/bar").appendPath("ba/z");
 		UriComponents result = builder.build().encode();
 
 		assertThat(result.getPath()).isEqualTo("/foo/barba/z");
@@ -406,7 +406,7 @@ class UriComponentsBuilderTests {
 
 	@Test
 	void pathSegmentsThenPath() {
-		UriComponentsBuilder builder = UriComponentsBuilder.newInstance().pathSegment("foo").path("/");
+		UriComponentsBuilder builder = UriComponentsBuilder.newInstance().pathSegment("foo").appendPath("/");
 		UriComponents result = builder.build();
 
 		assertThat(result.getPath()).isEqualTo("/foo/");
@@ -648,24 +648,24 @@ class UriComponentsBuilderTests {
 				.isEqualTo("../../");
 		assertThat(UriComponentsBuilder.fromUriString("../../").build().toUri().getPath())
 				.isEqualTo("../../");
-		assertThat(UriComponentsBuilder.fromUriString(baseUrl).path("foo/../bar").build().toString())
+		assertThat(UriComponentsBuilder.fromUriString(baseUrl).appendPath("foo/../bar").build().toString())
 				.isEqualTo(baseUrl + "/foo/../bar");
-		assertThat(UriComponentsBuilder.fromUriString(baseUrl).path("foo/../bar").build().toUriString())
+		assertThat(UriComponentsBuilder.fromUriString(baseUrl).appendPath("foo/../bar").build().toUriString())
 				.isEqualTo(baseUrl + "/foo/../bar");
-		assertThat(UriComponentsBuilder.fromUriString(baseUrl).path("foo/../bar").build().toUri().getPath())
+		assertThat(UriComponentsBuilder.fromUriString(baseUrl).appendPath("foo/../bar").build().toUri().getPath())
 				.isEqualTo("/foo/../bar");
 	}
 
 	@Test
 	void emptySegments() {
 		String baseUrl = "https://example.com/abc/";
-		assertThat(UriComponentsBuilder.fromUriString(baseUrl).path("/x/y/z").build().toString())
+		assertThat(UriComponentsBuilder.fromUriString(baseUrl).appendPath("/x/y/z").build().toString())
 				.isEqualTo("https://example.com/abc/x/y/z");
 		assertThat(UriComponentsBuilder.fromUriString(baseUrl).pathSegment("x", "y", "z").build().toString())
 				.isEqualTo("https://example.com/abc/x/y/z");
-		assertThat(UriComponentsBuilder.fromUriString(baseUrl).path("/x/").path("/y/z").build().toString())
+		assertThat(UriComponentsBuilder.fromUriString(baseUrl).appendPath("/x/").appendPath("/y/z").build().toString())
 				.isEqualTo("https://example.com/abc/x/y/z");
-		assertThat(UriComponentsBuilder.fromUriString(baseUrl).pathSegment("x").path("y").build().toString())
+		assertThat(UriComponentsBuilder.fromUriString(baseUrl).pathSegment("x").appendPath("y").build().toString())
 				.isEqualTo("https://example.com/abc/x/y");
 	}
 
@@ -685,10 +685,10 @@ class UriComponentsBuilderTests {
 	@Test  // gh-25243
 	void testCloneAndMerge() {
 		UriComponentsBuilder builder1 = UriComponentsBuilder.newInstance();
-		builder1.scheme("http").host("e1.com").path("/p1").pathSegment("ps1").queryParam("q1", "x").fragment("f1").encode();
+		builder1.scheme("http").host("e1.com").appendPath("/p1").pathSegment("ps1").queryParam("q1", "x").fragment("f1").encode();
 
 		UriComponentsBuilder builder2 = builder1.cloneBuilder();
-		builder2.scheme("https").host("e2.com").path("p2").pathSegment("{ps2}").queryParam("q2").fragment("f2");
+		builder2.scheme("https").host("e2.com").appendPath("p2").pathSegment("{ps2}").queryParam("q2").fragment("f2");
 
 		builder1.queryParam("q1", "y");  // one more entry for an existing parameter
 
@@ -714,7 +714,7 @@ class UriComponentsBuilderTests {
 		vars.put("ps2", "bar");
 
 		UriComponentsBuilder builder1 = UriComponentsBuilder.newInstance();
-		builder1.scheme("http").host("e1.com").userInfo("user:pwd").path("/p1").pathSegment("{ps1}")
+		builder1.scheme("http").host("e1.com").userInfo("user:pwd").appendPath("/p1").pathSegment("{ps1}")
 				.pathSegment("{ps2}").queryParam("q1").fragment("f1").uriVariables(vars).encode();
 
 		UriComponentsBuilder builder2 = builder1.cloneBuilder();
@@ -793,7 +793,7 @@ class UriComponentsBuilderTests {
 
 	@Test  // gh-26012
 	void verifyDoubleSlashReplacedWithSingleOne() {
-		String path = UriComponentsBuilder.fromPath("/home/").path("/path").build().getPath();
+		String path = UriComponentsBuilder.fromPath("/home/").appendPath("/path").build().getPath();
 		assertThat(path).isEqualTo("/home/path");
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsTests.java
@@ -103,7 +103,7 @@ class UriComponentsTests {
 
 	@Test
 	void expand() {
-		UriComponents uri = UriComponentsBuilder.fromUriString("https://example.com").path("/{foo} {bar}").build();
+		UriComponents uri = UriComponentsBuilder.fromUriString("https://example.com").appendPath("/{foo} {bar}").build();
 		uri = uri.expand("1 2", "3 4");
 
 		assertThat(uri.getPath()).isEqualTo("/1 2 3 4");
@@ -201,7 +201,7 @@ class UriComponentsTests {
 	@Test
 	void serializable() throws Exception {
 		UriComponents uri = UriComponentsBuilder.fromUriString(
-				"https://example.com").path("/{foo}").query("bar={baz}").build();
+				"https://example.com").appendPath("/{foo}").query("bar={baz}").build();
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		ObjectOutputStream oos = new ObjectOutputStream(bos);
@@ -226,9 +226,9 @@ class UriComponentsTests {
 	@Test
 	void equalsHierarchicalUriComponents() {
 		String url = "https://example.com";
-		UriComponents uric1 = UriComponentsBuilder.fromUriString(url).path("/{foo}").query("bar={baz}").build();
-		UriComponents uric2 = UriComponentsBuilder.fromUriString(url).path("/{foo}").query("bar={baz}").build();
-		UriComponents uric3 = UriComponentsBuilder.fromUriString(url).path("/{foo}").query("bin={baz}").build();
+		UriComponents uric1 = UriComponentsBuilder.fromUriString(url).appendPath("/{foo}").query("bar={baz}").build();
+		UriComponents uric2 = UriComponentsBuilder.fromUriString(url).appendPath("/{foo}").query("bar={baz}").build();
+		UriComponents uric3 = UriComponentsBuilder.fromUriString(url).appendPath("/{foo}").query("bin={baz}").build();
 
 		assertThat(uric1).isInstanceOf(HierarchicalUriComponents.class);
 		assertThat(uric1).isEqualTo(uric1);


### PR DESCRIPTION
The documentation of the function specifically mentions that the path is appended but the naming of the method
did not reflect said behaviour.
