### PR TITLE
Fix typos and improve wording in reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/jackson.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/jackson.adoc
@@ -81,7 +81,7 @@ Kotlin::
 ----
 ======
 
-NOTE: `@JsonView` allows an array of view classes but you can only specify only one per
+NOTE: `@JsonView` allows an array of view classes but you can specify only one per
 controller method. Use a composite interface if you need to activate multiple views.
 
 

--- a/framework-docs/modules/ROOT/pages/web/webmvc-view/mvc-jackson.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc-view/mvc-jackson.adoc
@@ -36,7 +36,7 @@ to render the response content as XML. If the model contains multiple entries, y
 explicitly set the object to be serialized by using the `modelKey` bean property. If the
 model contains a single entry, it is serialized automatically.
 
-You can customized XML mapping as needed by using JAXB or Jackson's provided
+You can customize XML mapping as needed by using JAXB or Jackson's provided
 annotations. When you need further control, you can inject a custom `XmlMapper`
 through the `ObjectMapper` property, for cases where custom XML
 you need to provide serializers and deserializers for specific types.

--- a/framework-docs/modules/ROOT/pages/web/webmvc-view/mvc-jsp.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc-view/mvc-jsp.adoc
@@ -683,7 +683,7 @@ the HTML would be as follows:
 ----
 
 What if we want to display the entire list of errors for a given page? The next example
-shows that the `errors` tag also supports some basic wildcarding functionality.
+shows that the `errors` tag also supports some basic wildcard functionality.
 
 * `path="{asterisk}"`: Displays all errors.
 * `path="lastName"`: Displays all errors associated with the `lastName` field.

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-async.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-async.adoc
@@ -507,8 +507,8 @@ The MVC configuration exposes the following options for asynchronous request pro
 
 You can configure the following:
 
-* Default timeout value for async requests, which if not set, depends
-on the underlying Servlet container.
+* The default timeout value for async requests depends
+on the underlying Servlet container, unless it is set explicitly.
 * `AsyncTaskExecutor` to use for blocking writes when streaming with
 xref:web/webmvc/mvc-ann-async.adoc#mvc-ann-async-reactive-types[Reactive Types] and for
 executing `Callable` instances returned from controller methods.

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-rest-exceptions.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-rest-exceptions.adoc
@@ -142,7 +142,7 @@ Message codes and arguments for each error are also resolved via `MessageSource`
 | `MethodArgumentNotValidException`
 | (default)
 | `+{0}+` the list of global errors, `+{1}+` the list of field errors.
-  Message codes and arguments for each error are also resolvedvia `MessageSource`.
+  Message codes and arguments for each error are also resolved via `MessageSource`.
 
 | `MissingRequestHeaderException`
 | (default)

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-config/enable.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-config/enable.adoc
@@ -7,7 +7,7 @@ You can use the `@EnableWebMvc` annotation to enable MVC configuration with prog
 
 include-code::./WebConfiguration[tag=snippet,indent=0]
 
-NOTE: When using Spring Boot, you may want to use `@Configuration` class of type `WebMvcConfigurer` but without `@EnableWebMvc` to keep Spring Boot MVC customizations. See more details in the xref:web/webmvc/mvc-config/customize.adoc[the MVC Config API section] and in {spring-boot-docs}/web.html#web.servlet.spring-mvc.auto-configuration[the dedicated Spring Boot documentation].
+NOTE: When using Spring Boot, you may want to use `@Configuration` class of type `WebMvcConfigurer` but without `@EnableWebMvc` to keep Spring Boot MVC customizations. See more details in xref:web/webmvc/mvc-config/customize.adoc[the MVC Config API section] and in {spring-boot-docs}/web.html#web.servlet.spring-mvc.auto-configuration[the dedicated Spring Boot documentation].
 
 The preceding example registers a number of Spring MVC
 xref:web/webmvc/mvc-servlet/special-bean-types.adoc[infrastructure beans] and adapts to dependencies

--- a/framework-docs/modules/ROOT/pages/web/websocket/stomp/application-context-events.adoc
+++ b/framework-docs/modules/ROOT/pages/web/websocket/stomp/application-context-events.adoc
@@ -8,7 +8,7 @@ received by implementing Spring's `ApplicationListener` interface:
 While the "`simple`" broker becomes available immediately on startup and remains so while
 the application is running, the STOMP "`broker relay`" can lose its connection
 to the full featured broker (for example, if the broker is restarted). The broker relay
-has reconnect logic and re-establishes the "`system`" connection to the broker
+has reconnected logic and re-establishes the "`system`" connection to the broker
 when it comes back. As a result, this event is published whenever the state changes from connected
 to disconnected and vice-versa. Components that use the `SimpMessagingTemplate` should
 subscribe to this event and avoid sending messages at times when the broker is not


### PR DESCRIPTION
Hi team!
Open this PR for fix typo in framework-docs/modules/ROOT/pages/web. Feel free to contact me if there is anything wrong. 😸Thanks!