### PR TITLE
Skip comparing variableResolver if underlying type is Class

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -999,7 +999,7 @@ public class ResolvableType implements Serializable {
 				!ObjectUtils.nullSafeEquals(this.typeProvider.getType(), otherType.typeProvider.getType()))) {
 			return false;
 		}
-		if (this.variableResolver != otherType.variableResolver &&
+		if (!(this.type instanceof Class<?>) && this.variableResolver != otherType.variableResolver &&
 				(this.variableResolver == null || otherType.variableResolver == null ||
 				!ObjectUtils.nullSafeEquals(this.variableResolver.getSource(), otherType.variableResolver.getSource()))) {
 			return false;

--- a/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
@@ -1403,6 +1403,13 @@ class ResolvableTypeTests {
 		assertThat(repository3.isAssignableFromResolvedPart(repository1)).isFalse();
 	}
 
+	@Test
+	void skipComparingVariableResolverIfUnderlyingTypeIsClass() {
+		ResolvableType type1 = ResolvableType.forClassWithGenerics(IProvider.class, String.class);
+		ResolvableType type2 = ResolvableType.forClassWithGenerics(IProvider.class,
+				ResolvableType.forClass(StringProvider.class).as(IProvider.class).getGenerics());
+		assertThat(type1).isEqualTo(type2);
+	}
 
 	private ResolvableType testSerialization(ResolvableType type) throws Exception {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -1717,6 +1724,9 @@ class ResolvableTypeTests {
 
 
 	public interface IProvider<P> {
+	}
+
+	public interface StringProvider extends IProvider<String> {
 	}
 
 	public interface IBase<BT extends IBase<BT>> {


### PR DESCRIPTION
Before this commit, given:
```java
ResolvableType type1 = ResolvableType.forClassWithGenerics(IProvider.class, String.class);
ResolvableType type2 = ResolvableType.forClassWithGenerics(IProvider.class,ResolvableType.forClass(StringProvider.class).as(IProvider.class).getGenerics());
assertThat(type1).isEqualTo(type2);
```
will cause:
```
Expected :org.springframework.core.ResolvableTypeTests$IProvider<java.lang.String>
Actual   :org.springframework.core.ResolvableTypeTests$IProvider<java.lang.String>
```