### PR TITLE
Fix typo in the bean validation section of the reference manual

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/validation/beanvalidation.adoc
+++ b/framework-docs/modules/ROOT/pages/core/validation/beanvalidation.adoc
@@ -377,7 +377,7 @@ Kotlin::
 
 A `ConstraintViolation` on `Person.name()` is adapted to a `FieldError` with the following:
 
-- Error codes `"Size.student.name"`, `"Size.name"`, `"Size.java.lang.String"`, and `"Size"`
+- Error codes `"Size.person.name"`, `"Size.name"`, `"Size.java.lang.String"`, and `"Size"`
 - Message arguments `"name"`, `10`, and `1` (the field name and the constraint attributes)
 - Default message "size must be between 1 and 10"
 


### PR DESCRIPTION
Documentation typo:
the error code seems to be on the Person class and therefore Size.person, instead of Size.student.