### PR TITLE
Fix  typo in NumberFormat javadoc

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/annotation/NumberFormat.java
+++ b/spring-context/src/main/java/org/springframework/format/annotation/NumberFormat.java
@@ -74,7 +74,7 @@ public @interface NumberFormat {
 
 		/**
 		 * The default format for the annotated type: typically 'number' but possibly
-		 * 'currency' for a money type (e.g. {@code javax.money.MonetaryAmount)}.
+		 * 'currency' for a money type (e.g. {@code javax.money.MonetaryAmount}).
 		 * @since 4.2
 		 */
 		DEFAULT,


### PR DESCRIPTION
Like other codes, {} bracket processing of `@Code` seems to have to be done first.
- e.g) [RequestMapping docs](https://github.com/spring-projects/spring-framework/blob/main/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMapping.java#L104)