### PR TITLE
Update to io.freefair.aspectj 8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'io.freefair.aspectj' version '8.3' apply false
+	id 'io.freefair.aspectj' version '8.4' apply false
 	// kotlinVersion is managed in gradle.properties
 	id 'org.jetbrains.kotlin.plugin.serialization' version "${kotlinVersion}" apply false
 	id 'org.jetbrains.dokka' version '1.8.20'

--- a/spring-aspects/spring-aspects.gradle
+++ b/spring-aspects/spring-aspects.gradle
@@ -2,12 +2,6 @@ description = "Spring Aspects"
 
 apply plugin: "io.freefair.aspectj"
 
-sourceSets.main.aspectj.srcDir "src/main/java"
-sourceSets.main.java.srcDirs = files()
-
-sourceSets.test.aspectj.srcDir "src/test/java"
-sourceSets.test.java.srcDirs = files()
-
 compileAspectj {
 	sourceCompatibility "17"
 	targetCompatibility "17"


### PR DESCRIPTION
Starting with version 8.4 the custom configuration to change the source directory from `src/*/aspectj` to `src/*/java` is not necessary anymore.

see https://github.com/freefair/gradle-plugins/issues/881