### PR TITLE
Fix Kotlin syntax errors in RestClient builder example in rest-clients.adoc

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/rest-clients.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/rest-clients.adoc
@@ -51,9 +51,9 @@ val defaultClient = RestClient.create()
 
 val customClient = RestClient.builder()
   .requestFactory(HttpComponentsClientHttpRequestFactory())
-  .messageConverters(converters -> converters.add(MyCustomMessageConverter()))
+  .messageConverters { converters -> converters.add(MyCustomMessageConverter()) }
   .baseUrl("https://example.com")
-  .defaultUriVariables(Map.of("variable", "foo"))
+  .defaultUriVariables(mapOf("variable" to "foo"))
   .defaultHeader("My-Header", "Foo")
   .requestInterceptor(myCustomInterceptor)
   .requestInitializer(myCustomInitializer)


### PR DESCRIPTION
Fix Kotlin syntax errors in RestClient builder example in rest-clients.adoc