### PR TITLE
Trim last allowed origin when parsing comma-delimited string

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -282,7 +282,7 @@ public class CorsConfiguration {
 			}
 		}
 		if (start < rawValue.length()) {
-			valueConsumer.accept(rawValue.substring(start));
+			valueConsumer.accept(rawValue.substring(start).trim());
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/cors/CorsConfigurationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/cors/CorsConfigurationTests.java
@@ -305,6 +305,11 @@ class CorsConfigurationTests {
 		assertThat(config.checkOrigin("https://a1.com")).isEqualTo("https://a1.com");
 		assertThat(config.checkOrigin("https://a2.com/")).isEqualTo("https://a2.com/");
 
+		// comma-delimited origins list with space
+		config.setAllowedOrigins(Collections.singletonList("https://a1.com, https://a2.com"));
+		assertThat(config.checkOrigin("https://a1.com")).isEqualTo("https://a1.com");
+		assertThat(config.checkOrigin("https://a2.com/")).isEqualTo("https://a2.com/");
+
 		// specific origin matches Origin header with or without trailing "/"
 		config.setAllowedOrigins(Collections.singletonList("https://domain.com"));
 		assertThat(config.checkOrigin("https://domain.com")).isEqualTo("https://domain.com");


### PR DESCRIPTION
Issue
checkOriginAllowed test pass comma-delimited origins list but comma-delimited origins list with space cannot

Resolution
comma-delimited origins last element need to trim