### PR TITLE
Add header-only constructor to create MessageHeaderAccessor

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
@@ -128,7 +128,7 @@ public class MessageHeaderAccessor {
 	 * A constructor to create new headers.
 	 */
 	public MessageHeaderAccessor() {
-		this(null);
+		this((Map<String, Object>) null);
 	}
 
 	/**
@@ -136,7 +136,15 @@ public class MessageHeaderAccessor {
 	 * @param message a message to copy the headers from, or {@code null} if none
 	 */
 	public MessageHeaderAccessor(@Nullable Message<?> message) {
-		this.headers = new MutableMessageHeaders(message != null ? message.getHeaders() : null);
+		this(message != null ? message.getHeaders() : null);
+	}
+
+	/**
+	 * A constructor accepting the headers of an existing headers map to copy.
+	 * @param headers a headers map to copy, or {@code null} if none
+	 */
+	public MessageHeaderAccessor(@Nullable Map<String, Object> headers) {
+		this.headers = new MutableMessageHeaders(headers);
 	}
 
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/support/MessageHeaderAccessorTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/support/MessageHeaderAccessorTests.java
@@ -24,6 +24,8 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.core.testfixture.io.SerializationTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
@@ -47,14 +49,16 @@ class MessageHeaderAccessorTests {
 		assertThat(accessor.toMap()).isEmpty();
 	}
 
-	@Test
-	void existingHeaders() {
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	void existingHeaders(boolean instantiateWithMessage) {
 		Map<String, Object> map = new HashMap<>();
 		map.put("foo", "bar");
 		map.put("bar", "baz");
-		GenericMessage<String> message = new GenericMessage<>("payload", map);
 
-		MessageHeaderAccessor accessor = new MessageHeaderAccessor(message);
+		MessageHeaderAccessor accessor = instantiateWithMessage ?
+				new MessageHeaderAccessor(new GenericMessage<>("payload", map)) :
+				new MessageHeaderAccessor(map);
 		MessageHeaders actual = accessor.getMessageHeaders();
 
 		assertThat(actual).hasSize(3);


### PR DESCRIPTION
Add a constructor that lets users create a `MessageHeaderAccessor` object given only a headers map.

This is a small optimization in high volume scenarios to avoid creating unnecessary `Message<?>` objects when you only have a headers map.

The specific use case I'm looking at, is being able to create a `MessageHeaderAccessor` object to process headers from a "consolidated headers" object (such as from the [Rabbit Binder](https://docs.spring.io/spring-cloud-stream/reference/rabbit/rabbit_overview/receiving-batch.html#consumer-side-batching) or [Solace Binder](https://github.com/SolaceProducts/solace-spring-cloud/tree/master/solace-spring-cloud-starters/solace-spring-cloud-stream-starter#batch-consumers)) created for a `Message<List<?>>` consumed from [Spring Cloud Stream's batched consumers](https://docs.spring.io/spring-cloud-stream/reference/spring-cloud-stream/producing-and-consuming-messages.html#batch-consumers).

e.g.: Being able to do something like this:

```java
@Bean
Consumer<Message<List<Payload>>> input() {
	return batchMsg -> {
		List<Payload> batchedPayloads = batchMsg.getPayload();
		List<Map<String, Object>> batchedHeaders = (List<Map<String, Object>>) batchMsg.getHeaders().get(SolaceBinderHeaders.BATCHED_HEADERS);

		for (int i = 0; i < batchedPayloads.size(); i++) {
			Map<String, Object> headersMap = batchedHeaders.get(i);
			MessageHeaderAccessor accessor = null;
			if (headersMap instanceof MessageHeaders headers) {
				accessor = MessageHeaderAccessor.getAccessor(headers, null);

			}
			if (accessor == null || || !headers.isMutable()) {
				accessor = new MessageHeaderAccessor(headersMap);
			}

			// Do some logic with the accessor
		}
	};
}
```

With the current implementation, instead of just being able to do:
```java
MessageHeaderAccessor accessor = new MessageHeaderAccessor(headersMap);
```

I would need to do this, which is pointless if the accessor's constructor will just extract the headers from the `Message<?>`:
```java
MessageHeaderAccessor accessor = new MessageHeaderAccessor(new GenericMessage<?>(payload, headersMap));
```