### PR TITLE
Add status handler to recognize unknown status codes outside of 4xx/5…

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpStatusCode.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatusCode.java
@@ -89,6 +89,15 @@ public sealed interface HttpStatusCode extends Serializable permits DefaultHttpS
 	}
 
 	/**
+	 * Checks whether the given status code is a well-known HTTP status code or not
+	 * @param statusCode the HTTP status code (potentially non-standard)
+	 * @return {@code true} if the status code corresponds to a standard HTTP status code
+	 */
+	static boolean isWellKnownStatusCode(HttpStatusCode statusCode) {
+		return HttpStatus.resolve(statusCode.value()) != null;
+	}
+
+	/**
 	 * Return an {@code HttpStatusCode} object for the given integer value.
 	 * @param code the status code as integer
 	 * @return the corresponding {@code HttpStatusCode}

--- a/spring-web/src/main/java/org/springframework/http/HttpStatusCode.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatusCode.java
@@ -89,12 +89,11 @@ public sealed interface HttpStatusCode extends Serializable permits DefaultHttpS
 	}
 
 	/**
-	 * Checks whether the given status code is a well-known HTTP status code or not
-	 * @param statusCode the HTTP status code (potentially non-standard)
-	 * @return {@code true} if the status code corresponds to a standard HTTP status code
+	 * Checks whether this status code is a well-known HTTP status code or not
+	 * @return {@code true} if the status code corresponds to a standard HTTP status code, {@code false} otherwise
 	 */
-	static boolean isWellKnownStatusCode(HttpStatusCode statusCode) {
-		return HttpStatus.resolve(statusCode.value()) != null;
+	default boolean isWellKnown() {
+		return HttpStatus.resolve(this.value()) != null;
 	}
 
 	/**

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -516,7 +516,7 @@ final class DefaultWebClient implements WebClient {
 	private static class DefaultResponseSpec implements ResponseSpec {
 
 		private static final Predicate<HttpStatusCode> STATUS_CODE_ERROR = HttpStatusCode::isError;
-		private static final Predicate<HttpStatusCode> STATUS_CODE_UNKNOWN = status -> !HttpStatusCode.isWellKnownStatusCode(status);
+		private static final Predicate<HttpStatusCode> STATUS_CODE_UNKNOWN = status -> !status.isWellKnown();
 		private static final StatusHandler DEFAULT_ERROR_STATUS_HANDLER =
 				new StatusHandler(STATUS_CODE_ERROR, ClientResponse::createException);
 		private static final StatusHandler DEFAULT_UNKNOWN_STATUS_HANDLER =

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -516,9 +516,11 @@ final class DefaultWebClient implements WebClient {
 	private static class DefaultResponseSpec implements ResponseSpec {
 
 		private static final Predicate<HttpStatusCode> STATUS_CODE_ERROR = HttpStatusCode::isError;
-
-		private static final StatusHandler DEFAULT_STATUS_HANDLER =
+		private static final Predicate<HttpStatusCode> STATUS_CODE_UNKNOWN = status -> !HttpStatusCode.isWellKnownStatusCode(status);
+		private static final StatusHandler DEFAULT_ERROR_STATUS_HANDLER =
 				new StatusHandler(STATUS_CODE_ERROR, ClientResponse::createException);
+		private static final StatusHandler DEFAULT_UNKNOWN_STATUS_HANDLER =
+				new StatusHandler(STATUS_CODE_UNKNOWN, ClientResponse::createException);
 
 		private final HttpMethod httpMethod;
 
@@ -537,7 +539,8 @@ final class DefaultWebClient implements WebClient {
 			this.uri = uri;
 			this.responseMono = responseMono;
 			this.statusHandlers.addAll(defaultStatusHandlers);
-			this.statusHandlers.add(DEFAULT_STATUS_HANDLER);
+			this.statusHandlers.add(DEFAULT_ERROR_STATUS_HANDLER);
+			this.statusHandlers.add(DEFAULT_UNKNOWN_STATUS_HANDLER);
 			this.defaultStatusHandlerCount = this.statusHandlers.size();
 		}
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
@@ -674,6 +674,40 @@ class WebClientIntegrationTests {
 	}
 
 	@ParameterizedWebClientTest
+	void retrieve929CustomUnknownStatus(ClientHttpConnector connector) {
+		startServer(connector);
+
+		int errorStatus = 929;
+		assertThat(HttpStatus.resolve(errorStatus)).isNull();
+		String errorMessage = "Something went wrong";
+		prepareResponse(response -> response.setResponseCode(errorStatus)
+				.setHeader("Content-Type", "text/plain").setBody(errorMessage));
+
+		Mono<String> result = this.webClient.get()
+				.uri("/unknownPage")
+				.retrieve()
+				.bodyToMono(String.class);
+
+		StepVerifier.create(result)
+				.expectErrorSatisfies(throwable -> {
+					assertThat(throwable).isInstanceOf(UnknownHttpStatusCodeException.class);
+					UnknownHttpStatusCodeException ex = (UnknownHttpStatusCodeException) throwable;
+					assertThat(ex.getMessage()).isEqualTo(("Unknown status code ["+errorStatus+"]"));
+					assertThat(ex.getStatusCode().value()).isEqualTo(errorStatus);
+					assertThat(ex.getStatusText()).isEmpty();
+					assertThat(ex.getHeaders().getContentType()).isEqualTo(MediaType.TEXT_PLAIN);
+					assertThat(ex.getResponseBodyAsString()).isEqualTo(errorMessage);
+				})
+				.verify(Duration.ofSeconds(3));
+
+		expectRequestCount(1);
+		expectRequest(request -> {
+			assertThat(request.getHeader(HttpHeaders.ACCEPT)).isEqualTo("*/*");
+			assertThat(request.getPath()).isEqualTo("/unknownPage");
+		});
+	}
+
+	@ParameterizedWebClientTest
 	void postPojoAsJson(ClientHttpConnector connector) {
 		startServer(connector);
 


### PR DESCRIPTION
…xx and throw an UnknownHttpStatusCodeException

org.springframework.web.reactive.function.client.UnknownHttpStatusCodeException claims in its Javadoc that it will be thrown to signal that "an unknown (or custom) HTTP status code is received". Up until Spring 5/Spring Boot 2 this was indeed true. We recently upgraded to Spring Boot 3/Spring 6, and our code that expected to receive this exception no longer works.

It turns out that the DEFAULT_STATUS_HANDLER in DefaultWebClient tests HttpStatusCode.isError as a predicate before calling DefaultClientResponse#createException. createException is the only place UnknownHttpStatusException is instantiated.

This is a behavior change from Spring 5, since now only 4xx/5xx custom status codes can lead to a UnknownHttpStatusException, in spite of what the exception's javadoc says.

This PR splits DEFAULT_STATUS_HANDLER into one for errors, and one for unknown codes. Both call the same function, with different predicates - one calls isError(), the other calls a new function isWellKnownStatusCode(). I kept the logic for both WebClientResponseException and UnknownHttpStatusCodeException in createException(), since there still can be a custom 4xx/5xx code. I also provide a test that validates the behavior for custom codes outside of that range, in addition to the existing test which only verified for a custom 5xx code.