### PR TITLE
Clarify that DI is a type of IoC

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/introduction.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/introduction.adoc
@@ -2,7 +2,7 @@
 = Introduction to the Spring IoC Container and Beans
 
 This chapter covers the Spring Framework implementation of the Inversion of Control
-(IoC) principle. IoC is also known as dependency injection (DI). It is a process whereby
+(IoC) principle. An important kind of IoC is dependency injection (DI). It is a process whereby
 objects define their dependencies (that is, the other objects they work with) only through
 constructor arguments, arguments to a factory method, or properties that are set on the
 object instance after it is constructed or returned from a factory method. The container


### PR DESCRIPTION
The documentation currently states that Inversion of Control (IoC) and Dependency Injection (DI) are the same thing. Although the two terms are related, they are not synonymous, but DI is a type of IoC.

I believe this change is important because using the terms interchangeably really muddies the water about the meaning of these two fundamental concepts of software frameworks.