### PR TITLE
Specify use of regexp Path Pattern in javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
@@ -43,7 +43,8 @@ import org.springframework.util.StringUtils;
  * <li>{@code *} matches zero or more characters within a path segment</li>
  * <li>{@code **} matches zero or more <em>path segments</em> until the end of the path</li>
  * <li><code>{spring}</code> matches a <em>path segment</em> and captures it as a variable named "spring"</li>
- * <li><code>{spring:[a-z]+}</code> matches the regexp {@code [a-z]+} against a path segment and captures it a path variable named "spring"</li>
+ * <li><code>{spring:[a-z]+}</code> matches the regexp {@code [a-z]+} against a path segment
+ * and captures it a path variable named "spring"</li>
  * <li><code>{*spring}</code> matches zero or more <em>path segments</em> until the end of the path
  * and captures it as a variable named "spring"</li>
  * </ul>

--- a/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
@@ -43,7 +43,7 @@ import org.springframework.util.StringUtils;
  * <li>{@code *} matches zero or more characters within a path segment</li>
  * <li>{@code **} matches zero or more <em>path segments</em> until the end of the path</li>
  * <li><code>{spring}</code> matches a <em>path segment</em> and captures it as a variable named "spring"</li>
- * <li><code>{spring:[a-z]+}</code> matches the regexp {@code [a-z]+} as a path variable named "spring"</li>
+ * <li><code>{spring:[a-z]+}</code> matches the regexp {@code [a-z]+} against a path segment and captures it a path variable named "spring"</li>
  * <li><code>{*spring}</code> matches zero or more <em>path segments</em> until the end of the path
  * and captures it as a variable named "spring"</li>
  * </ul>


### PR DESCRIPTION
As far I saw how the framework process web requests Mapping and as far I read the code of CaptureVariablePathElement, when using  a path pattern with a regexp (like `{spring:[a-z]+}`) in a @RequestMapping, the regexp can match only one path segment of the path of the request. So this PR proposes to improve the javadoc of PathPattern to specify that the regexp match can only happen in one path segment.