### PR TITLE
Update `autowired-qualifiers.adoc` to refer the `-parameters` Java compiler flag

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/annotation-config/autowired-qualifiers.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/annotation-config/autowired-qualifiers.adoc
@@ -155,6 +155,8 @@ If there is no other resolution indicator (such as a qualifier or a primary mark
 for a non-unique dependency situation, Spring matches the injection point name
 (that is, the field name or parameter name) against the target bean names and chooses the
 same-named candidate, if any.
+
+Since version 6.1, this requires the `-parameters` Java compiler flag to be present.
 ====
 
 That said, if you intend to express annotation-driven injection by name, do not


### PR DESCRIPTION
As described in [Parameter Name Retention section for the Spring Upgrade Guide for 6.1](https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention), Spring only matches the injection point name (e.g. parameter name of a constructor) against the target bean names if the `-parameters` Java compiler flag is present.