### PR TITLE
Remove unused code

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/ComponentScanAnnotationIntegrationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ComponentScanAnnotationIntegrationTests.java
@@ -456,11 +456,6 @@ class ComponentScanAnnotatedConfig_WithValueAttribute {
 }
 
 @Configuration
-@ComponentScan
-class ComponentScanWithNoPackagesConfig {
-}
-
-@Configuration
 @ComponentScan(basePackages = "example.scannable", nameGenerator = MyBeanNameGenerator.class)
 class ComponentScanWithBeanNameGenerator {
 }


### PR DESCRIPTION
- remove the unused `ComponentScanWithNoPackagesConfig` class from the `ComponentScanAnnotationIntegrationTests` class