### PR TITLE
Handle DataBufferLimitException as HTTP 413 responses

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/ServerWebInputTooLargeException.java
+++ b/spring-web/src/main/java/org/springframework/web/server/ServerWebInputTooLargeException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.server;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+
+/**
+ * Exception for errors that fit response status 413 (payload too large) for use in
+ * Spring Web applications.
+ *
+ * @author Kim Bosung
+ * @since 6.2
+ */
+@SuppressWarnings("serial")
+public class ServerWebInputTooLargeException extends ResponseStatusException {
+
+	public ServerWebInputTooLargeException(@Nullable Throwable cause) {
+		super(HttpStatus.PAYLOAD_TOO_LARGE, null, cause);
+	}
+
+}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/MessageReaderArgumentResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/MessageReaderArgumentResolverTests.java
@@ -54,6 +54,7 @@ import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.reactive.BindingContext;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.ServerWebInputException;
+import org.springframework.web.server.ServerWebInputTooLargeException;
 import org.springframework.web.server.UnsupportedMediaTypeStatusException;
 import org.springframework.web.testfixture.http.server.reactive.MockServerHttpRequest;
 import org.springframework.web.testfixture.method.ResolvableMethod;
@@ -110,6 +111,24 @@ class MessageReaderArgumentResolverTests {
 				param, true, this.bindingContext, exchange).block();
 
 		StepVerifier.create(result).expectError(ServerWebInputException.class).verify();
+	}
+
+	@Test @SuppressWarnings("unchecked")
+	public void tooLargeBody() {
+		StringBuilder bodyBuilder = new StringBuilder();
+		while (bodyBuilder.toString().getBytes().length < 256 * 1024) {
+			bodyBuilder.append("The default maximum input length is 256kb.");
+		}
+		String body = "{\"bar\":\"BARBAR\",\"foo\":\"" + bodyBuilder + "\"}";
+
+		MockServerHttpRequest request = post("/path").contentType(MediaType.APPLICATION_JSON).body(body);
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		ResolvableType type = forClassWithGenerics(Mono.class, TestBean.class);
+		MethodParameter param = this.testMethod.arg(type);
+		Mono<TestBean> result = (Mono<TestBean>) this.resolver.readBody(
+				param, true, this.bindingContext, exchange).block();
+
+		StepVerifier.create(result).expectError(ServerWebInputTooLargeException.class).verify();
 	}
 
 	@Test


### PR DESCRIPTION
origin issue: https://github.com/spring-projects/spring-framework/issues/32113

hello. In WebFlux, when a DataBufferLimitException occurs because the payload is larger than the setting value (spring.codec.max-in-memory-size), a 413 Too Large Body status code should be returned, but a 500 status code was returned, so that part has been corrected.

1. A ServerWebInputTooLargeException exception was declared, which inherits ResponseStatusException.
2. When determining whether there is an error in the request value in AbstractMessageReaderArgumentResolver, if a DataBufferLimitException occurs, it is converted to ServerWebInputTooLargeException.
3. Added tooLargeBody test code.