### PR TITLE
Support direct shard database operation routing in Spring JDBC

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/ShardingKeyProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/ShardingKeyProvider.java
@@ -8,19 +8,10 @@ import org.springframework.lang.Nullable;
 /**
  * Interface defines methods for retrieving sharding keys, which are used to establish
  * direct shard connections (in the context of sharded databases). This is used as a
- * way of providing the sharding key, besides the thread-bound sharding keys in
+ * way of providing the sharding key in
  * {@link org.springframework.jdbc.datasource.ShardingKeyDataSourceAdapter}.
  *
- * <p>It is particularly useful in scenarios where using {@link DirectShardCallbackTemplate} is not
- * practical, like when the sharding key is independent of the specific query being executed.
- * For instance, the sharding key may depend on an HTTP session (authenticated user's data).</p>
- *
- * <p>In cases where used in parallel with {@link DirectShardCallbackTemplate}, the sharding key
- * provided in the {@link DirectShardCallbackTemplate} method is the one that will be used, and
- * not the one provided by {@link ShardingKeyProvider}.</p>
- *
  * @author Mohamed Lahyane (Anir)
- * @see DirectShardCallbackTemplate
  */
 
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/ShardingKeyProvider.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/ShardingKeyProvider.java
@@ -1,0 +1,47 @@
+package org.springframework.jdbc.core;
+
+import java.sql.SQLException;
+import java.sql.ShardingKey;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Interface defines methods for retrieving sharding keys, which are used to establish
+ * direct shard connections (in the context of sharded databases). This is used as a
+ * way of providing the sharding key, besides the thread-bound sharding keys in
+ * {@link org.springframework.jdbc.datasource.ShardingKeyDataSourceAdapter}.
+ *
+ * <p>It is particularly useful in scenarios where using {@link DirectShardCallbackTemplate} is not
+ * practical, like when the sharding key is independent of the specific query being executed.
+ * For instance, the sharding key may depend on an HTTP session (authenticated user's data).</p>
+ *
+ * <p>In cases where used in parallel with {@link DirectShardCallbackTemplate}, the sharding key
+ * provided in the {@link DirectShardCallbackTemplate} method is the one that will be used, and
+ * not the one provided by {@link ShardingKeyProvider}.</p>
+ *
+ * @author Mohamed Lahyane (Anir)
+ * @see DirectShardCallbackTemplate
+ */
+
+
+public interface ShardingKeyProvider {
+	/**
+	 * Retrieves the sharding key. This method returns the sharding key relevant to the current context,
+	 * which will be used to obtain a direct shard connection.
+	 *
+	 * @return The sharding key, or null if it is not available or cannot be determined.
+	 * @throws SQLException If an error occurs while obtaining the sharding key.
+	 */
+	@Nullable
+	ShardingKey getShardingKey() throws SQLException;
+
+	/**
+	 * Retrieves the super sharding key. This method returns the super sharding key relevant to the
+	 * current context, which will be used to obtain a direct shard connection.
+	 *
+	 * @return The super sharding key, or null if it is not available or cannot be determined.
+	 * @throws SQLException If an error occurs while obtaining the super sharding key.
+	 */
+	@Nullable
+	ShardingKey getSuperShardingKey() throws SQLException;
+}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/ShardingKeyDataSourceAdapter.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/ShardingKeyDataSourceAdapter.java
@@ -1,0 +1,195 @@
+package org.springframework.jdbc.datasource;
+
+import java.sql.Connection;
+import java.sql.ConnectionBuilder;
+import java.sql.SQLException;
+import java.sql.ShardingKey;
+import java.sql.ShardingKeyBuilder;
+
+import javax.sql.DataSource;
+
+import org.springframework.core.NamedThreadLocal;
+import org.springframework.jdbc.core.ShardingKeyProvider;
+import org.springframework.lang.Nullable;
+
+/**
+ * An adapter for a target {@link DataSource}, designed to apply sharding keys, if specified,
+ * to every standard {@code getConnection()} call, returning a direct connection to the shard
+ * corresponding to the specified sharding key value. All other methods are simply delegated
+ * to the corresponding methods of the target DataSource.
+ *
+ * <p>The target {@link DataSource} must implement the {@code createConnectionBuilder()} method;
+ * otherwise, a {@link java.sql.SQLFeatureNotSupportedException} will be thrown when attempting
+ * to acquire shard connections.</p>
+ *
+ * <p>This proxy datasource also takes a {@link ShardingKeyProvider} object as an attribute,
+ * which is used to get the sharding keys in case the thread-bound sharding key is null.</p>
+ *
+ * <p>This proxy is used internally by {@link org.springframework.jdbc.core.DirectShardCallbackTemplate}.</p>
+ *
+ * @author Mohamed Lahyane (Anir)
+ * @see #getConnection
+ * @see #createConnectionBuilder()
+ * @see UserCredentialsDataSourceAdapter
+ * @see org.springframework.jdbc.core.DirectShardCallbackTemplate
+ */
+public class ShardingKeyDataSourceAdapter extends DelegatingDataSource {
+
+	private final ThreadLocal<ShardingKey> threadBoundShardingKey =
+			new NamedThreadLocal<>("Current Sharding key");
+	private final ThreadLocal<ShardingKey> threadBoundSuperShardingKey =
+			new NamedThreadLocal<>("Current Super Sharding key");
+
+	@Nullable
+	private ShardingKeyProvider shardingkeyProvider;
+
+	/**
+	 * Creates a new instance of ShardingKeyDataSourceAdapter, wrapping the given {@link DataSource}.
+	 *
+	 * @param dataSource the target DataSource to be wrapped.
+	 */
+	public ShardingKeyDataSourceAdapter(DataSource dataSource) {
+		super(dataSource);
+	}
+
+	/**
+	 * Sets the {@link ShardingKeyProvider} for this adapter.
+	 *
+	 * @param shardingKeyProvider the ShardingKeyProvider to set.
+	 */
+	public void setShardingKeyProvider(ShardingKeyProvider shardingKeyProvider) {
+		this.shardingkeyProvider = shardingKeyProvider;
+	}
+
+	/**
+	 * Set the sharding key for the current thread.
+	 * The given sharding key will be used to get direct shard connections
+	 * in all subsequent {@code getConnection} calls on this DataSource proxy.
+	 *
+	 * @param shardingKey the sharding key to apply.
+	 * @see #removeShardingKeyFromCurrentThread()
+	 */
+	public void setShardingKeyForCurrentThread(ShardingKey shardingKey) {
+		this.threadBoundShardingKey.set(shardingKey);
+	}
+
+	/**
+	 * Sets the super sharding key for the current thread.
+	 *
+	 * @param superShardingKey the super sharding key to apply.
+	 * @see #setShardingKeyForCurrentThread
+	 */
+	public void setSuperShardingKeyForCurrentThread(ShardingKey superShardingKey) {
+		this.threadBoundSuperShardingKey.set(superShardingKey);
+	}
+
+	/**
+	 * Removes any {@code ShardingKey} for this proxy from the current thread.
+	 * @see #setShardingKeyForCurrentThread
+	 */
+	public void removeShardingKeyFromCurrentThread() {
+		this.threadBoundShardingKey.remove();
+	}
+
+	/**
+	 * Removes any super sharding key for this proxy from the current thread.
+	 * @see #setSuperShardingKeyForCurrentThread
+	 */
+	public void removeSuperShardingKeyFromCurrentThread() {
+		this.threadBoundSuperShardingKey.remove();
+	}
+
+	/**
+	 * Removes any sharding key and super sharding key for this proxy from the current thread.
+	 * @see #setShardingKeyForCurrentThread
+	 * @see #setSuperShardingKeyForCurrentThread
+	 */
+	public void clearShardingKeysFromCurrentThread() {
+		removeShardingKeyFromCurrentThread();
+		removeSuperShardingKeyFromCurrentThread();
+	}
+
+	/**
+	 * Obtains a connection to the database shard using the provided sharding key
+	 * and super sharding key (if available).
+	 * <p>the sharding key is obtained from the thread local storage, if is {@code null},
+	 * it is obtained from the {@link ShardingKeyProvider}.</p>
+	 *
+	 * @return a Connection object representing a direct shard connection.
+	 * @throws SQLException if an error occurs while creating the connection.
+	 * @see #createConnectionBuilder()
+	 */
+	@Override
+	public Connection getConnection() throws SQLException {
+		return createConnectionBuilder().build();
+	}
+
+	/**
+	 * Obtains a connection to the database shard using the provided username and password,
+	 * considering the sharding keys (if available) and the given credentials.
+	 *
+	 * @param username the database user on whose behalf the connection is being made.
+	 * @param password the user's password.
+	 * @return a Connection object representing a direct shard connection.
+	 * @throws SQLException if an error occurs while creating the connection.
+	 */
+	@Override
+	public Connection getConnection(String username, String password) throws SQLException {
+		return createConnectionBuilder().user(username).password(password).build();
+	}
+
+	/**
+	 * Creates a new instance of {@link ConnectionBuilder} using the target DataSource's
+	 * {@code createConnectionBuilder()} method, and sets the appropriate sharding keys
+	 * from the thread-local storage or the {@link ShardingKeyProvider}.
+	 *
+	 * @return a ConnectionBuilder object representing a builder for direct shard connections.
+	 * @throws SQLException if an error occurs while creating the ConnectionBuilder.
+	 */
+	@Override
+	public ConnectionBuilder createConnectionBuilder() throws SQLException {
+		ConnectionBuilder connectionBuilder = obtainTargetDataSource().createConnectionBuilder();
+
+		ShardingKey shardingKey = this.threadBoundShardingKey.get();
+		ShardingKey superShardingKey = this.threadBoundSuperShardingKey.get();
+
+		if (shardingKey == null && shardingkeyProvider != null) {
+			shardingKey = shardingkeyProvider.getShardingKey();
+			superShardingKey = shardingkeyProvider.getSuperShardingKey();
+		}
+
+		return connectionBuilder.shardingKey(shardingKey).superShardingKey(superShardingKey);
+	}
+
+	/**
+	 * Creates a new instance of {@link ShardingKeyBuilder} using the target DataSource's
+	 * {@code createShardingKeyBuilder()} method.
+	 *
+	 * @return a ShardingKeyBuilder object representing a builder for sharding keys.
+	 * @throws SQLException if an error occurs while creating the ShardingKeyBuilder.
+	 */
+	@Override
+	public ShardingKeyBuilder createShardingKeyBuilder() throws SQLException {
+		return obtainTargetDataSource().createShardingKeyBuilder();
+	}
+
+	/**
+	 * Retrieves the sharding key bound to the current thread, if any.
+	 *
+	 * @return the ShardingKey object representing the sharding key for the current thread, or null if none is bound.
+	 */
+	@Nullable
+	public ShardingKey getShardingKeyForCurrentThread() {
+		return this.threadBoundShardingKey.get();
+	}
+
+	/**
+	 * Retrieves the super sharding key bound to the current thread, if any.
+	 *
+	 * @return the ShardingKey object representing the super sharding key for the current thread, or null if none is bound.
+	 */
+	@Nullable
+	public ShardingKey getSuperShardingKeyForCurrentThread() {
+		return this.threadBoundSuperShardingKey.get();
+	}
+}

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/ShardingKeyDataSourceAdapterTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/ShardingKeyDataSourceAdapterTests.java
@@ -1,0 +1,119 @@
+package org.springframework.jdbc.datasource;
+
+import java.sql.Connection;
+import java.sql.ConnectionBuilder;
+import java.sql.SQLException;
+import java.sql.ShardingKey;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.jdbc.core.ShardingKeyProvider;
+import org.springframework.lang.Nullable;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+public class ShardingKeyDataSourceAdapterTests {
+	private final Connection connection = mock();
+	private final Connection shardConnection = mock();
+	private final DataSource dataSource = mock(DataSource.class, RETURNS_DEEP_STUBS);
+	private final ConnectionBuilder connectionBuilder = mock(ConnectionBuilder.class, RETURNS_DEEP_STUBS);
+	private final ConnectionBuilder shardConnectionBuilder = mock();
+
+	@Test
+	public void testThreadBoundShardingKeys() throws SQLException {
+		ShardingKeyDataSourceAdapter dataSourceAdapter = new ShardingKeyDataSourceAdapter(dataSource);
+		ShardingKey shardingKey = mock();
+		ShardingKey superShardingKey = mock();
+
+		given(this.dataSource.createConnectionBuilder()).willReturn(this.connectionBuilder);
+		when(this.connectionBuilder.shardingKey(shardingKey).superShardingKey(superShardingKey)).thenReturn(this.shardConnectionBuilder);
+		given(this.shardConnectionBuilder.build()).willReturn(this.shardConnection);
+
+		dataSourceAdapter.setShardingKeyForCurrentThread(shardingKey);
+		dataSourceAdapter.setSuperShardingKeyForCurrentThread(superShardingKey);
+
+		assertThat(dataSourceAdapter.getConnection()).isEqualTo(shardConnection);
+	}
+
+	@Test
+	public void testThreadBoundShardingKeyAndProviderAreNotNull() throws SQLException {
+		ShardingKey providerKey = mock();
+		ShardingKey threadBoundKey = mock();
+		Connection providerKeyShardConn = mock();
+		Connection threadBoundShardConn = mock();
+
+		Connection resultConnection = getShardedConnection(providerKey, threadBoundKey, providerKeyShardConn, threadBoundShardConn);
+		assertThat(resultConnection).isEqualTo(threadBoundShardConn);
+	}
+
+	@Test
+	public void testThreadBoundKeyIsNullAndProviderKeyIsNotNull() throws SQLException {
+		ShardingKey providerKey = mock();
+		ShardingKey threadBoundKey = null;
+		Connection providerKeyShardConn = mock();
+		Connection threadBoundShardConn = mock();
+
+		Connection resultConnection = getShardedConnection(providerKey, threadBoundKey, providerKeyShardConn, threadBoundShardConn);
+		assertThat(resultConnection).isEqualTo(providerKeyShardConn);
+	}
+
+
+	@Test
+	public void testThreadBoundShardingKeyAndProviderAreNull() throws SQLException {
+		ShardingKey providerKey = null;
+		ShardingKey threadBoundKey = null;
+		Connection providerKeyShardConn = mock();
+		Connection threadBoundShardConn = mock();
+
+		Connection resultConnection = getShardedConnection(providerKey, threadBoundKey, providerKeyShardConn, threadBoundShardConn);
+		assertThat(resultConnection).isEqualTo(this.connection);
+	}
+
+	@Test
+	public void testConnectionWithUsernameAndPassword() throws SQLException {
+		ShardingKeyDataSourceAdapter shardingKeyDataSourceAdapter = new ShardingKeyDataSourceAdapter(dataSource);
+		ShardingKey shardingKey = mock();
+		ShardingKey superShardingKey = mock();
+		String username = "anir";
+		String password = "spring";
+
+		given(this.dataSource.createConnectionBuilder()).willReturn(this.connectionBuilder);
+		when(this.connectionBuilder.shardingKey(shardingKey).superShardingKey(superShardingKey)).thenReturn(this.connectionBuilder);
+		when(this.connectionBuilder.user(username).password(password).build()).thenReturn(this.connection);
+
+		shardingKeyDataSourceAdapter.setShardingKeyForCurrentThread(shardingKey);
+		shardingKeyDataSourceAdapter.setSuperShardingKeyForCurrentThread(superShardingKey);
+
+		Connection resultConnection = shardingKeyDataSourceAdapter.getConnection(username, password);
+
+		Assertions.assertEquals(this.connection, resultConnection);
+	}
+
+	private Connection getShardedConnection(@Nullable ShardingKey providerKey, @Nullable ShardingKey threadBoundKey, Connection providerKeyShardConn, Connection threadBoundShardConn) throws SQLException {
+		ShardingKeyProvider provider = mock();
+		ConnectionBuilder providerConnectionBuilder = mock();
+		ConnectionBuilder threadBoundConnectionBuilder = mock();
+
+		given(this.dataSource.createConnectionBuilder()).willReturn(this.connectionBuilder);
+		when(this.connectionBuilder.shardingKey(providerKey).superShardingKey(null)).thenReturn(providerConnectionBuilder);
+		when(this.connectionBuilder.shardingKey(threadBoundKey).superShardingKey(null)).thenReturn(threadBoundConnectionBuilder);
+
+		when(this.connectionBuilder.shardingKey(null).superShardingKey(null)).thenReturn(this.connectionBuilder);
+		given(this.connectionBuilder.build()).willReturn(this.connection);
+
+		given(providerConnectionBuilder.build()).willReturn(providerKeyShardConn);
+		given(threadBoundConnectionBuilder.build()).willReturn(threadBoundShardConn);
+		given(provider.getShardingKey()).willReturn(providerKey);
+		given(provider.getSuperShardingKey()).willReturn(null);
+
+		ShardingKeyDataSourceAdapter dataSourceAdapter = new ShardingKeyDataSourceAdapter(dataSource);
+		dataSourceAdapter.setShardingKeyForCurrentThread(threadBoundKey);
+		dataSourceAdapter.setShardingKeyProvider(provider);
+
+		return dataSourceAdapter.getConnection();
+	}
+}


### PR DESCRIPTION
This PR is a follow up to https://github.com/spring-projects/spring-framework/pull/30988.
Goal is to add support for direct database operation routing in sharded databases in Spring JDBC. 

This functionality is achieved by acquiring a shard connection through the JDBC API 
DataSource.createConnectionBuilder().shardingKey(key).build().

In this PR we will focus on one of the two approaches that were introduced in the previous PR.

We introduce a DataSource adapter class that applies sharding keys to every standard getConnection() call. The sharding keys are specified through a ShardingKeyProvider object.

Here's an example of how to use it:

```java
ShardingKeyDataSourceAdapter dataSourceAdapter = new ShardingKeyDataSourceAdapter(dataSource);

dataSourceAdapter.setShardingKeyProvider(new ShardingKeyProvider() {
    public ShardingKey getShardingKey() throws SQLException {
        // Example: The sharding key is derived from the user name.
        String name = SecurityContextHolder.getContext().getAuthentication().getName();
        return dataSource.createShardingKeyBuilder().subKey(name, JDBCType.VARCHAR).build();
    }
    
    public ShardingKey getSuperShardingKey() throws SQLException {
        return null;
    }
});

JdbcTemplate shardingJdbcTemplate = new JdbcTemplate(dataSourceAdapter);

// The SQL query will be executed directly in the shard corresponding 
// to the sharding key returned from the ShardingKeyProvider.getShardingKey() method.
shardingJdbcTemplate.execute(SQL);
```