### PR TITLE
Add `@Router` and `@Handler`

### DIFF
--- a/spring-context/src/main/java/org/springframework/stereotype/Handler.java
+++ b/spring-context/src/main/java/org/springframework/stereotype/Handler.java
@@ -1,0 +1,21 @@
+package org.springframework.stereotype;
+
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface Handler {
+
+	/**
+	 * Alias for {@link Component#value}.
+	 */
+	@AliasFor(annotation = Component.class)
+	String value() default "";
+
+}

--- a/spring-context/src/main/java/org/springframework/stereotype/Router.java
+++ b/spring-context/src/main/java/org/springframework/stereotype/Router.java
@@ -1,0 +1,19 @@
+package org.springframework.stereotype;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Configuration
+public @interface Router {
+
+	/**
+	 * Alias for {@link Configuration#value}.
+	 */
+	@AliasFor(annotation = Configuration.class)
+	String value() default "";
+
+}


### PR DESCRIPTION
In general, annotation-based controller allows you to refer to controllers with unique annotations such as `@Controller`, while functional endpoint refers to routers and handlers with the traditional `@Configuration` and `@Component` annotations. I felt **there was a need for annotations to uniquely refer to routers and handlers more explicitly(
Whether used simply for writing explicit code or for AOP)**, so posted this PR.

