### PR TITLE
Add Kotlin extension for `PropertyResolver#getProperty(String, Class<T>, T)`

### DIFF
--- a/spring-core/src/main/kotlin/org/springframework/core/env/PropertyResolverExtensions.kt
+++ b/spring-core/src/main/kotlin/org/springframework/core/env/PropertyResolverExtensions.kt
@@ -43,6 +43,16 @@ inline fun <reified T> PropertyResolver.getProperty(key: String) : T? =
 		getProperty(key, T::class.java)
 
 /**
+ * Extension for [PropertyResolver.getProperty] providing a `getProperty<Foo>(...)`
+ * variant returning a non-nullable `Foo` with a default value.
+ *
+ * @author John Burns
+ * @since 6.1
+ */
+inline fun <reified T : Any> PropertyResolver.getProperty(key: String, default: T) : T =
+	getProperty(key, T::class.java, default)
+
+/**
  * Extension for [PropertyResolver.getRequiredProperty] providing a
  * `getRequiredProperty<Foo>(...)` variant.
  *

--- a/spring-core/src/test/kotlin/org/springframework/core/env/PropertyResolverExtensionsKotlinTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/env/PropertyResolverExtensionsKotlinTests.kt
@@ -19,7 +19,7 @@ package org.springframework.core.env
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Disabled
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 /**
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test
  *
  * @author Sebastien Deleuze
  */
-@Disabled
 class PropertyResolverExtensionsKotlinTests {
 
 	val propertyResolver = mockk<PropertyResolver>()
@@ -44,6 +43,13 @@ class PropertyResolverExtensionsKotlinTests {
 		every { propertyResolver.getProperty("name", String::class.java) } returns "foo"
 		propertyResolver.getProperty<String>("name")
 		verify { propertyResolver.getProperty("name", String::class.java) }
+	}
+
+	@Test
+	fun `getProperty with default extension`() {
+		every { propertyResolver.getProperty("name", String::class.java, "default") } returns "default"
+		assertThat(propertyResolver.getProperty<String>("name", "default")).isEqualTo("default")
+		verify { propertyResolver.getProperty("name", String::class.java, "default") }
 	}
 
 	@Test


### PR DESCRIPTION
Allows Kotlin caller to get a non-nullable property, using a default value when the property is not set. A method already exists on PropertyResolver which does this, but takes a type parameter.
The extension method can eliminate the parameter via reified type, similar to the other extension methods which exist already.

Remove `@Disabled` from PropertyResolverExtensionsKotlinTests to allow tests to run