### PR TITLE
Use relative path for javadoc overview

### DIFF
--- a/framework-api/framework-api.gradle
+++ b/framework-api/framework-api.gradle
@@ -27,7 +27,7 @@ javadoc {
 		author = true
 		header = rootProject.description
 		use = true
-		overview = "$rootProject.rootDir/framework-docs/src/docs/api/overview.html"
+		overview = project.relativePath("$rootProject.rootDir/framework-docs/src/docs/api/overview.html")
 		destinationDir = file("${project.buildDir}/docs/javadoc-api")
 		splitIndex = true
 		links(rootProject.ext.javadocLinks)


### PR DESCRIPTION
Updates the build configuration to use a relative path when setting the `:framework-api:javadoc` tasks's `overview` property. This will help prevent a cache miss when a local build should have hit on a remote cache entry populated by a CI build, or in the case that the repository is relocated on disk. This cache miss [adds around 46s of serial execution time to the build](https://ge.solutions-team.gradle.com/s/gywweox2morvm/timeline?cacheability=cacheable,overlapping-outputs,validation-failure&outcome=success,failed&sort=longest#e5oqjtraalnou).

### Tests

Running back to back builds with no changes from different file system locations...
* [task input comparison prior to this PR](https://ge.solutions-team.gradle.com/c/nxjkpx66ngzfs/im4w6ayyopqxo/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure) - although no changes were made between these builds, the `:framework-api:javadoc` task re-executed because of this input difference.

* [task input comparison with the changes in this PR applied](https://ge.solutions-team.gradle.com/c/652iibuj52diy/kahbojwf76rsm/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure) - there is no longer an input difference, so the `:framework-api:javadoc` task came from cache

Using IntelliJ to compare the generated javadoc jar files, the javadoc jars produced before and after this change have the same contents.

<img width="1422" alt="image" src="https://github.com/tylerbertrand/spring-framework/assets/121591679/f54bf7c5-5b6b-4c47-87df-71e4819dbc13">