### PR TITLE
Fix alias/name inversion in `SimpleAliasRegistry` and increase test coverage

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/SimpleAliasRegistry.java
+++ b/spring-core/src/main/java/org/springframework/core/SimpleAliasRegistry.java
@@ -195,7 +195,7 @@ public class SimpleAliasRegistry implements AliasRegistry {
 	 * @see #hasAlias
 	 */
 	protected void checkForAliasCircle(String name, String alias) {
-		if (hasAlias(alias, name)) {
+		if (hasAlias(name, alias)) {
 			throw new IllegalStateException("Cannot register alias '" + alias +
 					"' for name '" + name + "': Circular reference - '" +
 					name + "' is a direct or indirect alias for '" + alias + "' already");


### PR DESCRIPTION
I noticed that there was an inversion inside `checkForAliasCircle`, which was using `hasAlias(alias, name)`. However, the method signature should be `hasAlias(String name, String alias)`, so I corrected it. The tests didn't break, so I took the opportunity to increase the test coverage for untested methods.