### PR TITLE
introduce internal single value map handle for MultiValueMap

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/LinkedMultiValueMap.java
+++ b/spring-core/src/main/java/org/springframework/util/LinkedMultiValueMap.java
@@ -104,4 +104,24 @@ public class LinkedMultiValueMap<K, V> extends MultiValueMapAdapter<K, V>  // ne
 		return new LinkedMultiValueMap<>(this);
 	}
 
+	/**
+	 * Create a new LinkedMultiValueMap from a Map with List values.
+	 * @param map the Map whose mappings are to be placed in this Map
+	 * @return a new LinkedMultiValueMap containing the mappings from the specified Map
+	 */
+	public static <K, V> LinkedMultiValueMap<K, V> ofMulti(Map<K, List<V>> map) {
+		return new LinkedMultiValueMap<>(map);
+	}
+
+	/**
+	 * Create a new LinkedMultiValueMap from a Map with single values.
+	 * Each entry in the Map will be converted to a List containing the single value.
+	 * @param map the Map whose mappings are to be placed in this Map
+	 * @return a new LinkedMultiValueMap containing the mappings from the specified Map
+	 */
+	public static <K, V> LinkedMultiValueMap<K, V> ofSingle(Map<K, V> map) {
+		LinkedMultiValueMap<K, V> multiValueMap = new LinkedMultiValueMap<>();
+		map.forEach((key, value) -> multiValueMap.add(key, value));
+		return multiValueMap;
+	}
 }

--- a/spring-core/src/test/java/org/springframework/util/LinkedMultiValueMapTests.java
+++ b/spring-core/src/test/java/org/springframework/util/LinkedMultiValueMapTests.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Arjen Poutsma
@@ -128,6 +129,26 @@ class LinkedMultiValueMapTests {
 		o2.put("key1", Collections.singletonList("value1"));
 		assertThat(o2).isEqualTo(map);
 		assertThat(map).isEqualTo(o2);
+	}
+
+	@Test
+	public void testMultiValueMapOfMulti() {
+		Map<String, List<Object>> map = new HashMap<>();
+		map.put("key1", List.of("value1", "value2"));
+		map.put("key2", List.of("value3"));
+		MultiValueMap<String, Object> multiValueMap = LinkedMultiValueMap.ofMulti(map);
+		assertEquals(2, multiValueMap.get("key1").size());
+		assertEquals(1, multiValueMap.get("key2").size());
+		assertThat(map.get("key1")).containsExactly("value1","value2");
+	}
+
+	@Test
+	public void testMultiValueMapOfSingle() {
+		Map<String, String> map = Map.of("key1", "value1", "key2", "value2");
+		MultiValueMap<String, String> multiValueMap = LinkedMultiValueMap.ofSingle(map);
+		assertEquals(1, multiValueMap.get("key1").size());
+		assertEquals("value1", multiValueMap.getFirst("key1"));
+		assertEquals("value2", multiValueMap.getFirst("key2"));
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/converter/FormHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/FormHttpMessageConverterTests.java
@@ -49,6 +49,7 @@ import org.springframework.web.testfixture.http.MockHttpOutputMessage;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
@@ -148,6 +149,17 @@ class FormHttpMessageConverterTests {
 				.as("Invalid content-type").isEqualTo(APPLICATION_FORM_URLENCODED);
 		assertThat(outputMessage.getHeaders().getContentLength())
 				.as("Invalid content-length").isEqualTo(outputMessage.getBodyAsBytes().length);
+	}
+
+	@Test
+	public void writeFormWithSingleValueMap() throws IOException {
+		Map<String, Object> singleValueMap = Map.of("username", "testUser", "password", "testPass");
+		FormHttpMessageConverter converter = new FormHttpMessageConverter();
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+		this.converter.write(LinkedMultiValueMap.ofSingle(singleValueMap), MediaType.APPLICATION_FORM_URLENCODED, outputMessage);
+
+		assertThat(outputMessage.getBodyAsString(UTF_8))
+				.as("Invalid result").isEqualTo("username=testUser&password=testPass");
 	}
 
 	@Test
@@ -376,7 +388,6 @@ class FormHttpMessageConverterTests {
 		assertThat(parameters).containsOnlyKeys("boundary", "charset");
 		assertThat(parameters).containsEntry("charset", "ISO-8859-1");
 	}
-
 	private void assertCanRead(MediaType mediaType) {
 		assertCanRead(MultiValueMap.class, mediaType);
 	}

--- a/spring-web/src/test/java/org/springframework/web/client/RestClientIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestClientIntegrationTests.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -54,8 +55,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.testfixture.xml.Pojo;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Named.named;
 
@@ -569,6 +569,55 @@ class RestClientIntegrationTests {
 		});
 	}
 
+
+	@ParameterizedRestClientTest // gh-31361
+	public void postFormSingleMapInputTest(ClientHttpRequestFactory requestFactory) {
+		startServer(requestFactory);
+
+		prepareResponse(response -> response.setResponseCode(200));
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("key1", "value1");
+		map.put("key2", "value2");
+
+		MultiValueMap<String, Object> formData =  LinkedMultiValueMap.ofSingle(map);
+
+		ResponseEntity<Void> result = this.restClient.post()
+				.uri("/form")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.body(formData)
+				.retrieve()
+				.toBodilessEntity();
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+	}
+
+	@ParameterizedRestClientTest // gh-31361
+	public void postFormMultiMapInputTest(ClientHttpRequestFactory requestFactory) {
+		startServer(requestFactory);
+
+		prepareResponse(response -> response.setResponseCode(200));
+
+		MultiValueMap<String, Object> multiValueMap = new LinkedMultiValueMap<>();
+
+		multiValueMap.add("key1","value1");
+		multiValueMap.add("key1","value1+1");
+		multiValueMap.add("key2","value2");
+
+
+		MultiValueMap<String, Object> formData =  LinkedMultiValueMap.ofMulti(multiValueMap);
+
+		ResponseEntity<Void> result = this.restClient.post()
+				.uri("/form")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.body(formData)
+				.retrieve()
+				.toBodilessEntity();
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+	}
 
 	@ParameterizedRestClientTest
 	void statusHandler(ClientHttpRequestFactory requestFactory) {


### PR DESCRIPTION
According to #32826 and #32832 problem description and solution proposal, I introduce 2 static methods `ofMulti` and `ofsingle` into`MultiValueMap`(`LinkedMultiValueMap`). 

Briefly, It simplifies the conversion of Map to LinkedMultiValueMap, enhancing code simplicity and consistency while maintaining backward compatibility.

Now you can use ` LinkedMultiValueMap.ofSingle(map)` to quickly transfer the normal single value map into a multivalue map which match the `FormHttpMessageConverter` input requirement. 

-------

The `toMulti` method seems useless because it will not need any work if you build a multivalue mao by default.
These are a bit of my personal thinking and not sure if it is true. 


