### PR TITLE
Add implementation of the isCandidateClass method to do full introspection

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationUtilsTests.java
@@ -61,6 +61,7 @@ import static org.springframework.core.annotation.AnnotationUtils.getValue;
 import static org.springframework.core.annotation.AnnotationUtils.isAnnotationDeclaredLocally;
 import static org.springframework.core.annotation.AnnotationUtils.isAnnotationInherited;
 import static org.springframework.core.annotation.AnnotationUtils.isAnnotationMetaPresent;
+import static org.springframework.core.annotation.AnnotationUtils.isCandidateClass;
 import static org.springframework.core.annotation.AnnotationUtils.synthesizeAnnotation;
 
 /**
@@ -81,6 +82,57 @@ class AnnotationUtilsTests {
 		AnnotationUtils.clearCache();
 	}
 
+	@Test
+	void isCandidateClassAnnotationsOnClass() {
+		assertThat(isCandidateClass(SubSubClassWithInheritedMetaAnnotation.class, Meta1.class)).isTrue();
+		assertThat(isCandidateClass(SubSubClassWithInheritedMetaAnnotation.class, Meta2.class)).isTrue();
+		assertThat(isCandidateClass(SubSubClassWithInheritedMetaAnnotation.class, Component.class)).isTrue();
+		assertThat(isCandidateClass(SubSubClassWithInheritedMetaAnnotation.class, MetaMeta.class)).isFalse();
+
+		assertThat(isCandidateClass(ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class, Meta1.class)).isTrue();
+		assertThat(isCandidateClass(ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class, Meta2.class)).isTrue();
+		assertThat(isCandidateClass(ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class, Component.class)).isTrue();
+		assertThat(isCandidateClass(ClassWithLocalMetaAnnotationAndMetaAnnotatedInterface.class, MetaMeta.class)).isFalse();
+	}
+
+	@Test
+	void isCandidateClassAnnotationsOnMethods() {
+		assertThat(isCandidateClass(Root.class, Meta1.class)).isTrue();
+		assertThat(isCandidateClass(Root.class, Order.class)).isTrue();
+		assertThat(isCandidateClass(Root.class, Component.class)).isTrue();
+		assertThat(isCandidateClass(Root.class, Meta2.class)).isFalse();
+
+		assertThat(isCandidateClass(Leaf.class, Meta1.class)).isTrue();
+		assertThat(isCandidateClass(Leaf.class, Meta2.class)).isTrue();
+		assertThat(isCandidateClass(Leaf.class, MetaMeta.class)).isTrue();
+		assertThat(isCandidateClass(Leaf.class, MetaMetaMeta.class)).isFalse();
+	}
+
+	@Test
+	void isCandidateClassAnnotationsOnSuperMethodsOnly() {
+		assertThat(isCandidateClass(InterfaceWithAnnotatedMethod.class, Order.class)).isTrue();
+		assertThat(isCandidateClass(InterfaceWithAnnotatedMethod.class, Meta1.class)).isFalse();
+
+		assertThat(isCandidateClass(ImplementsInterfaceWithAnnotatedMethod.class, Order.class)).isTrue();
+		assertThat(isCandidateClass(ImplementsInterfaceWithAnnotatedMethod.class, Meta1.class)).isFalse();
+		assertThat(isCandidateClass(SubOfImplementsInterfaceWithAnnotatedMethod.class, Order.class)).isTrue();
+		assertThat(isCandidateClass(SubOfImplementsInterfaceWithAnnotatedMethod.class, Meta1.class)).isFalse();
+
+		assertThat(isCandidateClass(AbstractDoesNotImplementInterfaceWithAnnotatedMethod.class, Meta1.class)).isFalse();
+		assertThat(isCandidateClass(AbstractDoesNotImplementInterfaceWithAnnotatedMethod.class, Order.class)).isTrue();
+	}
+
+	@Test
+	void isCandidateClassAnnotationsOnFields() {
+		assertThat(isCandidateClass(ClassWithMetaAnnotatedFields.class, Meta1.class)).isTrue();
+		assertThat(isCandidateClass(ClassWithMetaAnnotatedFields.class, Component.class)).isTrue();
+		assertThat(isCandidateClass(ClassWithMetaAnnotatedFields.class, MetaMeta.class)).isFalse();
+
+		assertThat(isCandidateClass(SubClassWithMetaAnnotatedFields.class, Meta1.class)).isTrue();
+		assertThat(isCandidateClass(SubClassWithMetaAnnotatedFields.class, Meta2.class)).isTrue();
+		assertThat(isCandidateClass(SubClassWithMetaAnnotatedFields.class, Component.class)).isTrue();
+		assertThat(isCandidateClass(SubClassWithMetaAnnotatedFields.class, MetaMeta.class)).isFalse();
+	}
 
 	@Test
 	void findMethodAnnotationOnLeaf() throws Exception {
@@ -1026,6 +1078,16 @@ class AnnotationUtilsTests {
 	@MetaCycle2
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface MetaCycle3 {
+	}
+
+	static class ClassWithMetaAnnotatedFields {
+		@Meta1
+		String foo = "bar";
+	}
+
+	static class SubClassWithMetaAnnotatedFields extends ClassWithMetaAnnotatedFields {
+		@Meta2
+		String baz = "qux";
 	}
 
 	@Meta1


### PR DESCRIPTION
Hello,

This PR implements the method `isCandidateClass`, which introspects annotations at the type, method, and field levels to determine if the provided annotation is applied. Although it was mentioned in the comment, it was not implemented, so I have done it!

I ensured that adhered to the existing Spring team's code style and made minor changes to ReflectionUtils to align with the reflection code style.

Since this is my second PR, there might be issues. If there are any problems, I would appreciate the opportunity to fix them.

Thank you!

<img width="733" alt="Screenshot 2024-04-18 at 10 51 09" src="https://github.com/spring-projects/spring-framework/assets/66157320/40a9f977-6a03-42c2-b883-8e7d249f02aa">
