### PR TITLE
Adds support for qualifying columns with table.

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/rowset/ResultSetWrappingSqlRowSet.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/rowset/ResultSetWrappingSqlRowSet.java
@@ -99,13 +99,22 @@ public class ResultSetWrappingSqlRowSet implements SqlRowSet {
 			ResultSetMetaData rsmd = resultSet.getMetaData();
 			if (rsmd != null) {
 				int columnCount = rsmd.getColumnCount();
-				this.columnLabelMap = CollectionUtils.newHashMap(columnCount);
+				this.columnLabelMap = CollectionUtils.newHashMap(columnCount * 2);
 				for (int i = 1; i <= columnCount; i++) {
 					String key = rsmd.getColumnLabel(i);
 					// Make sure to preserve first matching column for any given name,
 					// as defined in ResultSet's type-level javadoc (lines 81 to 83).
 					if (!this.columnLabelMap.containsKey(key)) {
 						this.columnLabelMap.put(key, i);
+					}
+					// Also support column names prefixed with table name
+					// as in {table_name}.{column.name}.
+					String table = rsmd.getTableName(i);
+					if (table != null && !table.isEmpty()) {
+						key = table + "." + rsmd.getColumnName(i);
+						if (!this.columnLabelMap.containsKey(key)) {
+							this.columnLabelMap.put(key, i);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Adds support common in other ResultSet implemenatations for qualifying column names with table name to distinguish potentially duplicate column names in a join of two or more tables from one another. The expected format is {table_name}.{column_namne}, where column_name is the actuall designated column name and not the column label.