### PR TITLE
Document exception handling for HTTP Interface client with `RestClient` and `RestTemplate`

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/rest-clients.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/rest-clients.adoc
@@ -1079,10 +1079,30 @@ underlying HTTP client, which operates at a lower level and provides more contro
 
 [[rest-http-interface-exceptions]]
 === Exception Handling
+In order to provide a custom way of handling errors, you can register response
+status handlers on the underlying HTTP clients.
 
-By default, `WebClient` raises `WebClientResponseException` for 4xx and 5xx HTTP status
-codes. To customize this, you can register a response status handler that applies to all
-responses performed through the client:
+For `RestClient`:
+
+By default, `RestClient` raises `RestClientException` for 4xx and 5xx HTTP status codes. To customize this, you can register a response status handler that applies to all responses performed through the client:
+
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+    RestClient restClient = RestClient.builder()
+			.defaultStatusHandler(HttpStatusCode::isError,
+            (request, response) -> ...)
+            .build();
+
+    RestClientAdapter clientAdapter = RestClientAdapter.create(restClient);
+	HttpServiceProxyFactory factory = HttpServiceProxyFactory
+            .builderFor(clientAdapter).build();
+----
+
+For more details and options, such as suppressing error status codes, see the Javadoc of `defaultStatusHandler` in `RestClient.Builder`.
+
+For `WebClient`:
+
+By default, `WebClient` raises `WebClientResponseException` for 4xx and 5xx HTTP status codes. To customize this, you can register a response status handler that applies to all responses performed through the client:
 
 [source,java,indent=0,subs="verbatim,quotes"]
 ----
@@ -1095,5 +1115,20 @@ responses performed through the client:
 			.builder(clientAdapter).build();
 ----
 
-For more details and options, such as suppressing error status codes, see the Javadoc of
-`defaultStatusHandler` in `WebClient.Builder`.
+For more details and options, such as suppressing error status codes, see the Javadoc of `defaultStatusHandler` in `WebClient.Builder`.
+
+For `RestTemplate`:
+
+By default, `RestTemplate` raises `RestClientException` for 4xx and 5xx HTTP status codes. To customize this, you can register an error handler that applies to all responses performed through the client:
+
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+    RestTemplate restTemplate = new RestTemplate();
+    restTemplate.setErrorHandler(aCustomErrorHandler);
+
+    RestTemplateAdapter clientAdapter = RestTemplateAdapter.create(restTemplate);
+    HttpServiceProxyFactory factory = HttpServiceProxyFactory
+            .builderFor(clientAdapter).build();
+----
+
+For more details and options, see the Javadoc of `setErrorHandler` in `RestTemplate`.


### PR DESCRIPTION
Fixes gh-31782.