### PR TITLE
 Fix ClassCastException from return value validation with proxy when adaptConstraintViolations=true

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationInterceptor.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationInterceptor.java
@@ -174,7 +174,7 @@ public class MethodValidationInterceptor implements MethodInterceptor {
 		Object returnValue = invocation.proceed();
 
 		if (this.adaptViolations) {
-			this.validationAdapter.applyReturnValueValidation(target, method, null, arguments, groups);
+			this.validationAdapter.applyReturnValueValidation(target, method, null, returnValue, groups);
 		}
 		else {
 			violations = this.validationAdapter.invokeValidatorForReturnValue(target, method, returnValue, groups);


### PR DESCRIPTION
Fixed method arguments of `applyReturnValueValidation` to be called with the return value, no the method arguments.
Added some tests with "adaptConstraintViolations=true" which also failed before the fix.

But I'm not into reactive programming, so I couln't figure out a way to do return value validation on Monos.