### PR TITLE
Fix Javadoc `@since` tag for `ChannelRegistration.executor()`

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/config/ChannelRegistration.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/config/ChannelRegistration.java
@@ -71,7 +71,7 @@ public class ChannelRegistration {
 	 * taking precedence over a {@linkplain #taskExecutor() task executor
 	 * registration} if any.
 	 * @param executor the executor to use
-	 * @since 6.1.4
+	 * @since 6.2
 	 */
 	public ChannelRegistration executor(Executor executor) {
 		this.executor = executor;


### PR DESCRIPTION
The signature for the `ChannelRegistration.executor()` has been changed in f526b23fd728ea3eb6cf7245142f4563df34dbbd, but its Javadoc `@since` tag update seems to have been missed.

See gh-32129