### PR TITLE
Resolve property-dependent parameter names for exception messages

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/AbstractNamedValueMethodArgumentResolver.java
@@ -99,7 +99,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements SyncHa
 			else if (namedValueInfo.required && !nestedParameter.isOptional()) {
 				handleMissingValue(resolvedName.toString(), nestedParameter, message);
 			}
-			arg = handleNullValue(namedValueInfo.name, arg, nestedParameter.getNestedParameterType());
+			arg = handleNullValue(resolvedName.toString(), arg, nestedParameter.getNestedParameterType());
 		}
 		else if ("".equals(arg) && namedValueInfo.defaultValue != null) {
 			arg = resolveEmbeddedValuesAndExpressions(namedValueInfo.defaultValue);

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/AbstractNamedValueMethodArgumentResolver.java
@@ -97,7 +97,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements SyncHa
 				arg = resolveEmbeddedValuesAndExpressions(namedValueInfo.defaultValue);
 			}
 			else if (namedValueInfo.required && !nestedParameter.isOptional()) {
-				handleMissingValue(namedValueInfo.name, nestedParameter, message);
+				handleMissingValue(resolvedName.toString(), nestedParameter, message);
 			}
 			arg = handleNullValue(namedValueInfo.name, arg, nestedParameter.getNestedParameterType());
 		}
@@ -113,7 +113,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements SyncHa
 					arg = resolveEmbeddedValuesAndExpressions(namedValueInfo.defaultValue);
 				}
 				else if (namedValueInfo.required && !nestedParameter.isOptional()) {
-					handleMissingValue(namedValueInfo.name, nestedParameter, message);
+					handleMissingValue(resolvedName.toString(), nestedParameter, message);
 				}
 			}
 		}

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/AbstractNamedValueMethodArgumentResolver.java
@@ -107,7 +107,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements Handle
 			else if (namedValueInfo.required && !nestedParameter.isOptional()) {
 				handleMissingValue(resolvedName.toString(), nestedParameter, message);
 			}
-			arg = handleNullValue(namedValueInfo.name, arg, nestedParameter.getNestedParameterType());
+			arg = handleNullValue(resolvedName.toString(), arg, nestedParameter.getNestedParameterType());
 		}
 		else if ("".equals(arg) && namedValueInfo.defaultValue != null) {
 			arg = resolveEmbeddedValuesAndExpressions(namedValueInfo.defaultValue);

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/support/AbstractNamedValueMethodArgumentResolver.java
@@ -105,7 +105,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements Handle
 				arg = resolveEmbeddedValuesAndExpressions(namedValueInfo.defaultValue);
 			}
 			else if (namedValueInfo.required && !nestedParameter.isOptional()) {
-				handleMissingValue(namedValueInfo.name, nestedParameter, message);
+				handleMissingValue(resolvedName.toString(), nestedParameter, message);
 			}
 			arg = handleNullValue(namedValueInfo.name, arg, nestedParameter.getNestedParameterType());
 		}
@@ -121,7 +121,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements Handle
 					arg = resolveEmbeddedValuesAndExpressions(namedValueInfo.defaultValue);
 				}
 				else if (namedValueInfo.required && !nestedParameter.isOptional()) {
-					handleMissingValue(namedValueInfo.name, nestedParameter, message);
+					handleMissingValue(resolvedName.toString(), nestedParameter, message);
 				}
 			}
 		}

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/reactive/HeaderMethodArgumentResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/reactive/HeaderMethodArgumentResolverTests.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.messaging.handler.annotation.MessagingPredicates.header;
 import static org.springframework.messaging.handler.annotation.MessagingPredicates.headerPlain;
 
@@ -149,6 +150,21 @@ class HeaderMethodArgumentResolverTests {
 		MethodParameter param = this.resolvable.annot(header("foo")).arg(Optional.class, String.class);
 		Object result = resolveArgument(param, message);
 		assertThat(result).isEqualTo(Optional.empty());
+	}
+
+	@Test
+	void missingParameterFromSystemPropertyThroughPlaceholder() {
+		String expected = "sysbar";
+		System.setProperty("systemProperty", expected);
+		Message<byte[]> message = MessageBuilder.withPayload(new byte[0]).build();
+		MethodParameter param = this.resolvable.annot(header("#{systemProperties.systemProperty}")).arg();
+
+		assertThatThrownBy(() ->
+				resolveArgument(param, message))
+				.isInstanceOf(MessageHandlingException.class)
+				.hasMessageContaining(expected);
+
+		System.clearProperty("systemProperty");
 	}
 
 	@SuppressWarnings({"unchecked", "ConstantConditions"})

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/reactive/HeaderMethodArgumentResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/reactive/HeaderMethodArgumentResolverTests.java
@@ -167,6 +167,22 @@ class HeaderMethodArgumentResolverTests {
 		System.clearProperty("systemProperty");
 	}
 
