### PR TITLE
Sort AspectJ annotated advice methods using `@Order`

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/InstantiationModelAwarePointcutAdvisorImpl.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/InstantiationModelAwarePointcutAdvisorImpl.java
@@ -31,6 +31,8 @@ import org.springframework.aop.aspectj.InstantiationModelAwarePointcutAdvisor;
 import org.springframework.aop.aspectj.annotation.AbstractAspectJAdvisorFactory.AspectJAnnotation;
 import org.springframework.aop.support.DynamicMethodMatcherPointcut;
 import org.springframework.aop.support.Pointcuts;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.Order;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 
@@ -42,6 +44,7 @@ import org.springframework.util.ObjectUtils;
  * @author Rod Johnson
  * @author Juergen Hoeller
  * @author Sam Brannen
+ * @author Tang Xiong
  * @since 2.0
  */
 @SuppressWarnings("serial")
@@ -181,6 +184,10 @@ final class InstantiationModelAwarePointcutAdvisorImpl
 
 	@Override
 	public int getOrder() {
+		Order order = AnnotationUtils.getAnnotation(this.aspectJAdviceMethod, Order.class);
+		if (order != null) {
+			return order.value();
+		}
 		return this.aspectInstanceFactory.getOrder();
 	}
 

--- a/spring-aop/src/test/java/org/springframework/aop/aspectj/annotation/AbstractAspectJAdvisorFactoryTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/aspectj/annotation/AbstractAspectJAdvisorFactoryTests.java
@@ -480,6 +480,16 @@ abstract class AbstractAspectJAdvisorFactoryTests {
 	}
 
 	@Test
+	void orderedAdvice() {
+		OrderedAspect aspect = new OrderedAspect();
+		List<Advisor> advisors = getAdvisorFactory().getAdvisors(aspectInstanceFactory(aspect, "orderedAspect"));
+		OrderObject orderObject = createProxy(new OrderObject(), OrderObject.class, advisors);
+		orderObject.ordered();
+		List<Integer> orders = aspect.orders;
+		assertThat(orders).containsExactly(1, 2, 3);
+	}
+
+	@Test
 	void nonAbstractParentAspect() {
 		IncrementingAspect aspect = new IncrementingAspect();
 
@@ -760,6 +770,11 @@ abstract class AbstractAspectJAdvisorFactoryTests {
 		}
 	}
 
+	static class OrderObject {
+
+		void ordered() {}
+	}
+
 
 	@Aspect
 	static class DoublingAspect {
@@ -821,6 +836,37 @@ abstract class AbstractAspectJAdvisorFactoryTests {
 		void after() {
 			invocations.add("after");
 		}
+	}
+
+	@Aspect
+	private static class OrderedAspect {
+
+		private final List<Integer> orders = new ArrayList<>();
+
+		@Pointcut("execution(* ordered())")
+		void ordered() {
+		}
+
+		@Before("ordered()")
+		@Order(2)
+		void order2() {
+			orders.add(2);
+		}
+
+
+		@Before("ordered()")
+		@Order(1)
+		void order1() {
+			orders.add(1);
+		}
+
+
+		@Before("ordered()")
+		@Order(3)
+		void order3() {
+			orders.add(3);
+		}
+
 	}
 
 


### PR DESCRIPTION
This PR provides the ability to use `@Order` sorting for Advice Annotation.

Example:

```java
@Aspect
public class MyAspect {

    @Order(1)
    @Before("execution(* org.example.AopObj.*(..))")
    public void method1() {
        System.out.println("Before method-1");
    }

    @Order(2)
    @Before("execution(* org.example.AopObj.*(..))")
    public void method2() {
        System.out.println("Before method-2");
    }
    
}
```

`method1()` will be executed before `method2()` because the sequence number of `method1()` is smaller.
