### PR TITLE
Use switch expression instead of If-Else

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/PathMatchConfigurer.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/PathMatchConfigurer.java
@@ -35,12 +35,10 @@ public class PathMatchConfigurer {
 	@Nullable
 	private Boolean trailingSlashMatch;
 
-
 	@Nullable
 	private Boolean caseSensitiveMatch;
 
-	@Nullable
-	private Map<String, Predicate<Class<?>>> pathPrefixes;
+	private Map<String, Predicate<Class<?>>> pathPrefixes = new LinkedHashMap<>();;
 
 
 	/**
@@ -79,9 +77,6 @@ public class PathMatchConfigurer {
 	 * @since 5.1
 	 */
 	public PathMatchConfigurer addPathPrefix(String prefix, Predicate<Class<?>> predicate) {
-		if (this.pathPrefixes == null) {
-			this.pathPrefixes = new LinkedHashMap<>();
-		}
 		this.pathPrefixes.put(prefix, predicate);
 		return this;
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/ResourceChainRegistration.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/ResourceChainRegistration.java
@@ -81,15 +81,13 @@ public class ResourceChainRegistration {
 	public ResourceChainRegistration addResolver(ResourceResolver resolver) {
 		Assert.notNull(resolver, "The provided ResourceResolver should not be null");
 		this.resolvers.add(resolver);
-		if (resolver instanceof VersionResourceResolver) {
-			this.hasVersionResolver = true;
-		}
-		else if (resolver instanceof PathResourceResolver) {
-			this.hasPathResolver = true;
-		}
-		else if (resolver instanceof WebJarsResourceResolver) {
-			this.hasWebjarsResolver = true;
-		}
+
+        switch (resolver) {
+            case VersionResourceResolver ignored -> this.hasVersionResolver = true;
+            case PathResourceResolver ignored -> this.hasPathResolver = true;
+            case WebJarsResourceResolver ignored -> this.hasWebjarsResolver = true;
+        }
+		
 		return this;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
@@ -302,44 +302,30 @@ public class WebClientResponseException extends WebClientException {
 			HttpStatusCode statusCode, String statusText, HttpHeaders headers,
 			byte[] body, @Nullable Charset charset, @Nullable HttpRequest request) {
 
-		if (statusCode instanceof HttpStatus httpStatus) {
-			switch (httpStatus) {
-				case BAD_REQUEST:
-					return new WebClientResponseException.BadRequest(statusText, headers, body, charset, request);
-				case UNAUTHORIZED:
-					return new WebClientResponseException.Unauthorized(statusText, headers, body, charset, request);
-				case FORBIDDEN:
-					return new WebClientResponseException.Forbidden(statusText, headers, body, charset, request);
-				case NOT_FOUND:
-					return new WebClientResponseException.NotFound(statusText, headers, body, charset, request);
-				case METHOD_NOT_ALLOWED:
-					return new WebClientResponseException.MethodNotAllowed(statusText, headers, body, charset, request);
-				case NOT_ACCEPTABLE:
-					return new WebClientResponseException.NotAcceptable(statusText, headers, body, charset, request);
-				case CONFLICT:
-					return new WebClientResponseException.Conflict(statusText, headers, body, charset, request);
-				case GONE:
-					return new WebClientResponseException.Gone(statusText, headers, body, charset, request);
-				case UNSUPPORTED_MEDIA_TYPE:
-					return new WebClientResponseException.UnsupportedMediaType(statusText, headers, body, charset, request);
-				case TOO_MANY_REQUESTS:
-					return new WebClientResponseException.TooManyRequests(statusText, headers, body, charset, request);
-				case UNPROCESSABLE_ENTITY:
-					return new WebClientResponseException.UnprocessableEntity(statusText, headers, body, charset, request);
-				case INTERNAL_SERVER_ERROR:
-					return new WebClientResponseException.InternalServerError(statusText, headers, body, charset, request);
-				case NOT_IMPLEMENTED:
-					return new WebClientResponseException.NotImplemented(statusText, headers, body, charset, request);
-				case BAD_GATEWAY:
-					return new WebClientResponseException.BadGateway(statusText, headers, body, charset, request);
-				case SERVICE_UNAVAILABLE:
-					return new WebClientResponseException.ServiceUnavailable(statusText, headers, body, charset, request);
-				case GATEWAY_TIMEOUT:
-					return new WebClientResponseException.GatewayTimeout(statusText, headers, body, charset, request);
-			}
-		}
-		return new WebClientResponseException(statusCode, statusText, headers, body, charset, request);
-	}
+		return switch (statusCode) {
+			case HttpStatus httpStatus -> {
+	            yield switch (httpStatus) {
+	                case BAD_REQUEST -> new WebClientResponseException.BadRequest(statusText, headers, body, charset, request);
+	                case UNAUTHORIZED -> new WebClientResponseException.Unauthorized(statusText, headers, body, charset, request);
+	                case FORBIDDEN -> new WebClientResponseException.Forbidden(statusText, headers, body, charset, request);
+	                case NOT_FOUND -> new WebClientResponseException.NotFound(statusText, headers, body, charset, request);
+	                case METHOD_NOT_ALLOWED -> new WebClientResponseException.MethodNotAllowed(statusText, headers, body, charset, request);
+	                case NOT_ACCEPTABLE -> new WebClientResponseException.NotAcceptable(statusText, headers, body, charset, request);
+	                case CONFLICT -> new WebClientResponseException.Conflict(statusText, headers, body, charset, request);
+	                case GONE -> new WebClientResponseException.Gone(statusText, headers, body, charset, request);
+	                case UNSUPPORTED_MEDIA_TYPE -> new WebClientResponseException.UnsupportedMediaType(statusText, headers, body, charset, request);
+	                case TOO_MANY_REQUESTS -> new WebClientResponseException.TooManyRequests(statusText, headers, body, charset, request);
+	                case UNPROCESSABLE_ENTITY -> new WebClientResponseException.UnprocessableEntity(statusText, headers, body, charset, request);
+	                case INTERNAL_SERVER_ERROR -> new WebClientResponseException.InternalServerError(statusText, headers, body, charset, request);
+	                case NOT_IMPLEMENTED -> new WebClientResponseException.NotImplemented(statusText, headers, body, charset, request);
+	                case BAD_GATEWAY -> new WebClientResponseException.BadGateway(statusText, headers, body, charset, request);
+	                case SERVICE_UNAVAILABLE -> new WebClientResponseException.ServiceUnavailable(statusText, headers, body, charset, request);
+	                case GATEWAY_TIMEOUT -> new WebClientResponseException.GatewayTimeout(statusText, headers, body, charset, request);
+	                default -> new WebClientResponseException(statusCode, statusText, headers, body, charset, request);
+	            };
+	        }
+        default -> new WebClientResponseException(statusCode, statusText, headers, body, charset, request);
+    };
 
 
 	// Subclasses for specific, client-side, HTTP status codes


### PR DESCRIPTION
**[Use switch expression instead of If-Else]**

I refactored the code using the new switch expression introduced since Java 12, which I used to make the code more concise and readable. 
This code uses Java's new switch expression to check each ResourceResolver subtype and set the corresponding boolean flag. The case L -> syntax allows us to concisely write the executable code for each case in a single line. Note that ignored is the variable used in the pattern matching, which is not actually used in this case.
The variable name ignored is used to indicate that this variable is not actually used, meaning that we are only checking to see if it is of type VersionResourceResolver, and not interested in any particular instance of that type.

Refactoring the code in this way improves readability and allows us to omit the break statement that would have been required in a traditional switch statement.


**[Changes to avoid unnecessary null checks]**

"== null" check is a common and intuitive way to ensure that an object is not initialized in Java. However, I considered a different approach to improve the readability and maintainability of the code. 
In this code, the pathPrefixes field is initialized to a LinkedHashMap upon declaration, eliminating the need for a null check.


**[Use switch expression where feasible]**

In Java 12 and later versions, I use the new switch expression to make my code more concise.