### PR TITLE
Improve containsValue Method for CharSequence Comparison

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/support/Netty5HeadersAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/support/Netty5HeadersAdapter.java
@@ -115,9 +115,12 @@ public final class Netty5HeadersAdapter implements MultiValueMap<String, String>
 
 	@Override
 	public boolean containsValue(Object value) {
-		return (value instanceof String &&
-				StreamSupport.stream(this.headers.spliterator(), false)
-						.anyMatch(entry -> value.equals(entry.getValue())));
+		if (value instanceof CharSequence) {
+			String valueStr = value.toString();
+			return StreamSupport.stream(this.headers.spliterator(), false)
+					.anyMatch(entry -> valueStr.equals(entry.getValue().toString()));
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
**Problem**

The current implementation of the `containsValue` method checks if a provided value is an instance of `String` and then compares this value to the entries within headers using `String.equals()`. This approach limits the comparison strictly to String instances and does not account for other CharSequence implementations like `StringBuilder` or `StringBuffer`, which might also represent valid sequences of characters to be compared.

**Solution**

This MR introduces an improvement to the `containsValue` method, enabling it to handle comparisons with any objects implementing the `CharSequence` interface, not just String. This is achieved by converting both the value and the entry value to String before comparison, ensuring that the comparison logic remains effective while becoming more flexible.

**Changes Made**

-  Check if value is an instance of CharSequence instead of strictly String.
-  Convert value to String (if it's a CharSequence) before the comparison.
-  Update the comparison logic to ensure it correctly handles CharSequence implementations.