### PR TITLE
Use Spliterator of underlying collection in MutablePropertyValues / MutablePropertySources

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/MutablePropertyValues.java
+++ b/spring-beans/src/main/java/org/springframework/beans/MutablePropertyValues.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.stream.Stream;
 
 import org.springframework.lang.Nullable;
@@ -255,7 +254,7 @@ public class MutablePropertyValues implements PropertyValues, Serializable {
 
 	@Override
 	public Spliterator<PropertyValue> spliterator() {
-		return Spliterators.spliterator(this.propertyValueList, 0);
+		return this.propertyValueList.spliterator();
 	}
 
 	@Override

--- a/spring-core/src/main/java/org/springframework/core/env/MutablePropertySources.java
+++ b/spring-core/src/main/java/org/springframework/core/env/MutablePropertySources.java
@@ -19,7 +19,6 @@ package org.springframework.core.env;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
 
@@ -69,7 +68,7 @@ public class MutablePropertySources implements PropertySources {
 
 	@Override
 	public Spliterator<PropertySource<?>> spliterator() {
-		return Spliterators.spliterator(this.propertySourceList, 0);
+		return this.propertySourceList.spliterator();
 	}
 
 	@Override


### PR DESCRIPTION
Delegate to the spliterator method of the underyling collection in MutablePropertyValues and MutablePropertySources. In both cases, those collection types have specialized Spliterator implementations. Delegating to these Spliterators also means the characteristics of the Spliterator are properly set.

Note: this spliterator was already exposed via the stream() method, since that would delegate to the underlying collection. This mostly just makes things consistent.