### PR TITLE
Allow formatting of Collection values for `@RequestParam` with HTTP interface client

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/service/invoker/RequestParamArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/RequestParamArgumentResolver.java
@@ -55,11 +55,11 @@ import org.springframework.web.bind.annotation.RequestParam;
  */
 public class RequestParamArgumentResolver extends AbstractNamedValueArgumentResolver {
 
-	private boolean formatAsSingleValue;
+	private boolean formatAsSingleValue = true;
+
 
 	public RequestParamArgumentResolver(ConversionService conversionService) {
 		super(conversionService);
-		this.formatAsSingleValue = true;
 	}
 
 	public RequestParamArgumentResolver(ConversionService conversionService, boolean formatAsSingleValue) {
@@ -67,13 +67,6 @@ public class RequestParamArgumentResolver extends AbstractNamedValueArgumentReso
 		this.formatAsSingleValue = formatAsSingleValue;
 	}
 
-	protected boolean isFormatAsSingleValue() {
-		return this.formatAsSingleValue;
-	}
-
-	protected void setFormatAsSingleValue(boolean formatAsSingleValue) {
-		this.formatAsSingleValue = formatAsSingleValue;
-	}
 
 	@Override
 	@Nullable
@@ -104,6 +97,14 @@ public class RequestParamArgumentResolver extends AbstractNamedValueArgumentReso
 			String name, Object value, MethodParameter parameter, HttpRequestValues.Builder requestValues) {
 
 		requestValues.addRequestParameter(name, (String) value);
+	}
+
+	protected boolean isFormatAsSingleValue() {
+		return this.formatAsSingleValue;
+	}
+
+	protected void setFormatAsSingleValue(boolean formatAsSingleValue) {
+		this.formatAsSingleValue = formatAsSingleValue;
 	}
 
 	protected boolean isMultiValueFormContentType(MediaType contentType) {

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/RequestParamArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/RequestParamArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class RequestParamArgumentResolver extends AbstractNamedValueArgumentReso
 	}
 
 	protected boolean isFormatAsSingleValue() {
-		return formatAsSingleValue;
+		return this.formatAsSingleValue;
 	}
 
 	protected void setFormatAsSingleValue(boolean formatAsSingleValue) {
@@ -80,7 +80,7 @@ public class RequestParamArgumentResolver extends AbstractNamedValueArgumentReso
 	protected NamedValueInfo createNamedValueInfo(MethodParameter parameter, HttpRequestValues.Metadata requestValues) {
 		MediaType contentType = requestValues.getContentType();
 		if (contentType != null && isMultiValueFormContentType(contentType)) {
-			formatAsSingleValue = true;
+			this.formatAsSingleValue = true;
 		}
 
 		return createNamedValueInfo(parameter);
@@ -95,7 +95,8 @@ public class RequestParamArgumentResolver extends AbstractNamedValueArgumentReso
 		}
 
 		return (annot == null ? null :
-				new NamedValueInfo(annot.name(), annot.required(), annot.defaultValue(), "request parameter", formatAsSingleValue));
+				new NamedValueInfo(annot.name(), annot.required(), annot.defaultValue(),
+						"request parameter", this.formatAsSingleValue));
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/web/service/invoker/RequestParamArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/invoker/RequestParamArgumentResolverTests.java
@@ -47,6 +47,7 @@ class RequestParamArgumentResolverTests {
 
 	private final HttpServiceProxyFactory.Builder builder = HttpServiceProxyFactory.builderFor(this.client);
 
+
 	@Test
 	@SuppressWarnings("unchecked")
 	void requestParam() {

--- a/spring-web/src/test/java/org/springframework/web/service/invoker/RequestParamArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/invoker/RequestParamArgumentResolverTests.java
@@ -16,16 +16,17 @@
 
 package org.springframework.web.service.invoker;
 
+import java.util.HashMap;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
+
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.PostExchange;
-
-import java.util.HashMap;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,6 +61,7 @@ class RequestParamArgumentResolverTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	void requestParamWithDisabledFormattingCollectionValue() {
 		ConversionService conversionService = new DefaultConversionService();
 		boolean formatAsSingleValue = false;
@@ -71,8 +73,7 @@ class RequestParamArgumentResolverTests {
 		service.getForm("value 1", collectionParams);
 
 		Object uriVariables = this.client.getRequestValues().getUriVariables();
-		assertThat(uriVariables).isNotInstanceOf(MultiValueMap.class)
-				.isInstanceOf(HashMap.class);
+		assertThat(uriVariables).isNotInstanceOf(MultiValueMap.class).isInstanceOf(HashMap.class);
 		assertThat((HashMap<String, String>) uriVariables).hasSize(4)
 				.containsEntry("queryParam0", "param1")
 				.containsEntry("queryParam0[0]", "value 1")

--- a/spring-web/src/test/java/org/springframework/web/service/invoker/RequestParamArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/invoker/RequestParamArgumentResolverTests.java
@@ -16,13 +16,15 @@
 
 package org.springframework.web.service.invoker;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
-
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.service.annotation.PostExchange;
+import org.springframework.web.service.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,12 +59,155 @@ class RequestParamArgumentResolverTests {
 				.containsEntry("param2", List.of("value 2"));
 	}
 
+	@Test
+	void requestParam2() {
+		ConversionService conversionService = new DefaultConversionService();
+		boolean formatAsSingleValue = false;
+		Service service =
+				HttpServiceProxyFactory.builderFor(this.client)
+						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
+						.build().createClient(Service.class);
+		List<String> collectionParams = List.of("1", "2", "3");
+		service.getForm("value 1", collectionParams);
+
+		Object uriVariables = this.client.getRequestValues().getUriVariables();
+		assertThat(uriVariables).isNotInstanceOf(MultiValueMap.class)
+				.isInstanceOf(HashMap.class);
+		assertThat((HashMap<String, String>) uriVariables).hasSize(4)
+				.containsEntry("queryParam0", "param1")
+				.containsEntry("queryParam0[0]", "value 1")
+				.containsEntry("queryParam1", "param2")
+				.containsEntry("queryParam1[0]", String.join(",", collectionParams));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void requestParam3() {
+		ConversionService conversionService = new DefaultConversionService();
+		boolean formatAsSingleValue = false;
+		Service service =
+				HttpServiceProxyFactory.builderFor(this.client)
+						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
+						.build().createClient(Service.class);
+		List<String> collectionParams = List.of("1", "2", "3");
+		service.putForm("value 1", collectionParams);
+
+		Object body = this.client.getRequestValues().getBodyValue();
+		assertThat(body).isInstanceOf(MultiValueMap.class);
+		assertThat((MultiValueMap<String, String>) body).hasSize(2)
+				.containsEntry("param1", List.of("value 1"))
+				.containsEntry("param2", collectionParams);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void requestParam4() {
+		ConversionService conversionService = new DefaultConversionService();
+		boolean formatAsSingleValue = false;
+		Service service =
+				HttpServiceProxyFactory.builderFor(this.client)
+						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
+						.build().createClient(Service.class);
+		List<String> collectionParams = List.of("1", "2", "3");
+		service.deleteForm("value 1", collectionParams);
+
+		Object body = this.client.getRequestValues().getBodyValue();
+		assertThat(body).isInstanceOf(MultiValueMap.class);
+		assertThat((MultiValueMap<String, String>) body).hasSize(2)
+				.containsEntry("param1", List.of("value 1"))
+				.containsEntry("param2", collectionParams);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void requestParam5() {
+		ConversionService conversionService = new DefaultConversionService();
+		boolean formatAsSingleValue = false;
+		Service service =
+				HttpServiceProxyFactory.builderFor(this.client)
+						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
+						.build().createClient(Service.class);
+		List<String> collectionParams = List.of("1", "2", "3");
+		service.patchForm("value 1", collectionParams);
+
+		Object body = this.client.getRequestValues().getBodyValue();
+		assertThat(body).isInstanceOf(MultiValueMap.class);
+		assertThat((MultiValueMap<String, String>) body).hasSize(2)
+				.containsEntry("param1", List.of("value 1"))
+				.containsEntry("param2", collectionParams);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void requestParam6() {
+		ConversionService conversionService = new DefaultConversionService();
+		boolean formatAsSingleValue = false;
+		Service2 service =
+				HttpServiceProxyFactory.builderFor(this.client)
+						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
+						.build().createClient(Service2.class);
+		List<String> collectionParams = List.of("1", "2", "3");
+		service.getForm("value 1", collectionParams);
+
+		Object body = this.client.getRequestValues().getBodyValue();
+		assertThat(body).isInstanceOf(MultiValueMap.class);
+		assertThat((MultiValueMap<String, String>) body).hasSize(2)
+				.containsEntry("param1", List.of("value 1"))
+				.containsEntry("param2", collectionParams);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void requestParam7() {
+		ConversionService conversionService = new DefaultConversionService();
+		boolean formatAsSingleValue = false;
+		Service3 service =
+				HttpServiceProxyFactory.builderFor(this.client)
+						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
+						.build().createClient(Service3.class);
+		List<String> collectionParams = List.of("1", "2", "3");
+		service.getForm("value 1", collectionParams);
+
+		Object uriVariables = this.client.getRequestValues().getUriVariables();
+		assertThat(uriVariables).isNotInstanceOf(MultiValueMap.class)
+				.isInstanceOf(HashMap.class);
+		assertThat((HashMap<String, String>) uriVariables).hasSize(4)
+				.containsEntry("queryParam0", "param1")
+				.containsEntry("queryParam0[0]", "value 1")
+				.containsEntry("queryParam1", "param2")
+				.containsEntry("queryParam1[0]", String.join(",", collectionParams));
+	}
+
 
 	private interface Service {
 
 		@PostExchange(contentType = "application/x-www-form-urlencoded")
 		void postForm(@RequestParam String param1, @RequestParam String param2);
 
+		@GetExchange
+		void getForm(@RequestParam String param1, @RequestParam List<String> param2);
+
+		@PutExchange(contentType = "application/x-www-form-urlencoded")
+		void putForm(@RequestParam String param1, @RequestParam List<String> param2);
+
+		@PutExchange(contentType = "application/x-www-form-urlencoded")
+		void deleteForm(@RequestParam String param1, @RequestParam List<String> param2);
+
+		@PatchExchange(contentType = "application/x-www-form-urlencoded")
+		void patchForm(@RequestParam String param1, @RequestParam List<String> param2);
 	}
 
+	@HttpExchange(contentType = "application/x-www-form-urlencoded")
+	private interface Service2 {
+
+		@GetExchange
+		void getForm(@RequestParam String param1, @RequestParam List<String> param2);
+	}
+
+	@HttpExchange
+	private interface Service3 {
+
+		@GetExchange
+		void getForm(@RequestParam String param1, @RequestParam List<String> param2);
+	}
 }

--- a/spring-web/src/test/java/org/springframework/web/service/invoker/RequestParamArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/invoker/RequestParamArgumentResolverTests.java
@@ -21,7 +21,8 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.service.annotation.*;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
 
 import java.util.HashMap;
 import java.util.List;
@@ -43,14 +44,13 @@ class RequestParamArgumentResolverTests {
 
 	private final TestExchangeAdapter client = new TestExchangeAdapter();
 
-	private final Service service =
-			HttpServiceProxyFactory.builderFor(this.client).build().createClient(Service.class);
-
+	private final HttpServiceProxyFactory.Builder builder = HttpServiceProxyFactory.builderFor(this.client);
 
 	@Test
 	@SuppressWarnings("unchecked")
 	void requestParam() {
-		this.service.postForm("value 1", "value 2");
+		Service service = builder.build().createClient(Service.class);
+		service.postForm("value 1", "value 2");
 
 		Object body = this.client.getRequestValues().getBodyValue();
 		assertThat(body).isInstanceOf(MultiValueMap.class);
@@ -60,13 +60,13 @@ class RequestParamArgumentResolverTests {
 	}
 
 	@Test
-	void requestParam2() {
+	void requestParamWithDisabledFormattingCollectionValue() {
 		ConversionService conversionService = new DefaultConversionService();
 		boolean formatAsSingleValue = false;
-		Service service =
-				HttpServiceProxyFactory.builderFor(this.client)
-						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
-						.build().createClient(Service.class);
+		Service service = builder.customArgumentResolver(
+						new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
+				.build()
+				.createClient(Service.class);
 		List<String> collectionParams = List.of("1", "2", "3");
 		service.getForm("value 1", collectionParams);
 
@@ -79,105 +79,6 @@ class RequestParamArgumentResolverTests {
 				.containsEntry("queryParam1", "param2")
 				.containsEntry("queryParam1[0]", String.join(",", collectionParams));
 	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	void requestParam3() {
-		ConversionService conversionService = new DefaultConversionService();
-		boolean formatAsSingleValue = false;
-		Service service =
-				HttpServiceProxyFactory.builderFor(this.client)
-						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
-						.build().createClient(Service.class);
-		List<String> collectionParams = List.of("1", "2", "3");
-		service.putForm("value 1", collectionParams);
-
-		Object body = this.client.getRequestValues().getBodyValue();
-		assertThat(body).isInstanceOf(MultiValueMap.class);
-		assertThat((MultiValueMap<String, String>) body).hasSize(2)
-				.containsEntry("param1", List.of("value 1"))
-				.containsEntry("param2", collectionParams);
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	void requestParam4() {
-		ConversionService conversionService = new DefaultConversionService();
-		boolean formatAsSingleValue = false;
-		Service service =
-				HttpServiceProxyFactory.builderFor(this.client)
-						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
-						.build().createClient(Service.class);
-		List<String> collectionParams = List.of("1", "2", "3");
-		service.deleteForm("value 1", collectionParams);
-
-		Object body = this.client.getRequestValues().getBodyValue();
-		assertThat(body).isInstanceOf(MultiValueMap.class);
-		assertThat((MultiValueMap<String, String>) body).hasSize(2)
-				.containsEntry("param1", List.of("value 1"))
-				.containsEntry("param2", collectionParams);
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	void requestParam5() {
-		ConversionService conversionService = new DefaultConversionService();
-		boolean formatAsSingleValue = false;
-		Service service =
-				HttpServiceProxyFactory.builderFor(this.client)
-						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
-						.build().createClient(Service.class);
-		List<String> collectionParams = List.of("1", "2", "3");
-		service.patchForm("value 1", collectionParams);
-
-		Object body = this.client.getRequestValues().getBodyValue();
-		assertThat(body).isInstanceOf(MultiValueMap.class);
-		assertThat((MultiValueMap<String, String>) body).hasSize(2)
-				.containsEntry("param1", List.of("value 1"))
-				.containsEntry("param2", collectionParams);
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	void requestParam6() {
-		ConversionService conversionService = new DefaultConversionService();
-		boolean formatAsSingleValue = false;
-		Service2 service =
-				HttpServiceProxyFactory.builderFor(this.client)
-						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
-						.build().createClient(Service2.class);
-		List<String> collectionParams = List.of("1", "2", "3");
-		service.getForm("value 1", collectionParams);
-
-		Object body = this.client.getRequestValues().getBodyValue();
-		assertThat(body).isInstanceOf(MultiValueMap.class);
-		assertThat((MultiValueMap<String, String>) body).hasSize(2)
-				.containsEntry("param1", List.of("value 1"))
-				.containsEntry("param2", collectionParams);
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	void requestParam7() {
-		ConversionService conversionService = new DefaultConversionService();
-		boolean formatAsSingleValue = false;
-		Service3 service =
-				HttpServiceProxyFactory.builderFor(this.client)
-						.customArgumentResolver(new RequestParamArgumentResolver(conversionService, formatAsSingleValue))
-						.build().createClient(Service3.class);
-		List<String> collectionParams = List.of("1", "2", "3");
-		service.getForm("value 1", collectionParams);
-
-		Object uriVariables = this.client.getRequestValues().getUriVariables();
-		assertThat(uriVariables).isNotInstanceOf(MultiValueMap.class)
-				.isInstanceOf(HashMap.class);
-		assertThat((HashMap<String, String>) uriVariables).hasSize(4)
-				.containsEntry("queryParam0", "param1")
-				.containsEntry("queryParam0[0]", "value 1")
-				.containsEntry("queryParam1", "param2")
-				.containsEntry("queryParam1[0]", String.join(",", collectionParams));
-	}
-
 
 	private interface Service {
 
@@ -186,28 +87,6 @@ class RequestParamArgumentResolverTests {
 
 		@GetExchange
 		void getForm(@RequestParam String param1, @RequestParam List<String> param2);
-
-		@PutExchange(contentType = "application/x-www-form-urlencoded")
-		void putForm(@RequestParam String param1, @RequestParam List<String> param2);
-
-		@PutExchange(contentType = "application/x-www-form-urlencoded")
-		void deleteForm(@RequestParam String param1, @RequestParam List<String> param2);
-
-		@PatchExchange(contentType = "application/x-www-form-urlencoded")
-		void patchForm(@RequestParam String param1, @RequestParam List<String> param2);
 	}
 
-	@HttpExchange(contentType = "application/x-www-form-urlencoded")
-	private interface Service2 {
-
-		@GetExchange
-		void getForm(@RequestParam String param1, @RequestParam List<String> param2);
-	}
-
-	@HttpExchange
-	private interface Service3 {
-
-		@GetExchange
-		void getForm(@RequestParam String param1, @RequestParam List<String> param2);
-	}
 }


### PR DESCRIPTION
## Motivation:

Make it possible to format `Collection`, `@RequestParam` arguments to a single String value. On the server side, the `ConversionService` parses a String value to the target method parameter type. On the client side, the reverse could be done to format the `MethodParameter` to a String. 

See original request and discussion under #33154.

## Modifications:

Add customization for handling collection types to `RequestParamArgumentResolver`

## Additional info:

- I plan to polish the code after checking with the maintainer to make sure I'm working in the direction I intended.
- If we have a way to format it according to the checkstyle rules, please let me know 🙏 
