### PR TITLE
Open observation scope in RestClient

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
@@ -520,6 +520,7 @@ final class DefaultRestClient implements RestClient {
 
 			ClientHttpResponse clientResponse = null;
 			Observation observation = null;
+			Observation.Scope scope = null;
 			URI uri = null;
 			try {
 				uri = initUri();
@@ -532,6 +533,7 @@ final class DefaultRestClient implements RestClient {
 				observationContext.setUriTemplate((String) attributes.get(URI_TEMPLATE_ATTRIBUTE));
 				observation = ClientHttpObservationDocumentation.HTTP_CLIENT_EXCHANGES.observation(observationConvention,
 						DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, observationRegistry).start();
+				scope = observation.openScope();
 				if (this.body != null) {
 					this.body.writeTo(clientRequest);
 				}
@@ -559,8 +561,13 @@ final class DefaultRestClient implements RestClient {
 				throw error;
 			}
 			finally {
-				if (close && clientResponse != null) {
-					clientResponse.close();
+				if (close) {
+					if (clientResponse != null) {
+						clientResponse.close();
+					}
+					if (scope != null) {
+						scope.close();
+					}
 					if (observation != null) {
 						observation.stop();
 					}

--- a/spring-web/src/test/java/org/springframework/web/client/RestClientObservationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestClientObservationTests.java
@@ -225,6 +225,16 @@ class RestClientObservationTests {
 	}
 
 	@Test
+	void exchangeInternalShouldOpenAndCloseObservationScope() throws Exception {
+		mockSentRequest(GET, "https://example.org");
+		mockResponseStatus(HttpStatus.OK);
+		mockResponseBody("Hello World", MediaType.TEXT_PLAIN);
+
+		client.get().uri("https://example.org").exchange((request, response) -> response.bodyTo(String.class));
+		assertThat(observationRegistry).isNotNull();
+	}
+
+	@Test
 	void registerObservationWhenReadingStream() throws Exception {
 		mockSentRequest(GET, "https://example.org");
 		mockResponseStatus(HttpStatus.OK);


### PR DESCRIPTION
This is to address issue - RestClient doesn't open a scope for the processing of the request #33397. The scope is now opened and properly closed, which ensures that any observations captured during the execution are appropriately handled, even in the presence of exceptions.

Changes
- Refactored exchangeInternal method to manage Observation.Scope more effectively.
- Added a test to verify the proper creation and closure of the observation scope.