### PR TITLE
Replace deprecated method `getBuildDir()` in Gradle build

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/api/ApiDiffPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/api/ApiDiffPlugin.java
@@ -131,7 +131,8 @@ public class ApiDiffPlugin implements Plugin<Project> {
 	}
 
 	private File getOutputFile(String baseLineVersion, Project project) {
-		Path outDir = Paths.get(project.getRootProject().getBuildDir().getAbsolutePath(),
+		Path outDir = Paths.get(project.getRootProject()
+						.getLayout().getBuildDirectory().getAsFile().get().getAbsolutePath(),
 				"reports", "api-diff",
 				baseLineVersion + "_to_" + project.getRootProject().getVersion());
 		return project.file(outDir.resolve(project.getName() + ".html").toString());

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,7 +41,7 @@ rootProject.children.each {project ->
 settings.gradle.projectsLoaded {
 	gradleEnterprise {
 		buildScan {
-			File buildDir = settings.gradle.rootProject.getBuildDir()
+			File buildDir = settings.gradle.rootProject.getLayout().getBuildDirectory().getAsFile().get()
 			buildDir.mkdirs()
 			new File(buildDir, "build-scan-uri.txt").text = "(build scan not generated)"
 			buildScanPublished { scan ->


### PR DESCRIPTION
According to the [documentation ](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getBuildDir--), the method `getBuildDir()` is deprecated and should be replaced with `getLayout().getBuildDirectory()`.

The implementation of the deprecated method `getBuildDir()` is `org.gradle.api.internal.project.DefaultProject#getBuildDir`, and to be more explicit:
```
    @Deprecated
    public File getBuildDir() {
        return (File)this.getLayout().getBuildDirectory().getAsFile().get();
    }
```
Therefore, in order to remove the usage of the deprecated method and the warning, a solution is simply to apply the method's implementation directly in the code.