### PR TITLE
Remove unnecessary else statements in AbstractMediaTypeExpression

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/AbstractMediaTypeExpression.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/AbstractMediaTypeExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/AbstractMediaTypeExpression.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/AbstractMediaTypeExpression.java
@@ -73,12 +73,10 @@ abstract class AbstractMediaTypeExpression implements MediaTypeExpression, Compa
 		if (mediaType1.isMoreSpecific(mediaType2)) {
 			return -1;
 		}
-		else if (mediaType1.isLessSpecific(mediaType2)) {
+		if (mediaType1.isLessSpecific(mediaType2)) {
 			return 1;
 		}
-		else {
-			return 0;
-		}
+		return 0;
 	}
 
 	protected boolean matchParameters(MediaType contentType) {


### PR DESCRIPTION
In this PR, I've refactored the `compareTo` method in the `AbstractMediaTypeExpression` class. The main change involves simplifying the conditional structure by removing the unnecessary `else` statements. This enhances readability and align the code style with the `equals` method

**Changes Made:**
- Removed unnecessary `else` statements in the `compareTo` method.
- Retained the original logic and functionality.