### PR TITLE
Fix incorrect class reference syntax in Kotlin code sample

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/webtestclient.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/webtestclient.adoc
@@ -672,13 +672,13 @@ Kotlin::
 	val result = client.get().uri("/persons/1")
 			.exchange()
 			.expectStatus().isOk()
-			.expectBody(Person.class)
-			.returnResult();
+			.expectBody(Person::class.java)
+			.returnResult()
 
 	// For a response without a body
 	val result = client.get().uri("/path")
 			.exchange()
-			.expectBody().isEmpty();
+			.expectBody().isEmpty()
 ----
 ======
 


### PR DESCRIPTION
Hi Team,

I noticed an incorrect class reference in the documentation, and I've attempted to correct it.