### PR TITLE
Added TextEventStreamType check before response caching

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/ContentCachingResponseWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ContentCachingResponseWrapper.java
@@ -32,6 +32,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
 import org.springframework.util.FastByteArrayOutputStream;
 
@@ -295,7 +296,9 @@ public class ContentCachingResponseWrapper extends HttpServletResponseWrapper {
 			HttpServletResponse rawResponse = (HttpServletResponse) getResponse();
 			if (!rawResponse.isCommitted()) {
 				if (complete || this.contentLength != null) {
-					if (rawResponse.getHeader(HttpHeaders.TRANSFER_ENCODING) == null) {
+					String contentType = rawResponse.getContentType();
+					boolean isTextEventStreamType = MediaType.TEXT_EVENT_STREAM_VALUE.equals(contentType);
+					if (rawResponse.getHeader(HttpHeaders.TRANSFER_ENCODING) == null && !isTextEventStreamType) {
 						rawResponse.setContentLength(complete ? this.content.size() : this.contentLength);
 					}
 					this.contentLength = null;

--- a/spring-web/src/test/java/org/springframework/web/filter/ContentCachingResponseWrapperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/ContentCachingResponseWrapperTests.java
@@ -270,6 +270,22 @@ class ContentCachingResponseWrapperTests {
 				.withMessageContaining(overflow);
 	}
 
+	@Test
+	void copyBodyToResponseWithTextEventStream() throws Exception{
+		byte[] responseBody = "3\r\nSse 4\r\nMessage0\r\n\r\n".getBytes(UTF_8);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+		responseWrapper.setStatus(HttpServletResponse.SC_CREATED);
+		responseWrapper.setContentType("text/event-stream");
+		FileCopyUtils.copy(responseBody, responseWrapper.getOutputStream());
+		responseWrapper.copyBodyToResponse();
+
+		assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_CREATED);
+		assertHeader(response, CONTENT_LENGTH, null);
+		assertThat(response.getContentAsByteArray()).isEqualTo(responseBody);
+	}
+
 
 	private void assertHeader(HttpServletResponse response, String header, int value) {
 		assertHeader(response, header, Integer.toString(value));


### PR DESCRIPTION
When using SSE (Server-Sent Events) technology in Spring, the response typically includes a Chunked header and the text/event-stream content type.

An issue arises when response caching occurs before the Chunked header is assigned, resulting in the content-length being set. In HTTP, if a response has both the Chunked type and a set content-length, it does not function as intended in chunked mode.

This change ensures that even if caching occurs before the Chunked header is assigned, the content-length is not set, allowing for proper functionality.