### PR TITLE
HttpHeaders should reject negative ContentLength values

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -969,8 +969,14 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	/**
 	 * Set the length of the body in bytes, as specified by the
 	 * {@code Content-Length} header.
+	 * @param contentLength content length (greater than or equal to zero)
+	 * @throws IllegalArgumentException if the content length is negative
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc2616#section-14.13">RFC 2616, section 14.13</a>
 	 */
 	public void setContentLength(long contentLength) {
+		if (contentLength < 0){
+			throw new IllegalArgumentException("Content-Length must be a non-negative number");
+		}
 		set(CONTENT_LENGTH, Long.toString(contentLength));
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
@@ -155,6 +155,18 @@ class HttpHeadersTests {
 	}
 
 	@Test
+	void setContentLengthWithNegativeValue() {
+		assertThatIllegalArgumentException().isThrownBy(() ->
+				headers.setContentLength(-1));
+	}
+
+	@Test
+	void getContentLengthReturnsMinusOneForAbsentHeader() {
+		headers.remove(HttpHeaders.CONTENT_LENGTH);
+		assertThat(headers.getContentLength()).isEqualTo(-1);
+	}
+
+	@Test
 	void contentType() {
 		MediaType contentType = new MediaType("text", "html", StandardCharsets.UTF_8);
 		headers.setContentType(contentType);


### PR DESCRIPTION
Hello ! 👋

Found a code with a possible bug. [here](https://github.com/spring-projects/spring-framework/blob/f21e05a9e42475bce0f99951fd2d5fbcbcf21b84/spring-web/src/main/java/org/springframework/http/HttpHeaders.java#L973)
```java
	/**
	 * Set the length of the body in bytes, as specified by the
	 * {@code Content-Length} header.
	 */
	public void setContentLength(long contentLength) {
		set(CONTENT_LENGTH, Long.toString(contentLength));
	}

	/**
	 * Return the length of the body in bytes, as specified by the
	 * {@code Content-Length} header.
	 * <p>Returns -1 when the content-length is unknown.
	 */
	public long getContentLength() {
		String value = getFirst(CONTENT_LENGTH);
		return (value != null ? Long.parseLong(value) : -1);
	}
```
---
1. Negative values should not be present in this header.
> "Any Content-Length greater than or equal to zero is a valid value."
https://www.rfc-editor.org/rfc/rfc2616#section-14.13
2. If the user accidentally puts in -1, a misunderstanding may occur as if there is no header by the getContentHeader().

example -> see [this code](https://github.com/spring-projects/spring-framework/blob/f21e05a9e42475bce0f99951fd2d5fbcbcf21b84/spring-web/src/main/java/org/springframework/http/client/AbstractBufferingClientHttpRequest.java#L45).
```java
	@Override
	protected ClientHttpResponse executeInternal(HttpHeaders headers) throws IOException {
		byte[] bytes = this.bufferedOutput.toByteArrayUnsafe();
		if (headers.getContentLength() < 0) {
			headers.setContentLength(bytes.length);
		}
		ClientHttpResponse result = executeInternal(headers, bytes);
		this.bufferedOutput.reset();
		return result;
	}
```
This code is checking for headers through a value of -1.

---

Let me know, If there's anything you need to change