### PR TITLE
Enable checkstyle in buildSrc

### DIFF
--- a/buildSrc/config/checkstyle/checkstyle.xml
+++ b/buildSrc/config/checkstyle/checkstyle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+		"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+		"https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="com.puppycrawl.tools.checkstyle.Checker">
+
+	<!-- TreeWalker Checks -->
+	<module name="com.puppycrawl.tools.checkstyle.TreeWalker">
+
+		<!-- Imports -->
+		<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck">
+			<property name="processJavadoc" value="true"/>
+		</module>
+
+	</module>
+
+</module>


### PR DESCRIPTION
This PR applies the `UnusedImportsCheck` Checkstyle module to the `buildSrc`.

See gh-31305