### PR TITLE
Jaxb2XmlEncoder does not support JAXBElement subtypes

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/xml/Jaxb2XmlEncoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/xml/Jaxb2XmlEncoder.java
@@ -93,7 +93,7 @@ public class Jaxb2XmlEncoder extends AbstractSingleValueEncoder<Object> {
 			Class<?> outputClass = elementType.toClass();
 			return (outputClass.isAnnotationPresent(XmlRootElement.class) ||
 					outputClass.isAnnotationPresent(XmlType.class) ||
-					elementType.isAssignableFrom(JAXBElement.class));
+					JAXBElement.class.isAssignableFrom(outputClass));
 		}
 		else {
 			return false;

--- a/spring-web/src/test/java/org/springframework/http/codec/xml/Jaxb2XmlEncoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/xml/Jaxb2XmlEncoderTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.http.codec.xml;
 
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -64,6 +65,7 @@ class Jaxb2XmlEncoderTests extends AbstractEncoderTests<Jaxb2XmlEncoder> {
 		assertThat(this.encoder.canEncode(forClass(getClass()), MediaType.APPLICATION_XML)).isFalse();
 
 		assertThat(this.encoder.canEncode(forClass(JAXBElement.class), MediaType.APPLICATION_XML)).isTrue();
+		assertThat(this.encoder.canEncode(forClass(JAXBElementSubclass.class), MediaType.APPLICATION_XML)).isTrue();
 
 		// SPR-15464
 		assertThat(this.encoder.canEncode(ResolvableType.NONE, null)).isFalse();
@@ -120,6 +122,16 @@ class Jaxb2XmlEncoderTests extends AbstractEncoderTests<Jaxb2XmlEncoder> {
 			String actual = new String(resultBytes, UTF_8);
 			assertThat(XmlContent.from(actual)).isSimilarTo(expected);
 		};
+	}
+
+	public static class JAXBElementSubclass extends JAXBElement<Pojo>{
+		@Serial
+		private static final long serialVersionUID = 1L;
+
+		protected final static QName NAME = new QName("http://foo/schema/common/1.0", "Pojo");
+		public JAXBElementSubclass() {
+			super(NAME, Pojo.class, null, null);
+		}
 	}
 
 	public static class Model {}


### PR DESCRIPTION
# Overview
This PR provides the ability to serialize a JAXBElement using the Jaxb2XmlEncoder by updating canEncode() accordingly.

It is fix this [`Pull Request`](https://github.com/spring-projects/spring-framework/pull/32977)


[Here](https://github.com/spring-projects/spring-framework/blob/a4c2f291d986ccf988f37af5466265a7f534c16a/spring-oxm/src/main/java/org/springframework/oxm/jaxb/Jaxb2Marshaller.java#L632) you can find similar example of usage
