### PR TITLE
`LinkedCaseInsensitiveMap#getOrDefault` should return default value instead of null

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
+++ b/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
@@ -181,7 +181,9 @@ public class LinkedCaseInsensitiveMap<V> implements Map<String, V>, Serializable
 		if (key instanceof String string) {
 			String caseInsensitiveKey = this.caseInsensitiveKeys.get(convertKey(string));
 			if (caseInsensitiveKey != null) {
-				return this.targetMap.get(caseInsensitiveKey);
+				V v = this.targetMap.get(caseInsensitiveKey);
+				if (v != null)
+					return v;
 			}
 		}
 		return defaultValue;


### PR DESCRIPTION
This method directly calls the LinkedHashMap # get of the parent class, 
but after obtaining the value, it does not determine whether it is a null value