### PR TITLE
Remove unnecessary else statements in RequestMethodsRequestCondition

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/RequestMethodsRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/RequestMethodsRequestCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/RequestMethodsRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/RequestMethodsRequestCondition.java
@@ -99,13 +99,10 @@ public final class RequestMethodsRequestCondition extends AbstractRequestConditi
 	 */
 	@Override
 	public RequestMethodsRequestCondition combine(RequestMethodsRequestCondition other) {
-		if (isEmpty() && other.isEmpty()) {
+		if (other.isEmpty()) {
 			return this;
 		}
-		else if (other.isEmpty()) {
-			return this;
-		}
-		else if (isEmpty()) {
+		if (isEmpty()) {
 			return other;
 		}
 		Set<RequestMethod> set = new LinkedHashSet<>(this.methods);
@@ -185,11 +182,11 @@ public final class RequestMethodsRequestCondition extends AbstractRequestConditi
 		if (other.methods.size() != this.methods.size()) {
 			return other.methods.size() - this.methods.size();
 		}
-		else if (this.methods.size() == 1) {
+		if (this.methods.size() == 1) {
 			if (this.methods.contains(RequestMethod.HEAD) && other.methods.contains(RequestMethod.GET)) {
 				return -1;
 			}
-			else if (this.methods.contains(RequestMethod.GET) && other.methods.contains(RequestMethod.HEAD)) {
+			if (this.methods.contains(RequestMethod.GET) && other.methods.contains(RequestMethod.HEAD)) {
 				return 1;
 			}
 		}


### PR DESCRIPTION

The main change is the simplification of the conditional structure by removing unnecessary else statements.

**Changes Made:**
- Removed redundant validations
- Removed unnecessary `else` statements 
- Retained the original logic and functionality.

- [x] The test code was executed and passed successfully.