### PR TITLE
Complete frame callback when opcode is not PONG

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketHandlerAdapter.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketHandlerAdapter.java
@@ -114,6 +114,8 @@ public class JettyWebSocketHandlerAdapter {
 				callback.fail(ex);
 				ExceptionWebSocketHandlerDecorator.tryCloseWithError(this.wsSession, ex, logger);
 			}
+		} else {
+			callback.succeed();
 		}
 	}
 


### PR DESCRIPTION
onWebSocketFrame method should complete callback. more details see issue [JETTY 11088](https://github.com/jetty/jetty.project/issues/11088)