### PR TITLE
Merge Expires and Max-Age attributes

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -1549,19 +1549,35 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 				headerValue = headerValue.substring(0, parametersIndex);
 			}
 
-			for (DateTimeFormatter dateFormatter : DATE_PARSERS) {
-				try {
-					return ZonedDateTime.parse(headerValue, dateFormatter);
-				}
-				catch (DateTimeParseException ex) {
-					// ignore
-				}
+			ZonedDateTime zonedDateTime = getZonedDateTime(headerValue);
+			if (zonedDateTime != null) {
+				return zonedDateTime;
 			}
 
 		}
 		if (rejectInvalid) {
 			throw new IllegalArgumentException("Cannot parse date value \"" + headerValue +
 					"\" for \"" + headerName + "\" header");
+		}
+		return null;
+	}
+
+	/**
+	 * Parses the date in headers with Date formats specified in the HTTP RFC to use for parsing.
+	 * {@link HttpHeaders#DATE_PARSERS}
+	 * @param date the date header value as string
+	 * @return the parsed date header value
+	 */
+	// used in ClientHttpResponse
+	@Nullable
+	public static ZonedDateTime getZonedDateTime(String date) {
+		for (DateTimeFormatter dateFormatter : DATE_PARSERS) {
+			try {
+				return ZonedDateTime.parse(date, dateFormatter);
+			}
+			catch (DateTimeParseException ex) {
+				// ignore
+			}
 		}
 		return null;
 	}

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpResponse.java
@@ -70,8 +70,7 @@ class HttpComponentsClientHttpResponse extends AbstractClientHttpResponse {
 	}
 
 	private static long getMaxAgeSeconds(Cookie cookie) {
-		String maxAgeAttribute = cookie.getAttribute(Cookie.MAX_AGE_ATTR);
-		return (maxAgeAttribute != null ? Long.parseLong(maxAgeAttribute) : -1);
+		return ClientHttpResponse.mergeMaxAgeAndExpires(cookie.getAttribute(Cookie.MAX_AGE_ATTR), cookie.getAttribute(Cookie.EXPIRES_ATTR));
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpResponse.java
@@ -128,7 +128,7 @@ class ReactorNetty2ClientHttpResponse implements ClientHttpResponse {
 						ResponseCookie.fromClientResponse(cookie.name().toString(), cookie.value().toString())
 								.domain(toString(cookie.domain()))
 								.path(toString(cookie.path()))
-								.maxAge(toLong(cookie.maxAge()))
+								.maxAge(getMaxAgeSeconds(cookie))
 								.secure(cookie.isSecure())
 								.httpOnly(cookie.isHttpOnly())
 								.sameSite(getSameSite(cookie))
@@ -136,13 +136,16 @@ class ReactorNetty2ClientHttpResponse implements ClientHttpResponse {
 		return CollectionUtils.unmodifiableMultiValueMap(result);
 	}
 
+	private static long getMaxAgeSeconds(HttpSetCookie cookie) {
+		String maxAge = (cookie.maxAge() == null) ? null : cookie.maxAge().toString();
+		String expires = toString(cookie.expires());
+
+		return ClientHttpResponse.mergeMaxAgeAndExpires(maxAge, expires);
+	}
+
 	@Nullable
 	private static String toString(@Nullable CharSequence value) {
 		return (value != null ? value.toString() : null);
-	}
-
-	private static long toLong(@Nullable Long value) {
-		return (value != null ? value : -1);
 	}
 
 	@Nullable


### PR DESCRIPTION
`org.springframework.http.client.reactive.ClientHttpResponse` and its implementations don't process `Expires` Cookie attribute. However, they only process `Max-Age` attribute.

Logic defined in [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.3). Point 3 of section 5.3 in this RFC gives higher precedence to `Max-Age` over `Expires`. This change follows this RFC and does the following:
1- If both `Max-Age` and `Expires` attribute are present in the cookie, set `maxAge` field in `ResponseCookie` to `Max-Age` attribute.
2- If only `Expires` attribute is present in the cookie, set `maxAge` field in `ResponseCookie` to `Expires` attribute.
2- If only `Max-Age` attribute is present in the cookie, set `maxAge` field in `ResponseCookie` to `Max-Age` attribute.

Closes https://github.com/spring-projects/spring-framework/issues/33157