### PR TITLE
Align StandaloneMockMvcBuilder with trailing slash defaults

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/setup/StandaloneMockMvcBuilder.java
@@ -132,7 +132,7 @@ public class StandaloneMockMvcBuilder extends AbstractMockMvcBuilder<StandaloneM
 
 	private boolean useSuffixPatternMatch = false;
 
-	private boolean useTrailingSlashPatternMatch = true;
+	private boolean useTrailingSlashPatternMatch = false;
 
 	@Nullable
 	private Boolean removeSemicolonContent;


### PR DESCRIPTION
Spring no longer supports trailing slashes by default, as of https://github.com/spring-projects/spring-framework/issues/28552. However, unit tests that are setup using the `StandaloneMockMvcBuilder` still have default support for trailing slashes. This causes an inconsistency that does not reflect what spring does by default. By changing the default to false, unit tests will accurately reflect the base implementation, which will cause less confusion when unit tests are working and production code is not.