### PR TITLE
Complete Kotlin example for HTTP message codecs in reference doc

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webflux/config.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/config.adoc
@@ -331,7 +331,7 @@ Kotlin::
 	class WebConfig : WebFluxConfigurer {
 
 		override fun configureHttpMessageCodecs(configurer: ServerCodecConfigurer) {
-			// ...
+			configurer.defaultCodecs().maxInMemorySize(512 * 1024)
 		}
 	}
 ----


### PR DESCRIPTION
![Screenshot 2024-05-23 14:24:22](https://github.com/spring-projects/spring-framework/assets/66462458/9c964f75-405f-4715-b507-ff3e300f0e8e)
![Screenshot 2024-05-23 14:24:33](https://github.com/spring-projects/spring-framework/assets/66462458/f1032b6d-65d3-4795-a408-df9ffd21058b)

It already has one written in Java:
```java
@Configuration
@EnableWebFlux
public class WebConfig implements WebFluxConfigurer {

	@Override
	public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
		configurer.defaultCodecs().maxInMemorySize(512 * 1024);
	}
}
```

It's straightforward to translate to Kotlin so...