### PR TITLE
Fix handling value class with private constructor on proxy

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java
@@ -130,7 +130,9 @@ public abstract class CoroutinesUtils {
 									KType type = parameter.getType();
 									if (!(type.isMarkedNullable() && arg == null) && type.getClassifier() instanceof KClass<?> kClass
 											&& KotlinDetector.isInlineClass(JvmClassMappingKt.getJavaClass(kClass))) {
-										arg = KClasses.getPrimaryConstructor(kClass).call(arg);
+										KFunction<?> valueClassConstructor = KClasses.getPrimaryConstructor(kClass);
+										KCallablesJvm.setAccessible(valueClassConstructor, true);
+										arg = valueClassConstructor.call(arg);
 									}
 									argMap.put(parameter, arg);
 								}

--- a/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
@@ -319,7 +319,9 @@ public class InvocableHandlerMethod extends HandlerMethod {
 							KType type = parameter.getType();
 							if (!(type.isMarkedNullable() && arg == null) && type.getClassifier() instanceof KClass<?> kClass
 									&& KotlinDetector.isInlineClass(JvmClassMappingKt.getJavaClass(kClass))) {
-								arg = KClasses.getPrimaryConstructor(kClass).call(arg);
+								KFunction<?> valueClassConstructor = KClasses.getPrimaryConstructor(kClass);
+								KCallablesJvm.setAccessible(valueClassConstructor, true);
+								arg = valueClassConstructor.call(arg);
 							}
 							argMap.put(parameter, arg);
 						}

--- a/spring-web/src/test/kotlin/org/springframework/web/method/support/InvocableHandlerMethodKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/method/support/InvocableHandlerMethodKotlinTests.kt
@@ -113,6 +113,13 @@ class InvocableHandlerMethodKotlinTests {
 	}
 
 	@Test
