### PR TITLE
prevent ClassCastException with EntityManagerHolder

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/hibernate5/HibernateTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/hibernate5/HibernateTransactionManager.java
@@ -424,9 +424,9 @@ public class HibernateTransactionManager extends AbstractPlatformTransactionMana
 		txObject.setSavepointAllowed(isNestedTransactionAllowed());
 
 		SessionFactory sessionFactory = obtainSessionFactory();
-		SessionHolder sessionHolder =
-				(SessionHolder) TransactionSynchronizationManager.getResource(sessionFactory);
-		if (sessionHolder != null) {
+		Object sessionHolderObject = TransactionSynchronizationManager.getResource(sessionFactory);
+		if (sessionHolder instanceof SessionHolder) {
+			SessionHolder sessionHolder = (SessionHolder) sessionHolderObject;
 			if (logger.isDebugEnabled()) {
 				logger.debug("Found thread-bound Session [" + sessionHolder.getSession() + "] for Hibernate transaction");
 			}


### PR DESCRIPTION
Hello, I have a complex auto wiring scenario that seems to be only happening in production.

Affected versions:

- Spring Core 5.3.27
- Spring Batch 4.3.8
- Spring ORM 5.3.27
- Hibernate 5.4.33
- Note I am not using Spring Boot at all.

In particular, I have a `transactionManager` bean that is a `HibernateTransactionManager` and another `transactionManagerTarget` bean that is of type `DataSourceTransactionManager`. The `doGetTransaction()` method is failing at runtime because of a ClassCastException.

While I am not able to reproduce the issue to send as a sample project (I tried), I wanted to offer this small rewrite. It is 100% backwards compatible and simply routes into the `else` block instead of throwing a ClassCastException at runtime. I would greatly appreciate if it could be considered in an upcoming release!

- `instanceof` check automatically handles the `!= null` case
- rewriting cast to avoid potential ClassCastException scenarios
- specifically avoiding runtime `java.lang.ClassCastException: org.springframework.orm.jpa.EntityManagerHolder cannot be cast to org.springframework.orm.hibernate5.SessionHolder`

Lastly, here is the original stack trace. Thank you!

```
Caused by: java.lang.ClassCastException: org.springframework.orm.jpa.EntityManagerHolder cannot be cast to org.springframework.orm.hibernate5.SessionHolder
    at org.springframework.orm.hibernate5.HibernateTransactionManager.doGetTransaction(HibernateTransactionManager.java:425)
    at org.springframework.transaction.support.AbstractPlatformTransactionManager.getTransaction(AbstractPlatformTransactionManager.java:347)
    at org.springframework.transaction.interceptor.TransactionAspectSupport.createTransactionIfNecessary(TransactionAspectSupport.java:595)
    at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:382)
    at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
    at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:241)
    at com.sun.proxy.$Proxy74.updateExecutionContext(Unknown Source)~[?:?]
    at org.springframework.batch.core.step.tasklet.TaskletStep$ChunkTransactionCallback.doInTransaction(TaskletStep.java:452)
    ... 14 more
```