### PR TITLE
Use of @Value in compact constructor of a record should not register method injection

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AutowiredAnnotationBeanPostProcessor.java
@@ -582,7 +582,7 @@ public class AutowiredAnnotationBeanPostProcessor implements SmartInstantiationA
 						}
 						return;
 					}
-					if (method.getParameterCount() == 0) {
+					if (!method.getDeclaringClass().isRecord() && method.getParameterCount() == 0) {
 						if (logger.isInfoEnabled()) {
 							logger.info("Autowired annotation should only be used on methods with parameters: " +
 									method);


### PR DESCRIPTION
When I try to use `@Value` annotation a record property, I get a warning in the logs that autowiring should only be used on methods with parameters. What that seems to imply is that attaching `@Value` on the property is actually attaching it on the generated method `property()`, which has no parameters.

Example:
```java
@Component
public record MyRecord(@Value("${myProp}") String prop) {}
```

Output:
```
02:21:15.043 [main] INFO  o.s.b.f.a.AutowiredAnnotationBeanPostProcessor - Autowired annotation should only be used on methods with parameters: public java.lang.String com.example.MyRecord.prop()
```

My fix is to just check first, if the bean is a record or not.