### PR TITLE
Replace double spaces with single spaces in code and comments in `spring-webmvc`

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/DefaultServletHandlerBeanDefinitionParser.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/DefaultServletHandlerBeanDefinitionParser.java
@@ -34,7 +34,7 @@ import org.springframework.web.servlet.resource.DefaultServletHttpRequestHandler
 
 /**
  * {@link BeanDefinitionParser} that parses a {@code default-servlet-handler} element to
- * register a {@link DefaultServletHttpRequestHandler}.  Will also register a
+ * register a {@link DefaultServletHttpRequestHandler}. Will also register a
  * {@link SimpleUrlHandlerMapping} for mapping resource requests, and a
  * {@link HttpRequestHandlerAdapter}.
  *

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/MvcNamespaceUtils.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/MvcNamespaceUtils.java
@@ -131,7 +131,7 @@ public abstract class MvcNamespaceUtils {
 	}
 
 	/**
-	 * Registers  an {@link HttpRequestHandlerAdapter} under a well-known
+	 * Registers an {@link HttpRequestHandlerAdapter} under a well-known
 	 * name unless already registered.
 	 */
 	private static void registerBeanNameUrlHandlerMapping(ParserContext context, @Nullable Object source) {
@@ -148,7 +148,7 @@ public abstract class MvcNamespaceUtils {
 	}
 
 	/**
-	 * Registers  an {@link HttpRequestHandlerAdapter} under a well-known
+	 * Registers an {@link HttpRequestHandlerAdapter} under a well-known
 	 * name unless already registered.
 	 */
 	private static void registerHttpRequestHandlerAdapter(ParserContext context, @Nullable Object source) {
@@ -203,7 +203,7 @@ public abstract class MvcNamespaceUtils {
 	}
 
 	/**
-	 * Registers  an {@link HandlerMappingIntrospector} under a well-known name
+	 * Registers an {@link HandlerMappingIntrospector} under a well-known name
 	 * unless already registered.
 	 */
 	private static void registerHandlerMappingIntrospector(ParserContext context, @Nullable Object source) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RequestPredicates.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RequestPredicates.java
@@ -1189,7 +1189,7 @@ public abstract class RequestPredicates {
 
 		@Override
 		public String toString() {
-			return method() + " " +  path();
+			return method() + " " + path();
 		}
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerRequest.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerRequest.java
@@ -501,7 +501,7 @@ public interface ServerRequest {
 
 		/**
 		 * Add the given header value(s) under the given name.
-		 * @param headerName  the header name
+		 * @param headerName the header name
 		 * @param headerValues the header value(s)
 		 * @return this builder
 		 * @see HttpHeaders#add(String, String)

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
@@ -635,7 +635,7 @@ public interface ServerResponse {
 		/**
 		 * Register a callback to be invoked when an error occurs during SSE
 		 * processing.
-		 * @param onError  the callback to invoke on error
+		 * @param onError the callback to invoke on error
 		 * @return this builder
 		 */
 		SseBuilder onError(Consumer<Throwable> onError);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/WebContentInterceptor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/WebContentInterceptor.java
@@ -155,7 +155,7 @@ public class WebContentInterceptor extends WebContentGenerator implements Handle
 	}
 
 	/**
-	 * Map settings for  cache seconds to specific URL paths via patterns.
+	 * Map settings for cache seconds to specific URL paths via patterns.
 	 * <p>Overrides the default cache seconds setting of this interceptor.
 	 * Can specify "-1" to exclude a URL path from default caching.
 	 * <p>For pattern syntax see {@link AntPathMatcher} and {@link PathPattern}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/PatternsRequestCondition.java
@@ -80,7 +80,7 @@ public class PatternsRequestCondition extends AbstractRequestCondition<PatternsR
 	 * {@link PathMatcher} and flag for matching trailing slashes.
 	 * @since 5.3
 	 */
-	public PatternsRequestCondition(String[] patterns,  boolean useTrailingSlashMatch,
+	public PatternsRequestCondition(String[] patterns, boolean useTrailingSlashMatch,
 			@Nullable PathMatcher pathMatcher) {
 
 		this(patterns, null, pathMatcher, useTrailingSlashMatch);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RedirectAttributesMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RedirectAttributesMethodArgumentResolver.java
@@ -63,7 +63,7 @@ public class RedirectAttributesMethodArgumentResolver implements HandlerMethodAr
 			redirectAttributes = new RedirectAttributesModelMap(dataBinder);
 		}
 		else {
-			redirectAttributes  = new RedirectAttributesModelMap();
+			redirectAttributes = new RedirectAttributesModelMap();
 		}
 		mavContainer.setRedirectModel(redirectAttributes);
 		return redirectAttributes;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestAttributeMethodArgumentResolver.java
@@ -57,7 +57,7 @@ public class RequestAttributeMethodArgumentResolver extends AbstractNamedValueMe
 	@Override
 	protected void handleMissingValue(String name, MethodParameter parameter) throws ServletException {
 		throw new ServletRequestBindingException("Missing request attribute '" + name +
-				"' of type " +  parameter.getNestedParameterType().getSimpleName());
+				"' of type " + parameter.getNestedParameterType().getSimpleName());
 	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletRequestDataBinderFactory.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ServletRequestDataBinderFactory.java
@@ -49,7 +49,7 @@ public class ServletRequestDataBinderFactory extends InitBinderDataBinderFactory
 	 */
 	@Override
 	protected ServletRequestDataBinder createBinderInstance(
-			@Nullable Object target, String objectName, NativeWebRequest request) throws Exception  {
+			@Nullable Object target, String objectName, NativeWebRequest request) throws Exception {
 
 		return new ExtendedServletRequestDataBinder(target, objectName);
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
@@ -498,7 +498,7 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	 * Handle an {@link ErrorResponse} exception.
 	 * <p>The default implementation sets status and the headers of the response
 	 * to those obtained from the {@code ErrorResponse}. If available, the
-	 * {@link ProblemDetail#getDetail()}  is used as the message for
+	 * {@link ProblemDetail#getDetail()} is used as the message for
 	 * {@link HttpServletResponse#sendError(int, String)}.
 	 * @param errorResponse the exception to be handled
 	 * @param request current HTTP request

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/DefaultServletHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/DefaultServletHttpRequestHandler.java
@@ -35,7 +35,7 @@ import org.springframework.web.context.ServletContextAware;
  *
  * <p>This handler is intended to be used with a "/*" mapping when the
  * {@link org.springframework.web.servlet.DispatcherServlet DispatcherServlet}
- * is mapped to "/", thus  overriding the Servlet container's default handling of static resources.
+ * is mapped to "/", thus overriding the Servlet container's default handling of static resources.
  * The mapping to this handler should generally be ordered as the last in the chain so that it will
  * only execute when no other more specific mappings (i.e., to controllers) can be matched.
  *
@@ -45,7 +45,7 @@ import org.springframework.web.context.ServletContextAware;
  * handler checks at initialization time for the presence of the default Servlet of well-known
  * containers such as Tomcat, Jetty, Resin, WebLogic and WebSphere. However, when running in a
  * container where the default Servlet's name is not known, or where it has been customized
- * via server configuration, the  {@code defaultServletName} will need to be set explicitly.
+ * via server configuration, the {@code defaultServletName} will need to be set explicitly.
  *
  * @author Jeremy Grelle
  * @author Juergen Hoeller

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/HtmlEscapeTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/HtmlEscapeTag.java
@@ -20,7 +20,7 @@ import jakarta.servlet.jsp.JspException;
 
 /**
  * The {@code <htmlEscape>} tag sets default HTML escape value for the current
- * page. The actual value  can be overridden by escaping-aware tags.
+ * page. The actual value can be overridden by escaping-aware tags.
  * The default is "false".
  *
  * <p>Note: You can also set a "defaultHtmlEscape" web.xml context-param.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/UrlTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/UrlTag.java
@@ -57,13 +57,13 @@ import org.springframework.web.util.UriUtils;
  * string.
  *
  * <p>Use of the spring:param tag for URI template variables is strongly recommended
- * over direct EL substitution as the values are URL encoded.  Failure to properly
+ * over direct EL substitution as the values are URL encoded. Failure to properly
  * encode URL can leave an application vulnerable to XSS and other injection attacks.
  *
  * <p>URLs can be HTML/XML escaped by setting the {@link #setHtmlEscape(boolean)
- * 'htmlEscape'} attribute to 'true'.  Detects an HTML escaping setting, either on
+ * 'htmlEscape'} attribute to 'true'. Detects an HTML escaping setting, either on
  * this tag instance, the page level, or the {@code web.xml} level. The default
- * is 'false'.  When setting the URL value into a variable, escaping is not recommended.
+ * is 'false'. When setting the URL value into a variable, escaping is not recommended.
  *
  * <p>Example usage:
  * <pre class="code">&lt;spring:url value="/url/path/{variableName}"&gt;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractHtmlElementTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractHtmlElementTag.java
@@ -33,7 +33,7 @@ import org.springframework.util.StringUtils;
  * across elements.
  *
  * <p>Additionally, this base class allows for rendering non-standard attributes
- * as part of the tag's output.  These attributes are accessible to subclasses if
+ * as part of the tag's output. These attributes are accessible to subclasses if
  * needed via the {@link AbstractHtmlElementTag#getDynamicAttributes() dynamicAttributes}
  * map.
  *

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/OptionWriter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/OptionWriter.java
@@ -43,7 +43,7 @@ import org.springframework.web.servlet.support.BindStatus;
  * the {@code labelProperty}). These properties are then used when
  * rendering each element of the array/{@link Collection} as an '{@code option}'.
  * If either property name is omitted, the value of {@link Object#toString()} of
- * the corresponding array/{@link Collection} element is used instead.  However,
+ * the corresponding array/{@link Collection} element is used instead. However,
  * if the item is an enum, {@link Enum#name()} is used as the default value.
  * </p>
  * <h3>Using a {@link Map}:</h3>

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
@@ -38,7 +38,7 @@ import org.springframework.web.servlet.View;
  *
  * <p>By default, the entire contents of the model map (with the exception of framework-specific classes)
  * will be encoded as JSON. If the model contains only one key, you can have it extracted encoded as JSON
- * alone via  {@link #setExtractValueFromSingleKeyModel}.
+ * alone via {@link #setExtractValueFromSingleKeyModel}.
  *
  * <p>The default constructor uses the default configuration provided by {@link Jackson2ObjectMapperBuilder}.
  *


### PR DESCRIPTION
Except for meaningful double spaces (e.g. to align the indentation of comments), I replaced all meaningless double spaces with single spaces in webmvc module.