### PR TITLE
Ignore trailing semicolons when parsing Accept-Language header

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -502,6 +502,9 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 */
 	public List<Locale.LanguageRange> getAcceptLanguage() {
 		String value = getFirst(ACCEPT_LANGUAGE);
+		if (value != null) {
+			value = StringUtils.trimTrailingCharacter(value, ';');
+		}
 		return (StringUtils.hasText(value) ? Locale.LanguageRange.parse(value) : Collections.emptyList());
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
@@ -489,6 +489,19 @@ class HttpHeadersTests {
 		assertThat(headers.getAcceptLanguageAsLocales()).element(0).isEqualTo(Locale.FRANCE);
 	}
 
+	@Test
+	void acceptLanguageTrailingSemicolon() {
+		String headerValue = "en-us,en;";
+		headers.set(HttpHeaders.ACCEPT_LANGUAGE, headerValue);
+		assertThat(headers.getFirst(HttpHeaders.ACCEPT_LANGUAGE)).isEqualTo(headerValue);
+
+		List<Locale.LanguageRange> expectedRanges = Arrays.asList(
+				new Locale.LanguageRange("en-us"),
+				new Locale.LanguageRange("en")
+		);
+		assertThat(headers.getAcceptLanguage()).isEqualTo(expectedRanges);
+	}
+
 	@Test // SPR-15603
 	void acceptLanguageWithEmptyValue() {
 		this.headers.set(HttpHeaders.ACCEPT_LANGUAGE, "");


### PR DESCRIPTION
Something I'm seeing in the wild is a trailing semicolon for `Accept-Language` headers. Partial example stack trace:

```
java.lang.IllegalArgumentException: range=en;
    at java.util.Locale$LanguageRange.<init>(Locale.java:3099)
    at sun.util.locale.LocaleMatcher.parse(LocaleMatcher.java:525)
    at java.util.Locale$LanguageRange.parse(Locale.java:3214)
    at org.springframework.http.HttpHeaders.getAcceptLanguage(HttpHeaders.java:505)
    at org.springframework.http.HttpHeaders.getAcceptLanguageAsLocales(HttpHeaders.java:526)
```

I don't think it would hurt to be more lenient here and drop the trailing semicolon before attempting to parse it.