### PR TITLE
Fix `AsyncContext` to be completed on `AsyncListener.onError()`

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/async/StandardServletAsyncWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/async/StandardServletAsyncWebRequest.java
@@ -151,6 +151,9 @@ public class StandardServletAsyncWebRequest extends ServletWebRequest implements
 
 	@Override
 	public void onError(AsyncEvent event) throws IOException {
+		if (this.asyncContext != null) {
+			this.asyncContext.complete();
+		}
 		this.exceptionHandlers.forEach(consumer -> consumer.accept(event.getThrowable()));
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/context/request/async/StandardServletAsyncWebRequestTests.java
+++ b/spring-web/src/test/java/org/springframework/web/context/request/async/StandardServletAsyncWebRequestTests.java
@@ -16,9 +16,12 @@
 
 package org.springframework.web.context.request.async;
 
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -122,6 +125,36 @@ public class StandardServletAsyncWebRequestTests {
 		Exception e = new Exception();
 		this.asyncRequest.onError(new AsyncEvent(new MockAsyncContext(this.request, this.response), e));
 		verify(errorHandler).accept(e);
+	}
+
+	@Test
+	public void onErrorShouldCompleteAsyncContext() throws Exception {
+		this.asyncRequest.startAsync();
+		AtomicInteger completeCounter = new AtomicInteger();
+		MockAsyncContext context = (MockAsyncContext) this.request.getAsyncContext();
+		context.addListener(new AsyncListener() {
+			@Override
+			public void onComplete(AsyncEvent asyncEvent) throws IOException {
+				completeCounter.incrementAndGet();
+			}
+
+			@Override
+			public void onTimeout(AsyncEvent asyncEvent) throws IOException {
+
+			}
+
+			@Override
+			public void onError(AsyncEvent asyncEvent) throws IOException {
+
+			}
+
+			@Override
+			public void onStartAsync(AsyncEvent asyncEvent) throws IOException {
+
+			}
+		});
+		this.asyncRequest.onError(new AsyncEvent(new MockAsyncContext(this.request, this.response), new Exception()));
+		assertThat(completeCounter.get()).isOne();
 	}
 
 	@Test


### PR DESCRIPTION
Closes gh-31541

### Motivation
```
According to https://bz.apache.org/bugzilla/show_bug.cgi?id=66875#c11,
our StandardServletAsyncWebRequest.onError implementation should call asyncContext.complete()
if that context is still non-null.
Let's sort this out for 6.1.3 and backport it to 6.0.16 and 5.3.32 from there.
```
- On https://github.com/spring-projects/spring-framework/issues/31541#issuecomment-1870120560, we found that our` StandardServletAsyncWebRequest.onError` implementation should call `asyncContext.complete()` if that context is still non-null.


```
Tomcat's error handling triggers the onError event.
...
Spring and/or the application should be calling complete() or dispatch() as a result of the onError() event.
```
- See [bug report](https://bz.apache.org/bugzilla/show_bug.cgi?id=66875#c11) for the details

### Modification
- Fix `AsyncContext` to be completed on `StandardServletAsyncWebRequest.onError()`

### Result
- Closes https://github.com/spring-projects/spring-framework/issues/31541