### PR TITLE
Upgrade to com.gradle.enterprise 3.16.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id "com.gradle.enterprise" version "3.16.1"
+	id "com.gradle.enterprise" version "3.16.2"
 	id "io.spring.ge.conventions" version "0.0.15"
 	id "org.gradle.toolchains.foojay-resolver-convention" version "0.7.0"
 }


### PR DESCRIPTION
# Bumps [com.gradle.enterprise](https://plugins.gradle.org/plugin/com.gradle.enterprise) from 3.16.1 to 3.16.2.

> Compatibility was not changed with this minor release

### Compatibility
- scans.gradle.com and Develocity 2023.4 or later.

### Release notes
- [FIX] Test Distribution: File transfer start/finish events are sometimes ordered incorrectly



