### PR TITLE
Fix an issue with uninitialized beans being fetched when circular dependencies are used

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -1322,7 +1322,13 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 		if (bean instanceof NullBean) {
 			return null;
 		}
-		return new NamedBeanHolder<>(beanName, adaptBeanInstance(beanName, bean, requiredType.toClass()));
+		NamedBeanHolder<T> holder = new NamedBeanHolder<>(beanName, adaptBeanInstance(beanName, bean, requiredType.toClass()));
+		if (isSingletonCurrentlyInCreation(beanName)) {
+			synchronized (getSingletonMutex()) {
+				return holder;
+			}
+		}
+		return holder;
 	}
 
 	@Override


### PR DESCRIPTION
The PR changed the org. Springframework. Beans. Factory. Support. DefaultListableBeanFactory resolveNamedBean method, To resolve the issue of getting an uninitialized bean that can occur when concurrently executing getBean to get a bean that contains a loop dependency.
Ref: #31261