### PR TITLE
Refactor Test Assertions for Improved Bean Injection Handling

### DIFF
--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/BeanMethodQualificationTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/BeanMethodQualificationTests.java
@@ -102,12 +102,10 @@ class BeanMethodQualificationTests {
 		assertThat(pojo.testBean.getName()).isEqualTo("interesting");
 		assertThat(pojo.testBean2.getName()).isEqualTo("boring");
 		assertThat(pojo.testBean2.getSpouse().getName()).isEqualTo("interesting");
-		assertThat((List<Object>) pojo.testBean2.getPets()).contains(
-				ctx.getBean("testBean1x"), ctx.getBean("testBean2x"));  // array injection
-		assertThat((List<Object>) pojo.testBean2.getSomeList()).contains(
-				ctx.getBean("testBean1x"), ctx.getBean("testBean2x"));  // list injection
-		assertThat((Map<String, TestBean>) pojo.testBean2.getSomeMap()).containsKeys(
-				"testBean1x", "testBean2x");  // map injection
+		List<?> otherBeans = List.of(ctx.getBean("testBean1"), ctx.getBean("testBean1x"), ctx.getBean("testBean2x"));
+		assertThat((List<Object>) pojo.testBean2.getPets()).containsAll(otherBeans);  // array injection
+		assertThat((List<Object>) pojo.testBean2.getSomeList()).containsAll(otherBeans);  // list injection
+		assertThat((Map<String, TestBean>) pojo.testBean2.getSomeMap()).containsOnlyKeys("testBean1", "testBean1x", "testBean2x");  // map injection
 
 		ConstructorPojo pojo2 = ctx.getBean(ConstructorPojo.class);
 		assertThat(pojo2.testBean).isSameAs(pojo.testBean);


### PR DESCRIPTION
### Overview
This PR refactors the existing test assertions related to bean injections in the codebase. The changes focus on enhancing readability and ensuring completeness of the assertions.

### Changes Made

   - Updated assertions to verify all expected beans (`testBean1`, `testBean1x`, `testBean2x`) are present where applicable (`getPets`, `getSomeList`, `getSomeMap`).
   - Used `containsAll` to ensure all expected beans are included in the lists (`getPets`, `getSomeList`).
   - Employed `containsOnlyKeys` to validate that the map (`getSomeMap`) contains exact keys without additional entries.

