### PR TITLE
Fix modelAttribitePredicate typos

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/annotation/HandlerMethodValidationException.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/HandlerMethodValidationException.java
@@ -56,7 +56,7 @@ public class HandlerMethodValidationException extends ResponseStatusException im
 
 	private final MethodValidationResult validationResult;
 
-	private final Predicate<MethodParameter> modelAttribitePredicate;
+	private final Predicate<MethodParameter> modelAttributePredicate;
 
 	private final Predicate<MethodParameter> requestParamPredicate;
 
@@ -68,11 +68,11 @@ public class HandlerMethodValidationException extends ResponseStatusException im
 	}
 
 	public HandlerMethodValidationException(MethodValidationResult validationResult,
-			Predicate<MethodParameter> modelAttribitePredicate, Predicate<MethodParameter> requestParamPredicate) {
+			Predicate<MethodParameter> modelAttributePredicate, Predicate<MethodParameter> requestParamPredicate) {
 
 		super(initHttpStatus(validationResult), "Validation failure", null, null, null);
 		this.validationResult = validationResult;
-		this.modelAttribitePredicate = modelAttribitePredicate;
+		this.modelAttributePredicate = modelAttributePredicate;
 		this.requestParamPredicate = requestParamPredicate;
 	}
 
@@ -128,7 +128,7 @@ public class HandlerMethodValidationException extends ResponseStatusException im
 				visitor.matrixVariable(matrixVariable, result);
 				continue;
 			}
-			if (this.modelAttribitePredicate.test(param)) {
+			if (this.modelAttributePredicate.test(param)) {
 				ModelAttribute modelAttribute = param.getParameterAnnotation(ModelAttribute.class);
 				visitor.modelAttribute(modelAttribute, asErrors(result));
 				continue;

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/HandlerMethodValidator.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/HandlerMethodValidator.java
@@ -56,16 +56,16 @@ public final class HandlerMethodValidator implements MethodValidator {
 
 	private final MethodValidationAdapter validationAdapter;
 
-	private final Predicate<MethodParameter> modelAttribitePredicate;
+	private final Predicate<MethodParameter> modelAttributePredicate;
 
 	private final Predicate<MethodParameter> requestParamPredicate;
 
 
 	private HandlerMethodValidator(MethodValidationAdapter validationAdapter,
-			Predicate<MethodParameter> modelAttribitePredicate, Predicate<MethodParameter> requestParamPredicate) {
+			Predicate<MethodParameter> modelAttributePredicate, Predicate<MethodParameter> requestParamPredicate) {
 
 		this.validationAdapter = validationAdapter;
-		this.modelAttribitePredicate = modelAttribitePredicate;
+		this.modelAttributePredicate = modelAttributePredicate;
 		this.requestParamPredicate = requestParamPredicate;
 	}
 
@@ -104,7 +104,7 @@ public final class HandlerMethodValidator implements MethodValidator {
 		}
 
 		throw new HandlerMethodValidationException(
-				result, this.modelAttribitePredicate, this.requestParamPredicate);
+				result, this.modelAttributePredicate, this.requestParamPredicate);
 	}
 
 	@Override
@@ -142,7 +142,7 @@ public final class HandlerMethodValidator implements MethodValidator {
 	@Nullable
 	public static MethodValidator from(
 			@Nullable WebBindingInitializer initializer, @Nullable ParameterNameDiscoverer paramNameDiscoverer,
-			Predicate<MethodParameter> modelAttribitePredicate, Predicate<MethodParameter> requestParamPredicate) {
+			Predicate<MethodParameter> modelAttributePredicate, Predicate<MethodParameter> requestParamPredicate) {
 
 		if (initializer instanceof ConfigurableWebBindingInitializer configurableInitializer) {
 			Validator validator = getValidator(configurableInitializer);
@@ -156,7 +156,7 @@ public final class HandlerMethodValidator implements MethodValidator {
 				if (codesResolver != null) {
 					adapter.setMessageCodesResolver(codesResolver);
 				}
-				return new HandlerMethodValidator(adapter, modelAttribitePredicate, requestParamPredicate);
+				return new HandlerMethodValidator(adapter, modelAttributePredicate, requestParamPredicate);
 			}
 		}
 		return null;


### PR DESCRIPTION
Replace occurrences of `modelAttribitePredicate` with `modelAttributePredicate` in `HandlerMethodValidationException` and the associated validator.