### PR TITLE
Fix typo in documentation: mvc-ann-rest-exceptions.adoc

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-rest-exceptions.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-rest-exceptions.adoc
@@ -185,7 +185,7 @@ Message codes and arguments for each error are also resolved via `MessageSource`
 |===
 
 NOTE: Unlike other exceptions, the message arguments for
-`MethodArgumentValidException` and `HandlerMethodValidationException` are baed on a list of
+`MethodArgumentValidException` and `HandlerMethodValidationException` are based on a list of
 `MessageSourceResolvable` errors that can also be customized through a
 xref:core/beans/context-introduction.adoc#context-functionality-messagesource[MessageSource]
 resource bundle. See


### PR DESCRIPTION
Fixed a small typo.

Link to the relevant webpage, see under the table: [https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-ann-rest-exceptions.html](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-ann-rest-exceptions.html)