### PR TITLE
`JdbcClient` should be exposed `JdbcTemplate`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/DefaultJdbcClient.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/DefaultJdbcClient.java
@@ -83,6 +83,25 @@ final class DefaultJdbcClient implements JdbcClient {
 		this.namedParamOps = jdbcTemplate;
 	}
 
+	/**
+	 * Expose the classic Spring JdbcTemplate to allow invocation of
+	 * classic JDBC operations.
+	 */
+	@Override
+	public JdbcOperations getJdbcOperations() {
+		return this.classicOps;
+	}
+
+	/**
+	 * Expose the classic Spring {@link JdbcTemplate} itself, if available,
+	 * in particular for passing it on to other {@code JdbcTemplate} consumers.
+	 * <p>If sufficient for the purposes at hand, {@link #getJdbcOperations()}
+	 * is recommended over this variant.
+	 */
+	public JdbcTemplate getJdbcTemplate() {
+		Assert.state(this.classicOps instanceof JdbcTemplate, "No JdbcTemplate available");
+		return (JdbcTemplate) this.classicOps;
+	}
 
 	@Override
 	public StatementSpec sql(String sql) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/JdbcClient.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/JdbcClient.java
@@ -28,6 +28,7 @@ import javax.sql.DataSource;
 
 import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.RowMapper;
@@ -76,6 +77,19 @@ public interface JdbcClient {
 	 */
 	StatementSpec sql(String sql);
 
+	/**
+	 * Expose the classic Spring JdbcTemplate to allow invocation of
+	 * classic JDBC operations.
+	 */
+	JdbcOperations getJdbcOperations();
+
+	/**
+	 * Expose the classic Spring {@link JdbcTemplate} itself, if available,
+	 * in particular for passing it on to other {@code JdbcTemplate} consumers.
+	 * <p>If sufficient for the purposes at hand, {@link #getJdbcOperations()}
+	 * is recommended over this variant.
+	 */
+	JdbcTemplate getJdbcTemplate();
 
 	// Static factory methods
 


### PR DESCRIPTION
I think `JdbcClient` should be exposed `JdbcTemplate` like `NamedParameterJdbcTemplate` or `AbstractJdbcCall`.