### PR TITLE
Allow capacity = 0 in `ConcurrentLruCache` again

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ConcurrentLruCache.java
+++ b/spring-core/src/main/java/org/springframework/util/ConcurrentLruCache.java
@@ -81,7 +81,7 @@ public final class ConcurrentLruCache<K, V> {
 	}
 
 	private ConcurrentLruCache(int capacity, Function<K, V> generator, int concurrencyLevel) {
-		Assert.isTrue(capacity > 0, "Capacity must be > 0");
+		Assert.isTrue(capacity >= 0, "Capacity must be >= 0");
 		this.capacity = capacity;
 		this.cache = new ConcurrentHashMap<>(16, 0.75f, concurrencyLevel);
 		this.generator = generator;


### PR DESCRIPTION
Fix for ConcurrentLruCache initialised with capacity = 0, previous behaviour allowed capacity = 0 (current public constructor allows it according to its javadoc)