### PR TITLE
Add error handling function in R2DBC `DatabaseClient`

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,10 @@
 package org.springframework.r2dbc.core;
 
 import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.function.*;
 
-import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.*;
 import io.r2dbc.spi.Readable;
-import io.r2dbc.spi.Result;
-import io.r2dbc.spi.Row;
-import io.r2dbc.spi.RowMetadata;
-import io.r2dbc.spi.Statement;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -56,6 +48,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Juergen Hoeller
+ * @author Injae Kim
  * @since 5.3
  */
 public interface DatabaseClient extends ConnectionAccessor {
@@ -145,6 +138,12 @@ public interface DatabaseClient extends ConnectionAccessor {
 		 * @see NamedParameterExpander
 		 */
 		Builder namedParameters(boolean enabled);
+
+		/**
+		 * Handle the given error on {@link ConnectionAccessor#inConnection}
+		 * or {@link ConnectionAccessor#inConnectionMany}.
+		 */
+		Builder handleInConnectionError(BiConsumer<? super Throwable, ? super Connection> handleInConnectionError);
 
 		/**
 		 * Apply a {@link Consumer} to configure this builder.

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
@@ -150,10 +150,12 @@ public interface DatabaseClient extends ConnectionAccessor {
 		Builder namedParameters(boolean enabled);
 
 		/**
-		 * Handle the given error on {@link ConnectionAccessor#inConnection}
+		 * Handle an exception thrown from {@link ConnectionAccessor#inConnection}
 		 * or {@link ConnectionAccessor#inConnectionMany}.
+		 * @param errorHandler a {@code BiConsumer} that handles the connection error
+		 * @since 6.2
 		 */
-		Builder onConnectionError(BiConsumer<? super Throwable, ? super Connection> onConnectionError);
+		Builder onConnectionError(BiConsumer<? super Throwable, ? super Connection> errorHandler);
 
 		/**
 		 * Apply a {@link Consumer} to configure this builder.

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
@@ -17,10 +17,20 @@
 package org.springframework.r2dbc.core;
 
 import java.util.Map;
-import java.util.function.*;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
-import io.r2dbc.spi.*;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Readable;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
+import io.r2dbc.spi.Statement;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DatabaseClient.java
@@ -153,7 +153,7 @@ public interface DatabaseClient extends ConnectionAccessor {
 		 * Handle the given error on {@link ConnectionAccessor#inConnection}
 		 * or {@link ConnectionAccessor#inConnectionMany}.
 		 */
-		Builder handleInConnectionError(BiConsumer<? super Throwable, ? super Connection> handleInConnectionError);
+		Builder onConnectionError(BiConsumer<? super Throwable, ? super Connection> onConnectionError);
 
 		/**
 		 * Apply a {@link Consumer} to configure this builder.

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClient.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClient.java
@@ -89,10 +89,11 @@ final class DefaultDatabaseClient implements DatabaseClient {
 	private final NamedParameterExpander namedParameterExpander;
 
 
-	DefaultDatabaseClient(BindMarkersFactory bindMarkersFactory, ConnectionFactory connectionFactory,
-						  ExecuteFunction executeFunction,
-						  BiConsumer<? super Throwable, ? super Connection> onConnectionError,
-						  boolean namedParameters) {
+	DefaultDatabaseClient(BindMarkersFactory bindMarkersFactory,
+			ConnectionFactory connectionFactory,
+			ExecuteFunction executeFunction,
+			BiConsumer<? super Throwable, ? super Connection> onConnectionError,
+			boolean namedParameters) {
 
 		this.bindMarkersFactory = bindMarkersFactory;
 		this.connectionFactory = connectionFactory;
@@ -130,10 +131,10 @@ final class DefaultDatabaseClient implements DatabaseClient {
 			Connection connectionToUse = createConnectionProxy(connectionCloseHolder.connection);
 					try {
 						return action.apply(connectionToUse)
-								.doOnError(t -> onConnectionError.accept(t, connectionCloseHolder.connection));
+								.doOnError(t -> this.onConnectionError.accept(t, connectionCloseHolder.connection));
 					}
 					catch (Throwable ex) {
-						onConnectionError.accept(ex, connectionCloseHolder.connection);
+						this.onConnectionError.accept(ex, connectionCloseHolder.connection);
 						if (ex instanceof R2dbcException) {
 							String sql = getSql(action);
 							return Mono.error(ConnectionFactoryUtils.convertR2dbcException(
@@ -158,10 +159,10 @@ final class DefaultDatabaseClient implements DatabaseClient {
 			Connection connectionToUse = createConnectionProxy(connectionCloseHolder.connection);
 					try {
 						return action.apply(connectionToUse)
-								.doOnError(t -> onConnectionError.accept(t, connectionCloseHolder.connection));
+								.doOnError(t -> this.onConnectionError.accept(t, connectionCloseHolder.connection));
 					}
 					catch (Throwable ex) {
-						onConnectionError.accept(ex, connectionCloseHolder.connection);
+						this.onConnectionError.accept(ex, connectionCloseHolder.connection);
 						if (ex instanceof R2dbcException) {
 							String sql = getSql(action);
 							return Flux.error(ConnectionFactoryUtils.convertR2dbcException(

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClientBuilder.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClientBuilder.java
@@ -45,7 +45,7 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 
 	private ExecuteFunction executeFunction = Statement::execute;
 
-	private BiConsumer<? super Throwable, ? super Connection> onConnectionError = (t, conn) -> {};
+	private BiConsumer<? super Throwable, ? super Connection> errorHandler = (t, conn) -> {};
 
 	private boolean namedParameters = true;
 
@@ -83,8 +83,8 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 
 	@Override
 	public DatabaseClient.Builder onConnectionError(
-			BiConsumer<? super Throwable, ? super Connection> onConnectionError) {
-		this.onConnectionError = onConnectionError;
+			BiConsumer<? super Throwable, ? super Connection> errorHandler) {
+		this.errorHandler = errorHandler;
 		return this;
 	}
 
@@ -104,7 +104,7 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 
 		return new DefaultDatabaseClient(
 				bindMarkers, this.connectionFactory,
-				this.executeFunction, this.onConnectionError, this.namedParameters);
+				this.executeFunction, this.errorHandler, this.namedParameters);
 	}
 
 	@Override

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClientBuilder.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/DefaultDatabaseClientBuilder.java
@@ -45,7 +45,7 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 
 	private ExecuteFunction executeFunction = Statement::execute;
 
-	private BiConsumer<? super Throwable, ? super Connection> handleInConnectionError = (t, conn) -> {};
+	private BiConsumer<? super Throwable, ? super Connection> onConnectionError = (t, conn) -> {};
 
 	private boolean namedParameters = true;
 
@@ -82,9 +82,9 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 	}
 
 	@Override
-	public DatabaseClient.Builder handleInConnectionError(
-			BiConsumer<? super Throwable, ? super Connection> handleInConnectionError) {
-		this.handleInConnectionError = handleInConnectionError;
+	public DatabaseClient.Builder onConnectionError(
+			BiConsumer<? super Throwable, ? super Connection> onConnectionError) {
+		this.onConnectionError = onConnectionError;
 		return this;
 	}
 
@@ -104,7 +104,7 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 
 		return new DefaultDatabaseClient(
 				bindMarkers, this.connectionFactory,
-				this.executeFunction, this.handleInConnectionError, this.namedParameters);
+				this.executeFunction, this.onConnectionError, this.namedParameters);
 	}
 
 	@Override

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientTests.java
@@ -21,7 +21,11 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
-import io.r2dbc.spi.*;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Parameters;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.test.MockColumnMetadata;
 import io.r2dbc.spi.test.MockResult;
 import io.r2dbc.spi.test.MockRow;

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientTests.java
@@ -135,13 +135,13 @@ class DefaultDatabaseClientTests {
 	@Test
 	void onConnectionError() {
 		AtomicInteger onErrorCounter = new AtomicInteger();
-		BiConsumer<Throwable, Connection> onConnectionError = (t, conn) -> {
+		BiConsumer<Throwable, Connection> errorHandler = (t, conn) -> {
 			onErrorCounter.incrementAndGet();
 			conn.getMetadata();
 		};
 
 		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder
-				.onConnectionError(onConnectionError)
+				.onConnectionError(errorHandler)
 				.build();
 		Mono<Object> mono = databaseClient.inConnection(connection -> Mono.error(new IllegalStateException()));
 
@@ -157,13 +157,13 @@ class DefaultDatabaseClientTests {
 	@Test
 	void onConnectionErrorActionThrow() {
 		AtomicInteger onErrorCounter = new AtomicInteger();
-		BiConsumer<Throwable, Connection> onConnectionError = (t, conn) -> {
+		BiConsumer<Throwable, Connection> errorHandler = (t, conn) -> {
 			onErrorCounter.incrementAndGet();
 			conn.getMetadata();
 		};
 
 		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder
-				.onConnectionError(onConnectionError)
+				.onConnectionError(errorHandler)
 				.build();
 		Mono<Object> mono = databaseClient.inConnection(connection -> {
 			throw new IllegalStateException();
@@ -181,13 +181,13 @@ class DefaultDatabaseClientTests {
 	@Test
 	void onConnectionErrorInConnectionMany() {
 		AtomicInteger onErrorCounter = new AtomicInteger();
-		BiConsumer<Throwable, Connection> onConnectionError = (t, conn) -> {
+		BiConsumer<Throwable, Connection> errorHandler = (t, conn) -> {
 			onErrorCounter.incrementAndGet();
 			conn.getMetadata();
 		};
 
 		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder
-				.onConnectionError(onConnectionError)
+				.onConnectionError(errorHandler)
 				.build();
 		Flux<Object> flux = databaseClient.inConnectionMany(connection -> Flux.error(new IllegalStateException()));
 
@@ -203,13 +203,13 @@ class DefaultDatabaseClientTests {
 	@Test
 	void onConnectionErrorInConnectionManyActionThrow() {
 		AtomicInteger onErrorCounter = new AtomicInteger();
-		BiConsumer<Throwable, Connection> onConnectionError = (t, conn) -> {
+		BiConsumer<Throwable, Connection> errorHandler = (t, conn) -> {
 			onErrorCounter.incrementAndGet();
 			conn.getMetadata();
 		};
 
 		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder
-				.onConnectionError(onConnectionError)
+				.onConnectionError(errorHandler)
 				.build();
 		Flux<Object> flux = databaseClient.inConnectionMany(connection -> {
 			throw new IllegalStateException();

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/DefaultDatabaseClientTests.java
@@ -133,37 +133,37 @@ class DefaultDatabaseClientTests {
 	}
 
 	@Test
-	void shouldHandleErrorInConnection() {
-		AtomicInteger handleErrorCounter = new AtomicInteger();
-		BiConsumer<Throwable, Connection> handleInConnectionError = (t, conn) -> {
-			handleErrorCounter.incrementAndGet();
+	void onConnectionError() {
+		AtomicInteger onErrorCounter = new AtomicInteger();
+		BiConsumer<Throwable, Connection> onConnectionError = (t, conn) -> {
+			onErrorCounter.incrementAndGet();
 			conn.getMetadata();
 		};
 
 		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder
-				.handleInConnectionError(handleInConnectionError)
+				.onConnectionError(onConnectionError)
 				.build();
 		Mono<Object> mono = databaseClient.inConnection(connection -> Mono.error(new IllegalStateException()));
 
 		StepVerifier.create(mono)
 				.verifyErrorSatisfies(t -> {
 					assertThat(t).isInstanceOf(IllegalStateException.class);
-					assertThat(handleErrorCounter.get()).isOne();
+					assertThat(onErrorCounter.get()).isOne();
 					verify(connection, times(1)).getMetadata();
 				});
 		verify(connection, times(1)).close();
 	}
 
 	@Test
-	void shouldHandleErrorInConnectionActionThrow() {
-		AtomicInteger handleErrorCounter = new AtomicInteger();
-		BiConsumer<Throwable, Connection> handleInConnectionError = (t, conn) -> {
-			handleErrorCounter.incrementAndGet();
+	void onConnectionErrorActionThrow() {
+		AtomicInteger onErrorCounter = new AtomicInteger();
+		BiConsumer<Throwable, Connection> onConnectionError = (t, conn) -> {
+			onErrorCounter.incrementAndGet();
 			conn.getMetadata();
 		};
 
 		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder
-				.handleInConnectionError(handleInConnectionError)
+				.onConnectionError(onConnectionError)
 				.build();
 		Mono<Object> mono = databaseClient.inConnection(connection -> {
 			throw new IllegalStateException();
@@ -172,44 +172,44 @@ class DefaultDatabaseClientTests {
 		StepVerifier.create(mono)
 				.verifyErrorSatisfies(t -> {
 					assertThat(t).isInstanceOf(IllegalStateException.class);
-					assertThat(handleErrorCounter.get()).isOne();
+					assertThat(onErrorCounter.get()).isOne();
 					verify(connection, times(1)).getMetadata();
 				});
 		verify(connection, times(1)).close();
 	}
 
 	@Test
-	void shouldHandleErrorInConnectionMany() {
-		AtomicInteger handleErrorCounter = new AtomicInteger();
-		BiConsumer<Throwable, Connection> handleInConnectionError = (t, conn) -> {
-			handleErrorCounter.incrementAndGet();
+	void onConnectionErrorInConnectionMany() {
+		AtomicInteger onErrorCounter = new AtomicInteger();
+		BiConsumer<Throwable, Connection> onConnectionError = (t, conn) -> {
+			onErrorCounter.incrementAndGet();
 			conn.getMetadata();
 		};
 
 		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder
-				.handleInConnectionError(handleInConnectionError)
+				.onConnectionError(onConnectionError)
 				.build();
 		Flux<Object> flux = databaseClient.inConnectionMany(connection -> Flux.error(new IllegalStateException()));
 
 		StepVerifier.create(flux)
 				.verifyErrorSatisfies(t -> {
 					assertThat(t).isInstanceOf(IllegalStateException.class);
-					assertThat(handleErrorCounter.get()).isOne();
+					assertThat(onErrorCounter.get()).isOne();
 					verify(connection, times(1)).getMetadata();
 				});
 		verify(connection, times(1)).close();
 	}
 
 	@Test
-	void shouldHandleErrorInConnectionManyActionThrow() {
-		AtomicInteger handleErrorCounter = new AtomicInteger();
-		BiConsumer<Throwable, Connection> handleInConnectionError = (t, conn) -> {
-			handleErrorCounter.incrementAndGet();
+	void onConnectionErrorInConnectionManyActionThrow() {
+		AtomicInteger onErrorCounter = new AtomicInteger();
+		BiConsumer<Throwable, Connection> onConnectionError = (t, conn) -> {
+			onErrorCounter.incrementAndGet();
 			conn.getMetadata();
 		};
 
 		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder
-				.handleInConnectionError(handleInConnectionError)
+				.onConnectionError(onConnectionError)
 				.build();
 		Flux<Object> flux = databaseClient.inConnectionMany(connection -> {
 			throw new IllegalStateException();
@@ -218,7 +218,7 @@ class DefaultDatabaseClientTests {
 		StepVerifier.create(flux)
 				.verifyErrorSatisfies(t -> {
 					assertThat(t).isInstanceOf(IllegalStateException.class);
-					assertThat(handleErrorCounter.get()).isOne();
+					assertThat(onErrorCounter.get()).isOne();
 					verify(connection, times(1)).getMetadata();
 				});
 		verify(connection, times(1)).close();


### PR DESCRIPTION
Closes gh-31256

### Motivation
```java
// users want to handle error like this on various cases!
    @Override
    public <T> Mono<T> inConnection(Function<Connection, Mono<T>> action) throws DataAccessException {
        return super.inConnection(con -> action.apply(con)
                .onErrorResume(e -> {
                    handleError(e, con); // here
                    return Mono.error(e);
                }));
    }

    @Override
    public <T> Flux<T> inConnectionMany(Function<Connection, Flux<T>> action) throws DataAccessException {
        return super.inConnectionMany(con -> action.apply(con)
                .onErrorResume(e -> {
                    handleError(e, con); // here
                    return Mono.error(e);
                }));
    }
```
- We found that users want to handle error by user's custom error handling logic on `DatabaseClient`, but currently impossible

### Modification
```java
DatabaseClient.builder()
    .handleInConnectionError((t, conn) -> { /* error handling logic */})
    .build()
```
- Add error handling function on R2DBC DatabaseClient and it's builder

### Result
- Now user can use their custom error handling logic on R2DBC DatabaseClient
- Close https://github.com/spring-projects/spring-framework/issues/31256