### PR TITLE
Optimize containsAll Method for Improved Performance

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/AutoPopulatingList.java
+++ b/spring-core/src/main/java/org/springframework/util/AutoPopulatingList.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -128,7 +129,7 @@ public class AutoPopulatingList<E> implements List<E>, Serializable {
 
 	@Override
 	public boolean containsAll(Collection<?> c) {
-		return this.backingList.containsAll(c);
+		return new HashSet<>(this.backingList).containsAll(c);
 	}
 
 	/**


### PR DESCRIPTION
This pull request introduces an optimization to the `containsAll` method in collection handling. It is aim to improve the method's performance, especially when dealing with large collections.

Previously, the `containsAll` method used `this.backingList.containsAll(c)`, iterating over each element in the collection `c` and checking for its presence in `this.backingList`. This approach, while straightforward, can lead to suboptimal performance for large collections due to the potential for repeated linear searches.

This change has 2 benefits:
- Improved Performance: This change significantly reduces the computational complexity of the `containsAll` method, especially beneficial when `this.backingList` and `c` are large.
- Scalability: As the size of the collections grows, the performance benefits of this optimization become even more pronounced, making collection handling more scalable.