### PR TITLE
Implement Pattern Matching for instanceof in AnnotationWriter

### DIFF
--- a/spring-core/src/main/java/org/springframework/asm/AnnotationWriter.java
+++ b/spring-core/src/main/java/org/springframework/asm/AnnotationWriter.java
@@ -207,51 +207,43 @@ final class AnnotationWriter extends AnnotationVisitor {
       annotation.put12('S', symbolTable.addConstantInteger(((Short) value).shortValue()).index);
     } else if (value instanceof Type) {
       annotation.put12('c', symbolTable.addConstantUtf8(((Type) value).getDescriptor()));
-    } else if (value instanceof byte[]) {
-      byte[] byteArray = (byte[]) value;
-      annotation.put12('[', byteArray.length);
+    } else if (value instanceof byte[] byteArray) {
+		annotation.put12('[', byteArray.length);
       for (byte byteValue : byteArray) {
         annotation.put12('B', symbolTable.addConstantInteger(byteValue).index);
       }
-    } else if (value instanceof boolean[]) {
-      boolean[] booleanArray = (boolean[]) value;
-      annotation.put12('[', booleanArray.length);
+    } else if (value instanceof boolean[] booleanArray) {
+		annotation.put12('[', booleanArray.length);
       for (boolean booleanValue : booleanArray) {
         annotation.put12('Z', symbolTable.addConstantInteger(booleanValue ? 1 : 0).index);
       }
-    } else if (value instanceof short[]) {
-      short[] shortArray = (short[]) value;
-      annotation.put12('[', shortArray.length);
+    } else if (value instanceof short[] shortArray) {
+		annotation.put12('[', shortArray.length);
       for (short shortValue : shortArray) {
         annotation.put12('S', symbolTable.addConstantInteger(shortValue).index);
       }
-    } else if (value instanceof char[]) {
-      char[] charArray = (char[]) value;
-      annotation.put12('[', charArray.length);
+    } else if (value instanceof char[] charArray) {
+		annotation.put12('[', charArray.length);
       for (char charValue : charArray) {
         annotation.put12('C', symbolTable.addConstantInteger(charValue).index);
       }
-    } else if (value instanceof int[]) {
-      int[] intArray = (int[]) value;
-      annotation.put12('[', intArray.length);
+    } else if (value instanceof int[] intArray) {
+		annotation.put12('[', intArray.length);
       for (int intValue : intArray) {
         annotation.put12('I', symbolTable.addConstantInteger(intValue).index);
       }
-    } else if (value instanceof long[]) {
-      long[] longArray = (long[]) value;
-      annotation.put12('[', longArray.length);
+    } else if (value instanceof long[] longArray) {
+		annotation.put12('[', longArray.length);
       for (long longValue : longArray) {
         annotation.put12('J', symbolTable.addConstantLong(longValue).index);
       }
-    } else if (value instanceof float[]) {
-      float[] floatArray = (float[]) value;
-      annotation.put12('[', floatArray.length);
+    } else if (value instanceof float[] floatArray) {
+		annotation.put12('[', floatArray.length);
       for (float floatValue : floatArray) {
         annotation.put12('F', symbolTable.addConstantFloat(floatValue).index);
       }
-    } else if (value instanceof double[]) {
-      double[] doubleArray = (double[]) value;
-      annotation.put12('[', doubleArray.length);
+    } else if (value instanceof double[] doubleArray) {
+		annotation.put12('[', doubleArray.length);
       for (double doubleValue : doubleArray) {
         annotation.put12('D', symbolTable.addConstantDouble(doubleValue).index);
       }


### PR DESCRIPTION
This enhancement leverages Java 16's pattern matching for instanceof to streamline and improve the readability of type checking and casting within the annotation processing method. By replacing explicit casting after instanceof checks with pattern variables, the code becomes more concise, readable, and less prone to errors.

**Key Changes:**

- Utilize pattern matching for instanceof to eliminate the need for manual casting of array types (e.g., byte[], boolean[], short[], char[], int[], long[], float[], double[]).
- Enhance code maintainability and readability by reducing boilerplate and leveraging Java's type inference within control flow blocks.
-  Ensure backward compatibility by maintaining the logic and functionality of the annotation processing while adopting modern language features for better code quality.

This update not only adopts the latest Java language features for better development practices but also sets a precedent for future code enhancements and refactoring efforts, promoting a more modern and efficient coding style within the project.
