### PR TITLE
Remove unnecessary final modifier

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassAndBFPPTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassAndBFPPTests.java
@@ -88,7 +88,7 @@ class ConfigurationClassAndBFPPTests {
 		@Autowired TestBean autowiredTestBean;
 
 		@Bean
-		public static final BeanFactoryPostProcessor bfpp() {
+		public static BeanFactoryPostProcessor bfpp() {
 			return beanFactory -> {
 				// no-op
 			};

--- a/spring-core/src/test/java/org/springframework/core/type/AbstractMethodMetadataTests.java
+++ b/spring-core/src/test/java/org/springframework/core/type/AbstractMethodMetadataTests.java
@@ -263,7 +263,7 @@ public abstract class AbstractMethodMetadataTests {
 	public static class WithPrivateMethod {
 
 		@Tag
-		private final String test() {
+		private String test() {
 			return "";
 		}
 

--- a/spring-test/src/main/java/org/springframework/test/annotation/SystemProfileValueSource.java
+++ b/spring-test/src/main/java/org/springframework/test/annotation/SystemProfileValueSource.java
@@ -34,7 +34,7 @@ public final class SystemProfileValueSource implements ProfileValueSource {
 	/**
 	 * Obtain the canonical instance of this ProfileValueSource.
 	 */
-	public static final SystemProfileValueSource getInstance() {
+	public static SystemProfileValueSource getInstance() {
 		return INSTANCE;
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/context/cache/ContextCacheTestUtils.java
+++ b/spring-test/src/test/java/org/springframework/test/context/cache/ContextCacheTestUtils.java
@@ -32,7 +32,7 @@ public class ContextCacheTestUtils {
 	/**
 	 * Reset the state of the static context cache in {@link DefaultCacheAwareContextLoaderDelegate}.
 	 */
-	public static final void resetContextCache() {
+	public static void resetContextCache() {
 		DefaultCacheAwareContextLoaderDelegate.defaultContextCache.reset();
 	}
 
@@ -43,7 +43,7 @@ public class ContextCacheTestUtils {
 	 * @param expectedHitCount the expected hit count
 	 * @param expectedMissCount the expected miss count
 	 */
-	public static final void assertContextCacheStatistics(int expectedSize, int expectedHitCount, int expectedMissCount) {
+	public static void assertContextCacheStatistics(int expectedSize, int expectedHitCount, int expectedMissCount) {
 		assertContextCacheStatistics(null, expectedSize, expectedHitCount, expectedMissCount);
 	}
 
@@ -55,8 +55,8 @@ public class ContextCacheTestUtils {
 	 * @param expectedHitCount the expected hit count
 	 * @param expectedMissCount the expected miss count
 	 */
-	public static final void assertContextCacheStatistics(String usageScenario, int expectedSize, int expectedHitCount,
-			int expectedMissCount) {
+	public static void assertContextCacheStatistics(String usageScenario, int expectedSize, int expectedHitCount,
+													int expectedMissCount) {
 		assertContextCacheStatistics(DefaultCacheAwareContextLoaderDelegate.defaultContextCache, usageScenario,
 			expectedSize, expectedHitCount, expectedMissCount);
 	}
@@ -70,8 +70,8 @@ public class ContextCacheTestUtils {
 	 * @param expectedHitCount the expected hit count
 	 * @param expectedMissCount the expected miss count
 	 */
-	public static final void assertContextCacheStatistics(ContextCache contextCache, String usageScenario,
-			int expectedSize, int expectedHitCount, int expectedMissCount) {
+	public static void assertContextCacheStatistics(ContextCache contextCache, String usageScenario,
+													int expectedSize, int expectedHitCount, int expectedMissCount) {
 
 		String context = (StringUtils.hasText(usageScenario) ? " (" + usageScenario + ")" : "");
 

--- a/spring-web/src/test/java/org/springframework/web/util/pattern/PathPatternParserTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/pattern/PathPatternParserTests.java
@@ -474,7 +474,7 @@ public class PathPatternParserTests {
 	}
 
 	@SafeVarargs
-	private final void assertPathElements(PathPattern p, Class<? extends PathElement>... sectionClasses) {
+	private void assertPathElements(PathPattern p, Class<? extends PathElement>... sectionClasses) {
 		PathElement head = p.getHeadSection();
 		for (Class<? extends PathElement> sectionClass : sectionClasses) {
 			if (head == null) {


### PR DESCRIPTION
`final` is useless for `private` and `static` methods