### PR TITLE
Skip buffer allocation in `StreamUtils.copy(String)`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StreamUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StreamUtils.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.nio.charset.Charset;
 
 import org.springframework.lang.Nullable;
@@ -133,9 +131,8 @@ public abstract class StreamUtils {
 		Assert.notNull(charset, "No Charset specified");
 		Assert.notNull(out, "No OutputStream specified");
 
-		Writer writer = new OutputStreamWriter(out, charset);
-		writer.write(in);
-		writer.flush();
+		out.write(in.getBytes(charset));
+		out.flush();
 	}
 
 	/**


### PR DESCRIPTION
```java
Writer writer = new OutputStreamWriter(out, charset);
writer.write(in);
writer.flush();
```
OutputStreamWriter constuctor does unnecessary buffer allocation (8kb)

Given that it already has a string, maybe it can be avoided writing a string to the stream directly.
```java
out.write(in.getBytes(charset));
out.flush();
```

It's used in plaintext endpoints through `StringHttpMessageConverter`

<details>
  <summary>Here's approximate difference in time</summary>

```noformat
| String Length | copy (ns/op) | copyOSW (ns/op) |
| ------------- | ------------ | --------------- |
| 10            | 4.314        | 311.848         |
| 100           | 9.187        | 310.556         |
| 1,000         | 35.274       | 569.202         |
| 10,000        | 545.262      | 1581.522        |
| 50,000        | 1833.014     | 6171.236        |
| 100,000       | 3341.869     | 11976.815       |
```

</details>
