### PR TITLE
Provides a mechanism that allows to customize reactive type

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
@@ -18,6 +18,7 @@ package org.springframework.transaction.interceptor;
 
 import java.lang.reflect.Method;
 import java.util.Properties;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -51,6 +52,7 @@ import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.TransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.TransactionSystemException;
+import org.springframework.transaction.reactive.ReactiveAdapterRegistryProvider;
 import org.springframework.transaction.reactive.TransactionContextManager;
 import org.springframework.transaction.support.CallbackPreferringPlatformTransactionManager;
 import org.springframework.util.Assert;
@@ -199,7 +201,10 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 
 	protected TransactionAspectSupport() {
 		if (reactiveStreamsPresent) {
-			this.reactiveAdapterRegistry = ReactiveAdapterRegistry.getSharedInstance();
+			this.reactiveAdapterRegistry = ServiceLoader.load(ReactiveAdapterRegistryProvider.class)
+					.findFirst()
+					.map(ReactiveAdapterRegistryProvider::get)
+					.orElseGet(ReactiveAdapterRegistry::getSharedInstance);
 		}
 		else {
 			this.reactiveAdapterRegistry = null;

--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/ReactiveAdapterRegistryProvider.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/ReactiveAdapterRegistryProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.transaction.reactive;
+
+import org.springframework.core.ReactiveAdapterRegistry;
+
+/**
+ * Service provider interface (SPI) that allows to customize usage of reactive type adapters in Spring Transactions.
+ * <p/>
+ * By default, Spring Transactions uses the global registry provided by
+ * {@link ReactiveAdapterRegistry#getSharedInstance()}, but this behavior can be changed by implementing this provider
+ * and <a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/ServiceLoader.html#deploying-service-providers-on-the-class-path-heading">deploying it on a class path</a>.
+ * <p/>
+ * The implementations of the SPI should be threadsafe.
+ *
+ * @author Bohdan Pryshedko
+ */
+public interface ReactiveAdapterRegistryProvider {
+	/**
+	 * Returns instance of the registry that will be used by Spring Transactions.
+	 * <p/>
+	 * The implementation shouldn't make any assumption about when it is called, how much time it can be called, and if
+	 * the result is cached or not.
+	 * @return registry to be used by Spring Transactions.
+	 */
+	ReactiveAdapterRegistry get();
+}

--- a/spring-tx/src/test/resources/META-INF/services/org.springframework.transaction.reactive.ReactiveAdapterRegistryProvider
+++ b/spring-tx/src/test/resources/META-INF/services/org.springframework.transaction.reactive.ReactiveAdapterRegistryProvider
@@ -1,0 +1,1 @@
+org.springframework.transaction.testfixture.DelegatingReactiveAdapterRegistryProvider

--- a/spring-tx/src/testFixtures/java/org/springframework/transaction/testfixture/DelegatingReactiveAdapterRegistryProvider.java
+++ b/spring-tx/src/testFixtures/java/org/springframework/transaction/testfixture/DelegatingReactiveAdapterRegistryProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.transaction.testfixture;
+
+import org.springframework.core.ReactiveAdapter;
+import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.transaction.reactive.ReactiveAdapterRegistryProvider;
+
+/**
+ * @author Bohdan Pryshedko
+ */
+public class DelegatingReactiveAdapterRegistryProvider implements ReactiveAdapterRegistryProvider {
+	@Override
+	public ReactiveAdapterRegistry get() {
+		return InstanceHolder.INSTANCE;
+	}
+
+	private static final class InstanceHolder {
+		private static final ReactiveAdapterRegistry INSTANCE = new DelegatingReactiveAdapterRegistry();
+	}
+
+	private static final class DelegatingReactiveAdapterRegistry extends ReactiveAdapterRegistry {
+		@Override
+		public boolean hasAdapters() {
+			return super.hasAdapters() || ReactiveAdapterRegistry.getSharedInstance().hasAdapters();
+		}
+
+		@Override
+		public ReactiveAdapter getAdapter(Class<?> reactiveType) {
+			var result = ReactiveAdapterRegistry.getSharedInstance().getAdapter(reactiveType);
+			if (result == null) {
+				return super.getAdapter(reactiveType);
+			}
+			return result;
+		}
+
+		@Override
+		public ReactiveAdapter getAdapter(Class<?> reactiveType, Object source) {
+			var result = ReactiveAdapterRegistry.getSharedInstance().getAdapter(reactiveType, source);
+			if (result == null) {
+				return super.getAdapter(reactiveType, source);
+			}
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
### Problem description

For historical reason in our project we have services like:
```
interface Service<I, O> {
    String name();
    Mono<O> execute(I input);
}
```
And when we started using reactive Spring transactions, we couldn't always avoid applying `@Transactional` on a interface/class level, so we needed a solution that tolerates such mix of reactive and non-reactive public methods in classes with `@Transactional` annotation.

Registering reactive type adapters in shared instance of `ReactiveAdapterRegistry` looked as a standard way to go, so we used it, and it worked well for a while. But now we are trying to start using Spring Data JPA framework in our project, and having reactive adapters for non-reactive types in the shared repository causes issues in the framework, because it makes an assumption that every reactive type is a type with a type parameter, and fails to figure out the type parameters of non-reactive types with reactive adapters. For instance, if we have an adapter for `String`, when Spring Data will try to create a repository with a method like this:
```
public Collection<String> findSometing(...);
```
it will fail with `Can't resolve required component type for java.lang.String`.

So this PR addresses the problem described above by providing a mechanism that allows to customize reactive type adapters only for Reactive Spring Transactions without affecting the shared `ReactiveAdapterRegistry`.
