### PR TITLE
Do not swallow exceptions on failing to release a savepoint

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/JdbcTransactionObjectSupport.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/JdbcTransactionObjectSupport.java
@@ -186,7 +186,7 @@ public abstract class JdbcTransactionObjectSupport implements SavepointManager, 
 			conHolder.getConnection().releaseSavepoint((Savepoint) savepoint);
 		}
 		catch (Throwable ex) {
-			logger.debug("Could not explicitly release JDBC savepoint", ex);
+			throw new TransactionSystemException("Could not explicitly release JDBC savepoint", ex);
 		}
 	}
 


### PR DESCRIPTION
By swallowing the exception on failing to release a savepoint, we are hiding client code from database errors that they may need to be aware of or handle.

e.g. if the connection is now dead when trying to release the savepoint, by swallowing the exception here, client code has no way of knowing this now until the next operation on the database, which will yield a confusing message about the problem and obscures where the failure occurred as it will be in a different part of their code that throws any exception.

Swallowing the exception here is also inconsistent with all the other database calls in the Transaction Object, where we always raise an exception up and let client code decide how to handle the error.