### PR TITLE
Fix WebFlux temporary file not always deleted with parallel uploads

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/DefaultPartHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/DefaultPartHttpMessageReader.java
@@ -125,7 +125,7 @@ public class DefaultPartHttpMessageReader extends LoggingCodecSupport implements
 	/**
 	 * Set the directory used to store parts larger than
 	 * {@link #setMaxInMemorySize(int) maxInMemorySize}. By default, a directory
-	 * named {@code spring-webflux-multipart} is created under the system
+	 * named {@code spring-multipart} is created under the system
 	 * temporary directory.
 	 * <p>Note that this property is ignored when
 	 * {@link #setMaxInMemorySize(int) maxInMemorySize} is set to -1.

--- a/spring-web/src/test/java/org/springframework/http/codec/multipart/DefaultPartHttpMessageReaderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/multipart/DefaultPartHttpMessageReaderTests.java
@@ -102,13 +102,13 @@ class DefaultPartHttpMessageReaderTests {
 				new ClassPathResource("no-header.multipart", getClass()), "boundary");
 		Flux<Part> result = reader.read(forClass(Part.class), request, emptyMap());
 
-			StepVerifier.create(result)
-					.consumeNextWith(part -> {
-						assertThat(part.headers()).isEmpty();
-						part.content().subscribe(DataBufferUtils::release);
-					})
-					.verifyComplete();
-		}
+		StepVerifier.create(result)
+				.consumeNextWith(part -> {
+					assertThat(part.headers()).isEmpty();
+					part.content().subscribe(DataBufferUtils::release);
+				})
+				.verifyComplete();
+	}
 
 	@ParameterizedDefaultPartHttpMessageReaderTest
 	void noEndBoundary(DefaultPartHttpMessageReader reader) {
@@ -383,6 +383,8 @@ class DefaultPartHttpMessageReaderTests {
 			Path tempFile = Files.createTempFile("DefaultMultipartMessageReaderTests", null);
 
 			filePart.transferTo(tempFile)
+					.then(Mono.fromCallable(() -> Files.deleteIfExists(tempFile)).then())
+					.then(filePart.delete())
 					.subscribe(null,
 							throwable -> {
 								throw Exceptions.bubble(throwable);
@@ -394,7 +396,6 @@ class DefaultPartHttpMessageReaderTests {
 								finally {
 									latch.countDown();
 								}
-
 							});
 		}
 		catch (Exception ex) {

--- a/spring-web/src/test/java/org/springframework/http/codec/multipart/DefaultPartsTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/multipart/DefaultPartsTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.codec.multipart;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.FileSystemUtils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for  {@link DefaultParts.FileContent}.
+ * @author Maksim Sasnouski
+ */
+public class DefaultPartsTests {
+
+	private static Path tempDir;
+
+	@BeforeAll
+	static void setup() throws IOException {
+		tempDir = Files.createTempDirectory("DefaultPartsTests");
+	}
+
+	@AfterAll
+	static void cleanup() throws IOException {
+		FileSystemUtils.deleteRecursively(tempDir);
+	}
+
+	@Test
+	void tempFilesDeletedBlocking() throws IOException {
+		List<Path> tempFiles = createTempFiles(10);
+		List<Part> parts = createParts(tempFiles);
+		parts.forEach(part -> part.delete().block());
+		tempFiles.forEach(file -> assertTrue(Files.notExists(file)));
+	}
+
+	@Test
+	void tempFilesDeletedNonBlocking() throws IOException {
+		List<Path> tempFiles = createTempFiles(10);
+		List<Part> parts = createParts(tempFiles);
+
+		List<Mono<Void>> deletionTasks = parts.stream()
+				.map(Part::delete)
+				.toList();
+
+		// Emulate subscribe downstream (do not use .blockLast())
+		Flux.concat(deletionTasks).subscribe();
+
+		tempFiles.forEach(file -> assertTrue(Files.notExists(file)));
+	}
+
+	private List<Part> createParts(List<Path> tempFiles) {
+		return tempFiles
+				.stream()
+				.map(this::createPart)
+				.toList();
+	}
+
+	private Part createPart(Path file) {
+		return DefaultParts.part(HttpHeaders.EMPTY, file, Schedulers.boundedElastic());
+	}
+
+	private List<Path> createTempFiles(int count) {
+		return IntStream.range(0, count)
+				.mapToObj(i -> createTempFile())
+				.toList();
+	}
+
+	private Path createTempFile() {
+		try {
+			return Files.createTempFile(tempDir, "part", ".tmp");
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
# Fixes gh-31217. Delete temp files after multipart exchange

### Now temporary files removed as expected and we do not have gigabytes of data stored in temp folder after multipart exchange.

Actual fix is only in DefaultParts.java
All other changes - cleaning temp data after test runs

p.s. @poutsma pull request is for 6.1.x as per assigned milestone
