### PR TITLE
RestClient documentation improvements

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/RestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClient.java
@@ -673,26 +673,26 @@ public interface RestClient {
 		 *     .retrieve()
 		 *     .toBodilessEntity();
 		 * </pre>
-		 * @param body the body of the response
-		 * @return the built response
+		 * @param body the body of the request
+		 * @return this builder
 		 */
 		RequestBodySpec body(Object body);
 
 		/**
-		 * Set the body of the response to the given {@code Object}.
+		 * Set the body of the request to the given {@code Object}.
 		 * The parameter {@code bodyType} is used to capture the generic type.
-		 * @param body the body of the response
+		 * @param body the body of the request
 		 * @param bodyType the type of the body, used to capture the generic type
-		 * @return the built response
+		 * @return this builder
 		 */
 		<T> RequestBodySpec body(T body, ParameterizedTypeReference<T> bodyType);
 
 		/**
-		 * Set the body of the response to the given function that writes to
+		 * Set the body of the request to the given function that writes to
 		 * an {@link OutputStream}.
 		 * @param body a function that takes an {@code OutputStream} and can
 		 * throw an {@code IOException}
-		 * @return the built response
+		 * @return this builder
 		 */
 		RequestBodySpec body(StreamingHttpOutputMessage.Body body);
 	}


### PR DESCRIPTION
Confusion between request/response and builder/built response in the documentation auf RestClient corrected.