### PR TITLE
Fix `DefaultDataBuffer#getNativeBuffer()` to set correct limit

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DefaultDataBuffer.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DefaultDataBuffer.java
@@ -37,6 +37,7 @@ import org.springframework.util.ObjectUtils;
  * @author Arjen Poutsma
  * @author Juergen Hoeller
  * @author Brian Clozel
+ * @author Injae Kim
  * @since 5.0
  * @see DefaultDataBufferFactory
  */
@@ -81,12 +82,12 @@ public class DefaultDataBuffer implements DataBuffer {
 	/**
 	 * Directly exposes the native {@code ByteBuffer} that this buffer is based
 	 * on also updating the {@code ByteBuffer's} position and limit to match
-	 * the current {@link #readPosition()} and {@link #readableByteCount()}.
+	 * the current {@link #readPosition()} and {@link #writePosition()}.
 	 * @return the wrapped byte buffer
 	 */
 	public ByteBuffer getNativeBuffer() {
 		this.byteBuffer.position(this.readPosition);
-		this.byteBuffer.limit(readableByteCount());
+		this.byteBuffer.limit(this.writePosition);
 		return this.byteBuffer;
 	}
 

--- a/spring-core/src/test/java/org/springframework/core/io/buffer/DefaultDataBufferTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/buffer/DefaultDataBufferTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.io.buffer;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.core.io.buffer.DataBufferUtils.release;
+
+/**
+ * Tests for {@link DefaultDataBuffer}.
+ *
+ * @author Injae Kim
+ * @since 6.2
+ */
+class DefaultDataBufferTests {
+
+	private final DefaultDataBufferFactory bufferFactory = new DefaultDataBufferFactory();
+
+	@Test // gh-30967
+	void getNativeBuffer() {
+		DefaultDataBuffer buffer = bufferFactory.allocateBuffer(256);
+		buffer.write("0123456789", StandardCharsets.UTF_8);
+
+		byte[] result = new byte[7];
+		buffer.read(result);
+		assertThat(result).isEqualTo("0123456".getBytes(StandardCharsets.UTF_8));
+
+		ByteBuffer nativeBuffer = buffer.getNativeBuffer();
+		assertThat(nativeBuffer.position()).isEqualTo(7);
+		assertThat(buffer.readPosition()).isEqualTo(7);
+		assertThat(nativeBuffer.limit()).isEqualTo(10);
+		assertThat(buffer.writePosition()).isEqualTo(10);
+
+		release(buffer);
+	}
+
+}


### PR DESCRIPTION
Closes gh-30967

### Motivation
```java
// DefaultDataBuffer
	public ByteBuffer getNativeBuffer() {
		this.byteBuffer.position(this.readPosition);
		this.byteBuffer.limit(readableByteCount()); // 👈 limit should be writePosition, not readableByteCount
		return this.byteBuffer;
	}
```
- We found that `DefaultDataBuffer#getNativeBuffer` set `byteBuffer#limit` as `readableByteCount()` incorrectly so fix to `writePosition`

### Modification
- Fix `DefaultDataBuffer#getNativeBuffer()` to set correct limit as `writePosition` instead of `readableByteCount()`

### Result
- Now `DefaultDataBuffer#getNativeBuffer()` return native bytebuffer with correct limit
- Close #30967 