### PR TITLE
Change FlushGuardedOutputStream to override write() methods properly

### DIFF
--- a/spring-web/src/main/java/org/springframework/remoting/httpinvoker/HttpInvokerServiceExporter.java
+++ b/spring-web/src/main/java/org/springframework/remoting/httpinvoker/HttpInvokerServiceExporter.java
@@ -205,7 +205,17 @@ public class HttpInvokerServiceExporter extends org.springframework.remoting.rmi
 		public FlushGuardedOutputStream(OutputStream out) {
 			super(out);
 		}
+		
+		@Override
+		public void write(@NotNull byte[] b) throws IOException {
+			out.write(b);
+		}
 
+		@Override
+		public void write(@NotNull byte[] b, int off, int len) throws IOException {
+			out.write(b, off, len);
+		}
+		
 		@Override
 		public void flush() throws IOException {
 			// Do nothing on flush


### PR DESCRIPTION
FlushGuardedOutputStream does not override write(byte[]) and write(byte[], int, int) method. Therefore, the previous code calls the delegate's write(int) which performs a lot of checks on buffer length while creating a lot of garbage. By overriding write(byte[]) and write(byte[], int, int) help improving performance by calling into the respective methods directly