### PR TITLE
Fix Javadoc for `MockRestServiceServer.bindTo(RestClient.Builder)`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/MockRestServiceServer.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/MockRestServiceServer.java
@@ -140,7 +140,7 @@ public final class MockRestServiceServer {
 
 	/**
 	 * Return a builder for a {@code MockRestServiceServer} that should be used
-	 * to reply to the given {@code RestTemplate}.
+	 * to reply to the given {@code RestClient.Builder}.
 	 * @since 6.1
 	 */
 	public static MockRestServiceServerBuilder bindTo(RestClient.Builder restClientBuilder) {


### PR DESCRIPTION
I modified the comment for the bindTo(RestClient.Builder) method inside the MockRestServiceServer.