### PR TITLE
Resolve to empty `MultiValueMap` when no matrix variables are provided

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MatrixVariableMapMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/MatrixVariableMapMethodArgumentResolver.java
@@ -69,7 +69,7 @@ public class MatrixVariableMapMethodArgumentResolver implements HandlerMethodArg
 						HandlerMapping.MATRIX_VARIABLES_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
 
 		if (CollectionUtils.isEmpty(matrixVariables)) {
-			return Collections.emptyMap();
+			return (isSingleValueMap(parameter) ? Collections.emptyMap() : new LinkedMultiValueMap<>(0));
 		}
 
 		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/MatrixVariablesMapMethodArgumentResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/MatrixVariablesMapMethodArgumentResolverTests.java
@@ -156,6 +156,18 @@ public class MatrixVariablesMapMethodArgumentResolverTests {
 	}
 
 	@Test
+	public void resolveMultiValueMapArgumentNoParams() throws Exception {
+
+		MethodParameter param = this.testMethod.annot(matrixAttribute().noPathVar())
+				.arg(MultiValueMap.class, String.class, String.class);
+
+		Object result = this.resolver.resolveArgument(param, this.mavContainer, this.webRequest, null);
+
+		//noinspection unchecked
+		assertThat(result).isInstanceOfSatisfying(MultiValueMap.class, map -> assertThat(map).isEmpty());
+	}
+
+	@Test
 	public void resolveArgumentNoMatch() throws Exception {
 		MultiValueMap<String, String> params2 = getVariablesFor("planes");
 		params2.add("colors", "yellow");


### PR DESCRIPTION
When no matrix variables are provided to an endpoint with a `MultiValueMap` parameter, the argument should resolve to a `MultiValueMap`, not to `Collections.emptyMap()`.