### PR TITLE
Introduce "autowireCandidate" and "defaultCandidate" for stereotype annotations

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AnnotatedBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AnnotatedBeanDefinition.java
@@ -16,6 +16,8 @@
 
 package org.springframework.beans.factory.annotation;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.MethodMetadata;
@@ -27,6 +29,7 @@ import org.springframework.lang.Nullable;
  * about its bean class - without requiring the class to be loaded yet.
  *
  * @author Juergen Hoeller
+ * @author Yanming Zhou
  * @since 2.5
  * @see AnnotatedGenericBeanDefinition
  * @see org.springframework.core.type.AnnotationMetadata
@@ -48,4 +51,15 @@ public interface AnnotatedBeanDefinition extends BeanDefinition {
 	@Nullable
 	MethodMetadata getFactoryMethodMetadata();
 
+	/**
+	 * Configure this bean definition with metadata.
+	 * @since 6.2
+	 */
+	default void configureWithMetadata() {
+		Map<String, Object> attributes = getMetadata().getAnnotationAttributes("org.springframework.stereotype.Component");
+		if (attributes != null) {
+			setAutowireCandidate((Boolean) attributes.get("autowireCandidate"));
+			setDefaultCandidate((Boolean) attributes.get("defaultCandidate"));
+		}
+	}
 }

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AnnotatedGenericBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/AnnotatedGenericBeanDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  *
  * @author Juergen Hoeller
  * @author Chris Beams
+ * @author Yanming Zhou
  * @since 2.5
  * @see AnnotatedBeanDefinition#getMetadata()
  * @see org.springframework.core.type.StandardAnnotationMetadata
@@ -56,6 +57,7 @@ public class AnnotatedGenericBeanDefinition extends GenericBeanDefinition implem
 	public AnnotatedGenericBeanDefinition(Class<?> beanClass) {
 		setBeanClass(beanClass);
 		this.metadata = AnnotationMetadata.introspect(beanClass);
+		configureWithMetadata();
 	}
 
 	/**
@@ -77,6 +79,7 @@ public class AnnotatedGenericBeanDefinition extends GenericBeanDefinition implem
 			setBeanClassName(metadata.getClassName());
 		}
 		this.metadata = metadata;
+		configureWithMetadata();
 	}
 
 	/**

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/BeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/BeanDefinition.java
@@ -33,6 +33,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Juergen Hoeller
  * @author Rob Harrop
+ * @author Yanming Zhou
  * @since 19.03.2004
  * @see ConfigurableListableBeanFactory#getBeanDefinition
  * @see org.springframework.beans.factory.support.RootBeanDefinition
@@ -173,6 +174,25 @@ public interface BeanDefinition extends AttributeAccessor, BeanMetadataElement {
 	 * Return whether this bean is a candidate for getting autowired into some other bean.
 	 */
 	boolean isAutowireCandidate();
+
+	/**
+	 * Set whether this bean is a candidate for getting autowired into some other
+	 * bean based on the plain type, without any further indications such as a
+	 * qualifier match.
+	 * <p>Default is {@code true}, allowing injection by type at any injection point.
+	 * Switch this to {@code false} in order to restrict injection by default,
+	 * effectively enforcing an additional indication such as a qualifier match.
+	 * @since 6.2
+	 */
+	void setDefaultCandidate(boolean defaultCandidate);
+
+	/**
+	 * Return whether this bean is a candidate for getting autowired into some other
+	 * bean based on the plain type, without any further indications such as a
+	 * qualifier match?
+	 * @since 6.2
+	 */
+	boolean isDefaultCandidate();
 
 	/**
 	 * Set whether this bean is a primary autowire candidate.

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanDefinition.java
@@ -728,6 +728,7 @@ public abstract class AbstractBeanDefinition extends BeanMetadataAttributeAccess
 	 * effectively enforcing an additional indication such as a qualifier match.
 	 * @since 6.2
 	 */
+	@Override
 	public void setDefaultCandidate(boolean defaultCandidate) {
 		this.defaultCandidate = defaultCandidate;
 	}
@@ -738,6 +739,7 @@ public abstract class AbstractBeanDefinition extends BeanMetadataAttributeAccess
 	 * qualifier match?
 	 * @since 6.2
 	 */
+	@Override
 	public boolean isDefaultCandidate() {
 		return this.defaultCandidate;
 	}

--- a/spring-context/src/main/java/org/springframework/context/annotation/ScannedGenericBeanDefinition.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ScannedGenericBeanDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
  *
  * @author Juergen Hoeller
  * @author Chris Beams
+ * @author Yanming Zhou
  * @since 2.5
  * @see #getMetadata()
  * @see #getBeanClassName()
