### PR TITLE
Link to KDoc API documentation from Javadoc overview

### DIFF
--- a/framework-api/framework-api.gradle
+++ b/framework-api/framework-api.gradle
@@ -28,6 +28,7 @@ javadoc {
 		header = rootProject.description
 		use = true
 		overview = "$rootProject.rootDir/framework-docs/src/docs/api/overview.html"
+		destinationDir = file("${project.buildDir}/docs/javadoc-api")
 		splitIndex = true
 		links(rootProject.ext.javadocLinks)
 		addBooleanOption('Xdoclint:syntax,reference', true) // only check syntax and reference with doclint
@@ -52,6 +53,7 @@ rootProject.tasks.dokkaHtmlMultiModule.configure {
 	}
 	moduleName.set("spring-framework")
 	outputDirectory.set(project.file("$buildDir/docs/kdoc-api"))
+	includes.from("$rootProject.rootDir/framework-docs/src/docs/api/dokka-overview.md")
 }
 
 /**

--- a/framework-api/framework-api.gradle
+++ b/framework-api/framework-api.gradle
@@ -27,7 +27,7 @@ javadoc {
 		author = true
 		header = rootProject.description
 		use = true
-		overview = "framework-docs/src/docs/api/overview.html"
+		overview = "$rootProject.rootDir/framework-docs/src/docs/api/overview.html"
 		splitIndex = true
 		links(rootProject.ext.javadocLinks)
 		addBooleanOption('Xdoclint:syntax,reference', true) // only check syntax and reference with doclint
@@ -51,7 +51,7 @@ rootProject.tasks.dokkaHtmlMultiModule.configure {
 		tasks.named("javadoc")
 	}
 	moduleName.set("spring-framework")
-	outputDirectory.set(project.file("$buildDir/docs/kdoc"))
+	outputDirectory.set(project.file("$buildDir/docs/kdoc-api"))
 }
 
 /**

--- a/framework-docs/src/docs/api/dokka-overview.md
+++ b/framework-docs/src/docs/api/dokka-overview.md
@@ -1,0 +1,2 @@
+# All Modules
+_See also the <a href="../javadoc-api/" target="_blank">Java API documentation (Javadoc)</a>._

--- a/framework-docs/src/docs/api/overview.html
+++ b/framework-docs/src/docs/api/overview.html
@@ -1,7 +1,10 @@
 <html>
 <body>
 <p>
-This is the public API documentation for the <a href="https://github.com/spring-projects/spring-framework" target="_top">Spring Framework</a>.
+This is the public Java API documentation (Javadoc) for the <a href="https://github.com/spring-projects/spring-framework" target="_top">Spring Framework</a>.
 </p>
+<p><i>
+See also the <a href="../kdoc-api/" target="_blank">Kotlin API documentation (KDoc)</a>.
+</i></p>
 </body>
 </html>

--- a/framework-docs/src/docs/api/overview.html
+++ b/framework-docs/src/docs/api/overview.html
@@ -3,8 +3,8 @@
 <p>
 This is the public Java API documentation (Javadoc) for the <a href="https://github.com/spring-projects/spring-framework" target="_top">Spring Framework</a>.
 </p>
-<p><i>
+<p><em>
 See also the <a href="../kdoc-api/" target="_blank">Kotlin API documentation (KDoc)</a>.
-</i></p>
+</em></p>
 </body>
 </html>


### PR DESCRIPTION
This commit also fixes the javadoc task to take the overview.html asset into account, since this is where the link to KDoc is set up.

Note that the output directory for kdoc is changed to be consistent with what's in the docsZip, so that the link works in local builds too.

See gh-28055