### PR TITLE
Fix condition for "Too many elements" in `MimeTypeUtils.sortBySpecificity()`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -362,7 +362,7 @@ public abstract class MimeTypeUtils {
 	 */
 	public static <T extends MimeType> void sortBySpecificity(List<T> mimeTypes) {
 		Assert.notNull(mimeTypes, "'mimeTypes' must not be null");
-		if (mimeTypes.size() >= 50) {
+		if (mimeTypes.size() > 50) {
 			throw new InvalidMimeTypeException(mimeTypes.toString(), "Too many elements");
 		}
 


### PR DESCRIPTION
This PR fixes condition for "Too many elements" in `MimeTypeUtils.sortBySpecificity()` that seems to have been changed accidentally in 05c3ffb2fbdf358c6a23309a3118b0a64ecb4b40 to align with its Javadoc again.

See gh-31254