### PR TITLE
Fix typo in the Simple Broker section of the reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/websocket/stomp/handle-simple-broker.adoc
+++ b/framework-docs/modules/ROOT/pages/web/websocket/stomp/handle-simple-broker.adoc
@@ -13,7 +13,7 @@ If configured with a task scheduler, the simple broker supports
 https://stomp.github.io/stomp-specification-1.2.html#Heart-beating[STOMP heartbeats].
 To configure a scheduler, you can declare your own `TaskScheduler` bean and set it through
 the `MessageBrokerRegistry`. Alternatively, you can use the one that is automatically
-declared in the built-in WebSocket configuration, however, you'll' need `@Lazy` to avoid
+declared in the built-in WebSocket configuration, however, you'll need `@Lazy` to avoid
 a cycle between the built-in WebSocket configuration and your
 `WebSocketMessageBrokerConfigurer`. For example:
 


### PR DESCRIPTION
Fixed a small typo.

Link to the relevant webpage: https://docs.spring.io/spring-framework/reference/web/websocket/stomp/handle-simple-broker.html