### PR TITLE
Fix incorrect weak ETag validation

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -1073,8 +1073,8 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 	 */
 	public void setETag(@Nullable String etag) {
 		if (etag != null) {
-			Assert.isTrue(etag.startsWith("\"") || etag.startsWith("W/"),
-					"Invalid ETag: does not start with W/ or \"");
+			Assert.isTrue(etag.startsWith("\"") || etag.startsWith("W/\""),
+					"Invalid ETag: does not start with W/\" or \"");
 			Assert.isTrue(etag.endsWith("\""), "Invalid ETag: does not end with \"");
 			set(ETAG, etag);
 		}

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
@@ -220,6 +220,12 @@ class HttpHeadersTests {
 	}
 
 	@Test
+	void illegalETagWithoutQuoteAfterWSlash() {
+		String etag = "W/v2.6\"";
+		assertThatIllegalArgumentException().as("Invalid Weak ETag").isThrownBy(() -> headers.setETag(etag));
+	}
+
+	@Test
 	void ifMatch() {
 		String ifMatch = "\"v2.6\"";
 		headers.setIfMatch(ifMatch);


### PR DESCRIPTION
The validation logic checks for a prefix of `W/` when it should be checking for `W/"`. As per the spec (see [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) and [here](https://datatracker.ietf.org/doc/html/rfc7232#section-2.3)) this allows invalid values to pass through.