+	fun valueClassWithPrivateConstructor() {
+		composite.addResolver(StubArgumentResolver(Char::class.java, 'a'))
+		val value = getInvocable(ValueClassHandler::class.java, Char::class.java).invokeForRequest(request, null)
+		Assertions.assertThat(value).isEqualTo('a')
+	}
+
+	@Test
 	fun propertyAccessor() {
 		val value = getInvocable(PropertyAccessorHandler::class.java).invokeForRequest(request, null)
 		Assertions.assertThat(value).isEqualTo("foo")
@@ -191,6 +198,8 @@ class InvocableHandlerMethodKotlinTests {
 		fun valueClassWithNullable(limit: LongValueClass?) =
 			limit?.value
 
+		fun valueClassWithPrivateConstructor(limit: ValueClassWithPrivateConstructor) =
+			limit.value
 	}
 
 	private class PropertyAccessorHandler {
@@ -235,6 +244,13 @@ class InvocableHandlerMethodKotlinTests {
 			if (value.isEmpty()) {
 				throw IllegalArgumentException()
 			}
+		}
+	}
+
+	@JvmInline
+	value class ValueClassWithPrivateConstructor private constructor(val value: Char) {
+		companion object {
+			fun from(value: Char) = ValueClassWithPrivateConstructor(value)
 		}
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/InvocableHandlerMethod.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/InvocableHandlerMethod.java
@@ -332,7 +332,9 @@ public class InvocableHandlerMethod extends HandlerMethod {
 								KType type = parameter.getType();
 								if (!(type.isMarkedNullable() && arg == null) && type.getClassifier() instanceof KClass<?> kClass
 										&& KotlinDetector.isInlineClass(JvmClassMappingKt.getJavaClass(kClass))) {
-									arg = KClasses.getPrimaryConstructor(kClass).call(arg);
+									KFunction<?> valueClassConstructor = KClasses.getPrimaryConstructor(kClass);
+									KCallablesJvm.setAccessible(valueClassConstructor, true);
+									arg = valueClassConstructor.call(arg);
 								}
 								argMap.put(parameter, arg);
 							}

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/result/InvocableHandlerMethodKotlinTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/result/InvocableHandlerMethodKotlinTests.kt
@@ -223,6 +223,14 @@ class InvocableHandlerMethodKotlinTests {
 	}
 
 	@Test
+	fun valueClassWithPrivateConstructor() {
+		this.resolvers.add(stubResolver(1L, Long::class.java))
+		val method = ValueClassController::valueClassWithPrivateConstructor.javaMethod!!
+		val result = invoke(ValueClassController(), method, 1L)
+		assertHandlerResultValue(result, "1")
+	}
+
+	@Test
 	fun propertyAccessor() {
 		this.resolvers.add(stubResolver(null, String::class.java))
 		val method = PropertyAccessorController::prop.getter.javaMethod!!
@@ -368,6 +376,8 @@ class InvocableHandlerMethodKotlinTests {
 		fun valueClassWithNullable(limit: LongValueClass?) =
 			"${limit?.value}"
 
+		fun valueClassWithPrivateConstructor(limit: ValueClassWithPrivateConstructor) =
+			"${limit.value}"
 	}
 
 	class PropertyAccessorController {
@@ -413,6 +423,13 @@ class InvocableHandlerMethodKotlinTests {
 			if (value.isEmpty()) {
 				throw IllegalArgumentException()
 			}
+		}
+	}
+
+	@JvmInline
+	value class ValueClassWithPrivateConstructor private constructor(val value: Long) {
+		companion object {
+			fun from(value: Long) = ValueClassWithPrivateConstructor(value)
 		}
 	}
 


### PR DESCRIPTION
## Problem

`CoroutineUtils` and `InvocableHandlerMethod` will throw exception when value class whose constructor is private is given like

```kotlin
@JvmInline
value class ValueClassWithPrivateConstructor private constructor(val value: String) {
	companion object {
		fun from(value: String) = ValueClassWithPrivateConstructor(value)
	}
}
```

stacktrace

```
java.lang.IllegalAccessException: class kotlin.reflect.jvm.internal.calls.CallerImpl$Method cannot access a member of class org.springframework.core.CoroutinesUtilsTests$ValueClassWithPrivateConstructor with modifiers "private static"
kotlin.reflect.full.IllegalCallableAccessException: java.lang.IllegalAccessException: class kotlin.reflect.jvm.internal.calls.CallerImpl$Method cannot access a member of class org.springframework.core.CoroutinesUtilsTests$ValueClassWithPrivateConstructor with modifiers "private static"
	at kotlin.reflect.jvm.internal.KCallableImpl.call(KCallableImpl.kt:280)
	at org.springframework.core.CoroutinesUtils.lambda$invokeSuspendingFunction$3(CoroutinesUtils.java:135)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt$createCoroutineUnintercepted$$inlined$createCoroutineFromSuspendFunction$IntrinsicsKt__IntrinsicsJvmKt$4.invokeSuspend(IntrinsicsJvm.kt:270)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:367)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:30)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:25)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:110)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:126)
	at kotlinx.coroutines.reactor.MonoKt.monoInternal$lambda$2(Mono.kt:92)
	at reactor.core.publisher.MonoCreate.subscribe(MonoCreate.java:61)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4568)
	at kotlinx.coroutines.reactor.MonoKt.awaitSingleOrNull(Mono.kt:47)
	at org.springframework.core.CoroutinesUtilsTests$invokeSuspendingFunctionWithValueClassWithPrivateConstructorParameter$1.invokeSuspend(CoroutinesUtilsTests.kt:216)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:280)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at org.springframework.core.CoroutinesUtilsTests.invokeSuspendingFunctionWithValueClassWithPrivateConstructorParameter(CoroutinesUtilsTests.kt:215)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.IllegalAccessException: class kotlin.reflect.jvm.internal.calls.CallerImpl$Method cannot access a member of class org.springframework.core.CoroutinesUtilsTests$ValueClassWithPrivateConstructor with modifiers "private static"
	at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392)
	at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674)
	at java.base/java.lang.reflect.Method.invoke(Method.java:560)
	at kotlin.reflect.jvm.internal.calls.CallerImpl$Method.callMethod(CallerImpl.kt:97)
	at kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Static.call(CallerImpl.kt:106)
	at kotlin.reflect.jvm.internal.calls.ValueClassAwareCaller.call(ValueClassAwareCaller.kt:199)
	at kotlin.reflect.jvm.internal.KCallableImpl.call(KCallableImpl.kt:108)
	... 25 more
```

## Solution

use `KCallablesJvm.setAccessible` before creating object to avoid the exception

## Concern
in this PR, i modified three places. those of them are same. is it better to extract them into a single method?