### PR TITLE
Make BodyBuilder.bodyValueAndAwait() a reified type of function

### DIFF
--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/CoRouterFunctionDslTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/CoRouterFunctionDslTests.kt
@@ -334,7 +334,7 @@ class CoRouterFunctionDslTests {
 			}
 		}
 		GET(pathExtension { it == "properties" }) {
-			ok().bodyValueAndAwait("foo=bar")
+			ok().bodyValueAndAwait<String>("foo=bar")
 		}
 		path("/baz", ::handle)
 		GET("/rendering") { RenderingResponse.create("index").buildAndAwait() }

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/ServerResponseExtensionsTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/ServerResponseExtensionsTests.kt
@@ -63,15 +63,23 @@ class ServerResponseExtensionsTests {
 	}
 
 	@Test
-	fun `BodyBuilder#bodyAndAwait with object parameter`() {
+	fun `BodyBuilder#bodyValueAndAwait with reified type parameter`() {
 		val response = mockk<ServerResponse>()
 		val body = "foo"
-		every { bodyBuilder.bodyValue(ofType<String>()) } returns Mono.just(response)
+		every {
+			bodyBuilder.body(
+				ofType<Mono<String>>(),
+				object : ParameterizedTypeReference<String>() {}
+			)
+		} returns Mono.just(response)
 		runBlocking {
-			bodyBuilder.bodyValueAndAwait(body)
+			bodyBuilder.bodyValueAndAwait<String>(body)
 		}
 		verify {
-			bodyBuilder.bodyValue(ofType<String>())
+			bodyBuilder.body(
+				ofType<Mono<String>>(),
+				object : ParameterizedTypeReference<String>() {}
+			)
 		}
 	}
 


### PR DESCRIPTION
## Summary

`ServerResponse.BodyBuilder.bodyValueAndAwait` API is broken when it is used with an application it
uses for serialization the `kotlinx.serialization` library and the provided body uses generics.
The library is unable to serialize the body since it is a type of `Any` and spring falls back
to default one. This could lead to unexpected responses.

For example:

```kotlin
@Serializable
data class SomeBody(@SerialName("user_id") val userId: Int, val name: String)

suspend fun returnBody(request: ServerRequest): ServerResponse {
    return ServerResponse
        .ok()
        // Note: `fun ServerResponse.BodyBuilder.bodyValueAndAwait(body: Any)`
        // is not a reified function and is subject to type erasure.
        // In cases where response is a collection, the object is serialized as `Collection<Any>`,
        // and the response does not have the proper format, which is not expected.
        // Actual response: [{"userId":1,"name":"name"}]
        // Expected response : [{"user_id":1,"name":"name"}]
        .bodyValueAndAwait(listOf(SomeBody(1, "name")))
}
```

A minimum reproducible example can be found [here](https://github.com/GeorgePap-719/interview-template/blob/reproduce-spring-issue/src/main/kotlin/ServerResponseRouter.kt).

## Proposal

Make BodyBuilder.bodyValueAndAwait() a reified type of function. We can also migrate the API without
breaking existing functionality.

## Alternatives

Only document the behavior and accept it as the intended behavior.