### PR TITLE
Fix `HttpExchange` is found from not declaring class

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceMethod.java
@@ -179,7 +179,10 @@ final class HttpServiceMethod {
 				Method method, Class<?> containingClass, @Nullable StringValueResolver embeddedValueResolver,
 				Supplier<HttpRequestValues.Builder> requestValuesSupplier) {
 
-			HttpExchange annot1 = AnnotatedElementUtils.findMergedAnnotation(containingClass, HttpExchange.class);
+			HttpExchange annot1 = AnnotatedElementUtils.findMergedAnnotation(method.getDeclaringClass(), HttpExchange.class);
+			if (annot1 == null) {
+				annot1 = AnnotatedElementUtils.getMergedAnnotation(containingClass, HttpExchange.class);
+			}
 			HttpExchange annot2 = AnnotatedElementUtils.findMergedAnnotation(method, HttpExchange.class);
 
 			Assert.notNull(annot2, "Expected HttpRequest annotation");

--- a/spring-web/src/test/java/org/springframework/web/service/invoker/HttpServiceMethodTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/invoker/HttpServiceMethodTests.java
@@ -204,6 +204,26 @@ class HttpServiceMethodTests {
 		assertThat(requestValues.getHeaders().getAccept()).containsExactly(MediaType.APPLICATION_JSON);
 	}
 
+	@Test
+	void nestedAnnotatedService() {
+		SubAnnotatedService service = this.proxyFactory.createClient(SubAnnotatedService.class);
+
+		service.performGet();
+
+		HttpRequestValues requestValues = this.client.getRequestValues();
+		assertThat(requestValues.getUriTemplate()).isEqualTo("/api");
+
+		service.performV1Get();
+
+		requestValues = this.client.getRequestValues();
+		assertThat(requestValues.getUriTemplate()).isEqualTo("/v1/api");
+
+		service.performV2Get();
+
+		requestValues = this.client.getRequestValues();
+		assertThat(requestValues.getUriTemplate()).isEqualTo("/v2/api");
+	}
+
 	protected void verifyReactorClientInvocation(String methodName, @Nullable ParameterizedTypeReference<?> expectedBodyType) {
 		assertThat(this.reactorClient.getInvokedMethodName()).isEqualTo(methodName);
 		assertThat(this.reactorClient.getBodyType()).isEqualTo(expectedBodyType);
@@ -308,6 +328,34 @@ class HttpServiceMethodTests {
 	@SuppressWarnings("unused")
 	@HttpExchange(url = "${baseUrl}", contentType = APPLICATION_CBOR_VALUE, accept = APPLICATION_CBOR_VALUE)
 	private interface TypeAndMethodLevelAnnotatedService extends MethodLevelAnnotatedService {
+	}
+
+
+	private interface SuperAnnotatedService {
+
+		@GetExchange("/api")
+		void performGet();
+
+	}
+
+	@HttpExchange("/v1")
+	private interface SuperAnnotatedServiceV1 {
+
+		@GetExchange("/api")
+		void performV1Get();
+
+	}
+
+	@HttpExchange("/v2")
+	private interface SuperAnnotatedServiceV2 {
+
+		@GetExchange("/api")
+		void performV2Get();
+
+	}
+
+	private interface SubAnnotatedService
+			extends SuperAnnotatedService, SuperAnnotatedServiceV1, SuperAnnotatedServiceV2 {
 	}
 
 }


### PR DESCRIPTION
It might be common to composite HTTP interfaces like:

```java
@HttpExchange("/v1")
interface V1Api { ... }

@HttpExchange("/v2")
interface V2Api { ... }

interface Api extends V1Api, V2Api {}
```

There's a probable defect that the `HttpExchange` is not resolved as expected. The `HttpExchange` of `V2Api` is not resolved because the annotation is found based on the `Api` class. So, when we execute a method in the `V2Api` class, `/v1` prefix is added because the first annotation of the `Api` class is `@HttpExchange("/v1")` on `V1Api`.

This commit fixes the bug by finding the annotation from the declaring class first. `HttpRequestValuesInitializer` tries to **get** the annotation from the containing class only when the declaring class is not annotated.