### PR TITLE
Polish Javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/WriteResultPublisher.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/WriteResultPublisher.java
@@ -117,7 +117,7 @@ class WriteResultPublisher implements Publisher<Void> {
 		}
 
 		@Override
-		public final void request(long n) {
+		public void request(long n) {
 			if (rsWriteResultLogger.isTraceEnabled()) {
 				rsWriteResultLogger.trace(this.publisher.logPrefix +
 						"request " + (n != Long.MAX_VALUE ? n : "Long.MAX_VALUE"));
@@ -126,7 +126,7 @@ class WriteResultPublisher implements Publisher<Void> {
 		}
 
 		@Override
-		public final void cancel() {
+		public void cancel() {
 			State state = getState();
 			if (rsWriteResultLogger.isTraceEnabled()) {
 				rsWriteResultLogger.trace(this.publisher.logPrefix + "cancel [" + state + "]");

--- a/spring-web/src/main/java/org/springframework/web/accept/AbstractMappingContentNegotiationStrategy.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/AbstractMappingContentNegotiationStrategy.java
@@ -69,7 +69,7 @@ public abstract class AbstractMappingContentNegotiationStrategy extends MappingM
 
 	/**
 	 * Whether to only use the registered mappings to look up file extensions,
-	 * or also to use dynamic resolution (e.g. via {@link MediaTypeFactory}.
+	 * or also to use dynamic resolution (e.g. via {@link MediaTypeFactory}).
 	 * <p>By default this is set to {@code false}.
 	 */
 	public void setUseRegisteredExtensionsOnly(boolean useRegisteredExtensionsOnly) {

--- a/spring-web/src/main/java/org/springframework/web/accept/MappingMediaTypeFileExtensionResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/MappingMediaTypeFileExtensionResolver.java
@@ -35,7 +35,7 @@ import org.springframework.lang.Nullable;
  * lookups between file extensions and MediaTypes in both directions.
  *
  * <p>Initially created with a map of file extensions and media types.
- * Subsequently subclasses can use {@link #addMapping} to add more mappings.
+ * Subsequently, subclasses can use {@link #addMapping} to add more mappings.
  *
  * @author Rossen Stoyanchev
  * @author Juergen Hoeller


### PR DESCRIPTION
- remove final keyword in final class.

  I noticed that `WriteResultSubscription` is declared as a final class, so in my opinion, I removed the final keyword from methods, as they are already within a final class

- fix minor typos in java comments(javadoc)

