### PR TITLE
add synchronized code when add new data source

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/lookup/AbstractRoutingDataSource.java
@@ -60,7 +60,7 @@ public abstract class AbstractRoutingDataSource extends AbstractDataSource imple
 	@Nullable
 	private DataSource resolvedDefaultDataSource;
 
-	private Object resolvedDataSourceMonitor=new Object();
+	private final Object resolvedDataSourceMonitor=new Object();
 
 
 	/**


### PR DESCRIPTION
Currently we use AbstractRoutingDataSource to dynamically switch data source. But sometimes switch would have some exception, then we found when switch concurrently, exception may happen. So add synchronized code when add new data source(initialize() and determineTargetDataSource()).