### PR TITLE
spring-form JSP tags should escape HTML value based on response character encoding

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractFormTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractFormTag.java
@@ -92,7 +92,7 @@ public abstract class AbstractFormTag extends HtmlEscapingAwareTag {
 	 * as required. This version is <strong>not</strong> {@link PropertyEditor}-aware.
 	 */
 	protected String getDisplayString(@Nullable Object value) {
-		return ValueFormatter.getDisplayString(value, isHtmlEscape());
+		return ValueFormatter.getDisplayString(value, this::htmlEscape);
 	}
 
 	/**
@@ -102,7 +102,7 @@ public abstract class AbstractFormTag extends HtmlEscapingAwareTag {
 	 * to obtain the display value.
 	 */
 	protected String getDisplayString(@Nullable Object value, @Nullable PropertyEditor propertyEditor) {
-		return ValueFormatter.getDisplayString(value, propertyEditor, isHtmlEscape());
+		return ValueFormatter.getDisplayString(value, propertyEditor, this::htmlEscape);
 	}
 
 	/**

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/InputTagTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/tags/form/InputTagTests.java
@@ -96,8 +96,8 @@ class InputTagTests extends AbstractFormTagTests {
 
 	@Test
 	void simpleBindWithHtmlEscaping() throws Exception {
-		final String NAME = "Rob \"I Love Mangos\" Harrop";
-		final String HTML_ESCAPED_NAME = "Rob &quot;I Love Mangos&quot; Harrop";
+		final String NAME = "Rob \"I Love Café\" Harrop";
+		final String HTML_ESCAPED_NAME = "Rob &quot;I Love Caf&eacute;&quot; Harrop";
 
 		this.tag.setPath("name");
 		this.rob.setName(NAME);
@@ -111,6 +111,26 @@ class InputTagTests extends AbstractFormTagTests {
 		assertContainsAttribute(output, "type", getType());
 		assertValueAttribute(output, HTML_ESCAPED_NAME);
 	}
+
+	@Test
+	void simpleBindWithHtmlEscapingAndCharacterEncoding() throws Exception {
+		final String NAME = "Rob \"I Love Café\" Harrop";
+		final String HTML_ESCAPED_NAME = "Rob &quot;I Love Café&quot; Harrop";
+
+		this.getPageContext().getResponse().setCharacterEncoding("UTF-8");
+		this.tag.setPath("name");
+		this.rob.setName(NAME);
+
+		assertThat(this.tag.doStartTag()).isEqualTo(Tag.SKIP_BODY);
+
+		String output = getOutput();
+		assertTagOpened(output);
+		assertTagClosed(output);
+
+		assertContainsAttribute(output, "type", getType());
+		assertValueAttribute(output, HTML_ESCAPED_NAME);
+	}
+
 
 	protected void assertValueAttribute(String output, String expectedValue) {
 		assertContainsAttribute(output, "value", expectedValue);


### PR DESCRIPTION
I notice that spring-form JSP tags always escapes attribute `value` with character encoding `ISO-8859-1` defined in class `WebUtils`. It is preferable to align with response character encoding (likely `UTF-8`).

Spring Framework taglib should only use "HTML escape function" based on response character encoding.
