### PR TITLE
Fix Javadoc

### DIFF
--- a/spring-aop/src/testFixtures/java/org/springframework/aop/testfixture/mixin/LockMixin.java
+++ b/spring-aop/src/testFixtures/java/org/springframework/aop/testfixture/mixin/LockMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class LockMixin extends DelegatingIntroductionInterceptor implements Lock
 	}
 
 	/**
-	 * @see test.mixin.AopProxyTests.Lockable#locked()
+	 * @see org.springframework.aop.testfixture.mixin.Lockable#locked()
 	 */
 	@Override
 	public boolean locked() {
@@ -57,7 +57,7 @@ public class LockMixin extends DelegatingIntroductionInterceptor implements Lock
 	 * If the method is a setter and we're locked, prevent execution.
 	 * Otherwise let super.invoke() handle it, and do normal
 	 * Lockable(this) then target behaviour.
-	 * @see org.aopalliance.MethodInterceptor#invoke(org.aopalliance.MethodInvocation)
+	 * @see org.aopalliance.intercept.MethodInterceptor#invoke(MethodInvocation)
 	 */
 	@Override
 	public Object invoke(MethodInvocation invocation) throws Throwable {

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/MethodDescriptor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/MethodDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,9 @@ record MethodDescriptor(Class<?> declaringClass, String methodName, Class<?>... 
 
 	/**
 	 * Create a {@link MethodDescriptor} for the supplied bean class and method name.
-	 * <p>The supplied {@code methodName} may be a {@linkplain Method#getName()
+	 * <p>The supplied {@code methodName} may be a {@linkplain java.lang.reflect.Method#getName()
 	 * simple method name} or a
-	 * {@linkplain org.springframework.util.ClassUtils#getQualifiedMethodName(Method)
+	 * {@linkplain org.springframework.util.ClassUtils#getQualifiedMethodName(java.lang.reflect.Method)
 	 * qualified method name}.
 	 * <p>If the method name is fully qualified, this utility will parse the
 	 * method name and its declaring class from the qualified method name and then

--- a/spring-beans/src/test/java/org/springframework/beans/ExtendedBeanInfoTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/ExtendedBeanInfoTests.java
@@ -554,7 +554,7 @@ class ExtendedBeanInfoTests {
 	 * IntrospectionException regarding a "type mismatch between indexed and non-indexed
 	 * methods" intermittently (approximately one out of every four times) under JDK 7
 	 * due to non-deterministic results from {@link Class#getDeclaredMethods()}.
-	 * See https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7023180
+	 * @see <a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7023180">JDK-7023180 : Change in specified-to-be-unspecified ordering of getDeclaredMethods causes application problems</a>
 	 * @see #cornerSpr9702()
 	 */
 	@Test

--- a/spring-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
@@ -266,9 +266,9 @@ public final class BridgeMethodResolver {
 	/**
 	 * Compare the signatures of the bridge method and the method which it bridges. If
 	 * the parameter and return types are the same, it is a 'visibility' bridge method
-	 * introduced in Java 6 to fix https://bugs.openjdk.org/browse/JDK-6342411.
-	 * See also https://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html
+	 * introduced in Java 6 to fix <a href="https://bugs.openjdk.org/browse/JDK-6342411">JDK-6342411</a>.
 	 * @return whether signatures match as described
+	 * @see <a href="https://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html">Java bridge methods explained</a>
 	 */
 	public static boolean isVisibilityBridgeMethodPair(Method bridgeMethod, Method bridgedMethod) {
 		if (bridgeMethod == bridgedMethod) {

--- a/spring-core/src/test/java/org/springframework/core/annotation/NestedRepeatableAnnotationsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/NestedRepeatableAnnotationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Sam Brannen
  * @since 5.3.24
- * @see https://github.com/spring-projects/spring-framework/issues/20279
+ * @see <a href="https://github.com/spring-projects/spring-framework/issues/20279">gh-20279</a>
  */
 @SuppressWarnings("unused")
 class NestedRepeatableAnnotationsTests {

--- a/spring-expression/src/main/java/org/springframework/expression/spel/ast/FunctionReference.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/ast/FunctionReference.java
@@ -163,8 +163,8 @@ public class FunctionReference extends SpelNodeImpl {
 	/**
 	 * Execute a function represented as {@link MethodHandle}.
 	 * <p>Method types that take no arguments (fully bound handles or static methods
-	 * with no parameters) can use {@link MethodHandle#invoke()} which is the most
-	 * efficient. Otherwise, {@link MethodHandle#invokeWithArguments()} is used.
+	 * with no parameters) can use {@link MethodHandle#invoke(Object... var1)} which is the most
+	 * efficient. Otherwise, {@link MethodHandle#invokeWithArguments(Object... arguments)} is used.
 	 * @param state the expression evaluation state
 	 * @param methodHandle the method handle to invoke
 	 * @return the return value of the invoked Java method

--- a/spring-expression/src/test/java/org/springframework/expression/spel/ScenariosForSpringSecurityExpressionTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/ScenariosForSpringSecurityExpressionTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 ///CLOVER:OFF
 /**
- * Spring Security scenarios from https://docs.spring.io/spring-security/reference/servlet/authorization/expression-based.html
+ * Spring Security scenarios from <a href="https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html#authorization-expressions">Expressing Authorization with SpEL</a>
  *
  * @author Andy Clement
  */

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/init/H2DatabasePopulatorTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/datasource/init/H2DatabasePopulatorTests.java
@@ -44,7 +44,7 @@ class H2DatabasePopulatorTests extends AbstractDatabasePopulatorTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-15896
+	 * <a href="https://jira.spring.io/browse/SPR-15896">SPR-15896</a>
 	 *
 	 * @since 5.0
 	 */
@@ -62,7 +62,7 @@ class H2DatabasePopulatorTests extends AbstractDatabasePopulatorTests {
 	}
 
 	/**
-	 * https://github.com/spring-projects/spring-framework/issues/27008
+	 * <a href="https://github.com/spring-projects/spring-framework/issues/27008">gh-27008</a>
 	 *
 	 * @since 5.3.11
 	 */

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessagingTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ public class SimpMessagingTemplate extends AbstractMessageSendingTemplate<String
 	 * SimpMessageHeaderAccessor#DESTINATION_HEADER} then the message is sent without
 	 * further changes.
 	 * <p>If a destination header is not already present ,the message is sent
-	 * to the configured {@link #setDefaultDestination(Object) defaultDestination}
+	 * to the configured {@link AbstractMessageSendingTemplate#setDefaultDestination(Object) defaultDestination}
 	 * or an exception an {@code IllegalStateException} is raised if that isn't
 	 * configured.
 	 * @param message the message to send (never {@code null})

--- a/spring-test/src/test/java/org/springframework/test/context/event/DirtiesContextEventPublishingTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/event/DirtiesContextEventPublishingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
  *
  * @author Sam Brannen
  * @since 5.3.17
- * @see https://github.com/spring-projects/spring-framework/issues/27757
+ * @see <a href="https://github.com/spring-projects/spring-framework/issues/27757">gh-27757</a>
  */
 class DirtiesContextEventPublishingTests {
 

--- a/spring-test/src/test/java/org/springframework/test/context/event/EagerTestExecutionEventPublishingTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/event/EagerTestExecutionEventPublishingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
  *
  * @author Sam Brannen
  * @since 5.3.17
- * @see https://github.com/spring-projects/spring-framework/issues/27757
+ * @see <a href="https://github.com/spring-projects/spring-framework/issues/27757">gh-27757</a>
  */
 class EagerTestExecutionEventPublishingTests {
 

--- a/spring-test/src/test/java/org/springframework/test/context/jdbc/PrimaryDataSourceTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/jdbc/PrimaryDataSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import static org.springframework.test.transaction.TransactionAssert.assertThatT
  *
  * @author Sam Brannen
  * @since 4.3
- * @see org.springframework.test.context.transaction.PrimaryTransactionManagerTests
+ * @see org.springframework.test.context.transaction.manager.PrimaryTransactionManagerTests
  */
 @SpringJUnitConfig
 @DirtiesContext

--- a/spring-test/src/test/java/org/springframework/test/context/junit4/rules/AutowiredRuleTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/junit4/rules/AutowiredRuleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration tests for an issue raised in https://jira.spring.io/browse/SPR-15927.
+ * Integration tests for an issue raised in <a href="https://jira.spring.io/browse/SPR-15927">SPR-15927</a>.
  *
  * @author Sam Brannen
  * @since 5.0

--- a/spring-test/src/test/java/org/springframework/test/context/support/ContextLoaderUtilsContextHierarchyTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/support/ContextLoaderUtilsContextHierarchyTests.java
@@ -328,7 +328,7 @@ class ContextLoaderUtilsContextHierarchyTests extends AbstractContextConfigurati
 	}
 
 	/**
-	 * Used to reproduce bug reported in https://jira.spring.io/browse/SPR-10997
+	 * Used to reproduce bug reported in <a href="https://jira.spring.io/browse/SPR-10997">SPR-10997</a>
 	 */
 	@Test
 	void buildContextHierarchyMapForTestClassHierarchyWithMultiLevelContextHierarchiesAndOverriddenInitializers() {
@@ -505,7 +505,7 @@ class ContextLoaderUtilsContextHierarchyTests extends AbstractContextConfigurati
 	}
 
 	/**
-	 * Used to reproduce bug reported in https://jira.spring.io/browse/SPR-10997
+	 * Used to reproduce bug reported in <a href="https://jira.spring.io/browse/SPR-10997">SPR-10997</a>
 	 */
 	@ContextHierarchy({//
 	//
@@ -516,7 +516,7 @@ class ContextLoaderUtilsContextHierarchyTests extends AbstractContextConfigurati
 	}
 
 	/**
-	 * Used to reproduce bug reported in https://jira.spring.io/browse/SPR-10997
+	 * Used to reproduce bug reported in <a href="https://jira.spring.io/browse/SPR-10997">SPR-10997</a>
 	 */
 	@ContextHierarchy({//
 	//
@@ -528,7 +528,7 @@ class ContextLoaderUtilsContextHierarchyTests extends AbstractContextConfigurati
 	}
 
 	/**
-	 * Used to reproduce bug reported in https://jira.spring.io/browse/SPR-10997
+	 * Used to reproduce bug reported in <a href="https://jira.spring.io/browse/SPR-10997">SPR-10997</a>
 	 */
 	private static class DummyApplicationContextInitializer implements
 			ApplicationContextInitializer<ConfigurableApplicationContext> {

--- a/spring-web/src/jmh/java/org/springframework/web/bind/ServletRequestUtilsBenchmark.java
+++ b/spring-web/src/jmh/java/org/springframework/web/bind/ServletRequestUtilsBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 
 
 /**
- * Benchmarks for extracting parameters from {@libnk ServletRequest}.
+ * Benchmarks for extracting parameters from {@link jakarta.servlet.ServletRequest}.
  * @author Brian Clozel
  */
 @BenchmarkMode(Mode.Throughput)

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractListenerWriteProcessor.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/AbstractListenerWriteProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public abstract class AbstractListenerWriteProcessor<T> implements Processor<T, 
 	 * Indicates we're waiting for one last isReady-onWritePossible cycle
 	 * after "onComplete" because some Servlet containers expect this to take
 	 * place prior to calling AsyncContext.complete().
-	 * See https://github.com/eclipse-ee4j/servlet-api/issues/273
+	 * @see <a href="https://github.com/eclipse-ee4j/servlet-api/issues/273">gh-273</a>
 	 */
 	private volatile boolean readyToCompleteAfterLastWrite;
 

--- a/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityReferences.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityReferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.util.Assert;
  * HTML 4.0 standard.
  *
  * <p>A complete description of the HTML 4.0 character set can be found
- * at https://www.w3.org/TR/html4/charset.html.
+ * at <a href="https://www.w3.org/TR/html4/charset.html">https://www.w3.org/TR/html4/charset.html</a>.
  *
  * @author Juergen Hoeller
  * @author Martin Kersten

--- a/spring-web/src/test/java/org/springframework/http/WebBeanUtilsRuntimeHintsTests.java
+++ b/spring-web/src/test/java/org/springframework/http/WebBeanUtilsRuntimeHintsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.util.ClassUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Web-related tests for {@link BeanUtilsRuntimeHints}.
+ * Web-related tests for {@link org.springframework.beans.BeanUtilsRuntimeHints}.
  *
  * @author Sebastien Deleuze
  * @since 6.0.10

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/document/AbstractPdfView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/document/AbstractPdfView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ public abstract class AbstractPdfView extends AbstractView {
 	 * The subclass can either have fixed preferences or retrieve
 	 * them from bean properties defined on the View.
 	 * @return an int containing the bits information against PdfWriter definitions
-	 * @see com.lowagie.text.pdf.PdfWriter#AllowPrinting
+	 * @see com.lowagie.text.pdf.PdfWriter#ALLOW_PRINTING
 	 * @see com.lowagie.text.pdf.PdfWriter#PageLayoutSinglePage
 	 */
 	protected int getViewerPreferences() {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/UrlFilenameViewControllerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/UrlFilenameViewControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,7 +170,7 @@ class UrlFilenameViewControllerTests {
 
 	/**
 	 * This is the expected behavior, and it now has a test to prove it.
-	 * https://opensource.atlassian.com/projects/spring/browse/SPR-2789
+	 * @see <a href="https://opensource.atlassian.com/projects/spring/browse/SPR-2789">SPR-2789</a>
 	 */
 	@PathPatternsParameterizedTest
 	void nestedPathisUsedAsViewName_InBreakingChangeFromSpring12Line(

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/ErrorsTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/ErrorsTagTests.java
@@ -356,7 +356,7 @@ public class ErrorsTagTests extends AbstractFormTagTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-2788
+	 * <a href="https://jira.spring.io/browse/SPR-2788">SPR-2788</a>
 	 */
 	@Test
 	void asBodyTagWithErrorsAndExistingMessagesAttributeInNonPageScopeAreNotClobbered() throws Exception {
@@ -380,7 +380,7 @@ public class ErrorsTagTests extends AbstractFormTagTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-2788
+	 * <a href="https://jira.spring.io/browse/SPR-2788">SPR-2788</a>
 	 */
 	@Test
 	void asBodyTagWithNoErrorsAndExistingMessagesAttributeInApplicationScopeAreNotClobbered() throws Exception {
@@ -388,7 +388,7 @@ public class ErrorsTagTests extends AbstractFormTagTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-2788
+	 * <a href="https://jira.spring.io/browse/SPR-2788">SPR-2788</a>
 	 */
 	@Test
 	void asBodyTagWithNoErrorsAndExistingMessagesAttributeInSessionScopeAreNotClobbered() throws Exception {
@@ -396,7 +396,7 @@ public class ErrorsTagTests extends AbstractFormTagTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-2788
+	 * <a href="https://jira.spring.io/browse/SPR-2788">SPR-2788</a>
 	 */
 	@Test
 	void asBodyTagWithNoErrorsAndExistingMessagesAttributeInPageScopeAreNotClobbered() throws Exception {
@@ -404,7 +404,7 @@ public class ErrorsTagTests extends AbstractFormTagTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-2788
+	 * <a href="https://jira.spring.io/browse/SPR-2788">SPR-2788</a>
 	 */
 	@Test
 	void asBodyTagWithNoErrorsAndExistingMessagesAttributeInRequestScopeAreNotClobbered() throws Exception {
@@ -412,7 +412,7 @@ public class ErrorsTagTests extends AbstractFormTagTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-4005
+	 * <a href="https://jira.spring.io/browse/SPR-4005">SPR-4005</a>
 	 */
 	@Test
 	void omittedPathMatchesObjectErrorsOnly() throws Exception {

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/PasswordInputTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/PasswordInputTagTests.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 class PasswordInputTagTests extends InputTagTests {
 
 	/**
-	 * https://jira.spring.io/browse/SPR-2866
+	 * <a href="https://jira.spring.io/browse/SPR-2866">SPR-2866</a>
 	 */
 	@Test
 	void passwordValueIsNotRenderedByDefault() throws Exception {
@@ -49,7 +49,7 @@ class PasswordInputTagTests extends InputTagTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-2866
+	 * <a href="https://jira.spring.io/browse/SPR-2866">SPR-2866</a>
 	 */
 	@Test
 	void passwordValueIsRenderedIfShowPasswordAttributeIsSetToTrue() throws Exception {
@@ -67,7 +67,7 @@ class PasswordInputTagTests extends InputTagTests {
 	}
 
 	/**
-	 * https://jira.spring.io/browse/SPR-2866
+	 * <a href="https://jira.spring.io/browse/SPR-2866">SPR-2866</a>
 	 */
 	@Test
 	void passwordValueIsNotRenderedIfShowPasswordAttributeIsSetToFalse() throws Exception {


### PR DESCRIPTION
# Fixes some warnings and errors in JavaDoc

## Whats done:
- Fixed error when building framework-api:javadoc in [AbstractPdfView.java](spring-webmvc/src/main/java/org/springframework/web/servlet/view/document/AbstractPdfView.java)
- Fixed incorrect links in [ScenariosForSpringSecurityExpressionTests.java](spring-expression/src/test/java/org/springframework/expression/spel/ScenariosForSpringSecurityExpressionTests.java) and [ServletRequestUtilsBenchmark.java](spring-web/src/jmh/java/org/springframework/web/bind/ServletRequestUtilsBenchmark.java)
- Fixed warnings (shown es errors) **Cannot resolve symbol 'https' -> Replace URL with HTML Link**
- Fixed method references
    
## Note
Pull request is for 6.1.x version as we have build error here (and main too)