### PR TITLE
Prevent package summaries from being truncated due to incorrect sentence detection

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/type/filter/package-info.java
+++ b/spring-core/src/main/java/org/springframework/core/type/filter/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Core support package for type filtering (e.g. for classpath scanning).
+ * Core support package for type filtering (for example for classpath scanning).
  */
 @NonNullApi
 @NonNullFields

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/package-info.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Support for various programming model styles including the invocation of
- * different types of handlers, e.g. annotated controller vs simple WebHandler,
- * including the handling of handler result values, e.g. @ResponseBody, view
+ * different types of handlers like an annotated controller or a simple WebHandler.
+ * Includes the handling of handler result values, e.g. @ResponseBody, view
  * resolution, and so on.
  */
 @NonNullApi

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/script/package-info.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/script/package-info.java
@@ -1,6 +1,6 @@
 /**
  * Support classes for views based on the JSR-223 script engine abstraction
- * (as included in Java 6+), e.g. using JavaScript via Nashorn on JDK 8.
+ * (as included in Java 6+). For example using JavaScript via Nashorn on JDK 8.
  * Contains a View implementation for scripted templates.
  */
 @NonNullApi


### PR DESCRIPTION
Javadoc doesn't seem to like having `e.g.` as it thinks the sentence ends there which is usually incorrect and results in broken descriptions. Replacing the breakable space with a nonbreakable one works around it.