### PR TITLE
Use count in ParamsRequestCondition#getValueMatchCount

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/ParamsRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/ParamsRequestCondition.java
@@ -137,13 +137,9 @@ public final class ParamsRequestCondition extends AbstractRequestCondition<Param
 	}
 
 	private long getValueMatchCount(Set<ParamExpression> expressions) {
-		long count = 0;
-		for (ParamExpression e : expressions) {
-			if (e.getValue() != null && !e.isNegated()) {
-				count++;
-			}
-		}
-		return count;
+		return expressions.stream()
+				.filter(e -> e.getValue() != null && !e.isNegated())
+				.count();
 	}
 
 


### PR DESCRIPTION

The `getValueMatchCount` method was refactored to use a `Stream` instead of a `for-each loop`, eliminating the need for the unnecessary local variable `count`. This change was made to reduce the risk of accidental modifications during future maintenance, as the implementation is possible without using a local variable. Additionally, the refactoring was done for enhanced stability and maintainability, especially since there was no need to interrupt the loop under specific conditions.



- [x]  The test code was executed and passed successfully.