### PR TITLE
Ensure removal of `Content-Type` header if body `Publisher` is empty

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/EncoderHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/EncoderHttpMessageWriter.java
@@ -16,20 +16,15 @@
 
 package org.springframework.http.codec;
 
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.logging.Log;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.AbstractEncoder;
 import org.springframework.core.codec.Encoder;
 import org.springframework.core.codec.Hints;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpLogging;
 import org.springframework.http.MediaType;
 import org.springframework.http.ReactiveHttpOutputMessage;
@@ -38,6 +33,11 @@ import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * {@code HttpMessageWriter} that wraps and delegates to an {@link Encoder}.
@@ -127,6 +127,7 @@ public class EncoderHttpMessageWriter<T> implements HttpMessageWriter<T> {
 			return body
 					.singleOrEmpty()
 					.switchIfEmpty(Mono.defer(() -> {
+						message.getHeaders().remove(HttpHeaders.CONTENT_TYPE);
 						message.getHeaders().setContentLength(0);
 						return message.setComplete().then(Mono.empty());
 					}))

--- a/spring-web/src/test/java/org/springframework/http/codec/EncoderHttpMessageWriterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/EncoderHttpMessageWriterTests.java
@@ -16,6 +16,29 @@
 
 package org.springframework.http.codec;
 
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.CharSequenceEncoder;
+import org.springframework.core.codec.Encoder;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpOutputMessage;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.testfixture.http.client.reactive.MockClientHttpRequest;
+import org.springframework.web.testfixture.http.server.reactive.MockServerHttpResponse;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -23,24 +46,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
-import org.springframework.core.codec.CharSequenceEncoder;
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DefaultDataBufferFactory;
-import org.springframework.http.MediaType;
-import org.springframework.util.MimeType;
-import org.springframework.util.MimeTypeUtils;
-import org.springframework.util.ReflectionUtils;
-import org.springframework.web.testfixture.http.server.reactive.MockServerHttpResponse;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -197,6 +202,35 @@ class EncoderHttpMessageWriterTests {
 		assertThat((Boolean) method.invoke(writer, streamingMediaType)).isTrue();
 		assertThat((Boolean) method.invoke(writer, new MediaType(TEXT_PLAIN, Collections.singletonMap("streaming", "false")))).isFalse();
 		assertThat((Boolean) method.invoke(writer, TEXT_HTML)).isFalse();
+	}
+
+	@Test
+	public void ifBodyPublisherEmpty_noContentTypeHeader() {
+		Encoder<CharSequence> encoder = CharSequenceEncoder.textPlainOnly();
+		EncoderHttpMessageWriter<CharSequence> writer = new EncoderHttpMessageWriter<>(encoder);
+		ReactiveHttpOutputMessage outputMessage = new MockClientHttpRequest(HttpMethod.POST, "/");
+		Mono<Void> writerMono = writer.write(Mono.empty(), ResolvableType.forClass(String.class),
+				null, outputMessage, NO_HINTS);
+
+		StepVerifier.create(writerMono)
+				.verifyComplete();
+		assertThat(outputMessage.getHeaders()).doesNotContainKey(HttpHeaders.CONTENT_TYPE);
+	}
+
+	@Test
+	public void ifBodyPublisherEmpty_contentLengthZero() {
+		Encoder<CharSequence> encoder = CharSequenceEncoder.textPlainOnly();
+		EncoderHttpMessageWriter<CharSequence> writer = new EncoderHttpMessageWriter<>(encoder);
+		ReactiveHttpOutputMessage outputMessage = new MockClientHttpRequest(HttpMethod.POST, "/");
+		Mono<Void> writerMono = writer.write(Mono.empty(), ResolvableType.forClass(String.class),
+				null, outputMessage, NO_HINTS);
+
+		StepVerifier.create(writerMono)
+				.verifyComplete();
+		List<String> contentLengthValues = outputMessage.getHeaders().get(HttpHeaders.CONTENT_LENGTH);
+		assertThat(contentLengthValues).hasSize(1);
+		int contentLength = Integer.parseInt(contentLengthValues.get(0));
+		assertThat(contentLength).isEqualTo(0);
 	}
 
 	private void configureEncoder(MimeType... mimeTypes) {


### PR DESCRIPTION
I added a removal of `Content-Type` header in `org.springframework.http.codec.EncoderHttpMessageWriter` if the body `Publisher` is empty

Added a couple of tests to assert on the writer's correct behavior when dealing with empty body `Publishers`

The GH-32620 issue is a blocker for a [Spring Cloud Gateway issue](https://github.com/spring-cloud/spring-cloud-gateway/issues/3242) I've been researching