### PR TITLE
Replace String.join with String.repeat for generating placeholders

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -17,7 +17,6 @@
 package org.springframework.jdbc.core.metadata;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -351,7 +350,7 @@ public class TableMetaDataContext {
 				throw new InvalidDataAccessApiUsageException(message);
 			}
 		}
-		String params = String.join(", ", Collections.nCopies(columnCount, "?"));
+		String params = columnCount == 0 ? "" : "?" + ", ?".repeat(columnCount - 1);
 		insertStatement.append(params);
 		insertStatement.append(')');
 		return insertStatement.toString();


### PR DESCRIPTION
Replaced the use of String.join combined with Collections.nCopies to generate SQL placeholders with the more concise and efficient String.repeat method.

- This change simplifies the code and improves readability.
- Performance might be slightly improved as String.repeat is more direct.

No functionality change; only a refactoring to improve code clarity and efficiency.

<img width="686" alt="benchmark" src="https://github.com/user-attachments/assets/f747deff-b42b-4591-a301-5d25452968bc">
