### PR TITLE
Avoid byte array copy in getContentAsString

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
@@ -205,7 +205,7 @@ public class ContentCachingRequestWrapper extends HttpServletRequestWrapper {
 	 * @see #getContentAsByteArray()
 	 */
 	public String getContentAsString() {
-		return new String(this.cachedContent.toByteArray(), Charset.forName(getCharacterEncoding()));
+		return new String(this.cachedContent.toByteArrayUnsafe(), Charset.forName(getCharacterEncoding()));
 	}
 
 	/**


### PR DESCRIPTION
The getContentAsString method was originally added in d9b8826 to avoid the extra copying inherent to calling ByteArrayOutputStream.toByteArray; however, in f83c609 the class was updated to instead use FastByteArrayOutputStream, and in the process the extra copy was brought back when getContentAsString was changed to call toByteArray. Switch to calling toByteArrayUnsafe, a method provided by FastByteArrayOutputStream, which avoids the extra copy; since we immediately pass the byte array to the String constructor and it isn't accessed anywhere else, the usage is safe.