### PR TITLE
Use schema-based config in sql-error-codes.xml

### DIFF
--- a/spring-jdbc/src/main/resources/org/springframework/jdbc/support/sql-error-codes.xml
+++ b/spring-jdbc/src/main/resources/org/springframework/jdbc/support/sql-error-codes.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
 	- Default SQL error codes for well-known databases.
@@ -12,7 +11,9 @@
 	- If this property is present, then it will be used instead of the id for
 	- looking up the error codes based on the current database.
 	-->
-<beans>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="DB2" name="Db2" class="org.springframework.jdbc.support.SQLErrorCodes">
 		<property name="databaseProductName">


### PR DESCRIPTION
This commit replaces the reference to the beans DTD in sql-error-codes.xml with the preferred schema-based configuration approach.

Apart from using the preferred approach as per the docs, this also closes #27332. 