### PR TITLE
Introduce `initialize()` method in `AbstractRoutingDataSource` and `AbstractRoutingConnectionFactory`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSource.java
@@ -116,7 +116,7 @@ public abstract class AbstractRoutingDataSource extends AbstractDataSource imple
 
 	@Override
 	public void afterPropertiesSet() {
-		refresh();
+		initialize();
 	}
 
 	/**
@@ -124,7 +124,7 @@ public abstract class AbstractRoutingDataSource extends AbstractDataSource imple
 	 * and defaultTargetDataSource to resolvedDefaultDataSource.
 	 * @throws IllegalArgumentException in case of targetDataSources is null
 	 */
-	public void refresh() {
+	public void initialize() {
 		if (this.targetDataSources == null) {
 			throw new IllegalArgumentException("Property 'targetDataSources' is required");
 		}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSource.java
@@ -116,6 +116,15 @@ public abstract class AbstractRoutingDataSource extends AbstractDataSource imple
 
 	@Override
 	public void afterPropertiesSet() {
+		refresh();
+	}
+
+	/**
+	 * Synchronizes targetDataSources to resolvedDataSources
+	 * and defaultTargetDataSource to resolvedDefaultDataSource.
+	 * @throws IllegalArgumentException in case of targetDataSources is null
+	 */
+	public void refresh() {
 		if (this.targetDataSources == null) {
 			throw new IllegalArgumentException("Property 'targetDataSources' is required");
 		}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSourceTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSourceTests.java
@@ -147,7 +147,7 @@ class AbstractRoutingDataSourceTests {
 	}
 
 	@Test
-	void testRefresh_SynchronizeTargetDataSourcesToResolvedDataSources() {
+	void testInitialize_synchronizeTargetDataSourcesToResolvedDataSources() {
 		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
 			@Override
 			protected Object determineCurrentLookupKey() {
@@ -163,7 +163,7 @@ class AbstractRoutingDataSourceTests {
 		targetDataSources.put("ds2", ds2);
 		routingDataSource.setTargetDataSources(targetDataSources);
 
-		routingDataSource.refresh();
+		routingDataSource.initialize();
 
 		Map<Object, DataSource> resolvedDataSources = routingDataSource.getResolvedDataSources();
 		assertThat(resolvedDataSources).hasSize(2);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSourceTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSourceTests.java
@@ -147,6 +147,31 @@ class AbstractRoutingDataSourceTests {
 	}
 
 	@Test
+	void testRefresh_SynchronizeTargetDataSourcesToResolvedDataSources() {
+		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return null;
+			}
+		};
+
+		DataSource ds1 = new StubDataSource();
+		DataSource ds2 = new StubDataSource();
+
+		Map<Object, Object> targetDataSources = new HashMap<>();
+		targetDataSources.put("ds1", ds1);
+		targetDataSources.put("ds2", ds2);
+		routingDataSource.setTargetDataSources(targetDataSources);
+
+		routingDataSource.refresh();
+
+		Map<Object, DataSource> resolvedDataSources = routingDataSource.getResolvedDataSources();
+		assertThat(resolvedDataSources).hasSize(2);
+		assertThat(resolvedDataSources.get("ds1")).isSameAs(ds1);
+		assertThat(resolvedDataSources.get("ds2")).isSameAs(ds2);
+	}
+
+	@Test
 	public void notInitialized() {
 		AbstractRoutingDataSource routingDataSource = new AbstractRoutingDataSource() {
 			@Override

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/lookup/AbstractRoutingConnectionFactory.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/lookup/AbstractRoutingConnectionFactory.java
@@ -127,14 +127,14 @@ public abstract class AbstractRoutingConnectionFactory implements ConnectionFact
 
 	@Override
 	public void afterPropertiesSet() {
-		refresh();
+		initialize();
 	}
 
 	/**
 	 * Synchronizes targetConnectionFactories to resolvedConnectionFactories
 	 * and defaultTargetConnectionFactory to resolvedDefaultConnectionFactory.
 	 */
-	public void refresh() {
+	public void initialize() {
 		Assert.notNull(this.targetConnectionFactories, "Property 'targetConnectionFactories' must not be null");
 
 		this.resolvedConnectionFactories = CollectionUtils.newHashMap(this.targetConnectionFactories.size());

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/lookup/AbstractRoutingConnectionFactory.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/lookup/AbstractRoutingConnectionFactory.java
@@ -127,6 +127,14 @@ public abstract class AbstractRoutingConnectionFactory implements ConnectionFact
 
 	@Override
 	public void afterPropertiesSet() {
+		refresh();
+	}
+
+	/**
+	 * Synchronizes targetConnectionFactories to resolvedConnectionFactories
+	 * and defaultTargetConnectionFactory to resolvedDefaultConnectionFactory.
+	 */
+	public void refresh() {
 		Assert.notNull(this.targetConnectionFactories, "Property 'targetConnectionFactories' must not be null");
 
 		this.resolvedConnectionFactories = CollectionUtils.newHashMap(this.targetConnectionFactories.size());

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/lookup/AbstractRoutingConnectionFactoryUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/lookup/AbstractRoutingConnectionFactoryUnitTests.java
@@ -182,6 +182,19 @@ public class AbstractRoutingConnectionFactoryUnitTests {
 				.verifyComplete();
 	}
 
+	@Test
+	void testRefresh_shouldDetermineRoutedFactory() {
+		connectionFactory.setTargetConnectionFactories(
+				singletonMap("key", routedConnectionFactory));
+		connectionFactory.setConnectionFactoryLookup(new MapConnectionFactoryLookup());
+		connectionFactory.refresh();
+
+		connectionFactory.determineTargetConnectionFactory()
+				.contextWrite(Context.of(ROUTING_KEY, "key"))
+				.as(StepVerifier::create)
+				.expectNext(routedConnectionFactory)
+				.verifyComplete();
+	}
 
 	static class DummyRoutingConnectionFactory extends AbstractRoutingConnectionFactory {
 

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/lookup/AbstractRoutingConnectionFactoryUnitTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/lookup/AbstractRoutingConnectionFactoryUnitTests.java
@@ -183,11 +183,11 @@ public class AbstractRoutingConnectionFactoryUnitTests {
 	}
 
 	@Test
-	void testRefresh_shouldDetermineRoutedFactory() {
+	void testInitialize_shouldDetermineRoutedFactory() {
 		connectionFactory.setTargetConnectionFactories(
 				singletonMap("key", routedConnectionFactory));
 		connectionFactory.setConnectionFactoryLookup(new MapConnectionFactoryLookup());
-		connectionFactory.refresh();
+		connectionFactory.initialize();
 
 		connectionFactory.determineTargetConnectionFactory()
 				.contextWrite(Context.of(ROUTING_KEY, "key"))


### PR DESCRIPTION
Situation is that you want to add DataSource to the DataSources of AbstractRoutingDataSource during runtime.

When i put a Data Source, I need to synchronize target Data Sources to resolved Data Sources.

At that time, I call `afterPropertiesSet()` as below.

```java
@Component
public class MultiDatabaseManager {

    private final Map<Object, Object> dataSourceMap = new ConcurrentHashMap<>();

    private AbstractRoutingDataSource multiDataSource;

    public DataSource createMultiDataSource() {
        MultiDataSource multiDataSource = new MultiDataSource();
        multiDataSource.setTargetDataSources(dataSourceMap);
        multiDataSource.setDefaultTargetDataSource(defaultDataSource());
        return multiDataSource;
    }

    public void addDataSource(String hostIp, ...) throws SQLException {
        DataSource dataSource = DataSourceBuilder
                .create()
                .username(username)
                .password(password)
                .url(url)
                .driverClassName(driverClassName)
                .build();

        try (Connection c = dataSource.getConnection()) {
            dataSourceMap.put(hostIp, dataSource);
            multiDataSource.afterPropertiesSet(); // unclear intentions
        }
    }

}
```

However, `afterPropertiesSet()` is unclear.

So I suggest extract `refresh()` method. Then, intent can be exposed.

Please feel free to share your opinions or advice.

thanks you.