### PR TITLE
Refactor ContentDisposition class

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -347,6 +347,7 @@ public final class ContentDisposition {
 	 * @see #toString()
 	 */
 	public static ContentDisposition parse(String contentDisposition) {
+		Assert.notNull(contentDisposition, "'contentDisposition' must not be null");
 		List<String> parts = tokenize(contentDisposition);
 		String type = parts.get(0);
 		String name = null;

--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -45,6 +45,7 @@ import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
  * @author Juergen Hoeller
  * @author Rossen Stoyanchev
  * @author Sergey Tsypanov
+ * @author Onji Kim
  * @since 5.0
  * @see <a href="https://tools.ietf.org/html/rfc6266">RFC 6266</a>
  */
@@ -123,7 +124,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isAttachment() {
-		return (this.type != null && this.type.equalsIgnoreCase("attachment"));
+		return (this.type != null && this.type.equalsIgnoreCase(Type.ATTACHMENT));
 	}
 
 	/**
@@ -131,7 +132,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isFormData() {
-		return (this.type != null && this.type.equalsIgnoreCase("form-data"));
+		return (this.type != null && this.type.equalsIgnoreCase(Type.FORM_DATA));
 	}
 
 	/**
@@ -139,7 +140,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isInline() {
-		return (this.type != null && this.type.equalsIgnoreCase("inline"));
+		return (this.type != null && this.type.equalsIgnoreCase(Type.INLINE));
 	}
 
 	/**
@@ -300,11 +301,11 @@ public final class ContentDisposition {
 
 
 	/**
-	 * Return a builder for a {@code ContentDisposition} of type {@literal "attachment"}.
+	 * Return a builder for a {@code ContentDisposition} of type {@literal Type.ATTACHMENT}.
 	 * @since 5.3
 	 */
 	public static Builder attachment() {
-		return builder("attachment");
+		return builder(Type.ATTACHMENT);
 	}
 
 	/**
@@ -312,7 +313,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public static Builder formData() {
-		return builder("form-data");
+		return builder(Type.FORM_DATA);
 	}
 
 	/**
@@ -320,7 +321,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public static Builder inline() {
-		return builder("inline");
+		return builder(Type.INLINE);
 	}
 
 	/**
@@ -328,6 +329,12 @@ public final class ContentDisposition {
 	 * @param type the disposition type like for example {@literal inline},
 	 * {@literal attachment}, or {@literal form-data}
 	 * @return the builder
+	 * @see ContentDisposition.Type#ATTACHMENT
+	 * @see ContentDisposition.Type#INLINE
+	 * @see ContentDisposition.Type#FORM_DATA
+	 * @see #attachment()
+	 * @see #formData()
+	 * @see #inline()
 	 */
 	public static Builder builder(String type) {
 		return new BuilderImpl(type);
@@ -846,6 +853,30 @@ public final class ContentDisposition {
 			return new ContentDisposition(this.type, this.name, this.filename, this.charset,
 					this.size, this.creationDate, this.modificationDate, this.readDate);
 		}
+	}
+
+	/**
+	 * Common Content-Disposition's Disposition-Type values.
+	 */
+	public interface Type {
+		/**
+		 * The {@literal "attachment"} type.<br>
+		 * Indicates that the content should be offered as a download.<br>
+		 * Most browsers will present a "Save As" dialog to the user.
+		 */
+		String ATTACHMENT = "attachment";
+		/**
+		 * The {@literal "inline"} type.<br>
+		 * Indicates that the content should be displayed automatically.<br>
+		 * Most browsers will display the content inline.
+		 */
+		String INLINE = "inline";
+		/**
+		 * The {@literal "form-data"} type.<br>
+		 * When Content-Disposition is used to provide information for each subpart of {@literal multipart/form-data} request body,
+		 * the type of {@literal Content-Disposition} header should always be {@literal "form-data"}.
+		 */
+		String FORM_DATA = "form-data";
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,8 @@ public final class ContentDisposition {
 
 	private static final BitSet PRINTABLE = new BitSet(256);
 
+	private static final ContentDisposition EMPTY =
+			new ContentDisposition(null, null, null, null, null, null, null, null); // toString() returns ""
 
 	static {
 		// RFC 2045, Section 6.7, and RFC 2047, Section 4.2
@@ -149,6 +151,10 @@ public final class ContentDisposition {
 	@Nullable
 	public String getType() {
 		return this.type;
+	}
+
+	public boolean isEmpty(){
+		return this.equals(EMPTY);
 	}
 
 	/**
@@ -331,7 +337,7 @@ public final class ContentDisposition {
 	 * Return an empty content disposition.
 	 */
 	public static ContentDisposition empty() {
-		return new ContentDisposition("", null, null, null, null, null, null, null);
+		return EMPTY;
 	}
 
 	/**

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -347,4 +347,23 @@ class ContentDispositionTests {
 				.isEqualTo(filename);
 	}
 
+	@Test
+	void emptyToStringReturnsBlankString(){
+		ContentDisposition emptyContentDisposition = ContentDisposition.empty();
+		assertThat(emptyContentDisposition.toString()).isEqualTo("");
+	}
+
+	@Test
+	void isEmptyReturnTrueWithEmptyContentDisposition(){
+		ContentDisposition emptyContentDisposition = ContentDisposition.empty();
+		assertThat(emptyContentDisposition.isEmpty()).isTrue();
+	}
+
+	@Test
+	void isEmptyReturnFalseWithNonEmptyContentDisposition(){
+		ContentDisposition nonEmptyContentDisposition = ContentDisposition.builder("form-data")
+				.name("foo")
+				.filename("foo.txt").build();
+		assertThat(nonEmptyContentDisposition.isEmpty()).isFalse();
+	}
 }


### PR DESCRIPTION
### 1st Commit (8293b4b1b4313f81d20c646525b6f7661c31950d)
- In the old code, the code returns the same object every time, but it was always creating the object.
- In the new code, I improved this by making the constant return.
- Update License Date Range(https://github.com/spring-projects/spring-framework/wiki/Code-Style#license)
- Add Test code for empty
- Add `boolean isEmpty()` for check is empty Content Disposition(In the old code, you should have checked everything or called a heavy toString() method.)

### 2nd Commit (876e41cbc073917360fd90c8ff1b8d2b6a07d79d)
- I added null check on static parse method, like the rest of the static methods.
- The old code had the possibility of NPE occurring.

### 3rd Commit (7c9d1154784a9b6bcae05421eebe986b28170dd8)
- In the old code, the type is used as a simple string, so there was a possibility of human error.
```java
// like
ContentDisposition.builder("iline")
```
- So I added a String-based constant value, and a simple annotation so that beginners don't panic.
- And I also Add `@see` java doc tag on static builder method
```java
// you can use like this
ContentDisposition.builder(Type.FORM_DATA)
```
---
Overall, there is no change in the code interface, but I improve the way it works internally. Everything works the same way as before.

Thank you !!