+	@Test
+	void notNullablePrimitiveParameterFromSystemPropertyThroughPlaceholder() {
+		String expected = "sysbar";
+		System.setProperty("systemProperty", expected);
+		Message<byte[]> message = MessageBuilder.withPayload(new byte[0]).build();
+		MethodParameter param = this.resolvable.annot(header("${systemProperty}").required(false)).arg();
+
+		assertThatThrownBy(() ->
+				resolver.resolveArgument(param, message))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining(expected);
+
+		System.clearProperty("systemProperty");
+	}
+
+
 	@SuppressWarnings({"unchecked", "ConstantConditions"})
 	private <T> T resolveArgument(MethodParameter param, Message<?> message) {
 		return (T) this.resolver.resolveArgument(param, message).block(Duration.ofSeconds(5));
@@ -181,7 +197,8 @@ class HeaderMethodArgumentResolverTests {
 			@Header(name = "#{systemProperties.systemProperty}") String param4,
 			String param5,
 			@Header("foo") Optional<String> param6,
-			@Header("nativeHeaders.param1") String nativeHeaderParam1) {
+			@Header("nativeHeaders.param1") String nativeHeaderParam1,
+			@Header(name = "${systemProperty}", required = false) int primitivePlaceholderParam) {
 	}
 
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/HeaderMethodArgumentResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/HeaderMethodArgumentResolverTests.java
@@ -154,6 +154,21 @@ class HeaderMethodArgumentResolverTests {
 	}
 
 	@Test
+	void notNullablePrimitiveParameterFromSystemPropertyThroughPlaceholder() {
+		String expected = "sysbar";
+		System.setProperty("systemProperty", expected);
+		Message<byte[]> message = MessageBuilder.withPayload(new byte[0]).build();
+		MethodParameter param = this.resolvable.annot(header("${systemProperty}").required(false)).arg();
+
+		assertThatThrownBy(() ->
+				resolver.resolveArgument(param, message))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining(expected);
+
+		System.clearProperty("systemProperty");
+	}
+
+	@Test
 	void resolveOptionalHeaderWithValue() throws Exception {
 		Message<String> message = MessageBuilder.withPayload("foo").setHeader("foo", "bar").build();
 		MethodParameter param = this.resolvable.annot(header("foo")).arg(Optional.class, String.class);
@@ -178,7 +193,8 @@ class HeaderMethodArgumentResolverTests {
 			@Header(name = "#{systemProperties.systemProperty}") String param4,
 			String param5,
 			@Header("foo") Optional<String> param6,
-			@Header("nativeHeaders.param1") String nativeHeaderParam1) {
+			@Header("nativeHeaders.param1") String nativeHeaderParam1,
+			@Header(name = "${systemProperty}", required = false) int primitivePlaceholderParam) {
 	}
 
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/HeaderMethodArgumentResolverTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/handler/annotation/support/HeaderMethodArgumentResolverTests.java
@@ -35,6 +35,7 @@ import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.messaging.handler.annotation.MessagingPredicates.header;
 import static org.springframework.messaging.handler.annotation.MessagingPredicates.headerPlain;
 
@@ -135,6 +136,21 @@ class HeaderMethodArgumentResolverTests {
 		finally {
 			System.clearProperty("systemProperty");
 		}
+	}
+
+	@Test
+	void missingParameterFromSystemPropertyThroughPlaceholder() {
+		String expected = "sysbar";
+		System.setProperty("systemProperty", expected);
+		Message<byte[]> message = MessageBuilder.withPayload(new byte[0]).build();
+		MethodParameter param = this.resolvable.annot(header("#{systemProperties.systemProperty}")).arg();
+
+		assertThatThrownBy(() ->
+				resolver.resolveArgument(param, message))
+				.isInstanceOf(MessageHandlingException.class)
+				.hasMessageContaining(expected);
+
+		System.clearProperty("systemProperty");
 	}
 
 	@Test

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractNamedValueMethodArgumentResolver.java
@@ -122,7 +122,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements Handle
 				arg = resolveEmbeddedValuesAndExpressions(namedValueInfo.defaultValue);
 			}
 			else if (namedValueInfo.required && !nestedParameter.isOptional()) {
-				handleMissingValue(namedValueInfo.name, nestedParameter, webRequest);
+				handleMissingValue(resolvedName.toString(), nestedParameter, webRequest);
 			}
 			if (!hasDefaultValue) {
 				arg = handleNullValue(namedValueInfo.name, arg, nestedParameter.getNestedParameterType());

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractNamedValueMethodArgumentResolver.java
@@ -125,7 +125,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements Handle
 				handleMissingValue(resolvedName.toString(), nestedParameter, webRequest);
 			}
 			if (!hasDefaultValue) {
-				arg = handleNullValue(namedValueInfo.name, arg, nestedParameter.getNestedParameterType());
+				arg = handleNullValue(resolvedName.toString(), arg, nestedParameter.getNestedParameterType());
 			}
 		}
 		else if ("".equals(arg) && namedValueInfo.defaultValue != null) {

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractNamedValueMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/AbstractNamedValueMethodArgumentResolver.java
@@ -141,7 +141,7 @@ public abstract class AbstractNamedValueMethodArgumentResolver implements Handle
 					arg = convertIfNecessary(parameter, webRequest, binderFactory, namedValueInfo, arg);
 				}
 				else if (namedValueInfo.required && !nestedParameter.isOptional()) {
-					handleMissingValueAfterConversion(namedValueInfo.name, nestedParameter, webRequest);
+					handleMissingValueAfterConversion(resolvedName.toString(), nestedParameter, webRequest);
 				}
 			}
 		}

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/RequestHeaderMethodArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/RequestHeaderMethodArgumentResolverTests.java
@@ -187,6 +187,20 @@ class RequestHeaderMethodArgumentResolverTests {
 	}
 
 	@Test
