### PR TITLE
Link to `spring.factories` used in the TestContext framework in the reference manual

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/testcontext-framework/ctx-management/context-customizers.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/testcontext-framework/ctx-management/context-customizers.adoc
@@ -45,10 +45,10 @@ issue is addressed through support for automatic discovery of default
 Specifically, the modules that make up the testing support in Spring Framework and Spring
 Boot declare all core default `ContextCustomizerFactory` implementations under the
 `org.springframework.test.context.ContextCustomizerFactory` key in their
-`META-INF/spring.factories` properties files. Third-party frameworks and developers can
-contribute their own `ContextCustomizerFactory` implementations to the list of default
-factories in the same manner through their own `META-INF/spring.factories` properties
-files.
+{spring-framework-code}/spring-test/src/main/resources/META-INF/spring.factories[`META-INF/spring.factories`]
+properties files. Third-party frameworks and developers can contribute their own
+`ContextCustomizerFactory` implementations to the list of default factories in the same
+manner through their own `META-INF/spring.factories` properties files.
 
 
 [[testcontext-context-customizers-merging]]

--- a/framework-docs/modules/ROOT/pages/testing/testcontext-framework/tel-config.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/testcontext-framework/tel-config.adoc
@@ -82,8 +82,9 @@ issue is addressed through support for automatic discovery of default
 
 Specifically, the `spring-test` module declares all core default `TestExecutionListener`
 implementations under the `org.springframework.test.context.TestExecutionListener` key in
-its `META-INF/spring.factories` properties file. Third-party frameworks and developers
-can contribute their own `TestExecutionListener` implementations to the list of default
+{spring-framework-code}/spring-test/src/main/resources/META-INF/spring.factories[its
+`META-INF/spring.factories` properties file]. Third-party frameworks and developers can
+contribute their own `TestExecutionListener` implementations to the list of default
 listeners in the same manner through their own `META-INF/spring.factories` properties
 file.
 
@@ -207,4 +208,3 @@ Kotlin::
 	}
 ----
 ======
-


### PR DESCRIPTION
This type of change would be useful (since it makes it easier for the reader to find this file), but... will it be hard to support with different versions of the docs? Given that it should technically refer to the "same version" of the file (replacing `main` in the URL with the tag in question), to be really great.