### PR TITLE
Refactor closeConnection Method to Use Try-With-Resources

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/connection/SingleConnectionFactory.java
+++ b/spring-jms/src/main/java/org/springframework/jms/connection/SingleConnectionFactory.java
@@ -575,13 +575,10 @@ public class SingleConnectionFactory implements ConnectionFactory, QueueConnecti
 			logger.debug("Closing shared JMS Connection: " + con);
 		}
 		try {
-			try {
+			try (con) {
 				if (this.startedCount > 0) {
 					con.stop();
 				}
-			}
-			finally {
-				con.close();
 			}
 		}
 		catch (jakarta.jms.IllegalStateException ex) {


### PR DESCRIPTION
**Overview:**
This MR introduces a refinement in the closeConnection method within the `org.springframework.jms.connection` package. The primary goal is to leverage the try-with-resources statement for more concise and reliable resource management.

**Changes Made:**
- Modified the closeConnection method to use the try-with-resources statement for managing the Connection instance. This adjustment ensures that the Connection resource is automatically closed after its use, thereby improving the reliability and readability of the resource management process.
- Removed the explicit finally block that previously handled the con.close() invocation. The try-with-resources construct implicitly covers this operation, eliminating the need for manual closure and error handling related to the resource's termination.