### PR TITLE
JdbcTemplate should store generated keys only if database driver supports it 

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1568,6 +1568,10 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 	}
 
 	private void storeGeneratedKeys(KeyHolder generatedKeyHolder, PreparedStatement ps, int rowsExpected) throws SQLException {
+		if(!JdbcUtils.supportsGeneratedKeys(ps.getConnection())){
+			logger.trace("Generated keys is not supported");
+			return;
+		}
 		List<Map<String, Object>> generatedKeys = generatedKeyHolder.getKeyList();
 		ResultSet keys = ps.getGeneratedKeys();
 		if (keys != null) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcUtils.java
@@ -445,6 +445,33 @@ public abstract class JdbcUtils {
 	}
 
 	/**
+	 * Return whether the given JDBC driver supports JDBC generated keys.
+	 *
+	 * @param con
+	 *            the Connection to check
+	 * @return whether JDBC generated keys are supported
+	 * @see DatabaseMetaData#supportsGetGeneratedKeys() ()
+	 */
+	public static boolean supportsGeneratedKeys(Connection con) {
+		try {
+			DatabaseMetaData dbmd = con.getMetaData();
+			if (dbmd != null) {
+				if (dbmd.supportsGetGeneratedKeys()) {
+					logger.debug("JDBC driver supports generated keys");
+					return true;
+				}
+				else {
+					logger.debug("JDBC driver does not support generated keys");
+				}
+			}
+		}
+		catch (SQLException ex) {
+			logger.debug("JDBC driver 'supportsGeneratedKeys' method threw exception", ex);
+		}
+		return false;
+	}
+
+	/**
 	 * Extract a common name for the target database in use even if
 	 * various drivers/platforms provide varying names at runtime.
 	 * @param source the name as provided in database meta-data

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java
@@ -1112,6 +1112,7 @@ public class JdbcTemplateTests {
 		given(this.preparedStatement.executeBatch()).willReturn(rowsAffected);
 		DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
 		given(databaseMetaData.supportsBatchUpdates()).willReturn(true);
+		given(databaseMetaData.supportsGetGeneratedKeys()).willReturn(true);
 		given(this.connection.getMetaData()).willReturn(databaseMetaData);
 		ResultSet generatedKeysResultSet = mock(ResultSet.class);
 		ResultSetMetaData rsmd = mock(ResultSetMetaData.class);
@@ -1149,6 +1150,7 @@ public class JdbcTemplateTests {
 		given(this.preparedStatement.executeBatch()).willReturn(rowsAffected);
 		DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
 		given(databaseMetaData.supportsBatchUpdates()).willReturn(false);
+		given(databaseMetaData.supportsGetGeneratedKeys()).willReturn(true);
 		given(this.connection.getMetaData()).willReturn(databaseMetaData);
 		ResultSetMetaData rsmd = mock(ResultSetMetaData.class);
 		given(rsmd.getColumnCount()).willReturn(1);

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/JdbcUtilsTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/JdbcUtilsTests.java
@@ -16,11 +16,19 @@
 
 package org.springframework.jdbc.support;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
 import java.sql.Types;
 
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Unit tests for {@link JdbcUtils}.
@@ -55,6 +63,25 @@ public class JdbcUtilsTests {
 		assertThat(JdbcUtils.convertUnderscoreNameToPropertyName("yOUR_nAME")).isEqualTo("yourName");
 		assertThat(JdbcUtils.convertUnderscoreNameToPropertyName("a_name")).isEqualTo("AName");
 		assertThat(JdbcUtils.convertUnderscoreNameToPropertyName("someone_elses_name")).isEqualTo("someoneElsesName");
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	public void supportsGeneratedKeys(boolean supports) throws SQLException {
+		Connection con = mock();
+		DatabaseMetaData dmd = mock();
+		given(con.getMetaData()).willReturn(dmd);
+
+		assertThat(JdbcUtils.supportsGeneratedKeys(mockSupportsGetGeneratedKeys(supports))).isEqualTo(supports);
+	}
+
+	private Connection mockSupportsGetGeneratedKeys(boolean ret) throws SQLException {
+		Connection con = mock();
+		DatabaseMetaData dmd = mock();
+
+		given(con.getMetaData()).willReturn(dmd);
+		when(dmd.supportsGetGeneratedKeys()).thenReturn(ret);
+		return con;
 	}
 
 }


### PR DESCRIPTION
Not every database supports `PreparedStatement#getGeneratedKeys()`, for example, SQLLitle does not, and calling this method throws an exception, it has been discussed here: https://github.com/xerial/sqlite-jdbc/issues/996 

`JdbcTemplate`  calls `PreparedStatement#getGeneratedKeys()` whether it's supported or not, and in the case of SQLLitle, it causes an exception.

This PR changes the behavior of `JdbcTemplate` that it will call `PreparedStatement#getGeneratedKeys()` only if the underlying driver supports it by querying:  `DatabaseMetaData#supportsGetGeneratedKeys()`.