### PR TITLE
Restore support for recursive annotations in Kotlin

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMapping.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMapping.java
@@ -103,8 +103,8 @@ final class AnnotationTypeMapping {
 	private final Set<Method> claimedAliases = new HashSet<>();
 
 
-	AnnotationTypeMapping(@Nullable AnnotationTypeMapping source,
-			Class<? extends Annotation> annotationType, @Nullable Annotation annotation) {
+	AnnotationTypeMapping(@Nullable AnnotationTypeMapping source, Class<? extends Annotation> annotationType,
+    		@Nullable Annotation annotation, Set<Class<? extends Annotation>> visitedAnnotationTypes) {
 
 		this.source = source;
 		this.root = (source != null ? source.getRoot() : this);
@@ -124,7 +124,7 @@ final class AnnotationTypeMapping {
 		processAliases();
 		addConventionMappings();
 		addConventionAnnotationValues();
-		this.synthesizable = computeSynthesizableFlag();
+		this.synthesizable = computeSynthesizableFlag(visitedAnnotationTypes);
 	}
 
 
@@ -374,7 +374,10 @@ final class AnnotationTypeMapping {
 	}
 
 	@SuppressWarnings("unchecked")
-	private boolean computeSynthesizableFlag() {
+	private boolean computeSynthesizableFlag(Set<Class<? extends Annotation>> visitedAnnotationTypes) {
+		// Track that we have visited the current annotation type.
+		visitedAnnotationTypes.add(this.annotationType);
+
 		// Uses @AliasFor for local aliases?
 		for (int index : this.aliasMappings) {
 			if (index != -1) {
@@ -403,8 +406,12 @@ final class AnnotationTypeMapping {
 				if (type.isAnnotation() || (type.isArray() && type.componentType().isAnnotation())) {
 					Class<? extends Annotation> annotationType =
 							(Class<? extends Annotation>) (type.isAnnotation() ? type : type.componentType());
-					if (annotationType != this.annotationType) {
-						AnnotationTypeMapping mapping = AnnotationTypeMappings.forAnnotationType(annotationType).get(0);
+					// Ensure we have not yet visited the current nested annotation type, in order
+					// to avoid infinite recursion for JVM languages other than Java that support
+					// recursive annotation definitions.
+					if (visitedAnnotationTypes.add(annotationType)) {
+						AnnotationTypeMapping mapping =
+								AnnotationTypeMappings.forAnnotationType(annotationType, visitedAnnotationTypes).get(0);
 						if (mapping.isSynthesizable()) {
 							return true;
 						}

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,10 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.ConcurrentReferenceHashMap;
@@ -40,6 +42,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  * be searched once, regardless of how many times they are actually used.
  *
  * @author Phillip Webb
+ * @author Sam Brannen
  * @since 5.2
  * @see AnnotationTypeMapping
  */
@@ -60,19 +63,21 @@ final class AnnotationTypeMappings {
 
 
 	private AnnotationTypeMappings(RepeatableContainers repeatableContainers,
-			AnnotationFilter filter, Class<? extends Annotation> annotationType) {
+			AnnotationFilter filter, Class<? extends Annotation> annotationType,
+		    Set<Class<? extends Annotation>> visitedAnnotationTypes) {
 
 		this.repeatableContainers = repeatableContainers;
 		this.filter = filter;
 		this.mappings = new ArrayList<>();
-		addAllMappings(annotationType);
+		addAllMappings(annotationType, visitedAnnotationTypes);
 		this.mappings.forEach(AnnotationTypeMapping::afterAllMappingsSet);
 	}
 
 
-	private void addAllMappings(Class<? extends Annotation> annotationType) {
+	private void addAllMappings(Class<? extends Annotation> annotationType,
+			Set<Class<? extends Annotation>> visitedAnnotationTypes) {
 		Deque<AnnotationTypeMapping> queue = new ArrayDeque<>();
-		addIfPossible(queue, null, annotationType, null);
+		addIfPossible(queue, null, annotationType, null, visitedAnnotationTypes);
 		while (!queue.isEmpty()) {
 			AnnotationTypeMapping mapping = queue.removeFirst();
 			this.mappings.add(mapping);
@@ -102,14 +107,15 @@ final class AnnotationTypeMappings {
 	}
 
 	private void addIfPossible(Deque<AnnotationTypeMapping> queue, AnnotationTypeMapping source, Annotation ann) {
-		addIfPossible(queue, source, ann.annotationType(), ann);
+		addIfPossible(queue, source, ann.annotationType(), ann, new HashSet<>());
 	}
 
 	private void addIfPossible(Deque<AnnotationTypeMapping> queue, @Nullable AnnotationTypeMapping source,
-			Class<? extends Annotation> annotationType, @Nullable Annotation ann) {
+			Class<? extends Annotation> annotationType, @Nullable Annotation ann,
+		    Set<Class<? extends Annotation>> visitedAnnotationTypes) {
 
 		try {
-			queue.addLast(new AnnotationTypeMapping(source, annotationType, ann));
+			queue.addLast(new AnnotationTypeMapping(source, annotationType, ann, visitedAnnotationTypes));
 		}
 		catch (Exception ex) {
 			AnnotationUtils.rethrowAnnotationConfigurationException(ex);
@@ -166,20 +172,22 @@ final class AnnotationTypeMappings {
 	 * @return type mappings for the annotation type
 	 */
 	static AnnotationTypeMappings forAnnotationType(Class<? extends Annotation> annotationType) {
-		return forAnnotationType(annotationType, AnnotationFilter.PLAIN);
+		return forAnnotationType(annotationType, new HashSet<>());
 	}
 
 	/**
 	 * Create {@link AnnotationTypeMappings} for the specified annotation type.
 	 * @param annotationType the source annotation type
-	 * @param annotationFilter the annotation filter used to limit which
-	 * annotations are considered
+	 * @param visitedAnnotationTypes the set of annotations that we have already
+	 * visited; used to avoid infinite recursion for recursive annotations which
+	 * some JVM languages support (such as Kotlin)
 	 * @return type mappings for the annotation type
 	 */
-	static AnnotationTypeMappings forAnnotationType(
-			Class<? extends Annotation> annotationType, AnnotationFilter annotationFilter) {
+	static AnnotationTypeMappings forAnnotationType(Class<? extends Annotation> annotationType,
+			Set<Class<? extends Annotation>> visitedAnnotationTypes) {
 
-		return forAnnotationType(annotationType, RepeatableContainers.standardRepeatables(), annotationFilter);
+		return forAnnotationType(annotationType, RepeatableContainers.standardRepeatables(),
+				AnnotationFilter.PLAIN, visitedAnnotationTypes);
 	}
 
 	/**
@@ -194,15 +202,35 @@ final class AnnotationTypeMappings {
 	static AnnotationTypeMappings forAnnotationType(Class<? extends Annotation> annotationType,
 			RepeatableContainers repeatableContainers, AnnotationFilter annotationFilter) {
 
+		return forAnnotationType(annotationType, repeatableContainers, annotationFilter, new HashSet<>());
+	}
+
+	/**
+	 * Create {@link AnnotationTypeMappings} for the specified annotation type.
+	 * @param annotationType the source annotation type
+	 * @param repeatableContainers the repeatable containers that may be used by
+	 * the meta-annotations
+	 * @param annotationFilter the annotation filter used to limit which
+	 * annotations are considered
+	 * @param visitedAnnotationTypes the set of annotations that we have already
+	 * visited; used to avoid infinite recursion for recursive annotations which
+	 * some JVM languages support (such as Kotlin)
+	 * @return type mappings for the annotation type
+	 */
+	static AnnotationTypeMappings forAnnotationType(Class<? extends Annotation> annotationType,
+			RepeatableContainers repeatableContainers, AnnotationFilter annotationFilter,
+			Set<Class<? extends Annotation>> visitedAnnotationTypes) {
+
 		if (repeatableContainers == RepeatableContainers.standardRepeatables()) {
 			return standardRepeatablesCache.computeIfAbsent(annotationFilter,
-					key -> new Cache(repeatableContainers, key)).get(annotationType);
+					key -> new Cache(repeatableContainers, key)).get(annotationType, visitedAnnotationTypes);
 		}
 		if (repeatableContainers == RepeatableContainers.none()) {
 			return noRepeatablesCache.computeIfAbsent(annotationFilter,
-					key -> new Cache(repeatableContainers, key)).get(annotationType);
+					key -> new Cache(repeatableContainers, key)).get(annotationType, visitedAnnotationTypes);
 		}
-		return new AnnotationTypeMappings(repeatableContainers, annotationFilter, annotationType);
+		return new AnnotationTypeMappings(repeatableContainers, annotationFilter, annotationType,
+				visitedAnnotationTypes);
 	}
 
 	static void clearCache() {
@@ -235,14 +263,20 @@ final class AnnotationTypeMappings {
 		/**
 		 * Get or create {@link AnnotationTypeMappings} for the specified annotation type.
 		 * @param annotationType the annotation type
+		 * @param visitedAnnotationTypes the set of annotations that we have already
+		 * visited; used to avoid infinite recursion for recursive annotations which
+		 * some JVM languages support (such as Kotlin)
 		 * @return a new or existing {@link AnnotationTypeMappings} instance
 		 */
-		AnnotationTypeMappings get(Class<? extends Annotation> annotationType) {
-			return this.mappings.computeIfAbsent(annotationType, this::createMappings);
+		AnnotationTypeMappings get(Class<? extends Annotation> annotationType,
+	    		Set<Class<? extends Annotation>> visitedAnnotationTypes) {
+			return this.mappings.computeIfAbsent(annotationType, key -> createMappings(key, visitedAnnotationTypes));
 		}
 
-		AnnotationTypeMappings createMappings(Class<? extends Annotation> annotationType) {
-			return new AnnotationTypeMappings(this.repeatableContainers, this.filter, annotationType);
+		private AnnotationTypeMappings createMappings(Class<? extends Annotation> annotationType,
+	    		Set<Class<? extends Annotation>> visitedAnnotationTypes) {
+			return new AnnotationTypeMappings(this.repeatableContainers, this.filter, annotationType,
+					visitedAnnotationTypes);
 		}
 	}
 

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ class AnnotationTypeMappingsTests {
 	@Test
 	void forAnnotationTypeWhenRepeatableMetaAnnotationIsFiltered() {
 		AnnotationTypeMappings mappings = AnnotationTypeMappings.forAnnotationType(WithRepeatedMetaAnnotations.class,
-				Repeating.class.getName()::equals);
+				RepeatableContainers.standardRepeatables(), Repeating.class.getName()::equals);
 		assertThat(getAll(mappings)).flatExtracting(AnnotationTypeMapping::getAnnotationType)
 				.containsExactly(WithRepeatedMetaAnnotations.class);
 	}

--- a/spring-core/src/test/kotlin/org/springframework/core/annotation/FilterWithAlias.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/annotation/FilterWithAlias.kt
@@ -1,0 +1,31 @@
+/*
+  * Copyright 2002-2023 the original author or authors.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      https://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package org.springframework.core.annotation
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FilterWithAlias(
+
+	@get:AliasFor("name")
+	val value: String = "",
+
+	@get:AliasFor("value")
+	val name: String = "",
+
+	val and: FiltersWithoutAlias = FiltersWithoutAlias()
+
+)

--- a/spring-core/src/test/kotlin/org/springframework/core/annotation/FiltersWithoutAlias.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/annotation/FiltersWithoutAlias.kt
@@ -1,0 +1,25 @@
+/*
+  * Copyright 2002-2023 the original author or authors.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      https://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package org.springframework.core.annotation
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class FiltersWithoutAlias(
+
+	vararg val value: FilterWithAlias
+
+)


### PR DESCRIPTION
This PR resolves https://github.com/spring-projects/spring-framework/issues/31400 (follow up).

It effectively reverts:
- (1): https://github.com/spring-projects/spring-framework/commit/bf9f261b9512a3d0f84844dfa75943a231ed5a87
- (2): https://github.com/spring-projects/spring-framework/commit/5459304a4b5e8dc6ce08ff8d9e09228ab7d72659

### (1)
This commit removed the support for cycling annotations, because it was assumed that Kotlin will no longer support them starting with `1.9.0`. 

Kotlin only removed support for direct cycles.
For example:
```kotlin
annotation class X(val value: X)
annotation class X1(val value: X2)
annotation class X2(val value: X1)
```
This code will not compile with  >= `1.9.0`

However, Kotlin did not remove support for indirect cycles.
For example:
```kotlin
annotation class Y1(val value: Array<Y1>)
annotation class Y2(vararg val value: Y2)

annotation class Z1(val value: Z2)
annotation class Z2(val value: Array<Z1>)

annotation class Z3(val value: Z4)
annotation class Z4(vararg val value: Z3)
```
This code is valid and will compile, because the cycle includes an array.

### (2)
This commit restored part of the recursive annotation support, but missed the nested cycles. Hence, the implementation is not sufficient to support Kotlin annotations.

**Please note that this PR will not add any new logic, but only restores the implementation before https://github.com/spring-projects/spring-framework/commit/bf9f261b9512a3d0f84844dfa75943a231ed5a87**