### PR TITLE
GeneratedFiles#addSource does not provide proper context if the specified class name is invalid

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/generate/GeneratedFiles.java
+++ b/spring-core/src/main/java/org/springframework/aot/generate/GeneratedFiles.java
@@ -161,7 +161,7 @@ public interface GeneratedFiles {
 
 	private static String getClassNamePath(String className) {
 		Assert.hasLength(className, "'className' must not be empty");
-		Assert.isTrue(isJavaIdentifier(className), "'className' must be a valid identifier");
+		Assert.isTrue(isJavaIdentifier(className), "'className' " + className + " must be a valid identifier");
 		return ClassUtils.convertClassNameToResourcePath(className) + ".java";
 	}
 

--- a/spring-core/src/test/java/org/springframework/aot/generate/GeneratedFilesTests.java
+++ b/spring-core/src/test/java/org/springframework/aot/generate/GeneratedFilesTests.java
@@ -78,7 +78,7 @@ class GeneratedFilesTests {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> this.generatedFiles
 						.addSourceFile("com/example/HelloWorld.java", "{}"))
-				.withMessage("'className' must be a valid identifier");
+				.withMessage("'className' com/example/HelloWorld.java must be a valid identifier");
 	}
 
 	@Test


### PR DESCRIPTION
# Context

I tried to build native Spring boot artifact and spent hours to struggle with build failed obscure error. I was not able to spot the build failed root cause because of the too generic error message `'className' must be a valid identifier`

This error message prevents me to fix the problem

I did not found any related issue to this specific point.

# Observation

`GeneratedFiles.getClassNamePath(String className)` error message is too generic

```bash
Exception in thread "main" java.lang.IllegalArgumentException: 'className' must be a valid identifier
	at org.springframework.util.Assert.isTrue(Assert.java:122)
	at org.springframework.aot.generate.GeneratedFiles.getClassNamePath(GeneratedFiles.java:164)
```

# Proposal

Put className value in the error message

```bash
Exception in thread "main" java.lang.IllegalArgumentException: 'className' com/example/HelloWorld.java must be a valid identifier
	at org.springframework.util.Assert.isTrue(Assert.java:122)
	at org.springframework.aot.generate.GeneratedFiles.getClassNamePath(GeneratedFiles.java:164)
```

