### PR TITLE
Fix typo in WebTestClient expectedXml

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -1060,7 +1060,7 @@ public interface WebTestClient {
 		 * <p>Use of this method requires the
 		 * <a href="https://github.com/xmlunit/xmlunit">XMLUnit</a> library on
 		 * the classpath.
-		 * @param expectedXml the expected JSON content.
+		 * @param expectedXml the expected XML content.
 		 * @since 5.1
 		 * @see org.springframework.test.util.XmlExpectationsHelper#assertXmlEqual(String, String)
 		 */


### PR DESCRIPTION
Fix javadoc for expectedXml parameter. The xml(..) assert expects XML content not JSON.