### PR TITLE
Use `List#isEmpty()` in `DispatcherServlet`

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -1018,7 +1018,7 @@ public class DispatcherServlet extends FrameworkServlet {
 
 			if (traceOn) {
 				List<String> values = Collections.list(request.getHeaderNames());
-				String headers = values.size() > 0 ? "masked" : "";
+				String headers = values.isEmpty() ? "" : "masked";
 				if (isEnableLoggingRequestDetails()) {
 					headers = values.stream().map(name -> name + ":" + Collections.list(request.getHeaders(name)))
 							.collect(Collectors.joining(", "));

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -1518,7 +1518,7 @@ public class DispatcherServlet extends FrameworkServlet {
 		}
 	}
 
-	private static String getRequestUri(HttpServletRequest request) {
+	private String getRequestUri(HttpServletRequest request) {
 		String uri = (String) request.getAttribute(WebUtils.INCLUDE_REQUEST_URI_ATTRIBUTE);
 		if (uri == null) {
 			uri = request.getRequestURI();


### PR DESCRIPTION
There was no reason for getRequestUri() to be static, so we removed it.

If the reason the method is static is because it does not access state from the instance, then I think there are several more candidates for static.
Based on this, I think that static in `getRequestUri()` is unnecessary.

<br>

And, all the methods in `DispatcherServlet` used `isEmpty()`, and only one part used `size() > 0`.
I changed this to `isEmpty()` for uniformity.