### PR TITLE
Simplify `ServerRequestExtensions.queryParamOrNull()`

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
@@ -173,7 +173,7 @@ fun ServerRequest.attributeOrNull(name: String): Any? = attributes()[name]
  */
 fun ServerRequest.queryParamOrNull(name: String): String? {
 	val queryParamValues = queryParams()[name]
-	return if (queryParamValues.isNullOrEmpty()) null else queryParamValues!![0] ?: ""
+	return if (queryParamValues.isNullOrEmpty()) null else queryParamValues[0] ?: ""
 }
 
 /**

--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
@@ -173,7 +173,7 @@ fun ServerRequest.attributeOrNull(name: String): Any? = attributes()[name]
  */
 fun ServerRequest.queryParamOrNull(name: String): String? {
 	val queryParamValues = queryParams()[name]
-	return queryParamValues?.getOrNull(0) ?: ""
+	return queryParamValues!!.getOrNull(0) ?: ""
 }
 
 /**

--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
@@ -173,7 +173,7 @@ fun ServerRequest.attributeOrNull(name: String): Any? = attributes()[name]
  */
 fun ServerRequest.queryParamOrNull(name: String): String? {
 	val queryParamValues = queryParams()[name]
-	return queryParamValues!!.getOrNull(0) ?: ""
+	return queryParamValues?.getOrNull(0) ?: ""
 }
 
 /**

--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
@@ -173,15 +173,7 @@ fun ServerRequest.attributeOrNull(name: String): Any? = attributes()[name]
  */
 fun ServerRequest.queryParamOrNull(name: String): String? {
 	val queryParamValues = queryParams()[name]
-	return if (CollectionUtils.isEmpty(queryParamValues)) {
-		null
-	} else {
-		var value: String? = queryParamValues!![0]
-		if (value == null) {
-			value = ""
-		}
-		value
-	}
+	return queryParamValues?.getOrNull(0) ?: ""
 }
 
 /**

--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
@@ -173,7 +173,7 @@ fun ServerRequest.attributeOrNull(name: String): Any? = attributes()[name]
  */
 fun ServerRequest.queryParamOrNull(name: String): String? {
 	val queryParamValues = queryParams()[name]
-	return queryParamValues?.getOrNull(0) ?: ""
+	return if (queryParamValues.isNullOrEmpty()) null else queryParamValues!![0] ?: ""
 }
 
 /**


### PR DESCRIPTION
### What this PR is about is

**Null value processing has been modified more concisely.**

---

While I was looking at the implementation of **ServerRequestExtensions** on the webflux side of the spring framework, I think I can correct it more correlatedly by putting the default string "" in the function named `queryParamOrNull()` when the parameter value is null.

And instead of the CollectionUtil library, I used `isNullOrEmpty()` provided by the Kotlin standard library.

I've tried handling null values using the elvis operator, please check it out and merge this PR if you like it!

---

### Before

```kotlin
fun ServerRequest.queryParamOrNull(name: String): String? {
	val queryParamValues = queryParams()[name]
	return if (CollectionUtils.isEmpty(queryParamValues)) {
		null
	} else {
		var value: String? = queryParamValues!![0]
		if (value == null) {
			value = ""
		}
		value
	}
}
```



### After

```kotlin
fun ServerRequest.queryParamOrNull(name: String): String? {
	val queryParamValues = queryParams()[name]
	return if (queryParamValues.isNullOrEmpty()) null else queryParamValues[0] ?: ""
}
```

Thank you :)