### PR TITLE
Upgrade to Gradle 8.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
[Gradle 8.8 crashed on MacOS 11.x (8.7 still works as expected) · Issue #29476 · gradle/gradle](https://github.com/gradle/gradle/issues/29476), 

and Gradle 8.9 fix the bug, [Disable file-system watching on macOS 11 and before by lptr · Pull Request #29514 · gradle/gradle](https://github.com/gradle/gradle/pull/29514).