### PR TITLE
Upgrade to snakeyaml 2.2

### DIFF
--- a/framework-platform/framework-platform.gradle
+++ b/framework-platform/framework-platform.gradle
@@ -148,6 +148,6 @@ dependencies {
 		api("org.webjars:webjars-locator-core:0.53")
 		api("org.xmlunit:xmlunit-assertj:2.9.1")
 		api("org.xmlunit:xmlunit-matchers:2.9.1")
-		api("org.yaml:snakeyaml:2.0")
+		api("org.yaml:snakeyaml:2.2")
 	}
 }


### PR DESCRIPTION
Snakeyaml 2.2 [has a fix](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes) where the package `org.yaml.snakeyaml.inspector` is not exported from its module, requiring a manual `--add-exports` when running spring on the module path.