### PR TITLE
Use `String#isEmpty` where feasible

### DIFF
--- a/spring-core/src/main/java/org/springframework/cglib/core/EmitUtils.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/EmitUtils.java
@@ -653,14 +653,14 @@ public class EmitUtils {
             e.dup();
             e.ifnull(skip);
             e.swap();
-            if (delims != null && delims.before != null && !"".equals(delims.before)) {
+            if (delims != null && delims.before != null && !delims.before.isEmpty()) {
                 e.push(delims.before);
                 e.invoke_virtual(Constants.TYPE_STRING_BUFFER, APPEND_STRING);
                 e.swap();
             }
             EmitUtils.process_array(e, type, callback);
             shrinkStringBuffer(e, 2);
-            if (delims != null && delims.after != null && !"".equals(delims.after)) {
+            if (delims != null && delims.after != null && !delims.after.isEmpty()) {
                 e.push(delims.after);
                 e.invoke_virtual(Constants.TYPE_STRING_BUFFER, APPEND_STRING);
             }

--- a/spring-core/src/main/java/org/springframework/cglib/core/TypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/TypeUtils.java
@@ -230,7 +230,7 @@ public class TypeUtils {
     }
 
     private static String map(String type) {
-        if (type.equals("")) {
+        if (type.isEmpty()) {
             return type;
         }
         String t = (String)transforms.get(type);

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -877,7 +877,7 @@ public abstract class StringUtils {
 	@SuppressWarnings("deprecation")  // for Locale constructors on JDK 19
 	@Nullable
 	public static Locale parseLocaleString(String localeString) {
-		if (localeString.equals("")) {
+		if (localeString.isEmpty()) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR replaces checks for empty strings (`"".equals(...)`) with the `String#isEmpty` method.

This change not only improves readability but also aligns with best practices in Java for string emptiness checking.