### PR TITLE
Remove unused imports

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/JavaConventions.java
+++ b/buildSrc/src/main/java/org/springframework/build/JavaConventions.java
@@ -27,7 +27,6 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
-import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 /**

--- a/buildSrc/src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
@@ -20,7 +20,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSetContainer;
 

--- a/spring-test/src/main/java/org/springframework/test/context/junit/jupiter/SpringExtension.java
+++ b/spring-test/src/main/java/org/springframework/test/context/junit/jupiter/SpringExtension.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -179,7 +180,7 @@ public class SpringExtension implements BeforeAllCallback, AfterAllCallback, Tes
 								testClass.getName(), Arrays.toString(methodsWithErrors)));
 			}, String.class);
 
-		if (errorMessage != NO_VIOLATIONS_DETECTED) {
+		if (!Objects.equals(errorMessage, NO_VIOLATIONS_DETECTED)) {
 			throw new IllegalStateException(errorMessage);
 		}
 	}
@@ -218,7 +219,7 @@ public class SpringExtension implements BeforeAllCallback, AfterAllCallback, Tes
 					published by other tests since the application context may be shared.""";
 		}, String.class);
 
-		if (errorMessage != NO_VIOLATIONS_DETECTED) {
+		if (!Objects.equals(errorMessage, NO_VIOLATIONS_DETECTED)) {
 			throw new IllegalStateException(errorMessage);
 		}
 	}


### PR DESCRIPTION
### Summary:

- Switched from direct reference (!=) to Objects.equals() for string comparisons to ensure consistent content comparison, null safety, and clearer code intention.
- Remove unused imports