+	void missingParameterFromSystemPropertyThroughPlaceholder() {
+		String expected = "bar";
+
+		System.setProperty("systemProperty", expected);
+
+		assertThatThrownBy(() ->
+				resolver.resolveArgument(paramResolvedNameWithPlaceholder, null, webRequest, null))
+				.isInstanceOf(MissingRequestHeaderException.class)
+				.extracting("headerName").isEqualTo(expected);
+
+		System.clearProperty("systemProperty");
+	}
+
+	@Test
 	void resolveDefaultValueFromRequest() throws Exception {
 		servletRequest.setContextPath("/bar");
 

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolverTests.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import jakarta.servlet.http.Part;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
@@ -37,7 +38,9 @@ import org.springframework.web.bind.support.DefaultDataBinderFactory;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.bind.support.WebRequestDataBinder;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.support.GenericWebApplicationContext;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
@@ -50,6 +53,7 @@ import org.springframework.web.testfixture.servlet.MockPart;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.web.testfixture.method.MvcAnnotationPredicates.requestParam;
@@ -64,7 +68,7 @@ import static org.springframework.web.testfixture.method.MvcAnnotationPredicates
  */
 class RequestParamMethodArgumentResolverTests {
 
-	private RequestParamMethodArgumentResolver resolver = new RequestParamMethodArgumentResolver(null, true);
+	private RequestParamMethodArgumentResolver resolver;
 
 	private MockHttpServletRequest request = new MockHttpServletRequest();
 
@@ -72,6 +76,15 @@ class RequestParamMethodArgumentResolverTests {
 
 	private ResolvableMethod testMethod = ResolvableMethod.on(getClass()).named("handle").build();
 
+	@BeforeEach
+	void setup() {
+		GenericWebApplicationContext context = new GenericWebApplicationContext();
+		context.refresh();
+		resolver = new RequestParamMethodArgumentResolver(context.getBeanFactory(), true);
+
+		// Expose request to the current thread (for SpEL expressions)
+		RequestContextHolder.setRequestAttributes(webRequest);
+	}
 
 	@Test
 	void supportsParameter() {
@@ -678,7 +691,43 @@ class RequestParamMethodArgumentResolverTests {
 		assertThat(actual).isEqualTo(Optional.empty());
 	}
 
+	@Test
+	void resolveNameFromSystemPropertyThroughPlaceholder() throws Exception {
+		ConfigurableWebBindingInitializer initializer = new ConfigurableWebBindingInitializer();
+		initializer.setConversionService(new DefaultConversionService());
+		WebDataBinderFactory binderFactory = new DefaultDataBinderFactory(initializer);
 
+		Integer expected = 100;
+		request.addParameter("name", expected.toString());
+
+		System.setProperty("systemProperty", "name");
+
+		try {
+			MethodParameter param = this.testMethod.annot(requestParam().name("${systemProperty}")).arg(Integer.class);
+			Object result = resolver.resolveArgument(param, null, webRequest, binderFactory);
+			boolean condition = result instanceof Integer;
+			assertThat(condition).isTrue();
+			assertThat(result).as("Invalid result").isEqualTo(expected);
+		}
+		finally {
+			System.clearProperty("systemProperty");
+		}
+	}
+
+	@Test
+	void missingParameterFromSystemPropertyThroughPlaceholder() {
+		String expected = "name";
+		System.setProperty("systemProperty", expected);
+
+		MethodParameter param = this.testMethod.annot(requestParam().name("${systemProperty}")).arg(Integer.class);
+		assertThatThrownBy(() ->
+				resolver.resolveArgument(param, null, webRequest, null))
+				.isInstanceOf(MissingServletRequestParameterException.class)
+				.extracting("parameterName").isEqualTo(expected);
+
+		System.clearProperty("systemProperty");
+	}
+	
 	@SuppressWarnings({"unused", "OptionalUsedAsFieldOrParameterType"})
 	public void handle(
 			@RequestParam(name = "name", defaultValue = "bar") String param1,
@@ -702,7 +751,8 @@ class RequestParamMethodArgumentResolverTests {
 			@RequestParam("name") Optional<Integer[]> paramOptionalArray,
 			@RequestParam("name") Optional<List<?>> paramOptionalList,
 			@RequestParam("mfile") Optional<MultipartFile> multipartFileOptional,
-			@RequestParam(defaultValue = "false") Boolean booleanParam) {
+			@RequestParam(defaultValue = "false") Boolean booleanParam,
+			@RequestParam("${systemProperty}") Integer placeholderParam) {
 	}
 
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractNamedValueArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractNamedValueArgumentResolver.java
@@ -119,7 +119,7 @@ public abstract class AbstractNamedValueArgumentResolver extends HandlerMethodAr
 					return Mono.justOrEmpty(arg);
 				})
 				.switchIfEmpty(getDefaultValue(
-						namedValueInfo, parameter, bindingContext, model, exchange));
+						namedValueInfo, resolvedName.toString(), parameter, bindingContext, model, exchange));
 	}
 
 	/**
@@ -218,7 +218,7 @@ public abstract class AbstractNamedValueArgumentResolver extends HandlerMethodAr
 	/**
 	 * Resolve the default value, if any.
 	 */
