### PR TITLE
Support varargs invocations in SpEL for varargs array subtype

### DIFF
--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
@@ -4648,6 +4648,17 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 		assertThat(tc.s).isEqualTo("aaabbbccc");
 		tc.reset();
 
+		expression = parser.parseExpression("sixteen(seventeen)");
+		assertCannotCompile(expression);
+		expression.getValue(tc);
+		assertThat(tc.s).isEqualTo("aaabbbccc");
+		assertCanCompile(expression);
+		tc.reset();
+		// see TODO below
+		// expression.getValue(tc);
+		// assertThat(tc.s).isEqualTo("aaabbbccc");
+		// tc.reset();
+
 		// TODO Determine why the String[] is passed as the first element of the Object... varargs array instead of the entire varargs array.
 		// expression = parser.parseExpression("sixteen(stringArray)");
 		// assertCantCompile(expression);
@@ -6501,6 +6512,10 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 					s += varg;
 				}
 			}
+		}
+
+		public String[] seventeen() {
+			return new String[] { "aaa", "bbb", "ccc" };
 		}
 	}
 

--- a/spring-expression/src/test/java/org/springframework/expression/spel/support/ReflectionHelperTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/support/ReflectionHelperTests.java
@@ -40,6 +40,8 @@ import org.springframework.expression.spel.support.ReflectionHelper.ArgumentsMat
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.array;
 import static org.springframework.expression.spel.support.ReflectionHelper.ArgumentsMatchKind.CLOSE;
 import static org.springframework.expression.spel.support.ReflectionHelper.ArgumentsMatchKind.EXACT;
 import static org.springframework.expression.spel.support.ReflectionHelper.ArgumentsMatchKind.REQUIRES_CONVERSION;
@@ -252,14 +254,75 @@ class ReflectionHelperTests extends AbstractExpressionTests {
 
 	@Test
 	void setupArgumentsForVarargsInvocation() {
-		Object[] newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
-				new Class<?>[] {String[].class}, "a", "b", "c");
+		Object[] newArray;
 
-		assertThat(newArray).hasSize(1);
-		Object firstParam = newArray[0];
-		assertThat(firstParam.getClass().componentType()).isEqualTo(String.class);
-		Object[] firstParamArray = (Object[]) firstParam;
-		assertThat(firstParamArray).containsExactly("a", "b", "c");
+		newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] {String[].class}, "a", "b", "c");
+		assertThat(newArray)
+				.singleElement()
+				.asInstanceOf(array(String[].class))
+				.containsExactly("a", "b", "c");
+
+		newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] { Object[].class }, "a", "b", "c");
+		assertThat(newArray)
+				.singleElement()
+				.asInstanceOf(array(Object[].class))
+				.containsExactly("a", "b", "c");
+
+		newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] { Integer.class, Integer.class, String[].class }, 123, 456, "a", "b", "c");
+		assertThat(newArray)
+				.satisfiesExactly(
+						i -> assertThat(i).isEqualTo(123),
+						i -> assertThat(i).isEqualTo(456),
+						i -> assertThat(i).asInstanceOf(array(String[].class)).containsExactly("a", "b", "c"));
+
+		newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] { String[].class });
+		assertThat(newArray)
+				.singleElement()
+				.asInstanceOf(array(String[].class))
+				.isEmpty();
+
+		newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] { String[].class }, new Object[] { new String[] { "a", "b", "c" } });
+		assertThat(newArray)
+				.singleElement()
+				.asInstanceOf(array(String[].class))
+				.containsExactly("a", "b", "c");
+
+		newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] { Object[].class }, new Object[] { new String[] { "a", "b", "c" } });
+		assertThat(newArray)
+				.singleElement()
+				.asInstanceOf(array(Object[].class))
+				.containsExactly("a", "b", "c");
+
+		newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] { String[].class }, "a");
+		assertThat(newArray)
+				.singleElement()
+				.asInstanceOf(array(String[].class))
+				.containsExactly("a");
+
+
+		newArray = ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] { String[].class }, new Object[]{null});
+		assertThat(newArray)
+				.singleElement()
+				.asInstanceOf(array(String[].class))
+				.singleElement()
+				.isNull();
+
+		assertThatThrownBy(() -> ReflectionHelper.setupArgumentsForVarargsInvocation(
+				new Class<?>[] { Integer.class, Integer.class }, 123, 456))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Method must be varargs");
+
+		assertThatThrownBy(() -> ReflectionHelper.setupArgumentsForVarargsInvocation(new Class[] {}, "a", "b", "c"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Required parameter types must not be empty");
 	}
 
 	@Test


### PR DESCRIPTION
There was a bug in SpEL where an array passed into a varargs method could be wrapped one too many times if the component type of the argument didn't match the component type of the parameter. For example:

```java
@Test
void givenArrayFromVariable_whenInvokeVarargsMethod_thenCorrectArguments() {
	ExpressionParser parser = new SpelExpressionParser();
	StandardEvaluationContext context = new StandardEvaluationContext();
	Recorder recorder = new Recorder();
	context.setVariable("recorder", recorder);
	context.setVariable("myArray", new String[] { "a", "b" });

	parser.parseExpression("#recorder.record(#myArray)").getValue(context);

	assertThat(recorder.getArgs()).asInstanceOf(ARRAY).containsExactly("a", "b");
}

private static class Recorder {
	@Nullable private Object[] args;

        // test would pass with (String... args)
	public void record(Object... args) {
		this.args = args;
	}
	
	@Nullable
	public Object[] getArgs() {
		return args;
	}
}
```

This fails with the following error message:

```
Expecting actual:
  [["a", "b"]]
to contain exactly (and in same order):
  ["a", "b"]
```

I've added more exhaustive test cases for the method where the bug was, as well as a test in `SpelCompilationCoverageTests`. I've added this last test just next to another test that was commented out with a TODO, and had to comment out part of my test because of the same bug, but fixing this exposes another underlying bug that I've fixed in another branch, and I was able to uncomment the tests that were commented out. The fix is ready, I'm just waiting for this one to be merged.

I may also have accidentally uncovered another bug in SpEL. At line 4651 in `SpelCompilationCoverageTests`, the method `seventeen()` isn't actually invoked with `()`, yet it's still executed and its result value is available. I'm not sure this is desirable behaviour.