### PR TITLE
Introduce overloaded `MockPart` constructor that accepts the `Content-Type`

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockPart.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockPart.java
@@ -70,6 +70,19 @@ public class MockPart implements Part {
 		this.headers.setContentDispositionFormData(name, filename);
 	}
 
+	/**
+	 * Constructor for a part with a filename, byte[] content and MediaType mediaType.
+	 * @see #getHeaders()
+	 */
+	public MockPart(String name, @Nullable String filename, @Nullable byte[] content, @Nullable MediaType) {
+		Assert.hasLength(name, "'name' must not be empty");
+		this.name = name;
+		this.filename = filename;
+		this.content = (content != null ? content : new byte[0]);
+		this.headers.setContentDispositionFormData(name, filename);
+		this.headers.setContentType(mediaType);
+	}
+
 
 	@Override
 	public String getName() {

--- a/spring-test/src/main/java/org/springframework/mock/web/MockPart.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockPart.java
@@ -74,7 +74,7 @@ public class MockPart implements Part {
 	 * Constructor for a part with a filename, byte[] content and MediaType mediaType.
 	 * @see #getHeaders()
 	 */
-	public MockPart(String name, @Nullable String filename, @Nullable byte[] content, @Nullable MediaType) {
+	public MockPart(String name, @Nullable String filename, @Nullable byte[] content, @Nullable MediaType mediaType) {
 		Assert.hasLength(name, "'name' must not be empty");
 		this.name = name;
 		this.filename = filename;


### PR DESCRIPTION
This PR introduces a constructor to MockPart, enabling the configuration of Content-Type. 

When testing controllers that expect a specific format, such as JSON, as @RequestPart, this resolves the issue of encountering a 415 status code problem.