### PR TITLE
Separate out ETag validation and parsing logic

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ETag.java
+++ b/spring-web/src/main/java/org/springframework/http/ETag.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http;
+
+import org.springframework.util.Assert;
+
+/**
+ * ETag header value holder.
+ *
+ * @author Riley Park
+ * @since TODO
+ * @param value value that uniquely represents the resource
+ * @param weak if weak validation should be used
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag">ETag Header</a>
+ */
+public record ETag(
+		String value,
+		boolean weak
+) {
+
+	/**
+	 * ETag prefix.
+	 *
+	 * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#directives">ETag Header Directives</a>
+	 */
+	public static final String PREFIX = "\"";
+
+	/**
+	 * ETag prefix, with a weak validator.
+	 *
+	 * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#directives">ETag Header Directives</a>
+	 * @see <a href=https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests#weak_validation">Weak Validation</a>
+	 */
+	public static final String PREFIX_WEAK = "W/\"";
+
+	/**
+	 * ETag suffix.
+	 *
+	 * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#directives">ETag Header Directives</a>
+	 */
+	public static final String SUFFIX = "\"";
+
+	/**
+	 * Parses an {@code ETag} header value as defined in RFC 7232.
+	 * @param etag the {@literal ETag} header value
+	 * @return the parsed content disposition
+	 * @see #toString()
+	 */
+	public static ETag parse(String etag) {
+		boolean weak = etag.startsWith(PREFIX_WEAK);
+		Assert.isTrue(etag.startsWith(PREFIX) || weak,
+				"Invalid ETag: does not start with " + PREFIX + " or " + PREFIX_WEAK);
+		Assert.isTrue(etag.endsWith(SUFFIX), "Invalid ETag: does not end with " + SUFFIX);
+		int start = (weak ? PREFIX_WEAK.length() : PREFIX.length());
+		String value = etag.substring(start, etag.length() - SUFFIX.length());
+		return new ETag(value, weak);
+	}
+
+	public String toHeaderValue() {
+		return (weak ? PREFIX_WEAK : PREFIX) + value + SUFFIX;
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -1072,11 +1072,16 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 * Set the (new) entity tag of the body, as specified by the {@code ETag} header.
 	 */
 	public void setETag(@Nullable String etag) {
+		setETag((etag != null) ? ETag.parse(etag) : null);
+	}
+
+	/**
+	 * Set the (new) entity tag of the body, as specified by the {@code ETag} header.
+	 * @since TODO
+	 */
+	public void setETag(@Nullable ETag etag) {
 		if (etag != null) {
-			Assert.isTrue(etag.startsWith("\"") || etag.startsWith("W/"),
-					"Invalid ETag: does not start with W/ or \"");
-			Assert.isTrue(etag.endsWith("\""), "Invalid ETag: does not end with \"");
-			set(ETAG, etag);
+			set(ETAG, etag.toHeaderValue());
 		}
 		else {
 			remove(ETAG);

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -407,6 +407,15 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 		B eTag(@Nullable String etag);
 
 		/**
+		 * Set the entity tag of the body, as specified by the {@code ETag} header.
+		 * @since TODO
+		 * @param etag the new entity tag
+		 * @return this builder
+		 * @see HttpHeaders#setETag(ETag)
+		 */
+		B eTag(@Nullable ETag etag);
+
+		/**
 		 * Set the time the resource was last changed, as specified by the
 		 * {@code Last-Modified} header.
 		 * @param lastModified the last modified date
@@ -569,14 +578,12 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 
 		@Override
 		public BodyBuilder eTag(@Nullable String etag) {
-			if (etag != null) {
-				if (!etag.startsWith("\"") && !etag.startsWith("W/\"")) {
-					etag = "\"" + etag;
-				}
-				if (!etag.endsWith("\"")) {
-					etag = etag + "\"";
-				}
-			}
+			this.headers.setETag(etag);
+			return this;
+		}
+
+		@Override
+		public BodyBuilder eTag(@Nullable ETag etag) {
 			this.headers.setETag(etag);
 			return this;
 		}

--- a/spring-web/src/main/java/org/springframework/web/server/adapter/DefaultServerWebExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/DefaultServerWebExchange.java
@@ -33,6 +33,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.i18n.LocaleContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.codec.Hints;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -368,10 +369,10 @@ public class DefaultServerWebExchange implements ServerWebExchange {
 		if (!StringUtils.hasLength(etag)) {
 			return etag;
 		}
-		if ((etag.startsWith("\"") || etag.startsWith("W/\"")) && etag.endsWith("\"")) {
+		if ((etag.startsWith(ETag.PREFIX) || etag.startsWith(ETag.PREFIX_WEAK)) && etag.endsWith(ETag.SUFFIX)) {
 			return etag;
 		}
-		return "\"" + etag + "\"";
+		return ETag.PREFIX + etag + ETag.SUFFIX;
 	}
 
 	private boolean eTagStrongMatch(@Nullable String first, @Nullable String second) {

--- a/spring-web/src/test/java/org/springframework/http/ETagTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ETagTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link ETag}.
+ * @author Riley Park
+ */
+class ETagTests {
+
+	@Test
+	void parse() {
+		String raw = "\"v2.6\"";
+		ETag etag = ETag.parse(raw);
+		assertThat(etag.value()).isEqualTo("v2.6");
+		assertThat(etag.weak()).isFalse();
+		assertThat(etag.toHeaderValue()).isEqualTo(raw);
+	}
+
+	@Test
+	void parseWeak() {
+		String raw = "W/\"v2.6\"";
+		ETag etag = ETag.parse(raw);
+		assertThat(etag.value()).isEqualTo("v2.6");
+		assertThat(etag.weak()).isTrue();
+		assertThat(etag.toHeaderValue()).isEqualTo(raw);
+	}
+
+	@Test
+	void illegalETagWithoutQuoteAfterWSlash() {
+		String raw = "W/v2.6\"";
+		assertThatIllegalArgumentException().isThrownBy(() -> ETag.parse(raw));
+	}
+
+}

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
@@ -190,6 +190,14 @@ class HttpHeadersTests {
 	}
 
 	@Test
+	void eTagW() {
+		String eTag = "W\"v2.6\"";
+		headers.setETag(eTag);
+		assertThat(headers.getETag()).as("Invalid ETag header").isEqualTo(eTag);
+		assertThat(headers.getFirst("ETag")).as("Invalid ETag header").isEqualTo("W\"v2.6\"");
+	}
+
+	@Test
 	void host() {
 		InetSocketAddress host = InetSocketAddress.createUnresolved("localhost", 8080);
 		headers.setHost(host);
@@ -216,6 +224,12 @@ class HttpHeadersTests {
 	@Test
 	void illegalETag() {
 		String eTag = "v2.6";
+		assertThatIllegalArgumentException().isThrownBy(() -> headers.setETag(eTag));
+	}
+
+	@Test
+	void illegalETagWithoutQuoteAfterWSlash() {
+		String eTag = "W/v2.6\"";
 		assertThatIllegalArgumentException().isThrownBy(() -> headers.setETag(eTag));
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ResponseEntityTests.java
@@ -223,7 +223,7 @@ class ResponseEntityTests {
 		responseEntity = ResponseEntity.ok().eTag("W/\"foo\"").build();
 		assertThat(responseEntity.getHeaders().getETag()).isEqualTo("W/\"foo\"");
 
-		responseEntity = ResponseEntity.ok().eTag(null).build();
+		responseEntity = ResponseEntity.ok().eTag((String) null).build();
 		assertThat(responseEntity.getHeaders().getETag()).isNull();
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultEntityResponseBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultEntityResponseBuilder.java
@@ -32,6 +32,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.core.codec.Hints;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -148,12 +149,12 @@ class DefaultEntityResponseBuilder<T> implements EntityResponse.Builder<T> {
 
 	@Override
 	public EntityResponse.Builder<T> eTag(String etag) {
-		if (!etag.startsWith("\"") && !etag.startsWith("W/\"")) {
-			etag = "\"" + etag;
-		}
-		if (!etag.endsWith("\"")) {
-			etag = etag + "\"";
-		}
+		this.headers.setETag(etag);
+		return this;
+	}
+
+	@Override
+	public EntityResponse.Builder<T> eTag(ETag etag) {
 		this.headers.setETag(etag);
 		return this;
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerResponseBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/DefaultServerResponseBuilder.java
@@ -37,6 +37,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.codec.Hints;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
@@ -148,12 +149,13 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 	@Override
 	public ServerResponse.BodyBuilder eTag(String etag) {
 		Assert.notNull(etag, "etag must not be null");
-		if (!etag.startsWith("\"") && !etag.startsWith("W/\"")) {
-			etag = "\"" + etag;
-		}
-		if (!etag.endsWith("\"")) {
-			etag = etag + "\"";
-		}
+		this.headers.setETag(etag);
+		return this;
+	}
+
+	@Override
+	public ServerResponse.BodyBuilder eTag(ETag etag) {
+		Assert.notNull(etag, "etag must not be null");
 		this.headers.setETag(etag);
 		return this;
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/EntityResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/EntityResponse.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
@@ -219,6 +220,15 @@ public interface EntityResponse<T> extends ServerResponse {
 		 * @see HttpHeaders#setETag(String)
 		 */
 		Builder<T> eTag(String etag);
+
+		/**
+		 * Set the entity tag of the body, as specified by the {@code ETag} header.
+		 * @since TODO
+		 * @param etag the new entity tag
+		 * @return this builder
+		 * @see HttpHeaders#setETag(ETag)
+		 */
+		Builder<T> eTag(ETag etag);
 
 		/**
 		 * Set the time the resource was last changed, as specified by the

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/ServerResponse.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/ServerResponse.java
@@ -32,6 +32,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -299,6 +300,15 @@ public interface ServerResponse {
 		 * @see HttpHeaders#setETag(String)
 		 */
 		B eTag(String eTag);
+
+		/**
+		 * Set the entity tag of the body, as specified by the {@code ETag} header.
+		 * @since TODO
+		 * @param eTag the new entity tag
+		 * @return this builder
+		 * @see HttpHeaders#setETag(ETag)
+		 */
+		B eTag(ETag eTag);
 
 		/**
 		 * Set the time the resource was last changed, as specified by the

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/VersionResourceResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/VersionResourceResolver.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 import org.springframework.util.AntPathMatcher;
@@ -334,7 +335,7 @@ public class VersionResourceResolver extends AbstractResourceResolver {
 		public HttpHeaders getResponseHeaders() {
 			HttpHeaders headers = (this.original instanceof HttpResource httpResource ?
 					httpResource.getResponseHeaders() : new HttpHeaders());
-			headers.setETag("W/\"" + this.version + "\"");
+			headers.setETag(new ETag(this.version, true));
 			return headers;
 		}
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultEntityResponseBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultEntityResponseBuilder.java
@@ -46,6 +46,7 @@ import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourceRegion;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRange;
@@ -166,12 +167,12 @@ final class DefaultEntityResponseBuilder<T> implements EntityResponse.Builder<T>
 
 	@Override
 	public EntityResponse.Builder<T> eTag(String etag) {
-		if (!etag.startsWith("\"") && !etag.startsWith("W/\"")) {
-			etag = "\"" + etag;
-		}
-		if (!etag.endsWith("\"")) {
-			etag = etag + "\"";
-		}
+		this.headers.setETag(etag);
+		return this;
+	}
+
+	@Override
+	public EntityResponse.Builder<T> eTag(ETag etag) {
 		this.headers.setETag(etag);
 		return this;
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerResponseBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultServerResponseBuilder.java
@@ -31,6 +31,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
@@ -127,13 +128,13 @@ class DefaultServerResponseBuilder implements ServerResponse.BodyBuilder {
 
 	@Override
 	public ServerResponse.BodyBuilder eTag(String etag) {
+		this.headers.setETag(etag);
+		return this;
+	}
+
+	@Override
+	public ServerResponse.BodyBuilder eTag(ETag etag) {
 		Assert.notNull(etag, "etag must not be null");
-		if (!etag.startsWith("\"") && !etag.startsWith("W/\"")) {
-			etag = "\"" + etag;
-		}
-		if (!etag.endsWith("\"")) {
-			etag = etag + "\"";
-		}
 		this.headers.setETag(etag);
 		return this;
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/EntityResponse.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/EntityResponse.java
@@ -26,6 +26,7 @@ import jakarta.servlet.http.Cookie;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
@@ -154,6 +155,15 @@ public interface EntityResponse<T> extends ServerResponse {
 		 * @see HttpHeaders#setETag(String)
 		 */
 		Builder<T> eTag(String etag);
+
+		/**
+		 * Set the entity tag of the body, as specified by the {@code ETag} header.
+		 * @since TODO
+		 * @param etag the new entity tag
+		 * @return this builder
+		 * @see HttpHeaders#setETag(ETag)
+		 */
+		Builder<T> eTag(ETag etag);
 
 		/**
 		 * Set the time the resource was last changed, as specified by the

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
@@ -38,6 +38,7 @@ import org.reactivestreams.Publisher;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.http.CacheControl;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -399,6 +400,15 @@ public interface ServerResponse {
 		 * @see HttpHeaders#setETag(String)
 		 */
 		B eTag(String eTag);
+
+		/**
+		 * Set the entity tag of the body, as specified by the {@code ETag} header.
+		 * @since TODO
+		 * @param eTag the new entity tag
+		 * @return this builder
+		 * @see HttpHeaders#setETag(ETag)
+		 */
+		B eTag(ETag eTag);
 
 		/**
 		 * Set the time the resource was last changed, as specified by the

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/VersionResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/VersionResourceResolver.java
@@ -34,6 +34,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 import org.springframework.util.AntPathMatcher;
@@ -332,7 +333,7 @@ public class VersionResourceResolver extends AbstractResourceResolver {
 		public HttpHeaders getResponseHeaders() {
 			HttpHeaders headers = (this.original instanceof HttpResource httpResource ?
 					httpResource.getResponseHeaders() : new HttpHeaders());
-			headers.setETag("W/\"" + this.version + "\"");
+			headers.setETag(new ETag(this.version, true));
 			return headers;
 		}
 	}


### PR DESCRIPTION
This started off as fixing a [bug where weak-prefixed values were not properly validated](https://github.com/spring-projects/spring-framework/compare/main...kashike:feature/etag?expand=1#diff-e2d6218e6585f8b7e32682f6f8f7aed22dbd76d862ec92e86e0902243889556aL1076), and turned into a larger refactor to extract all of the repeated validation and parsing logic into a common `ETag` class.

If you'd like me to go a different route, just let me know. 😃 