### PR TITLE
Improved ObjectInputStream of DefaultDeserializer automatically return resources by applying try-with-resources syntax.

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/serializer/DefaultDeserializer.java
+++ b/spring-core/src/main/java/org/springframework/core/serializer/DefaultDeserializer.java
@@ -66,11 +66,9 @@ public class DefaultDeserializer implements Deserializer<Object> {
 	 */
 	@Override
 	public Object deserialize(InputStream inputStream) throws IOException {
-		ObjectInputStream objectInputStream = new ConfigurableObjectInputStream(inputStream, this.classLoader);
-		try {
+		try (ObjectInputStream objectInputStream = new ConfigurableObjectInputStream(inputStream, this.classLoader)) {
 			return objectInputStream.readObject();
-		}
-		catch (ClassNotFoundException ex) {
+		} catch (ClassNotFoundException ex) {
 			throw new IOException("Failed to deserialize object type", ex);
 		}
 	}


### PR DESCRIPTION
In the DefaultDeserializer class, there was a problem with not properly releasing resources used by the ObjectInputStream. 

I've improved it by using try-with-resources to ensure that resources are properly released, 
thereby preventing memory leaks.