### PR TITLE
Fix Comparators.nullsLow and Comporators.nullsHigh behavior

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/comparator/Comparators.java
+++ b/spring-core/src/main/java/org/springframework/util/comparator/Comparators.java
@@ -39,7 +39,7 @@ public abstract class Comparators {
 	/**
 	 * Return a {@link Comparable} adapter which accepts
 	 * null values and sorts them lower than non-null values.
-	 * @see Comparator#nullsLast(Comparator)
+	 * @see Comparator#nullsFirst(Comparator)
 	 */
 	public static <T> Comparator<T> nullsLow() {
 		return nullsLow(comparable());
@@ -48,16 +48,16 @@ public abstract class Comparators {
 	/**
 	 * Return a decorator for the given comparator which accepts
 	 * null values and sorts them lower than non-null values.
-	 * @see Comparator#nullsLast(Comparator)
+	 * @see Comparator#nullsFirst(Comparator)
 	 */
 	public static <T> Comparator<T> nullsLow(Comparator<T> comparator) {
-		return Comparator.nullsLast(comparator);
+		return Comparator.nullsFirst(comparator);
 	}
 
 	/**
 	 * Return a {@link Comparable} adapter which accepts
 	 * null values and sorts them higher than non-null values.
-	 * @see Comparator#nullsFirst(Comparator)
+	 * @see Comparator#nullsLast(Comparator)
 	 */
 	public static <T> Comparator<T> nullsHigh() {
 		return nullsHigh(comparable());
@@ -66,10 +66,10 @@ public abstract class Comparators {
 	/**
 	 * Return a decorator for the given comparator which accepts
 	 * null values and sorts them higher than non-null values.
-	 * @see Comparator#nullsFirst(Comparator)
+	 * @see Comparator#nullsLast(Comparator)
 	 */
 	public static <T> Comparator<T> nullsHigh(Comparator<T> comparator) {
-		return Comparator.nullsFirst(comparator);
+		return Comparator.nullsLast(comparator);
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/util/comparator/ComparatorsTest.java
+++ b/spring-core/src/test/java/org/springframework/util/comparator/ComparatorsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.util.comparator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Comparators}
+ */
+class ComparatorsTest {
+
+	@Test
+	void shouldCompareWithNullsLow() {
+		assertThat(Comparators.nullsLow().compare(null, "boo")).isNegative();
+		assertThat(Comparators.nullsLow().compare(null, null)).isZero();
+	}
+
+	@Test
+	void shouldCompareWithNullsLowAndComparator() {
+		assertThat(Comparators.nullsLow(String::compareTo).compare(null, "boo")).isNegative();
+		assertThat(Comparators.nullsLow(String::compareTo).compare(null, null)).isZero();
+	}
+
+	@Test
+	void shouldCompareWithNullsHigh() {
+		assertThat(Comparators.nullsHigh().compare(null, "boo")).isPositive();
+		assertThat(Comparators.nullsHigh().compare(null, null)).isZero();
+	}
+
+	@Test
+	void shouldCompareWithNullsHighAndComparator() {
+		assertThat(Comparators.nullsHigh(String::compareTo).compare(null, "boo")).isPositive();
+		assertThat(Comparators.nullsHigh(String::compareTo).compare(null, null)).isZero();
+	}
+}


### PR DESCRIPTION
`nullsLow` should s…ort null values lower than non-null values, `nullsHigh` should sort null values higher than non-null values
The reverse behavior has been introduced in Spring Framework 6.1.X, it was correct before.
See https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/test/java/org/springframework/util/comparator/NullSafeComparatorTests.java which tests the same comparators used before. 