### PR TITLE
Revise `AdvisedSupport.MethodCacheKey.equals()` implementation

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -645,7 +645,7 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 
 		@Override
 		public boolean equals(@Nullable Object other) {
-			return (this == other || (other instanceof MethodCacheKey that && this.method == that.method));
+			return (this == other || (other instanceof MethodCacheKey that && this.hashCode == that.hashCode));
 		}
 
 		@Override


### PR DESCRIPTION
spring-aop AdvisedSupport.MethodCacheKey.equals() use hashCode