### PR TITLE
DefaultFetchSpec should not buffer results in temporary list buffers

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultFetchSpec.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultFetchSpec.java
@@ -59,18 +59,11 @@ class DefaultFetchSpec<T> implements FetchSpec<T> {
 
 	@Override
 	public Mono<T> one() {
-		return all().buffer(2)
-				.flatMap(list -> {
-					if (list.isEmpty()) {
-						return Mono.empty();
-					}
-					if (list.size() > 1) {
-						return Mono.error(new IncorrectResultSizeDataAccessException(
-								String.format("Query [%s] returned non unique result.", this.resultFunction.getSql()),
-								1));
-					}
-					return Mono.just(list.get(0));
-				}).next();
+		return all().singleOrEmpty()
+			.onErrorMap(IndexOutOfBoundsException.class, ex -> {
+				String message = String.format("Query [%s] returned non unique result.", resultFunction.getSql());
+				return new IncorrectResultSizeDataAccessException(message, 1);
+			});
 	}
 
 	@Override


### PR DESCRIPTION
Avoid fetching and buffering results in temporary `List` buffers.

I stumbled across this while analyzing [a problem with oracle-r2dbc](https://github.com/oracle/oracle-r2dbc/issues/133) and thought that using `buffer()` is unnecessary when you could use `singleOrEmpty` instead.