### PR TITLE
Auto-configure a bootstrapExecutor bean to be used by Framework's background bean initialization

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/BootstrapExecutor.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/BootstrapExecutor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface BootstrapExecutor {
+	String threadNamePrefix() default "bootstrap-";
+	int corePoolSize() default 1;
+	// Set more properties here ...
+}

--- a/spring-context/src/main/java/org/springframework/context/config/BootstrapExecutorBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/context/config/BootstrapExecutorBeanDefinitionParser.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.context.config;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.BeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+public class BootstrapExecutorBeanDefinitionParser implements BeanDefinitionParser {
+
+	@Override
+	public BeanDefinition parse(Element element, ParserContext parserContext) {
+//		It's not getting executed, I'm looking into the problem
+//		This class's task is done by the processConfigBeanDefinitions method
+//		in ConfigurationClassPostProcessor right now, but I plan to move the logic back to this
+//		class once the problem is solved.
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(ThreadPoolTaskExecutor.class);
+
+		builder.addPropertyValue("threadNamePrefix", element.getAttribute("thread-name-prefix"));
+		builder.addPropertyValue("corePoolSize", element.getAttribute("core-pool-size"));
+		// Set more properties here ...
+		builder.addPropertyValue("daemon", true);
+
+		// Register bean
+		String beanName = "bootstrapExecutor";
+		parserContext.getRegistry().registerBeanDefinition(beanName, builder.getBeanDefinition());
+		return null;
+	}
+
+}

--- a/spring-context/src/main/java/org/springframework/context/config/ContextNamespaceHandler.java
+++ b/spring-context/src/main/java/org/springframework/context/config/ContextNamespaceHandler.java
@@ -40,6 +40,7 @@ public class ContextNamespaceHandler extends NamespaceHandlerSupport {
 		registerBeanDefinitionParser("spring-configured", new SpringConfiguredBeanDefinitionParser());
 		registerBeanDefinitionParser("mbean-export", new MBeanExportBeanDefinitionParser());
 		registerBeanDefinitionParser("mbean-server", new MBeanServerBeanDefinitionParser());
+		registerBeanDefinitionParser("bootstrap-executor", new BootstrapExecutorBeanDefinitionParser());
 	}
 
 }


### PR DESCRIPTION
Summary:
This pull request introduces the ability to auto-configure a `bootstrapExecutor` bean for background bean initialization in the Spring Framework. It provides an `@BootstrapExecutor` annotation to configure the properties of the `ThreadPoolTaskExecutor` used for background initialization.

Related Issues:
https://github.com/spring-projects/spring-boot/issues/39791
https://github.com/spring-projects/spring-framework/issues/13410#issuecomment-1967596598

Changes:
- Added `@BootstrapExecutor` annotation in `org.springframework.context.annotation` package to configure the bootstrap executor.
- Modified `ConfigurationClassPostProcessor` to detect the presence of `@BootstrapExecutor` annotation on configuration classes and register a `ThreadPoolTaskExecutor` bean with the configured properties.
- Added `BootstrapExecutorBeanDefinitionParser` to parse the `<context:bootstrap-executor>` XML element and register the `ThreadPoolTaskExecutor` bean. (Note: This is currently not functional and the logic is temporarily handled in `ConfigurationClassPostProcessor`.)
- Updated `ContextNamespaceHandler` to register the `BootstrapExecutorBeanDefinitionParser`.
- Added test cases in `ConfigurationClassPostProcessorTests` to verify the parallel bean initialization using the `@BootstrapExecutor` annotation.

Usage:
To use the `bootstrapExecutor` for background bean initialization:
1. Add the `@BootstrapExecutor` annotation to one of your `@Configuration` classes.
2. Configure the desired properties of the `ThreadPoolTaskExecutor` using the annotation attributes.
3. Use `@Bean(bootstrap = BACKGROUND)` on the beans that should be initialized in the background.

Example:
```java
@BootstrapExecutor(threadNamePrefix = "bootstrap-", corePoolSize = 2)
@Configuration
public class AppConfig {
    @Bean(bootstrap = BACKGROUND)
    public SlowInitBean slowBean() {
        return new SlowInitBean();
    }
}
```

Known Issues:
- The `BootstrapExecutorBeanDefinitionParser` is currently not functional due to a parsing issue. The logic is temporarily handled in the `processConfigBeanDefinitions` method of `ConfigurationClassPostProcessor`.

Next Steps:
- Investigate and resolve the issue with `BootstrapExecutorBeanDefinitionParser` to properly parse the `<context:bootstrap-executor>` XML element.
- Consider automatically configuring a `bootstrapExecutor` based on the number of `@Bean(bootstrap=BACKGROUND)` annotations if `@BootstrapExecutor` is not found.