### PR TITLE
Synchronize access to volatile variables in AsyncRequestInterceptor

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/hibernate5/support/AsyncRequestInterceptor.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate5/support/AsyncRequestInterceptor.java
@@ -67,8 +67,10 @@ class AsyncRequestInterceptor implements CallableProcessingInterceptor, Deferred
 	}
 
 	public void bindSession() {
-		this.timeoutInProgress = false;
-		this.errorInProgress = false;
+		synchronized (this) {
+			this.timeoutInProgress = false;
+			this.errorInProgress = false;
+		}
 		TransactionSynchronizationManager.bindResource(this.sessionFactory, this.sessionHolder);
 	}
 
@@ -79,13 +81,17 @@ class AsyncRequestInterceptor implements CallableProcessingInterceptor, Deferred
 
 	@Override
 	public <T> Object handleTimeout(NativeWebRequest request, Callable<T> task) {
-		this.timeoutInProgress = true;
+		synchronized (this) {
+			this.timeoutInProgress = true;
+		}
 		return RESULT_NONE;  // give other interceptors a chance to handle the timeout
 	}
 
 	@Override
 	public <T> Object handleError(NativeWebRequest request, Callable<T> task, Throwable t) {
-		this.errorInProgress = true;
+		synchronized (this) {
+			this.errorInProgress = true;
+		}
 		return RESULT_NONE;  // give other interceptors a chance to handle the error
 	}
 
@@ -106,13 +112,17 @@ class AsyncRequestInterceptor implements CallableProcessingInterceptor, Deferred
 
 	@Override
 	public <T> boolean handleTimeout(NativeWebRequest request, DeferredResult<T> deferredResult) {
-		this.timeoutInProgress = true;
+		synchronized (this) {
+			this.timeoutInProgress = true;
+		}
 		return true;  // give other interceptors a chance to handle the timeout
 	}
 
 	@Override
 	public <T> boolean handleError(NativeWebRequest request, DeferredResult<T> deferredResult, Throwable t) {
-		this.errorInProgress = true;
+		synchronized (this) {
+			this.errorInProgress = true;
+		}
 		return true;  // give other interceptors a chance to handle the error
 	}
 


### PR DESCRIPTION
This PR introduces synchronized blocks to synchronize access to volatile variables in the AsyncRequestInterceptor class. Previously, modifications to the volatile variables timeoutInProgress and errorInProgress were not synchronized, potentially leading to race conditions and inconsistent behavior in a multi-threaded environment.

By enclosing access to these variables within synchronized blocks, this PR ensures proper synchronization and consistency. This enhancement improves the reliability and stability of the AsyncRequestInterceptor class, particularly benefiting scenarios involving asynchronous web requests.