### PR TITLE
Fix broken link to vavr in the reference guide

### DIFF
--- a/framework-docs/modules/ROOT/pages/data-access/transaction/declarative/rolling-back.adoc
+++ b/framework-docs/modules/ROOT/pages/data-access/transaction/declarative/rolling-back.adoc
@@ -23,7 +23,7 @@ As of Spring Framework 5.2, the default configuration also provides support for
 Vavr's `Try` method to trigger transaction rollbacks when it returns a 'Failure'.
 This allows you to handle functional-style errors using Try and have the transaction
 automatically rolled back in case of a failure. For more information on Vavr's Try,
-refer to the [official Vavr documentation](https://www.vavr.io/vavr-docs/#_try).
+refer to the https://docs.vavr.io/#_try[official Vavr documentation].
 
 Here's an example of how to use Vavr's Try with a transactional method:
 [tabs]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=6.1.5-SNAPSHOT
+version=6.1.5
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
[Rolling Back a Declarative Transaction page](https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/rolling-back.html) has broken link and not applied asciidocs url syntax 

official Vavr documentation is https://docs.vavr.io/
check here https://github.com/vavr-io/vavr-docs

according to [Antora docs](https://docs.antora.org/antora/latest/asciidoc/external-urls/#url-syntax ), it should be 
```
https://docs.vavr.io/#_try[official Vavr documentation]
```
origin is 
```
[official Vavr documentation](https://www.vavr.io/vavr-docs/#_try)
```


