### PR TITLE
Add new method to set default headers in RestClient

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClientBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClientBuilder.java
@@ -277,6 +277,15 @@ final class DefaultRestClientBuilder implements RestClient.Builder {
 	}
 
 	@Override
+	public RestClient.Builder defaultHeaders(HttpHeaders httpHeaders) {
+		this.initHeaders();
+		if (this.defaultHeaders != null && httpHeaders != null) {
+			this.defaultHeaders.putAll(httpHeaders);
+		}
+		return this;
+	}
+
+	@Override
 	public RestClient.Builder defaultRequest(Consumer<RestClient.RequestHeadersSpec<?>> defaultRequest) {
 		this.defaultRequest = this.defaultRequest != null ?
 				this.defaultRequest.andThen(defaultRequest) : defaultRequest;

--- a/spring-web/src/main/java/org/springframework/web/client/RestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClient.java
@@ -281,6 +281,13 @@ public interface RestClient {
 		Builder defaultHeaders(Consumer<HttpHeaders> headersConsumer);
 
 		/**
+		 * Set the default headers to be used in HTTP requests.
+		 * @param httpHeaders the HttpHeaders
+		 * @return this builder
+		 */
+		Builder defaultHeaders(HttpHeaders httpHeaders);
+
+		/**
 		 * Provide a consumer to customize every request being built.
 		 * @param defaultRequest the consumer to use for modifying requests
 		 * @return this builder

--- a/spring-web/src/test/java/org/springframework/web/client/RestClientIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestClientIntegrationTests.java
@@ -863,8 +863,12 @@ class RestClientIntegrationTests {
 		prepareResponse(response -> response.setHeader("Content-Type", "text/plain")
 				.setBody("Hello Spring!"));
 
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.add("Hello", "Spring!");
+
 		RestClient headersClient = this.restClient.mutate()
 				.defaultHeaders(headers -> headers.add("foo", "bar"))
+				.defaultHeaders(httpHeaders)
 				.build();
 
 		String result = headersClient.get()
@@ -875,7 +879,10 @@ class RestClientIntegrationTests {
 		assertThat(result).isEqualTo("Hello Spring!");
 
 		expectRequestCount(1);
-		expectRequest(request -> assertThat(request.getHeader("foo")).isEqualTo("bar"));
+		expectRequest(request -> {
+			assertThat(request.getHeader("foo")).isEqualTo("bar");
+			assertThat(request.getHeader("Hello")).isEqualTo("Spring!");
+		});
 	}
 
 	@ParameterizedRestClientTest


### PR DESCRIPTION
## Motivation

The `RestClient.Builder` has [a method](https://github.com/spring-projects/spring-framework/blob/376d7839e0fb6acf902d33eb578b1df143bcaf0b/spring-web/src/main/java/org/springframework/web/client/RestClient.java#L281) that takes a parameter of type `Consumer<HttpHeaders>` to set the default headers.

```kotlin
val defaultHeaders = HttpHeaders().apply {
    contentType = MediaType.APPLICATION_JSON
    setBasicAuth("encodedCredentials")
}

val restClient = RestClient.builder()
    .baseUrl("https://spring.io")
    .defaultHeaders {
        defaultHeaders.forEach { headerName, headerValue -> it[headerName] = headerValue }
    }
    .build()
```

In addition to this, it would be nice to have an intuitive method to set `HttpHeaders` directly, just like the methods in the common builder pattern.

## Modifications

- Add new method to set default headers in `RestClient`
```java
Builder defaultHeaders(HttpHeaders httpHeaders);
```

## Result

```kotlin
val defaultHeaders = HttpHeaders().apply {
    contentType = MediaType.APPLICATION_JSON
    setBasicAuth("encodedCredentials")
}

val restClient = RestClient.builder()
    .baseUrl("https://spring.io")
    .defaultHeaders(defaultHeaders)
    .build()
```
Now we can now intuitively set our custom `HttpHeaders` as the default header.
