### PR TITLE
AntPathPatternMatcher hardcoded "/" separator in variables matching and comparator

### DIFF
--- a/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
+++ b/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 class AntPathMatcherTests {
 
 	private final AntPathMatcher pathMatcher = new AntPathMatcher();
+	private final AntPathMatcher dotSeparatedPathMatcher = new AntPathMatcher(".");
 
 
 	@Test
@@ -355,6 +356,24 @@ class AntPathMatcherTests {
 		expected.put("name", "test");
 		expected.put("extension", "html");
 		assertThat(result).isEqualTo(expected);
+	}
+
+	@Test // gh-26264
+	void extractUriTemplateVariablesFromDotSeparatedPath() {
+		Map<String, String> result = dotSeparatedPathMatcher.extractUriTemplateVariables("price.stock.{tickerSymbol}", "price.stock.aaa");
+		assertThat(result).isEqualTo(Collections.singletonMap("tickerSymbol", "aaa"));
+
+		result = dotSeparatedPathMatcher.extractUriTemplateVariables("price.stock.{ticker/symbol}", "price.stock.aaa");
+		assertThat(result).isEqualTo(Collections.singletonMap("ticker/symbol", "aaa"));
+
+		result = dotSeparatedPathMatcher.extractUriTemplateVariables("notification.**.{operation}", "notification.foo.update");
+		assertThat(result).isEqualTo(Collections.singletonMap("operation", "update"));
+
+		result = dotSeparatedPathMatcher.extractUriTemplateVariables("news.sports.feed/{type}", "news.sports.feed/xml");
+		assertThat(result).isEqualTo(Collections.singletonMap("type", "xml"));
+
+		result = dotSeparatedPathMatcher.extractUriTemplateVariables("news.sports.{operation}/*", "news.sports.feed/xml");
+		assertThat(result).isEqualTo(Collections.singletonMap("operation", "feed"));
 	}
 
 	@Test


### PR DESCRIPTION
Related: #26264 

When AntPathMatcher is constructed with a path separator other than default character "/", the functionality of extraction of URI template variables doesn’t work properly. If the matcher is specified with a non-default character, and a part of URI variable template includes default separator as a variable name, the variable name key mapping leads to exceptions or unexpected results. This is because the regex for URI template variables is hard-coded with "/", which is not considered as a part of variable key, although it can be placed if the matcher has a non-default path separator. To fix this, I updated it to pass a path separator to that regex.

Currently, for example, the matcher with non-default path separator seems to be leveraged on WebSocketConfiguration, in default, to map a "."-separated resource, which is a part of URI segment. Thus, for instance, if the path separator is specified as ".", extracting “price.stock.aaa“ with the template "price.stock.{ticker/symbol}" leads to IllegalStateException.

NOTE: A hard-coded variable pattern is still remaining. It seemed to be indirectly used in PathMatcher#compare implementation, but I’m not sure if this erroneous code causes some bug behaviors or not and is tracked by the team. And for isolation reasons, I would like to exclude it from the scope of code fix in this PR.

https://github.com/spring-projects/spring-framework/blob/b134f253b5a72200821501dbbf921d7d75ff964a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java#L81