### PR TITLE
Ensure `DataBinder` once again binds null values for nullable/optional constructor arguments

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/DataBinder.java
+++ b/spring-context/src/main/java/org/springframework/validation/DataBinder.java
@@ -948,7 +948,7 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 				Class<?> paramType = paramTypes[i];
 				Object value = valueResolver.resolveValue(paramPath, paramType);
 
-				if (value == null && shouldConstructArgument(param)) {
+				if (value == null && !param.isOptional() && shouldConstructArgument(param)) {
 					ResolvableType type = ResolvableType.forMethodParameter(param);
 					args[i] = createObject(type, paramPath + ".", valueResolver);
 				}

--- a/spring-context/src/test/java/org/springframework/validation/DataBinderConstructTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/DataBinderConstructTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.format.support.DefaultFormattingConversionService;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,6 +90,20 @@ public class DataBinderConstructTests {
 		assertThat(bindingResult.getFieldValue("param3")).isNull();
 	}
 
+	@Test
+	void dataClassBindingWithNestedClassAndNullableValue() {
+		MapValueResolver valueResolver = new MapValueResolver(Map.of("nested.name", "value1"));
+		DataBinder binder = new DataBinder(null);
+		binder.setTargetType(ResolvableType.forClass(OuterClass.class));
+
+		binder.construct(valueResolver);
+		OuterClass outerClass = getTarget(binder);
+
+		assertThat(outerClass.getNested().getName()).isEqualTo("value1");
+		assertThat(outerClass.getOptionalNested().isPresent()).isFalse();
+		assertThat(outerClass.getNullableNested()).isNull();
+	}
+
 	@SuppressWarnings("SameParameterValue")
 	private static DataBinder initDataBinder(Class<DataClass> targetType) {
 		DataBinder binder = new DataBinder(null);
@@ -151,4 +166,41 @@ public class DataBinderConstructTests {
 		}
 	}
 
+	private static class NestedClass {
+		private final String name;
+
+		public NestedClass(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	private static class OuterClass {
+		private final NestedClass nested;
+		private final Optional<NestedClass> optionalNested;
+		@Nullable
+		private final NestedClass nullableNested;
+
+		public OuterClass(NestedClass nested, Optional<NestedClass> optionalNested, @Nullable NestedClass nullableNested) {
+			this.nested = nested;
+			this.optionalNested = optionalNested;
+			this.nullableNested = nullableNested;
+		}
+
+		public NestedClass getNested() {
+			return nested;
+		}
+
+		public Optional<NestedClass> getOptionalNested() {
+			return optionalNested;
+		}
+
+		@Nullable
+		public NestedClass getNullableNested() {
+			return nullableNested;
+		}
+	}
 }


### PR DESCRIPTION
After https://github.com/spring-projects/spring-framework/commit/ea398d7b7e72d1e1a9f7a002a291f4e0b8660e70, DataBinder failed to bind nullable value through constructor.

We should check if param is nullable and do not trying to resolve nested constructor.