### PR TITLE
Allow UriTemplate to be built with an empty template

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriTemplate.java
@@ -66,7 +66,7 @@ public class UriTemplate implements Serializable {
 	 * @param uriTemplate the URI template string
 	 */
 	public UriTemplate(String uriTemplate) {
-		Assert.hasText(uriTemplate, "'uriTemplate' must not be null");
+		Assert.notNull(uriTemplate, "'uriTemplate' must not be null");
 		this.uriTemplate = uriTemplate;
 		this.uriComponents = UriComponentsBuilder.fromUriString(uriTemplate).build();
 

--- a/spring-web/src/test/java/org/springframework/web/util/UriTemplateTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriTemplateTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author Arjen Poutsma
@@ -216,6 +217,16 @@ class UriTemplateTests {
 		UriTemplate template = new UriTemplate("http://localhost/query={query}");
 		URI uri = template.expand("foo@bar");
 		assertThat(uri.toString()).isEqualTo("http://localhost/query=foo@bar");
+	}
+
+	@Test
+	void emptyPathDoesNotThrowException() {
+		assertThatNoException().isThrownBy(() -> new UriTemplate(""));
+	}
+
+	@Test
+	void emptyPathThrowsException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new UriTemplate(null));
 	}
 
 }


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-gateway#3201