### PR TITLE
Make ResourceArrayPropertyEditor supports comma delimited location patterns

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/io/support/ResourceArrayPropertyEditorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/support/ResourceArrayPropertyEditorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.beans.PropertyEditor;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileUrlResource;
 import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 /**
  * @author Dave Syer
  * @author Juergen Hoeller
+ * @author Yanming Zhou
  */
 class ResourceArrayPropertyEditorTests {
 
@@ -83,4 +86,13 @@ class ResourceArrayPropertyEditorTests {
 		}
 	}
 
+	@Test
+	void commaDelimitedResources() {
+		PropertyEditor editor = new ResourceArrayPropertyEditor();
+		editor.setAsText("classpath:org/springframework/core/io/support/ResourceArrayPropertyEditor.class,file:/foo/bar.txt");
+		Resource[] resources = (Resource[]) editor.getValue();
+		assertThat(resources).isNotNull();
+		assertThat(resources[0]).isInstanceOf(ClassPathResource.class);
+		assertThat(resources[1]).isInstanceOf(FileUrlResource.class);
+	}
 }


### PR DESCRIPTION
Fix https://github.com/spring-projects/spring-boot/issues/38556

See GH-31693