### PR TITLE
Simplify use of Reactor's cast operator

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/PartEventHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/PartEventHttpMessageReader.java
@@ -168,8 +168,7 @@ public class PartEventHttpMessageReader extends LoggingCodecSupport implements H
 
 									HttpHeaders headers = headersToken.headers();
 									Flux<MultipartParser.BodyToken> bodyTokens =
-											flux.filter(t -> t instanceof MultipartParser.BodyToken)
-													.cast(MultipartParser.BodyToken.class);
+											flux.ofType(MultipartParser.BodyToken.class);
 									return createEvents(headers, bodyTokens);
 								}
 								else {

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/MultipartRouterFunctionIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/MultipartRouterFunctionIntegrationTests.java
@@ -240,9 +240,8 @@ class MultipartRouterFunctionIntegrationTests extends AbstractRouterFunctionInte
 
 		public Mono<ServerResponse> transferTo(ServerRequest request) {
 			return request.body(BodyExtractors.toParts())
-					.filter(FilePart.class::isInstance)
+					.ofType(FilePart.class)
 					.next()
-					.cast(FilePart.class)
 					.flatMap(part -> createTempFile()
 							.flatMap(tempFile ->
 									part.transferTo(tempFile)


### PR DESCRIPTION
This commit replaces `filter(x -> x instanceof C).cast(C.class)` with the built-in `ofType(C.class)`.