### PR TITLE
Default strategy for ProblemDetail error codes wrongly document how "detail" is supported

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-rest-exceptions.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-rest-exceptions.adoc
@@ -78,14 +78,13 @@ It is a common requirement to customize and internationalize error response deta
 It is also good practice to customize the problem details for Spring MVC exceptions
 to avoid revealing implementation details. This section describes the support for that.
 
-An `ErrorResponse` exposes message codes for "type", "title", and "detail", as well as
-message code arguments for the "detail" field. `ResponseEntityExceptionHandler` resolves
+An `ErrorResponse` exposes message codes for "type" and "title". `ResponseEntityExceptionHandler` resolves
 these through a xref:core/beans/context-introduction.adoc#context-functionality-messagesource[MessageSource]
 and updates the corresponding `ProblemDetail` fields accordingly.
 
 The default strategy for message codes follows the pattern:
 
-`problemDetail.[type|title|detail].[fully qualified exception class name]`
+`problemDetail.[type|title].[fully qualified exception class name]`
 
 An `ErrorResponse` may expose more than one message code, typically adding a suffix
 to the default message code. The table below lists message codes, and arguments for


### PR DESCRIPTION
Doc fix for #32415
Removed 'details' attribute from documentation as it is not being used in implementation at all.