### PR TITLE
Remove redundant `static` declaration on `Search` class

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotations.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotations.java
@@ -507,7 +507,7 @@ public interface MergedAnnotations extends Iterable<MergedAnnotation<Annotation>
 	 *
 	 * @since 6.0
 	 */
-	static final class Search {
+	class Search {
 
 		static final Predicate<Class<?>> always = clazz -> true;
 

--- a/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotations.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotations.java
@@ -507,7 +507,7 @@ public interface MergedAnnotations extends Iterable<MergedAnnotation<Annotation>
 	 *
 	 * @since 6.0
 	 */
-	class Search {
+	final class Search {
 
 		static final Predicate<Class<?>> always = clazz -> true;
 


### PR DESCRIPTION
I found a very small mistake. : )

[9.3. Field (Constant) Declarations.](https://docs.oracle.com/javase/specs/jls/se17/html/jls-9.html#jls-9.3)

> Every field declaration in the body of an interface delaration is implicitly public, static, and final. It is permitted to redundantly specify any or all of these modifiers for such fields.