### PR TITLE
Add missing Javadoc since in AbstractUrlHandlerMapping

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
@@ -208,6 +208,7 @@ public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping i
 	/**
 	 * Remove the mapping for the handler registered for the given URL path.
 	 * @param urlPath the mapping to remove
+	 * @since 6.2
 	 */
 	public void unregisterHandler(String urlPath) {
 		Assert.notNull(urlPath, "URL path must not be null");


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `AbstractUrlHandlerMapping.unregisterHandler()`.

See gh-32064