### PR TITLE
Include query parameters in MockHttpServletRequest

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/HtmlUnitRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/HtmlUnitRequestBuilder.java
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpSession;
 import org.htmlunit.FormEncodingType;
 import org.htmlunit.WebClient;
 import org.htmlunit.WebRequest;
+import org.htmlunit.http.HttpUtils;
 import org.htmlunit.util.KeyDataPair;
 import org.htmlunit.util.NameValuePair;
 
@@ -364,6 +365,13 @@ final class HtmlUnitRequestBuilder implements RequestBuilder, Mergeable {
 	}
 
 	private void params(MockHttpServletRequest request) {
+		if (this.webRequest.getEncodingType() == FormEncodingType.URL_ENCODED && "POST".equals(request.getMethod())) {
+			List<NameValuePair> params = HttpUtils.parseUrlQuery(
+					this.webRequest.getUrl().getQuery(), this.webRequest.getCharset());
+			for (NameValuePair param : params) {
+				request.addParameter(param.getName(), (param.getValue() != null ? param.getValue() : ""));
+			}
+		}
 		for (NameValuePair param : this.webRequest.getParameters()) {
 			addRequestParameter(request, param);
 		}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/HtmlUnitRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/HtmlUnitRequestBuilderTests.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -33,6 +34,7 @@ import org.htmlunit.FormEncodingType;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebClient;
 import org.htmlunit.WebRequest;
+import org.htmlunit.util.NameValuePair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -149,6 +151,23 @@ public class HtmlUnitRequestBuilderTests {
 
 		assertThat(actualRequest.getContentType()).isEqualTo(contentType);
 		assertThat(actualRequest.getHeader("Content-Type")).isEqualTo(contentType);
+	}
+
+	@Test
+	void buildRequestParameterMapFromMultipleQueryParamsAndRequestParameters() throws Exception {
+		webRequest.setHttpMethod(HttpMethod.POST);
+		webRequest.setUrl(new URL("https://example.com/example/?param1=value1&param2=value2"));
+		webRequest.setRequestParameters(List.of(
+				new NameValuePair("param3", "value3"),
+				new NameValuePair("param4", "value4")));
+
+		MockHttpServletRequest actualRequest = requestBuilder.buildRequest(servletContext);
+
+		assertThat(actualRequest.getParameterMap()).hasSize(4);
+		assertThat(actualRequest.getParameter("param1")).isEqualTo("value1");
+		assertThat(actualRequest.getParameter("param2")).isEqualTo("value2");
+		assertThat(actualRequest.getParameter("param3")).isEqualTo("value3");
+		assertThat(actualRequest.getParameter("param4")).isEqualTo("value4");
 	}
 
 	@Test  // SPR-14916


### PR DESCRIPTION
WebRequest.getParameters() contains parameters from the request body.
We need to insert the query string parameters ourselves.
Parsing logic for the query mirrors WebRequest GET request approach.
Unfortunately the WebRequest.normalize method isn't public
and NameValuePair.normalized is marked as subject to change.
That means we'll need to deal with potential null values ourselves.
We fall back to an empty string to emulate the normalized behavior.

Closes gh-33249