### PR TITLE
Use Threadlocal.remove() instead of .set(null) in documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/aop-api/targetsource.adoc
+++ b/framework-docs/modules/ROOT/pages/core/aop-api/targetsource.adoc
@@ -222,7 +222,7 @@ incorrectly using them in multi-threaded and multi-classloader environments. You
 should always consider wrapping a `ThreadLocal` in some other class and never directly use
 the `ThreadLocal` itself (except in the wrapper class). Also, you should
 always remember to correctly set and unset (where the latter simply involves a call to
-`ThreadLocal.set(null)`) the resource local to the thread. Unsetting should be done in
+`ThreadLocal.remove()`) the resource local to the thread. Unsetting should be done in
 any case, since not unsetting it might result in problematic behavior. Spring's
 `ThreadLocal` support does this for you and should always be considered in favor of using
 `ThreadLocal` instances without other proper handling code.


### PR DESCRIPTION
Hi Team,

This PR updates the Spring Framework documentation to recommend using `ThreadLocal.remove()` instead of `ThreadLocal.set(null)` when unsetting a `ThreadLocal` value.

The current documentation suggests using `ThreadLocal.set(null)` to unset a `ThreadLocal` value. However, this approach can lead to memory leaks and other unexpected behaviors, particularly in multi-threaded and multi-classloader environments. Using `ThreadLocal.set(null)` does not completely remove the `ThreadLocal` instance, which means the associated memory may not be fully released. This can cause data inconsistencies and unexpected behaviors.

In the Spring Framework itself, `ThreadLocal.remove()` is used to ensure that the `ThreadLocal` values are properly cleaned up, preventing potential memory leaks and ensuring consistent behavior across different environments.