### PR TITLE
Add Javadoc since tag to CacheOperationContext.getGeneratedKey()

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
@@ -918,6 +918,11 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 			return this.key;
 		}
 
+		/**
+		 * Get generated key.
+		 * @return generated key
+		 * @since 6.1.2
+		 */
 		@Nullable
 		protected Object getGeneratedKey() {
 			return this.key;


### PR DESCRIPTION
This PR adds Javadoc `@since` to `CacheOperationContext.getGeneratedKey()`.

See gh-31789