### PR TITLE
Combine if-statements in `ScopedProxyBeanDefinitionDecorator`

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/config/ScopedProxyBeanDefinitionDecorator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/config/ScopedProxyBeanDefinitionDecorator.java
@@ -42,10 +42,8 @@ class ScopedProxyBeanDefinitionDecorator implements BeanDefinitionDecorator {
 	@Override
 	public BeanDefinitionHolder decorate(Node node, BeanDefinitionHolder definition, ParserContext parserContext) {
 		boolean proxyTargetClass = true;
-		if (node instanceof Element ele) {
-			if (ele.hasAttribute(PROXY_TARGET_CLASS)) {
-				proxyTargetClass = Boolean.parseBoolean(ele.getAttribute(PROXY_TARGET_CLASS));
-			}
+		if (node instanceof Element ele && ele.hasAttribute(PROXY_TARGET_CLASS)) {
+			proxyTargetClass = Boolean.parseBoolean(ele.getAttribute(PROXY_TARGET_CLASS));
 		}
 
 		// Register the original bean definition as it will be referenced by the scoped proxy


### PR DESCRIPTION
This pull request simplifies the code and makes it more readable by combining two conditions into a single statement using the logical AND operator (`&&`). Now, the enclosed statement executes only when both conditions (`a` and ` b`) are `true`.


Your review and consideration for merging are appreciated to improve overall code quality.