-	private Mono<Object> getDefaultValue(NamedValueInfo namedValueInfo, MethodParameter parameter,
+	private Mono<Object> getDefaultValue(NamedValueInfo namedValueInfo, String resolvedName, MethodParameter parameter,
 			BindingContext bindingContext, Model model, ServerWebExchange exchange) {
 
 		return Mono.fromSupplier(() -> {
@@ -230,10 +230,10 @@ public abstract class AbstractNamedValueArgumentResolver extends HandlerMethodAr
 				value = resolveEmbeddedValuesAndExpressions(namedValueInfo.defaultValue);
 			}
 			else if (namedValueInfo.required && !parameter.isOptional()) {
-				handleMissingValue(namedValueInfo.name, parameter, exchange);
+				handleMissingValue(resolvedName, parameter, exchange);
 			}
 			if (!hasDefaultValue) {
-				value = handleNullValue(namedValueInfo.name, value, parameter.getNestedParameterType());
+				value = handleNullValue(resolvedName, value, parameter.getNestedParameterType());
 			}
 			if (value != null || !hasDefaultValue) {
 				value = applyConversion(value, namedValueInfo, parameter, bindingContext, exchange);


### PR DESCRIPTION
When named value method arguments are defined through placeholders or SpeL and an exception is thrown because the required parameter is missing or can't be converted, the exception message references the placeholder instead of the resolved named value. Example:
```
Required header '${systemProperty}' is not present.
```

This PR enhances the error message by passing the resolved parameter name to the error handlers, so that the exception thrown is more relevant.

Closes #32323 