### PR TITLE
Clarify UnknownContentTypeException

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/UnknownContentTypeException.java
+++ b/spring-web/src/main/java/org/springframework/web/client/UnknownContentTypeException.java
@@ -79,7 +79,7 @@ public class UnknownContentTypeException extends RestClientException {
 			HttpStatusCode statusCode, String statusText, HttpHeaders responseHeaders, byte[] responseBody) {
 
 		super("Could not extract response: no suitable HttpMessageConverter found " +
-				"for response type [" + targetType + "] and content type [" + contentType + "]");
+				"for type [" + targetType + "] and response: code [" + statusCode.value() + "], content type [" + contentType + "]");
 
 		this.targetType = targetType;
 		this.contentType = contentType;


### PR DESCRIPTION
UnknownContentTypeException message should contain information important for analyze error. 

Before the PR message contains only response content type. After the PR message includes also status code.

Maybe response content should be also included. It would be useful for analyzing error, but on the other hand content may be very large.