### PR TITLE
Variables definition fixed

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/spring-mvc-test-framework/server-setup-options.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/spring-mvc-test-framework/server-setup-options.adoc
@@ -152,7 +152,7 @@ Kotlin::
 		@Autowired
 		lateinit var accountService: AccountService
 
-		lateinit mockMvc: MockMvc
+		lateinit var mockMvc: MockMvc
 
 		@BeforeEach
 		fun setup(wac: WebApplicationContext) {


### PR DESCRIPTION
In Kotlin variables should be defined as val or var. "mockMvc" was not defined properly