### PR TITLE
Fix class name typo in reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/validation/beanvalidation.adoc
+++ b/framework-docs/modules/ROOT/pages/core/validation/beanvalidation.adoc
@@ -438,7 +438,7 @@ A `ConstraintViolation` on `Person.name()` is adapted to a `FieldError` with the
 To customize the default message, you can add properties to
 xref:core/beans/context-introduction.adoc#context-functionality-messagesource[MessageSource]
 resource bundles using any of the above errors codes and message arguments. Note also that the
-message argument `"name"` is itself a `MessagreSourceResolvable` with error codes
+message argument `"name"` is itself a `MessageSourceResolvable` with error codes
 `"student.name"` and `"name"` and can customized too. For example:
 
 Properties::


### PR DESCRIPTION
Small typo in a class name.