### PR TITLE
Modify error message when timeout is less than TIMEOUT_DEFAULT

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/support/DefaultTransactionDefinition.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/DefaultTransactionDefinition.java
@@ -227,7 +227,7 @@ public class DefaultTransactionDefinition implements TransactionDefinition, Seri
 	 */
 	public final void setTimeout(int timeout) {
 		if (timeout < TIMEOUT_DEFAULT) {
-			throw new IllegalArgumentException("Timeout must be a positive integer or TIMEOUT_DEFAULT");
+			throw new IllegalArgumentException("Timeout must be a non-negative integer or TIMEOUT_DEFAULT");
 		}
 		this.timeout = timeout;
 	}


### PR DESCRIPTION
When `timeout` is zero(0), this method `setTimeout` runs normally, it will not throw the `IlleglArgumentException`. In other words, zero is valid timeout for this method. The valid arguments:
- TIMEOUT_DEFAULT(-1)
- Zero(0)
- Positive integer(>=1)

So, I think `non-negative` is better in this method.

(Actually when timeout is zero, it will throw `TransactionTimedOutException` on transaction starting)