### PR TITLE
Exclude URI query from remaining WebClient checkpoints

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -195,6 +195,18 @@ final class DefaultWebClient implements WebClient {
 		return response.releaseBody().onErrorComplete().then(Mono.error(ex));
 	}
 
+	private static URI getUriToLog(URI uri) {
+		if (StringUtils.hasText(uri.getQuery())) {
+			try {
+				uri = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), null, null);
+			}
+			catch (URISyntaxException ex) {
+				// ignore
+			}
+		}
+		return uri;
+	}
+
 
 	private class DefaultRequestBodyUriSpec implements RequestBodyUriSpec {
 
@@ -457,7 +469,7 @@ final class DefaultWebClient implements WebClient {
 				observationContext.setRequest(request);
 				Mono<ClientResponse> responseMono = filterFunction.apply(exchangeFunction)
 						.exchange(request)
-						.checkpoint("Request to " + this.httpMethod.name() + " " + this.uri + " [DefaultWebClient]")
+						.checkpoint("Request to " + this.httpMethod.name() + " " + getUriToLog(request.url()) + " [DefaultWebClient]")
 						.switchIfEmpty(NO_HTTP_CLIENT_RESPONSE_ERROR);
 				if (this.contextModifier != null) {
 					responseMono = responseMono.contextWrite(this.contextModifier);
@@ -696,18 +708,6 @@ final class DefaultWebClient implements WebClient {
 				}
 			}
 			return null;
-		}
-
-		private static URI getUriToLog(URI uri) {
-			if (StringUtils.hasText(uri.getQuery())) {
-				try {
-					uri = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), null, null);
-				}
-				catch (URISyntaxException ex) {
-					// ignore
-				}
-			}
-			return uri;
 		}
 
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.reactive.function.client;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -30,6 +32,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Exceptions that contain actual HTTP response data.
@@ -99,7 +102,19 @@ public class WebClientResponseException extends WebClientException {
 
 	private static String initMessage(HttpStatusCode status, String reasonPhrase, @Nullable HttpRequest request) {
 		return status.value() + " " + reasonPhrase +
-				(request != null ? " from " + request.getMethod() + " " + request.getURI() : "");
+				(request != null ? " from " + request.getMethod() + " " + getUriToLog(request.getURI()) : "");
+	}
+
+	private static URI getUriToLog(URI uri) {
+		if (StringUtils.hasText(uri.getQuery())) {
+			try {
+				uri = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), null, null);
+			}
+			catch (URISyntaxException ex) {
+				// ignore
+			}
+		}
+		return uri;
 	}
 
 	/**


### PR DESCRIPTION
**Affects:** latest (v6.1.2)
**Module:** spring-webflux

Continuing from this issue https://github.com/spring-projects/spring-framework/issues/29148 and its fix https://github.com/spring-projects/spring-framework/commit/f9d8367379371f52887a210f1bc8ff8682d596e2 regarding full request URIs including sensitive query parameters being included in mono checkpoints.

This PR sanitises URIs included in 
- the mono checkpoint in `DefaultWebClient.DefaultRequestBodyUriSpec::exchange`
- the message of `WebClientResponseException`s created via `WebClientResponseException::create`
