### PR TITLE
Replaces methods that will be deprecated by gradle (`project.buildDir` -> `project.layout.buildDirectory`)

### DIFF
--- a/framework-api/framework-api.gradle
+++ b/framework-api/framework-api.gradle
@@ -28,7 +28,7 @@ javadoc {
 		header = rootProject.description
 		use = true
 		overview = project.relativePath("$rootProject.rootDir/framework-docs/src/docs/api/overview.html")
-		destinationDir = file("${project.buildDir}/docs/javadoc-api")
+		destinationDir = file("${project.layout.buildDirectory}/docs/javadoc-api")
 		splitIndex = true
 		links(rootProject.ext.javadocLinks)
 		addBooleanOption('Xdoclint:syntax,reference', true) // only check syntax and reference with doclint


### PR DESCRIPTION
Replaces methods that will be deprecated by gradle

_Reference_
- [gradle 8.5 official documentation - Upgrading version 8.x to latest](https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir)