### PR TITLE
Add Javadoc since to AbstractClientHttpRequestFactoryWrapper.getDelegate()

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/AbstractClientHttpRequestFactoryWrapper.java
+++ b/spring-web/src/main/java/org/springframework/http/client/AbstractClientHttpRequestFactoryWrapper.java
@@ -56,6 +56,7 @@ public abstract class AbstractClientHttpRequestFactoryWrapper implements ClientH
 
 	/**
 	 * Return the delegate request factory.
+	 * @since 6.1.4
 	 */
 	public ClientHttpRequestFactory getDelegate() {
 		return this.requestFactory;


### PR DESCRIPTION
This PR adds Javadoc `@since` to `AbstractClientHttpRequestFactoryWrapper.getDelegate()`.

See gh-32038