### PR TITLE
Add a `requiredBody()` extension to `RestClient.ResponseSpec`

### DIFF
--- a/spring-web/src/main/kotlin/org/springframework/web/client/RestClientExtensions.kt
+++ b/spring-web/src/main/kotlin/org/springframework/web/client/RestClientExtensions.kt
@@ -43,10 +43,10 @@ inline fun <reified T : Any> RestClient.ResponseSpec.body(): T? =
 	body(object : ParameterizedTypeReference<T>() {})
 
 /**
- * Extension for [RestClient.ResponseSpec.body] providing a `bodyNotNull<Foo>()` variant
+ * Extension for [RestClient.ResponseSpec.body] providing a `requiredBody<Foo>()` variant
  * To leverage Kotlin null safety, this extension throws a [NoSuchElementException] if the response body is null.
  */
-inline fun <reified T : Any> RestClient.ResponseSpec.bodyNotNull(): T =
+inline fun <reified T : Any> RestClient.ResponseSpec.requiredBody(): T =
     body(object : ParameterizedTypeReference<T>() {}) ?: throw NoSuchElementException("Response body is null when a non-null type was expected.")
 
 /**

--- a/spring-web/src/main/kotlin/org/springframework/web/client/RestClientExtensions.kt
+++ b/spring-web/src/main/kotlin/org/springframework/web/client/RestClientExtensions.kt
@@ -42,6 +42,12 @@ inline fun <reified T : Any> RestClient.RequestBodySpec.bodyWithType(body: T): R
 inline fun <reified T : Any> RestClient.ResponseSpec.body(): T? =
 	body(object : ParameterizedTypeReference<T>() {})
 
+/**
+ * Extension for [RestClient.ResponseSpec.body] providing a `bodyNotNull<Foo>()` variant
+ * To leverage Kotlin null safety, this extension throws a [NoSuchElementException] if the response body is null.
+ */
+inline fun <reified T : Any> RestClient.ResponseSpec.bodyNotNull(): T =
+    body(object : ParameterizedTypeReference<T>() {}) ?: throw NoSuchElementException("Response body is null when a non-null type was expected.")
 
 /**
  * Extension for [RestClient.ResponseSpec.toEntity] providing a `toEntity<Foo>()` variant

--- a/spring-web/src/test/kotlin/org/springframework/web/client/RestClientExtensionsTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/client/RestClientExtensionsTests.kt
@@ -48,15 +48,15 @@ class RestClientExtensionsTests {
 	}
 
 	@Test
-	fun `ResponseSpec#bodyNotNull with reified type parameters`() {
-		responseSpec.bodyNotNull<List<Foo>>()
+	fun `ResponseSpec#requiredBody with reified type parameters`() {
+		responseSpec.requiredBody<List<Foo>>()
 		verify { responseSpec.body(object : ParameterizedTypeReference<List<Foo>>() {}) }
 	}
 
 	@Test
-	fun `ResponseSpec#bodyNotNull with null response throws NoSuchElementException`() {
+	fun `ResponseSpec#requiredBody with null response throws NoSuchElementException`() {
 		every { responseSpec.body(any<ParameterizedTypeReference<Foo>>()) } returns null
-		assertThrows<NoSuchElementException> { responseSpec.bodyNotNull<Foo>() }
+		assertThrows<NoSuchElementException> { responseSpec.requiredBody<Foo>() }
 	}
 
 	@Test

--- a/spring-web/src/test/kotlin/org/springframework/web/client/RestClientExtensionsTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/client/RestClientExtensionsTests.kt
@@ -16,9 +16,11 @@
 
 package org.springframework.web.client
 
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.core.ParameterizedTypeReference
 
 /**
@@ -43,6 +45,18 @@ class RestClientExtensionsTests {
 	fun `ResponseSpec#body with reified type parameters`() {
 		responseSpec.body<List<Foo>>()
 		verify { responseSpec.body(object : ParameterizedTypeReference<List<Foo>>() {}) }
+	}
+
+	@Test
+	fun `ResponseSpec#bodyNotNull with reified type parameters`() {
+		responseSpec.bodyNotNull<List<Foo>>()
+		verify { responseSpec.body(object : ParameterizedTypeReference<List<Foo>>() {}) }
+	}
+
+	@Test
+	fun `ResponseSpec#bodyNotNull with null response throws NoSuchElementException`() {
+		every { responseSpec.body(any<ParameterizedTypeReference<Foo>>()) } returns null
+		assertThrows<NoSuchElementException> { responseSpec.bodyNotNull<Foo>() }
 	}
 
 	@Test


### PR DESCRIPTION
# Description

In WebClientExtensions.kt, developers have the flexibility to handle responses with methods that either guarantee a non-null return type or can return null. This design caters to various nullability requirements, enhancing code safety and expressiveness. However, RestClientExtensionKt currently offers only a nullable return type method, which may lead to unnecessary null checks and potentially less idiomatic Kotlin code.

Given Kotlin's emphasis on type safety and explicit nullability, extending RestClientExtensionKt to include a non-nullable return type method would align with these principles, offering a more robust and intuitive toolset for REST client development.

# Proposal
I propose the addition of a bodyNonNull method to RestClientExtensionKt:

```kotlin
inline fun <reified T : Any> RestClient.ResponseSpec.bodyNotNull(): T =
    body(object : ParameterizedTypeReference<T>() {}) ?: throw NoSuchElementException("Expected a non-null response body")
```
This method complements the existing nullable variant, providing a straightforward way to enforce non-null responses, thereby aligning with Kotlin's null safety features and reducing boilerplate code.

# Impact and Use Cases
This enhancement introduces no breaking changes, enriching the API without affecting existing code. It particularly benefits scenarios where a non-null response is confidently expected, making error handling more explicit and idiomatic in Kotlin.

# Seeking Feedback
I welcome feedback on this proposal, including alternative approaches, potential impacts on usability, and any concerns regarding implementation details.

# Conclusion
By adopting this change, RestClientExtensionKt would not only align more closely with Kotlin's design principles but also offer developers a more expressive and safe way to handle REST responses. This proposal upholds the Kotlin ethos of safety and clarity, enhancing developer experience and code quality in REST client applications.

