### PR TITLE
Improve wording in Spring Framework Overview documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/overview.adoc
+++ b/framework-docs/modules/ROOT/pages/overview.adoc
@@ -10,7 +10,7 @@ Spring requires Java 17+.
 
 Spring supports a wide range of application scenarios. In a large enterprise, applications
 often exist for a long time and have to run on a JDK and application server whose upgrade
-cycle is beyond developer control. Others may run as a single jar with the server embedded,
+cycle is beyond the developer's control. Others may run as a single jar with the server embedded,
 possibly in a cloud environment. Yet others may be standalone applications (such as batch
 or integration workloads) that do not need a server.
 


### PR DESCRIPTION
This pull request fixes a small grammatical mistake by adding missing articles to improve readability and correctness in the Spring Framework documentation, specifically in the overview.adoc file.

<img width="1417" alt="Screenshot 2024-05-15 at 8 06 06 PM" src="https://github.com/spring-projects/spring-framework/assets/123795629/2102be91-1166-43f8-816b-2c04407769e6">

**Details of Changes:**

**Before:**
In a large enterprise, applications often exist for a long time and have to run on a JDK and application server whose upgrade cycle is beyond developer control.

**After:**
In a large enterprise, applications often exist for a long time and have to run on a JDK and application server whose upgrade cycle is beyond the developer's control.