### PR TITLE
Fix ClassCastException from return value validation with proxy when adaptConstraintViolations=true

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationInterceptor.java
@@ -174,7 +174,7 @@ public class MethodValidationInterceptor implements MethodInterceptor {
 		Object returnValue = invocation.proceed();
 
 		if (this.adaptViolations) {
-			this.validationAdapter.applyReturnValueValidation(target, method, null, arguments, groups);
+			this.validationAdapter.applyReturnValueValidation(target, method, null, returnValue, groups);
 		}
 		else {
 			violations = this.validationAdapter.invokeValidatorForReturnValue(target, method, returnValue, groups);


### PR DESCRIPTION
Fix argument in call to applyReturnValueValidation() method in MethodValidationInterceptor.java. Method argument was passed instead of the return value of the method that was being validated.

Closes gh-33092