### PR TITLE
Add Javadoc since for ExponentialBackOff.DEFAULT_MAX_ATTEMPTS

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/backoff/ExponentialBackOff.java
+++ b/spring-core/src/main/java/org/springframework/util/backoff/ExponentialBackOff.java
@@ -79,6 +79,7 @@ public class ExponentialBackOff implements BackOff {
 
 	/**
 	 * The default maximum attempts.
+	 * @since 6.1
 	 */
 	public static final int DEFAULT_MAX_ATTEMPTS = Integer.MAX_VALUE;
 


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `ExponentialBackOff.DEFAULT_MAX_ATTEMPTS`.

See gh-27071