### PR TITLE
Add invokeDefaultMethod utils for JDK dynamic proxy created by Spring AOP

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/ReflectiveMethodInvocationUtils.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/ReflectiveMethodInvocationUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Utility methods for {@link ReflectiveMethodInvocation}.
+ *
+ * @author Injae Kim
+ * @since 6.2
+ */
+public abstract class ReflectiveMethodInvocationUtils {
+
+	/**
+	 * Invoke default method in {@link ReflectiveMethodInvocation}.
+	 * @return {@code null} if method is not default method or invocation is not {@link ReflectiveMethodInvocation}
+	 */
+	@Nullable
+	public static Object invokeDefaultMethod(MethodInvocation invocation) throws Throwable {
+		Method method = invocation.getMethod();
+		if (method.isDefault() && invocation instanceof ReflectiveMethodInvocation reflectiveMethodInvocation) {
+			Object proxy = reflectiveMethodInvocation.getProxy();
+			return InvocationHandler.invokeDefault(proxy, method, invocation.getArguments());
+		}
+		return null;
+	}
+
+}

--- a/spring-aop/src/test/java/org/springframework/aop/framework/ReflectiveMethodInvocationUtilsTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/framework/ReflectiveMethodInvocationUtilsTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.framework;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ReflectiveMethodInvocationUtils}.
+ *
+ * @author Injae Kim
+ * @since 6.2
+ */
+public class ReflectiveMethodInvocationUtilsTests {
+
+	@Test
+	public void invokeDefaultMethod() {
+		Service service = ProxyFactory.getProxy(Service.class, (MethodInterceptor) ReflectiveMethodInvocationUtils::invokeDefaultMethod);
+
+		assertThat(service.getDefaultMethodValue()).isEqualTo("default method value");
+		assertThat(service.get()).isNull();
+	}
+
+	private interface Service {
+
+		String get();
+
+		default String getDefaultMethodValue() {
+			return "default method value";
+		}
+	}
+}

--- a/spring-messaging/src/main/java/org/springframework/messaging/rsocket/service/RSocketServiceProxyFactory.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/rsocket/service/RSocketServiceProxyFactory.java
@@ -16,7 +16,6 @@
 
 package org.springframework.messaging.rsocket.service;
 
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -29,7 +28,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
 import org.springframework.aop.framework.ProxyFactory;
-import org.springframework.aop.framework.ReflectiveMethodInvocation;
+import org.springframework.aop.framework.ReflectiveMethodInvocationUtils;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -46,6 +45,7 @@ import org.springframework.util.StringValueResolver;
  * {@link Builder Builder}.
  *
  * @author Rossen Stoyanchev
+ * @author Injae Kim
  * @since 6.0
  */
 public final class RSocketServiceProxyFactory {
@@ -253,11 +253,9 @@ public final class RSocketServiceProxyFactory {
 			if (serviceMethod != null) {
 				return serviceMethod.invoke(invocation.getArguments());
 			}
-			if (method.isDefault()) {
-				if (invocation instanceof ReflectiveMethodInvocation reflectiveMethodInvocation) {
-					Object proxy = reflectiveMethodInvocation.getProxy();
-					return InvocationHandler.invokeDefault(proxy, method, invocation.getArguments());
-				}
+			Object invokeDefaultMethod = ReflectiveMethodInvocationUtils.invokeDefaultMethod(invocation);
+			if (invokeDefaultMethod != null) {
+				return invokeDefaultMethod;
 			}
 			throw new IllegalStateException("Unexpected method invocation: " + method);
 		}

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceProxyFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceProxyFactory.java
@@ -16,7 +16,6 @@
 
 package org.springframework.web.service.invoker;
 
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -29,7 +28,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
 import org.springframework.aop.framework.ProxyFactory;
-import org.springframework.aop.framework.ReflectiveMethodInvocation;
+import org.springframework.aop.framework.ReflectiveMethodInvocationUtils;
 import org.springframework.core.KotlinDetector;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.ReactiveAdapterRegistry;
@@ -49,6 +48,7 @@ import org.springframework.web.service.annotation.HttpExchange;
  * {@link Builder Builder}.
  *
  * @author Rossen Stoyanchev
+ * @author Injae Kim
  * @since 6.0
  * @see org.springframework.web.client.support.RestClientAdapter
  * @see org.springframework.web.reactive.function.client.support.WebClientAdapter
@@ -302,11 +302,9 @@ public final class HttpServiceProxyFactory {
 						resolveCoroutinesArguments(invocation.getArguments()) : invocation.getArguments();
 				return httpServiceMethod.invoke(arguments);
 			}
-			if (method.isDefault()) {
-				if (invocation instanceof ReflectiveMethodInvocation reflectiveMethodInvocation) {
-					Object proxy = reflectiveMethodInvocation.getProxy();
-					return InvocationHandler.invokeDefault(proxy, method, invocation.getArguments());
-				}
+			Object invokeDefaultMethod = ReflectiveMethodInvocationUtils.invokeDefaultMethod(invocation);
+			if (invokeDefaultMethod != null) {
+				return invokeDefaultMethod;
 			}
 			throw new IllegalStateException("Unexpected method invocation: " + method);
 		}


### PR DESCRIPTION
Closes gh-28495

### Motivation
```java
@HttpExchange("http://localhost:8080")
public interface GreetingClient {

    @GetExchange("/greeting")
    Flux<Greeting> greetings();

    default Flux<Greeting> defaultMethod() {
        return greetings(new Greeting("default method test"))
                .flatMapMany(it -> greetings());
    }
}
```
- Like https://github.com/spring-projects/spring-framework/issues/28491, we may need to support default method on more proxies

> In JDK dynamic proxies created by Spring AOP, .. we cound **make it(support default method) easier via a utility.**

- Based on https://github.com/spring-projects/spring-framework/issues/28495#issue-1243003876, I want to introduce `ReflectiveMethodInvocationUtils#invokeDefaultMethod` first to support default method easily via a utility and reduce duplicated code!

### Modification
- Add `ReflectiveMethodInvocationUtils#invokeDefaultMethod`
- Replace duplicated default method invocation code on `HttpServiceProxyFactory` and `RSocketServiceProxyFactory`

### Result
- Now we can easily support default method via a utiliy in JDK dynamic proxies created by Spring AOP
- Close gh-28495