### PR TITLE
Add a non-null variant of `ServerRequest.queryParam()` and `ServerRequest.param()`.

### DIFF
--- a/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
+++ b/spring-webflux/src/main/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensions.kt
@@ -176,6 +176,15 @@ fun ServerRequest.queryParamOrNull(name: String): String? {
 }
 
 /**
+ * Non-nullable variant of [ServerRequest.queryParam].
+ * Please use only to retrieve query parameters that match the key corresponding to [RequestPredicates.queryParam].
+ *
+ * @author SangYun Jeong
+ */
+fun ServerRequest.queryParamNotNull(name: String): String =
+	queryParams()[name]!!.first()
+
+/**
  * Nullable variant of [ServerRequest.Headers.contentLength]
  *
  * @author Sebastien Deleuze

--- a/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensionsTests.kt
+++ b/spring-webflux/src/test/kotlin/org/springframework/web/reactive/function/server/ServerRequestExtensionsTests.kt
@@ -21,6 +21,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
@@ -191,6 +192,27 @@ class ServerRequestExtensionsTests {
 	fun `queryParamOrNull with null`() {
 		every { request.queryParams() } returns CollectionUtils.toMultiValueMap(mapOf("foo" to listOf("bar")))
 		assertThat(request.queryParamOrNull("baz")).isNull()
+		verify { request.queryParams() }
+	}
+
+	@Test
+	fun `queryParamNotNull with value`() {
+		every { request.queryParams() } returns CollectionUtils.toMultiValueMap(mapOf("foo" to listOf("bar")))
+		assertThat(request.queryParamNotNull("foo")).isEqualTo("bar")
+		verify { request.queryParams() }
+	}
+
+	@Test
+	fun `queryParamNotNull with empty query parameters`() {
+		every { request.queryParams() } returns CollectionUtils.toMultiValueMap(mapOf("foo" to listOf("")))
+		assertThat(request.queryParamNotNull("foo")).isEqualTo("")
+		verify { request.queryParams() }
+	}
+
+	@Test
+	fun `queryParamNotNull with absent query parameters`() {
+		every { request.queryParams() } returns CollectionUtils.toMultiValueMap(emptyMap())
+		assertThatThrownBy {  request.queryParamNotNull("foo") }.isInstanceOf(NullPointerException::class.java)
 		verify { request.queryParams() }
 	}
 

--- a/spring-webmvc/src/main/kotlin/org/springframework/web/servlet/function/ServerRequestExtensions.kt
+++ b/spring-webmvc/src/main/kotlin/org/springframework/web/servlet/function/ServerRequestExtensions.kt
@@ -56,6 +56,14 @@ fun ServerRequest.attributeOrNull(name: String): Any? = attribute(name).orElse(n
 fun ServerRequest.paramOrNull(name: String): String? = param(name).orElse(null)
 
 /**
+ * Non-nullable variant of [ServerRequest.param]
+ * Please use only to retrieve query parameters that match the key corresponding to [RequestPredicates.param].
+ *
+ * @author SangYun Jeong
+*/
+fun ServerRequest.paramNotNull(name: String): String = param(name).get()
+
+/**
  * Nullable variant of [ServerRequest.param]
  *
  * @author Sebastien Deleuze

--- a/spring-webmvc/src/test/kotlin/org/springframework/web/servlet/function/ServerRequestExtensionsTests.kt
+++ b/spring-webmvc/src/test/kotlin/org/springframework/web/servlet/function/ServerRequestExtensionsTests.kt
@@ -20,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
@@ -89,6 +90,27 @@ class ServerRequestExtensionsTests {
 	fun `paramOrNull with null`() {
 		every { request.param("foo") } returns Optional.empty()
 		assertThat(request.paramOrNull("foo")).isNull()
+		verify { request.param("foo") }
+	}
+
+	@Test
+	fun `paramNotNull with value`() {
+		every { request.param("foo") } returns Optional.of("bar")
+		assertThat(request.paramNotNull("foo")).isEqualTo("bar")
+		verify { request.param("foo") }
+	}
+
+	@Test
+	fun `paramNotNull with empty query parameters`() {
+		every { request.param("foo") } returns Optional.of("")
+		assertThat(request.paramNotNull("foo")).isEqualTo("")
+		verify { request.param("foo") }
+	}
+
+	@Test
+	fun `paramNotNull with absent query parameters`() {
+		every { request.param("foo") } returns Optional.empty()
+		assertThatThrownBy { request.paramNotNull("foo") }.isInstanceOf(NullPointerException::class.java)
 		verify { request.param("foo") }
 	}
 


### PR DESCRIPTION
In general, functional endpoint allows filtering HTTP requests via `RequestPredicates`. For query parameters, requests can be mapped only when specific query parameters are received through `RequestPredicate.queryParam()` or `RequestPredicate.param()`. **If request with a query parameter whose names do not match `RequestPredicate` is not received, handler mapping is not performed, so request with the corresponding query parameter must exist to reach the handler.** In this case, we have determined that null checking for query parameters is unnecessary, so posting this PR.

## Example

```kotlin
@Configuration
class TestRouter {
    @Bean
    fun testRoutes(handler: TestHandler): RouterFunction<ServerResponse> =
        router {
            // If there is no test query parameter, perform a handler mapping(404 NOT FOUND)
            GET("/test", queryParam("test") { true }, handler::test)
        }
}
```
```kotlin
@Component
class TestHandler {
    fun test(request: ServerRequest): Mono<ServerResponse> =
        ServerResponse.ok()
            // The test query parameter cannot be null.
            // It is an unnecessary null check(In the case of Java, there is an overhead due to Optional Wrapping)
            .bodyValue(request.queryParamOrNull("test")!!)
}
```

