### PR TITLE
AbstractErrors: use isEmpty() instead of length()

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/AbstractErrors.java
+++ b/spring-context/src/main/java/org/springframework/validation/AbstractErrors.java
@@ -82,7 +82,7 @@ public abstract class AbstractErrors implements Errors, Serializable {
 			nestedPath = "";
 		}
 		nestedPath = canonicalFieldName(nestedPath);
-		if (nestedPath.length() > 0 && !nestedPath.endsWith(NESTED_PATH_SEPARATOR)) {
+		if (!nestedPath.isEmpty() && !nestedPath.endsWith(NESTED_PATH_SEPARATOR)) {
 			nestedPath += NESTED_PATH_SEPARATOR;
 		}
 		this.nestedPath = nestedPath;


### PR DESCRIPTION
This pull request proposes an enhancement to the doSetNestedPath method where I replaced the check for an empty string using .length() > 0 with the more concise !nestedPath.isEmpty() in the conditional statement. This change improves readability and aligns with common Java best practices for string emptiness checks.