### PR TITLE
Modernize Antora Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ atlassian-ide-plugin.xml
 .vscode/
 
 cached-antora-playbook.yml
+
+node_modules

--- a/framework-docs/antora-playbook.yml
+++ b/framework-docs/antora-playbook.yml
@@ -1,0 +1,39 @@
+antora:
+  extensions:
+  - require: '@springio/antora-extensions'
+    root_component_name: 'framework'
+site:
+  title: Spring Framework
+  url: https://docs.spring.io/spring-framework/reference
+  robots: allow
+git:
+  ensure_git_suffix: false
+content:
+  sources:
+  - url: https://github.com/spring-projects/spring-framework
+    # Refname matching:
+    # https://docs.antora.org/antora/latest/playbook/content-refname-matching/
+    branches: ['main', '{6..9}.+({0..9}).x']
+    tags: ['v{6..9}.+({0..9}).+({0..9})?(-{RC,M}*)', '!(v6.0.{0..8})', '!(v6.0.0-{RC,M}{0..9})']
+    start_path: framework-docs
+asciidoc:
+  extensions:
+    - '@asciidoctor/tabs'
+    - '@springio/asciidoctor-extensions'
+    - '@springio/asciidoctor-extensions/include-code-extension'
+  attributes:
+    page-stackoverflow-url: https://stackoverflow.com/questions/tagged/spring
+    page-pagination: ''
+    hide-uri-scheme: '@'
+    tabs-sync-option: '@'
+    include-java: 'example$docs-src/main/java/org/springframework/docs'
+urls:
+  latest_version_segment_strategy: redirect:to
+  latest_version_segment: ''
+  redirect_facility: httpd
+runtime:
+  log:
+    failure_level: warn
+ui:
+  bundle:
+    url: https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.15/ui-bundle.zip

--- a/framework-docs/framework-docs.gradle
+++ b/framework-docs/framework-docs.gradle
@@ -10,27 +10,10 @@ apply from: "${rootDir}/gradle/ide.gradle"
 apply from: "${rootDir}/gradle/publications.gradle"
 
 antora {
-	version = '3.2.0-alpha.2'
-	playbook = 'cached-antora-playbook.yml'
-	playbookProvider {
-		repository = 'spring-projects/spring-framework'
-		branch = 'docs-build'
-		path = 'lib/antora/templates/per-branch-antora-playbook.yml'
-		checkLocalBranch = true
-	}
-	options = ['--clean', '--stacktrace']
+	options = [clean: true, fetch: !project.gradle.startParameter.offline, stacktrace: true]
 	environment = [
-			'ALGOLIA_API_KEY': '82c7ead946afbac3cf98c32446154691',
-			'ALGOLIA_APP_ID': '244V8V9FGG',
-			'ALGOLIA_INDEX_NAME': 'framework-docs'
-	]
-	dependencies = [
-			'@antora/atlas-extension': '1.0.0-alpha.1',
-			'@antora/collector-extension': '1.0.0-alpha.3',
-			'@asciidoctor/tabs': '1.0.0-beta.3',
-			'@opendevise/antora-release-line-extension': '1.0.0',
-			'@springio/antora-extensions': '1.8.2',
-			'@springio/asciidoctor-extensions': '1.0.0-alpha.9'
+			'BUILD_REFNAME': 'HEAD',
+			'BUILD_VERSION': project.version,
 	]
 }
 

--- a/framework-docs/package.json
+++ b/framework-docs/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "antora": "3.2.0-alpha.4",
+    "@antora/atlas-extension": "1.0.0-alpha.2",
+    "@antora/collector-extension": "1.0.0-alpha.3",
+    "@asciidoctor/tabs": "1.0.0-beta.6",
+    "@springio/antora-extensions": "1.11.1",
+    "@springio/asciidoctor-extensions": "1.0.0-alpha.10"
+  }
+}


### PR DESCRIPTION
- Use same playbook as docs-build
- Use Env Variables to cause partial build (same as docs-build)
- Use package.json so that dependencies can be updated with dependabot