### PR TITLE
Updated `JdbcClient.update` to enable returning generated keys when using named parameters and Oracle DB. 

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/DefaultJdbcClient.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/DefaultJdbcClient.java
@@ -245,6 +245,16 @@ final class DefaultJdbcClient implements JdbcClient {
 					classicOps.update(getPreparedStatementCreatorForIndexedParams(true), generatedKeyHolder));
 		}
 
+		@Override
+		public int update(KeyHolder generatedKeyHolder, String keyColumnName) {
+			return update(keyGenerator, List.of(keyColumnName));
+		}
+
+		@Override
+		public int update(KeyHolder generatedKeyHolder, List<String> keyColumnNames) {
+			return namedParamOps.update(this.sql, this.namedParamSource, generatedKeyHolder, keyColumnNames.toArray(new String[] {}));
+		}
+
 		private boolean useNamedParams() {
 			boolean hasNamedParams = (this.namedParams.hasValues() || this.namedParamSource != this.namedParams);
 			if (hasNamedParams && !this.indexedParams.isEmpty()) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/JdbcClient.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/JdbcClient.java
@@ -288,6 +288,27 @@ public interface JdbcClient {
 		 * @see java.sql.PreparedStatement#executeUpdate()
 		 */
 		int update(KeyHolder generatedKeyHolder);
+
+		/**
+		 * Execute the provided SQL statement as an update.
+		 * @param generatedKeyHolder a KeyHolder that will hold the generated keys
+		 * (typically a {@link org.springframework.jdbc.support.GeneratedKeyHolder})
+		 * @param keyColumnName name of the column that will have key generated for them
+		 * @return the number of rows affected
+		 * @see java.sql.PreparedStatement#executeUpdate()
+		 */
+		int update(KeyHolder generatedKeyHolder, String keyColumnName);
+
+		/**
+		 * Execute the provided SQL statement as an update.
+		 * @param generatedKeyHolder a KeyHolder that will hold the generated keys
+		 * (typically a {@link org.springframework.jdbc.support.GeneratedKeyHolder})
+		 * @param keyColumnNames names of the columns that will have keys generated for them
+		 * @return the number of rows affected
+		 * @see java.sql.PreparedStatement#executeUpdate()
+		 */
+		int update(KeyHolder generatedKeyHolder, List<String> keyColumnNames);
+
 	}
 
 


### PR DESCRIPTION
Updated `JdbcClient.update` to enable returning generated keys when using named parameters and Oracle DB. 
issue: https://github.com/spring-projects/spring-framework/issues/31607