### PR TITLE
Support "--" end of options in SimpleCommandLineArgsParser

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/env/SimpleCommandLineArgsParserTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/SimpleCommandLineArgsParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  *
  * @author Chris Beams
  * @author Sam Brannen
+ * @author Brian Clozel
  */
 class SimpleCommandLineArgsParserTests {
 
@@ -64,11 +65,6 @@ class SimpleCommandLineArgsParserTests {
 		assertThat(args.getOptionValues("o1")).containsExactly("v1");
 		assertThat(args.getOptionValues("o2")).isEqualTo(Collections.EMPTY_LIST);
 		assertThat(args.getOptionValues("o3")).isNull();
-	}
-
-	@Test
-	void withEmptyOptionText() {
-		assertThatIllegalArgumentException().isThrownBy(() -> parser.parse("--"));
 	}
 
 	@Test
@@ -110,6 +106,15 @@ class SimpleCommandLineArgsParserTests {
 		CommandLineArgs args = new SimpleCommandLineArgsParser().parse();
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() ->
 				args.getNonOptionArgs().add("foo"));
+	}
+
+	@Test
+	void supportsEndOfOptionsDelimiter() {
+		CommandLineArgs args = parser.parse("--o1=v1", "--", "--o2=v2");
+		assertThat(args.containsOption("o1")).isTrue();
+		assertThat(args.containsOption("o2")).isFalse();
+		assertThat(args.getOptionValues("o1")).containsExactly("v1");
+		assertThat(args.getNonOptionArgs()).contains("--o2=v2");
 	}
 
 }


### PR DESCRIPTION
Prior to this commit, the `SimpleCommandLineArgsParser` would reject
"--" arguments as invalid. As reported by the community, the POSIX
utility conventions (Guideline 10) state that

> The first -- argument that is not an option-argument should be
> accepted as a delimiter indicating the end of options.
> Any following arguments should be treated as operands, even if they
> begin with the '-' character.

This commit updates `SimpleCommandLineArgsParser` to not reject "--"
arguments and instead to consider remaining arguments as non-optional.

Fixes gh-21949
