### PR TITLE
Add support for common value objects and records to ValueCodeGenerator

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionMethodGeneratorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/BeanDefinitionMethodGeneratorTests.java
@@ -34,6 +34,9 @@ import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.generate.MethodReference;
 import org.springframework.aot.generate.MethodReference.ArgumentCodeGenerator;
 import org.springframework.aot.test.generate.TestGenerationContext;
+import org.springframework.beans.factory.aot.support.ObjectPair;
+import org.springframework.beans.factory.aot.support.RecordPair;
+import org.springframework.beans.factory.aot.support.RecordWithObject;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -681,6 +684,21 @@ class BeanDefinitionMethodGeneratorTests {
 		RootBeanDefinition beanDefinition = (RootBeanDefinition) BeanDefinitionBuilder
 				.rootBeanDefinition(Boolean.class).setFactoryMethod("parseBoolean").addConstructorArgValue("true").getBeanDefinition();
 		testBeanDefinitionMethodInCurrentFile(Boolean.class, beanDefinition);
+	}
+
+	@Test
+	void generateBeanDefinitionMethodWhenBeanIsOfCommonValueType() {
+		RootBeanDefinition beanDefinition = (RootBeanDefinition) BeanDefinitionBuilder
+				.rootBeanDefinition(RecordPair.class)
+				.setFactoryMethod("of")
+				.addConstructorArgValue(new RecordWithObject(0, null))
+				.addConstructorArgValue(new ObjectPair<>("Test", 0))
+				.getBeanDefinition();
+		BeanDefinitionMethodGenerator generator = new BeanDefinitionMethodGenerator(
+				this.methodGeneratorFactory, registerBean(beanDefinition), null, Collections.emptyList());
+		MethodReference method = generator.generateBeanDefinitionMethod(
+				this.generationContext, this.beanRegistrationsCode);
+		compile(method, (actual, compiled) -> assertThat(actual).isEqualTo(beanDefinition));
 	}
 
 	@Test

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/NestableObject.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/NestableObject.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+import java.util.Objects;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with nestable objects.
+ *
+ * @author Christopher Chianelli
+ */
+public class NestableObject {
+	private static final String A_STATIC_FIELD = "STATIC_FIELD";
+
+	public String name;
+	private int id;
+	private NestableObject nested;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public NestableObject getNested() {
+		return nested;
+	}
+
+	public void setNested(NestableObject nested) {
+		this.nested = nested;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object)
+			return true;
+		if (object == null || getClass() != object.getClass())
+			return false;
+		NestableObject that = (NestableObject) object;
+		return id == that.id
+				&& Objects.equals(name, that.name)
+				&& Objects.equals(nested, that.nested);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, id);
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/NestableRecord.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/NestableRecord.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with nestable records.
+ *
+ * @author Christopher Chianelli
+ */
+public record NestableRecord(int id, String name, @Nullable NestableRecord nested) {
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectPair.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectPair.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+import java.util.Objects;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with generic object pairs.
+ *
+ * @author Christopher Chianelli
+ */
+public class ObjectPair<L, R> {
+	L left;
+	R right;
+
+	public ObjectPair() {
+	}
+
+	public ObjectPair(L left, R right) {
+		this.left = left;
+		this.right = right;
+	}
+
+	public L getLeft() {
+		return left;
+	}
+
+	public void setLeft(L left) {
+		this.left = left;
+	}
+
+	public R getRight() {
+		return right;
+	}
+
+	public void setRight(R right) {
+		this.right = right;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object)
+			return true;
+		if (object == null || getClass() != object.getClass())
+			return false;
+		ObjectPair<?, ?> that = (ObjectPair<?, ?>) object;
+		return Objects.equals(left, that.left) && Objects.equals(right, that.right);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(left, right);
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithMissingConstructor.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithMissingConstructor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with objects without a no-args constructor.
+ *
+ * @author Christopher Chianelli
+ */
+public class ObjectWithMissingConstructor {
+	private String field;
+
+	public ObjectWithMissingConstructor(String field) {
+		this.field = field;
+	}
+
+	public String getField() {
+		return field;
+	}
+
+	public void setField(String field) {
+		this.field = field;
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithMissingSetter.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithMissingSetter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with objects missing a setter.
+ *
+ * @author Christopher Chianelli
+ */
+public class ObjectWithMissingSetter {
+	private static final String A_STATIC_FIELD = "STATIC_FIELD";
+	private String field;
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithPrivateConstructor.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithPrivateConstructor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with objects that have a private constructor.
+ *
+ * @author Christopher Chianelli
+ */
+public class ObjectWithPrivateConstructor {
+	private String field;
+
+	private ObjectWithPrivateConstructor() {
+	}
+
+	public String getField() {
+		return field;
+	}
+
+	public void setField(String field) {
+		this.field = field;
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithPrivateSetter.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithPrivateSetter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with objects that have a private setter.
+ *
+ * @author Christopher Chianelli
+ */
+public class ObjectWithPrivateSetter {
+	private String field;
+
+	private String getField() {
+		return field;
+	}
+
+	private void setField(String field) {
+		this.field = field;
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithRecord.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ObjectWithRecord.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+import java.util.Objects;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with objects containing a record.
+ *
+ * @author Christopher Chianelli
+ */
+public class ObjectWithRecord {
+	private int id;
+	@Nullable
+	private RecordWithObject nested;
+
+	public ObjectWithRecord() {
+	}
+
+	public ObjectWithRecord(int id) {
+		this(id, null);
+	}
+
+	public ObjectWithRecord(int id, @Nullable RecordWithObject nested) {
+		this.id = id;
+		this.nested = nested;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	@Nullable
+	public RecordWithObject getNested() {
+		return nested;
+	}
+
+	public void setNested(@Nullable RecordWithObject nested) {
+		this.nested = nested;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object)
+			return true;
+		if (object == null || getClass() != object.getClass())
+			return false;
+		ObjectWithRecord that = (ObjectWithRecord) object;
+		return id == that.id && Objects.equals(nested, that.nested);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ProtectedObject.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ProtectedObject.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with objects whose class is protected
+ *
+ * @author Christopher Chianelli
+ */
+class ProtectedObject {
+	public ProtectedObject() {}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ProtectedObjectCreator.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ProtectedObjectCreator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+/**
+ * Class for generating test objects and records that are protected.
+ *
+ * @author Christopher Chianelli
+ */
+public class ProtectedObjectCreator {
+	private ProtectedObjectCreator() {}
+
+	public static Object getProtectedRecord() {
+		return new ProtectedRecord();
+	}
+
+	public static Object getProtectedObject() {
+		return new ProtectedObject();
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ProtectedRecord.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/ProtectedRecord.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with protected records.
+ *
+ * @author Christopher Chianelli
+ */
+record ProtectedRecord() {
+	public ProtectedRecord() {}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/RecordPair.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/RecordPair.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with generic records.
+ *
+ * @author Christopher Chianelli
+ */
+public record RecordPair<Left_, Right_>(Left_ left, Right_ right) {
+	public static <Left_, Right_> RecordPair<Left_, Right_> of(Left_ left, Right_ right) {
+		return new RecordPair<>(left, right);
+	}
+}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/RecordWithObject.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/support/RecordWithObject.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.beans.factory.aot.support;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Test class for testing {@link org.springframework.aot.generate.ValueCodeGenerator}
+ * with nested records.
+ *
+ * @author Christopher Chianelli
+ */
+public record RecordWithObject(int id, @Nullable ObjectWithRecord record) {}

--- a/spring-core/src/main/java/org/springframework/aot/generate/ValueCodeGenerator.java
+++ b/spring-core/src/main/java/org/springframework/aot/generate/ValueCodeGenerator.java
@@ -18,7 +18,10 @@ package org.springframework.aot.generate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.javapoet.CodeBlock;
 import org.springframework.lang.Nullable;
@@ -32,8 +35,9 @@ import org.springframework.util.Assert;
  * @since 6.1.2
  */
 public final class ValueCodeGenerator {
+	static final String DEFAULT_IDENTIFIER_PREFIX = "$valueCodeGeneratorObject";
 
-	private static final ValueCodeGenerator INSTANCE = new ValueCodeGenerator(ValueCodeGeneratorDelegates.INSTANCES, null);
+	private static final ValueCodeGenerator INSTANCE = new ValueCodeGenerator(DEFAULT_IDENTIFIER_PREFIX, ValueCodeGeneratorDelegates.INSTANCES, null);
 
 	private static final CodeBlock NULL_VALUE_CODE_BLOCK = CodeBlock.of("null");
 
@@ -42,7 +46,13 @@ public final class ValueCodeGenerator {
 	@Nullable
 	private final GeneratedMethods generatedMethods;
 
-	private ValueCodeGenerator(List<Delegate> delegates, @Nullable GeneratedMethods generatedMethods) {
+	private final ThreadLocal<Integer> generatedCodeDepth = ThreadLocal.withInitial(() -> 0);
+	private final ThreadLocal<Set<Object>> toGenerateObjectSet = ThreadLocal.withInitial(() -> Collections.newSetFromMap(new IdentityHashMap<>()));
+
+	private final String identifierPrefix;
+
+	private ValueCodeGenerator(String identifierPrefix, List<Delegate> delegates, @Nullable GeneratedMethods generatedMethods) {
+		this.identifierPrefix = identifierPrefix;
 		this.delegates = delegates;
 		this.generatedMethods = generatedMethods;
 	}
@@ -72,14 +82,27 @@ public final class ValueCodeGenerator {
 	 */
 	public static ValueCodeGenerator with(List<Delegate> delegates) {
 		Assert.notEmpty(delegates, "Delegates must not be empty");
-		return new ValueCodeGenerator(new ArrayList<>(delegates), null);
+		return new ValueCodeGenerator(DEFAULT_IDENTIFIER_PREFIX, new ArrayList<>(delegates), null);
 	}
 
 	public ValueCodeGenerator add(List<Delegate> additionalDelegates) {
 		Assert.notEmpty(additionalDelegates, "AdditionalDelegates must not be empty");
 		List<Delegate> allDelegates = new ArrayList<>(this.delegates);
 		allDelegates.addAll(additionalDelegates);
-		return new ValueCodeGenerator(allDelegates, this.generatedMethods);
+		return new ValueCodeGenerator(DEFAULT_IDENTIFIER_PREFIX, allDelegates, this.generatedMethods);
+	}
+
+	/**
+	 * Return a new {@link ValueCodeGenerator} that uses the given {@link String} as the
+	 * prefix for all of its identifiers.
+	 * @param identifierPrefix the prefix to use for each identifier. Cannot be null or empty.
+	 * @return a new {@link ValueCodeGenerator} with the same delegates and generated methods
+	 * as this {@link ValueCodeGenerator}.
+	 */
+	public ValueCodeGenerator withIdentifierPrefix(String identifierPrefix) {
+		Assert.notNull(identifierPrefix, "Identifier prefix must not be null");
+		Assert.state(!identifierPrefix.isEmpty(), "Identifier prefix must not be empty");
+		return new ValueCodeGenerator(identifierPrefix, this.delegates, this.generatedMethods);
 	}
 
 	/**
@@ -91,7 +114,7 @@ public final class ValueCodeGenerator {
 	 * @return an instance scoped to the specified generated methods
 	 */
 	public ValueCodeGenerator scoped(GeneratedMethods generatedMethods) {
-		return new ValueCodeGenerator(this.delegates, generatedMethods);
+		return new ValueCodeGenerator(DEFAULT_IDENTIFIER_PREFIX, this.delegates, generatedMethods);
 	}
 
 	/**
@@ -103,7 +126,13 @@ public final class ValueCodeGenerator {
 		if (value == null) {
 			return NULL_VALUE_CODE_BLOCK;
 		}
+		if (this.toGenerateObjectSet.get().contains(value)) {
+			throw new ValueCodeGenerationException("Unable to generate code for (" + value + ") because it contains a cyclic reference.",
+					value, null);
+		}
 		try {
+			this.toGenerateObjectSet.get().add(value);
+			this.generatedCodeDepth.set(this.generatedCodeDepth.get() + 1);
 			for (Delegate delegate : this.delegates) {
 				CodeBlock code = delegate.generateCode(this, value);
 				if (code != null) {
@@ -115,8 +144,23 @@ public final class ValueCodeGenerator {
 		catch (Exception ex) {
 			throw new ValueCodeGenerationException(value, ex);
 		}
+		finally {
+			this.generatedCodeDepth.set(this.generatedCodeDepth.get() - 1);
+			this.toGenerateObjectSet.get().remove(value);
+		}
 	}
 
+	/**
+	 * Returns a String that can be used as a new identifier in
+	 * a {@link CodeBlock} expression.
+	 * For a given {@link Delegate} call, it will always return the same value.
+	 * That is, each {@link Delegate} can define at most one new variable.
+	 * @return an identifier that can be used in a {@link CodeBlock} that
+	 * is guaranteed to not be used in an upper {@link Delegate} call.
+	 */
+	public String getIdentifierForCurrentDepth() {
+		return this.identifierPrefix + this.generatedCodeDepth.get();
+	}
 
 	/**
 	 * Return the {@link GeneratedMethods} that represents the scope

--- a/spring-core/src/test/java/org/springframework/tests/sample/objects/TestRecord.java
+++ b/spring-core/src/test/java/org/springframework/tests/sample/objects/TestRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.tests.sample.objects;
+
+public record TestRecord(String name, int age, TestRecord spouse) {
+	public TestRecord(String name, int age) {
+		this(name, age, null);
+	}
+}


### PR DESCRIPTION
Add support for generating code to create common value Objects and Records. A common value Record is a public, accessible Record class that has common value objects for all of its components. A common value Object is a public, accessible Object class that has public setters for all of its non-public instance fields, with each field being assigned a common value.

The code generated for a common value Record calls the Record's canonical constructor with the generated code for each of its component. For instance, for `record MyRecord(String a, int b)`, and instance `MyRecord("Example", 1)`, it would generate the following code:

```java
    new MyRecord("Example", 1)
```

The code generated for a common value Object calls the Object's public no-args constructor and sets its fields. Public fields are set by direct access. Non-public fields are set by calling their setters. The code will be wrapped by an inlined Supplier so the generated code can be used anywhere. For example, given the following class:

```java
    class MyObject {
        public String name;
        private int age;

        public void setAge(int age) {
            this.age = age;
        }
    }
```

The code generated for MyObject("Example", 2) would be

```java
    ((Supplier<MyObject>) () -> {
        MyObject $valueCodeGeneratorObject1 = new MyObject();
        $valueCodeGeneratorObject1.setAge(2);
        $valueCodeGeneratorObject1.name = "Example";
        return $valueCodeGeneratorObject1;
    }).get()
```

ValueCodeGenerator uses a ThreadLocal keeping track of the number of generateCode calls in the current Thread's stack. This allows the Delegate for Object to use an unused identifier for the variable holding the Object under construction.

Known limitations are that cyclic references cannot be handled. If a cyclic reference is detected, a ValueCodeGenerationException will be raised.

Additionally, if the same Object is used for multiple fields/components in Objects/Records, they will be different instances instead of the same instance.

This change will allow common value objects and records to be passed to the constructor of BeanDefinitions in an AOT native image. For instance, the following will now work in native image, provided `myConfig` is a common value object:

```java
    MyConfig myConfig = new MyConfig();
    // ...Set fields of MyConfig ...
    RootBeanDefinition rootBeanDefinition = new RootBeanDefinition(
        MyBean.class);
    rootBeanDefinition.setFactoryMethodName("of");
    rootBeanDefinition.getConstructorArgumentValues()
       .addGenericArgumentValue(myConfig);
    registry.registerBeanDefinition(BEAN_NAME,
        rootBeanDefinition);
```