### PR TITLE
Code sample has wrong reference to configurePathMatching

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webflux/config.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/config.adoc
@@ -679,7 +679,7 @@ Java::
 	public class WebConfig implements WebFluxConfigurer {
 
 		@Override
-		public void configurePathMatch(PathMatchConfigurer configurer) {
+		public void configurePathMatching(PathMatchConfigurer configurer) {
 			configurer.addPathPrefix(
 					"/api", HandlerTypePredicate.forAnnotation(RestController.class));
 		}
@@ -694,7 +694,7 @@ Kotlin::
 	class WebConfig : WebFluxConfigurer {
 
 		@Override
-		fun configurePathMatch(configurer: PathMatchConfigurer) {
+		fun configurePathMatching(configurer: PathMatchConfigurer) {
 			configurer.addPathPrefix(
 					"/api", HandlerTypePredicate.forAnnotation(RestController::class.java))
 		}


### PR DESCRIPTION
In interface WebFluxConfigurer, the method to path matching is "configurePathMatching", NOT "configurePathMatch". Detail is in https://github.com/spring-projects/spring-framework/blob/main/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurer.java#L129