### PR TITLE
Modernize Antora Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ atlassian-ide-plugin.xml
 .vscode/
 
 cached-antora-playbook.yml
+
+node_modules

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,14 +1,7 @@
 antora:
   extensions:
-  - '@springio/antora-extensions/partial-build-extension'
-  # atlas-extension must be before latest-version-extension so latest versions are applied to imported versions
-  - '@antora/atlas-extension'
-  - require: '@springio/antora-extensions/latest-version-extension'
-  - require: '@springio/antora-extensions/inject-collector-cache-config-extension'
-  - '@antora/collector-extension'
-  - require: '@springio/antora-extensions/root-component-extension'
+  - require: '@springio/antora-extensions'
     root_component_name: 'framework'
-  - '@springio/antora-extensions/static-page-extension'
 site:
   title: Spring Framework
   url: https://docs.spring.io/spring-framework/reference
@@ -43,5 +36,4 @@ runtime:
     failure_level: warn
 ui:
   bundle:
-    url: https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.13/ui-bundle.zip
-    snapshot: true
+    url: https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.15/ui-bundle.zip

--- a/build.gradle
+++ b/build.gradle
@@ -4,20 +4,5 @@ plugins {
 }
 
 antora {
-	version = '3.2.0-alpha.2'
 	options = [clean: true, fetch: true, stacktrace: true]
-	environment = [
-		'ALGOLIA_API_KEY': '042f6aaab6ce998d2ea29e60167e1660',
-		'ALGOLIA_APP_ID': 'WB1FQYI187',
-		'ALGOLIA_INDEX_NAME': 'springdocs'
-    ]
-	// NOTE remember to update the versions in lib/antora/templates/per-branch-antora-playbook.yml as well
-	dependencies = [
-			'@antora/atlas-extension': '1.0.0-alpha.1',
-			'@antora/collector-extension': '1.0.0-alpha.3',
-			'@asciidoctor/tabs': '1.0.0-beta.3',
-			'@opendevise/antora-release-line-extension': '1.0.0',
-			'@springio/antora-extensions': '1.8.2',
-			'@springio/asciidoctor-extensions': '1.0.0-alpha.10',
-	]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "antora": "3.2.0-alpha.4",
+    "@antora/atlas-extension": "1.0.0-alpha.2",
+    "@antora/collector-extension": "1.0.0-alpha.3",
+    "@asciidoctor/tabs": "1.0.0-beta.6",
+    "@springio/antora-extensions": "1.11.1",
+    "@springio/asciidoctor-extensions": "1.0.0-alpha.10"
+  }
+}


### PR DESCRIPTION
- Use package.json so dependabot can automatically update JS dependencies
- Use @springio/antora-extensions (automatically apply default extensions in proper order)
- Leverage set-algolia-env-extension to manage algolia env variables
- Update to latest ui