### PR TITLE
Update to OpenPDF 2.0.2

### DIFF
--- a/framework-platform/framework-platform.gradle
+++ b/framework-platform/framework-platform.gradle
@@ -27,7 +27,7 @@ dependencies {
 		api("com.fasterxml:aalto-xml:1.3.2")
 		api("com.fasterxml.woodstox:woodstox-core:6.6.2")
 		api("com.github.ben-manes.caffeine:caffeine:3.1.8")
-		api("com.github.librepdf:openpdf:1.3.43")
+		api("com.github.librepdf:openpdf:2.0.2")
 		api("com.google.code.findbugs:findbugs:3.0.1")
 		api("com.google.code.findbugs:jsr305:3.0.2")
 		api("com.google.code.gson:gson:2.10.1")


### PR DESCRIPTION
Update to OpenPDF 2.0.2. 

Release notes: https://github.com/LibrePDF/OpenPDF/releases/tag/2.0.2