### PR TITLE
Use `Method#isDefault` to find default methods in interfaces

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -491,7 +491,7 @@ public abstract class ReflectionUtils {
 		List<Method> result = null;
 		for (Class<?> ifc : clazz.getInterfaces()) {
 			for (Method ifcMethod : ifc.getMethods()) {
-				if (!Modifier.isAbstract(ifcMethod.getModifiers())) {
+				if (ifcMethod.isDefault()) {
 					if (result == null) {
 						result = new ArrayList<>();
 					}


### PR DESCRIPTION
Use `Method#isDefault` to replace the logic in `ReflectionUtils#findConcreteMethodsOnInterfaces`.

- see #31198 