### PR TITLE
Initialize (another) Map with correct size in RequestPredicates

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RequestPredicates.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RequestPredicates.java
@@ -1237,7 +1237,7 @@ public abstract class RequestPredicates {
 			PathPattern oldPathPattern = (PathPattern) request.attribute(RouterFunctions.MATCHING_PATTERN_ATTRIBUTE)
 					.orElse(null);
 
-			Map<String, Object> result = new LinkedHashMap<>(2);
+			Map<String, Object> result = CollectionUtils.newLinkedHashMap(2);
 			result.put(RouterFunctions.URI_TEMPLATE_VARIABLES_ATTRIBUTE, mergeMaps(oldPathVariables, newPathVariables));
 			result.put(RouterFunctions.MATCHING_PATTERN_ATTRIBUTE, mergePatterns(oldPathPattern, newPathPattern));
 			return result;


### PR DESCRIPTION
Fix another instance where a LinkedHashMap was initialized with an initial capacity that would always cause a resize / rehash to occur. Switch to CollectionUtils.newLinkedHashMap to size the map appropiately for the expected number of items.

See d5cb1d9ad, this is just another case I missed.