### PR TITLE
Rename test method to clarify the purpose related to SPR-6063

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -475,7 +475,7 @@ class BeanUtilsTests {
 	}
 
 	@Test
-	void spr6063() {
+	void propertyDescriptorShouldMatchWithCachedDescriptors() {
 		PropertyDescriptor[] descrs = BeanUtils.getPropertyDescriptors(Bean.class);
 
 		PropertyDescriptor keyDescr = BeanUtils.getPropertyDescriptor(Bean.class, "value");


### PR DESCRIPTION
This PR renames the test method `spr6063` to `propertyDescriptorShouldMatchWithCachedDescriptors` to better reflect the intent of the test. The original method name was tied to the issue number, but it did not convey the specific purpose of the test.

The updated method name now clearly indicates that the test is designed to verify the consistency between the results of `BeanUtils.getPropertyDescriptor()` and `BeanUtils.getPropertyDescriptors()`.

This change was made following the discussion and issue raised in [SPR-6063](https://github.com/spring-projects/spring-framework/issues/10731), ensuring that the test method name is descriptive and aligns with best practices.
