### PR TITLE
EMFU#doGetTransactionalEntityManager to check for actual transaction

### DIFF
--- a/integration-tests/src/test/java/org/springframework/orm/jpa/SharedEntityManagerCreatorTransactionSyncTests.java
+++ b/integration-tests/src/test/java/org/springframework/orm/jpa/SharedEntityManagerCreatorTransactionSyncTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.jpa;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Query;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Arseniy Skvortsov
+ */
+@ExtendWith(MockitoExtension.class)
+public class SharedEntityManagerCreatorTransactionSyncTests {
+
+	@Test
+	public void noSharingInNeverPropagation() {
+		EntityManagerFactory emf = mock(EntityManagerFactory.class);
+		EntityManager em = mock(EntityManager.class);
+		var transactionManager = new JpaTransactionManager(emf);
+		//Could be also remedied by switching this to 'SYNCHRONIZATION_ON_ACTUAL_TRANSACTION'.
+		transactionManager.setTransactionSynchronization(AbstractPlatformTransactionManager.SYNCHRONIZATION_ALWAYS);
+		TransactionTemplate tt = new TransactionTemplate(transactionManager);
+		Query query = mock(Query.class);
+		given(emf.createEntityManager()).willReturn(em);
+		given(em.createQuery("x")).willReturn(query);
+		given(em.isOpen()).willReturn(true);
+		tt.setPropagationBehavior(TransactionDefinition.PROPAGATION_NEVER);
+		tt.executeWithoutResult(status -> {
+			SharedEntityManagerCreator
+					.createSharedEntityManager(emf)
+					.createQuery("x")
+					.executeUpdate();
+			verify(query).executeUpdate();
+			verify(em).close();
+		});
+	}
+}

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryUtils.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryUtils.java
@@ -245,7 +245,7 @@ public abstract class EntityManagerFactoryUtils {
 				}
 			}
 		}
-		else if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+		else if (!TransactionSynchronizationManager.isActualTransactionActive()) {
 			// Indicate that we can't obtain a transactional EntityManager.
 			return null;
 		}

--- a/spring-orm/src/test/java/org/springframework/orm/jpa/EntityManagerFactoryUtilsTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/jpa/EntityManagerFactoryUtilsTests.java
@@ -69,6 +69,7 @@ public class EntityManagerFactoryUtilsTests {
 			EntityManagerFactory factory = mock();
 			EntityManager manager = mock();
 
+			TransactionSynchronizationManager.setActualTransactionActive(true);
 			TransactionSynchronizationManager.initSynchronization();
 			given(factory.createEntityManager()).willReturn(manager);
 
@@ -77,6 +78,7 @@ public class EntityManagerFactoryUtilsTests {
 			assertThat(((EntityManagerHolder) TransactionSynchronizationManager.unbindResource(factory)).getEntityManager()).isSameAs(manager);
 		}
 		finally {
+			TransactionSynchronizationManager.setActualTransactionActive(false);
 			TransactionSynchronizationManager.clearSynchronization();
 		}
 


### PR DESCRIPTION
… rather than just a synchronization. Otherwise, at least SharedEntityManagerCreator will create a 'lingering' EM inside NEVER/NOT_SUPPORTED propagation, which is closed only after exiting from inside that boundary.

I did look at some other usage of isSynchronizationActive, and I'm not sure if it is more proper to use isActualTransactionActive there. I suspect this might be true for a couple of places.

isActualTransactionActive and doGetTransactionalEntityManager seem to be [around](https://github.com/spring-projects/spring-framework/blame/a3d7dc09ef7af361705704ca9f457b4901815663/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryUtils.java) [here](https://github.com/spring-projects/spring-framework/blame/main/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java) since before the recorded history, so we can't say if isActualTransactionActive was added after or before doGetTransactionalEntityManager.

Edit of #29430, which I messed up by pushing to main in my repository.