### PR TITLE
speed up the finding the applicable AOP advisors by parallelism

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/AbstractAdvisorAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/AbstractAdvisorAutoProxyCreator.java
@@ -118,18 +118,10 @@ public abstract class AbstractAdvisorAutoProxyCreator extends AbstractAutoProxyC
 	 * @param beanClass the target's bean class
 	 * @param beanName the target's bean name
 	 * @return the List of applicable Advisors
-	 * @see ProxyCreationContext#getCurrentProxiedBeanName()
 	 */
 	protected List<Advisor> findAdvisorsThatCanApply(
 			List<Advisor> candidateAdvisors, Class<?> beanClass, String beanName) {
-
-		ProxyCreationContext.setCurrentProxiedBeanName(beanName);
-		try {
-			return AopUtils.findAdvisorsThatCanApply(candidateAdvisors, beanClass);
-		}
-		finally {
-			ProxyCreationContext.setCurrentProxiedBeanName(null);
-		}
+		return AopUtils.findAdvisorsThatCanApply(candidateAdvisors, beanClass, beanName);
 	}
 
 	/**

--- a/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/ProxyCreationContext.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/autoproxy/ProxyCreationContext.java
@@ -51,7 +51,7 @@ public final class ProxyCreationContext {
 	 * Set the name of the currently proxied bean instance.
 	 * @param beanName the name of the bean, or {@code null} to reset it
 	 */
-	static void setCurrentProxiedBeanName(@Nullable String beanName) {
+	public static void setCurrentProxiedBeanName(@Nullable String beanName) {
 		if (beanName != null) {
 			currentProxiedBeanName.set(beanName);
 		}


### PR DESCRIPTION
the Determining the sublist of a list of candidate advisors that are applicable to the given class can be simply parallelized using the parallelStream to speed up the spring-context start-up process.