### PR TITLE
Refresh cache in `ReloadableResourceBundleMessageSource`

### DIFF
--- a/spring-context/src/test/resources/org/springframework/context/support/messages2_de.properties
+++ b/spring-context/src/test/resources/org/springframework/context/support/messages2_de.properties
@@ -1,0 +1,1 @@
+code3=nachricht3


### PR DESCRIPTION
This change allows subclasses to call getMergedProperties(locale) when
cacheSeconds > 0 and get refreshed contents. Useful for SPA webapps to
deliver all translations to the browser.

Since all individual files can be refreshed concurrently, the thread that
refreshes mergedHolder can get stale data for any file being refreshed
so simply comparing maximal fileTimestamp is not enough to detect
change - used hashCode for this purpose.