### PR TITLE
Fix issue when the allowedOrigin list contains strings with spaces

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -183,7 +183,7 @@ public class CorsConfiguration {
 			setAllowedOrigins(DEFAULT_PERMIT_ALL);
 		}
 		parseCommaDelimitedOrigin(origin, value -> {
-			value = trimTrailingSlash(value);
+			value = trimTrailingSlash(value).trim();
 			this.allowedOrigins.add(value);
 		});
 	}


### PR DESCRIPTION
### Issue
When the `List<String> allowedOrigins` contains Strings that have spaces, it will cause the CORS comparison checks with the Origin header to not be equal

### Resolution
By trimming the values when they get inserted into `allowedOrigins`, the comparison checks will pass. Since we trim the spaces out of the comma delimited String, we might as well do it for the `List<>` too. There would be no reason that a URL would contain a space before or after the string