### PR TITLE
Add web support for YAML via Jackson

### DIFF
--- a/spring-web/spring-web.gradle
+++ b/spring-web/spring-web.gradle
@@ -15,6 +15,7 @@ dependencies {
 	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
 	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
 	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
+	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 	optional("com.fasterxml.woodstox:woodstox-core")
 	optional("com.google.code.gson:gson")
 	optional("com.google.protobuf:protobuf-java-util")

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.util.StringUtils;
  * @author Sebastien Deleuze
  * @author Kazuki Shimizu
  * @author Sam Brannen
+ * @author Hyoungjune Kim
  * @since 3.0
  * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">
  *     HTTP 1.1: Semantics and Content, section 3.1.1.1</a>
@@ -312,6 +313,16 @@ public class MediaType extends MimeType implements Serializable {
 	public static final String APPLICATION_XML_VALUE = "application/xml";
 
 	/**
+	 * Public constant media type for {@code application/yaml}.
+	 */
+	public static final MediaType APPLICATION_YAML;
+
+	/**
+	 * A String equivalent of {@link MediaType#APPLICATION_YAML}.
+	 */
+	public static final String APPLICATION_YAML_VALE = "application/yaml";
+
+	/**
 	 * Public constant media type for {@code image/gif}.
 	 */
 	public static final MediaType IMAGE_GIF;
@@ -454,6 +465,7 @@ public class MediaType extends MimeType implements Serializable {
 		APPLICATION_STREAM_JSON = new MediaType("application", "stream+json");
 		APPLICATION_XHTML_XML = new MediaType("application", "xhtml+xml");
 		APPLICATION_XML = new MediaType("application", "xml");
+		APPLICATION_YAML = new MediaType("application", "yaml");
 		IMAGE_GIF = new MediaType("image", "gif");
 		IMAGE_JPEG = new MediaType("image", "jpeg");
 		IMAGE_PNG = new MediaType("image", "png");

--- a/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
 import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.context.ApplicationContext;
@@ -95,6 +96,7 @@ import org.springframework.util.xml.StaxUtils;
  * @author Juergen Hoeller
  * @author Tadaya Tsuyukubo
  * @author Eddú Meléndez
+ * @author Hyoungjune Kim
  * @since 4.1.1
  * @see #build()
  * @see #configure(ObjectMapper)
@@ -936,6 +938,15 @@ public class Jackson2ObjectMapperBuilder {
 		return new Jackson2ObjectMapperBuilder().factory(new CborFactoryInitializer().create());
 	}
 
+	/**
+	 * Obtain a {@link Jackson2ObjectMapperBuilder} instance in order to
+	 * build a Yaml data format {@link ObjectMapper} instance.
+	 * @since 6.2
+	 */
+	public static Jackson2ObjectMapperBuilder yaml() {
+		return new Jackson2ObjectMapperBuilder().factory(new YamlFactoryInitializer().create());
+	}
+
 
 	private static class XmlObjectMapperInitializer {
 
@@ -973,6 +984,13 @@ public class Jackson2ObjectMapperBuilder {
 
 		public JsonFactory create() {
 			return new CBORFactory();
+		}
+	}
+
+	private static class YamlFactoryInitializer {
+
+		public JsonFactory create() {
+			return new YAMLFactory();
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/converter/yaml/MappingJackson2YamlHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/yaml/MappingJackson2YamlHttpMessageConverter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.converter.yaml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link org.springframework.http.converter.HttpMessageConverter
+ * HttpMessageConverter} that can read and write the <a href="https://yaml.io/">YAML</a>
+ * data format using <a href="https://github.com/FasterXML/jackson-dataformat-yaml/tree/master">
+ * the dedicated Jackson 2.x extension</a>.
+ *
+ * <p>By default, this converter supports the {@link MediaType#APPLICATION_YAML_VALE}
+ * media type. This can be overridden by setting the {@link #setSupportedMediaTypes
+ * supportedMediaTypes} property.
+ *
+ * <p>The default constructor uses the default configuration provided by
+ * {@link Jackson2ObjectMapperBuilder}.
+ *
+ * @author Hyoungjune Kim
+ * @since 6.2
+ */
+public class MappingJackson2YamlHttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+	/**
+	 * Construct a new {@code MappingJackson2YamlHttpMessageConverter} using the
+	 * default configuration provided by {@code Jackson2ObjectMapperBuilder}.
+	 */
+	public MappingJackson2YamlHttpMessageConverter() {
+		this(Jackson2ObjectMapperBuilder.yaml().build());
+	}
+
+	/**
+	 * Construct a new {@code MappingJackson2YamlHttpMessageConverter} with a
+	 * custom {@link ObjectMapper} (must be configured with a {@code YAMLFactory}
+	 * instance).
+	 * <p>You can use {@link Jackson2ObjectMapperBuilder} to build it easily.
+	 * @see Jackson2ObjectMapperBuilder#yaml()
+	 */
+	public MappingJackson2YamlHttpMessageConverter(ObjectMapper objectMapper) {
+		super(objectMapper, MediaType.APPLICATION_YAML);
+		Assert.isInstanceOf(YAMLFactory.class, objectMapper.getFactory(), "YAMLFactory required");
+	}
+
+
+	/**
+	 * {@inheritDoc}
+	 * The {@code ObjectMapper} must be configured with a {@code YAMLFactory} instance.
+	 */
+	@Override
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		Assert.isInstanceOf(YAMLFactory.class, objectMapper.getFactory(), "YAMLFactory required");
+		super.setObjectMapper(objectMapper);
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/converter/yaml/package-info.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/yaml/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Provides an HttpMessageConverter for the Yaml data format.
+ */
+@NonNullApi
+@NonNullFields
+package org.springframework.http.converter.yaml;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClientBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClientBuilder.java
@@ -48,6 +48,7 @@ import org.springframework.http.converter.json.KotlinSerializationJsonHttpMessag
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.smile.MappingJackson2SmileHttpMessageConverter;
 import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
+import org.springframework.http.converter.yaml.MappingJackson2YamlHttpMessageConverter;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -60,6 +61,7 @@ import org.springframework.web.util.UriTemplateHandler;
  * Default implementation of {@link RestClient.Builder}.
  *
  * @author Arjen Poutsma
+ * @author Hyoungjune Kim
  * @since 6.1
  */
 final class DefaultRestClientBuilder implements RestClient.Builder {
@@ -86,6 +88,8 @@ final class DefaultRestClientBuilder implements RestClient.Builder {
 
 	private static final boolean jackson2CborPresent;
 
+	private static final boolean jackson2YamlPresent;
+
 
 	static {
 		ClassLoader loader = DefaultRestClientBuilder.class.getClassLoader();
@@ -101,6 +105,7 @@ final class DefaultRestClientBuilder implements RestClient.Builder {
 		kotlinSerializationJsonPresent = ClassUtils.isPresent("kotlinx.serialization.json.Json", loader);
 		jackson2SmilePresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.smile.SmileFactory", loader);
 		jackson2CborPresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.cbor.CBORFactory", loader);
+		jackson2YamlPresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.yaml.YAMLFactory", loader);
 	}
 
 	@Nullable
@@ -393,6 +398,9 @@ final class DefaultRestClientBuilder implements RestClient.Builder {
 			}
 			if (jackson2CborPresent) {
 				this.messageConverters.add(new MappingJackson2CborHttpMessageConverter());
+			}
+			if (jackson2YamlPresent) {
+				this.messageConverters.add(new MappingJackson2YamlHttpMessageConverter());
 			}
 		}
 		return this.messageConverters;

--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -66,6 +66,7 @@ import org.springframework.http.converter.smile.MappingJackson2SmileHttpMessageC
 import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
 import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.http.converter.yaml.MappingJackson2YamlHttpMessageConverter;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -108,6 +109,7 @@ import org.springframework.web.util.UriTemplateHandler;
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Sebastien Deleuze
+ * @author Hyoungjune Kim
  * @since 3.0
  * @see HttpMessageConverter
  * @see RequestCallback
@@ -127,6 +129,8 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 	private static final boolean jackson2SmilePresent;
 
 	private static final boolean jackson2CborPresent;
+
+	private static final boolean jackson2YamlPresent;
 
 	private static final boolean gsonPresent;
 
@@ -149,6 +153,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 		jackson2XmlPresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.xml.XmlMapper", classLoader);
 		jackson2SmilePresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.smile.SmileFactory", classLoader);
 		jackson2CborPresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.cbor.CBORFactory", classLoader);
+		jackson2YamlPresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.yaml.YAMLFactory", classLoader);
 		gsonPresent = ClassUtils.isPresent("com.google.gson.Gson", classLoader);
 		jsonbPresent = ClassUtils.isPresent("jakarta.json.bind.Jsonb", classLoader);
 		kotlinSerializationCborPresent = ClassUtils.isPresent("kotlinx.serialization.cbor.Cbor", classLoader);
@@ -220,6 +225,10 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 		}
 		else if (kotlinSerializationCborPresent) {
 			this.messageConverters.add(new KotlinSerializationCborHttpMessageConverter());
+		}
+
+		if (jackson2YamlPresent) {
+			this.messageConverters.add(new MappingJackson2YamlHttpMessageConverter());
 		}
 
 		updateErrorHandlerConverters();

--- a/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilderTests.java
@@ -79,6 +79,7 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import kotlin.ranges.IntRange;
 import org.junit.jupiter.api.Test;
@@ -95,6 +96,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  *
  * @author Sebastien Deleuze
  * @author Eddú Meléndez
+ * @author Hyoungjune Kim
  */
 @SuppressWarnings("deprecation")
 class Jackson2ObjectMapperBuilderTests {
@@ -586,6 +588,13 @@ class Jackson2ObjectMapperBuilderTests {
 		ObjectMapper objectMapper = new Jackson2ObjectMapperBuilder().factory(new SmileFactory()).build();
 		assertThat(objectMapper).isNotNull();
 		assertThat(objectMapper.getFactory().getClass()).isEqualTo(SmileFactory.class);
+	}
+
+	@Test
+	void yaml() {
+		ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.yaml().build();
+		assertThat(objectMapper).isNotNull();
+		assertThat(objectMapper.getFactory().getClass()).isEqualTo(YAMLFactory.class);
 	}
 
 	@Test

--- a/spring-webmvc/spring-webmvc.gradle
+++ b/spring-webmvc/spring-webmvc.gradle
@@ -19,6 +19,7 @@ dependencies {
 	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
 	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
 	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
+	optional("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 	optional("com.github.librepdf:openpdf")
 	optional("com.rometools:rome")
 	optional("io.micrometer:context-propagation")

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import org.springframework.http.converter.smile.MappingJackson2SmileHttpMessageC
 import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
 import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.http.converter.yaml.MappingJackson2YamlHttpMessageConverter;
 import org.springframework.lang.Nullable;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
@@ -182,6 +183,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * @author Rossen Stoyanchev
  * @author Brian Clozel
  * @author Sebastien Deleuze
+ * @author Hyoungjune Kim
  * @since 3.1
  * @see EnableWebMvc
  * @see WebMvcConfigurer
@@ -199,6 +201,8 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	private static final boolean jackson2SmilePresent;
 
 	private static final boolean jackson2CborPresent;
+
+	private static final boolean jackson2YamlPresent;
 
 	private static final boolean gsonPresent;
 
@@ -219,6 +223,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 		jackson2XmlPresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.xml.XmlMapper", classLoader);
 		jackson2SmilePresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.smile.SmileFactory", classLoader);
 		jackson2CborPresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.cbor.CBORFactory", classLoader);
+		jackson2YamlPresent = ClassUtils.isPresent("com.fasterxml.jackson.dataformat.yaml.YAMLFactory", classLoader);
 		gsonPresent = ClassUtils.isPresent("com.google.gson.Gson", classLoader);
 		jsonbPresent = ClassUtils.isPresent("jakarta.json.bind.Jsonb", classLoader);
 		kotlinSerializationCborPresent = ClassUtils.isPresent("kotlinx.serialization.cbor.Cbor", classLoader);
@@ -462,6 +467,9 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 		}
 		if (jackson2CborPresent || kotlinSerializationCborPresent) {
 			map.put("cbor", MediaType.APPLICATION_CBOR);
+		}
+		if (jackson2YamlPresent) {
+			map.put("yaml", MediaType.APPLICATION_YAML);
 		}
 		return map;
 	}
@@ -934,6 +942,13 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 				builder.applicationContext(this.applicationContext);
 			}
 			messageConverters.add(new MappingJackson2CborHttpMessageConverter(builder.build()));
+		}
+		if (jackson2YamlPresent) {
+			Jackson2ObjectMapperBuilder builder = Jackson2ObjectMapperBuilder.yaml();
+			if (this.applicationContext != null) {
+				builder.applicationContext(this.applicationContext);
+			}
+			messageConverters.add(new MappingJackson2YamlHttpMessageConverter(builder.build()));
 		}
 	}
 


### PR DESCRIPTION
Hello. This is my first spring framework contribution code.

I created this PR to add an application/yaml MediaType.

Recently, I noticed that application/yaml has been officially added to MediaType. The link I checked is below.

Link
- https://www.rfc-editor.org/rfc/rfc9512.html
- https://www.iana.org/assignments/media-types/media-types.xhtml

Thanks a lot.