### PR TITLE
Fix adaptation of violations on Set method parameter

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationAdapter.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/MethodValidationAdapter.java
@@ -346,6 +346,10 @@ public class MethodValidationAdapter implements MethodValidator {
 					value = map.get(key);
 					container = map;
 				}
+				else if (arg instanceof Set<?>) {
+					value = arg;
+					container = null;
+				}
 				else if (arg instanceof Optional<?> optional) {
 					value = optional.orElse(null);
 					container = optional;


### PR DESCRIPTION
Since commit 8552e149b5faae31cab6c7d9d3f0f189904e4a8e, validation of Set values (for example `Set<@NotBlank String>`) crashes with error : No way to unwrap Iterable without index

With this fix we don't know which value exactly is the problem, but at least we have a working validation

Maybe there is a way to know exactly which value(s) are the culprit, but without an index I don't know how to find it. 

Or maybe there is a better way to fix the problem, I trust you'll do a thorough review and find it, I'm not that familiar with the codebase 😄 .

Thanks

This is the error without the fix : 
```
java.lang.IllegalStateException: No way to unwrap Iterable without index
	at org.springframework.util.Assert.state(Assert.java:78)
	at org.springframework.validation.beanvalidation.MethodValidationAdapter.adaptViolations(MethodValidationAdapter.java:358)
	at org.springframework.validation.beanvalidation.MethodValidationAdapter.validateArguments(MethodValidationAdapter.java:247)
	at org.springframework.validation.beanvalidation.MethodValidationAdapterTests.testArgs(MethodValidationAdapterTests.java:237)
	at org.springframework.validation.beanvalidation.MethodValidationAdapterTests.validateValueSetArgument(MethodValidationAdapterTests.java:223)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```