### PR TITLE
Fix regression in JmsAccessor#setSessionAcknowledgeMode

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/support/JmsAccessor.java
+++ b/spring-jms/src/main/java/org/springframework/jms/support/JmsAccessor.java
@@ -167,8 +167,6 @@ public abstract class JmsAccessor implements InitializingBean {
 	 * @see jakarta.jms.Connection#createSession(boolean, int)
 	 */
 	public void setSessionAcknowledgeMode(int sessionAcknowledgeMode) {
-		Assert.isTrue(sessionConstants.containsValue(sessionAcknowledgeMode),
-				"Only values of acknowledge mode constants allowed");
 		this.sessionAcknowledgeMode = sessionAcknowledgeMode;
 	}
 

--- a/spring-jms/src/test/java/org/springframework/jms/support/JmsAccessorTests.java
+++ b/spring-jms/src/test/java/org/springframework/jms/support/JmsAccessorTests.java
@@ -98,8 +98,6 @@ class JmsAccessorTests {
 
 	@Test
 	void setSessionAcknowledgeMode() {
-		assertThatIllegalArgumentException().isThrownBy(() -> accessor.setSessionAcknowledgeMode(999));
-
 		accessor.setSessionAcknowledgeMode(Session.AUTO_ACKNOWLEDGE);
 		assertThat(accessor.getSessionAcknowledgeMode()).isEqualTo(Session.AUTO_ACKNOWLEDGE);
 
@@ -111,6 +109,9 @@ class JmsAccessorTests {
 
 		accessor.setSessionAcknowledgeMode(Session.SESSION_TRANSACTED);
 		assertThat(accessor.getSessionAcknowledgeMode()).isEqualTo(Session.SESSION_TRANSACTED);
+
+		accessor.setSessionAcknowledgeMode(999);
+		assertThat(accessor.getSessionAcknowledgeMode()).isEqualTo(999);
 	}
 
 	@Test


### PR DESCRIPTION
This commit partially reverts 3b8dd0a5, which introduced a strict validation in `JmsAccessor#setSessionAcknowledgeMode` that prevents use of vendor-specific acknowledge modes.

---

See also:
- https://github.com/spring-projects/spring-boot/pull/37576