### PR TITLE
Fix DefaultServerObservation httpUrl value

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/observation/DefaultServerRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/observation/DefaultServerRequestObservationConvention.java
@@ -171,7 +171,7 @@ public class DefaultServerRequestObservationConvention implements ServerRequestO
 
 	protected KeyValue httpUrl(ServerRequestObservationContext context) {
 		if (context.getCarrier() != null) {
-			return KeyValue.of(HighCardinalityKeyNames.HTTP_URL, context.getCarrier().getPath().toString());
+			return KeyValue.of(HighCardinalityKeyNames.HTTP_URL, context.getCarrier().getURI().toString());
 		}
 		return HTTP_URL_UNKNOWN;
 	}


### PR DESCRIPTION
See `DefaultServerRequestObservationConvention.java` :
```java
	@Override
	public KeyValues getHighCardinalityKeyValues(ServerRequestObservationContext context) {
		// Make sure that KeyValues entries are already sorted by name for better performance
		return KeyValues.of(httpUrl(context));
	}

```

httpUrl is HighCardinalityKey, It should use `context.getCarrier().getURI().toString()` in DefaultServerRequestObservationConvention#httpUrl(ServerRequestObservationContext context) (line:174)

![image](https://github.com/spring-projects/spring-framework/assets/24709538/cf1b0ea6-1286-4557-a434-5299d472591b)