@@ -61,6 +62,7 @@ public class ScannedGenericBeanDefinition extends GenericBeanDefinition implemen
 		this.metadata = metadataReader.getAnnotationMetadata();
 		setBeanClassName(this.metadata.getClassName());
 		setResource(metadataReader.getResource());
+		configureWithMetadata();
 	}
 
 

--- a/spring-context/src/main/java/org/springframework/stereotype/Component.java
+++ b/spring-context/src/main/java/org/springframework/stereotype/Component.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import java.lang.annotation.Target;
  *
  * @author Mark Fisher
  * @author Sam Brannen
+ * @author Yanming Zhou
  * @since 2.5
  * @see Repository
  * @see Service
@@ -75,5 +76,27 @@ public @interface Component {
 	 * @return the suggested component name, if any (or empty String otherwise)
 	 */
 	String value() default "";
+
+	/**
+	 * Is this bean a candidate for getting autowired into some other bean at all?
+	 * <p>Default is {@code true}; set this to {@code false} for internal delegates
+	 * that are not meant to get in the way of beans of the same type in other places.
+	 * @since 6.2
+	 * @see #defaultCandidate()
+	 */
+	boolean autowireCandidate() default true;
+
+	/**
+	 * Is this bean a candidate for getting autowired into some other bean based on
+	 * the plain type, without any further indications such as a qualifier match?
+	 * <p>Default is {@code true}; set this to {@code false} for restricted delegates
+	 * that are supposed to be injectable in certain areas but are not meant to get
+	 * in the way of beans of the same type in other places.
+	 * <p>This is a variation of {@link #autowireCandidate()} which does not disable
+	 * injection in general, just enforces an additional indication such as a qualifier.
+	 * @since 6.2
+	 * @see #autowireCandidate()
+	 */
+	boolean defaultCandidate() default true;
 
 }

--- a/spring-context/src/main/java/org/springframework/stereotype/Repository.java
+++ b/spring-context/src/main/java/org/springframework/stereotype/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.core.annotation.AliasFor;
  *
  * @author Rod Johnson
  * @author Juergen Hoeller
+ * @author Yanming Zhou
  * @since 2.0
  * @see Component
  * @see Service
@@ -65,5 +66,19 @@ public @interface Repository {
 	 */
 	@AliasFor(annotation = Component.class)
 	String value() default "";
+
+	/**
+	 * Alias for {@link Component#autowireCandidate}.
+	 * @since 6.2
+	 */
+	@AliasFor(annotation = Component.class)
+	boolean autowireCandidate() default true;
+
+	/**
+	 * Alias for {@link Component#defaultCandidate}.
+	 * @since 6.2
+	 */
+	@AliasFor(annotation = Component.class)
+	boolean defaultCandidate() default true;
 
 }

--- a/spring-context/src/main/java/org/springframework/stereotype/Service.java
+++ b/spring-context/src/main/java/org/springframework/stereotype/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.core.annotation.AliasFor;
  * allowing for implementation classes to be autodetected through classpath scanning.
  *
  * @author Juergen Hoeller
+ * @author Yanming Zhou
  * @since 2.5
  * @see Component
  * @see Repository
@@ -52,5 +53,19 @@ public @interface Service {
 	 */
 	@AliasFor(annotation = Component.class)
 	String value() default "";
+
+	/**
+	 * Alias for {@link Component#autowireCandidate}.
+	 * @since 6.2
+	 */
+	@AliasFor(annotation = Component.class)
+	boolean autowireCandidate() default true;
+
+	/**
+	 * Alias for {@link Component#defaultCandidate}.
+	 * @since 6.2
+	 */
+	@AliasFor(annotation = Component.class)
+	boolean defaultCandidate() default true;
 
 }

--- a/spring-context/src/test/java/org/springframework/context/annotation/stereotype/NonDefaultComponent.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/stereotype/NonDefaultComponent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.stereotype;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Yanming Zhou
+ */
+@Component(value = NonDefaultComponent.BEAN_NAME, autowireCandidate = false, defaultCandidate = false)
+public class NonDefaultComponent {
+	public static final String BEAN_NAME = "nonDefaultComponent";
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/stereotype/NonDefaultRepository.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/stereotype/NonDefaultRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.stereotype;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Yanming Zhou
+ */
+@Component(value = NonDefaultRepository.BEAN_NAME, autowireCandidate = false, defaultCandidate = false)
+public class NonDefaultRepository {
+	public static final String BEAN_NAME = "nonDefaultRepository";
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/stereotype/NonDefaultService.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/stereotype/NonDefaultService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation.stereotype;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Yanming Zhou
+ */
+@Component(value = NonDefaultService.BEAN_NAME, autowireCandidate = false, defaultCandidate = false)
+public class NonDefaultService {
+	public static final String BEAN_NAME = "nonDefaultService";
+}


### PR DESCRIPTION
`@Controller` is excluded since it's not likely to have multiple implementations in practice.