### PR TITLE
Document how `@JvmName` could mitigate Kotlin `internal` modifier impact

### DIFF
--- a/framework-docs/modules/ROOT/pages/languages/kotlin/spring-projects-in.adoc
+++ b/framework-docs/modules/ROOT/pages/languages/kotlin/spring-projects-in.adoc
@@ -167,7 +167,7 @@ public class SampleConfiguration {
 
 As a consequence, the related bean name represented as a Kotlin string is `"sampleBean\$demo_kotlin_internal_test"`,
 instead of `"sampleBean"` for the regular `public` function use-case. Make sure to use the mangled name when injecting
-such bean by name.
+such bean by name, or add `@JvmName("sampleBean")` to disable name mangling.
 
 [[injecting-configuration-properties]]
 == Injecting Configuration Properties


### PR DESCRIPTION
Continue https://github.com/spring-projects/spring-framework/commit/01b28561149127eeb7c7ec5d3977d83877cee6d4