### PR TITLE
Avoid duplicate JAR resources in `PathMatchingResourcePatternResolver` on MS Windows

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/support/PathMatchingResourcePatternResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/PathMatchingResourcePatternResolver.java
@@ -430,7 +430,8 @@ public class PathMatchingResourcePatternResolver implements ResourcePatternResol
 					int prefixIndex = filePath.indexOf(':');
 					if (prefixIndex == 1) {
 						// Possibly "c:" drive prefix on Windows, to be upper-cased for proper duplicate detection
-						filePath = StringUtils.capitalize(filePath);
+						// to resolve find duplicate jar resource on windows
+						filePath = "/" + StringUtils.capitalize(filePath);
 					}
 					// # can appear in directories/filenames, java.net.URL should not treat it as a fragment
 					filePath = StringUtils.replace(filePath, "#", "%23");


### PR DESCRIPTION
To avoid duplicate JAR resources on MS Windows.

If you use `mybatis-plus` and your `mapper-locations` starts with `classpath*:`, Spring will find duplicate `UrlResource`s for XML files which results in a crash on application startup.

Since their `getCleanedUrl` values are different mybatis will throw an exception, even though they represent the same resource.