### PR TITLE
Update Kotlin examples in `autowired.adoc`

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/annotation-config/autowired.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/annotation-config/autowired.adoc
@@ -255,7 +255,7 @@ Kotlin::
 ----
 	class MovieRecommender {
 
-		@Autowired
+		@set:Autowired
 		lateinit var movieCatalogs: Set<MovieCatalog>
 
 		// ...

--- a/framework-docs/modules/ROOT/pages/core/beans/annotation-config/autowired.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/annotation-config/autowired.adoc
@@ -317,7 +317,7 @@ Kotlin::
 ----
 	class MovieRecommender {
 
-		@Autowired
+		@set:Autowired
 		lateinit var movieCatalogs: Map<String, MovieCatalog>
 
 		// ...
@@ -359,7 +359,7 @@ Kotlin::
 ----
 	class SimpleMovieLister {
 
-		@Autowired(required = false)
+		@set:Autowired(required = false)
 		var movieFinder: MovieFinder? = null
 
 		// ...
@@ -446,7 +446,7 @@ Kotlin::
 ----
 	class SimpleMovieLister {
 
-		@Autowired
+		@set:Autowired
 		var movieFinder: MovieFinder? = null
 
 		// ...


### PR DESCRIPTION
Hello, I recently started to read Spring documentations and I really enjoy it.
Thank you for your great contributions.
I think I found something to fix in the [doc](https://docs.spring.io/spring-framework/reference/core/beans/annotation-config/autowired.html) that explains annotation `@Autowired`.

In the doc, java code shows setter-based injection

```java
	public class MovieRecommender {
		private Set<MovieCatalog> movieCatalogs;
		@Autowired
		public void setMovieCatalogs(Set<MovieCatalog> movieCatalogs) {
			this.movieCatalogs = movieCatalogs;
		}
		// ...
	}
```

and Kotlin code is property-based injection example.
```kotlin
class MovieRecommender {
		@Autowired
		lateinit var movieCatalogs: Set<MovieCatalog>
		// ...
	}
```
but both must be equivalent as much as possible cause they are in the same box.