### PR TITLE
Fix error on Jaxb2RootElementHttpMessageConverter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/xml/Jaxb2RootElementHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/xml/Jaxb2RootElementHttpMessageConverter.java
@@ -121,7 +121,7 @@ public class Jaxb2RootElementHttpMessageConverter extends AbstractJaxb2HttpMessa
 
 	@Override
 	public boolean canWrite(Class<?> clazz, @Nullable MediaType mediaType) {
-		boolean supportedType = (JAXBElement.class.isAssignableFrom(clazz) ||
+		boolean supportedType = (clazz.isAssignableFrom(JAXBElement.class) ||
 				AnnotationUtils.findAnnotation(clazz, XmlRootElement.class) != null);
 		return (supportedType && canWrite(mediaType));
 	}


### PR DESCRIPTION
Can encode can now support child class of JAXBElement

fix issue on https://github.com/spring-projects/spring-framework/pull/32977

See comment  https://github.com/spring-projects/spring-framework/pull/32977#issuecomment-2243482641