### PR TITLE
Replace `String.join` with `String.repeat` for generating placeholders in `TableMetaDataContext`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -350,7 +350,7 @@ public class TableMetaDataContext {
 				throw new InvalidDataAccessApiUsageException(message);
 			}
 		}
-		String params = String.join(", ", Collections.nCopies(columnCount, "?"));
+		String params = "?" + ", ?".repeat(columnCount - 1);
 		insertStatement.append(params);
 		insertStatement.append(')');
 		return insertStatement.toString();


### PR DESCRIPTION
Replaced the use of String.join combined with Collections.nCopies to generate SQL placeholders with the more concise and efficient String.repeat method.

- This change simplifies the code and improves readability.
- Performance might be slightly improved as String.repeat is more direct.

No functionality change; only a refactoring to improve code clarity and efficiency.

Benchmark          Mode  Cnt      Score      Error   Units
JoinTest.nCopies  thrpt    5   5938.720 ±   84.293  ops/ms
JoinTest.repeat   thrpt    5  37268.560 ± 1977.043  ops/ms