### PR TITLE
Feature: Support primitive array to Object[] conversion.

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/ArrayToArrayConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/ArrayToArrayConverter.java
@@ -64,13 +64,27 @@ final class ArrayToArrayConverter implements ConditionalGenericConverter {
 	public Object convert(@Nullable Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
 		if (this.conversionService instanceof GenericConversionService genericConversionService) {
 			TypeDescriptor targetElement = targetType.getElementTypeDescriptor();
-			if (targetElement != null && genericConversionService.canBypassConvert(
-					sourceType.getElementTypeDescriptor(), targetElement)) {
-				return source;
+			if (targetElement != null) {
+				TypeDescriptor sourceElement = sourceType.getElementTypeDescriptor();
+				if (genericConversionService.canBypassConvert(sourceElement, targetElement) && canBypassArrayConvert(sourceElement, targetElement)) {
+					return source;
+				}
 			}
 		}
 		List<Object> sourceList = Arrays.asList(ObjectUtils.toObjectArray(source));
 		return this.helperConverter.convert(sourceList, sourceType, targetType);
+	}
+
+	private static boolean canBypassArrayConvert(@Nullable TypeDescriptor sourceElement, TypeDescriptor targetElement) {
+		if (sourceElement == null) {
+			return true;
+		}
+
+		if(sourceElement.isPrimitive() && targetElement.isPrimitive()) {
+			return sourceElement.getObjectType() == targetElement.getObjectType();
+		}
+
+		return !sourceElement.isPrimitive() && !targetElement.isPrimitive();
 	}
 
 }

--- a/spring-core/src/test/java/org/springframework/core/convert/converter/DefaultConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/converter/DefaultConversionServiceTests.java
@@ -43,7 +43,6 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.MethodParameter;
@@ -635,12 +634,17 @@ class DefaultConversionServiceTests {
 	}
 
 	@Test
+	void convertIntegerArrayToObjectArray() {
+		Object[] result = conversionService.convert(new Integer[] {1, 2, 3}, Object[].class);
+		assertThat(result).containsExactly(1, 2, 3);
+	}
+
+	@Test
 	void convertObjectArrayToIntArray() {
 		int[] result = conversionService.convert(new Object[] {1, 2, 3}, int[].class);
 		assertThat(result).containsExactly(1, 2, 3);
 	}
 
-	@Disabled("Primitive array to Object[] conversion is not currently supported")
 	@Test
 	void convertIntArrayToObjectArray() {
 		Object[] result = conversionService.convert(new int[] {1, 2}, Object[].class);


### PR DESCRIPTION
This commit fixes issue #33212.  

## Context: 
Previously, attempting to convert a primitive array to an Object array caused a java.lang.ClassCastException.  

This happened because the check to bypass array conversion only checked if the types of the array elements were convertible.  This is not sufficient to determine if two arrays are convertible, because—while an int can be cast to an Integer—an int[] cannot be cast to an Integer[].  

## Solution
This commit fixes the issue by only bypassing conversion for arrays if one of the following conditions is true:
- the source and target array elements have the same primitive type
- the source and target array elements have non-primitive types

## Comments
This is my first contribution so please feel free to make suggestions.  I moved the boolean logic into a separate function to improve code clarity, but I'm happy to inline the logic to improve performance.