### PR TITLE
Remove redundant conditions

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/hint/ExecutableHint.java
+++ b/spring-core/src/main/java/org/springframework/aot/hint/ExecutableHint.java
@@ -127,9 +127,10 @@ public final class ExecutableHint extends MemberHint implements Comparable<Execu
 		 * @param mode the required mode
 		 * @return {@code this}, to facilitate method chaining
 		 */
+		@SuppressWarnings("NullAway")
 		public Builder withMode(ExecutableMode mode) {
 			Assert.notNull(mode, "'mode' must not be null");
-			if ((this.mode == null) || !this.mode.includes(mode)) {
+			if (!this.mode.includes(mode)) {
 				this.mode = mode;
 			}
 			return this;


### PR DESCRIPTION
Revised the portion where null check was performed after Assert.notNull(), eliminating redundant null checks.
