### PR TITLE
Fix typo in comment

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/DefaultBindingErrorProcessor.java
+++ b/spring-context/src/main/java/org/springframework/validation/DefaultBindingErrorProcessor.java
@@ -66,7 +66,7 @@ public class DefaultBindingErrorProcessor implements BindingErrorProcessor {
 
 	@Override
 	public void processPropertyAccessException(PropertyAccessException ex, BindingResult bindingResult) {
-		// Create field error with the exceptions's code, e.g. "typeMismatch".
+		// Create field error with the exception's code, e.g. "typeMismatch".
 		String field = ex.getPropertyName();
 		Assert.state(field != null, "No field in exception");
 		String[] codes = bindingResult.resolveMessageCodes(ex.getErrorCode(), field);


### PR DESCRIPTION
Fix small typo in comment in `DefaultBindingErrorProcessor`: `exceptions's` -> `exception's`