### PR TITLE
Omit empty resource description in `DeprecatedBeanWarner`'s log message

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/DeprecatedBeanWarner.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/DeprecatedBeanWarner.java
@@ -85,7 +85,7 @@ public class DeprecatedBeanWarner implements BeanFactoryPostProcessor {
 		builder.append(beanName);
 		builder.append('\'');
 		String resourceDescription = beanDefinition.getResourceDescription();
-		if (StringUtils.hasLength(resourceDescription)) {
+		if (StringUtils.hasText(resourceDescription)) {
 			builder.append(" in ");
 			builder.append(resourceDescription);
 		}


### PR DESCRIPTION
In this context, the hasText() method seems more appropriate. This is because considering cases where the resourceDescription string contains only whitespace ensures clearer logging, as it accounts for scenarios where the string is not empty but consists solely of whitespace characters.