### PR TITLE
Improve method validation support for errors on elements within a container

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/method/ParameterErrors.java
+++ b/spring-context/src/main/java/org/springframework/validation/method/ParameterErrors.java
@@ -32,11 +32,10 @@ import org.springframework.validation.ObjectError;
  * {@link Errors#getAllErrors()}, but this subclass provides access to the same
  * as {@link FieldError}s.
  *
- * <p>When the method parameter is a {@link List} or {@link java.util.Map},
- * a separate {@link ParameterErrors} is created for each list or map value for
- * which there are validation errors. In such cases, the {@link #getContainer()}
- * method returns the list or map, while {@link #getContainerIndex()}
- * and {@link #getContainerKey()} return the value index or key.
+ * <p>When the method parameter is a multi-element container like {@link List} or
+ * {@link java.util.Map}, a separate {@link ParameterErrors} is created for each
+ * value for which there are validation errors. Otherwise, only a single
+ * {@link ParameterErrors} will be created.
  *
  * @author Rossen Stoyanchev
  * @since 6.1
@@ -71,11 +70,12 @@ public class ParameterErrors extends ParameterValidationResult implements Errors
 
 
 	/**
-	 * When {@code @Valid} is declared on a {@link List} or {@link java.util.Map}
-	 * method parameter, this method returns the list or map that contained the
-	 * validated object {@link #getArgument() argument}, while
-	 * {@link #getContainerIndex()} and {@link #getContainerKey()} returns the
-	 * respective index or key.
+	 * When {@code @Valid} is declared on a container type method parameter such as
+	 * {@link java.util.Collection}, {@link java.util.Optional} or {@link java.util.Map},
+	 * this method returns the parent that contained the validated object
+	 * {@link #getArgument() argument}, while {@link #getContainerIndex()} and
+	 * {@link #getContainerKey()} returns the respective index or key if the parameter's
+	 * datatype supports such access.
 	 */
 	@Nullable
 	public Object getContainer() {
@@ -83,9 +83,10 @@ public class ParameterErrors extends ParameterValidationResult implements Errors
 	}
 
 	/**
-	 * When {@code @Valid} is declared on a {@link List}, this method returns
-	 * the index under which the validated object {@link #getArgument() argument}
-	 * is stored in the list {@link #getContainer() container}.
+	 * When {@code @Valid} is declared on an indexed type, such as {@link List},
+	 * this method returns the index under which the validated object
+	 * {@link #getArgument() argument} is stored in the list
+	 * {@link #getContainer() container}.
 	 */
 	@Nullable
 	public Integer getContainerIndex() {
@@ -93,8 +94,8 @@ public class ParameterErrors extends ParameterValidationResult implements Errors
 	}
 
 	/**
-	 * When {@code @Valid} is declared on a {@link java.util.Map}, this method
-	 * returns the key under which the validated object {@link #getArgument()
+	 * When {@code @Valid} is declared on a keyed typed, such as {@link java.util.Map},
+	 * this method returns the key under which the validated object {@link #getArgument()
 	 * argument} is stored in the map {@link #getContainer()}.
 	 */
 	@Nullable

--- a/spring-context/src/test/java/org/springframework/validation/beanvalidation/MethodValidationAdapterTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/beanvalidation/MethodValidationAdapterTests.java
@@ -17,13 +17,16 @@
 package org.springframework.validation.beanvalidation;
 
 import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,9 +50,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class MethodValidationAdapterTests {
 
-	private static final Person faustino1234 = new Person("Faustino1234");
+	private static final Person faustino1234 = new Person("Faustino1234", List.of("Working on Spring"));
 
-	private static final Person cayetana6789 = new Person("Cayetana6789");
+	private static final Person cayetana6789 = new Person("Cayetana6789", List.of("  "));
 
 
 	private final MethodValidationAdapter validationAdapter = new MethodValidationAdapter();
@@ -88,7 +91,13 @@ public class MethodValidationAdapterTests {
 				codes [Size.guardian.name,Size.name,Size.java.lang.String,Size]; \
 				arguments [org.springframework.context.support.DefaultMessageSourceResolvable: \
 				codes [guardian.name,name]; arguments []; default message [name],10,1]; \
-				default message [size must be between 1 and 10]"""));
+				default message [size must be between 1 and 10]""", """
+				Field error in object 'guardian' on field 'hobbies[0]': rejected value [  ]; \
+				codes [NotBlank.guardian.hobbies[0],NotBlank.guardian.hobbies,NotBlank.hobbies[0],\
+				NotBlank.hobbies,NotBlank.java.lang.String,NotBlank]; arguments \
+				[org.springframework.context.support.DefaultMessageSourceResolvable: codes \
+				[guardian.hobbies[0],hobbies[0]]; arguments []; default message [hobbies[0]]]; \
+				default message [must not be blank]"""));
 
 			assertValueResult(ex.getValueResults().get(0), 2, 3, List.of("""
 				org.springframework.context.support.DefaultMessageSourceResolvable: \
@@ -106,7 +115,7 @@ public class MethodValidationAdapterTests {
 
 		this.validationAdapter.setObjectNameResolver((param, value) -> "studentToAdd");
 
-		testArgs(target, method, new Object[] {faustino1234, new Person("Joe"), 1}, ex -> {
+		testArgs(target, method, new Object[] {faustino1234, new Person("Joe", List.of()), 1}, ex -> {
 
 			assertThat(ex.getAllValidationResults()).hasSize(1);
 
@@ -178,7 +187,49 @@ public class MethodValidationAdapterTests {
 				codes [Size.people.name,Size.name,Size.java.lang.String,Size]; \
 				arguments [org.springframework.context.support.DefaultMessageSourceResolvable: \
 				codes [people.name,name]; arguments []; default message [name],10,1]; \
-				default message [size must be between 1 and 10]"""));
+				default message [size must be between 1 and 10]""", """
+				Field error in object 'people' on field 'hobbies[0]': rejected value [  ]; \
+				codes [NotBlank.people.hobbies[0],NotBlank.people.hobbies,NotBlank.hobbies[0],\
+				NotBlank.hobbies,NotBlank.java.lang.String,NotBlank]; arguments \
+				[org.springframework.context.support.DefaultMessageSourceResolvable: codes \
+				[people.hobbies[0],hobbies[0]]; arguments []; default message [hobbies[0]]]; \
+				default message [must not be blank]"""));
+		});
+	}
+
+	@Test
+	void validateSetArgument() {
+		MyService target = new MyService();
+		Method method = getMethod(target, "addPeople");
+
+		testArgs(target, method, new Object[] {Set.of(faustino1234, cayetana6789)}, ex -> {
+
+			assertThat(ex.getAllValidationResults()).hasSize(2);
+
+			int paramIndex = 0;
+			String objectName = "people";
+			List<ParameterErrors> results = ex.getBeanResults();
+
+			assertThat(results).satisfiesExactlyInAnyOrder(
+				result -> assertBeanResult(result, paramIndex, objectName, faustino1234, List.of("""
+					Field error in object 'people' on field 'name': rejected value [Faustino1234]; \
+					codes [Size.people.name,Size.name,Size.java.lang.String,Size]; \
+					arguments [org.springframework.context.support.DefaultMessageSourceResolvable: \
+					codes [people.name,name]; arguments []; default message [name],10,1]; \
+					default message [size must be between 1 and 10]""")),
+				result -> assertBeanResult(result, paramIndex, objectName, cayetana6789, List.of("""
+					Field error in object 'people' on field 'name': rejected value [Cayetana6789]; \
+					codes [Size.people.name,Size.name,Size.java.lang.String,Size]; \
+					arguments [org.springframework.context.support.DefaultMessageSourceResolvable: \
+					codes [people.name,name]; arguments []; default message [name],10,1]; \
+					default message [size must be between 1 and 10]""", """
+					Field error in object 'people' on field 'hobbies[0]': rejected value [  ]; \
+					codes [NotBlank.people.hobbies[0],NotBlank.people.hobbies,NotBlank.hobbies[0],\
+					NotBlank.hobbies,NotBlank.java.lang.String,NotBlank]; arguments \
+					[org.springframework.context.support.DefaultMessageSourceResolvable: codes \
+					[people.hobbies[0],hobbies[0]]; arguments []; default message [hobbies[0]]]; \
+					default message [must not be blank]"""))
+			);
 		});
 	}
 
@@ -191,7 +242,7 @@ public class MethodValidationAdapterTests {
 	}
 
 	private static void assertBeanResult(
-			ParameterErrors errors, int parameterIndex, String objectName, Object argument,
+			ParameterErrors errors, int parameterIndex, String objectName, @Nullable Object argument,
 			List<String> fieldErrors) {
 
 		assertThat(errors.getMethodParameter().getParameterIndex()).isEqualTo(parameterIndex);
@@ -234,14 +285,14 @@ public class MethodValidationAdapterTests {
 			throw new UnsupportedOperationException();
 		}
 
-		public void addPeople(@Valid List<Person> people) {
+		public void addPeople(@Valid Collection<Person> people) {
 		}
 
 	}
 
 
 	@SuppressWarnings("unused")
-	private record Person(@Size(min = 1, max = 10) String name) {
+	private record Person(@Size(min = 1, max = 10) String name, List<@NotBlank String> hobbies) {
 	}
 
 }


### PR DESCRIPTION
Expands on the validation behaviour added as part of the work for https://github.com/spring-projects/spring-framework/issues/30645, motivated by an issue with Sets containing an object with nested Lists, introduced in https://github.com/spring-projects/spring-framework/issues/29825. The adapter should now better handle nested objects for types beyond those of List or Map.