### PR TITLE
Fix non-ASCII character handling in StringUtils.uriDecode

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -819,7 +819,7 @@ public abstract class StringUtils {
 					if (u == -1 || l == -1) {
 						throw new IllegalArgumentException("Invalid encoded sequence \"" + source.substring(i) + "\"");
 					}
-					baos.write((char) ((u << 4) + l));
+					baos.write((byte) ((u << 4) + l));
 					i += 2;
 					changed = true;
 				}
@@ -828,7 +828,9 @@ public abstract class StringUtils {
 				}
 			}
 			else {
-				baos.write(ch);
+				String characterAsString = Character.toString((char) ch);
+				byte[] bytes = characterAsString.getBytes(charset);
+				baos.write(bytes, 0, bytes.length);
 			}
 		}
 		return (changed ? StreamUtils.copyToString(baos, charset) : source);


### PR DESCRIPTION
StringUtils.uriDecode now correctly handles non-ASCII characters regardless of the presence of "%" encoding.

Previously, the method took two different paths depending on whether "%" was found, leading to incorrect handling of non-ASCII characters in the absence of "%" encoding.

This fix ensures that all characters, including non-ASCII ones, are properly decoded using the provided Charset, improving the method's reliability and consistency across all inputs.

This change addresses issues with decoding multibyte characters and ensures compatibility with a wider range of character encodings, enhancing the utility's overall functionality.

#32360