### PR TITLE
Add `MappingJackson2MessageConverter` constructors that accept an `ObjectMapper`

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/support/converter/MappingJackson2MessageConverter.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/converter/MappingJackson2MessageConverter.java
@@ -96,6 +96,11 @@ public class MappingJackson2MessageConverter implements SmartMessageConverter, B
 		this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 	}
 
+	public MappingJackson2MessageConverter(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		this.objectMapper = objectMapper;
+	}
+
 	/**
 	 * Specify the {@link ObjectMapper} to use instead of using the default.
 	 */

--- a/spring-messaging/src/main/java/org/springframework/messaging/converter/MappingJackson2MessageConverter.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/converter/MappingJackson2MessageConverter.java
@@ -85,6 +85,13 @@ public class MappingJackson2MessageConverter extends AbstractMessageConverter {
 		this.objectMapper = initObjectMapper();
 	}
 
+	public MappingJackson2MessageConverter(ObjectMapper objectMapper) {
+		super(new MimeType("application", "json"), new MimeType("application", "*+json"));
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		this.objectMapper = objectMapper;
+	}
+
+
 
 	@SuppressWarnings("deprecation")  // on Jackson 2.13: configure(MapperFeature, boolean)
 	private ObjectMapper initObjectMapper() {


### PR DESCRIPTION
Prior to this commit in the message converters it was possible to set a pre-configured ObjectMapper. However the constructor would still create and configure an ObjectMapper.

With the added constructor it is now possible to directly construct the message converter with the proper ObjectMapper. This prevents the this additional ObjectMapper to be constructed.